### PR TITLE
Add platypus component

### DIFF
--- a/submissions/examples/platypus-as/README.md
+++ b/submissions/examples/platypus-as/README.md
@@ -1,0 +1,24 @@
+# Platypus
+
+### What does this do?
+
+It shows a platypus paddling along a creek. It rides the surface, dips its bill, sweeps its flat tail to steer, rows with its webbed paws, and blinks, while ripples spread and bubbles rise around it. Under reduced motion it floats still.
+
+### How is it used?
+
+```html
+<div class="platy">
+  <span class="bodyp2"></span>
+  <span class="tailp2"></span>
+  <div class="headp2">
+    <span class="skullp2"></span>
+    <span class="bill"></span>
+  </div>
+</div>
+```
+
+The bill's shape is one asymmetric `border-radius`: heavily rounded on the outer end and nearly square where it meets the face, which is what gives it the flat duck-bill profile without a clip path. The head dips from `transform-origin: 92% 80%`, the point where the skull meets the neck, so the bill sweeps down into the water while the back of the head stays put. The tail steers from its own root, and the two paws row on the same keyframe half a cycle apart, so they alternate rather than paddling together.
+
+### Why is it useful?
+
+Wildlife, river, and unusual animal themes use a platypus. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/platypus-as/demo.html
+++ b/submissions/examples/platypus-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Platypus</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="platy">
+      <span class="tailp2"></span>
+      <span class="bodyp2"></span>
+      <span class="pawp pp1"></span>
+      <span class="pawp pp2"></span>
+      <div class="headp2">
+        <span class="skullp2"></span>
+        <span class="eyep2 epl"></span>
+        <span class="eyep2 epr"></span>
+        <span class="bill"></span>
+        <span class="nostril"></span>
+      </div>
+    </div>
+    <span class="ripplep rp1"></span>
+    <span class="ripplep rp2"></span>
+    <span class="bubp bp1"></span>
+    <span class="bubp bp2"></span>
+    <span class="creek"></span>
+    <span class="reedp rd1"></span>
+    <span class="reedp rd2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/platypus-as/style.css
+++ b/submissions/examples/platypus-as/style.css
@@ -1,0 +1,267 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #4c7f6a, #12261f 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.creek {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 120px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.07) 0 4px,
+      transparent 4px 30px
+    ),
+    linear-gradient(180deg, #3d8f7a, #14392f);
+  z-index: 5;
+}
+
+.reedp {
+  position: absolute;
+  bottom: 104px;
+  width: 12px;
+  height: 92px;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(180deg, #6fbf5f, #2f6f34);
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: swayrd 4.6s ease-in-out infinite;
+}
+
+.rd1 { left: 34px; }
+
+.rd2 {
+  right: 40px;
+  height: 72px;
+  animation-delay: 1.8s;
+}
+
+.ripplep {
+  position: absolute;
+  bottom: 108px;
+  left: 50%;
+  width: 160px;
+  height: 20px;
+  margin-left: -80px;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 255, 245, 0.55);
+  opacity: 0;
+  z-index: 6;
+  animation: spreadp2 4.2s ease-out infinite;
+}
+
+.rp2 { animation-delay: 2.1s; }
+
+.platy {
+  position: absolute;
+  bottom: 128px;
+  left: 50%;
+  width: 280px;
+  height: 130px;
+  margin-left: -140px;
+  z-index: 4;
+  animation: paddle 4.2s ease-in-out infinite;
+}
+
+.bodyp2 {
+  position: absolute;
+  bottom: 0;
+  left: 74px;
+  width: 150px;
+  height: 72px;
+  border-radius: 46% 40% 40% 46% / 56% 50% 50% 56%;
+  background: linear-gradient(180deg, #8a5f3c, #4e3320);
+  box-shadow: inset 0 -8px 16px rgba(30, 18, 8, 0.45);
+  z-index: 3;
+}
+
+.tailp2 {
+  position: absolute;
+  bottom: 6px;
+  right: 4px;
+  width: 92px;
+  height: 40px;
+  border-radius: 10px 50% 50% 10px / 10px 60% 60% 10px;
+  background: linear-gradient(90deg, #6f4a2c, #3d2716);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: steer 3.2s ease-in-out infinite;
+}
+
+.pawp {
+  position: absolute;
+  bottom: -6px;
+  width: 40px;
+  height: 18px;
+  border-radius: 6px 12px 10px 6px;
+  background: linear-gradient(180deg, #6b4728, #442b16);
+  transform-origin: 20% 20%;
+  z-index: 2;
+  animation: rowp 1.6s ease-in-out infinite;
+}
+
+.pp1 { left: 96px; }
+
+.pp2 {
+  left: 158px;
+  animation-delay: 0.8s;
+}
+
+.headp2 {
+  position: absolute;
+  bottom: 40px;
+  left: 6px;
+  width: 130px;
+  height: 84px;
+  transform-origin: 92% 80%;
+  z-index: 5;
+  animation: dip 4.2s ease-in-out infinite;
+}
+
+.skullp2 {
+  position: absolute;
+  bottom: 0;
+  right: 6px;
+  width: 78px;
+  height: 66px;
+  border-radius: 46% 50% 44% 44% / 52% 52% 48% 48%;
+  background: linear-gradient(180deg, #96683f, #5c3c22);
+  z-index: 3;
+}
+
+.eyep2 {
+  position: absolute;
+  bottom: 40px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #20140a;
+  box-shadow: inset -2px 2px 0 -1px rgba(255, 255, 255, 0.8);
+  z-index: 5;
+  animation: blinkp2 5s ease-in-out infinite;
+}
+
+.epl { right: 54px; }
+.epr { right: 22px; }
+
+.bill {
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  width: 84px;
+  height: 34px;
+  border-radius: 50% 22% 22% 50% / 60% 40% 40% 60%;
+  background: linear-gradient(180deg, #6f8794, #3f515d);
+  box-shadow: inset 0 -4px 8px rgba(20, 30, 40, 0.45);
+  z-index: 4;
+}
+
+.nostril {
+  position: absolute;
+  bottom: 24px;
+  left: 8px;
+  width: 8px;
+  height: 5px;
+  border-radius: 50%;
+  background: #1e2830;
+  box-shadow: 12px 0 0 -1px #1e2830;
+  z-index: 5;
+}
+
+.bubp {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 255, 245, 0.7);
+  opacity: 0;
+  z-index: 6;
+  animation: upp 4.6s ease-in infinite;
+}
+
+.bp1 {
+  bottom: 150px;
+  left: 74px;
+  width: 10px;
+  height: 10px;
+}
+
+.bp2 {
+  bottom: 168px;
+  left: 52px;
+  width: 7px;
+  height: 7px;
+  animation-delay: 2.3s;
+}
+
+@keyframes paddle {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-7px) rotate(1deg); }
+}
+
+@keyframes dip {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes steer {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(7deg); }
+}
+
+@keyframes rowp {
+  0%, 100% { transform: rotate(-16deg); }
+  50% { transform: rotate(16deg); }
+}
+
+@keyframes blinkp2 {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes swayrd {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes spreadp2 {
+  0% { transform: scale(0.4); opacity: 0.8; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+@keyframes upp {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translateY(-120px) translateX(16px) scale(1.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .platy,
+  .headp2,
+  .tailp2,
+  .pawp,
+  .eyep2,
+  .reedp,
+  .ripplep,
+  .bubp {
+    animation: none;
+  }
+
+  .ripplep,
+  .bubp {
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a platypus built for #45228. The bill's flat duck profile is one asymmetric border-radius, heavily rounded on the outer end and nearly square where it meets the face, with no clip path. The head dips from a `transform-origin` where the skull meets the neck, so the bill sweeps down into the water while the back of the head stays put, the tail steers from its own root, and the two paws run the same keyframe half a cycle apart so they alternate rather than paddling together. Reduced motion fallback included. Pure CSS. Closes #45228.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a platypus with a grey duck bill, webbed paws and a flat paddle tail, riding the surface of a creek with reeds and ripples.
