### PR TITLE
fix: remove unreachable conditional in modal initialization

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -25,10 +25,6 @@
 
           const modal = overlay.querySelector('.ease-modal');
           if (modal) {
-            if (!overlay.classList.contains('is-active')) {
-              previousFocusedElement = document.activeElement;
-            }
-
             modal.setAttribute('tabindex', '-1');
             modal.focus();
           }


### PR DESCRIPTION
## Pull Request Description

This PR removes an unreachable conditional block from `core/modal.js` that could never be executed due to a logical contradiction in the modal initialization flow.

The redundant check occurred immediately after `overlay.classList.add('is-active')`, making the condition `!overlay.classList.contains('is-active')` always evaluate to `false`. Since `previousFocusedElement` is already captured before the modal is activated, removing this dead code does not affect functionality while improving code clarity and maintainability.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are limited to the required file(s)
- [x] No unrelated code changes
- [x] Existing functionality preserved
- [x] Code style follows the project's conventions
- [x] One issue addressed in this PR

---

## Bug Fix Description

**What was fixed?**

Removed an unreachable conditional block that checked whether the overlay lacked the `is-active` class immediately after that class had already been added.

**Why was this necessary?**

The condition was impossible to satisfy, resulting in dead code that could never execute. Eliminating it simplifies the modal initialization logic without changing behavior.

**Impact**

- Removes redundant code
- Improves readability and maintainability
- Preserves existing modal functionality
- No functional or behavioral changes

---

## Testing

- [x] Verified the application builds successfully
- [x] Confirmed modal behavior remains unchanged
- [x] Verified no regressions introduced

---

## Notes for Maintainer

This is a minimal cleanup fix that removes an unreachable code path without modifying the existing modal behavior or introducing any functional changes.