### PR TITLE
Add woodpecker component

### DIFF
--- a/submissions/examples/woodpecker-as/README.md
+++ b/submissions/examples/woodpecker-as/README.md
@@ -1,0 +1,23 @@
+# Woodpecker
+
+### What does this do?
+
+It shows a woodpecker clinging to a tree trunk, hammering at the bark. The head snaps forward and back on a fast loop, the wing flexes as it braces, and wood chips fly off and tumble away. Under reduced motion the drumming stops.
+
+### How is it used?
+
+```html
+<div class="bird">
+  <span class="bodyw"></span>
+  <div class="headw">
+    <span class="skull"></span>
+    <span class="beakw"></span>
+  </div>
+</div>
+```
+
+The peck comes from rotating the head wrapper around `transform-origin: 84% 86%`, the base of the skull where it meets the neck. Because the pivot sits behind the head rather than in its centre, the beak swings through a wide arc into the trunk while the back of the skull barely moves, which is what makes a small rotation read as a hard strike. The flying chips share one keyframe and take their landing spot from a `--cx` custom property, so each chip tumbles off on its own path.
+
+### Why is it useful?
+
+Wildlife, forest, and "working on it" or building themes use a woodpecker. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/woodpecker-as/demo.html
+++ b/submissions/examples/woodpecker-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Woodpecker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="trunk"></span>
+    <span class="holew"></span>
+    <div class="bird">
+      <span class="tailw"></span>
+      <span class="bodyw"></span>
+      <span class="wingw"></span>
+      <div class="headw">
+        <span class="crest"></span>
+        <span class="skull"></span>
+        <span class="cheek"></span>
+        <span class="eyew"></span>
+        <span class="beakw"></span>
+      </div>
+      <span class="footw fw1"></span>
+      <span class="footw fw2"></span>
+    </div>
+    <span class="chip ch1"></span>
+    <span class="chip ch2"></span>
+    <span class="chip ch3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/woodpecker-as/style.css
+++ b/submissions/examples/woodpecker-as/style.css
@@ -1,0 +1,233 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #3f5a3a, #14200f 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.trunk {
+  position: absolute;
+  top: -100vh;
+  left: 50%;
+  width: 120px;
+  height: calc(100vh + 340px);
+  margin-left: -110px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 34, 12, 0.45) 0 3px,
+      transparent 3px 17px
+    ),
+    linear-gradient(90deg, #8a5c30, #5d3c1c 60%, #3f2812);
+}
+
+.holew {
+  position: absolute;
+  top: 210px;
+  left: 50%;
+  width: 44px;
+  height: 52px;
+  margin-left: -76px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 36%, #2a1a0c, #120b04);
+  box-shadow: inset 0 5px 10px rgba(0, 0, 0, 0.7);
+  z-index: 2;
+}
+
+.bird {
+  position: absolute;
+  top: 78px;
+  left: 50%;
+  width: 170px;
+  height: 170px;
+  margin-left: -22px;
+  z-index: 4;
+}
+
+.bodyw {
+  position: absolute;
+  top: 34px;
+  left: 22px;
+  width: 74px;
+  height: 104px;
+  border-radius: 46% 50% 40% 40% / 40% 44% 56% 56%;
+  background: linear-gradient(160deg, #2c2c33, #17171c);
+  box-shadow: inset -6px -6px 12px rgba(0, 0, 0, 0.4);
+  z-index: 3;
+}
+
+.wingw {
+  position: absolute;
+  top: 48px;
+  left: 44px;
+  width: 54px;
+  height: 76px;
+  border-radius: 40% 50% 46% 40% / 34% 50% 50% 44%;
+  background: linear-gradient(160deg, #3c3c46, #212128);
+  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.4);
+  transform-origin: 30% 20%;
+  z-index: 4;
+  animation: gripw 3.2s ease-in-out infinite;
+}
+
+.tailw {
+  position: absolute;
+  top: 118px;
+  left: 46px;
+  width: 30px;
+  height: 62px;
+  border-radius: 6px 6px 14px 14px;
+  background: linear-gradient(180deg, #26262d, #101014);
+  transform: rotate(-8deg);
+  transform-origin: 50% 0;
+  z-index: 2;
+}
+
+.headw {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 110px;
+  height: 66px;
+  transform-origin: 84% 86%;
+  z-index: 5;
+  animation: peckw 0.9s ease-in-out infinite;
+}
+
+.skull {
+  position: absolute;
+  top: 10px;
+  left: 34px;
+  width: 62px;
+  height: 56px;
+  border-radius: 50% 50% 44% 44%;
+  background: linear-gradient(160deg, #2f2f37, #1b1b21);
+  z-index: 3;
+}
+
+.cheek {
+  position: absolute;
+  top: 30px;
+  left: 44px;
+  width: 34px;
+  height: 24px;
+  border-radius: 50%;
+  background: #f2ece0;
+  z-index: 4;
+}
+
+.crest {
+  position: absolute;
+  top: 0;
+  left: 46px;
+  width: 46px;
+  height: 26px;
+  border-radius: 60% 40% 30% 60%;
+  background: linear-gradient(160deg, #e2452c, #a41f11);
+  transform: rotate(-14deg);
+  z-index: 2;
+}
+
+.eyew {
+  position: absolute;
+  top: 26px;
+  left: 62px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #f5f2ea;
+  box-shadow: inset -3px 0 0 -1px #14140f;
+  z-index: 5;
+}
+
+.beakw {
+  position: absolute;
+  top: 34px;
+  left: 4px;
+  width: 44px;
+  height: 10px;
+  border-radius: 6px 3px 3px 6px;
+  background: linear-gradient(90deg, #6f7681, #3d434c);
+  z-index: 5;
+}
+
+.footw {
+  position: absolute;
+  left: 16px;
+  width: 22px;
+  height: 8px;
+  border-radius: 4px;
+  background: #8a5f2c;
+  z-index: 2;
+}
+
+.fw1 { top: 74px; }
+.fw2 { top: 112px; }
+
+.chip {
+  position: absolute;
+  top: 116px;
+  left: 50%;
+  width: 9px;
+  height: 5px;
+  margin-left: -22px;
+  border-radius: 2px;
+  background: #d3a05c;
+  opacity: 0;
+  z-index: 6;
+  animation: flyw 1.8s ease-out infinite;
+}
+
+.ch2 {
+  animation-delay: 0.6s;
+
+  --cx: -46px;
+}
+
+.ch3 {
+  animation-delay: 1.2s;
+
+  --cx: -18px;
+}
+
+@keyframes peckw {
+  0%, 100% { transform: rotate(-15deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes gripw {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes flyw {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  20% { opacity: 1; }
+
+  100% {
+    transform: translate(var(--cx, -34px), 60px) rotate(220deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .headw,
+  .wingw,
+  .chip {
+    animation: none;
+  }
+
+  .chip {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a woodpecker built for #45177. The peck comes from rotating the head wrapper around a `transform-origin` at the base of the skull where it meets the neck. Because the pivot sits behind the head rather than in its centre, the beak swings through a wide arc into the trunk while the back of the skull barely moves, which is what makes a small rotation read as a hard strike. The flying chips share one keyframe and take their landing spot from a `--cx` custom property, so each tumbles off on its own path. Reduced motion fallback included. Pure CSS. Closes #45177.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a woodpecker with a red crest gripping a bark textured trunk, its beak driven into the wood, chips flying off, and a nest hole below it.
