### PR TITLE
Add xylophone component

### DIFF
--- a/submissions/examples/xylophone-as/README.md
+++ b/submissions/examples/xylophone-as/README.md
@@ -1,0 +1,21 @@
+# Xylophone
+
+### What does this do?
+
+It shows a toy xylophone being played. The mallet swings down and taps the top bar on a loop, notes float up and fade, and every bar can be struck by hand: hovering or focusing a bar presses it down and lights it up. Under reduced motion the mallet rests and the bars stop reacting.
+
+### How is it used?
+
+```html
+<div class="xylo">
+  <span class="frame"></span>
+  <span class="bar bx1" tabindex="0"></span>
+  <span class="bar bx2" tabindex="0"></span>
+</div>
+```
+
+The mallet swings from `transform-origin: 92% 88%`, the grip at the far end of the stick, so the head travels a long arc down onto the bar while the hand end barely moves. The notes are timed to that swing rather than run on their own clock: they share the mallet's 1.6 second duration and stay invisible until 30 percent of the cycle, the moment the head lands, so the sound always appears on the strike. Each bar carries `tabindex="0"`, so a keyboard user can tab through the scale and get the same press and glow a mouse gives.
+
+### Why is it useful?
+
+Music, toy, and playful interface themes use a xylophone. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/xylophone-as/demo.html
+++ b/submissions/examples/xylophone-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Xylophone</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="xylo">
+      <span class="frame"></span>
+      <span class="bar bx1" tabindex="0"></span>
+      <span class="bar bx2" tabindex="0"></span>
+      <span class="bar bx3" tabindex="0"></span>
+      <span class="bar bx4" tabindex="0"></span>
+      <span class="bar bx5" tabindex="0"></span>
+      <span class="bar bx6" tabindex="0"></span>
+      <span class="bar bx7" tabindex="0"></span>
+      <span class="rail r1"></span>
+      <span class="rail r2"></span>
+    </div>
+    <div class="mallet">
+      <span class="stick2"></span>
+      <span class="knob"></span>
+    </div>
+    <span class="note nt1"></span>
+    <span class="note nt2"></span>
+    <span class="note nt3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/xylophone-as/style.css
+++ b/submissions/examples/xylophone-as/style.css
@@ -1,0 +1,212 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #3b3f52, #14161f 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.xylo {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 280px;
+  height: 240px;
+  margin-left: -140px;
+  z-index: 3;
+}
+
+.frame {
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(2% 0, 98% 0, 82% 100%, 18% 100%);
+  background: linear-gradient(180deg, #8d6236, #573a1c);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.45);
+}
+
+.rail {
+  position: absolute;
+  left: 50%;
+  width: 8px;
+  height: 226px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #d8c9a8, #a08a63);
+  z-index: 4;
+}
+
+.r1 {
+  top: 8px;
+  margin-left: -118px;
+  transform: rotate(4deg);
+}
+
+.r2 {
+  top: 8px;
+  margin-left: 110px;
+  transform: rotate(-4deg);
+}
+
+.bar {
+  position: absolute;
+  left: 50%;
+  height: 22px;
+  border-radius: 5px;
+  box-shadow:
+    inset 0 3px 5px rgba(255, 255, 255, 0.45),
+    0 4px 8px rgba(0, 0, 0, 0.4);
+  outline: none;
+  z-index: 5;
+  transition: transform 0.12s ease, filter 0.12s ease;
+}
+
+.bar:hover,
+.bar:focus-visible {
+  transform: translateY(3px) scaleX(0.98);
+  filter: brightness(1.35);
+}
+
+.bx1 {
+  top: 14px;
+  width: 250px;
+  margin-left: -125px;
+  background: linear-gradient(180deg, #ff6b6b, #d43a3a);
+}
+
+.bx2 {
+  top: 46px;
+  width: 232px;
+  margin-left: -116px;
+  background: linear-gradient(180deg, #ffa94d, #e2891f);
+}
+
+.bx3 {
+  top: 78px;
+  width: 214px;
+  margin-left: -107px;
+  background: linear-gradient(180deg, #ffe066, #e3bd23);
+}
+
+.bx4 {
+  top: 110px;
+  width: 196px;
+  margin-left: -98px;
+  background: linear-gradient(180deg, #7ede8a, #3cae52);
+}
+
+.bx5 {
+  top: 142px;
+  width: 178px;
+  margin-left: -89px;
+  background: linear-gradient(180deg, #63c7f0, #2b8fc4);
+}
+
+.bx6 {
+  top: 174px;
+  width: 160px;
+  margin-left: -80px;
+  background: linear-gradient(180deg, #8f8ef0, #5451c4);
+}
+
+.bx7 {
+  top: 206px;
+  width: 142px;
+  margin-left: -71px;
+  background: linear-gradient(180deg, #d98ff0, #a64cc4);
+}
+
+.mallet {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 150px;
+  height: 120px;
+  margin-left: 10px;
+  transform-origin: 92% 88%;
+  z-index: 6;
+  animation: tapx 1.6s ease-in-out infinite;
+}
+
+.stick2 {
+  position: absolute;
+  bottom: 10px;
+  right: 4px;
+  width: 118px;
+  height: 9px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #7a5228, #c39154);
+}
+
+.knob {
+  position: absolute;
+  bottom: 2px;
+  left: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #fdfaf2, #c9bfa6 72%);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.4);
+}
+
+.note {
+  position: absolute;
+  top: 40px;
+  left: 90px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #f4f1ff;
+  box-shadow: 9px -12px 0 -3px #f4f1ff;
+  opacity: 0;
+  z-index: 7;
+  animation: floatx 1.6s ease-out infinite;
+}
+
+.nt2 {
+  left: 140px;
+  animation-delay: 0.5s;
+
+  --nx: 26px;
+}
+
+.nt3 {
+  left: 190px;
+  animation-delay: 1s;
+
+  --nx: -22px;
+}
+
+@keyframes tapx {
+  0%, 100% { transform: rotate(-26deg); }
+  35% { transform: rotate(2deg); }
+  50% { transform: rotate(-4deg); }
+}
+
+@keyframes floatx {
+  0%, 30% { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  40% { opacity: 1; }
+  100% { transform: translate(var(--nx, 14px), -70px) scale(1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mallet,
+  .note {
+    animation: none;
+  }
+
+  .bar {
+    transition: none;
+  }
+
+  .note {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a xylophone built for #45201. The mallet swings from a `transform-origin` at the grip end of the stick, so the head travels a long arc onto the bar while the hand end barely moves. The floating notes are timed to that swing rather than running on their own clock: they share the mallet's 1.6 second duration and stay invisible until the moment the head lands, so the note always appears on the strike. Every bar carries `tabindex="0"`, so a keyboard user can tab through the scale and get the same press and glow that a mouse gives. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45201.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a toy xylophone with seven graduated coloured bars on a trapezoid frame, a mallet mid swing and notes rising from the struck bar.
