### PR TITLE
fix: correct RTL reversal in horizontal slide animations

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -60,7 +60,7 @@
 @keyframes ease-kf-slide-in-left {
   from {
     opacity: 0;
-    transform: translate3d(-32px, 0, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * -32px), 0, 0);
   }
 
   to {
@@ -72,7 +72,7 @@
 @keyframes ease-kf-slide-in-right {
   from {
     opacity: 0;
-    transform: translate3d(32px, 0, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * 32px), 0, 0);
   }
 
   to {
@@ -108,7 +108,7 @@
 @keyframes ease-kf-slide-in-from-left {
   from {
     opacity: 0;
-    transform: translate3d(-100%, 0, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * -100%), 0, 0);
   }
 
   to {
@@ -120,7 +120,7 @@
 @keyframes ease-kf-slide-in-from-right {
   from {
     opacity: 0;
-    transform: translate3d(100%, 0, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * 100%), 0, 0);
   }
 
   to {
@@ -132,7 +132,7 @@
 @keyframes ease-kf-slide-in-from-top-left {
   from {
     opacity: 0;
-    transform: translate3d(-100%, -100%, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * -100%), -100%, 0);
   }
 
   to {
@@ -144,7 +144,7 @@
 @keyframes ease-kf-slide-in-from-top-right {
   from {
     opacity: 0;
-    transform: translate3d(100%, -100%, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * 100%), -100%, 0);
   }
 
   to {
@@ -156,7 +156,7 @@
 @keyframes ease-kf-slide-in-from-bottom-left {
   from {
     opacity: 0;
-    transform: translate3d(-100%, 100%, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * -100%), 100%, 0);
   }
 
   to {
@@ -168,7 +168,7 @@
 @keyframes ease-kf-slide-in-from-bottom-right {
   from {
     opacity: 0;
-    transform: translate3d(100%, 100%, 0);
+    transform: translate3d(calc(var(--ease-slide-dir, 1) * 100%), 100%, 0);
   }
 
   to {

--- a/core/variables.css
+++ b/core/variables.css
@@ -24,6 +24,10 @@
   /* Controls how many times looping animations run by default. */
   --ease-animation-iterations: infinite;
 
+  /* RTL direction multiplier for horizontal slide animations.
+     1  = LTR (default), -1 = RTL — used inside calc() in keyframes */
+  --ease-slide-dir: 1;
+
   /* ── Color Palette ─────────────────────────────────────── */
   --ease-color-primary:       #6c63ff;
   --ease-color-primary-light: #a09af8;
@@ -147,6 +151,12 @@
   --ease-z-overlay: 100;
   --ease-z-modal:   1000;
   --ease-z-toast:   9999;
+}
+
+/* ── RTL Support ────────────────────────────────────────────── */
+[dir="rtl"],
+[data-direction="rtl"] {
+  --ease-slide-dir: -1;
 }
 
 @supports (color: color-mix(in srgb, red 50%, transparent)) {

--- a/easemotion/slide.css
+++ b/easemotion/slide.css
@@ -28,7 +28,7 @@
 @keyframes ease-kf-slide-in-left {
   from {
     opacity: 0;
-    transform: translateX(-32px);
+    transform: translateX(calc(var(--ease-slide-dir, 1) * -32px));
   }
 
   to {
@@ -40,7 +40,7 @@
 @keyframes ease-kf-slide-in-right {
   from {
     opacity: 0;
-    transform: translateX(32px);
+    transform: translateX(calc(var(--ease-slide-dir, 1) * 32px));
   }
 
   to {
@@ -76,7 +76,7 @@
 @keyframes ease-kf-slide-in-from-left {
   from {
     opacity: 0;
-    transform: translateX(-100%);
+    transform: translateX(calc(var(--ease-slide-dir, 1) * -100%));
   }
 
   to {
@@ -88,7 +88,7 @@
 @keyframes ease-kf-slide-in-from-right {
   from {
     opacity: 0;
-    transform: translateX(100%);
+    transform: translateX(calc(var(--ease-slide-dir, 1) * 100%));
   }
 
   to {
@@ -100,7 +100,7 @@
 @keyframes ease-kf-slide-in-from-top-left {
   from {
     opacity: 0;
-    transform: translate(-100%, -100%);
+    transform: translate(calc(var(--ease-slide-dir, 1) * -100%), -100%);
   }
 
   to {
@@ -112,7 +112,7 @@
 @keyframes ease-kf-slide-in-from-top-right {
   from {
     opacity: 0;
-    transform: translate(100%, -100%);
+    transform: translate(calc(var(--ease-slide-dir, 1) * 100%), -100%);
   }
 
   to {
@@ -124,7 +124,7 @@
 @keyframes ease-kf-slide-in-from-bottom-left {
   from {
     opacity: 0;
-    transform: translate(-100%, 100%);
+    transform: translate(calc(var(--ease-slide-dir, 1) * -100%), 100%);
   }
 
   to {
@@ -136,7 +136,7 @@
 @keyframes ease-kf-slide-in-from-bottom-right {
   from {
     opacity: 0;
-    transform: translate(100%, 100%);
+    transform: translate(calc(var(--ease-slide-dir, 1) * 100%), 100%);
   }
 
   to {
@@ -152,7 +152,7 @@
   }
 
   to {
-    transform: translateX(100%);
+    transform: translateX(calc(var(--ease-slide-dir, 1) * 100%));
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Fix: RTL reversal in horizontal slide animations

Closes #44669

### Problem
When `dir="rtl"` is set on the `<html>` element, `.ease-slide-in-left` and `.ease-slide-in-right` (and all `slide-in-from-*` horizontal variants) animate from the wrong direction. This breaks animations for Arabic, Hebrew, and Urdu users.

### Solution
Introduce a `--ease-slide-dir` CSS custom property:
- Default value: `1` (LTR)
- RTL override: `-1` (set via `[dir="rtl"]` and `[data-direction="rtl"]` selectors)
- All horizontal `translateX` / `translate3d` X-axis values now use `calc(var(--ease-slide-dir, 1) * Npx)` or `calc(var(--ease-slide-dir, 1) * N%)`

### Files Changed
- **core/variables.css**: Added `--ease-slide-dir: 1` token in `:root` and RTL override block
- **core/animations.css**: Updated 8 horizontal keyframes to use `calc()` with `--ease-slide-dir`
- **easemotion/slide.css**: Updated matching keyframes with the same `calc()` pattern

### Backward Compatibility
- In LTR layouts, `calc(1 * -32px)` resolves to `-32px` — identical to the previous hardcoded value
- The `var(--ease-slide-dir, 1)` fallback ensures the variable works even if `variables.css` is not loaded

### Testing
- Verified that in LTR, animations behave identically to the previous version
- Verified that in RTL (`dir="rtl"`), slide-left and slide-right correctly swap directions
- All corner variants (top-left, top-right, bottom-left, bottom-right) also flip correctly