### PR TITLE
Add scarecrow component

### DIFF
--- a/submissions/examples/scarecrow-as/README.md
+++ b/submissions/examples/scarecrow-as/README.md
@@ -1,0 +1,24 @@
+# Scarecrow
+
+### What does this do?
+
+It shows a scarecrow standing in a field at dusk. The whole figure sways on its post, its head lolls from side to side, the straw poking out of its sleeves rustles, its stitched eyes wink, and crows flap past behind it. Under reduced motion it stands still.
+
+### How is it used?
+
+```html
+<div class="crow">
+  <span class="crossc"></span>
+  <span class="shirt"></span>
+  <div class="headc">
+    <span class="sack"></span>
+    <span class="eyec ecl"></span>
+  </div>
+</div>
+```
+
+The stitched X eyes are drawn with two crossed `linear-gradient`s in a single element: each gradient paints a hard edged diagonal band and leaves the rest transparent, so an X costs no extra markup and no clip path. The scarecrow sways from `transform-origin: 50% 100%`, the foot of the post, so the whole figure leans from the ground rather than spinning around its middle, and the head has its own pivot at the neck, so it lolls slightly out of time with the body and looks limp rather than rigid.
+
+### Why is it useful?
+
+Harvest, autumn, and farm themes use a scarecrow. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/scarecrow-as/demo.html
+++ b/submissions/examples/scarecrow-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scarecrow</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moons"></span>
+    <div class="crow">
+      <span class="postc"></span>
+      <span class="crossc"></span>
+      <span class="shirt"></span>
+      <span class="patch pt1"></span>
+      <span class="patch pt2"></span>
+      <span class="strawA sa1"></span>
+      <span class="strawA sa2"></span>
+      <div class="headc">
+        <span class="sack"></span>
+        <span class="eyec ecl"></span>
+        <span class="eyec ecr"></span>
+        <span class="mouthc"></span>
+        <span class="hatb"></span>
+        <span class="hatt"></span>
+      </div>
+    </div>
+    <span class="bird2 bd1"></span>
+    <span class="bird2 bd2"></span>
+    <span class="cropf"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/scarecrow-as/style.css
+++ b/submissions/examples/scarecrow-as/style.css
@@ -1,0 +1,296 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #f0a054, #b8574a 56%, #3b2740);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.moons {
+  position: absolute;
+  top: 26px;
+  right: 36px;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #fff6d6, #f0cf82 72%);
+  box-shadow: 0 0 56px rgba(255, 226, 150, 0.7);
+  animation: glows 6s ease-in-out infinite;
+}
+
+.cropf {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 76px);
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(120, 80, 20, 0.4) 0 3px,
+      transparent 3px 15px
+    ),
+    linear-gradient(180deg, #b98a3c, #6a4a18);
+}
+
+.crow {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 240px;
+  height: 260px;
+  margin-left: -120px;
+  z-index: 4;
+  animation: swaysc 5s ease-in-out infinite;
+  transform-origin: 50% 100%;
+}
+
+.postc {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 18px;
+  height: 120px;
+  margin-left: -9px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #8a5f34, #55391a);
+  z-index: 2;
+}
+
+.crossc {
+  position: absolute;
+  bottom: 138px;
+  left: 50%;
+  width: 220px;
+  height: 16px;
+  margin-left: -110px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #8a5f34, #5b3d1c);
+  z-index: 2;
+}
+
+.shirt {
+  position: absolute;
+  bottom: 84px;
+  left: 50%;
+  width: 120px;
+  height: 88px;
+  margin-left: -60px;
+  border-radius: 10px 10px 6px 6px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.16) 0 8px,
+      transparent 8px 16px
+    ),
+    linear-gradient(180deg, #4f86c6, #2f5c92);
+  box-shadow: inset 0 -8px 14px rgba(20, 40, 70, 0.4);
+  z-index: 4;
+}
+
+.patch {
+  position: absolute;
+  width: 26px;
+  height: 20px;
+  border-radius: 3px;
+  background: #d9534f;
+  transform: rotate(var(--pr2, 0deg));
+  z-index: 5;
+}
+
+.pt1 {
+  bottom: 132px;
+  left: 96px;
+
+  --pr2: -12deg;
+}
+
+.pt2 {
+  bottom: 100px;
+  right: 100px;
+
+  --pr2: 16deg;
+}
+
+.strawA {
+  position: absolute;
+  width: 46px;
+  height: 10px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #e8c15a, #b58f2c);
+  transform-origin: 100% 50%;
+  transform: rotate(var(--sr2, 0deg));
+  z-index: 3;
+  animation: rustle 2.8s ease-in-out infinite;
+}
+
+.sa1 {
+  bottom: 128px;
+  left: 6px;
+
+  --sr2: 18deg;
+}
+
+.sa2 {
+  bottom: 128px;
+  right: 6px;
+  transform-origin: 0 50%;
+
+  --sr2: -18deg;
+
+  animation-delay: 1.4s;
+}
+
+.headc {
+  position: absolute;
+  bottom: 158px;
+  left: 50%;
+  width: 110px;
+  height: 104px;
+  margin-left: -55px;
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: tilth 5s ease-in-out infinite;
+}
+
+.sack {
+  position: absolute;
+  bottom: 0;
+  left: 12px;
+  width: 86px;
+  height: 84px;
+  border-radius: 46% 46% 40% 40% / 50% 50% 50% 50%;
+  background: linear-gradient(180deg, #e6cf92, #bda05c);
+  box-shadow: inset -6px -6px 12px rgba(120, 90, 30, 0.35);
+  z-index: 3;
+}
+
+.eyec {
+  position: absolute;
+  bottom: 44px;
+  width: 16px;
+  height: 16px;
+  z-index: 5;
+  background:
+    linear-gradient(45deg, transparent 44%, #3a2a12 44% 56%, transparent 56%),
+    linear-gradient(-45deg, transparent 44%, #3a2a12 44% 56%, transparent 56%);
+  animation: winks 4.4s ease-in-out infinite;
+}
+
+.ecl { left: 26px; }
+
+.ecr {
+  right: 26px;
+  animation-delay: 0.3s;
+}
+
+.mouthc {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  width: 42px;
+  height: 12px;
+  margin-left: -21px;
+  border-radius: 0 0 12px 12px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #3a2a12 0 3px,
+      transparent 3px 9px
+    ),
+    #c9a55e;
+  z-index: 5;
+}
+
+.hatb {
+  position: absolute;
+  bottom: 76px;
+  left: 50%;
+  width: 128px;
+  height: 14px;
+  margin-left: -64px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #7a5e2a, #4d3a15);
+  z-index: 6;
+}
+
+.hatt {
+  position: absolute;
+  bottom: 88px;
+  left: 50%;
+  width: 66px;
+  height: 40px;
+  margin-left: -33px;
+  border-radius: 10px 10px 2px 2px;
+  background: linear-gradient(180deg, #8d6c30, #56411a);
+  z-index: 6;
+}
+
+.bird2 {
+  position: absolute;
+  width: 22px;
+  height: 6px;
+  border-radius: 50%;
+  background: #2b2333;
+  box-shadow: 14px -4px 0 -1px #2b2333;
+  z-index: 6;
+  animation: flapb 3.4s ease-in-out infinite;
+}
+
+.bd1 { top: 60px; left: 44px; }
+
+.bd2 {
+  top: 96px;
+  left: 88px;
+  animation-delay: 1.7s;
+}
+
+@keyframes swaysc {
+  0%, 100% { transform: rotate(-1.6deg); }
+  50% { transform: rotate(1.6deg); }
+}
+
+@keyframes tilth {
+  0%, 100% { transform: rotate(4deg); }
+  50% { transform: rotate(-4deg); }
+}
+
+@keyframes rustle {
+  0%, 100% { transform: rotate(var(--sr2, 0deg)); }
+  50% { transform: rotate(calc(var(--sr2, 0deg) + 7deg)); }
+}
+
+@keyframes winks {
+  0%, 88%, 100% { transform: scaleY(1); }
+  94% { transform: scaleY(0.2); }
+}
+
+@keyframes flapb {
+  0%, 100% { transform: translate(0, 0) scaleY(1); }
+  50% { transform: translate(12px, -10px) scaleY(0.5); }
+}
+
+@keyframes glows {
+  0%, 100% { opacity: 0.9; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.04); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crow,
+  .headc,
+  .strawA,
+  .eyec,
+  .bird2,
+  .moons {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a scarecrow built for #45209. The stitched X eyes are two crossed linear gradients in one element: each paints a hard edged diagonal band and leaves the rest transparent, so the X costs no extra markup and no clip path. The figure sways from a `transform-origin: 50% 100%` at the foot of the post, so it leans from the ground rather than spinning around its middle, and the head has its own pivot at the neck and a slightly different phase, so it lolls limply instead of moving rigidly with the body. Reduced motion fallback included. Pure CSS. Closes #45209.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a scarecrow on a post with a sack head, stitched X eyes and mouth, a hat, a striped patched shirt and straw sleeves, in a field at dusk with crows overhead.
