### PR TITLE
Add meerkat component

### DIFF
--- a/submissions/examples/meerkat-as/README.md
+++ b/submissions/examples/meerkat-as/README.md
@@ -1,0 +1,24 @@
+# Meerkat
+
+### What does this do?
+
+It shows a meerkat standing sentry on a mound in the desert. It rises on its toes, sweeps its head left and right scanning the horizon, its tail sways for balance, it blinks, and the sun pulses behind it. Under reduced motion the sentry holds its pose.
+
+### How is it used?
+
+```html
+<div class="kat">
+  <span class="bodyk"></span>
+  <span class="tailk"></span>
+  <div class="headk">
+    <span class="facek"></span>
+    <span class="snout"></span>
+  </div>
+</div>
+```
+
+The head scan is the key part: the head wrapper turns from `transform-origin: 50% 100%`, the point where the neck meets the body, so the whole face swings on the neck instead of spinning around its own middle. The tail does the same from its base. Because the scan lives on the wrapper, the eyes and ears keep their own positions inside it and only need their own blink animation.
+
+### Why is it useful?
+
+Wildlife, watchful, and lookout or monitoring themes use a meerkat. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/meerkat-as/demo.html
+++ b/submissions/examples/meerkat-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Meerkat</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sun"></span>
+    <div class="kat">
+      <span class="tailk"></span>
+      <span class="bodyk"></span>
+      <span class="tummy"></span>
+      <span class="armk akl"></span>
+      <span class="armk akr"></span>
+      <div class="headk">
+        <span class="eark ekl"></span>
+        <span class="eark ekr"></span>
+        <span class="facek"></span>
+        <span class="snout"></span>
+        <span class="nosek"></span>
+        <span class="eyek ekl2"></span>
+        <span class="eyek ekr2"></span>
+      </div>
+    </div>
+    <span class="mound"></span>
+    <span class="dune"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/meerkat-as/style.css
+++ b/submissions/examples/meerkat-as/style.css
@@ -1,0 +1,230 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #f0a35a, #b8552a 60%, #6b2c14);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.sun {
+  position: absolute;
+  top: 30px;
+  right: 34px;
+  width: 74px;
+  height: 74px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff3c4, #ffcf5c 66%);
+  box-shadow: 0 0 60px rgba(255, 210, 120, 0.8);
+  animation: glowk 5s ease-in-out infinite;
+}
+
+.dune {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 76px);
+  background:
+    radial-gradient(circle at 18% 0, rgba(90, 40, 14, 0.35) 0 12px, transparent 12px),
+    radial-gradient(circle at 74% 8%, rgba(90, 40, 14, 0.3) 0 9px, transparent 9px),
+    linear-gradient(180deg, #d4864a, #8a4520);
+  z-index: 4;
+}
+
+.mound {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  width: 190px;
+  height: 54px;
+  margin-left: -95px;
+  border-radius: 50% 50% 0 0;
+  background: linear-gradient(180deg, #c9793f, #9a5326);
+  z-index: 3;
+}
+
+.kat {
+  position: absolute;
+  bottom: 104px;
+  left: 50%;
+  width: 150px;
+  height: 210px;
+  margin-left: -75px;
+  z-index: 5;
+  animation: alertk 5s ease-in-out infinite;
+}
+
+.bodyk {
+  position: absolute;
+  bottom: 0;
+  left: 34px;
+  width: 82px;
+  height: 130px;
+  border-radius: 42% 42% 38% 38% / 46% 46% 30% 30%;
+  background: linear-gradient(180deg, #c99b62, #9b7040);
+  box-shadow: inset -6px -6px 12px rgba(60, 35, 10, 0.35);
+}
+
+.tummy {
+  position: absolute;
+  bottom: 12px;
+  left: 50px;
+  width: 50px;
+  height: 92px;
+  border-radius: 40% 40% 36% 36% / 44% 44% 30% 30%;
+  background: linear-gradient(180deg, #efd7a8, #d5b076);
+  z-index: 2;
+}
+
+.tailk {
+  position: absolute;
+  bottom: 0;
+  right: 14px;
+  width: 18px;
+  height: 76px;
+  border-radius: 9px;
+  background: linear-gradient(180deg, #b58a52, #7d5730);
+  transform-origin: 50% 100%;
+  animation: swayk 3.6s ease-in-out infinite;
+}
+
+.armk {
+  position: absolute;
+  bottom: 56px;
+  width: 18px;
+  height: 44px;
+  border-radius: 9px;
+  background: linear-gradient(180deg, #a87a48, #6f4c24);
+  z-index: 3;
+  transform: rotate(var(--ak, 0deg));
+}
+
+.akl {
+  left: 28px;
+
+  --ak: 10deg;
+}
+
+.akr {
+  right: 28px;
+
+  --ak: -10deg;
+}
+
+.headk {
+  position: absolute;
+  bottom: 116px;
+  left: 50%;
+  width: 96px;
+  height: 88px;
+  margin-left: -48px;
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: scank 5s ease-in-out infinite;
+}
+
+.facek {
+  position: absolute;
+  bottom: 0;
+  left: 12px;
+  width: 72px;
+  height: 74px;
+  border-radius: 48% 48% 44% 44% / 52% 52% 48% 48%;
+  background: linear-gradient(180deg, #d6a96e, #a87c48);
+  z-index: 2;
+}
+
+.eark {
+  position: absolute;
+  bottom: 52px;
+  width: 24px;
+  height: 20px;
+  border-radius: 50%;
+  background: #3e2c17;
+}
+
+.ekl { left: 2px; }
+.ekr { right: 2px; }
+
+.snout {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  width: 40px;
+  height: 30px;
+  margin-left: -20px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #f0dcb4, #cdb083);
+  z-index: 3;
+}
+
+.nosek {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  width: 16px;
+  height: 12px;
+  margin-left: -8px;
+  border-radius: 50% 50% 60% 60%;
+  background: #3a2412;
+  z-index: 4;
+}
+
+.eyek {
+  position: absolute;
+  bottom: 42px;
+  width: 20px;
+  height: 14px;
+  border-radius: 50%;
+  background: #23180c;
+  box-shadow: inset 2px -2px 0 -1px rgba(255, 255, 255, 0.35);
+  z-index: 4;
+  animation: blink2 4.4s ease-in-out infinite;
+}
+
+.ekl2 { left: 18px; }
+.ekr2 { right: 18px; }
+
+@keyframes alertk {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@keyframes scank {
+  0%, 100% { transform: rotate(-9deg); }
+  50% { transform: rotate(9deg); }
+}
+
+@keyframes swayk {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes blink2 {
+  0%, 90%, 100% { transform: scaleY(1); }
+  95% { transform: scaleY(0.12); }
+}
+
+@keyframes glowk {
+  0%, 100% { transform: scale(1); opacity: 0.9; }
+  50% { transform: scale(1.06); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kat,
+  .headk,
+  .tailk,
+  .eyek,
+  .sun {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a meerkat built for #45173. The head scan is the interesting part: the head wrapper turns from a `transform-origin: 50% 100%` at the point where the neck meets the body, so the whole face swings on the neck instead of spinning around its own middle, and the tail does the same from its base. Because the scan lives on the wrapper, the eyes and ears keep their own positions inside it and only carry their own blink. Reduced motion fallback included. Pure CSS. Closes #45173.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a meerkat standing upright on a mound with dark eye patches, ears, forelegs and a tail, against a desert sun.
