### PR TITLE
feat: add breadcrumb step fade example

### DIFF
--- a/submissions/examples/breadcrumb-step-fade/README.md
+++ b/submissions/examples/breadcrumb-step-fade/README.md
@@ -1,0 +1,14 @@
+# Breadcrumb Step Fade
+
+A breadcrumb trail that fades each step upward and highlights the current page.
+
+## Files
+
+- `demo.html` - breadcrumb navigation markup with `aria-current`.
+- `style.css` - staggered fade, hover and focus states, and reduced-motion fallback.
+
+## Highlights
+
+- Uses semantic breadcrumb navigation.
+- Staggers the final active page after earlier steps.
+- Keeps the reduced-motion state static and readable.

--- a/submissions/examples/breadcrumb-step-fade/demo.html
+++ b/submissions/examples/breadcrumb-step-fade/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumb Step Fade</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion breadcrumb</p>
+    <h1 id="demo-title">Breadcrumb step fade</h1>
+    <p class="intro">A breadcrumb trail where each step fades upward and the active item settles last.</p>
+
+    <nav class="breadcrumbs" aria-label="Demo breadcrumb">
+      <a href="#">Workspace</a>
+      <span aria-hidden="true">/</span>
+      <a href="#">Projects</a>
+      <span aria-hidden="true">/</span>
+      <a class="current" href="#" aria-current="page">Motion kit</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-step-fade/style.css
+++ b/submissions/examples/breadcrumb-step-fade/style.css
@@ -1,0 +1,114 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 52%, #fff7ed 100%);
+}
+
+.panel {
+  width: min(92vw, 32rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(79, 70, 229, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.8rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(79, 70, 229, 0.12);
+}
+
+.breadcrumbs a,
+.breadcrumbs span {
+  opacity: 0;
+  transform: translateY(0.45rem);
+  animation: crumb-fade 520ms ease forwards;
+}
+
+.breadcrumbs a {
+  border-radius: 999px;
+  padding: 0.45rem 0.7rem;
+  color: #475569;
+  font-weight: 800;
+  text-decoration: none;
+  transition: color 180ms ease, background 180ms ease;
+}
+
+.breadcrumbs span {
+  color: #94a3b8;
+}
+
+.breadcrumbs a:nth-child(3) {
+  animation-delay: 120ms;
+}
+
+.breadcrumbs span:nth-child(4) {
+  animation-delay: 180ms;
+}
+
+.breadcrumbs a:nth-child(5) {
+  animation-delay: 240ms;
+}
+
+.breadcrumbs a:hover,
+.breadcrumbs a:focus-visible,
+.breadcrumbs .current {
+  color: #3730a3;
+  background: #e0e7ff;
+}
+
+.breadcrumbs a:focus-visible {
+  outline: 0.18rem solid #818cf8;
+  outline-offset: 0.2rem;
+}
+
+@keyframes crumb-fade {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumbs a,
+  .breadcrumbs span {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a breadcrumb step fade navigation example
- include current page and focus-visible states
- document the staggered fade and reduced-motion fallback

## Verification
- git diff --cached --check