### PR TITLE
Add banjo component

### DIFF
--- a/submissions/examples/banjo-as/README.md
+++ b/submissions/examples/banjo-as/README.md
@@ -1,0 +1,22 @@
+# Banjo
+
+### What does this do?
+
+It shows a banjo being played. The instrument rocks with the rhythm, the four strings blur as they vibrate, and notes drift up off the head. Under reduced motion the strings go quiet and the banjo rests.
+
+### How is it used?
+
+```html
+<div class="banjo">
+  <span class="potB"></span>
+  <span class="headB"></span>
+  <span class="bracketB"></span>
+  <span class="stringB sb1"></span>
+</div>
+```
+
+The tension brackets around the rim are a single `repeating-conic-gradient`, so the ring of hardware that would normally be a dozen elements is one property. The vibrating strings are the interesting trick: each string is only two pixels wide, and the keyframe scales it with `scaleX(2.4)`. Because a two pixel line widening and narrowing many times a second reads as a blur rather than a resize, that single scale is enough to sell a plucked string, and staggered delays keep the four from pulsing in unison.
+
+### Why is it useful?
+
+Music, folk, and instrument themes use a banjo. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/banjo-as/demo.html
+++ b/submissions/examples/banjo-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Banjo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="banjo">
+      <span class="neckB"></span>
+      <span class="fretsB"></span>
+      <span class="headstock"></span>
+      <span class="pegB pg1"></span>
+      <span class="pegB pg2"></span>
+      <span class="pegB pg3"></span>
+      <span class="pegB pg4"></span>
+      <span class="potB"></span>
+      <span class="headB"></span>
+      <span class="bracketB"></span>
+      <span class="bridgeB"></span>
+      <span class="stringB sb1"></span>
+      <span class="stringB sb2"></span>
+      <span class="stringB sb3"></span>
+      <span class="stringB sb4"></span>
+    </div>
+    <span class="noteB nb1"></span>
+    <span class="noteB nb2"></span>
+    <span class="noteB nb3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/banjo-as/style.css
+++ b/submissions/examples/banjo-as/style.css
@@ -1,0 +1,231 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #3e3226, #150f08 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.banjo {
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  width: 280px;
+  height: 300px;
+  margin-left: -140px;
+  transform: rotate(-16deg);
+  transform-origin: 50% 80%;
+  z-index: 4;
+  animation: strumB 3.6s ease-in-out infinite;
+}
+
+.potB {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 170px;
+  height: 170px;
+  margin-left: -85px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #d8b46a, #8a6a24 74%);
+  box-shadow:
+    inset -10px -10px 22px rgba(70, 46, 6, 0.5),
+    0 14px 30px rgba(0, 0, 0, 0.5);
+  z-index: 3;
+}
+
+.headB {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  width: 142px;
+  height: 142px;
+  margin-left: -71px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #fdfaf0, #d8d0bc 76%);
+  box-shadow: inset 0 -6px 14px rgba(120, 100, 60, 0.35);
+  z-index: 4;
+}
+
+.bracketB {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 170px;
+  height: 170px;
+  margin-left: -85px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(90, 70, 20, 0.55) 0 3deg,
+      transparent 3deg 30deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 40%, #000 42%);
+  z-index: 5;
+  pointer-events: none;
+}
+
+.bridgeB {
+  position: absolute;
+  bottom: 52px;
+  left: 50%;
+  width: 44px;
+  height: 12px;
+  margin-left: -22px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #7b5220, #4a2f10);
+  z-index: 7;
+}
+
+.neckB {
+  position: absolute;
+  bottom: 150px;
+  left: 50%;
+  width: 34px;
+  height: 130px;
+  margin-left: -17px;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(90deg, #5c3a18, #8a5c2a);
+  z-index: 2;
+}
+
+.fretsB {
+  position: absolute;
+  bottom: 150px;
+  left: 50%;
+  width: 34px;
+  height: 130px;
+  margin-left: -17px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(220, 220, 220, 0.75) 0 2px,
+      transparent 2px 20px
+    );
+  z-index: 3;
+}
+
+.headstock {
+  position: absolute;
+  bottom: 264px;
+  left: 50%;
+  width: 52px;
+  height: 46px;
+  margin-left: -26px;
+  border-radius: 8px 8px 4px 4px;
+  background: linear-gradient(180deg, #4a2f10, #2f1d08);
+  z-index: 3;
+}
+
+.pegB {
+  position: absolute;
+  width: 16px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #dfe4ea, #97a0aa);
+  z-index: 4;
+}
+
+.pg1 { bottom: 296px; left: 50%; margin-left: -40px; }
+.pg2 { bottom: 278px; left: 50%; margin-left: -40px; }
+.pg3 { bottom: 296px; left: 50%; margin-left: 24px; }
+.pg4 { bottom: 278px; left: 50%; margin-left: 24px; }
+
+.stringB {
+  position: absolute;
+  bottom: 58px;
+  left: 50%;
+  width: 2px;
+  height: 232px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(200, 200, 200, 0.6));
+  transform-origin: 50% 100%;
+  z-index: 8;
+  animation: vibrate 0.28s ease-in-out infinite;
+}
+
+.sb1 {
+  margin-left: -12px;
+}
+
+.sb2 {
+  margin-left: -4px;
+  animation-delay: 0.06s;
+}
+
+.sb3 {
+  margin-left: 4px;
+  animation-delay: 0.12s;
+}
+
+.sb4 {
+  margin-left: 12px;
+  animation-delay: 0.18s;
+}
+
+.noteB {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #f7f3e8;
+  box-shadow: 9px -12px 0 -3px #f7f3e8;
+  opacity: 0;
+  z-index: 9;
+  animation: floatB 3.4s ease-out infinite;
+}
+
+.nb1 { bottom: 190px; right: 70px; }
+
+.nb2 {
+  bottom: 210px;
+  right: 40px;
+  animation-delay: 1.1s;
+
+  --bx: 26px;
+}
+
+.nb3 {
+  bottom: 170px;
+  right: 100px;
+  animation-delay: 2.2s;
+
+  --bx: -18px;
+}
+
+@keyframes strumB {
+  0%, 100% { transform: rotate(-16deg) translateY(0); }
+  50% { transform: rotate(-13deg) translateY(-5px); }
+}
+
+@keyframes vibrate {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(2.4); }
+}
+
+@keyframes floatB {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translate(var(--bx, 20px), -80px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .banjo,
+  .stringB,
+  .noteB {
+    animation: none;
+  }
+
+  .noteB {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a banjo built for #45244. The tension brackets are a single repeating conic gradient masked to a ring with a radial gradient, so the ring of hardware that would normally be a dozen elements is one property and it stays on the rim instead of striping the drum head. The vibrating strings are the fun part: each string is two pixels wide and the keyframe scales it with `scaleX(2.4)`, because a thin line widening and narrowing many times a second reads as a blur rather than a resize, and staggered delays stop the four pulsing in unison. Reduced motion fallback included. Pure CSS. Closes #45244.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a banjo with a round pot and white head, tension brackets around the rim, a fretted neck with tuning pegs, and four strings running to the bridge.
