### PR TITLE
Add popsicle component

### DIFF
--- a/submissions/examples/popsicle-as/README.md
+++ b/submissions/examples/popsicle-as/README.md
@@ -1,0 +1,22 @@
+# Popsicle
+
+### What does this do?
+
+It shows a three flavour popsicle with a bite taken out of it, melting in the sun. It rocks on its stick, frost crystals twinkle on the ice, drips stretch down off the bottom edge, and a puddle spreads beneath it. Hovering or focusing it makes it rock faster, as if it is about to slide off the stick. Under reduced motion it holds still.
+
+### How is it used?
+
+```html
+<div class="pop" tabindex="0">
+  <span class="stickp"></span>
+  <span class="ice"></span>
+  <span class="layer2"></span>
+  <span class="frost"></span>
+</div>
+```
+
+The bite is a genuine hole, not a coloured circle pasted on top. A `mask-image` with a transparent circle punched into an otherwise opaque radial gradient removes that part of the ice, so whatever is behind the popsicle shows through it, which is why the sun can sit inside the bite. Each drip stretches from `transform-origin: 50% 0`, so it grows downward off the bottom edge rather than expanding from its own middle, and the whole popsicle rocks from `50% 100%`, the tip of the stick, so it pivots where a hand would hold it.
+
+### Why is it useful?
+
+Summer, dessert, and playful themes use a popsicle. This builds one with pure CSS gradients, masks and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/popsicle-as/demo.html
+++ b/submissions/examples/popsicle-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popsicle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunp2"></span>
+    <div class="pop" tabindex="0">
+      <span class="stickp"></span>
+      <span class="ice"></span>
+      <span class="layer2"></span>
+      <span class="layer3"></span>
+      <span class="frost"></span>
+      <span class="glint"></span>
+    </div>
+    <span class="drip2 dr1"></span>
+    <span class="drip2 dr2"></span>
+    <span class="puddle"></span>
+    <span class="deck"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/popsicle-as/style.css
+++ b/submissions/examples/popsicle-as/style.css
@@ -1,0 +1,214 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #56cbe4, #1c7fa8 68%, #0d4a66);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+}
+
+.sunp2 {
+  position: absolute;
+  top: 24px;
+  right: 30px;
+  width: 76px;
+  height: 76px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff8d2, #ffd85e 68%);
+  box-shadow: 0 0 60px rgba(255, 220, 110, 0.8);
+  animation: pulsep 5s ease-in-out infinite;
+}
+
+.deck {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 52px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 60, 26, 0.28) 0 3px,
+      transparent 3px 42px
+    ),
+    linear-gradient(180deg, #d8a969, #a8794a);
+}
+
+.pop {
+  position: absolute;
+  top: 42px;
+  left: 50%;
+  width: 150px;
+  height: 250px;
+  margin-left: -75px;
+  outline: none;
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: tiltp 4.4s ease-in-out infinite;
+}
+
+.pop:hover,
+.pop:focus-visible {
+  animation: tiltp 1.2s ease-in-out infinite;
+}
+
+.stickp {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 26px;
+  height: 66px;
+  margin-left: -13px;
+  border-radius: 0 0 12px 12px;
+  background: linear-gradient(180deg, #d8ad6f, #b98c4a);
+  z-index: 2;
+}
+
+.ice {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 128px;
+  height: 196px;
+  margin-left: -64px;
+  border-radius: 26px 26px 16px 16px;
+  background: linear-gradient(180deg, #ff7aa8, #e13f74);
+  mask-image: radial-gradient(circle 30px at 116px 4px, transparent 0 30px, #000 31px);
+  box-shadow:
+    inset -10px 0 18px rgba(150, 20, 60, 0.35),
+    inset 10px 0 16px rgba(255, 200, 220, 0.4),
+    0 14px 26px rgba(0, 0, 0, 0.3);
+  z-index: 3;
+}
+
+.layer2 {
+  position: absolute;
+  top: 78px;
+  left: 50%;
+  width: 128px;
+  height: 60px;
+  margin-left: -64px;
+  background: linear-gradient(180deg, #ffb45e, #f08a2c);
+  z-index: 4;
+}
+
+.layer3 {
+  position: absolute;
+  top: 138px;
+  left: 50%;
+  width: 128px;
+  height: 58px;
+  margin-left: -64px;
+  border-radius: 0 0 16px 16px;
+  background: linear-gradient(180deg, #ffe266, #f3c024);
+  z-index: 4;
+}
+
+.frost {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 128px;
+  height: 190px;
+  margin-left: -64px;
+  border-radius: 24px 24px 16px 16px;
+  mask-image: radial-gradient(circle 30px at 116px 10px, transparent 0 30px, #000 31px);
+  background:
+    radial-gradient(circle at 24% 18%, rgba(255, 255, 255, 0.5) 0 5px, transparent 5px),
+    radial-gradient(circle at 62% 12%, rgba(255, 255, 255, 0.4) 0 4px, transparent 4px),
+    radial-gradient(circle at 40% 46%, rgba(255, 255, 255, 0.35) 0 5px, transparent 5px),
+    radial-gradient(circle at 76% 62%, rgba(255, 255, 255, 0.4) 0 4px, transparent 4px),
+    radial-gradient(circle at 26% 76%, rgba(255, 255, 255, 0.35) 0 5px, transparent 5px),
+    transparent;
+  z-index: 5;
+  animation: twinklep 3.4s ease-in-out infinite;
+}
+
+.glint {
+  position: absolute;
+  top: 16px;
+  left: 24px;
+  width: 18px;
+  height: 70px;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.45);
+  filter: blur(2px);
+  z-index: 6;
+}
+
+.drip2 {
+  position: absolute;
+  top: 232px;
+  width: 14px;
+  height: 20px;
+  border-radius: 0 0 10px 10px;
+  background: #ef5b86;
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: oozep 3.4s ease-in-out infinite;
+}
+
+.dr1 { left: 118px; }
+
+.dr2 {
+  right: 122px;
+  background: #f3c024;
+  animation-delay: 1.7s;
+}
+
+.puddle {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 130px;
+  height: 20px;
+  margin-left: -65px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(240, 90, 130, 0.6), transparent 70%);
+  filter: blur(2px);
+  z-index: 3;
+  animation: spreadp 4.4s ease-in-out infinite;
+}
+
+@keyframes tiltp {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes oozep {
+  0%, 100% { transform: scaleY(0.6); opacity: 0.8; }
+  50% { transform: scaleY(1.4); opacity: 1; }
+}
+
+@keyframes spreadp {
+  0%, 100% { transform: scaleX(0.9); opacity: 0.6; }
+  50% { transform: scaleX(1.1); opacity: 0.85; }
+}
+
+@keyframes twinklep {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+@keyframes pulsep {
+  0%, 100% { transform: scale(1); opacity: 0.9; }
+  50% { transform: scale(1.05); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pop,
+  .drip2,
+  .puddle,
+  .frost,
+  .sunp2 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a popsicle built for #45195. The bite is a genuine hole rather than a coloured circle pasted on top: a mask-image with a transparent circle punched into an otherwise opaque radial gradient removes that part of the ice, so whatever is behind the popsicle shows through the bite, which is why the sun can sit inside it. Each drip stretches from a `transform-origin: 50% 0` so it grows downward off the bottom edge instead of expanding from its own middle, and the popsicle rocks from the tip of the stick, where a hand would hold it. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45195.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a pink, orange and yellow popsicle on a stick with a bite genuinely cut out of the top corner (the sun shows through it), frost specks, drips and a melt puddle.
