### PR TITLE
fix: correct broken hover states for success, danger, and warning buttons

### DIFF
--- a/components/buttons.css
+++ b/components/buttons.css
@@ -71,8 +71,8 @@
 
 @media (hover: hover) and (pointer: fine) {
   .ease-btn-success:hover {
-    background-color: var(--ease-color-success-dark, #15803d);
-    border-color: var(--ease-color-success-dark, #15803d);
+    background-color: var(--ease-color-success-dark, #166534);
+    border-color: var(--ease-color-success-dark, #166534);
     box-shadow: var(--ease-glow-success, 0 0 16px rgba(34, 197, 94, 0.45));
   }
 }
@@ -89,9 +89,27 @@
 
 @media (hover: hover) and (pointer: fine) {
   .ease-btn-danger:hover {
-    background-color: var(--ease-color-danger-dark, #b91c1c);
-    border-color: var(--ease-color-danger-dark, #b91c1c);
+    background-color: var(--ease-color-danger-dark, #991b1b);
+    border-color: var(--ease-color-danger-dark, #991b1b);
     box-shadow: var(--ease-glow-danger, 0 0 16px rgba(239, 68, 68, 0.45));
+  }
+}
+
+/* Warning */
+.ease-btn-warning {
+  --ease-btn-focus: var(--ease-color-warning, #b45309);
+  --ease-btn-glow: var(--ease-glow-warning, 0 0 16px rgba(245, 158, 11, 0.45));
+
+  background-color: var(--ease-color-warning, #b45309);
+  color: #ffffff;
+  border-color: var(--ease-color-warning, #b45309);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-btn-warning:hover {
+    background-color: var(--ease-color-warning-dark, #92400e);
+    border-color: var(--ease-color-warning-dark, #92400e);
+    box-shadow: var(--ease-glow-warning, 0 0 16px rgba(245, 158, 11, 0.45));
   }
 }
 

--- a/core/variables.css
+++ b/core/variables.css
@@ -33,13 +33,13 @@
   --ease-color-secondary-dark:  #7c3aed;
   --ease-color-success:       #15803d;
   --ease-color-success-light: #86efac;
-  --ease-color-success-dark:  #15803d;
+  --ease-color-success-dark:  #166534;
   --ease-color-danger:        #b91c1c;
   --ease-color-danger-light:  #fca5a5;
-  --ease-color-danger-dark:   #b91c1c;
+  --ease-color-danger-dark:   #991b1b;
   --ease-color-warning:       #b45309;
   --ease-color-warning-light: #fcd34d;
-  --ease-color-warning-dark:  #b45309;
+  --ease-color-warning-dark:  #92400e;
   --ease-color-info:          #3b82f6;
   --ease-color-info-light:    #93c5fd;
   --ease-color-info-dark:     #1d4ed8;


### PR DESCRIPTION
## Fix: Broken Hover States for Success, Danger, and Warning Buttons

Closes #44507

### Problem
The hover background color transitions for Success, Danger, and Warning button variants were non-functional because their `-dark` color tokens were defined with the exact same hex codes as their default counterparts:

| Token | Base Value | Dark Value (before) | Result |
|-------|-----------|-------------------|--------|
| `--ease-color-success-dark` | `#15803d` | `#15803d` | No hover change |
| `--ease-color-danger-dark` | `#b91c1c` | `#b91c1c` | No hover change |
| `--ease-color-warning-dark` | `#b45309` | `#b45309` | No hover change |

### Solution
Updated the `-dark` tokens to proper darker shades that provide clear visual feedback on hover:

| Token | Old Value | New Value | Color Scale |
|-------|-----------|-----------|-------------|
| `--ease-color-success-dark` | `#15803d` | `#166534` | green-900 |
| `--ease-color-danger-dark` | `#b91c1c` | `#991b1b` | red-900 |
| `--ease-color-warning-dark` | `#b45309` | `#92400e` | amber-900 |

### Additional Changes
- Added the missing `.ease-btn-warning` variant to `components/buttons.css` with proper base, hover, focus, and glow states matching the pattern of existing variants
- Updated fallback values in hover rules to match the new `-dark` token values

### Testing
- Hovering over Success, Danger, and Warning buttons now shows a visible darkening transition
- The Warning button variant is now available as a first-class component