### PR TITLE
Add shimmer-word-counter component: blog-style word count progress wi…

### DIFF
--- a/submissions/examples/shimmer-word-counter-rashmi/README.md
+++ b/submissions/examples/shimmer-word-counter-rashmi/README.md
@@ -1,0 +1,74 @@
+# Shimmer Word Counter
+
+A word-count progress indicator for blog editors, with a shimmering fill bar and shimmering number. Inspired by the little "words remaining" widget you see in blog CMS sidebars. Pure CSS, no JavaScript.
+
+## Try it
+
+Open `demo.html` in a browser. It shows three states: a draft on track, one near its word limit, and one that's gone over.
+
+## How to use it
+
+```html
+<div class="ease-shimmer-counter ease-shimmer-counter--ok" style="--ease-counter-percent: 34;">
+  <div class="ease-shimmer-counter__head">
+    <span class="ease-shimmer-counter__icon" aria-hidden="true">✎</span>
+    <span class="ease-shimmer-counter__stat">
+      <span class="ease-shimmer-counter__value">412</span> / 1,200 words
+    </span>
+  </div>
+  <div
+    class="ease-shimmer-counter__track"
+    role="progressbar"
+    aria-valuenow="412"
+    aria-valuemin="0"
+    aria-valuemax="1200"
+    aria-label="Word count: 412 of 1,200 word target"
+  >
+    <div class="ease-shimmer-counter__fill"></div>
+  </div>
+  <span class="ease-shimmer-counter__caption">788 words to go</span>
+</div>
+```
+
+`--ease-counter-percent` controls how full the bar is (0–100). Set it inline per instance, based on however you're calculating word count on your end.
+
+## Color variants
+
+- `ease-shimmer-counter--ok` (blue, default — plenty of room left)
+- `ease-shimmer-counter--near` (amber — getting close to the target)
+- `ease-shimmer-counter--over` (red — past the target, fill maxes out at 100%)
+
+## About the "no JavaScript" part
+
+This component is honestly a CSS/visual layer, not a live word-counting engine — counting words as someone types has to come from somewhere, and that somewhere is always going to be a few lines of JS reading a textarea's value. What's pure CSS here is everything else: the shimmering fill bar, the shimmering number text, the color states, the responsive layout, and the accessibility markup. You plug in the actual word count (however you calculate it) by updating `--ease-counter-percent` and the visible numbers — that's the only "dynamic" part, and it's a one-line style update, not a rewrite of the component.
+
+If you're wiring this to a live textarea, something like this on the JS side is enough:
+
+```js
+counter.style.setProperty('--ease-counter-percent', percentValue);
+```
+
+## How the shimmer works
+
+The fill bar has a diagonal gradient sweeping across it in a loop (`ease-shimmer-sweep`), same idea as a skeleton loading shimmer. The number itself uses a gradient clipped to the text (`background-clip: text`) that slides back and forth (`ease-shimmer-text`), so the digits catch a bit of light as they animate.
+
+## Accessibility
+
+- The track has `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` so screen readers can announce actual progress, not just visuals
+- `aria-label` on the track spells out the count and target in plain language
+- The pencil icon is `aria-hidden` since it's decorative
+- `prefers-reduced-motion` turns off both shimmer animations and falls back to solid, readable text
+- Color isn't the only signal — the caption text ("788 words to go" / "250 words over target") carries the same meaning as the color change
+
+## Responsive
+
+Under 480px the counter drops its fixed minimum width and stretches to fill its container.
+
+## Files
+
+```
+shimmer-word-counter-himanshu/
+├── demo.html
+├── style.css
+└── README.md
+```

