### PR TITLE
Add corn cob component

### DIFF
--- a/submissions/examples/corn-cob-as/README.md
+++ b/submissions/examples/corn-cob-as/README.md
@@ -1,0 +1,21 @@
+# Corn Cob
+
+### What does this do?
+
+It shows a buttered cob of corn on a table. It leans gently, the silk threads wave, butter slides down the kernels, steam curls off it, and light glints along the cob. Hovering or focusing it peels the husks wide open. Under reduced motion it stands still and the husks stay closed.
+
+### How is it used?
+
+```html
+<div class="corn" tabindex="0">
+  <span class="cob"></span>
+  <span class="kernels"></span>
+  <span class="husk hkl"></span>
+</div>
+```
+
+The kernels are two crossed `repeating-linear-gradient`s laid over a cob shaped element. Because both are clipped by the same `border-radius`, the grid curves with the cob and stops cleanly at its rounded ends, so several hundred kernels cost one element and one property. Each husk keeps its own lean in a `--hk` custom property, and the peel multiplies it with `calc(var(--hk) * 3)`, so both leaves swing further out in the direction they already point instead of snapping to the same angle.
+
+### Why is it useful?
+
+Food, harvest, and summer cookout themes use corn. This builds a cob with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/corn-cob-as/demo.html
+++ b/submissions/examples/corn-cob-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Corn Cob</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="corn" tabindex="0">
+      <span class="silk sk1"></span>
+      <span class="silk sk2"></span>
+      <span class="silk sk3"></span>
+      <span class="cob"></span>
+      <span class="kernels"></span>
+      <span class="husk hkl"></span>
+      <span class="husk hkr"></span>
+      <span class="shinek"></span>
+    </div>
+    <span class="butterK bk1"></span>
+    <span class="butterK bk2"></span>
+    <span class="steamK stk1"></span>
+    <span class="steamK stk2"></span>
+    <span class="tableK"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/corn-cob-as/style.css
+++ b/submissions/examples/corn-cob-as/style.css
@@ -1,0 +1,252 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #4a3a24, #171208 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 330px;
+}
+
+.tableK {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 290px;
+  height: 28px;
+  margin-left: -145px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(70, 44, 14, 0.3) 0 2px,
+      transparent 2px 28px
+    ),
+    linear-gradient(180deg, #b98a54, #7d5c31);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+}
+
+.corn {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 200px;
+  height: 250px;
+  margin-left: -100px;
+  outline: none;
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: leank 5s ease-in-out infinite;
+}
+
+.cob {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  width: 96px;
+  height: 210px;
+  margin-left: -48px;
+  border-radius: 48% 48% 42% 42% / 24% 24% 76% 76%;
+  background: linear-gradient(180deg, #f7dc62, #c99a1c);
+  box-shadow:
+    inset -10px -8px 20px rgba(130, 90, 6, 0.45),
+    0 12px 24px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.kernels {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  width: 96px;
+  height: 210px;
+  margin-left: -48px;
+  border-radius: 48% 48% 42% 42% / 24% 24% 76% 76%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(150, 106, 8, 0.5) 0 2px,
+      transparent 2px 16px
+    ),
+    repeating-linear-gradient(
+      180deg,
+      rgba(150, 106, 8, 0.5) 0 2px,
+      transparent 2px 16px
+    );
+  z-index: 5;
+}
+
+.husk {
+  position: absolute;
+  bottom: 0;
+  width: 60px;
+  height: 190px;
+  border-radius: 60% 30% 40% 50% / 70% 30% 30% 60%;
+  background: linear-gradient(180deg, #86b545, #3e6b22);
+  box-shadow: inset -6px 0 10px rgba(20, 50, 10, 0.4);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--hk, 0deg));
+  transition: transform 0.55s ease;
+  z-index: 3;
+}
+
+.hkl {
+  left: 8px;
+
+  --hk: -12deg;
+}
+
+.hkr {
+  right: 8px;
+  border-radius: 30% 60% 50% 40% / 30% 70% 60% 30%;
+
+  --hk: 12deg;
+}
+
+.corn:hover .husk,
+.corn:focus-visible .husk {
+  transform: rotate(calc(var(--hk, 0deg) * 3)) translateY(6px);
+}
+
+.silk {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 8px;
+  height: 54px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #f0d68e, #b58d34);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--sl, 0deg));
+  z-index: 2;
+  animation: wavek 3.6s ease-in-out infinite;
+}
+
+.sk1 {
+  margin-left: -22px;
+
+  --sl: -20deg;
+}
+
+.sk2 {
+  margin-left: -4px;
+
+  --sl: 0deg;
+
+  animation-delay: 0.5s;
+}
+
+.sk3 {
+  margin-left: 14px;
+
+  --sl: 20deg;
+
+  animation-delay: 1s;
+}
+
+.shinek {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 20px;
+  height: 90px;
+  margin-left: -36px;
+  border-radius: 50%;
+  background: rgba(255, 250, 220, 0.35);
+  filter: blur(4px);
+  z-index: 6;
+  animation: glintk 3.8s ease-in-out infinite;
+}
+
+.butterK {
+  position: absolute;
+  width: 20px;
+  height: 12px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #ffe98a, #e6c23c);
+  box-shadow: 0 2px 4px rgba(90, 60, 10, 0.4);
+  z-index: 7;
+  animation: slidek 4.4s ease-in-out infinite;
+}
+
+.bk1 {
+  bottom: 220px;
+  left: 132px;
+}
+
+.bk2 {
+  bottom: 170px;
+  left: 156px;
+  animation-delay: 2.2s;
+}
+
+.steamK {
+  position: absolute;
+  bottom: 280px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+  filter: blur(4px);
+  opacity: 0;
+  z-index: 6;
+  animation: risek 4.4s ease-out infinite;
+}
+
+.stk1 { left: 120px; }
+
+.stk2 {
+  left: 172px;
+  animation-delay: 2.2s;
+}
+
+@keyframes leank {
+  0%, 100% { transform: rotate(-2deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@keyframes wavek {
+  0%, 100% { transform: rotate(var(--sl, 0deg)); }
+  50% { transform: rotate(calc(var(--sl, 0deg) + 8deg)); }
+}
+
+@keyframes glintk {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 0.7; }
+}
+
+@keyframes slidek {
+  0%, 100% { transform: translateY(0); opacity: 0.9; }
+  50% { transform: translateY(14px); opacity: 1; }
+}
+
+@keyframes risek {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.8; }
+  100% { transform: translateY(-60px) translateX(14px) scale(1.8); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .corn,
+  .silk,
+  .shinek,
+  .butterK,
+  .steamK {
+    animation: none;
+  }
+
+  .husk {
+    transition: none;
+  }
+
+  .steamK {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a corn cob built for #45238. The kernels are two crossed repeating gradients over a cob shaped element: because both are clipped by the same border-radius, the grid curves with the cob and stops cleanly at its rounded ends, so several hundred kernels cost one element and one property. Each husk keeps its lean in a `--hk` custom property and the peel multiplies it with `calc(var(--hk) * 3)`, so both leaves swing further out along the direction they already point instead of snapping to the same angle. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45238.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a corn cob with a curved kernel grid, green husks either side, silk threads on top and pats of butter melting down it.
