### PR TITLE
Add armadillo component

### DIFF
--- a/submissions/examples/armadillo-as/README.md
+++ b/submissions/examples/armadillo-as/README.md
@@ -1,0 +1,21 @@
+# Armadillo
+
+### What does this do?
+
+It shows an armadillo trotting across sand. Its legs step in sequence, its banded tail waggles, dust puffs up behind it, and it blinks. Hovering or focusing it makes the animal tuck: the head swings in under the shell and the armour bands close up around it. Under reduced motion it stands still and stays uncurled.
+
+### How is it used?
+
+```html
+<div class="dillo" tabindex="0">
+  <span class="shellA"></span>
+  <span class="bandA ba1"></span>
+  <div class="headd"><span class="snoutd"></span></div>
+</div>
+```
+
+Each armour band keeps its own angle in a `--bd` custom property, and the tuck restates the transform as `rotate(calc(var(--bd) * 1.9))`. Multiplying rather than replacing means every band closes further in the direction it already leans, so the plates fold around the shell instead of all snapping to one angle. The head pivots from `transform-origin: 100% 80%`, the neck joint, so it swings in under the shell rather than sliding sideways. Both effects are plain `transition`s, so the whole curl costs no keyframes.
+
+### Why is it useful?
+
+Wildlife, desert, and defensive or "protected" themes use an armadillo. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/armadillo-as/demo.html
+++ b/submissions/examples/armadillo-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Armadillo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="dillo" tabindex="0">
+      <span class="taild"></span>
+      <span class="legd ld1"></span>
+      <span class="legd ld2"></span>
+      <span class="legd ld3"></span>
+      <span class="shellA"></span>
+      <span class="bandA ba1"></span>
+      <span class="bandA ba2"></span>
+      <span class="bandA ba3"></span>
+      <span class="bandA ba4"></span>
+      <div class="headd">
+        <span class="snoutd"></span>
+        <span class="eard edl"></span>
+        <span class="eyed"></span>
+        <span class="nosed"></span>
+      </div>
+    </div>
+    <span class="dustd dd1"></span>
+    <span class="dustd dd2"></span>
+    <span class="sandd"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/armadillo-as/style.css
+++ b/submissions/examples/armadillo-as/style.css
@@ -1,0 +1,263 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #b98a5c, #4a3320 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.sandd {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 62px);
+  background:
+    radial-gradient(circle at 24% 0, rgba(255, 240, 210, 0.16) 0 14px, transparent 14px),
+    radial-gradient(circle at 72% 6%, rgba(255, 240, 210, 0.12) 0 10px, transparent 10px),
+    linear-gradient(180deg, #d8ab72, #8a5f34);
+}
+
+.dillo {
+  position: absolute;
+  bottom: 58px;
+  left: 50%;
+  width: 260px;
+  height: 170px;
+  margin-left: -130px;
+  outline: none;
+  z-index: 4;
+  animation: trot 3.2s ease-in-out infinite;
+}
+
+.shellA {
+  position: absolute;
+  bottom: 28px;
+  left: 46px;
+  width: 170px;
+  height: 104px;
+  border-radius: 50% 50% 30% 30% / 76% 76% 24% 24%;
+  background: linear-gradient(180deg, #b7845a, #6e4526);
+  box-shadow:
+    inset 0 -10px 18px rgba(50, 26, 8, 0.45),
+    inset 0 8px 14px rgba(255, 220, 180, 0.3);
+  z-index: 4;
+}
+
+.bandA {
+  position: absolute;
+  bottom: 36px;
+  left: 50%;
+  width: 16px;
+  height: 70px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, rgba(60, 32, 10, 0.55), rgba(120, 78, 40, 0.2));
+  transform-origin: 50% 100%;
+  transform: rotate(var(--bd, 0deg));
+  transition: transform 0.4s ease;
+  z-index: 5;
+}
+
+.ba1 {
+  margin-left: -52px;
+
+  --bd: -16deg;
+}
+
+.ba2 {
+  margin-left: -22px;
+
+  --bd: -5deg;
+}
+
+.ba3 {
+  margin-left: 8px;
+
+  --bd: 6deg;
+}
+
+.ba4 {
+  margin-left: 38px;
+
+  --bd: 17deg;
+}
+
+.dillo:hover .bandA,
+.dillo:focus-visible .bandA {
+  transform: rotate(calc(var(--bd, 0deg) * 1.9));
+}
+
+.headd {
+  position: absolute;
+  bottom: 34px;
+  left: 8px;
+  width: 76px;
+  height: 66px;
+  transform-origin: 100% 80%;
+  transition: transform 0.4s ease;
+  z-index: 3;
+}
+
+.dillo:hover .headd,
+.dillo:focus-visible .headd {
+  transform: translateX(26px) rotate(34deg);
+}
+
+.snoutd {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 70px;
+  height: 44px;
+  border-radius: 50% 30% 30% 50% / 60% 40% 40% 60%;
+  background: linear-gradient(180deg, #c99a6c, #8a5f34);
+  z-index: 3;
+}
+
+.eard {
+  position: absolute;
+  bottom: 36px;
+  right: 6px;
+  width: 18px;
+  height: 24px;
+  border-radius: 50% 50% 40% 40%;
+  background: #7d5330;
+  z-index: 2;
+}
+
+.eyed {
+  position: absolute;
+  bottom: 28px;
+  left: 34px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #241608;
+  box-shadow: inset -2px 2px 0 -1px rgba(255, 255, 255, 0.8);
+  z-index: 5;
+  animation: blinkd 5s ease-in-out infinite;
+}
+
+.nosed {
+  position: absolute;
+  bottom: 14px;
+  left: 2px;
+  width: 12px;
+  height: 9px;
+  border-radius: 50%;
+  background: #3a2412;
+  z-index: 5;
+}
+
+.legd {
+  position: absolute;
+  bottom: 8px;
+  width: 20px;
+  height: 30px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #8a5f34, #5b3c1c);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: stepd 0.8s ease-in-out infinite;
+}
+
+.ld1 { left: 66px; }
+
+.ld2 {
+  left: 122px;
+  animation-delay: 0.27s;
+}
+
+.ld3 {
+  left: 178px;
+  animation-delay: 0.54s;
+}
+
+.taild {
+  position: absolute;
+  bottom: 30px;
+  right: 6px;
+  width: 66px;
+  height: 14px;
+  border-radius: 7px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(50, 26, 8, 0.5) 0 3px,
+      transparent 3px 12px
+    ),
+    linear-gradient(90deg, #9a6b3d, #6b4522);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: waggle 2.6s ease-in-out infinite;
+}
+
+.dustd {
+  position: absolute;
+  bottom: 52px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(230, 200, 160, 0.6);
+  filter: blur(3px);
+  opacity: 0;
+  z-index: 3;
+  animation: puffd 2.4s ease-out infinite;
+}
+
+.dd1 { right: 62px; }
+
+.dd2 {
+  right: 96px;
+  animation-delay: 1.2s;
+}
+
+@keyframes trot {
+  0%, 100% { transform: translateY(0) rotate(-0.8deg); }
+  50% { transform: translateY(-5px) rotate(0.8deg); }
+}
+
+@keyframes stepd {
+  0%, 100% { transform: rotate(-14deg); }
+  50% { transform: rotate(14deg); }
+}
+
+@keyframes waggle {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(8deg); }
+}
+
+@keyframes blinkd {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes puffd {
+  0% { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  25% { opacity: 0.8; }
+  100% { transform: translate(30px, -26px) scale(1.8); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dillo,
+  .legd,
+  .taild,
+  .eyed,
+  .dustd {
+    animation: none;
+  }
+
+  .bandA,
+  .headd {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an armadillo built for #45216. Each armour band keeps its own angle in a `--bd` custom property, and the tuck restates the transform as `rotate(calc(var(--bd) * 1.9))`. Multiplying rather than replacing means every band closes further in the direction it already leans, so the plates fold around the shell instead of all snapping to one angle. The head pivots from its neck joint so it swings in under the shell rather than sliding sideways, and both effects are plain transitions, so the curl costs no keyframes. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45216.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an armadillo with a banded armour shell, a pointed snout, stepping legs and a ringed tail, trotting across sand with dust behind it.
