### PR TITLE
feat: add range thumb glide example

### DIFF
--- a/submissions/examples/range-thumb-glide/README.md
+++ b/submissions/examples/range-thumb-glide/README.md
@@ -1,0 +1,14 @@
+# Range Thumb Glide
+
+A styled range slider with a highlighted filled track and thumb scale on hover or focus.
+
+## Files
+
+- `demo.html` - range input markup with visible label and value.
+- `style.css` - track styling, thumb hover state, focus-visible ring, and reduced-motion support.
+
+## Highlights
+
+- Uses native range input behavior.
+- Supports WebKit and Firefox thumb styling.
+- Keeps keyboard focus visible.

--- a/submissions/examples/range-thumb-glide/demo.html
+++ b/submissions/examples/range-thumb-glide/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range Thumb Glide</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion input</p>
+    <h1 id="demo-title">Range thumb glide</h1>
+    <p class="intro">A styled range slider with a smooth thumb scale and track highlight on interaction.</p>
+
+    <label class="range-card">
+      <span class="range-label">Intensity</span>
+      <input type="range" min="0" max="100" value="68" />
+      <span class="range-value">68%</span>
+    </label>
+  </main>
+</body>
+</html>

--- a/submissions/examples/range-thumb-glide/style.css
+++ b/submissions/examples/range-thumb-glide/style.css
@@ -1,0 +1,122 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #fff7ed 0%, #ffffff 50%, #f0fdfa 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(234, 88, 12, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.range-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.2rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.11);
+}
+
+.range-label,
+.range-value {
+  font-weight: 900;
+}
+
+.range-value {
+  color: #ea580c;
+}
+
+input[type="range"] {
+  width: 100%;
+  height: 0.8rem;
+  border-radius: 999px;
+  outline: 0;
+  appearance: none;
+  background: linear-gradient(90deg, #ea580c 0 68%, #fed7aa 68% 100%);
+  cursor: pointer;
+  transition: box-shadow 180ms ease, transform 180ms ease;
+}
+
+input[type="range"]:hover,
+input[type="range"]:focus-visible {
+  box-shadow: 0 0.8rem 1.6rem rgba(234, 88, 12, 0.18);
+  transform: translateY(-0.12rem);
+}
+
+input[type="range"]:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.35rem;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  width: 1.65rem;
+  height: 1.65rem;
+  border: 0.22rem solid #ffffff;
+  border-radius: 50%;
+  appearance: none;
+  background: #ea580c;
+  box-shadow: 0 0.35rem 0.9rem rgba(15, 23, 42, 0.2);
+  transition: transform 180ms ease;
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 1.65rem;
+  height: 1.65rem;
+  border: 0.22rem solid #ffffff;
+  border-radius: 50%;
+  background: #ea580c;
+  box-shadow: 0 0.35rem 0.9rem rgba(15, 23, 42, 0.2);
+  transition: transform 180ms ease;
+}
+
+input[type="range"]:hover::-webkit-slider-thumb,
+input[type="range"]:focus-visible::-webkit-slider-thumb {
+  transform: scale(1.12);
+}
+
+input[type="range"]:hover::-moz-range-thumb,
+input[type="range"]:focus-visible::-moz-range-thumb {
+  transform: scale(1.12);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a range thumb glide input example
- include hover and focus-visible slider states
- document the range input and reduced-motion fallback

## Verification
- git diff --cached --check