### PR TITLE
Add anchor component

### DIFF
--- a/submissions/examples/anchor-as/README.md
+++ b/submissions/examples/anchor-as/README.md
@@ -1,0 +1,22 @@
+# Anchor
+
+### What does this do?
+
+It shows a ship's anchor hanging on its chain underwater. It swings slowly from the top of the chain, and bubbles rise past it. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="anch">
+  <span class="ringa"></span>
+  <span class="shank"></span>
+  <span class="arc"></span>
+  <span class="fluke2 f2l"></span>
+</div>
+```
+
+The curved arms are one element: a box with only its bottom two corners rounded and its `border-top-color` set to `transparent`, so the visible border draws a U and the middle stays hollow with no clip path or mask. The chain is a single `repeating-linear-gradient` of links running the full height of the scene, and the whole anchor swings from `transform-origin: 50% 0`, so it pivots at the shackle where the chain actually holds it rather than around its own middle.
+
+### Why is it useful?
+
+Nautical, harbour, and travel themes use an anchor. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/anchor-as/demo.html
+++ b/submissions/examples/anchor-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Anchor</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="chain"></span>
+    <div class="anch">
+      <span class="ringa"></span>
+      <span class="shank"></span>
+      <span class="stock"></span>
+      <span class="arc"></span>
+      <span class="fluke2 f2l"></span>
+      <span class="fluke2 f2r"></span>
+    </div>
+    <span class="buba ba1"></span>
+    <span class="buba ba2"></span>
+    <span class="buba ba3"></span>
+    <span class="floora"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/anchor-as/style.css
+++ b/submissions/examples/anchor-as/style.css
@@ -1,0 +1,188 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #16789c, #04202f 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+}
+
+.floora {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 54px);
+  background:
+    radial-gradient(circle at 24% 4%, #1d3f4e 0 40px, transparent 40px),
+    radial-gradient(circle at 70% 2%, #1d3f4e 0 32px, transparent 32px),
+    #17323e;
+  z-index: 4;
+}
+
+.chain {
+  position: absolute;
+  top: -100vh;
+  left: 50%;
+  width: 12px;
+  height: calc(100vh + 46px);
+  margin-left: -6px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #a9b6c2 0 10px,
+      #5d6873 10px 12px,
+      transparent 12px 16px
+    );
+  z-index: 2;
+}
+
+.anch {
+  position: absolute;
+  top: 46px;
+  left: 50%;
+  width: 220px;
+  height: 250px;
+  margin-left: -110px;
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: swinga 5s ease-in-out infinite;
+}
+
+.ringa {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 42px;
+  height: 42px;
+  margin-left: -21px;
+  border-radius: 50%;
+  border: 8px solid #b9c5d1;
+  box-sizing: border-box;
+  background: transparent;
+  box-shadow: inset 0 0 0 2px rgba(40, 60, 80, 0.4);
+}
+
+.shank {
+  position: absolute;
+  top: 36px;
+  left: 50%;
+  width: 20px;
+  height: 170px;
+  margin-left: -10px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #cfd9e3, #7d8894);
+  box-shadow: inset -4px 0 6px rgba(30, 50, 70, 0.35);
+}
+
+.stock {
+  position: absolute;
+  top: 74px;
+  left: 50%;
+  width: 150px;
+  height: 16px;
+  margin-left: -75px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #cfd9e3, #7d8894);
+  box-shadow: inset 0 -4px 6px rgba(30, 50, 70, 0.35);
+}
+
+.arc {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  width: 170px;
+  height: 120px;
+  margin-left: -85px;
+  border-radius: 0 0 90px 90px;
+  border: 18px solid #b9c5d1;
+  border-top-color: transparent;
+  box-sizing: border-box;
+  background: transparent;
+}
+
+.fluke2 {
+  position: absolute;
+  bottom: 30px;
+  width: 0;
+  height: 0;
+  border-left: 22px solid transparent;
+  border-right: 22px solid transparent;
+  border-bottom: 34px solid #b9c5d1;
+  transform: rotate(var(--fa, 0deg));
+}
+
+.f2l {
+  left: 16px;
+
+  --fa: -32deg;
+}
+
+.f2r {
+  right: 16px;
+
+  --fa: 32deg;
+}
+
+.buba {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 245, 255, 0.8);
+  background: rgba(190, 235, 255, 0.18);
+  opacity: 0;
+  z-index: 5;
+  animation: floata 5.6s ease-in infinite;
+}
+
+.ba1 {
+  bottom: 70px;
+  left: 52px;
+  width: 12px;
+  height: 12px;
+}
+
+.ba2 {
+  bottom: 60px;
+  right: 60px;
+  width: 8px;
+  height: 8px;
+  animation-delay: 1.9s;
+}
+
+.ba3 {
+  bottom: 84px;
+  right: 32px;
+  width: 16px;
+  height: 16px;
+  animation-delay: 3.8s;
+}
+
+@keyframes swinga {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes floata {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translateY(-220px) translateX(16px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .anch,
+  .buba {
+    animation: none;
+  }
+
+  .buba {
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an anchor built for #45103. The curved arms are one element: a box with only its bottom two corners rounded and its `border-top-color` set to transparent, so the visible border draws a U and the middle stays hollow with no clip path or mask. The chain is a single repeating gradient of links running the full height of the scene, and the anchor swings from a `transform-origin: 50% 0`, so it pivots at the shackle where the chain actually holds it rather than around its own middle. Reduced motion fallback included. Pure CSS. Closes #45103.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an anchor with a shackle ring, a crossbar, curved arms and pointed flukes, hanging on a chain above the seabed with bubbles.
