### PR TITLE
Add bagel component

### DIFF
--- a/submissions/examples/bagel-as/README.md
+++ b/submissions/examples/bagel-as/README.md
@@ -1,0 +1,22 @@
+# Bagel
+
+### What does this do?
+
+It shows a seeded bagel with cream cheese, lox and dill on a plate. It floats and tilts, the toppings settle on it, and hovering or focusing the bagel makes the whole thing spin instead. Under reduced motion it sits still.
+
+### How is it used?
+
+```html
+<div class="bagel" tabindex="0">
+  <span class="ring2"></span>
+  <span class="seeds"></span>
+  <span class="cream"></span>
+  <span class="holeb"></span>
+</div>
+```
+
+The seeds are ten hard stop `radial-gradient` circles painted into one element that is clipped to a circle, so they scatter across the crust and get cut off cleanly at the edge without a single seed element. The lox gets its fatty striping from a `repeating-linear-gradient` layered over the salmon colour. Each topping keeps its tilt in a `--lr` custom property that the settle keyframe reads back inside `rotate()`, so the shared animation lifts each piece without flattening its angle.
+
+### Why is it useful?
+
+Bakery, brunch, and menu themes use a bagel. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/bagel-as/demo.html
+++ b/submissions/examples/bagel-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bagel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="bagel" tabindex="0">
+      <span class="ring2"></span>
+      <span class="seeds"></span>
+      <span class="cream"></span>
+      <span class="holeb"></span>
+      <span class="lox lx1"></span>
+      <span class="lox lx2"></span>
+      <span class="dill dl1"></span>
+      <span class="dill dl2"></span>
+    </div>
+    <span class="platb"></span>
+    <span class="crumbb cb1"></span>
+    <span class="crumbb cb2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bagel-as/style.css
+++ b/submissions/examples/bagel-as/style.css
@@ -1,0 +1,192 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #43413c, #16150f 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.platb {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 280px;
+  height: 30px;
+  margin-left: -140px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #e6e2d6, #9b9689);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+}
+
+.bagel {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 230px;
+  height: 230px;
+  margin: -128px 0 0 -115px;
+  outline: none;
+  z-index: 3;
+  animation: hoverb 4.2s ease-in-out infinite;
+}
+
+.bagel:hover,
+.bagel:focus-visible {
+  animation: spinb 6s linear infinite;
+}
+
+.ring2 {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #e3b273, #a97130 74%);
+  box-shadow:
+    inset 0 -14px 24px rgba(90, 48, 8, 0.45),
+    inset 0 10px 18px rgba(255, 226, 180, 0.4),
+    0 16px 30px rgba(0, 0, 0, 0.45);
+}
+
+.seeds {
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 7%, #f7efdc 0 4px, transparent 4px),
+    radial-gradient(circle at 27% 14%, #efe4c8 0 3px, transparent 3px),
+    radial-gradient(circle at 73% 14%, #f7efdc 0 4px, transparent 4px),
+    radial-gradient(circle at 90% 33%, #efe4c8 0 3px, transparent 3px),
+    radial-gradient(circle at 93% 62%, #f7efdc 0 4px, transparent 4px),
+    radial-gradient(circle at 74% 88%, #efe4c8 0 3px, transparent 3px),
+    radial-gradient(circle at 48% 95%, #f7efdc 0 4px, transparent 4px),
+    radial-gradient(circle at 24% 87%, #efe4c8 0 3px, transparent 3px),
+    radial-gradient(circle at 8% 62%, #f7efdc 0 4px, transparent 4px),
+    radial-gradient(circle at 10% 32%, #efe4c8 0 3px, transparent 3px),
+    transparent;
+  z-index: 5;
+}
+
+.cream {
+  position: absolute;
+  inset: 30px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #fffdf7, #e6e0cc 78%);
+  box-shadow: inset 0 -6px 12px rgba(160, 150, 120, 0.35);
+  z-index: 4;
+}
+
+.holeb {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 74px;
+  height: 74px;
+  margin: -37px 0 0 -37px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 40%, #2b2a25, #16150f);
+  box-shadow: inset 0 6px 12px rgba(0, 0, 0, 0.6);
+  z-index: 6;
+}
+
+.lox {
+  position: absolute;
+  width: 96px;
+  height: 34px;
+  border-radius: 40% 60% 50% 50% / 60% 40% 60% 40%;
+  background:
+    repeating-linear-gradient(
+      108deg,
+      rgba(255, 255, 255, 0.5) 0 3px,
+      transparent 3px 14px
+    ),
+    linear-gradient(180deg, #ff9d63, #e3612d);
+  transform: rotate(var(--lr, 0deg));
+  z-index: 5;
+  animation: settleb 3.6s ease-in-out infinite;
+}
+
+.lx1 {
+  top: 58px;
+  left: 24px;
+
+  --lr: -14deg;
+}
+
+.lx2 {
+  bottom: 56px;
+  right: 22px;
+
+  --lr: 168deg;
+
+  animation-delay: 1.2s;
+}
+
+.dill {
+  position: absolute;
+  width: 22px;
+  height: 8px;
+  border-radius: 4px;
+  background: #4f9c3f;
+  transform: rotate(var(--lr, 0deg));
+  z-index: 6;
+  animation: settleb 3s ease-in-out infinite;
+}
+
+.dl1 {
+  top: 52px;
+  right: 60px;
+
+  --lr: 28deg;
+}
+
+.dl2 {
+  bottom: 52px;
+  left: 58px;
+
+  --lr: -34deg;
+
+  animation-delay: 1.5s;
+}
+
+.crumbb {
+  position: absolute;
+  bottom: 62px;
+  width: 8px;
+  height: 6px;
+  border-radius: 2px;
+  background: #cfa465;
+  z-index: 4;
+}
+
+.cb1 { left: 60px; }
+.cb2 { right: 66px; }
+
+@keyframes hoverb {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-14px) rotate(2deg); }
+}
+
+@keyframes spinb {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes settleb {
+  0%, 100% { transform: rotate(var(--lr, 0deg)) translateY(0); }
+  50% { transform: rotate(var(--lr, 0deg)) translateY(-3px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bagel,
+  .lox,
+  .dill {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bagel built for #45193. The seeds are ten hard stop radial gradients painted into one circular element, so they scatter across the crust and clip cleanly at the edge without a single seed element. The lox gets its fatty striping from a repeating gradient layered over the salmon colour, and each topping keeps its tilt in a `--lr` custom property that the settle keyframe reads back inside `rotate()`, so the shared animation lifts each piece without flattening its angle. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45193.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a seeded bagel with a hole, cream cheese, two slices of lox and dill, floating above a plate.
