### PR TITLE
Add puffin component

### DIFF
--- a/submissions/examples/puffin-as/README.md
+++ b/submissions/examples/puffin-as/README.md
@@ -1,0 +1,24 @@
+# Puffin
+
+### What does this do?
+
+It shows a puffin standing on a sea rock. It bobs in the wind, turns its head from side to side, flexes a wing, shuffles its orange feet, and blinks, while waves roll behind it. Under reduced motion it stands still.
+
+### How is it used?
+
+```html
+<div class="puffin">
+  <span class="bodypf"></span>
+  <span class="bib"></span>
+  <div class="headpf">
+    <span class="skullpf"></span>
+    <span class="beakpf"></span>
+  </div>
+</div>
+```
+
+The head is a wrapper that turns from `transform-origin: 40% 100%`, the point where the neck meets the body, so the beak swings through a real arc while the back of the skull barely moves. Everything inside it, the white cheek, the eye and the striped beak, keeps its own position and simply rides along, which means the head turn costs one rotation rather than five coordinated ones. The beak's shape is a single asymmetric `border-radius`, deep on the left and shallow on the right, which is what gives it the tall wedge profile a puffin has.
+
+### Why is it useful?
+
+Coastal, wildlife, and seabird themes use a puffin. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/puffin-as/demo.html
+++ b/submissions/examples/puffin-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Puffin</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="puffin">
+      <span class="wingpf"></span>
+      <span class="bodypf"></span>
+      <span class="bib"></span>
+      <div class="headpf">
+        <span class="skullpf"></span>
+        <span class="cheekpf"></span>
+        <span class="eyepf"></span>
+        <span class="beakpf"></span>
+        <span class="beakstripe"></span>
+      </div>
+      <span class="footpf fl"></span>
+      <span class="footpf fr"></span>
+    </div>
+    <span class="rock"></span>
+    <span class="wave wv1"></span>
+    <span class="wave wv2"></span>
+    <span class="seapf"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/puffin-as/style.css
+++ b/submissions/examples/puffin-as/style.css
@@ -1,0 +1,239 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #9fd4e8, #4f87a8 62%, #1e3d52);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.seapf {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 70px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.08) 0 4px,
+      transparent 4px 28px
+    ),
+    linear-gradient(180deg, #35708f, #16394c);
+  z-index: 3;
+}
+
+.wave {
+  position: absolute;
+  bottom: 62px;
+  width: 120px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+  filter: blur(2px);
+  z-index: 4;
+  animation: rollw 4s ease-in-out infinite;
+}
+
+.wv1 { left: 20px; }
+
+.wv2 {
+  right: 24px;
+  animation-delay: 2s;
+}
+
+.rock {
+  position: absolute;
+  bottom: 56px;
+  left: 50%;
+  width: 190px;
+  height: 60px;
+  margin-left: -95px;
+  border-radius: 40% 50% 10% 10% / 60% 60% 10% 10%;
+  background: linear-gradient(180deg, #7f8c92, #4a545a);
+  box-shadow: inset 0 -8px 14px rgba(20, 30, 36, 0.5);
+  z-index: 2;
+}
+
+.puffin {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 190px;
+  height: 200px;
+  margin-left: -95px;
+  z-index: 5;
+  animation: bobpf 4.4s ease-in-out infinite;
+}
+
+.bodypf {
+  position: absolute;
+  bottom: 0;
+  left: 34px;
+  width: 122px;
+  height: 140px;
+  border-radius: 50% 50% 44% 44% / 56% 56% 44% 44%;
+  background: linear-gradient(180deg, #2b2b33, #131318);
+  box-shadow: inset -8px -8px 16px rgba(0, 0, 0, 0.4);
+  z-index: 3;
+}
+
+.bib {
+  position: absolute;
+  bottom: 4px;
+  left: 52px;
+  width: 82px;
+  height: 116px;
+  border-radius: 50% 50% 44% 44% / 56% 56% 44% 44%;
+  background: linear-gradient(180deg, #fdfcf8, #d8d5cc);
+  z-index: 4;
+}
+
+.wingpf {
+  position: absolute;
+  bottom: 32px;
+  left: 22px;
+  width: 46px;
+  height: 88px;
+  border-radius: 60% 40% 50% 50% / 60% 40% 50% 50%;
+  background: linear-gradient(180deg, #33333c, #17171c);
+  transform-origin: 60% 12%;
+  z-index: 5;
+  animation: flappf 3.6s ease-in-out infinite;
+}
+
+.headpf {
+  position: absolute;
+  bottom: 118px;
+  left: 32px;
+  width: 130px;
+  height: 84px;
+  transform-origin: 40% 100%;
+  z-index: 6;
+  animation: turnpf 5s ease-in-out infinite;
+}
+
+.skullpf {
+  position: absolute;
+  bottom: 0;
+  left: 18px;
+  width: 88px;
+  height: 80px;
+  border-radius: 50% 50% 44% 44%;
+  background: linear-gradient(180deg, #2b2b33, #131318);
+  z-index: 3;
+}
+
+.cheekpf {
+  position: absolute;
+  bottom: 12px;
+  left: 24px;
+  width: 60px;
+  height: 54px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #fdfcf8, #dbd8cf);
+  z-index: 4;
+}
+
+.eyepf {
+  position: absolute;
+  bottom: 44px;
+  left: 42px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #14141a;
+  box-shadow: 0 0 0 3px rgba(200, 60, 40, 0.35);
+  z-index: 6;
+  animation: blinkpf 5s ease-in-out infinite;
+}
+
+.beakpf {
+  position: absolute;
+  bottom: 16px;
+  left: -2px;
+  width: 54px;
+  height: 44px;
+  border-radius: 60% 20% 20% 60% / 60% 30% 30% 60%;
+  background: linear-gradient(180deg, #f4a63a, #d9511f);
+  box-shadow: inset -4px 0 8px rgba(120, 40, 6, 0.4);
+  z-index: 5;
+}
+
+.beakstripe {
+  position: absolute;
+  bottom: 20px;
+  left: 22px;
+  width: 10px;
+  height: 36px;
+  border-radius: 4px;
+  background: #f7e1a8;
+  z-index: 6;
+}
+
+.footpf {
+  position: absolute;
+  bottom: -10px;
+  width: 40px;
+  height: 14px;
+  border-radius: 8px 10px 6px 6px;
+  background: linear-gradient(180deg, #f2a13a, #c96a12);
+  z-index: 2;
+  animation: shufflepf 3.2s ease-in-out infinite;
+}
+
+.fl { left: 46px; }
+
+.fr {
+  left: 106px;
+  animation-delay: 1.6s;
+}
+
+@keyframes bobpf {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-7px) rotate(1deg); }
+}
+
+@keyframes turnpf {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes flappf {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-14deg); }
+}
+
+@keyframes shufflepf {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(4px); }
+}
+
+@keyframes blinkpf {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes rollw {
+  0%, 100% { transform: translateX(0) scaleX(1); opacity: 0.5; }
+  50% { transform: translateX(16px) scaleX(1.15); opacity: 0.8; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .puffin,
+  .headpf,
+  .wingpf,
+  .footpf,
+  .eyepf,
+  .wave {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a puffin built for #45218. The head is a wrapper that turns from a `transform-origin` at the neck, so the beak swings through a real arc while the back of the skull barely moves, and everything inside it (cheek, eye, striped beak) keeps its own position and rides along, which means the head turn costs one rotation rather than five coordinated ones. The beak's tall wedge profile comes from a single asymmetric border-radius, deep on one side and shallow on the other. Reduced motion fallback included. Pure CSS. Closes #45218.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a puffin with a black back, white bib and cheek, a striped orange beak and orange feet, standing on a rock above the sea.
