### PR TITLE
Add kaleidoscope component

### DIFF
--- a/submissions/examples/kaleidoscope-as/README.md
+++ b/submissions/examples/kaleidoscope-as/README.md
@@ -1,0 +1,23 @@
+# Kaleidoscope
+
+### What does this do?
+
+It shows a kaleidoscope you can look into. Eight coloured wedges turn slowly inside the barrel, mirror lines cut across them, the glow around the lens breathes, and stars twinkle behind it. Hovering or focusing the scope spins the pattern four times faster, as if you gave the barrel a twist. Under reduced motion the pattern holds still.
+
+### How is it used?
+
+```html
+<div class="scope" tabindex="0">
+  <div class="drum">
+    <span class="wedge wd1"></span>
+    <span class="wedge wd2"></span>
+  </div>
+  <span class="facets"></span>
+</div>
+```
+
+Each wedge is a `clip-path` triangle pinned at the centre with `transform-origin: 0 0`, then turned to its own angle from a `--kw` custom property, so eight elements tile a full circle with no gaps. The spin lives on the wrapping drum rather than on the wedges, so it never overwrites their individual angles. The mirror lines are a single `repeating-conic-gradient` laid over the top, which is what sells the reflection without duplicating any of the artwork underneath.
+
+### Why is it useful?
+
+Toy, pattern, and visual interest themes use a kaleidoscope. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/kaleidoscope-as/demo.html
+++ b/submissions/examples/kaleidoscope-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kaleidoscope</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="scope" tabindex="0">
+      <span class="glow2"></span>
+      <div class="drum">
+        <span class="wedge wd1"></span>
+        <span class="wedge wd2"></span>
+        <span class="wedge wd3"></span>
+        <span class="wedge wd4"></span>
+        <span class="wedge wd5"></span>
+        <span class="wedge wd6"></span>
+        <span class="wedge wd7"></span>
+        <span class="wedge wd8"></span>
+      </div>
+      <span class="facets"></span>
+      <span class="rim"></span>
+      <span class="hub2"></span>
+    </div>
+    <span class="tubek"></span>
+    <span class="eyecup"></span>
+    <span class="starK sk1"></span>
+    <span class="starK sk2"></span>
+    <span class="starK sk3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/kaleidoscope-as/style.css
+++ b/submissions/examples/kaleidoscope-as/style.css
@@ -1,0 +1,225 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #2b2340, #0d0a16 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.starK {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff;
+  animation: twinkk 3s ease-in-out infinite;
+}
+
+.sk1 { top: 34px; left: 40px; }
+
+.sk2 {
+  top: 66px;
+  right: 44px;
+  animation-delay: 1s;
+}
+
+.sk3 {
+  bottom: 60px;
+  left: 56px;
+  animation-delay: 2s;
+}
+
+.tubek {
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  width: 62px;
+  height: 96px;
+  margin-left: -31px;
+  border-radius: 8px 8px 12px 12px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.12) 0 3px,
+      transparent 3px 14px
+    ),
+    linear-gradient(90deg, #8a5fbf, #4a2f78);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.eyecup {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  width: 84px;
+  height: 22px;
+  margin-left: -42px;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #c9a24a, #8a6a1e);
+  z-index: 3;
+}
+
+.scope {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 210px;
+  height: 210px;
+  margin-left: -105px;
+  border-radius: 50%;
+  outline: none;
+  z-index: 4;
+}
+
+.glow2 {
+  position: absolute;
+  inset: -24px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(190, 140, 255, 0.4), transparent 66%);
+  filter: blur(8px);
+  animation: pulsek 4s ease-in-out infinite;
+}
+
+.drum {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #14102a;
+  animation: turnk 12s linear infinite;
+}
+
+.scope:hover .drum,
+.scope:focus-visible .drum {
+  animation-duration: 3s;
+}
+
+.wedge {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 50%;
+  height: 50%;
+  transform-origin: 0 0;
+  clip-path: polygon(0 0, 100% 0, 62% 100%);
+  transform: rotate(var(--kw, 0deg));
+}
+
+.wd1 {
+  background: linear-gradient(160deg, #ff5f8d, #b31e52);
+
+  --kw: 0deg;
+}
+
+.wd2 {
+  background: linear-gradient(160deg, #ffb14e, #d97a10);
+
+  --kw: 45deg;
+}
+
+.wd3 {
+  background: linear-gradient(160deg, #ffe45e, #d9b310);
+
+  --kw: 90deg;
+}
+
+.wd4 {
+  background: linear-gradient(160deg, #7ee08a, #2f9a4a);
+
+  --kw: 135deg;
+}
+
+.wd5 {
+  background: linear-gradient(160deg, #5fd0e8, #1f8aa8);
+
+  --kw: 180deg;
+}
+
+.wd6 {
+  background: linear-gradient(160deg, #6f8ef0, #2f4ac4);
+
+  --kw: 225deg;
+}
+
+.wd7 {
+  background: linear-gradient(160deg, #b07ef0, #7030c4);
+
+  --kw: 270deg;
+}
+
+.wd8 {
+  background: linear-gradient(160deg, #f07ed0, #c430a0);
+
+  --kw: 315deg;
+}
+
+.facets {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(255, 255, 255, 0.16) 0 2deg,
+      transparent 2deg 22.5deg
+    );
+  z-index: 5;
+  pointer-events: none;
+}
+
+.rim {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 10px solid #caa64e;
+  box-sizing: border-box;
+  box-shadow:
+    inset 0 0 0 3px rgba(90, 60, 10, 0.5),
+    0 14px 28px rgba(0, 0, 0, 0.5);
+  z-index: 6;
+}
+
+.hub2 {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  margin: -15px 0 0 -15px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #fff6d8, #c9a24a 72%);
+  box-shadow: 0 0 14px rgba(255, 230, 160, 0.8);
+  z-index: 7;
+}
+
+@keyframes turnk {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes pulsek {
+  0%, 100% { opacity: 0.7; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.06); }
+}
+
+@keyframes twinkk {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.2; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drum,
+  .glow2,
+  .starK {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a kaleidoscope built for #45205. Each wedge is a clip-path triangle pinned at the centre with `transform-origin: 0 0` and turned to its own angle from a `--kw` custom property, so eight elements tile a full circle with no gaps. The spin lives on the wrapping drum rather than on the wedges, so it never overwrites their individual angles, and hovering or focusing simply shortens that one duration. The mirror lines are a single repeating conic gradient laid over the top, which sells the reflection without duplicating any of the artwork underneath. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45205.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a brass rimmed kaleidoscope lens filled with eight coloured wedges and mirror lines, on a ribbed tube with an eyecup, under twinkling stars.
