### PR TITLE
Add sea urchin component

### DIFF
--- a/submissions/examples/sea-urchin-as/README.md
+++ b/submissions/examples/sea-urchin-as/README.md
@@ -1,0 +1,21 @@
+# Sea Urchin
+
+### What does this do?
+
+It shows a sea urchin on the reef. Its twelve spines sway in the current one after another, the body pulses, and the crown at the top glows. Hovering or focusing it makes every spine push outward and stiffen, the way an urchin bristles when something touches it. Under reduced motion it sits still.
+
+### How is it used?
+
+```html
+<div class="urchin" tabindex="0">
+  <span class="spineu su1"></span>
+  <span class="spineu su2"></span>
+  <span class="testu"></span>
+</div>
+```
+
+Every spine is placed with `rotate(var(--ur)) translateY(-8px)`: rotate first, then push outward, so a single angle both aims the spine and sets how far from the centre it sits. Twelve spines at 30 degree steps therefore fill a full circle from one shared rule. Both the sway keyframe and the bristle hover state rebuild that same `rotate(var(--ur))` before adding their own offset, so neither one ever flattens a spine back to zero degrees.
+
+### Why is it useful?
+
+Ocean, reef, and defensive or spiky themes use a sea urchin. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/sea-urchin-as/demo.html
+++ b/submissions/examples/sea-urchin-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sea Urchin</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="raysu"></span>
+    <div class="urchin" tabindex="0">
+      <span class="spineu su1"></span>
+      <span class="spineu su2"></span>
+      <span class="spineu su3"></span>
+      <span class="spineu su4"></span>
+      <span class="spineu su5"></span>
+      <span class="spineu su6"></span>
+      <span class="spineu su7"></span>
+      <span class="spineu su8"></span>
+      <span class="spineu su9"></span>
+      <span class="spineu su10"></span>
+      <span class="spineu su11"></span>
+      <span class="spineu su12"></span>
+      <span class="testu"></span>
+      <span class="crown"></span>
+    </div>
+    <span class="bubu bu1"></span>
+    <span class="bubu bu2"></span>
+    <span class="reef"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sea-urchin-as/style.css
+++ b/submissions/examples/sea-urchin-as/style.css
@@ -1,0 +1,242 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #1c6d8c, #05202e 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 320px;
+}
+
+.raysu {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 240px);
+  background:
+    repeating-linear-gradient(
+      98deg,
+      rgba(190, 245, 255, 0.06) 0 24px,
+      transparent 24px 92px
+    );
+  pointer-events: none;
+}
+
+.reef {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 60px);
+  background:
+    radial-gradient(circle at 22% 0, rgba(255, 240, 200, 0.14) 0 24px, transparent 24px),
+    radial-gradient(circle at 68% 4%, rgba(255, 240, 200, 0.1) 0 18px, transparent 18px),
+    linear-gradient(180deg, #3d5f66, #16303a);
+}
+
+.urchin {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 220px;
+  height: 220px;
+  margin-left: -110px;
+  outline: none;
+  z-index: 4;
+  animation: pulseu 4.4s ease-in-out infinite;
+}
+
+.testu {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 104px;
+  height: 104px;
+  margin: -52px 0 0 -52px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #6b3d9e, #2c1450 74%);
+  box-shadow:
+    inset -8px -8px 18px rgba(20, 6, 40, 0.6),
+    0 12px 26px rgba(0, 0, 0, 0.45);
+  z-index: 5;
+}
+
+.crown {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      #f2a8ff 0 12deg,
+      #7b3ea8 12deg 24deg
+    );
+  box-shadow: 0 0 12px rgba(230, 160, 255, 0.7);
+  z-index: 6;
+  animation: glowu 3.2s ease-in-out infinite;
+}
+
+.spineu {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 96px;
+  margin: -96px 0 0 -5px;
+  border-radius: 5px 5px 2px 2px;
+  background: linear-gradient(180deg, #d9a6ff, #4a1f78);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--ur, 0deg)) translateY(-8px);
+  transition: transform 0.5s ease;
+  z-index: 4;
+  animation: swayu 4.4s ease-in-out infinite;
+}
+
+.urchin:hover .spineu,
+.urchin:focus-visible .spineu {
+  transform: rotate(var(--ur, 0deg)) translateY(-26px) scaleY(1.14);
+}
+
+.su1 {
+  --ur: 0deg;
+}
+
+.su2 {
+  --ur: 30deg;
+
+  animation-delay: 0.15s;
+}
+
+.su3 {
+  --ur: 60deg;
+
+  animation-delay: 0.3s;
+}
+
+.su4 {
+  --ur: 90deg;
+
+  animation-delay: 0.45s;
+}
+
+.su5 {
+  --ur: 120deg;
+
+  animation-delay: 0.6s;
+}
+
+.su6 {
+  --ur: 150deg;
+
+  animation-delay: 0.75s;
+}
+
+.su7 {
+  --ur: 180deg;
+
+  animation-delay: 0.9s;
+}
+
+.su8 {
+  --ur: 210deg;
+
+  animation-delay: 1.05s;
+}
+
+.su9 {
+  --ur: 240deg;
+
+  animation-delay: 1.2s;
+}
+
+.su10 {
+  --ur: 270deg;
+
+  animation-delay: 1.35s;
+}
+
+.su11 {
+  --ur: 300deg;
+
+  animation-delay: 1.5s;
+}
+
+.su12 {
+  --ur: 330deg;
+
+  animation-delay: 1.65s;
+}
+
+.bubu {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 245, 255, 0.7);
+  opacity: 0;
+  z-index: 5;
+  animation: upu 5.4s ease-in infinite;
+}
+
+.bu1 {
+  bottom: 150px;
+  left: 60px;
+  width: 12px;
+  height: 12px;
+}
+
+.bu2 {
+  bottom: 170px;
+  right: 66px;
+  width: 8px;
+  height: 8px;
+  animation-delay: 2.7s;
+}
+
+@keyframes pulseu {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+}
+
+@keyframes swayu {
+  0%, 100% { transform: rotate(var(--ur, 0deg)) translateY(-8px); }
+  50% { transform: rotate(calc(var(--ur, 0deg) + 4deg)) translateY(-12px); }
+}
+
+@keyframes glowu {
+  0%, 100% { opacity: 0.75; transform: rotate(0deg); }
+  50% { opacity: 1; transform: rotate(20deg); }
+}
+
+@keyframes upu {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translateY(-150px) translateX(18px) scale(1.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .urchin,
+  .spineu,
+  .crown,
+  .bubu {
+    animation: none;
+  }
+
+  .spineu {
+    transition: none;
+  }
+
+  .bubu {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sea urchin built for #45224. Every spine is placed with `rotate(var(--ur)) translateY(-8px)`, rotating first and then pushing outward, so a single angle both aims the spine and sets how far from the centre it sits, and twelve spines at 30 degree steps fill a full circle from one shared rule. Both the sway keyframe and the bristle hover state rebuild that same rotation before adding their own offset, so neither ever flattens a spine back to zero. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45224.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a purple sea urchin with twelve spines radiating evenly around a round body and a glowing crown, over a reef bed.
