### PR TITLE
Add pinecone component

### DIFF
--- a/submissions/examples/pinecone-as/README.md
+++ b/submissions/examples/pinecone-as/README.md
@@ -1,0 +1,21 @@
+# Pinecone
+
+### What does this do?
+
+It shows a pinecone hanging from a snowy twig. It swings on the branch, the pine needles sway, and snow drifts past. Hovering or focusing the cone makes every scale lift and open outward, the way a cone opens when it dries. Under reduced motion it hangs still and the scales stay shut.
+
+### How is it used?
+
+```html
+<div class="cone" tabindex="0">
+  <span class="body2"></span>
+  <span class="scale s1"></span>
+  <span class="scale s2"></span>
+</div>
+```
+
+Each scale keeps its own tilt in a `--pa` custom property, and the open state restates the transform as `rotate(var(--pa)) translateY(-7px) scale(1.06)`. Because the rotation is rebuilt from the same custom property, hovering pushes each scale outward along the direction it already points instead of flattening all nine to a single angle. A `transition` on `transform` is all that is needed to animate the opening, so the effect costs no keyframes at all.
+
+### Why is it useful?
+
+Winter, forest, and seasonal themes use a pinecone. This builds one with pure CSS gradients and a transition driven hover, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/pinecone-as/demo.html
+++ b/submissions/examples/pinecone-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pinecone</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="needle nda"></span>
+    <span class="needle ndb"></span>
+    <span class="twig"></span>
+    <div class="cone" tabindex="0">
+      <span class="body2"></span>
+      <span class="scale s1"></span>
+      <span class="scale s2"></span>
+      <span class="scale s3"></span>
+      <span class="scale s4"></span>
+      <span class="scale s5"></span>
+      <span class="scale s6"></span>
+      <span class="scale s7"></span>
+      <span class="scale s8"></span>
+      <span class="scale s9"></span>
+      <span class="tip"></span>
+    </div>
+    <span class="snowp sp1"></span>
+    <span class="snowp sp2"></span>
+    <span class="snowp sp3"></span>
+    <span class="floor2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pinecone-as/style.css
+++ b/submissions/examples/pinecone-as/style.css
@@ -1,0 +1,247 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #33465a, #101821 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+}
+
+.floor2 {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 44px);
+  background: linear-gradient(180deg, #e8eef5, #9fb0c1);
+}
+
+.twig {
+  position: absolute;
+  top: 30px;
+  left: -50vw;
+  right: 50%;
+  height: 12px;
+  margin-right: -30px;
+  border-radius: 0 6px 6px 0;
+  background: linear-gradient(180deg, #6b4d2c, #402c15);
+}
+
+.needle {
+  position: absolute;
+  top: 22px;
+  width: 76px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #3f7f4c, #1e4a2a);
+  transform-origin: 0 50%;
+  transform: rotate(var(--nr, 0deg));
+  animation: swayn 4.6s ease-in-out infinite;
+}
+
+.nda {
+  left: 96px;
+
+  --nr: 22deg;
+}
+
+.ndb {
+  left: 104px;
+
+  --nr: -16deg;
+
+  animation-delay: 1.2s;
+}
+
+.cone {
+  position: absolute;
+  top: 42px;
+  left: 50%;
+  width: 150px;
+  height: 210px;
+  margin-left: -75px;
+  outline: none;
+  transform-origin: 50% 0;
+  z-index: 4;
+  animation: swingc 4.2s ease-in-out infinite;
+}
+
+.body2 {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 106px;
+  height: 146px;
+  margin-left: -53px;
+  border-radius: 50% 50% 44% 44% / 34% 34% 66% 66%;
+  background: linear-gradient(180deg, #8a5c30, #4f3117);
+  box-shadow: inset -8px -10px 20px rgba(40, 22, 6, 0.5);
+  z-index: 2;
+}
+
+.scale {
+  position: absolute;
+  left: 50%;
+  width: 44px;
+  height: 24px;
+  border-radius: 50% 50% 40% 40% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #c08c4c, #7d5124);
+  box-shadow:
+    inset 0 -3px 5px rgba(60, 34, 8, 0.45),
+    0 2px 3px rgba(30, 16, 4, 0.4);
+  transform: rotate(var(--pa, 0deg));
+  transition: transform 0.45s ease;
+  z-index: 3;
+}
+
+.cone:hover .scale,
+.cone:focus-visible .scale {
+  transform: rotate(var(--pa, 0deg)) translateY(-7px) scale(1.06);
+}
+
+.s1 {
+  top: 22px;
+  margin-left: -46px;
+
+  --pa: -16deg;
+}
+
+.s2 {
+  top: 18px;
+  margin-left: -22px;
+
+  --pa: 0deg;
+}
+
+.s3 {
+  top: 22px;
+  margin-left: 2px;
+
+  --pa: 16deg;
+}
+
+.s4 {
+  top: 52px;
+  margin-left: -54px;
+
+  --pa: -14deg;
+}
+
+.s5 {
+  top: 48px;
+  margin-left: -22px;
+
+  --pa: 0deg;
+}
+
+.s6 {
+  top: 52px;
+  margin-left: 10px;
+
+  --pa: 14deg;
+}
+
+.s7 {
+  top: 84px;
+  margin-left: -46px;
+
+  --pa: -12deg;
+}
+
+.s8 {
+  top: 80px;
+  margin-left: -22px;
+
+  --pa: 0deg;
+}
+
+.s9 {
+  top: 84px;
+  margin-left: 2px;
+
+  --pa: 12deg;
+}
+
+.tip {
+  position: absolute;
+  top: 116px;
+  left: 50%;
+  width: 44px;
+  height: 26px;
+  margin-left: -22px;
+  border-radius: 50% 50% 40% 40% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #b07f42, #6d451d);
+  transform: rotate(var(--pa, 0deg));
+  z-index: 3;
+
+  --pa: 0deg;
+}
+
+.snowp {
+  position: absolute;
+  top: 40px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  opacity: 0;
+  z-index: 5;
+  animation: fallp 7s linear infinite;
+}
+
+.sp1 { left: 40px; }
+
+.sp2 {
+  left: 230px;
+  animation-delay: 2.4s;
+
+  --sx: -40px;
+}
+
+.sp3 {
+  left: 280px;
+  animation-delay: 4.8s;
+
+  --sx: -70px;
+}
+
+@keyframes swingc {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes swayn {
+  0%, 100% { transform: rotate(var(--nr, 0deg)); }
+  50% { transform: rotate(calc(var(--nr, 0deg) + 5deg)); }
+}
+
+@keyframes fallp {
+  0% { transform: translate(0, 0); opacity: 0; }
+  12% { opacity: 1; }
+  88% { opacity: 1; }
+  100% { transform: translate(var(--sx, 30px), 270px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cone,
+  .needle,
+  .snowp {
+    animation: none;
+  }
+
+  .scale {
+    transition: none;
+  }
+
+  .snowp {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pinecone built for #45189. Each scale keeps its own tilt in a `--pa` custom property, and the open state restates the transform as `rotate(var(--pa)) translateY(-7px) scale(1.06)`. Because the rotation is rebuilt from the same custom property, hovering pushes each scale outward along the direction it already points instead of flattening all nine to a single angle, and a transition on transform is all that is needed, so the opening costs no keyframes at all. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45189.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a pinecone hanging from a twig with pine needles, rows of overlapping scales down to the tip, and snow drifting past.
