### PR TITLE
feat: add Swing Color Picker for Neon

### DIFF
--- a/submissions/examples/swing-color-picker-neon/README.md
+++ b/submissions/examples/swing-color-picker-neon/README.md
@@ -1,0 +1,47 @@
+# Swing Color Picker — Neon
+
+A neon-inspired color picker component with swing animation, built with EaseMotion CSS.
+
+## Overview
+
+This component features a row of color swatches that gently swing in a staggered pendulum motion, creating an eye-catching neon aesthetic. When a color is selected, the swatch stops swinging and highlights with a glow effect.
+
+## Features
+
+- **Swing Animation**: Swatches gently rock back and forth using a custom `ease-swing` keyframe animation with staggered delays
+- **Neon Glow**: Active and hovered swatches emit a neon glow matching their color
+- **Pure CSS Animations**: All animations are CSS-only; JavaScript is only used for selection state
+- **Keyboard Accessible**: Full arrow-key navigation between swatches with visible focus indicators
+- **ARIA Support**: Uses `role="radiogroup"` and `role="radio"` with `aria-checked` states
+- **Responsive**: Adapts to smaller screens with reduced swatch sizes
+- **Reduced Motion**: Respects `prefers-reduced-motion` preference
+
+## Usage
+
+1. Include EaseMotion CSS in your project
+2. Add the HTML structure from `demo.html`
+3. Include the styles from `style.css`
+4. The minimal JavaScript handles color selection and keyboard navigation
+
+## EaseMotion Classes Used
+
+- CSS custom properties from `--ease-*` variable system
+- `--ease-radius-*` for border radius tokens
+- `--ease-color-*` for color tokens
+- `--ease-font-*` for typography tokens
+- Custom `ease-swing` keyframe animation
+
+## Color Palette
+
+| Color   | Hex       | Name         |
+|---------|-----------|--------------|
+| Neon Pink   | `#FF006E` | Vibrant magenta |
+| Neon Purple | `#8338EC` | Electric violet |
+| Neon Blue   | `#3A86FF` | Bright azure |
+| Neon Teal   | `#00F5D4` | Aqua glow |
+| Neon Yellow | `#FEE440` | Sun flare |
+| Neon Orange | `#FB5607` | Blaze amber |
+
+## Browser Support
+
+Works in all modern browsers that support CSS custom properties and keyframe animations.

