### PR TITLE
Add paper plane component

### DIFF
--- a/submissions/examples/paper-plane-as/README.md
+++ b/submissions/examples/paper-plane-as/README.md
@@ -1,0 +1,23 @@
+# Paper Plane
+
+### What does this do?
+
+It shows a folded paper plane gliding across a bright sky. It climbs and dives along its flight path while rocking from wing to wing, speed streaks flick past behind it, and the clouds drift by. Under reduced motion the plane hangs still in the sky.
+
+### How is it used?
+
+```html
+<div class="flight">
+  <div class="plane">
+    <span class="wingp"></span>
+    <span class="wingfar"></span>
+    <span class="fin"></span>
+  </div>
+</div>
+```
+
+The plane is three `clip-path` triangles at different shades: the near wing, a darker far wing behind it, and a lighter fin on top, which is what gives a flat shape its folded, three dimensional look. The motion is split across two nested elements on purpose: the outer `.flight` carries the glide path, and the inner `.plane` carries the banking roll. Because they are separate elements, the two transforms compose instead of overwriting each other, which a single element could not do with one `transform` property.
+
+### Why is it useful?
+
+Send, share, and onboarding themes use a paper plane. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/paper-plane-as/demo.html
+++ b/submissions/examples/paper-plane-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Paper Plane</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="cloudp cp1"></span>
+    <span class="cloudp cp2"></span>
+    <div class="flight">
+      <div class="plane">
+        <span class="wingp"></span>
+        <span class="wingfar"></span>
+        <span class="fin"></span>
+        <span class="fold"></span>
+      </div>
+      <span class="trail tr1"></span>
+      <span class="trail tr2"></span>
+      <span class="trail tr3"></span>
+    </div>
+    <span class="sunp"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/paper-plane-as/style.css
+++ b/submissions/examples/paper-plane-as/style.css
@@ -1,0 +1,185 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #7ec2ee, #d9eefb 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 18px;
+}
+
+.sunp {
+  position: absolute;
+  top: 26px;
+  right: 34px;
+  width: 78px;
+  height: 78px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 38%, #fff6cf, #ffd85e 74%);
+  box-shadow: 0 0 50px rgba(255, 226, 140, 0.85);
+  animation: pulsep 5s ease-in-out infinite;
+}
+
+.cloudp {
+  position: absolute;
+  height: 40px;
+  border-radius: 40px;
+  background:
+    radial-gradient(circle at 26% 40%, #fff 0 30px, transparent 30px),
+    radial-gradient(circle at 60% 30%, #fff 0 26px, transparent 26px),
+    #fff;
+  opacity: 0.9;
+  animation: driftp 16s linear infinite;
+}
+
+.cp1 {
+  top: 60px;
+  left: 40px;
+  width: 130px;
+}
+
+.cp2 {
+  top: 190px;
+  left: 210px;
+  width: 100px;
+  height: 32px;
+  animation-delay: 6s;
+}
+
+.flight {
+  position: absolute;
+  top: 120px;
+  left: 40px;
+  width: 130px;
+  height: 90px;
+  z-index: 4;
+  animation: glidep 7s ease-in-out infinite;
+}
+
+.plane {
+  position: absolute;
+  inset: 0;
+  animation: bankp 3.4s ease-in-out infinite;
+}
+
+.wingp {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 130px;
+  height: 84px;
+  clip-path: polygon(0 46%, 100% 0, 44% 100%);
+  background: linear-gradient(150deg, #fdfdfd, #cdd8e4);
+  filter: drop-shadow(0 8px 10px rgba(40, 70, 100, 0.28));
+  z-index: 3;
+}
+
+.wingfar {
+  position: absolute;
+  top: 6px;
+  left: 4px;
+  width: 124px;
+  height: 66px;
+  clip-path: polygon(0 40%, 100% 0, 60% 74%);
+  background: linear-gradient(150deg, #dfe7f0, #a9b8c9);
+  z-index: 2;
+}
+
+.fin {
+  position: absolute;
+  top: 34px;
+  left: 8px;
+  width: 88px;
+  height: 46px;
+  clip-path: polygon(0 12%, 100% 0, 30% 100%);
+  background: linear-gradient(150deg, #eef3f8, #b9c6d6);
+  z-index: 4;
+}
+
+.fold {
+  position: absolute;
+  top: 24px;
+  left: 10px;
+  width: 74px;
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(90, 115, 145, 0.45);
+  transform: rotate(21deg);
+  transform-origin: 0 50%;
+  z-index: 5;
+}
+
+.trail {
+  position: absolute;
+  top: 44px;
+  left: -10px;
+  width: 46px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.9);
+  opacity: 0;
+  z-index: 2;
+  animation: streakp 2.2s ease-out infinite;
+}
+
+.tr2 {
+  top: 28px;
+  width: 34px;
+  animation-delay: 0.7s;
+}
+
+.tr3 {
+  top: 62px;
+  width: 28px;
+  animation-delay: 1.4s;
+}
+
+@keyframes glidep {
+  0% { transform: translate(0, 40px); }
+  50% { transform: translate(120px, -30px); }
+  100% { transform: translate(0, 40px); }
+}
+
+@keyframes bankp {
+  0%, 100% { transform: rotate(-7deg); }
+  50% { transform: rotate(7deg); }
+}
+
+@keyframes streakp {
+  0% { transform: translateX(0) scaleX(0.4); opacity: 0; }
+  25% { opacity: 0.9; }
+  100% { transform: translateX(-90px) scaleX(1.4); opacity: 0; }
+}
+
+@keyframes driftp {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-420px); }
+}
+
+@keyframes pulsep {
+  0%, 100% { transform: scale(1); opacity: 0.95; }
+  50% { transform: scale(1.05); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flight,
+  .plane,
+  .trail,
+  .cloudp,
+  .sunp {
+    animation: none;
+  }
+
+  .trail {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a paper plane built for #45111. The plane is three clip-path triangles at different shades, a near wing, a darker far wing behind it and a lighter fin on top, which is what gives a flat shape its folded look. The motion is deliberately split across two nested elements: the outer wrapper carries the glide path and the inner plane carries the banking roll, so the two transforms compose instead of overwriting each other, which one element with a single `transform` property could not do. Reduced motion fallback included. Pure CSS. Closes #45111.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a folded paper plane with a shaded far wing and a fold crease, banking across a blue sky with drifting clouds, a sun and speed streaks behind it.
