### PR TITLE
Add avocado component

### DIFF
--- a/submissions/examples/avocado-as/README.md
+++ b/submissions/examples/avocado-as/README.md
@@ -1,0 +1,23 @@
+# Avocado
+
+### What does this do?
+
+It shows an avocado on a cutting board. It bobs gently and the pit shifts in its socket. Hovering or focusing it splits the fruit: the two halves swing apart and tilt away from each other, revealing the pit on one side and the empty hollow on the other. Under reduced motion it sits closed and still.
+
+### How is it used?
+
+```html
+<div class="avo" tabindex="0">
+  <div class="halfA left">
+    <span class="skinA"></span>
+    <span class="fleshA"></span>
+    <span class="pitA"></span>
+  </div>
+</div>
+```
+
+Only one half is actually designed. The right half reuses the same markup and is flipped with `scaleX(-1)`, so the two sides mirror each other exactly without a second set of shapes. That flip is the reason the hover rule looks asymmetric: the right half's `translateX(-34px)` moves it right on screen, because it is written in the flipped half's own coordinate space. The flesh is a `radial-gradient` running from pale yellow at the pit out to green at the skin, which is what makes it read as a cut surface rather than a flat disc.
+
+### Why is it useful?
+
+Food, brunch, and fresh produce themes use an avocado. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/avocado-as/demo.html
+++ b/submissions/examples/avocado-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Avocado</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="avo" tabindex="0">
+      <div class="halfA left">
+        <span class="skinA"></span>
+        <span class="fleshA"></span>
+        <span class="pitA"></span>
+        <span class="glossA"></span>
+      </div>
+      <div class="halfA right">
+        <span class="skinA"></span>
+        <span class="fleshA"></span>
+        <span class="hollow"></span>
+      </div>
+    </div>
+    <span class="boardA"></span>
+    <span class="crumbA ca1"></span>
+    <span class="crumbA ca2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/avocado-as/style.css
+++ b/submissions/examples/avocado-as/style.css
@@ -1,0 +1,176 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #3f4a35, #14180f 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.boardA {
+  position: absolute;
+  bottom: 48px;
+  left: 50%;
+  width: 300px;
+  height: 28px;
+  margin-left: -150px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(80, 50, 20, 0.28) 0 2px,
+      transparent 2px 26px
+    ),
+    linear-gradient(180deg, #c39a63, #8a6a3c);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.5);
+}
+
+.avo {
+  position: absolute;
+  bottom: 70px;
+  left: 50%;
+  width: 300px;
+  height: 200px;
+  margin-left: -150px;
+  outline: none;
+  z-index: 4;
+  animation: bobA 4.2s ease-in-out infinite;
+}
+
+.halfA {
+  position: absolute;
+  bottom: 0;
+  width: 130px;
+  height: 190px;
+  transition: transform 0.5s ease;
+}
+
+.left {
+  left: 22px;
+  transform: rotate(-4deg);
+}
+
+.right {
+  right: 22px;
+  transform: rotate(4deg) scaleX(-1);
+}
+
+.avo:hover .left,
+.avo:focus-visible .left {
+  transform: rotate(-12deg) translateX(-34px);
+}
+
+.avo:hover .right,
+.avo:focus-visible .right {
+  transform: rotate(12deg) scaleX(-1) translateX(-34px);
+}
+
+.skinA {
+  position: absolute;
+  inset: 0;
+  border-radius: 46% 46% 40% 40% / 32% 32% 68% 68%;
+  background: linear-gradient(180deg, #3f6b2c, #22401a);
+  box-shadow:
+    inset -6px -6px 14px rgba(10, 24, 6, 0.5),
+    0 12px 24px rgba(0, 0, 0, 0.4);
+}
+
+.fleshA {
+  position: absolute;
+  inset: 10px;
+  border-radius: 46% 46% 40% 40% / 32% 32% 68% 68%;
+  background: radial-gradient(circle at 44% 62%, #f2eda0, #a8c85e 62%, #74a545);
+  z-index: 2;
+}
+
+.pitA {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 66px;
+  height: 66px;
+  margin-left: -33px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #b07a3c, #6d4318 72%);
+  box-shadow: inset -4px -4px 10px rgba(50, 26, 4, 0.5);
+  z-index: 4;
+  animation: nudge 4.2s ease-in-out infinite;
+}
+
+.hollow {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 66px;
+  height: 66px;
+  margin-left: -33px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #9dbb5c, #6f9640 70%);
+  box-shadow: inset 0 6px 12px rgba(50, 70, 20, 0.45);
+  z-index: 3;
+}
+
+.glossA {
+  position: absolute;
+  top: 30px;
+  left: 26px;
+  width: 26px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.28);
+  filter: blur(4px);
+  z-index: 5;
+}
+
+.crumbA {
+  position: absolute;
+  bottom: 74px;
+  width: 9px;
+  height: 6px;
+  border-radius: 3px;
+  background: #8fae52;
+  z-index: 5;
+  animation: jiggleA 3s ease-in-out infinite;
+}
+
+.ca1 { left: 62px; }
+
+.ca2 {
+  right: 66px;
+  animation-delay: 1.5s;
+}
+
+@keyframes bobA {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@keyframes nudge {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-3px) rotate(2deg); }
+}
+
+@keyframes jiggleA {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .avo,
+  .pitA,
+  .crumbA {
+    animation: none;
+  }
+
+  .halfA {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an avocado built for #45232. Only one half is actually designed: the right half reuses the same markup and is flipped with `scaleX(-1)`, so both sides mirror exactly without a second set of shapes. That flip is why the hover rule looks asymmetric, since the right half's `translateX(-34px)` moves it right on screen, written in the flipped half's own coordinate space. The flesh is a radial gradient running from pale yellow at the pit out to green at the skin, which is what makes it read as a cut surface rather than a flat disc. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45232.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an avocado cut in two on a board, with a brown pit in one half and an empty hollow in the other, flesh grading from pale centre to green skin.
