### PR TITLE
feat: add ease-ripple CSS-only click ripple effect utility class

### DIFF
--- a/submissions/examples/ease-ripple-av/README.md
+++ b/submissions/examples/ease-ripple-av/README.md
@@ -1,0 +1,101 @@
+# ease-ripple — CSS-only Click Ripple Effect
+
+A **Material Design-style ripple effect** built with pure CSS for the EaseMotion CSS library. Click or tap any element with the `.ease-ripple` class and watch a radial ripple expand from the center — no JavaScript required.
+
+## Features
+
+- Pure CSS implementation — zero JavaScript
+- `::after` pseudo-element with `transform: scale()` and `opacity` animation on `:active` state
+- Customizable via CSS variables: color, duration, and size
+- Color variants: default (white), dark, primary, success, danger
+- Origin modifier: top-left expansion for list items and menus
+- Works on buttons, links, list items, or any element
+- Respects `prefers-reduced-motion`
+- Lightweight — no dependencies
+
+## Folder Structure
+
+```
+submissions/examples/ease-ripple-av/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Apply to any element:
+
+```html
+<button class="ease-ripple">Click me</button>
+```
+
+### Color Variants
+
+```html
+<!-- Dark ripple for light backgrounds -->
+<div class="ease-ripple ease-ripple-dark">Light surface</div>
+
+<!-- Primary-tinted ripple -->
+<button class="ease-ripple ease-ripple-primary">Primary</button>
+
+<!-- Success-tinted ripple -->
+<button class="ease-ripple ease-ripple-success">Success</button>
+
+<!-- Danger-tinted ripple -->
+<button class="ease-ripple ease-ripple-danger">Danger</button>
+```
+
+### Custom Colors and Speed
+
+Override CSS variables inline or in your stylesheet:
+
+```css
+.custom-ripple {
+  --ease-ripple-color: rgba(255, 165, 0, 0.3);
+  --ease-ripple-duration: 0.8s;
+  --ease-ripple-size: 250%;
+}
+```
+
+### Origin Modifier
+
+```html
+<!-- Ripple expands from top-left corner -->
+<li class="ease-ripple ease-ripple-origin-tl">Menu item</li>
+```
+
+## CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-ripple-color` | `rgba(255, 255, 255, 0.35)` | Ripple background color |
+| `--ease-ripple-duration` | `0.6s` | Animation duration |
+| `--ease-ripple-size` | `200%` | Ripple diameter relative to element |
+
+## Browser Support
+
+- Chrome 80+
+- Firefox 75+
+- Edge 80+
+- Safari 14+
+
+## Accessibility
+
+- Respects `prefers-reduced-motion: reduce` — ripple animation is disabled
+- Works with keyboard focus (`tabindex="0"`)
+- Non-intrusive — does not interfere with element content
+
+## Author
+
+**GitHub:** @AliMahmoudDev
+
+---
+
+Created for **EaseMotion CSS** — Issue **#44673** (Add ease-ripple CSS-only click ripple effect utility class).

