### PR TITLE
feat: add sidebar rail slide example

### DIFF
--- a/submissions/examples/sidebar-rail-slide/README.md
+++ b/submissions/examples/sidebar-rail-slide/README.md
@@ -1,0 +1,14 @@
+# Sidebar Rail Slide
+
+A compact sidebar rail pattern with a sliding item background and active navigation state.
+
+## Files
+
+- `demo.html` - nav rail markup with active item.
+- `style.css` - sliding highlight, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Keeps the active item visible without layout shifts.
+- Uses hover and keyboard focus states.
+- Includes a reduced-motion fallback.

--- a/submissions/examples/sidebar-rail-slide/demo.html
+++ b/submissions/examples/sidebar-rail-slide/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sidebar Rail Slide</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion navigation</p>
+    <h1 id="demo-title">Sidebar rail slide</h1>
+    <p class="intro">A compact nav rail pattern with sliding labels and active indicator motion.</p>
+
+    <nav class="rail" aria-label="Demo navigation">
+      <a href="#"><span>H</span><strong>Home</strong></a>
+      <a class="active" href="#"><span>R</span><strong>Reports</strong></a>
+      <a href="#"><span>S</span><strong>Settings</strong></a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sidebar-rail-slide/style.css
+++ b/submissions/examples/sidebar-rail-slide/style.css
@@ -1,0 +1,118 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #f8fafc 0%, #f5f3ff 50%, #ecfeff 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(124, 58, 237, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #6d28d9;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.rail {
+  display: grid;
+  gap: 0.7rem;
+  width: min(100%, 16rem);
+  padding: 0.75rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(109, 40, 217, 0.12);
+}
+
+.rail a {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 3rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.8rem;
+  color: #334155;
+  overflow: hidden;
+  text-decoration: none;
+  transition: color 180ms ease, transform 180ms ease;
+}
+
+.rail a::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: #ede9fe;
+  transform: translateX(-105%);
+  transition: transform 240ms ease;
+}
+
+.rail span,
+.rail strong {
+  position: relative;
+}
+
+.rail span {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  color: #ffffff;
+  background: #6d28d9;
+}
+
+.rail a:hover,
+.rail a:focus-visible,
+.rail a.active {
+  color: #4c1d95;
+  transform: translateX(0.2rem);
+}
+
+.rail a:hover::before,
+.rail a:focus-visible::before,
+.rail a.active::before {
+  transform: translateX(0);
+}
+
+.rail a:focus-visible {
+  outline: 0.18rem solid #a78bfa;
+  outline-offset: 0.2rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a sidebar rail slide navigation example
- include active, hover, and focus-visible states
- document the nav motion and reduced-motion fallback

## Verification
- git diff --cached --check