### PR TITLE
Add deer component

### DIFF
--- a/submissions/examples/deer-as/README.md
+++ b/submissions/examples/deer-as/README.md
@@ -1,0 +1,22 @@
+# Deer
+
+### What does this do?
+
+It shows a deer standing in a moonlit clearing while snow falls. It breathes, its ears flick, it blinks, its tail flicks, and a hoof shifts now and then. Under reduced motion the deer stands still and no snow falls.
+
+### How is it used?
+
+```html
+<div class="deer">
+  <span class="antler anl"></span>
+  <span class="headd"></span>
+  <span class="bodyd"></span>
+  <span class="legd lf1"></span>
+</div>
+```
+
+Each antler is a single element: the tines are two offset `box-shadow` copies of the beam, so a branching rack costs no extra nodes. Each ear parks its rest angle in an `--er` custom property, and the flick keyframe multiplies it with `calc(var(--er) * 1.6)`, so one animation twitches both ears outward from wherever they already sit rather than snapping them to a shared angle. The pine trees are pure `border` triangles.
+
+### Why is it useful?
+
+Forest, winter, and holiday themes use a deer. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/deer-as/demo.html
+++ b/submissions/examples/deer-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Deer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moond"></span>
+    <span class="treed td1"></span>
+    <span class="treed td2"></span>
+    <div class="deer">
+      <span class="antler anl"></span>
+      <span class="antler anr"></span>
+      <span class="headd"></span>
+      <span class="eard el2"></span>
+      <span class="eard er2"></span>
+      <span class="eyed"></span>
+      <span class="nosed"></span>
+      <span class="neckd"></span>
+      <span class="bodyd"></span>
+      <span class="spotd sd1"></span>
+      <span class="spotd sd2"></span>
+      <span class="spotd sd3"></span>
+      <span class="legd lf1"></span>
+      <span class="legd lf2"></span>
+      <span class="legd lb1"></span>
+      <span class="legd lb2"></span>
+      <span class="taild"></span>
+    </div>
+    <span class="groundd"></span>
+    <span class="fleck fk1"></span>
+    <span class="fleck fk2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/deer-as/style.css
+++ b/submissions/examples/deer-as/style.css
@@ -1,0 +1,306 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 70% 24%, #35406b, #12162c 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 320px;
+}
+
+.moond {
+  position: absolute;
+  top: 18px;
+  right: 34px;
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #fffdf2, #d9dcc4 76%);
+  box-shadow: 0 0 44px rgba(255, 250, 220, 0.6);
+  animation: glowd 5s ease-in-out infinite;
+}
+
+.treed {
+  position: absolute;
+  bottom: 76px;
+  width: 0;
+  height: 0;
+  border-left: 34px solid transparent;
+  border-right: 34px solid transparent;
+  border-bottom: 130px solid #1d3a34;
+  z-index: 2;
+}
+
+.td1 { left: 6px; }
+
+.td2 {
+  right: 10px;
+  border-left-width: 26px;
+  border-right-width: 26px;
+  border-bottom-width: 100px;
+  border-bottom-color: #16302b;
+}
+
+.groundd {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 80px);
+  background:
+    radial-gradient(circle at 22% 4%, rgba(255, 255, 255, 0.12) 0 24px, transparent 24px),
+    radial-gradient(circle at 72% 6%, rgba(255, 255, 255, 0.1) 0 30px, transparent 30px),
+    linear-gradient(180deg, #2a3350, #161c2f);
+  z-index: 5;
+}
+
+.deer {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  width: 240px;
+  height: 220px;
+  margin-left: -120px;
+  z-index: 4;
+  animation: breathed 4.4s ease-in-out infinite;
+}
+
+.bodyd {
+  position: absolute;
+  bottom: 46px;
+  left: 30px;
+  width: 150px;
+  height: 76px;
+  border-radius: 50% 46% 44% 50% / 56% 54% 46% 44%;
+  background: linear-gradient(180deg, #c58a52, #8a5227);
+  box-shadow: inset 0 -10px 16px rgba(80, 40, 10, 0.4);
+  z-index: 3;
+}
+
+.neckd {
+  position: absolute;
+  bottom: 96px;
+  left: 146px;
+  width: 36px;
+  height: 60px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #cf9358, #9b5c2c);
+  transform: rotate(14deg);
+  z-index: 2;
+}
+
+.headd {
+  position: absolute;
+  bottom: 138px;
+  left: 160px;
+  width: 62px;
+  height: 46px;
+  border-radius: 40% 60% 44% 44% / 50% 60% 44% 40%;
+  background: linear-gradient(180deg, #d59a5f, #a1622f);
+  z-index: 4;
+}
+
+.eard {
+  position: absolute;
+  bottom: 168px;
+  width: 30px;
+  height: 20px;
+  border-radius: 50% 50% 40% 40%;
+  background: linear-gradient(180deg, #b87d47, #6d3f1a);
+  transform: rotate(var(--er, 0deg));
+  z-index: 5;
+  animation: flickd 4s ease-in-out infinite;
+}
+
+.el2 {
+  left: 142px;
+
+  --er: -26deg;
+}
+
+.er2 {
+  left: 210px;
+
+  --er: 26deg;
+
+  animation-delay: 1.2s;
+}
+
+.eyed {
+  position: absolute;
+  bottom: 160px;
+  left: 198px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #201408;
+  z-index: 5;
+  animation: blinkd 5s ease-in-out infinite;
+}
+
+.nosed {
+  position: absolute;
+  bottom: 144px;
+  left: 214px;
+  width: 12px;
+  height: 9px;
+  border-radius: 50%;
+  background: #2d1a0c;
+  z-index: 5;
+}
+
+.antler {
+  position: absolute;
+  bottom: 172px;
+  width: 8px;
+  height: 48px;
+  border-radius: 4px;
+  background: #b79162;
+  transform-origin: 50% 100%;
+  z-index: 2;
+  box-shadow:
+    -9px -12px 0 -1px #b79162,
+    9px -18px 0 -1px #b79162;
+}
+
+.anl {
+  left: 166px;
+  transform: rotate(-20deg);
+}
+
+.anr {
+  left: 202px;
+  transform: rotate(20deg);
+}
+
+.spotd {
+  position: absolute;
+  width: 12px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(255, 240, 210, 0.75);
+  z-index: 4;
+}
+
+.sd1 { bottom: 96px; left: 62px; }
+.sd2 { bottom: 84px; left: 96px; }
+.sd3 { bottom: 98px; left: 126px; }
+
+.legd {
+  position: absolute;
+  bottom: 0;
+  width: 14px;
+  height: 56px;
+  border-radius: 5px 5px 4px 4px;
+  background: linear-gradient(180deg, #a96c36, #6d3f18);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: stepd 4.4s ease-in-out infinite;
+}
+
+.lf1 { left: 152px; }
+
+.lf2 {
+  left: 132px;
+  animation-delay: 1.1s;
+}
+
+.lb1 {
+  left: 48px;
+  animation-delay: 2.2s;
+}
+
+.lb2 {
+  left: 30px;
+  animation-delay: 3.3s;
+}
+
+.taild {
+  position: absolute;
+  bottom: 96px;
+  left: 20px;
+  width: 20px;
+  height: 26px;
+  border-radius: 10px 4px 10px 10px;
+  background: linear-gradient(180deg, #d9a26a, #8a5227);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: wagd 2.6s ease-in-out infinite;
+}
+
+.fleck {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+  z-index: 6;
+  animation: falld 6s linear infinite;
+}
+
+.fk1 { top: -10px; left: 110px; }
+
+.fk2 {
+  top: -10px;
+  left: 250px;
+  animation-delay: 3s;
+}
+
+@keyframes breathed {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+@keyframes glowd {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 1; }
+}
+
+@keyframes flickd {
+  0%, 88%, 100% { transform: rotate(var(--er, 0deg)); }
+  94% { transform: rotate(calc(var(--er, 0deg) * 1.6)); }
+}
+
+@keyframes blinkd {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes stepd {
+  0%, 84%, 100% { transform: rotate(0deg); }
+  92% { transform: rotate(8deg); }
+}
+
+@keyframes wagd {
+  0%, 100% { transform: rotate(-10deg); }
+  50% { transform: rotate(10deg); }
+}
+
+@keyframes falld {
+  0% { transform: translate(0, 0); opacity: 0; }
+  10% { opacity: 1; }
+  100% { transform: translate(-30px, 330px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deer,
+  .moond,
+  .eard,
+  .eyed,
+  .legd,
+  .taild,
+  .fleck {
+    animation: none;
+  }
+
+  .fleck {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a deer built for #45099. Each antler is a single element whose tines are two offset box-shadow copies of the beam, so a branching rack costs no extra nodes. Each ear parks its rest angle in an `--er` custom property and the flick keyframe multiplies it with `calc(var(--er) * 1.6)`, so one animation twitches both ears outward from wherever they already sit rather than snapping them to a shared angle. The pine trees are pure border triangles. Reduced motion fallback included. Pure CSS. Closes #45099.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a spotted deer with a branching antler rack, flicking ears and four legs, standing between pine trees under a full moon with falling snow.
