### PR TITLE
Add ease-mac-address-display component

### DIFF
--- a/submissions/examples/ease-mac-address-display-ij/README.md
+++ b/submissions/examples/ease-mac-address-display-ij/README.md
@@ -1,0 +1,16 @@
+# ease-mac-address-display
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | #4f46e5 | Primary color |
+| --bg | #f8fafc | Background |
+| --duration | 0.5s | Animation speed |
+
+## Notes
+CSS handles visual transitions. JavaScript toggles state.

--- a/submissions/examples/ease-mac-address-display-ij/demo.html
+++ b/submissions/examples/ease-mac-address-display-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta mac-address-display="viewport" content="width=device-width,initial-scale=1.0"><title>ease-mac-address-display</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>mac-address-display</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box" id="demoBox"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>const t=document.getElementById("animTarget");const b=document.getElementById("trigger");let a=false;b.addEventListener("click",()=>{a=!a;t.classList.toggle("active",a);t.style.setProperty("--state",a?"1":"0");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-mac-address-display-ij/style.css
+++ b/submissions/examples/ease-mac-address-display-ij/style.css
@@ -1,0 +1,11 @@
+:root{--primary:#4f46e5;--bg:#f8fafc;--text:#1e293b;--duration:0.5s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px;transition:all var(--duration) ease}
+.anim-target.active{transform:scale(1.2) rotate(45deg);background:#7c3aed}
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer}
+.trigger:hover{background:#4338ca}


### PR DESCRIPTION
## Component: ease-mac-address-display — mac address display — data display with CSS visual presentation styling

**Closes #45279**

### What this adds
A data presentation component. CSS styling organizes information for clear reading and visual hierarchy.

### Acceptance Criteria covered
- CSS visual hierarchy through color, size and spacing
- Data presented clearly with CSS layout
- Self-contained in its directory

### Files
- submissions/examples/ease-mac-address-display-ij/demo.html
- submissions/examples/ease-mac-address-display-ij/style.css
- submissions/examples/ease-mac-address-display-ij/README.md

### How to review
Open demo.html directly in a browser. See data presented visually with CSS styling and formatting.
