### PR TITLE
Add chili pepper component

### DIFF
--- a/submissions/examples/chili-pepper-as/README.md
+++ b/submissions/examples/chili-pepper-as/README.md
@@ -1,0 +1,21 @@
+# Chili Pepper
+
+### What does this do?
+
+It shows a red chili hanging by its stem. It swings gently, heat shimmers rise off it, and a warm glow pulses behind it. Hovering or focusing the chili makes it shake fast, as if it is too hot to hold. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="chili" tabindex="0">
+  <span class="stemc"></span>
+  <span class="pod pd1"></span>
+  <span class="pod pd2"></span>
+</div>
+```
+
+The curved pod is four tapering segments, each pivoted from `transform-origin: 50% 0`, its own top edge, and each turned a little further than the one above it via a `--pc` custom property. Chaining the pivots that way bends the pepper into a natural hook without a single clip path, and because each segment is narrower and shorter than the last, the tip tapers to a point. The whole chili swings from `50% 6%`, the point where the stem attaches, so it arcs from where it actually hangs.
+
+### Why is it useful?
+
+Food, spice, and heat or "hot" themes use a chili. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/chili-pepper-as/demo.html
+++ b/submissions/examples/chili-pepper-as/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chili Pepper</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="chili" tabindex="0">
+      <span class="stemc"></span>
+      <span class="calyx"></span>
+      <span class="pod pd1"></span>
+      <span class="pod pd2"></span>
+      <span class="pod pd3"></span>
+      <span class="pod pd4"></span>
+      <span class="shinec"></span>
+    </div>
+    <span class="heat h1"></span>
+    <span class="heat h2"></span>
+    <span class="heat h3"></span>
+    <span class="glowc"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/chili-pepper-as/style.css
+++ b/submissions/examples/chili-pepper-as/style.css
@@ -1,0 +1,202 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #3a1f22, #130a0b 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 340px;
+}
+
+.glowc {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 240px;
+  height: 240px;
+  margin-left: -120px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 80, 30, 0.28), transparent 66%);
+  filter: blur(10px);
+  animation: burn 2.8s ease-in-out infinite;
+}
+
+.chili {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 200px;
+  height: 270px;
+  margin-left: -100px;
+  outline: none;
+  transform-origin: 50% 6%;
+  z-index: 4;
+  animation: swingc2 4.4s ease-in-out infinite;
+}
+
+.chili:hover,
+.chili:focus-visible {
+  animation: shake 0.4s ease-in-out infinite;
+}
+
+.stemc {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 12px;
+  height: 46px;
+  margin-left: -6px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #6fa04a, #3d6b28);
+  transform: rotate(6deg);
+  z-index: 5;
+}
+
+.calyx {
+  position: absolute;
+  top: 38px;
+  left: 50%;
+  width: 60px;
+  height: 26px;
+  margin-left: -30px;
+  border-radius: 50% 50% 40% 40%;
+  background: linear-gradient(180deg, #79b053, #3d6b28);
+  box-shadow: inset 0 -4px 6px rgba(20, 50, 10, 0.4);
+  z-index: 5;
+}
+
+.pod {
+  position: absolute;
+  left: 50%;
+  border-radius: 50% 50% 46% 46% / 30% 30% 70% 70%;
+  background: linear-gradient(180deg, #f0402c, #a10f14);
+  box-shadow: inset -8px -8px 18px rgba(90, 6, 10, 0.5);
+  transform-origin: 50% 0;
+  transform: rotate(var(--pc, 0deg));
+  z-index: 3;
+}
+
+.pd1 {
+  top: 52px;
+  width: 78px;
+  height: 124px;
+  margin-left: -39px;
+
+  --pc: -2deg;
+}
+
+.pd2 {
+  top: 136px;
+  width: 68px;
+  height: 104px;
+  margin-left: -32px;
+
+  --pc: 10deg;
+}
+
+.pd3 {
+  top: 202px;
+  width: 54px;
+  height: 80px;
+  margin-left: -18px;
+
+  --pc: 22deg;
+}
+
+.pd4 {
+  top: 250px;
+  width: 36px;
+  height: 54px;
+  margin-left: 0;
+
+  --pc: 34deg;
+}
+
+.shinec {
+  position: absolute;
+  top: 76px;
+  left: 50%;
+  width: 18px;
+  height: 62px;
+  margin-left: -30px;
+  border-radius: 50%;
+  background: rgba(255, 220, 200, 0.45);
+  filter: blur(3px);
+  z-index: 6;
+  animation: glintc 3.4s ease-in-out infinite;
+}
+
+.heat {
+  position: absolute;
+  bottom: 230px;
+  width: 16px;
+  height: 26px;
+  border-radius: 50% 50% 44% 44% / 66% 66% 34% 34%;
+  background: linear-gradient(180deg, rgba(255, 200, 90, 0.85), rgba(255, 90, 30, 0.4));
+  filter: blur(3px);
+  opacity: 0;
+  z-index: 5;
+  animation: rise2 3s ease-out infinite;
+}
+
+.h1 { left: 96px; }
+
+.h2 {
+  left: 140px;
+  animation-delay: 1s;
+
+  --hx: 18px;
+}
+
+.h3 {
+  left: 178px;
+  animation-delay: 2s;
+
+  --hx: -14px;
+}
+
+@keyframes swingc2 {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes shake {
+  0%, 100% { transform: rotate(-2deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@keyframes glintc {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 0.8; }
+}
+
+@keyframes burn {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.08); }
+}
+
+@keyframes rise2 {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.9; }
+  100% { transform: translate(var(--hx, 10px), -70px) scale(1.6); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chili,
+  .shinec,
+  .glowc,
+  .heat {
+    animation: none;
+  }
+
+  .heat {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a chili pepper built for #45236. The curved pod is four overlapping segments, each pivoted from `transform-origin: 50% 0` at its own top edge and turned a little further than the one above via a `--pc` custom property. Chaining the pivots bends the pepper into a natural hook with no clip path, and because each segment is narrower and shorter than the last, the tip tapers to a point. The whole chili swings from the point where the stem attaches, so it arcs from where it actually hangs. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45236.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a red chili with a green stem and calyx, its body curving and tapering to a point, with heat shimmer rising and a warm glow behind it.
