### PR TITLE
Add tambourine component

### DIFF
--- a/submissions/examples/tambourine-as/README.md
+++ b/submissions/examples/tambourine-as/README.md
@@ -1,0 +1,21 @@
+# Tambourine
+
+### What does this do?
+
+It shows a tambourine being shaken. The frame rocks side to side, all eight jingles rattle in their slots, sound rings expand out from it, and the ribbons flow. Hovering or focusing it shakes the tambourine four times faster. Under reduced motion it holds still.
+
+### How is it used?
+
+```html
+<div class="tamb" tabindex="0">
+  <span class="hoopT"></span>
+  <span class="skinT"></span>
+  <span class="jingle j1"></span>
+</div>
+```
+
+Each jingle is placed with `rotate(var(--jr)) translateY(-104px)`: rotate first, then push outward, so one angle both aims the disc and sets how far from the centre it sits, and eight of them at 45 degree steps ring the hoop from a single rule. The rattle keyframe rebuilds that same rotation before nudging the disc a few pixels further out, so shaking never flattens a jingle back to the top of the frame. The hoop itself is a bordered circle, so its depth is just the border width.
+
+### Why is it useful?
+
+Music, percussion, and celebration themes use a tambourine. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/tambourine-as/demo.html
+++ b/submissions/examples/tambourine-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tambourine</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="tamb" tabindex="0">
+      <span class="hoopT"></span>
+      <span class="skinT"></span>
+      <span class="grainT"></span>
+      <span class="jingle j1"></span>
+      <span class="jingle j2"></span>
+      <span class="jingle j3"></span>
+      <span class="jingle j4"></span>
+      <span class="jingle j5"></span>
+      <span class="jingle j6"></span>
+      <span class="jingle j7"></span>
+      <span class="jingle j8"></span>
+      <span class="ribbonT rb1"></span>
+      <span class="ribbonT rb2"></span>
+    </div>
+    <span class="waveT wt1"></span>
+    <span class="waveT wt2"></span>
+    <span class="waveT wt3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tambourine-as/style.css
+++ b/submissions/examples/tambourine-as/style.css
@@ -1,0 +1,210 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 38%, #45364a, #150f18 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 330px;
+}
+
+.tamb {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 230px;
+  height: 230px;
+  margin: -115px 0 0 -115px;
+  outline: none;
+  z-index: 4;
+  animation: shakeT 1.4s ease-in-out infinite;
+}
+
+.tamb:hover,
+.tamb:focus-visible {
+  animation: shakeT 0.32s ease-in-out infinite;
+}
+
+.hoopT {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 20px solid #a9702f;
+  box-sizing: border-box;
+  background: transparent;
+  box-shadow:
+    inset 0 0 0 3px rgba(80, 44, 8, 0.5),
+    0 0 0 3px rgba(80, 44, 8, 0.45),
+    0 14px 30px rgba(0, 0, 0, 0.5);
+  z-index: 5;
+}
+
+.skinT {
+  position: absolute;
+  inset: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #fdf6e4, #ddd0b2 76%);
+  box-shadow: inset 0 -8px 16px rgba(120, 100, 60, 0.3);
+  z-index: 3;
+}
+
+.grainT {
+  position: absolute;
+  inset: 18px;
+  border-radius: 50%;
+  background:
+    repeating-linear-gradient(
+      104deg,
+      rgba(150, 125, 70, 0.16) 0 2px,
+      transparent 2px 16px
+    );
+  z-index: 4;
+}
+
+.jingle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border-radius: 50%;
+  border: 4px solid #e8d489;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 36% 32%, #fff6cf, #b8923a 74%);
+  transform: rotate(var(--jr, 0deg)) translateY(-104px);
+  z-index: 6;
+  animation: rattle 0.4s ease-in-out infinite;
+}
+
+.j1 {
+  --jr: 22deg;
+}
+
+.j2 {
+  --jr: 67deg;
+
+  animation-delay: 0.05s;
+}
+
+.j3 {
+  --jr: 112deg;
+
+  animation-delay: 0.1s;
+}
+
+.j4 {
+  --jr: 157deg;
+
+  animation-delay: 0.15s;
+}
+
+.j5 {
+  --jr: 202deg;
+
+  animation-delay: 0.2s;
+}
+
+.j6 {
+  --jr: 247deg;
+
+  animation-delay: 0.25s;
+}
+
+.j7 {
+  --jr: 292deg;
+
+  animation-delay: 0.3s;
+}
+
+.j8 {
+  --jr: 337deg;
+
+  animation-delay: 0.35s;
+}
+
+.ribbonT {
+  position: absolute;
+  top: 196px;
+  left: 50%;
+  width: 16px;
+  height: 96px;
+  border-radius: 8px;
+  transform-origin: 50% 0;
+  transform: rotate(var(--rr, 0deg));
+  z-index: 2;
+  animation: flowT 2.2s ease-in-out infinite;
+}
+
+.rb1 {
+  margin-left: -40px;
+  background: linear-gradient(180deg, #e8557f, #a8214a);
+
+  --rr: -24deg;
+}
+
+.rb2 {
+  margin-left: 24px;
+  background: linear-gradient(180deg, #55a8e8, #215a94);
+
+  --rr: 22deg;
+
+  animation-delay: 1.1s;
+}
+
+.waveT {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 240px;
+  height: 240px;
+  margin: -120px 0 0 -120px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 230, 170, 0.6);
+  opacity: 0;
+  z-index: 2;
+  animation: ringT 2.4s ease-out infinite;
+}
+
+.wt2 { animation-delay: 0.8s; }
+.wt3 { animation-delay: 1.6s; }
+
+@keyframes shakeT {
+  0%, 100% { transform: rotate(-6deg) translateX(0); }
+  50% { transform: rotate(6deg) translateX(6px); }
+}
+
+@keyframes rattle {
+  0%, 100% { transform: rotate(var(--jr, 0deg)) translateY(-104px) scale(1); }
+  50% { transform: rotate(var(--jr, 0deg)) translateY(-108px) scale(1.08); }
+}
+
+@keyframes flowT {
+  0%, 100% { transform: rotate(var(--rr, 0deg)); }
+  50% { transform: rotate(calc(var(--rr, 0deg) + 12deg)); }
+}
+
+@keyframes ringT {
+  0% { transform: scale(0.9); opacity: 0.7; }
+  100% { transform: scale(1.5); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tamb,
+  .jingle,
+  .ribbonT,
+  .waveT {
+    animation: none;
+  }
+
+  .waveT {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a tambourine built for #45246. Each jingle is placed with `rotate(var(--jr)) translateY(-104px)`, rotating first and then pushing outward, so one angle both aims the disc and sets its distance from the centre, and eight at 45 degree steps ring the hoop from a single rule. The rattle keyframe rebuilds that same rotation before nudging the disc further out, so shaking never flattens a jingle back to the top of the frame. The hoop is a bordered circle, so its depth is just the border width. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45246.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wooden tambourine with a grained skin, eight brass jingles set around the hoop, ribbons hanging from the frame and a sound ring expanding outward.