--- a/submissions/examples/ease-ripple-av/demo.html
+++ b/submissions/examples/ease-ripple-av/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — ease-ripple Click Effect</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="container">
+    <h1>ease-ripple</h1>
+    <p class="subtitle">
+      A CSS-only Material Design-style click ripple effect. No JavaScript required.
+    </p>
+
+    <div class="demo-grid">
+
+      <div class="demo-card ease-ripple" tabindex="0">
+        <h3>Default Ripple</h3>
+        <p>White ripple on dark surfaces</p>
+      </div>
+
+      <div class="demo-card card-light ease-ripple ease-ripple-dark" tabindex="0">
+        <h3>Dark Ripple</h3>
+        <p>Dark ripple for light surfaces</p>
+      </div>
+
+      <div class="demo-card card-primary ease-ripple ease-ripple-primary" tabindex="0">
+        <h3>Primary Ripple</h3>
+        <p>Tinted to match brand color</p>
+      </div>
+
+      <div class="demo-card card-success ease-ripple ease-ripple-success" tabindex="0">
+        <h3>Success Ripple</h3>
+        <p>Green-tinted feedback</p>
+      </div>
+
+      <div class="demo-card card-danger ease-ripple ease-ripple-danger" tabindex="0">
+        <h3>Danger Ripple</h3>
+        <p>Red-tinted destructive action</p>
+      </div>
+
+      <div class="demo-card ease-ripple ease-ripple-origin-tl" tabindex="0">
+        <h3>Top-Left Origin</h3>
+        <p>Ripple expands from corner</p>
+      </div>
+
+    </div>
+
+    <div class="code-block">
+      <span class="comment">/* Basic usage */</span><br>
+      &lt;button <span class="prop">class</span>=<span class="val">"ease-ripple"</span>&gt;Click me&lt;/button&gt;<br><br>
+      <span class="comment">/* Dark ripple on light surface */</span><br>
+      &lt;div <span class="prop">class</span>=<span class="val">"ease-ripple ease-ripple-dark"</span>&gt;...&lt;/div&gt;<br><br>
+      <span class="comment">/* Custom color &amp; speed */</span><br>
+      &lt;button <span class="prop">class</span>=<span class="val">"ease-ripple"</span><br>
+      &nbsp;&nbsp;<span class="prop">style</span>=<span class="val">"--ease-ripple-color: rgba(0,0,0,0.2);<br>
+      &nbsp;&nbsp;--ease-ripple-duration: 0.8s"</span>&gt;<br>
+      &nbsp;&nbsp;Custom Ripple<br>
+      &lt;/button&gt;
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/ease-ripple-av/style.css
+++ b/submissions/examples/ease-ripple-av/style.css
@@ -1,0 +1,233 @@
+/* ==========================
+   EaseMotion CSS — ease-ripple
+   CSS-only click ripple effect utility class
+   ========================== */
+
+:root {
+  --ease-ripple-color: rgba(255, 255, 255, 0.35);
+  --ease-ripple-duration: 0.6s;
+  --ease-ripple-size: 200%;
+}
+
+/* ── Ripple container ──────────────────────────────────── */
+
+.ease-ripple {
+  position: relative;
+  overflow: hidden;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* ── Ripple pseudo-element ─────────────────────────────── */
+
+.ease-ripple::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--ease-ripple-size);
+  height: var(--ease-ripple-size);
+  margin-left: calc(var(--ease-ripple-size) / -2);
+  margin-top: calc(var(--ease-ripple-size) / -2);
+  border-radius: 50%;
+  background: var(--ease-ripple-color);
+  transform: scale(0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── Active state triggers the ripple ──────────────────── */
+
+.ease-ripple:active::after {
+  transform: scale(1);
+  opacity: 1;
+  transition:
+    transform 0s,
+    opacity 0s;
+  animation: ease-ripple-expand var(--ease-ripple-duration) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)) forwards;
+}
+
+@keyframes ease-ripple-expand {
+  0% {
+    transform: scale(0);
+    opacity: 0.6;
+  }
+
+  100% {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+
+/* ── Variant: dark ripple for light surfaces ───────────── */
+
+.ease-ripple-dark {
+  --ease-ripple-color: rgba(0, 0, 0, 0.15);
+}
+
+/* ── Variant: colored ripple ───────────────────────────── */
+
+.ease-ripple-primary {
+  --ease-ripple-color: rgba(108, 99, 255, 0.3);
+}
+
+.ease-ripple-success {
+  --ease-ripple-color: rgba(34, 197, 94, 0.3);
+}
+
+.ease-ripple-danger {
+  --ease-ripple-color: rgba(239, 68, 68, 0.3);
+}
+
+/* ── Origin modifiers ──────────────────────────────────── */
+
+.ease-ripple-origin-tl::after {
+  top: 0;
+  left: 0;
+  margin-left: 0;
+  margin-top: 0;
+}
+
+.ease-ripple-origin-center::after {
+  top: 50%;
+  left: 50%;
+}
+
+/* ── Demo page styles ──────────────────────────────────── */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.container {
+  width: min(800px, 100%);
+  text-align: center;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  margin-bottom: 2.5rem;
+  font-size: 1.05rem;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.demo-card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 1rem;
+  padding: 2rem 1.5rem;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.demo-card:hover {
+  border-color: #6c63ff;
+  box-shadow: 0 8px 24px rgba(108, 99, 255, 0.15);
+}
+
+.demo-card h3 {
+  margin-bottom: 0.4rem;
+  font-size: 1.1rem;
+}
+
+.demo-card p {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.card-primary {
+  background: #6c63ff;
+  border-color: #6c63ff;
+}
+
+.card-primary p {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.card-success {
+  background: #15803d;
+  border-color: #15803d;
+}
+
+.card-success p {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.card-danger {
+  background: #b91c1c;
+  border-color: #b91c1c;
+}
+
+.card-danger p {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.card-light {
+  background: #f1f5f9;
+  border-color: #e2e8f0;
+  color: #1e293b;
+}
+
+.card-light p {
+  color: #64748b;
+}
+
+.code-block {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  text-align: left;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: #a5b4fc;
+  overflow-x: auto;
+}
+
+.code-block .comment {
+  color: #64748b;
+}
+
+.code-block .prop {
+  color: #f9a8d4;
+}
+
+.code-block .val {
+  color: #86efac;
+}
+
+/* ── Reduced motion ────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-ripple:active::after {
+    animation: none !important;
+    transform: scale(1) !important;
+    opacity: 0 !important;
+  }
+}


### PR DESCRIPTION
## Feature: ease-ripple — CSS-only Click Ripple Effect

Closes #44673

### Summary
Adds a Material Design-style ripple effect utility class implemented entirely in CSS. Click or tap any element with `.ease-ripple` and a radial ripple expands outward — zero JavaScript required.

### Implementation Details
- Uses `::after` pseudo-element with `transform: scale(0)` → `scale(1)` and `opacity` animation
- Triggered on `:active` state — no JS event listeners needed
- CSS variables for full customization:
  - `--ease-ripple-color` (default: `rgba(255, 255, 255, 0.35)`)
  - `--ease-ripple-duration` (default: `0.6s`)
  - `--ease-ripple-size` (default: `200%`)

### Variants
| Class | Description |
|-------|-------------|
| `.ease-ripple` | Default white ripple for dark surfaces |
| `.ease-ripple-dark` | Dark ripple for light surfaces |
| `.ease-ripple-primary` | Brand-purple tinted ripple |
| `.ease-ripple-success` | Green-tinted ripple |
| `.ease-ripple-danger` | Red-tinted ripple |
| `.ease-ripple-origin-tl` | Expands from top-left corner |

### Files Added
```
submissions/examples/ease-ripple-av/
├── demo.html
├── style.css
└── README.md
```

### Accessibility
- Respects `prefers-reduced-motion: reduce` — animation disabled
- Works with keyboard focus (`tabindex`)
- Non-intrusive — does not interfere with element content