### PR TITLE
Add guitar component

### DIFF
--- a/submissions/examples/guitar-as/README.md
+++ b/submissions/examples/guitar-as/README.md
@@ -1,0 +1,22 @@
+# Guitar
+
+### What does this do?
+
+It shows an acoustic guitar being strummed. The pick sweeps across the strings, all six strings blur as they ring, the body sways with the playing, and notes drift off. Under reduced motion the guitar rests silently.
+
+### How is it used?
+
+```html
+<div class="gtr">
+  <span class="upperg"></span>
+  <span class="lowerg"></span>
+  <span class="notchl"></span>
+  <span class="strg sg1"></span>
+</div>
+```
+
+The guitar's waist is carved rather than drawn: two circles in the page's own background colour bite into the sides where the bouts meet, so the classic curve costs no clip path. Each string blurs by scaling only in x from `transform-origin: 50% 100%`, which widens it in place without lifting it off the bridge, and the six strings stagger the same keyframe so the ring travels across them as the pick passes. The frets are a single `repeating-linear-gradient` down the neck.
+
+### Why is it useful?
+
+Music, band, and arts themes use a guitar. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/guitar-as/demo.html
+++ b/submissions/examples/guitar-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Guitar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="gtr">
+      <span class="upperg"></span>
+      <span class="lowerg"></span>
+      <span class="notchl"></span>
+      <span class="notchr"></span>
+      <span class="soundh"></span>
+      <span class="rosette"></span>
+      <span class="bridgeg"></span>
+      <span class="neckg"></span>
+      <span class="frets"></span>
+      <span class="headg"></span>
+      <span class="tuner tg1"></span>
+      <span class="tuner tg2"></span>
+      <span class="strg sg1"></span>
+      <span class="strg sg2"></span>
+      <span class="strg sg3"></span>
+      <span class="strg sg4"></span>
+      <span class="strg sg5"></span>
+      <span class="strg sg6"></span>
+      <span class="pick"></span>
+    </div>
+    <span class="noteg ng1">♪</span>
+    <span class="noteg ng2">♫</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/guitar-as/style.css
+++ b/submissions/examples/guitar-as/style.css
@@ -1,0 +1,272 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: #1d2230;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 380px;
+}
+
+.gtr {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  width: 200px;
+  height: 350px;
+  margin-left: -100px;
+  z-index: 3;
+  animation: swayg2 5s ease-in-out infinite;
+}
+
+.upperg {
+  position: absolute;
+  bottom: 128px;
+  left: 50%;
+  width: 140px;
+  height: 116px;
+  margin-left: -70px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 28%, #f0b96b, #b06a1c 78%);
+  box-shadow: inset 0 -8px 16px rgba(90, 45, 5, 0.4);
+  z-index: 2;
+}
+
+.lowerg {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  width: 176px;
+  height: 142px;
+  margin-left: -88px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 28%, #f0b96b, #b06a1c 78%);
+  box-shadow:
+    inset 0 -10px 20px rgba(90, 45, 5, 0.4),
+    0 18px 32px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.notchl,
+.notchr {
+  position: absolute;
+  bottom: 132px;
+  width: 54px;
+  height: 62px;
+  border-radius: 50%;
+  background: #1d2230;
+  z-index: 3;
+}
+
+.notchl { left: -16px; }
+.notchr { right: -16px; }
+
+.soundh {
+  position: absolute;
+  bottom: 128px;
+  left: 50%;
+  width: 62px;
+  height: 62px;
+  margin-left: -31px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 40%, #2a1a08, #120a03);
+  box-shadow: inset 0 4px 10px rgba(0, 0, 0, 0.7);
+  z-index: 4;
+}
+
+.rosette {
+  position: absolute;
+  bottom: 122px;
+  left: 50%;
+  width: 74px;
+  height: 74px;
+  margin-left: -37px;
+  border-radius: 50%;
+  border: 4px solid #7a4a12;
+  box-sizing: border-box;
+  background: transparent;
+  z-index: 3;
+}
+
+.bridgeg {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 76px;
+  height: 18px;
+  margin-left: -38px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #4a2d10, #24160a);
+  z-index: 5;
+}
+
+.neckg {
+  position: absolute;
+  bottom: 226px;
+  left: 50%;
+  width: 44px;
+  height: 96px;
+  margin-left: -22px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #3a2510, #221507);
+  z-index: 2;
+}
+
+.frets {
+  position: absolute;
+  bottom: 226px;
+  left: 50%;
+  width: 44px;
+  height: 96px;
+  margin-left: -22px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #b6a279 0 3px,
+      transparent 3px 20px
+    );
+  z-index: 3;
+}
+
+.headg {
+  position: absolute;
+  bottom: 314px;
+  left: 50%;
+  width: 56px;
+  height: 40px;
+  margin-left: -28px;
+  border-radius: 6px 6px 3px 3px;
+  background: linear-gradient(180deg, #4a2d10, #2b1a09);
+  z-index: 2;
+}
+
+.tuner {
+  position: absolute;
+  bottom: 330px;
+  width: 20px;
+  height: 6px;
+  border-radius: 3px;
+  background: #cfd6dd;
+  z-index: 4;
+}
+
+.tg1 { left: 40px; }
+
+.tg2 {
+  right: 40px;
+  bottom: 318px;
+}
+
+.strg {
+  position: absolute;
+  bottom: 68px;
+  width: 2px;
+  height: 268px;
+  background: rgba(255, 248, 226, 0.8);
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: vibeg 0.5s ease-in-out infinite;
+}
+
+.sg1 { left: 50%; margin-left: -15px; }
+
+.sg2 {
+  left: 50%;
+  margin-left: -9px;
+  animation-delay: 0.06s;
+}
+
+.sg3 {
+  left: 50%;
+  margin-left: -3px;
+  animation-delay: 0.12s;
+}
+
+.sg4 {
+  left: 50%;
+  margin-left: 3px;
+  animation-delay: 0.18s;
+}
+
+.sg5 {
+  left: 50%;
+  margin-left: 9px;
+  animation-delay: 0.24s;
+}
+
+.sg6 {
+  left: 50%;
+  margin-left: 15px;
+  animation-delay: 0.3s;
+}
+
+.pick {
+  position: absolute;
+  bottom: 92px;
+  left: 50%;
+  width: 20px;
+  height: 22px;
+  margin-left: -10px;
+  border-radius: 4px 4px 10px 10px;
+  background: linear-gradient(180deg, #ff5c7a, #c0203f);
+  z-index: 7;
+  animation: strumg 1.6s ease-in-out infinite;
+}
+
+.noteg {
+  position: absolute;
+  color: #ffe6a8;
+  font-size: 26px;
+  opacity: 0;
+  z-index: 6;
+  animation: floatg 4s ease-out infinite;
+}
+
+.ng1 { bottom: 190px; left: 22px; }
+
+.ng2 {
+  bottom: 210px;
+  right: 24px;
+  animation-delay: 2s;
+}
+
+@keyframes swayg2 {
+  0%, 100% { transform: rotate(-1.2deg); }
+  50% { transform: rotate(1.2deg); }
+}
+
+@keyframes vibeg {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(2.6); }
+}
+
+@keyframes strumg {
+  0%, 100% { transform: translate(-14px, 0) rotate(-14deg); }
+  50% { transform: translate(14px, 8px) rotate(14deg); }
+}
+
+@keyframes floatg {
+  0% { transform: translate(0, 0) scale(0.6) rotate(-8deg); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translate(-16px, -80px) scale(1.1) rotate(10deg); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gtr,
+  .strg,
+  .pick,
+  .noteg {
+    animation: none;
+  }
+
+  .noteg {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a guitar built for #45109. The waist is carved rather than drawn: two circles in the page's own background colour bite into the sides where the bouts meet, so the classic curve costs no clip path. Each string blurs by scaling only in x from a `transform-origin: 50% 100%`, which widens it in place without lifting it off the bridge, and the six strings stagger the same keyframe so the ring travels across them as the pick passes. The frets are a single repeating gradient down the neck. Reduced motion fallback included. Pure CSS. Closes #45109.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an acoustic guitar with a carved waist, a sound hole and rosette, a fretted neck, tuners, six strings and a pick caught mid strum.
