### PR TITLE
Add bat component

### DIFF
--- a/submissions/examples/bat-as/README.md
+++ b/submissions/examples/bat-as/README.md
@@ -1,0 +1,21 @@
+# Bat
+
+### What does this do?
+
+It shows a bat flying across a full moon. Its scalloped wings beat, it swoops up and down as it flies, its eyes blink, and sonar rings pulse out from it and fade. Under reduced motion the bat hangs still and the sonar stops.
+
+### How is it used?
+
+```html
+<div class="bat">
+  <span class="wingb wgl"></span>
+  <span class="wingb wgr"></span>
+  <span class="bodyb"></span>
+</div>
+```
+
+The scalloped wing edge is a `clip-path` polygon, so the classic bat silhouette comes from one property instead of stacked circles. Both wings share one `flapb` keyframe and hinge at the body because each stores its own pivot in `transform-origin: var(--wo) 30%`: the left wing pivots at its right edge, the right wing at its left. The beat itself is a `rotateX`, so the wings tilt through space and foreshorten rather than just squashing.
+
+### Why is it useful?
+
+Halloween, night, and spooky themes use a bat. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/bat-as/demo.html
+++ b/submissions/examples/bat-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bat</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moonb"></span>
+    <div class="bat">
+      <span class="wingb wgl"></span>
+      <span class="wingb wgr"></span>
+      <span class="bodyb"></span>
+      <span class="earb ebl"></span>
+      <span class="earb ebr"></span>
+      <span class="eyeb eyl"></span>
+      <span class="eyeb eyr"></span>
+      <span class="fangb fgl"></span>
+      <span class="fangb fgr"></span>
+    </div>
+    <span class="pulse pl1"></span>
+    <span class="pulse pl2"></span>
+    <span class="hillb"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bat-as/style.css
+++ b/submissions/examples/bat-as/style.css
@@ -1,0 +1,216 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #3a2b4f, #120b1c 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 320px;
+}
+
+.moonb {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 150px;
+  height: 150px;
+  margin-left: -75px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 38%, #fff6d8, #e2cf8f 76%);
+  box-shadow: 0 0 70px rgba(255, 240, 190, 0.55);
+  animation: glowb 6s ease-in-out infinite;
+}
+
+.hillb {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 70px);
+  background:
+    radial-gradient(circle at 26% 6%, #211634 0 60px, transparent 60px),
+    radial-gradient(circle at 74% 2%, #211634 0 52px, transparent 52px),
+    linear-gradient(180deg, #1a1129, #0d0816);
+  z-index: 5;
+}
+
+.bat {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 260px;
+  height: 110px;
+  margin-left: -130px;
+  z-index: 4;
+  animation: swoopb 6s ease-in-out infinite;
+}
+
+.bodyb {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 56px;
+  height: 66px;
+  margin-left: -28px;
+  border-radius: 46% 46% 50% 50% / 40% 40% 60% 60%;
+  background: linear-gradient(180deg, #4b3a68, #241a38);
+  z-index: 4;
+}
+
+.earb {
+  position: absolute;
+  top: 4px;
+  width: 0;
+  height: 0;
+  border-left: 11px solid transparent;
+  border-right: 11px solid transparent;
+  border-bottom: 24px solid #3d2f57;
+  z-index: 3;
+  transform: rotate(var(--br, 0deg));
+}
+
+.ebl {
+  left: 50%;
+  margin-left: -30px;
+
+  --br: -14deg;
+}
+
+.ebr {
+  left: 50%;
+  margin-left: 8px;
+
+  --br: 14deg;
+}
+
+.eyeb {
+  position: absolute;
+  top: 42px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffe98a, #e0a516 74%);
+  box-shadow: 0 0 10px rgba(255, 220, 110, 0.8);
+  z-index: 5;
+  animation: blinkb 4.4s ease-in-out infinite;
+}
+
+.eyl {
+  left: 50%;
+  margin-left: -18px;
+}
+
+.eyr {
+  left: 50%;
+  margin-left: 6px;
+}
+
+.fangb {
+  position: absolute;
+  top: 66px;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 10px solid #fff6ea;
+  z-index: 5;
+}
+
+.fgl {
+  left: 50%;
+  margin-left: -10px;
+}
+
+.fgr {
+  left: 50%;
+  margin-left: 2px;
+}
+
+.wingb {
+  position: absolute;
+  top: 14px;
+  width: 112px;
+  height: 74px;
+  background: linear-gradient(160deg, #5b4680, #2a1f42);
+  transform-origin: var(--wo, 100%) 30%;
+  animation: flapb 1.6s ease-in-out infinite;
+  z-index: 3;
+}
+
+.wgl {
+  left: 8px;
+  clip-path: polygon(2% 20%, 100% 0, 100% 100%, 74% 62%, 50% 96%, 26% 56%, 0 90%);
+  border-radius: 10px 0 0 10px;
+
+  --wo: 100%;
+}
+
+.wgr {
+  right: 8px;
+  clip-path: polygon(98% 20%, 0 0, 0 100%, 26% 62%, 50% 96%, 74% 56%, 100% 90%);
+  border-radius: 0 10px 10px 0;
+
+  --wo: 0%;
+}
+
+.pulse {
+  position: absolute;
+  top: 130px;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  margin-left: -20px;
+  border-radius: 50%;
+  border: 2px solid rgba(200, 180, 255, 0.6);
+  opacity: 0;
+  z-index: 2;
+  animation: sonarb 3.4s ease-out infinite;
+}
+
+.pl2 { animation-delay: 1.7s; }
+
+@keyframes flapb {
+  0%, 100% { transform: rotateX(0deg) scaleY(1); }
+  50% { transform: rotateX(58deg) scaleY(0.72); }
+}
+
+@keyframes swoopb {
+  0%, 100% { transform: translate(0, 0) rotate(-2deg); }
+  50% { transform: translate(0, -26px) rotate(2deg); }
+}
+
+@keyframes glowb {
+  0%, 100% { opacity: 0.9; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.02); }
+}
+
+@keyframes blinkb {
+  0%, 90%, 100% { transform: scaleY(1); }
+  95% { transform: scaleY(0.1); }
+}
+
+@keyframes sonarb {
+  0% { transform: scale(0.4); opacity: 0.8; }
+  100% { transform: scale(3.4); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bat,
+  .wingb,
+  .eyeb,
+  .moonb,
+  .pulse {
+    animation: none;
+  }
+
+  .pulse {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bat built for #45101. The scalloped wing edge is a clip-path polygon, so the classic bat silhouette comes from one property instead of stacked circles. Both wings share one `flapb` keyframe and still hinge at the body because each stores its own pivot in `transform-origin: var(--wo) 30%`, the left wing pivoting at its right edge and the right wing at its left. The beat is a rotateX, so the wings tilt through space and foreshorten rather than just squashing. Reduced motion fallback included. Pure CSS. Closes #45101.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot, including a frame with the wings held flat: a bat with scalloped wings, pointed ears, glowing eyes and fangs, crossing a full moon over dark hills.
