### PR TITLE
Add Orbit Command Palette (banking-style, pure CSS)

### DIFF
--- a/submissions/examples/orbit-palette-bank/README.md
+++ b/submissions/examples/orbit-palette-bank/README.md
@@ -1,0 +1,113 @@
+# Orbit Command Palette
+
+A banking-app style command palette — send money, pay bills, freeze a card,
+that sort of thing. Opens centered with a fade + scale-in. Pure CSS, no JS,
+just a checkbox hack.
+
+## Try it
+
+Open `demo.html`. Click "Open command palette" and watch the rows print in
+one after another, like a statement ticking itself off.
+
+## How to use it
+
+```html
+<div class="orbit-command-palette">
+  <input type="checkbox" id="orbit-toggle" class="orbit-state" aria-hidden="true" />
+
+  <label for="orbit-toggle" class="orbit-trigger" role="button" tabindex="0">
+    Open command palette
+  </label>
+
+  <div class="orbit-backdrop" role="dialog" aria-modal="true" aria-label="Command palette">
+    <label for="orbit-toggle" class="orbit-backdrop-close" aria-hidden="true"></label>
+
+    <div class="orbit-panel">
+      <div class="orbit-search">
+        <input type="text" placeholder="Search commands…" aria-label="Search commands" />
+      </div>
+
+      <div class="orbit-list">
+        <div class="orbit-group-label">Move money</div>
+
+        <button type="button" class="orbit-item" style="--i:0">
+          <span class="orbit-icon orbit-icon--move"><!-- svg --></span>
+          <span class="orbit-item-copy">
+            <span class="orbit-item-title">Send money</span>
+            <span class="orbit-item-desc">To a saved contact or new account</span>
+          </span>
+          <span class="orbit-item-shortcut">S M</span>
+        </button>
+        <!-- more .orbit-item rows -->
+      </div>
+
+      <div class="orbit-footer">
+        <div class="orbit-footer-hints">
+          <span><kbd>↑↓</kbd> Navigate</span>
+          <span><kbd>↵</kbd> Select</span>
+        </div>
+        <label for="orbit-toggle" class="orbit-esc-fallback">Esc · Close</label>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+A few things to know:
+
+- `--i:<n>` on each `.orbit-item` is what drives the stagger. Number them 0,
+  1, 2… in list order. Group labels don't need it.
+- `.orbit-icon--move`, `--card`, `--track` are the three tint variants used
+  in the demo — add more the same way.
+- Full grouped example (Move money / Cards & security / Track & save) is in
+  `demo.html`.
+
+## Why
+
+Command palettes get requested constantly, and this proves the pattern
+doesn't need a JS runtime — just checkboxes and labels.
+
+## The motion
+
+| Keyframe | On | Does |
+|---|---|---|
+| `ease-orbit-fade-in` | backdrop | fades the scrim in |
+| `ease-orbit-panel-in` | panel | fades + scales up from 0.94 → 1 |
+| `ease-orbit-item-in` | each row | staggered fade + rise |
+| `ease-orbit-tick-in` | each row's `::before` | draws in a brass tick right after the row lands |
+| `ease-orbit-sheet-in` | panel, ≤640px | slide-up instead of scale-in |
+
+Durations and easing live as custom properties on `.orbit-command-palette`
+(`--ease-duration-*`, `--ease-standard`, `--ease-emphasized`) so they're easy
+to retune without touching the keyframes.
+
+## Behavior
+
+- Respects `prefers-reduced-motion: reduce` — animation is cut, palette just
+  snaps open.
+- Click anywhere on the backdrop to close it.
+- Under 640px the panel docks to the bottom as a sheet instead of floating.
+
+## Known limitations
+
+- **No real Esc key.** The "Esc · Close" chip in the footer is clickable,
+  not a keyboard binding.
+- **No focus trap.** Tab will walk out of the palette into the rest of the
+  page.
+- **Search doesn't filter.** The input works, but narrowing the list as you
+  type needs JS.
+- **Label keyboard activation isn't guaranteed.** The trigger is a
+  `<label role="button">`, reliably clickable, but Enter/Space on a focused
+  label behaves differently across browsers than on a real `<button>`.
+
+A thin JS layer could add Escape handling, a focus trap, and live search on
+top of this markup later without touching the CSS.
+
+## Files
+
+```
+orbit-command-palette-bank/
+├── demo.html
+├── style.css
+└── README.md
+```

--- a/submissions/examples/orbit-palette-bank/demo.html
+++ b/submissions/examples/orbit-palette-bank/demo.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Orbit Command Palette — EaseMotion CSS demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  /* Demo page chrome only — not part of the component */
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: radial-gradient(circle at 50% 0%, #182338 0%, #0a1017 60%);
+    font-family: -apple-system, "Segoe UI", "Inter", system-ui, sans-serif;
+  }
+  .demo-stage {
+    text-align: center;
+    color: #e9ecf3;
+  }
+  .demo-stage p {
+    color: #8b96ac;
+    max-width: 380px;
+    margin: 14px auto 28px;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+  .demo-eyebrow {
+    display: inline-block;
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #c9a24b;
+    margin-bottom: 10px;
+  }
+</style>
+</head>
+<body>
+
+<div class="demo-stage">
+  <span class="demo-eyebrow">Orbit Bank</span>
+  <h1 style="margin:0;font-size:22px;font-weight:600;">Orbit Command Palette</h1>
+  <p>A pure-CSS, checkbox-hack command palette with a fade + scale-in entrance. Open it and watch the rows print in like a statement reconciling itself.</p>
+  <div class="orbit-command-palette">
+    <input type="checkbox" id="orbit-toggle" class="orbit-state" aria-hidden="true" />
+
+    <label for="orbit-toggle" class="orbit-trigger" role="button" tabindex="0">
+      Open command palette
+      <span class="orbit-kbd orbit-mono">⌘K</span>
+    </label>
+
+    <div class="orbit-backdrop" role="dialog" aria-modal="true" aria-label="Command palette">
+      <label for="orbit-toggle" class="orbit-backdrop-close" aria-hidden="true"></label>
+
+      <div class="orbit-panel">
+        <div class="orbit-search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+          <input type="text" placeholder="Search commands…" aria-label="Search commands" />
+        </div>
+
+        <div class="orbit-list">
+          <div class="orbit-group-label">Move money</div>
+
+          <button type="button" class="orbit-item" style="--i:0">
+            <span class="orbit-icon orbit-icon--move">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"></line><polyline points="5 12 12 5 19 12"></polyline></svg>
+            </span>
+            <span class="orbit-item-copy">
+              <span class="orbit-item-title">Send money</span>
+              <span class="orbit-item-desc">To a saved contact or new account</span>
+            </span>
+            <span class="orbit-item-shortcut orbit-mono">S M</span>
+          </button>
+
+          <button type="button" class="orbit-item" style="--i:1">
+            <span class="orbit-icon orbit-icon--move">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"></rect><line x1="2" y1="10" x2="22" y2="10"></line></svg>
+            </span>
+            <span class="orbit-item-copy">
+              <span class="orbit-item-title">Pay a bill</span>
+              <span class="orbit-item-desc">One-off or scheduled payment</span>
+            </span>
+            <span class="orbit-item-shortcut orbit-mono">P B</span>
+          </button>
+
+          <button type="button" class="orbit-item" style="--i:2">
+            <span class="orbit-icon orbit-icon--move">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 1 21 5 17 9"></polyline><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><polyline points="7 23 3 19 7 15"></polyline><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
+            </span>
+            <span class="orbit-item-copy">
+              <span class="orbit-item-title">Transfer between accounts</span>
+              <span class="orbit-item-desc">Checking, savings, or a pot</span>
+            </span>
+            <span class="orbit-item-shortcut orbit-mono">T A</span>
+          </button>
+
+          <div class="orbit-group-label">Cards &amp; security</div>
+
+          <button type="button" class="orbit-item" style="--i:3">
+            <span class="orbit-icon orbit-icon--card">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12h20"></path><path d="M12 2a10 10 0 0 1 0 20 10 10 0 0 1 0-20z"></path></svg>
+            </span>
+            <span class="orbit-item-copy">
+              <span class="orbit-item-title">Freeze card</span>
+              <span class="orbit-item-desc">Instantly pause spending</span>
+            </span>
+            <span class="orbit-item-shortcut orbit-mono">F C</span>
+          </button>
+
+          <button type="button" class="orbit-item" style="--i:4">
+            <span class="orbit-icon orbit-icon--card">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 3 6v6c0 5 3.8 8.7 9 10 5.2-1.3 9-5 9-10V6l-9-4z"></path></svg>
+            </span>
+            <span class="orbit-item-copy">
+              <span class="orbit-item-title">Report a lost card</span>
+              <span class="orbit-item-desc">Block it and order a replacement</span>
+            </span>
+            <span class="orbit-item-shortcut orbit-mono">R L</span>
+          </button>
+
+          <div class="orbit-group-label">Track &amp; save</div>
+
+          <button type="button" class="orbit-item" style="--i:5">
+            <span class="orbit-icon orbit-icon--track">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"></path><path d="M18.7 8 12 14.7l-3-3L3 17"></path></svg>
+            </span>
+            <span class="orbit-item-copy">
+              <span class="orbit-item-title">View statements</span>
+              <span class="orbit-item-desc">Download or print past months</span>
+            </span>
+            <span class="orbit-item-shortcut orbit-mono">V S</span>
+          </button>
+
+          <button type="button" class="orbit-item" style="--i:6">
+            <span class="orbit-icon orbit-icon--track">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 3"></path></svg>
+            </span>
+            <span class="orbit-item-copy">
+              <span class="orbit-item-title">Set a savings goal</span>
+              <span class="orbit-item-desc">Give a pot a target and a date</span>
+            </span>
+            <span class="orbit-item-shortcut orbit-mono">S G</span>
+          </button>
+        </div>
+
+        <div class="orbit-footer">
+          <div class="orbit-footer-hints">
+            <span><kbd>↑↓</kbd>Navigate</span>
+            <span><kbd>↵</kbd>Select</span>
+          </div>
+          <label for="orbit-toggle" class="orbit-esc-fallback">Esc · Close</label>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/orbit-palette-bank/style.css
+++ b/submissions/examples/orbit-palette-bank/style.css
@@ -1,0 +1,366 @@
+.orbit-command-palette {
+  --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-emphasized: cubic-bezier(0.34, 1.4, 0.64, 1);
+  --ease-duration-fast: 140ms;
+  --ease-duration-base: 220ms;
+  --ease-duration-slow: 380ms;
+
+
+  --orbit-ink: #0d1520;
+  --orbit-panel: #141f30;
+  --orbit-panel-raised: #1b2840;
+  --orbit-line: rgba(233, 236, 243, 0.09);
+  --orbit-text: #e9ecf3;
+  --orbit-muted: #8b96ac;
+  --orbit-brass: #c9a24b;
+  --orbit-brass-dim: rgba(201, 162, 75, 0.35);
+  --orbit-mint: #5fd6b0;
+  --orbit-slate: #7c93c9;
+
+  position: relative;
+  font-family: -apple-system, "Segoe UI", "Inter", system-ui, sans-serif;
+  color: var(--orbit-text);
+}
+
+.orbit-command-palette * {
+  box-sizing: border-box;
+}
+
+.orbit-mono {
+  font-family: "IBM Plex Mono", "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
+}
+
+.orbit-command-palette .orbit-state {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.orbit-command-palette .orbit-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--orbit-panel);
+  border: 1px solid var(--orbit-line);
+  color: var(--orbit-text);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color var(--ease-duration-fast) var(--ease-standard),
+              background var(--ease-duration-fast) var(--ease-standard);
+}
+
+.orbit-command-palette .orbit-trigger:hover {
+  border-color: var(--orbit-brass-dim);
+}
+
+.orbit-command-palette .orbit-trigger:focus-visible,
+.orbit-command-palette .orbit-backdrop-close:focus-visible,
+.orbit-command-palette .orbit-item:focus-visible,
+.orbit-command-palette .orbit-esc-fallback:focus-visible {
+  outline: 2px solid var(--orbit-brass);
+  outline-offset: 2px;
+}
+
+.orbit-command-palette .orbit-trigger .orbit-kbd {
+  padding: 2px 6px;
+  border-radius: 5px;
+  background: var(--orbit-ink);
+  border: 1px solid var(--orbit-line);
+  font-size: 12px;
+  color: var(--orbit-muted);
+}
+
+.orbit-command-palette .orbit-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh 16px 16px;
+  background: rgba(6, 10, 16, 0.6);
+  backdrop-filter: blur(3px);
+}
+
+.orbit-command-palette .orbit-state:checked ~ .orbit-backdrop {
+  display: flex;
+  animation: ease-orbit-fade-in var(--ease-duration-base) var(--ease-standard) both;
+}
+
+.orbit-command-palette .orbit-backdrop-close {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  cursor: default;
+}
+
+.orbit-command-palette .orbit-panel {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 560px;
+  max-height: 72vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--orbit-panel);
+  border: 1px solid var(--orbit-line);
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45), 0 2px 0 rgba(255, 255, 255, 0.02) inset;
+  overflow: hidden;
+}
+
+.orbit-command-palette .orbit-state:checked ~ .orbit-backdrop .orbit-panel {
+  animation: ease-orbit-panel-in var(--ease-duration-slow) var(--ease-emphasized) both;
+}
+
+.orbit-command-palette .orbit-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--orbit-line);
+  flex-shrink: 0;
+}
+
+.orbit-command-palette .orbit-search svg {
+  flex-shrink: 0;
+  color: var(--orbit-muted);
+}
+
+.orbit-command-palette .orbit-search input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--orbit-text);
+  font-size: 15px;
+  font-family: inherit;
+}
+
+.orbit-command-palette .orbit-search input::placeholder {
+  color: var(--orbit-muted);
+}
+
+.orbit-command-palette .orbit-list {
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.orbit-command-palette .orbit-group-label {
+  padding: 10px 10px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--orbit-muted);
+}
+
+.orbit-command-palette .orbit-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px 10px 16px;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: var(--orbit-text);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.orbit-command-palette .orbit-item:hover,
+.orbit-command-palette .orbit-item:focus-visible {
+  background: var(--orbit-panel-raised);
+}
+
+.orbit-command-palette .orbit-item::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  width: 3px;
+  height: 0;
+  border-radius: 2px;
+  background: var(--orbit-brass);
+  transform: translateY(-50%) scaleY(0);
+  transform-origin: center;
+}
+
+.orbit-command-palette .orbit-state:checked ~ .orbit-backdrop .orbit-item {
+  animation: ease-orbit-item-in var(--ease-duration-base) var(--ease-standard) both;
+  animation-delay: calc(var(--ease-duration-fast) + (var(--i, 0) * 34ms));
+}
+
+.orbit-command-palette .orbit-state:checked ~ .orbit-backdrop .orbit-item::before {
+  height: 60%;
+  animation: ease-orbit-tick-in var(--ease-duration-fast) var(--ease-standard) both;
+  animation-delay: calc(var(--ease-duration-base) + (var(--i, 0) * 34ms));
+}
+
+.orbit-command-palette .orbit-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+}
+
+.orbit-command-palette .orbit-icon--move { background: rgba(95, 214, 176, 0.14); color: var(--orbit-mint); }
+.orbit-command-palette .orbit-icon--card { background: rgba(201, 162, 75, 0.16); color: var(--orbit-brass); }
+.orbit-command-palette .orbit-icon--track { background: rgba(124, 147, 201, 0.16); color: var(--orbit-slate); }
+
+.orbit-command-palette .orbit-item-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.orbit-command-palette .orbit-item-title {
+  display: block;
+  font-weight: 500;
+}
+
+.orbit-command-palette .orbit-item-desc {
+  display: block;
+  margin-top: 1px;
+  font-size: 12.5px;
+  color: var(--orbit-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.orbit-command-palette .orbit-item-shortcut {
+  flex-shrink: 0;
+  padding: 3px 7px;
+  border-radius: 5px;
+  background: var(--orbit-ink);
+  border: 1px solid var(--orbit-line);
+  font-size: 11px;
+  color: var(--orbit-muted);
+}
+
+.orbit-command-palette .orbit-empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--orbit-muted);
+  font-size: 13.5px;
+}
+
+.orbit-command-palette .orbit-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--orbit-line);
+  background: var(--orbit-ink);
+  flex-shrink: 0;
+}
+
+.orbit-command-palette .orbit-footer-hints {
+  display: flex;
+  gap: 14px;
+  font-size: 11.5px;
+  color: var(--orbit-muted);
+}
+
+.orbit-command-palette .orbit-footer-hints kbd {
+  font-family: inherit;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--orbit-panel);
+  border: 1px solid var(--orbit-line);
+  margin-right: 4px;
+}
+
+.orbit-command-palette .orbit-esc-fallback {
+  padding: 5px 10px;
+  border-radius: 6px;
+  background: var(--orbit-panel);
+  border: 1px solid var(--orbit-line);
+  color: var(--orbit-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.orbit-command-palette .orbit-esc-fallback:hover {
+  color: var(--orbit-text);
+  border-color: var(--orbit-brass-dim);
+}
+
+@keyframes ease-orbit-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes ease-orbit-panel-in {
+  from { opacity: 0; transform: scale(0.94) translateY(10px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes ease-orbit-item-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ease-orbit-tick-in {
+  from { transform: translateY(-50%) scaleY(0); }
+  to   { transform: translateY(-50%) scaleY(1); }
+}
+
+@keyframes ease-orbit-sheet-in {
+  from { opacity: 0; transform: translateY(100%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 640px) {
+  .orbit-command-palette .orbit-backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .orbit-command-palette .orbit-panel {
+    max-width: 100%;
+    max-height: 82vh;
+    border-radius: 16px 16px 0 0;
+    border-bottom: none;
+  }
+
+  .orbit-command-palette .orbit-state:checked ~ .orbit-backdrop .orbit-panel {
+    animation-name: ease-orbit-sheet-in;
+  }
+
+  .orbit-command-palette .orbit-footer-hints span:nth-child(2) {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .orbit-command-palette .orbit-state:checked ~ .orbit-backdrop,
+  .orbit-command-palette .orbit-state:checked ~ .orbit-backdrop .orbit-panel,
+  .orbit-command-palette .orbit-state:checked ~ .orbit-backdrop .orbit-item,
+  .orbit-command-palette .orbit-state:checked ~ .orbit-backdrop .orbit-item::before {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .orbit-command-palette .orbit-item::before {
+    height: 60%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new pure-CSS example component: **Orbit Command Palette**, a banking-app-style
command palette (send money, pay bills, freeze card, etc.) with a fade + scale-in
entrance, driven entirely by the checkbox hack. Closes #<issue-number>.

---

## Type of Change
- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/orbit-command-palette-bank/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A searchable, banking-app-style command palette that opens in a centered modal with
a fade + scale-in entrance — no JavaScript, just a checkbox and labels.

**How does a developer use it?**
```html
<div class="orbit-command-palette">
  <input type="checkbox" id="orbit-toggle" class="orbit-state" aria-hidden="true" />

  <label for="orbit-toggle" class="orbit-trigger" role="button" tabindex="0">
    Open command palette
  </label>

  <div class="orbit-backdrop" role="dialog" aria-modal="true" aria-label="Command palette">
    <label for="orbit-toggle" class="orbit-backdrop-close" aria-hidden="true"></label>
    <div class="orbit-panel">
      <!-- .orbit-search, .orbit-list > .orbit-item, .orbit-footer -->
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Command palettes are one of the most commonly requested UI patterns, and this shows
the pattern can be built as a single lightweight, dependency-free animation block —
in line with EaseMotion CSS's goal of small, reusable, pure-CSS motion pieces that
work without a JS runtime. Timing and easing are exposed as custom properties
(`--ease-duration-*`, `--ease-standard`, `--ease-emphasized`) so they're easy to retune.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Pure CSS, so a couple of known limitations are called out in the README: no real
`Esc` key handling (a clickable "Esc · Close" chip is provided as a fallback), no
focus trap, and search doesn't filter live — all of these would need a small
optional JS layer on top if that's ever wanted. Happy to adjust the entrance timing
or stagger delay if it feels off during review.