### PR TITLE
Add torii gate component

### DIFF
--- a/submissions/examples/torii-gate-as/README.md
+++ b/submissions/examples/torii-gate-as/README.md
@@ -1,0 +1,22 @@
+# Torii Gate
+
+### What does this do?
+
+It shows a torii gate standing in shallow water at dusk, with the moon behind it. Cherry petals drift down past the gate, the moon glows, and the gate's reflection ripples on the water. Under reduced motion everything is still.
+
+### How is it used?
+
+```html
+<div class="torii">
+  <span class="kasagi"></span>
+  <span class="nuki"></span>
+  <span class="pillarT ptl"></span>
+  <span class="pillarT ptr"></span>
+</div>
+```
+
+The top lintel uses `perspective(300px) rotateX(6deg)`, which tilts it slightly away from the viewer and gives the gate a sense of depth that a flat rectangle cannot. The two pillars lean outward by a degree and a half each, mirroring one another, because a real torii's posts are not vertical, and that small asymmetry is what keeps the gate from looking like a plain goalpost. Each falling petal takes its drift from a `--px2` custom property, so they share one keyframe but never trace the same path.
+
+### Why is it useful?
+
+Japanese, shrine, and calm or reflective themes use a torii gate. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/torii-gate-as/demo.html
+++ b/submissions/examples/torii-gate-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Torii Gate</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moonT"></span>
+    <div class="torii">
+      <span class="kasagi"></span>
+      <span class="shimaki"></span>
+      <span class="nuki"></span>
+      <span class="gakuzuka"></span>
+      <span class="pillarT ptl"></span>
+      <span class="pillarT ptr"></span>
+      <span class="baseT btl"></span>
+      <span class="baseT btr"></span>
+    </div>
+    <span class="petalT pt1"></span>
+    <span class="petalT pt2"></span>
+    <span class="petalT pt3"></span>
+    <span class="petalT pt4"></span>
+    <span class="waterT"></span>
+    <span class="reflectT"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/torii-gate-as/style.css
+++ b/submissions/examples/torii-gate-as/style.css
@@ -1,0 +1,218 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #f0a37a, #b3566a 54%, #3d2a4a);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.moonT {
+  position: absolute;
+  top: 34px;
+  left: 50%;
+  width: 90px;
+  height: 90px;
+  margin-left: -45px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #fff6e2, #f5cf92 74%);
+  box-shadow: 0 0 70px rgba(255, 220, 160, 0.7);
+  z-index: 2;
+  animation: glowT2 6s ease-in-out infinite;
+}
+
+.waterT {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 66px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.08) 0 3px,
+      transparent 3px 26px
+    ),
+    linear-gradient(180deg, #5c4a7a, #241a38);
+  z-index: 5;
+}
+
+.reflectT {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 220px;
+  height: 60px;
+  margin-left: -110px;
+  background: linear-gradient(180deg, rgba(214, 76, 60, 0.35), transparent 80%);
+  filter: blur(3px);
+  z-index: 6;
+  animation: rippleT 5s ease-in-out infinite;
+}
+
+.torii {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 280px;
+  height: 250px;
+  margin-left: -140px;
+  z-index: 4;
+}
+
+.kasagi {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 280px;
+  height: 20px;
+  border-radius: 10px 10px 4px 4px;
+  background: linear-gradient(180deg, #e35a44, #a8261c);
+  box-shadow: 0 5px 12px rgba(60, 10, 6, 0.5);
+  transform: perspective(300px) rotateX(6deg);
+  z-index: 6;
+}
+
+.shimaki {
+  position: absolute;
+  top: 22px;
+  left: 16px;
+  width: 248px;
+  height: 12px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #c94232, #8e1c14);
+  z-index: 5;
+}
+
+.nuki {
+  position: absolute;
+  top: 66px;
+  left: 34px;
+  width: 212px;
+  height: 16px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #d64c3c, #9c2018);
+  z-index: 5;
+}
+
+.gakuzuka {
+  position: absolute;
+  top: 34px;
+  left: 50%;
+  width: 22px;
+  height: 34px;
+  margin-left: -11px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #e35a44, #a8261c);
+  z-index: 6;
+}
+
+.pillarT {
+  position: absolute;
+  top: 18px;
+  width: 26px;
+  height: 208px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #e35a44, #a02219 70%, #7d160f);
+  box-shadow: inset -6px 0 10px rgba(80, 12, 8, 0.5);
+  z-index: 4;
+}
+
+.ptl {
+  left: 52px;
+  transform: rotate(1.5deg);
+}
+
+.ptr {
+  right: 52px;
+  transform: rotate(-1.5deg);
+}
+
+.baseT {
+  position: absolute;
+  bottom: 18px;
+  width: 40px;
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #4a4458, #2a2634);
+  z-index: 5;
+}
+
+.btl { left: 44px; }
+.btr { right: 44px; }
+
+.petalT {
+  position: absolute;
+  top: 40px;
+  width: 16px;
+  height: 12px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #ffd6e8, #f293bd);
+  opacity: 0;
+  z-index: 7;
+  animation: fallT 7s linear infinite;
+}
+
+.pt1 { left: 40px; }
+
+.pt2 {
+  left: 130px;
+  animation-delay: 1.8s;
+
+  --px2: -40px;
+}
+
+.pt3 {
+  left: 230px;
+  animation-delay: 3.6s;
+
+  --px2: -70px;
+}
+
+.pt4 {
+  left: 300px;
+  animation-delay: 5.4s;
+
+  --px2: -110px;
+}
+
+@keyframes glowT2 {
+  0%, 100% { opacity: 0.92; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.03); }
+}
+
+@keyframes rippleT {
+  0%, 100% { transform: scaleY(1); opacity: 0.7; }
+  50% { transform: scaleY(1.18); opacity: 0.45; }
+}
+
+@keyframes fallT {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  12% { opacity: 1; }
+  88% { opacity: 1; }
+
+  100% {
+    transform: translate(var(--px2, 40px), 250px) rotate(300deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .moonT,
+  .reflectT,
+  .petalT {
+    animation: none;
+  }
+
+  .petalT {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a torii gate built for #45252. The top lintel uses `perspective(300px) rotateX(6deg)`, tilting it slightly away from the viewer and giving the gate a depth a flat rectangle cannot have. The two pillars lean outward by a degree and a half each, mirroring one another, because a real torii's posts are not vertical, and that small asymmetry is what keeps the gate from reading as a plain goalpost. Each falling petal takes its drift from a `--px2` custom property, so they share one keyframe but never trace the same path. Reduced motion fallback included. Pure CSS. Closes #45252.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a red torii gate with a tilted lintel and leaning pillars standing in water, the moon glowing behind it and cherry petals drifting past.
