### PR TITLE
Add easel component

### DIFF
--- a/submissions/examples/easel-as/README.md
+++ b/submissions/examples/easel-as/README.md
@@ -1,0 +1,21 @@
+# Easel
+
+### What does this do?
+
+It shows a painter's easel with a landscape on the canvas. The brush sweeps across the picture and, as it passes, the brush strokes paint themselves in from left to right. The sun in the painting pulses, paint blobs on the tray wobble, and the easel leans gently. Under reduced motion the brush rests and the strokes are simply shown finished.
+
+### How is it used?
+
+```html
+<div class="canvas2" tabindex="0">
+  <span class="paint"></span>
+  <span class="hill h1"></span>
+  <span class="stroke sk1"></span>
+</div>
+```
+
+A stroke paints itself by growing from `transform-origin: 0 50%` with `scaleX`, starting at 0 and running to 1. Because the origin is the left end, the stroke extends the way a brush actually lays paint down, rather than expanding outward from its middle. The stroke and the brush share the same four second duration, so the paint appears exactly while the brush is over it. Under reduced motion the stroke is pinned at `scaleX(1)`, so the picture is still finished rather than blank.
+
+### Why is it useful?
+
+Art, creativity, and portfolio themes use an easel. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/easel-as/demo.html
+++ b/submissions/examples/easel-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Easel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="stand">
+      <span class="lege ll"></span>
+      <span class="lege lr"></span>
+      <span class="lege lb"></span>
+      <span class="tray"></span>
+    </div>
+    <div class="canvas2" tabindex="0">
+      <span class="paint"></span>
+      <span class="hill h1"></span>
+      <span class="hill h2"></span>
+      <span class="sune"></span>
+      <span class="stroke sk1"></span>
+      <span class="stroke sk2"></span>
+    </div>
+    <div class="brush">
+      <span class="ferrule"></span>
+      <span class="bristle"></span>
+      <span class="shaft"></span>
+    </div>
+    <span class="blob bl1"></span>
+    <span class="blob bl2"></span>
+    <span class="blob bl3"></span>
+    <span class="floore"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/easel-as/style.css
+++ b/submissions/examples/easel-as/style.css
@@ -1,0 +1,277 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #4a4741, #17161a 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.floore {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 34px);
+  background: linear-gradient(180deg, #6a5b45, #2c2318);
+}
+
+.stand {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  width: 240px;
+  height: 280px;
+  margin-left: -120px;
+  z-index: 2;
+}
+
+.lege {
+  position: absolute;
+  bottom: 0;
+  width: 14px;
+  height: 270px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #a97c47, #6d4a24);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--er, 0deg));
+}
+
+.ll {
+  left: 44px;
+
+  --er: 9deg;
+}
+
+.lr {
+  right: 44px;
+
+  --er: -9deg;
+}
+
+.lb {
+  left: 50%;
+  margin-left: -7px;
+  height: 250px;
+  background: linear-gradient(180deg, #8c6437, #543718);
+
+  --er: 0deg;
+}
+
+.tray {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 220px;
+  height: 16px;
+  margin-left: -110px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #c39154, #7d5228);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+  z-index: 5;
+}
+
+.canvas2 {
+  position: absolute;
+  bottom: 90px;
+  left: 50%;
+  width: 196px;
+  height: 156px;
+  margin-left: -98px;
+  border: 8px solid #e9e2d2;
+  box-sizing: border-box;
+  outline: none;
+  background: #f7f3e8;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  z-index: 4;
+  animation: leane 6s ease-in-out infinite;
+}
+
+.paint {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, #bfe6f5 0 62%, #9ed48a 62%);
+  z-index: 2;
+}
+
+.hill {
+  position: absolute;
+  border-radius: 50% 50% 0 0;
+  background: linear-gradient(180deg, #6ab06a, #3d7a45);
+  z-index: 3;
+}
+
+.h1 {
+  bottom: 46px;
+  left: -14px;
+  width: 120px;
+  height: 56px;
+}
+
+.h2 {
+  bottom: 46px;
+  right: -10px;
+  width: 100px;
+  height: 44px;
+  background: linear-gradient(180deg, #7cbd74, #4a8a4e);
+}
+
+.sune {
+  position: absolute;
+  top: 18px;
+  right: 26px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff3b0, #ffd24a 70%);
+  box-shadow: 0 0 20px rgba(255, 210, 74, 0.8);
+  z-index: 4;
+  animation: glowe 4s ease-in-out infinite;
+}
+
+.stroke {
+  position: absolute;
+  height: 10px;
+  border-radius: 5px;
+  transform-origin: 0 50%;
+  transform: scaleX(0);
+  z-index: 5;
+  animation: painte 4s ease-in-out infinite;
+}
+
+.sk1 {
+  bottom: 24px;
+  left: 16px;
+  width: 90px;
+  background: #d9534f;
+}
+
+.sk2 {
+  bottom: 8px;
+  left: 40px;
+  width: 110px;
+  background: #4f83d9;
+  animation-delay: 2s;
+}
+
+.brush {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 150px;
+  height: 40px;
+  margin-left: -30px;
+  transform-origin: 100% 50%;
+  z-index: 6;
+  animation: strokee 4s ease-in-out infinite;
+}
+
+.shaft {
+  position: absolute;
+  top: 12px;
+  right: 0;
+  width: 108px;
+  height: 10px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #8a5c2a, #c99a58);
+}
+
+.ferrule {
+  position: absolute;
+  top: 10px;
+  left: 26px;
+  width: 26px;
+  height: 14px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #d3dae1, #8e99a4);
+  z-index: 2;
+}
+
+.bristle {
+  position: absolute;
+  top: 12px;
+  left: 4px;
+  width: 26px;
+  height: 11px;
+  border-radius: 6px 3px 3px 6px;
+  background: linear-gradient(90deg, #d9534f, #a63430);
+  z-index: 2;
+}
+
+.blob {
+  position: absolute;
+  bottom: 78px;
+  width: 18px;
+  height: 10px;
+  border-radius: 50%;
+  z-index: 6;
+  animation: wobblee 3.4s ease-in-out infinite;
+}
+
+.bl1 {
+  left: 76px;
+  background: #d9534f;
+}
+
+.bl2 {
+  left: 108px;
+  background: #4f83d9;
+  animation-delay: 0.6s;
+}
+
+.bl3 {
+  right: 82px;
+  background: #f0c419;
+  animation-delay: 1.2s;
+}
+
+@keyframes leane {
+  0%, 100% { transform: rotate(-0.6deg); }
+  50% { transform: rotate(0.6deg); }
+}
+
+@keyframes strokee {
+  0%, 100% { transform: rotate(-16deg) translateX(0); }
+  30% { transform: rotate(4deg) translateX(-30px); }
+  60% { transform: rotate(-6deg) translateX(-60px); }
+}
+
+@keyframes painte {
+  0% { transform: scaleX(0); }
+  35% { transform: scaleX(1); }
+  90% { transform: scaleX(1); }
+  100% { transform: scaleX(0); }
+}
+
+@keyframes glowe {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+}
+
+@keyframes wobblee {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(1.15); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas2,
+  .brush,
+  .stroke,
+  .sune,
+  .blob {
+    animation: none;
+  }
+
+  .stroke {
+    transform: scaleX(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an easel built for #45203. A stroke paints itself by growing from a `transform-origin: 0 50%` with scaleX from 0 to 1, so it extends the way a brush actually lays paint down rather than expanding outward from its middle. The stroke and the brush share the same four second duration, so the paint appears exactly while the brush is over it. The reduced motion branch pins the stroke at `scaleX(1)` rather than just cancelling the animation, so users who opt out still see a finished painting instead of a blank canvas. Pure CSS, no JavaScript. Closes #45203.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wooden tripod easel with a paint tray and blobs, holding a canvas with a sun and hills, and a brush sweeping a red stroke across it.
