### PR TITLE
Add teacup component

### DIFF
--- a/submissions/examples/teacup-as/README.md
+++ b/submissions/examples/teacup-as/README.md
@@ -1,0 +1,22 @@
+# Teacup
+
+### What does this do?
+
+It shows a cup of tea on a saucer with a teabag steeping in it. Steam curls up off the surface, rings ripple out across the brew, the teabag tag sways on its string, and the cup settles gently. Under reduced motion everything is still.
+
+### How is it used?
+
+```html
+<div class="cup">
+  <span class="handle2"></span>
+  <span class="bowl"></span>
+  <span class="brew"></span>
+  <span class="tagt"></span>
+</div>
+```
+
+The handle is a circle with one border side set to `transparent`, which leaves an open C shape with no clip path and no second element. The brew is a flat ellipse laid across the mouth of the cup, so the tea reads as a surface seen at an angle rather than a flat disc, and the ripple is one ring that scales outward from the middle of it while fading. The tag and its string share the same swing keyframe but pivot from different origins, so the string bends at the cup rim while the tag trails behind it.
+
+### Why is it useful?
+
+Cafe, cosy, and break time themes use a cup of tea. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/teacup-as/demo.html
+++ b/submissions/examples/teacup-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Teacup</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="steamt st1"></span>
+    <span class="steamt st2"></span>
+    <span class="steamt st3"></span>
+    <div class="cup">
+      <span class="handle2"></span>
+      <span class="bowl"></span>
+      <span class="brew"></span>
+      <span class="ripplet"></span>
+      <span class="tagline"></span>
+      <span class="tagt"></span>
+      <span class="bandt"></span>
+    </div>
+    <span class="saucer"></span>
+    <span class="spoon"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/teacup-as/style.css
+++ b/submissions/examples/teacup-as/style.css
@@ -1,0 +1,207 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #4b4436, #191509 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.cup {
+  position: absolute;
+  bottom: 76px;
+  left: 50%;
+  width: 200px;
+  height: 130px;
+  margin-left: -100px;
+  z-index: 4;
+  animation: settlet 5s ease-in-out infinite;
+}
+
+.bowl {
+  position: absolute;
+  bottom: 0;
+  left: 20px;
+  width: 160px;
+  height: 118px;
+  border-radius: 10px 10px 60px 60px / 6px 6px 70px 70px;
+  background: linear-gradient(180deg, #fdfcf8, #cfcabb);
+  box-shadow:
+    inset -12px -10px 22px rgba(120, 110, 90, 0.3),
+    0 12px 24px rgba(0, 0, 0, 0.35);
+  z-index: 4;
+}
+
+.brew {
+  position: absolute;
+  top: 8px;
+  left: 30px;
+  width: 140px;
+  height: 26px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 40% 34%, #b5732c, #7c4614 76%);
+  box-shadow: inset 0 3px 6px rgba(60, 30, 4, 0.5);
+  z-index: 5;
+}
+
+.ripplet {
+  position: absolute;
+  top: 12px;
+  left: 74px;
+  width: 50px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 226, 180, 0.5);
+  opacity: 0;
+  z-index: 6;
+  animation: ringt 3.6s ease-out infinite;
+}
+
+.bandt {
+  position: absolute;
+  bottom: 74px;
+  left: 22px;
+  width: 156px;
+  height: 12px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #4c86b8 0 10px,
+      #cfe3f2 10px 20px
+    );
+  z-index: 5;
+}
+
+.handle2 {
+  position: absolute;
+  bottom: 34px;
+  right: -2px;
+  width: 60px;
+  height: 62px;
+  box-sizing: border-box;
+  border: 12px solid #f2eee4;
+  border-left-color: transparent;
+  border-radius: 50%;
+  z-index: 3;
+}
+
+.tagline {
+  position: absolute;
+  top: 4px;
+  left: 56px;
+  width: 2px;
+  height: 40px;
+  background: rgba(120, 90, 40, 0.75);
+  transform-origin: 50% 0;
+  z-index: 6;
+  animation: swingt 3.2s ease-in-out infinite;
+}
+
+.tagt {
+  position: absolute;
+  top: -22px;
+  left: 34px;
+  width: 44px;
+  height: 26px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #fff6de, #e2d3ac);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transform-origin: 50% 120%;
+  z-index: 6;
+  animation: swingt 3.2s ease-in-out infinite;
+}
+
+.saucer {
+  position: absolute;
+  bottom: 54px;
+  left: 50%;
+  width: 250px;
+  height: 26px;
+  margin-left: -125px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #f0ece2, #a8a394);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45);
+  z-index: 3;
+}
+
+.spoon {
+  position: absolute;
+  bottom: 62px;
+  right: 20px;
+  width: 76px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #cfd6dd, #8e99a4);
+  box-shadow: -22px -3px 0 -1px #cfd6dd;
+  transform: rotate(-8deg);
+  z-index: 4;
+}
+
+.steamt {
+  position: absolute;
+  bottom: 190px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.45);
+  filter: blur(5px);
+  opacity: 0;
+  z-index: 5;
+  animation: riset 4.6s ease-out infinite;
+}
+
+.st1 { left: 110px; }
+
+.st2 {
+  left: 150px;
+  animation-delay: 1.5s;
+}
+
+.st3 {
+  left: 190px;
+  animation-delay: 3s;
+}
+
+@keyframes settlet {
+  0%, 100% { transform: translateY(0) rotate(-0.6deg); }
+  50% { transform: translateY(-3px) rotate(0.6deg); }
+}
+
+@keyframes swingt {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes ringt {
+  0% { transform: scale(0.4); opacity: 0.9; }
+  100% { transform: scale(1.6); opacity: 0; }
+}
+
+@keyframes riset {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.9; }
+  100% { transform: translateY(-90px) translateX(20px) scale(2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cup,
+  .tagline,
+  .tagt,
+  .ripplet,
+  .steamt {
+    animation: none;
+  }
+
+  .steamt,
+  .ripplet {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a teacup built for #45197. The handle is a circle with one border side set to transparent, which leaves an open C shape with no clip path and no second element. The brew is a flat ellipse laid across the mouth of the cup so the tea reads as a surface seen at an angle rather than a flat disc, and the ripple is one ring scaling outward from the middle of it while fading. The tag and its string share the same swing keyframe but pivot from different origins, so the string bends at the rim while the tag trails behind it. Reduced motion fallback included. Pure CSS. Closes #45197.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a white teacup with a C shaped handle and a patterned band, filled with tea, a teabag tag hanging over the rim, steam rising, on a saucer with a spoon.
