### PR TITLE
Add acorn component

### DIFF
--- a/submissions/examples/acorn-as/README.md
+++ b/submissions/examples/acorn-as/README.md
@@ -1,0 +1,21 @@
+# Acorn
+
+### What does this do?
+
+It shows an acorn hanging from an autumn branch. It swings gently on its stem, the leaves sway, light glints off the shell, and leaves drift down past it. Hovering or focusing the acorn makes it swing faster, as if it is about to drop. Under reduced motion everything hangs still.
+
+### How is it used?
+
+```html
+<div class="acorn" tabindex="0">
+  <span class="stem"></span>
+  <span class="cap"></span>
+  <span class="nut"></span>
+</div>
+```
+
+The cap's woven texture is a `repeating-conic-gradient` anchored near the top of the cap, so the scales radiate outward and downward the way a real cupule is woven, in one element instead of many. The acorn swings from `transform-origin: 50% 0`, the point where the stem meets the branch, so it arcs from where it actually hangs rather than pivoting around its own middle. Hover and focus just shorten the animation duration, so the same keyframe reads as an impatient wobble.
+
+### Why is it useful?
+
+Autumn, nature, and harvest themes use an acorn. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/acorn-as/demo.html
+++ b/submissions/examples/acorn-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Acorn</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="branch"></span>
+    <span class="leafa lfa"></span>
+    <span class="leafa lfb"></span>
+    <div class="acorn" tabindex="0">
+      <span class="stem"></span>
+      <span class="cap"></span>
+      <span class="nut"></span>
+      <span class="shine"></span>
+    </div>
+    <span class="fall fa1"></span>
+    <span class="fall fa2"></span>
+    <span class="fall fa3"></span>
+    <span class="groundA"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/acorn-as/style.css
+++ b/submissions/examples/acorn-as/style.css
@@ -1,0 +1,203 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #6d5a34, #241a0e 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+}
+
+.groundA {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 48px);
+  background: linear-gradient(180deg, #55431f, #241a0a);
+}
+
+.branch {
+  position: absolute;
+  top: 26px;
+  left: -50vw;
+  right: 50%;
+  height: 16px;
+  margin-right: -34px;
+  border-radius: 0 8px 8px 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(50, 30, 8, 0.35) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(180deg, #8a6134, #56391a);
+}
+
+.leafa {
+  position: absolute;
+  top: 30px;
+  width: 60px;
+  height: 30px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #c9752a, #8c3f12);
+  transform-origin: 0 0;
+  animation: swayl 4.4s ease-in-out infinite;
+}
+
+.lfa { left: 40px; }
+
+.lfb {
+  left: 96px;
+  width: 50px;
+  animation-delay: 1.4s;
+}
+
+.acorn {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 130px;
+  height: 190px;
+  margin-left: -65px;
+  outline: none;
+  transform-origin: 50% 0;
+  z-index: 4;
+  animation: dangle 3.6s ease-in-out infinite;
+}
+
+.acorn:hover,
+.acorn:focus-visible {
+  animation: dangle 1.1s ease-in-out infinite;
+}
+
+.stem {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 10px;
+  height: 34px;
+  margin-left: -5px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #6f4a1f, #4a3013);
+  z-index: 2;
+}
+
+.cap {
+  position: absolute;
+  top: 28px;
+  left: 50%;
+  width: 122px;
+  height: 66px;
+  margin-left: -61px;
+  border-radius: 50% 50% 42% 42% / 62% 62% 38% 38%;
+  background:
+    repeating-conic-gradient(
+      from 90deg at 50% 30%,
+      #8a5a24 0 6deg,
+      #6d4519 6deg 12deg
+    );
+  box-shadow: inset 0 -6px 12px rgba(50, 30, 6, 0.5);
+  z-index: 4;
+}
+
+.nut {
+  position: absolute;
+  top: 78px;
+  left: 50%;
+  width: 106px;
+  height: 106px;
+  margin-left: -53px;
+  border-radius: 46% 46% 50% 50% / 36% 36% 64% 64%;
+  background: linear-gradient(180deg, #d59b56, #a4682a);
+  box-shadow: inset -10px -8px 18px rgba(90, 50, 10, 0.4);
+  z-index: 3;
+}
+
+.shine {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 26px;
+  height: 34px;
+  margin-left: -32px;
+  border-radius: 50%;
+  background: rgba(255, 240, 210, 0.4);
+  filter: blur(3px);
+  z-index: 5;
+  animation: glinta 3.4s ease-in-out infinite;
+}
+
+.fall {
+  position: absolute;
+  top: 60px;
+  width: 34px;
+  height: 18px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #d08334, #8c3f12);
+  opacity: 0;
+  z-index: 2;
+  animation: drift 6s linear infinite;
+}
+
+.fa1 { left: 24px; }
+
+.fa2 {
+  left: 200px;
+  animation-delay: 2s;
+
+  --fx: -50px;
+}
+
+.fa3 {
+  left: 264px;
+  animation-delay: 4s;
+
+  --fx: -90px;
+}
+
+@keyframes dangle {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes swayl {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes glinta {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 0.75; }
+}
+
+@keyframes drift {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+
+  100% {
+    transform: translate(var(--fx, 40px), 250px) rotate(320deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acorn,
+  .leafa,
+  .shine,
+  .fall {
+    animation: none;
+  }
+
+  .fall {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an acorn built for #45187. The cap's woven texture is a repeating conic gradient anchored near the top of the cap, so the scales radiate outward and downward the way a real cupule is woven, in one element instead of many. The acorn swings from a `transform-origin: 50% 0` where the stem meets the branch, so it arcs from where it hangs rather than pivoting around its own middle, and hover or focus simply shortens the duration so the same keyframe reads as an impatient wobble. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45187.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an acorn hanging from a bark textured branch with a woven cap, a glossy nut, autumn leaves on the branch and leaves drifting down.
