### PR TITLE
Add pomegranate component

### DIFF
--- a/submissions/examples/pomegranate-as/README.md
+++ b/submissions/examples/pomegranate-as/README.md
@@ -1,0 +1,21 @@
+# Pomegranate
+
+### What does this do?
+
+It shows a pomegranate on a plate with a few loose seeds beside it. The fruit bobs, its crown turns slowly, and light glints off the rind. Hovering or focusing it opens the fruit: the pale pith and the packed red arils fade in, as if it had been cut across. Under reduced motion it stays whole and still.
+
+### How is it used?
+
+```html
+<div class="pom" tabindex="0">
+  <span class="rindP"></span>
+  <span class="arils"></span>
+  <span class="crownP"></span>
+</div>
+```
+
+The entire cut face is a single element. Eight hard stop `radial-gradient` circles paint the seeds, and the last layer in the same stack is a soft gradient for the pale pith they sit in, so one background does the whole interior and the seeds clip to the disc for free. Keeping it to one element also matters for the reveal: it is one `opacity` transition, and stacking a second translucent layer on top of the rind produced visible compositing seams in Chromium, which disappeared once the two were merged. The crown is a `conic-gradient` alternating between colour and `transparent`, which cuts the pointed calyx out of one square element without a clip path.
+
+### Why is it useful?
+
+Fruit, food, and seasonal themes use a pomegranate. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/pomegranate-as/demo.html
+++ b/submissions/examples/pomegranate-as/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pomegranate</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="pom" tabindex="0">
+      <span class="rindP"></span>
+      <span class="arils"></span>
+      <span class="crownP"></span>
+      <span class="glossP"></span>
+    </div>
+    <span class="seedP se1"></span>
+    <span class="seedP se2"></span>
+    <span class="seedP se3"></span>
+    <span class="plate3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pomegranate-as/style.css
+++ b/submissions/examples/pomegranate-as/style.css
@@ -1,0 +1,191 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #4a2b33, #170d10 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.plate3 {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 270px;
+  height: 26px;
+  margin-left: -135px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #e8e0d2, #9b9184);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.5);
+}
+
+.pom {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 220px;
+  height: 240px;
+  margin-left: -110px;
+  outline: none;
+  z-index: 4;
+  animation: bobP 4.6s ease-in-out infinite;
+}
+
+.rindP {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 200px;
+  height: 196px;
+  margin-left: -100px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #d8433f, #8c1220 74%);
+  box-shadow:
+    inset -12px -12px 26px rgba(70, 6, 16, 0.55),
+    0 14px 30px rgba(0, 0, 0, 0.45);
+  z-index: 3;
+}
+
+.arils {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  width: 148px;
+  height: 148px;
+  margin-left: -74px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 26%, #e8354f 0 15px, transparent 15px),
+    radial-gradient(circle at 62% 20%, #c4162f 0 13px, transparent 13px),
+    radial-gradient(circle at 76% 44%, #e8354f 0 14px, transparent 14px),
+    radial-gradient(circle at 26% 54%, #c4162f 0 14px, transparent 14px),
+    radial-gradient(circle at 52% 50%, #f0526a 0 15px, transparent 15px),
+    radial-gradient(circle at 70% 74%, #c4162f 0 13px, transparent 13px),
+    radial-gradient(circle at 38% 80%, #e8354f 0 14px, transparent 14px),
+    radial-gradient(circle at 12% 76%, #c4162f 0 11px, transparent 11px),
+    radial-gradient(circle at 42% 38%, #fdf3e0, #e0cdb0 72%);
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  z-index: 5;
+}
+
+.pom:hover .arils,
+.pom:focus-visible .arils {
+  opacity: 1;
+}
+
+.crownP {
+  position: absolute;
+  bottom: 176px;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  margin-left: -22px;
+  background:
+    conic-gradient(
+      from 0deg,
+      #8c1220 0 30deg,
+      transparent 30deg 60deg,
+      #a8202e 60deg 90deg,
+      transparent 90deg 120deg,
+      #8c1220 120deg 150deg,
+      transparent 150deg 180deg,
+      #a8202e 180deg 210deg,
+      transparent 210deg 240deg,
+      #8c1220 240deg 270deg,
+      transparent 270deg 300deg,
+      #a8202e 300deg 330deg,
+      transparent 330deg 360deg
+    );
+  z-index: 6;
+  animation: crownSpin 12s linear infinite;
+}
+
+.glossP {
+  position: absolute;
+  bottom: 118px;
+  left: 50%;
+  width: 34px;
+  height: 52px;
+  margin-left: -62px;
+  border-radius: 50%;
+  background: rgba(255, 230, 220, 0.35);
+  filter: blur(5px);
+  z-index: 6;
+  animation: glintP 3.6s ease-in-out infinite;
+}
+
+.seedP {
+  position: absolute;
+  bottom: 66px;
+  width: 16px;
+  height: 20px;
+  border-radius: 50% 50% 45% 45% / 60% 60% 40% 40%;
+  background: radial-gradient(circle at 36% 32%, #f0526a, #a8122a 72%);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  transform: rotate(var(--sp, 0deg));
+  z-index: 5;
+  animation: rollP 3.4s ease-in-out infinite;
+}
+
+.se1 {
+  left: 44px;
+
+  --sp: -18deg;
+}
+
+.se2 {
+  left: 74px;
+
+  --sp: 14deg;
+
+  animation-delay: 0.8s;
+}
+
+.se3 {
+  right: 52px;
+
+  --sp: 26deg;
+
+  animation-delay: 1.6s;
+}
+
+@keyframes bobP {
+  0%, 100% { transform: translateY(0) rotate(-1.5deg); }
+  50% { transform: translateY(-8px) rotate(1.5deg); }
+}
+
+@keyframes crownSpin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes glintP {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 0.75; }
+}
+
+@keyframes rollP {
+  0%, 100% { transform: rotate(var(--sp, 0deg)) translateY(0); }
+  50% { transform: rotate(var(--sp, 0deg)) translateY(-4px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pom,
+  .crownP,
+  .glossP,
+  .seedP {
+    animation: none;
+  }
+
+  .arils {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pomegranate built for #45234. The whole cut face is one element: eight hard stop radial gradients paint the seeds and the last layer of the same stack is the pale pith they sit in, so a single background does the entire interior and the seeds clip to the disc for free. Keeping it to one element also fixed a real bug: when the pith was a separate translucent layer over the rind, Chromium showed faint compositing seams across the fruit, and merging the two removed them. The crown is a conic gradient alternating between colour and transparent, which cuts the pointed calyx out of one square element with no clip path. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45234.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with screenshots of both states: closed, a red pomegranate with a pointed crown on a plate; opened on hover, a pale pith packed with red arils, with no rendering seams.