--- a/submissions/examples/shimmer-word-counter-rashmi/demo.html
+++ b/submissions/examples/shimmer-word-counter-rashmi/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Shimmer Word Counter — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<main class="ease-demo-page">
+  <div class="ease-demo-page__inner">
+    <h1>Shimmer Word Counter</h1>
+    <p>A blog-editor style word counter with a shimmering progress fill. Pure CSS — no JavaScript involved. Scroll down to see three states: on track, near the limit, and over the limit.</p>
+
+    <section class="ease-demo-article">
+      <h2>Draft: On Track</h2>
+      <p>A short paragraph of draft content sits above the counter, the way it would in a blog editor sidebar.</p>
+      <div
+        class="ease-shimmer-counter ease-shimmer-counter--ok"
+        style="--ease-counter-percent: 34;"
+      >
+        <div class="ease-shimmer-counter__head">
+          <span class="ease-shimmer-counter__icon" aria-hidden="true">✎</span>
+          <span class="ease-shimmer-counter__stat">
+            <span class="ease-shimmer-counter__value">412</span> / 1,200 words
+          </span>
+        </div>
+        <div
+          class="ease-shimmer-counter__track"
+          role="progressbar"
+          aria-valuenow="412"
+          aria-valuemin="0"
+          aria-valuemax="1200"
+          aria-label="Word count: 412 of 1,200 word target"
+        >
+          <div class="ease-shimmer-counter__fill"></div>
+        </div>
+        <span class="ease-shimmer-counter__caption">788 words to go</span>
+      </div>
+    </section>
+
+    <section class="ease-demo-article">
+      <h2>Draft: Near the Limit</h2>
+      <p>This draft is closer to its target length, so the counter shifts to an amber accent as a gentle heads-up.</p>
+      <div
+        class="ease-shimmer-counter ease-shimmer-counter--near"
+        style="--ease-counter-percent: 88;"
+      >
+        <div class="ease-shimmer-counter__head">
+          <span class="ease-shimmer-counter__icon" aria-hidden="true">✎</span>
+          <span class="ease-shimmer-counter__stat">
+            <span class="ease-shimmer-counter__value">1,056</span> / 1,200 words
+          </span>
+        </div>
+        <div
+          class="ease-shimmer-counter__track"
+          role="progressbar"
+          aria-valuenow="1056"
+          aria-valuemin="0"
+          aria-valuemax="1200"
+          aria-label="Word count: 1,056 of 1,200 word target"
+        >
+          <div class="ease-shimmer-counter__fill"></div>
+        </div>
+        <span class="ease-shimmer-counter__caption">144 words to go</span>
+      </div>
+    </section>
+
+    <section class="ease-demo-article">
+      <h2>Draft: Over the Limit</h2>
+      <p>Past the target length, the counter turns red so the writer knows to trim it down before publishing.</p>
+      <div
+        class="ease-shimmer-counter ease-shimmer-counter--over"
+        style="--ease-counter-percent: 100;"
+      >
+        <div class="ease-shimmer-counter__head">
+          <span class="ease-shimmer-counter__icon" aria-hidden="true">✎</span>
+          <span class="ease-shimmer-counter__stat">
+            <span class="ease-shimmer-counter__value">1,450</span> / 1,200 words
+          </span>
+        </div>
+        <div
+          class="ease-shimmer-counter__track"
+          role="progressbar"
+          aria-valuenow="1450"
+          aria-valuemin="0"
+          aria-valuemax="1200"
+          aria-label="Word count: 1,450 of 1,200 word target, over limit"
+        >
+          <div class="ease-shimmer-counter__fill"></div>
+        </div>
+        <span class="ease-shimmer-counter__caption">250 words over target</span>
+      </div>
+    </section>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/shimmer-word-counter-rashmi/style.css
+++ b/submissions/examples/shimmer-word-counter-rashmi/style.css
@@ -1,0 +1,207 @@
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+:root {
+  --ease-duration-fast: 180ms;
+  --ease-duration-base: 350ms;
+  --ease-duration-shimmer: 2200ms;
+  --ease-curve-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-curve-out: cubic-bezier(0.16, 1, 0.3, 1);
+
+  --ease-counter-bg: #ffffff;
+  --ease-counter-border: #e5e0d8;
+  --ease-counter-text: #2b2620;
+  --ease-counter-muted: #8a8378;
+  --ease-counter-track: #efeae2;
+  --ease-counter-accent: #3b82f6;
+  --ease-counter-accent-soft: #93c5fd;
+  --ease-counter-radius: 12px;
+}
+
+.ease-demo-page {
+  min-height: 100vh;
+  background: #faf7f2;
+  font-family: Georgia, "Times New Roman", serif;
+  color: #2b2620;
+  padding: 3rem 1.5rem;
+  box-sizing: border-box;
+}
+
+.ease-demo-page__inner {
+  max-width: 38rem;
+  margin: 0 auto;
+}
+
+.ease-demo-page h1 {
+  font-family: "Segoe UI", system-ui, sans-serif;
+  font-size: 1.5rem;
+  margin: 0 0 0.4rem;
+}
+
+.ease-demo-page > .ease-demo-page__inner > p {
+  font-family: "Segoe UI", system-ui, sans-serif;
+  color: #6b655a;
+  line-height: 1.5;
+  margin: 0 0 2.5rem;
+}
+
+.ease-demo-article {
+  margin-bottom: 2.5rem;
+}
+
+.ease-demo-article h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.6rem;
+}
+
+.ease-demo-article p {
+  line-height: 1.6;
+  color: #4a453c;
+  margin: 0 0 0.9rem;
+}
+
+.ease-shimmer-counter {
+  font-family: "Segoe UI", system-ui, sans-serif;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 14rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--ease-counter-radius);
+  background: var(--ease-counter-bg);
+  border: 1px solid var(--ease-counter-border);
+  box-shadow: 0 4px 14px rgba(43, 38, 32, 0.06);
+}
+
+.ease-shimmer-counter__head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.ease-shimmer-counter__icon {
+  font-size: 0.95rem;
+  flex: none;
+}
+
+.ease-shimmer-counter__stat {
+  font-size: 0.85rem;
+  color: var(--ease-counter-muted);
+}
+
+.ease-shimmer-counter__value {
+  font-weight: 700;
+  font-size: 0.95rem;
+  background: linear-gradient(
+    100deg,
+    var(--ease-counter-text) 40%,
+    var(--ease-counter-accent-soft) 50%,
+    var(--ease-counter-text) 60%
+  );
+  background-size: 250% 100%;
+  background-position: 0% 0%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: ease-shimmer-text var(--ease-duration-shimmer) var(--ease-curve-standard) infinite;
+}
+
+.ease-shimmer-counter__track {
+  position: relative;
+  height: 0.4rem;
+  border-radius: 999px;
+  background: var(--ease-counter-track);
+  overflow: hidden;
+}
+
+.ease-shimmer-counter__fill {
+  position: relative;
+  height: 100%;
+  border-radius: inherit;
+  width: calc(var(--ease-counter-percent, 0) * 1%);
+  max-width: 100%;
+  background: linear-gradient(90deg, var(--ease-counter-accent), var(--ease-counter-accent-soft));
+  transition: width var(--ease-duration-base) var(--ease-curve-out);
+  overflow: hidden;
+}
+
+.ease-shimmer-counter__fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 20%,
+    rgba(255, 255, 255, 0.75) 42%,
+    transparent 64%
+  );
+  transform: translateX(-100%);
+  animation: ease-shimmer-sweep var(--ease-duration-shimmer) var(--ease-curve-standard) infinite;
+}
+
+.ease-shimmer-counter__caption {
+  font-size: 0.72rem;
+  color: var(--ease-counter-muted);
+}
+
+.ease-shimmer-counter--ok {
+  --ease-counter-accent: #3b82f6;
+  --ease-counter-accent-soft: #93c5fd;
+}
+
+.ease-shimmer-counter--near {
+  --ease-counter-accent: #d97706;
+  --ease-counter-accent-soft: #fbbf24;
+}
+
+.ease-shimmer-counter--over {
+  --ease-counter-accent: #dc2626;
+  --ease-counter-accent-soft: #f87171;
+}
+
+.ease-shimmer-counter--over .ease-shimmer-counter__fill {
+  width: 100%;
+}
+
+@keyframes ease-shimmer-text {
+  0% {
+    background-position: 0% 0%;
+  }
+  100% {
+    background-position: -250% 0%;
+  }
+}
+
+@keyframes ease-shimmer-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  60%,
+  100% {
+    transform: translateX(220%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-shimmer-counter__value,
+  .ease-shimmer-counter__fill::after {
+    animation: none;
+  }
+
+  .ease-shimmer-counter__value {
+    background: none;
+    -webkit-background-clip: initial;
+    background-clip: initial;
+    color: var(--ease-counter-text);
+  }
+}
+
+@media (max-width: 480px) {
+  .ease-shimmer-counter {
+    min-width: 0;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
#42556 
## Pull Request Description
Adds a `shimmer-word-counter` component: a blog-editor style word count progress indicator with a shimmering fill bar and shimmering number.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/shimmer-word-counter-himanshu/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A word-count progress bar with a shimmering fill and shimmering number text, plus on-track/near-limit/over-limit color states.

**How does a developer use it?**
```html
<div class="ease-shimmer-counter ease-shimmer-counter--ok" style="--ease-counter-percent: 34;">
  <div class="ease-shimmer-counter__head">
    <span class="ease-shimmer-counter__icon" aria-hidden="true">✎</span>
    <span class="ease-shimmer-counter__stat">
      <span class="ease-shimmer-counter__value">412</span> / 1,200 words
    </span>
  </div>
  <div class="ease-shimmer-counter__track" role="progressbar" aria-valuenow="412" aria-valuemin="0" aria-valuemax="1200" aria-label="Word count: 412 of 1,200 word target">
    <div class="ease-shimmer-counter__fill"></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses `ease-*` naming and CSS custom properties for timing/colors. The animated shimmer is pure CSS; the only "dynamic" input is a single `--ease-counter-percent` variable that a developer sets based on their own word-count logic.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Counting words as someone types inherently needs JS to read the textarea — that part can't be pure CSS. What's pure CSS here is the entire visual/animation layer (shimmer, fill, color states, a11y markup); the component just exposes `--ease-counter-percent` as the single hook for wiring up live data. Documented this tradeoff clearly in the README.