### PR TITLE
Add weather vane component

### DIFF
--- a/submissions/examples/weather-vane-as/README.md
+++ b/submissions/examples/weather-vane-as/README.md
@@ -1,0 +1,24 @@
+# Weather Vane
+
+### What does this do?
+
+It shows a rooster weather vane on a rooftop. The arrow veers back and forth as the wind shifts, gusts streak past, and clouds drift behind it. Hovering or focusing the vane sends it spinning all the way round, as if a squall just hit. Under reduced motion it holds its heading.
+
+### How is it used?
+
+```html
+<div class="vane" tabindex="0">
+  <div class="spinner">
+    <span class="arrowHead"></span>
+    <span class="arrowShaft"></span>
+    <span class="rooster"></span>
+  </div>
+  <span class="poleV"></span>
+</div>
+```
+
+The arrow head and tail are `clip-path` polygons, which is what gives them true points and a swallowtail that a `border-radius` cannot produce. Everything that turns lives inside one `spinner` wrapper whose `transform-origin: 50% 0` sits exactly on the pivot ball, so the arrow, the fletching and the rooster all rotate around the same post rather than each needing its own transform. That also makes the hover trivial: swapping the keyframe on the wrapper alone takes the whole assembly from a nervous veer to a full spin.
+
+### Why is it useful?
+
+Weather, rooftop, and rustic themes use a weather vane. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/weather-vane-as/demo.html
+++ b/submissions/examples/weather-vane-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Weather Vane</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="cloudV cv1"></span>
+    <span class="cloudV cv2"></span>
+    <div class="vane" tabindex="0">
+      <div class="spinner">
+        <span class="arrowHead"></span>
+        <span class="arrowShaft"></span>
+        <span class="arrowTail"></span>
+        <span class="rooster"></span>
+      </div>
+      <span class="pivotV"></span>
+      <span class="dirV dn"></span>
+      <span class="dirV ds"></span>
+      <span class="dirV de"></span>
+      <span class="dirV dw"></span>
+      <span class="crossV"></span>
+      <span class="poleV"></span>
+    </div>
+    <span class="roofV"></span>
+    <span class="gust gu1"></span>
+    <span class="gust gu2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/weather-vane-as/style.css
+++ b/submissions/examples/weather-vane-as/style.css
@@ -1,0 +1,245 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #7fb6d8, #3d6b8f 62%, #1d3346);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.cloudV {
+  position: absolute;
+  width: 96px;
+  height: 30px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow:
+    26px -12px 0 -4px rgba(255, 255, 255, 0.7),
+    -22px -8px 0 -6px rgba(255, 255, 255, 0.7);
+  animation: driftV 12s linear infinite;
+}
+
+.cv1 { top: 44px; left: 20px; }
+
+.cv2 {
+  top: 96px;
+  right: 30px;
+  animation-delay: 6s;
+}
+
+.roofV {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 70px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 30, 20, 0.35) 0 3px,
+      transparent 3px 26px
+    ),
+    linear-gradient(180deg, #8c4a35, #4d2418);
+  z-index: 3;
+}
+
+.vane {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 230px;
+  height: 260px;
+  margin-left: -115px;
+  outline: none;
+  z-index: 4;
+}
+
+.poleV {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 14px;
+  height: 150px;
+  margin-left: -7px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #58606c, #2f353d);
+  z-index: 3;
+}
+
+.crossV {
+  position: absolute;
+  bottom: 120px;
+  left: 50%;
+  width: 130px;
+  height: 8px;
+  margin-left: -65px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6f7885, #3a4048);
+  box-shadow: 0 -61px 0 -1px transparent;
+  z-index: 3;
+}
+
+.dirV {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #cfd5de;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
+  z-index: 4;
+}
+
+.dn {
+  bottom: 178px;
+  left: 50%;
+  margin-left: -8px;
+}
+
+.ds {
+  bottom: 62px;
+  left: 50%;
+  margin-left: -8px;
+}
+
+.de {
+  bottom: 116px;
+  left: 50%;
+  margin-left: 58px;
+}
+
+.dw {
+  bottom: 116px;
+  left: 50%;
+  margin-left: -74px;
+}
+
+.pivotV {
+  position: absolute;
+  bottom: 176px;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin-left: -10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #e8edf4, #7c848f 72%);
+  z-index: 7;
+}
+
+.spinner {
+  position: absolute;
+  bottom: 186px;
+  left: 50%;
+  width: 220px;
+  height: 0;
+  margin-left: -110px;
+  transform-origin: 50% 0;
+  z-index: 6;
+  animation: veer 9s ease-in-out infinite;
+}
+
+.vane:hover .spinner,
+.vane:focus-visible .spinner {
+  animation: spinV 2.4s linear infinite;
+}
+
+.arrowShaft {
+  position: absolute;
+  top: -5px;
+  left: 22px;
+  width: 176px;
+  height: 10px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #4e5661, #8c95a2);
+}
+
+.arrowHead {
+  position: absolute;
+  top: -18px;
+  right: 0;
+  width: 40px;
+  height: 36px;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: linear-gradient(180deg, #c9a24a, #8a6a1e);
+}
+
+.arrowTail {
+  position: absolute;
+  top: -22px;
+  left: 6px;
+  width: 40px;
+  height: 44px;
+  clip-path: polygon(0 0, 100% 22%, 100% 78%, 0 100%);
+  background: linear-gradient(180deg, #c9a24a, #8a6a1e);
+}
+
+.rooster {
+  position: absolute;
+  top: -46px;
+  left: 96px;
+  width: 34px;
+  height: 44px;
+  border-radius: 50% 40% 30% 40% / 46% 50% 50% 40%;
+  background: linear-gradient(180deg, #d0a84e, #8a6a1e);
+  box-shadow: -10px 6px 0 -4px #b28f36;
+}
+
+.gust {
+  position: absolute;
+  width: 60px;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.6);
+  opacity: 0;
+  z-index: 5;
+  animation: blow 3.6s ease-out infinite;
+}
+
+.gu1 { top: 150px; left: 10px; }
+
+.gu2 {
+  top: 190px;
+  left: 30px;
+  width: 44px;
+  animation-delay: 1.8s;
+}
+
+@keyframes veer {
+  0%, 100% { transform: rotate(-14deg); }
+  30% { transform: rotate(10deg); }
+  60% { transform: rotate(-4deg); }
+}
+
+@keyframes spinV {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes driftV {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(60px); }
+}
+
+@keyframes blow {
+  0% { transform: translateX(0) scaleX(0.4); opacity: 0; }
+  30% { opacity: 0.9; }
+  100% { transform: translateX(150px) scaleX(1.4); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner,
+  .cloudV,
+  .gust {
+    animation: none;
+  }
+
+  .gust {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a weather vane built for #45242. The arrow head and tail are clip-path polygons, which give them true points and a swallowtail that a border-radius cannot produce. Everything that turns lives inside one spinner wrapper whose `transform-origin: 50% 0` sits exactly on the pivot ball, so the arrow, the fletching and the rooster all rotate around the same post rather than each carrying its own transform, and that makes the hover trivial: swapping the keyframe on the wrapper alone takes the whole assembly from a nervous veer to a full spin. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45242.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a weather vane on a rooftop with a pointed arrow and swallowtail, a rooster figure, direction markers on the cross arm, clouds drifting behind.