--- a/submissions/examples/swing-color-picker-neon/demo.html
+++ b/submissions/examples/swing-color-picker-neon/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Swing Color Picker — Neon | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-container">
+    <h1 class="demo-title">Swing Color Picker</h1>
+    <p class="demo-subtitle">Neon-inspired color picker with swing animation</p>
+
+    <div class="color-picker" role="radiogroup" aria-label="Color picker">
+      <div class="picker-display">
+        <div class="color-preview" id="colorPreview"></div>
+        <span class="color-hex" id="colorHex">#FF006E</span>
+      </div>
+
+      <div class="swatch-row">
+        <button class="swatch swing-delay-1" style="--swatch-color: #FF006E; --swing-delay: 0s"
+                data-color="#FF006E" role="radio" aria-checked="true" aria-label="Neon pink"
+                tabindex="0"></button>
+        <button class="swatch swing-delay-2" style="--swatch-color: #8338EC; --swing-delay: 0.05s"
+                data-color="#8338EC" role="radio" aria-checked="false" aria-label="Neon purple"
+                tabindex="-1"></button>
+        <button class="swatch swing-delay-3" style="--swatch-color: #3A86FF; --swing-delay: 0.1s"
+                data-color="#3A86FF" role="radio" aria-checked="false" aria-label="Neon blue"
+                tabindex="-1"></button>
+        <button class="swatch swing-delay-4" style="--swatch-color: #00F5D4; --swing-delay: 0.15s"
+                data-color="#00F5D4" role="radio" aria-checked="false" aria-label="Neon teal"
+                tabindex="-1"></button>
+        <button class="swatch swing-delay-5" style="--swatch-color: #FEE440; --swing-delay: 0.2s"
+                data-color="#FEE440" role="radio" aria-checked="false" aria-label="Neon yellow"
+                tabindex="-1"></button>
+        <button class="swatch swing-delay-6" style="--swatch-color: #FB5607; --swing-delay: 0.25s"
+                data-color="#FB5607" role="radio" aria-checked="false" aria-label="Neon orange"
+                tabindex="-1"></button>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2 class="section-title">Selected Color</h2>
+      <div class="preview-card" id="previewCard">
+        <div class="preview-icon">&#9670;</div>
+        <p>This card changes to the selected color with a swing transition.</p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Minimal JS for color selection state (pure CSS handles animations)
+    const swatches = document.querySelectorAll('.swatch');
+    const preview = document.getElementById('colorPreview');
+    const hexLabel = document.getElementById('colorHex');
+    const card = document.getElementById('previewCard');
+
+    swatches.forEach(swatch => {
+      swatch.addEventListener('click', () => {
+        const color = swatch.dataset.color;
+        // Update ARIA
+        swatches.forEach(s => {
+          s.setAttribute('aria-checked', 'false');
+          s.setAttribute('tabindex', '-1');
+        });
+        swatch.setAttribute('aria-checked', 'true');
+        swatch.setAttribute('tabindex', '0');
+        swatch.focus();
+        // Update display
+        preview.style.setProperty('--active-color', color);
+        hexLabel.textContent = color;
+        card.style.setProperty('--card-accent', color);
+      });
+
+      // Keyboard support
+      swatch.addEventListener('keydown', (e) => {
+        const swatchArray = Array.from(swatches);
+        const idx = swatchArray.indexOf(swatch);
+        let nextIdx;
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+          nextIdx = (idx + 1) % swatchArray.length;
+        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          nextIdx = (idx - 1 + swatchArray.length) % swatchArray.length;
+        }
+        if (nextIdx !== undefined) {
+          e.preventDefault();
+          swatchArray[nextIdx].click();
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/swing-color-picker-neon/style.css
+++ b/submissions/examples/swing-color-picker-neon/style.css
@@ -1,0 +1,204 @@
+/* ── Swing Color Picker — Neon ─────────────────────────── */
+/* Pure CSS component using EaseMotion CSS variables & keyframes */
+
+:root {
+  --active-color: #FF006E;
+  --card-accent: #FF006E;
+  --neon-glow: 0 0 10px rgba(255, 0, 110, 0.4), 0 0 30px rgba(255, 0, 110, 0.2);
+}
+
+/* ── Demo Container ──────────────────────────────────── */
+.demo-container {
+  max-width: 480px;
+  margin: 3rem auto;
+  padding: 2rem;
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  color: var(--ease-color-text, #e0e0e0);
+  background: var(--ease-color-bg, #0a0a0f);
+  border-radius: var(--ease-radius-xl, 1rem);
+  min-height: 100vh;
+  box-sizing: border-box;
+}
+
+.demo-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  text-align: center;
+  background: linear-gradient(135deg, #FF006E, #8338EC, #3A86FF);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.25rem;
+}
+
+.demo-subtitle {
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--ease-color-text-muted, #888);
+  margin-bottom: 2rem;
+}
+
+/* ── Color Picker ────────────────────────────────────── */
+.color-picker {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--ease-radius-xl, 1rem);
+  padding: 1.5rem;
+}
+
+/* ── Display Area ────────────────────────────────────── */
+.picker-display {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  padding: 0.75rem 1rem;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: var(--ease-radius-lg, 0.75rem);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.color-preview {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background-color: var(--active-color);
+  box-shadow: var(--neon-glow);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+  flex-shrink: 0;
+}
+
+.color-hex {
+  font-family: var(--ease-font-mono, 'SF Mono', 'Fira Code', monospace);
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: var(--ease-color-text, #e0e0e0);
+}
+
+/* ── Swatch Row ──────────────────────────────────────── */
+.swatch-row {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ── Individual Swatch ───────────────────────────────── */
+.swatch {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 3px solid transparent;
+  background-color: var(--swatch-color);
+  cursor: pointer;
+  position: relative;
+  transform-origin: top center;
+  animation: ease-swing 1.8s ease-in-out infinite;
+  animation-delay: var(--swing-delay, 0s);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+  outline: none;
+}
+
+.swatch:hover {
+  box-shadow: 0 0 12px var(--swatch-color), 0 0 24px rgba(255, 255, 255, 0.1);
+  transform: scale(1.15);
+}
+
+.swatch[aria-checked="true"] {
+  border-color: #fff;
+  box-shadow: 0 0 12px var(--swatch-color), 0 0 30px rgba(255, 255, 255, 0.15);
+  animation: none;
+  transform: scale(1.1);
+}
+
+.swatch:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+  animation: none;
+}
+
+/* ── Swing Animation (EaseMotion keyframe) ───────────── */
+@keyframes ease-swing {
+  0%, 100% {
+    transform: rotate(0deg);
+  }
+  20% {
+    transform: rotate(8deg);
+  }
+  40% {
+    transform: rotate(-6deg);
+  }
+  60% {
+    transform: rotate(4deg);
+  }
+  80% {
+    transform: rotate(-2deg);
+  }
+}
+
+/* ── Demo Section ────────────────────────────────────── */
+.demo-section {
+  margin-top: 2rem;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ease-color-text-muted, #888);
+  margin-bottom: 0.75rem;
+}
+
+.preview-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-left: 4px solid var(--card-accent);
+  border-radius: var(--ease-radius-lg, 0.75rem);
+  padding: 1.25rem;
+  transition: border-left-color 0.4s ease;
+}
+
+.preview-card .preview-icon {
+  font-size: 1.5rem;
+  color: var(--card-accent);
+  margin-bottom: 0.5rem;
+  transition: color 0.4s ease;
+}
+
+.preview-card p {
+  font-size: 0.875rem;
+  color: var(--ease-color-text-muted, #aaa);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+@media (max-width: 480px) {
+  .demo-container {
+    padding: 1.25rem;
+    margin: 1rem;
+  }
+
+  .swatch {
+    width: 38px;
+    height: 38px;
+  }
+
+  .swatch-row {
+    gap: 0.5rem;
+  }
+}
+
+/* ── Reduced Motion ──────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .swatch {
+    animation: none;
+  }
+
+  .color-preview,
+  .swatch,
+  .preview-card,
+  .preview-card .preview-icon {
+    transition-duration: 0.01ms;
+  }
+}


### PR DESCRIPTION
## Summary
Closes #42443

Adds a neon-inspired swing color picker component to EaseMotion CSS.

## What it includes

### `submissions/examples/swing-color-picker-neon/`
- **demo.html** — Live demo with 6 neon color swatches, a color preview display, and a preview card that changes accent color
- **style.css** — Pure CSS styling using EaseMotion CSS variable system and custom `ease-swing` keyframe
- **README.md** — Full documentation with features, usage, color palette, and browser support

## Key features
- **Swing animation**: Each swatch gently rocks using a staggered `ease-swing` keyframe animation with configurable delays
- **Neon glow**: Active and hovered swatches emit a CSS `box-shadow` glow matching their color
- **Pure CSS animations**: All visual effects are CSS-only; JavaScript is only for selection state management
- **Keyboard accessible**: Arrow key navigation between swatches with visible `:focus-visible` indicators
- **ARIA support**: Uses `role="radiogroup"` and `role="radio"` with `aria-checked` states for screen reader compatibility
- **Responsive**: Adapts to smaller screens with reduced swatch sizes
- **Reduced motion**: Respects `prefers-reduced-motion` preference by disabling animations

## EaseMotion integration
- Uses `--ease-*` CSS custom properties for tokens
- Uses `--ease-radius-*`, `--ease-color-*`, `--ease-font-*` variable families
- Custom `@keyframes ease-swing` follows the EaseMotion naming convention
- No JavaScript dependencies for core animation behavior