### PR TITLE
Add capybara component

### DIFF
--- a/submissions/examples/capybara-as/README.md
+++ b/submissions/examples/capybara-as/README.md
@@ -1,0 +1,24 @@
+# Capybara
+
+### What does this do?
+
+It shows a capybara relaxing in a hot spring with a yuzu balanced on its head. It floats and nods, its ears flick, it blinks, the fruit bobs with it, ripples spread out, and steam curls off the water. Under reduced motion it soaks in stillness.
+
+### How is it used?
+
+```html
+<div class="capy">
+  <span class="bodyCa"></span>
+  <div class="headCa">
+    <span class="skullCa"></span>
+    <span class="snoutCa"></span>
+  </div>
+  <span class="orange"></span>
+</div>
+```
+
+The head is a wrapper that nods from `transform-origin: 86% 90%`, where the neck meets the shoulders, so the blunt snout dips while the back of the skull barely moves. The fruit is not parented to the head: it runs the same five second clock as the body, so it rides the float without inheriting the nod, which is what keeps it sitting level rather than sliding off. The ears use a long-hold keyframe, resting for most of the cycle and flicking only near the end, so the movement reads as an idle twitch instead of a steady wag.
+
+### Why is it useful?
+
+Wildlife, relaxation, and cosy mascot themes use a capybara. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/capybara-as/demo.html
+++ b/submissions/examples/capybara-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Capybara</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="capy">
+      <span class="bodyCa"></span>
+      <span class="rumpCa"></span>
+      <div class="headCa">
+        <span class="earCa ecl"></span>
+        <span class="earCa ecr"></span>
+        <span class="skullCa"></span>
+        <span class="snoutCa"></span>
+        <span class="noseCa"></span>
+        <span class="eyeCa exl"></span>
+        <span class="eyeCa exr"></span>
+      </div>
+      <span class="orange"></span>
+      <span class="leafCa"></span>
+    </div>
+    <span class="rippleCa rc1"></span>
+    <span class="rippleCa rc2"></span>
+    <span class="steamCa sc1"></span>
+    <span class="steamCa sc2"></span>
+    <span class="waterCa"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/capybara-as/style.css
+++ b/submissions/examples/capybara-as/style.css
@@ -1,0 +1,261 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #3f5262, #101820 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 310px;
+}
+
+.waterCa {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 108px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.08) 0 3px,
+      transparent 3px 26px
+    ),
+    linear-gradient(180deg, #4f8fa8, #1f4356);
+  z-index: 5;
+}
+
+.rippleCa {
+  position: absolute;
+  bottom: 92px;
+  left: 50%;
+  width: 200px;
+  height: 26px;
+  margin-left: -100px;
+  border-radius: 50%;
+  border: 2px solid rgba(225, 250, 255, 0.5);
+  opacity: 0;
+  z-index: 6;
+  animation: spreadCa 4.4s ease-out infinite;
+}
+
+.rc2 { animation-delay: 2.2s; }
+
+.capy {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 280px;
+  height: 150px;
+  margin-left: -140px;
+  z-index: 4;
+  animation: floatCa 5s ease-in-out infinite;
+}
+
+.bodyCa {
+  position: absolute;
+  bottom: 0;
+  left: 74px;
+  width: 190px;
+  height: 74px;
+  border-radius: 40% 46% 30% 30% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #a5773f, #6b4a22);
+  box-shadow: inset 0 -8px 16px rgba(40, 24, 6, 0.4);
+  z-index: 3;
+}
+
+.rumpCa {
+  position: absolute;
+  bottom: 4px;
+  right: 8px;
+  width: 84px;
+  height: 60px;
+  border-radius: 50% 50% 40% 40% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #976c38, #5f4120);
+  z-index: 2;
+}
+
+.headCa {
+  position: absolute;
+  bottom: 26px;
+  left: 8px;
+  width: 130px;
+  height: 96px;
+  transform-origin: 86% 90%;
+  z-index: 5;
+  animation: nodCa 5s ease-in-out infinite;
+}
+
+.skullCa {
+  position: absolute;
+  bottom: 0;
+  left: 16px;
+  width: 100px;
+  height: 74px;
+  border-radius: 44% 40% 40% 44% / 52% 50% 50% 52%;
+  background: linear-gradient(180deg, #b5854b, #7a5527);
+  z-index: 3;
+}
+
+.snoutCa {
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  width: 54px;
+  height: 44px;
+  border-radius: 46% 30% 30% 46% / 50% 40% 40% 50%;
+  background: linear-gradient(180deg, #c39457, #86602f);
+  z-index: 4;
+}
+
+.noseCa {
+  position: absolute;
+  bottom: 30px;
+  left: 4px;
+  width: 16px;
+  height: 11px;
+  border-radius: 50%;
+  background: #33200e;
+  z-index: 6;
+}
+
+.eyeCa {
+  position: absolute;
+  bottom: 44px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #20140a;
+  box-shadow: inset -2px 2px 0 -1px rgba(255, 255, 255, 0.75);
+  z-index: 6;
+  animation: blinkCa 5.4s ease-in-out infinite;
+}
+
+.exl { left: 40px; }
+.exr { left: 78px; }
+
+.earCa {
+  position: absolute;
+  bottom: 62px;
+  width: 22px;
+  height: 20px;
+  border-radius: 50%;
+  background: #6b4a22;
+  z-index: 2;
+  animation: flickCa 4s ease-in-out infinite;
+}
+
+.ecl { left: 26px; }
+
+.ecr {
+  left: 86px;
+  animation-delay: 2s;
+}
+
+.orange {
+  position: absolute;
+  bottom: 96px;
+  left: 52px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffb14e, #d97a10 74%);
+  box-shadow: inset -4px -4px 10px rgba(120, 60, 4, 0.4);
+  z-index: 7;
+  animation: bobOr 5s ease-in-out infinite;
+}
+
+.leafCa {
+  position: absolute;
+  bottom: 138px;
+  left: 76px;
+  width: 26px;
+  height: 14px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #63b055, #2f6f34);
+  transform: rotate(-16deg);
+  z-index: 8;
+  animation: bobOr 5s ease-in-out infinite;
+}
+
+.steamCa {
+  position: absolute;
+  bottom: 150px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+  filter: blur(5px);
+  opacity: 0;
+  z-index: 6;
+  animation: riseCa 5s ease-out infinite;
+}
+
+.sc1 { right: 84px; }
+
+.sc2 {
+  right: 130px;
+  animation-delay: 2.5s;
+
+  --cx: -18px;
+}
+
+@keyframes floatCa {
+  0%, 100% { transform: translateY(0) rotate(-0.8deg); }
+  50% { transform: translateY(-6px) rotate(0.8deg); }
+}
+
+@keyframes nodCa {
+  0%, 100% { transform: rotate(-2deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes bobOr {
+  0%, 100% { transform: translateY(0) rotate(-16deg); }
+  50% { transform: translateY(-6px) rotate(-12deg); }
+}
+
+@keyframes flickCa {
+  0%, 88%, 100% { transform: rotate(0deg); }
+  94% { transform: rotate(-14deg); }
+}
+
+@keyframes blinkCa {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes spreadCa {
+  0% { transform: scale(0.5); opacity: 0.8; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+@keyframes riseCa {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.8; }
+  100% { transform: translate(var(--cx, 16px), -80px) scale(2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .capy,
+  .headCa,
+  .earCa,
+  .eyeCa,
+  .orange,
+  .leafCa,
+  .rippleCa,
+  .steamCa {
+    animation: none;
+  }
+
+  .rippleCa,
+  .steamCa {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a capybara built for #45574. The head nods from a `transform-origin` where the neck meets the shoulders, so the blunt snout dips while the back of the skull barely moves. The fruit is deliberately not parented to the head: it runs the body's own five second clock, so it rides the float without inheriting the nod, which is what keeps it sitting level instead of sliding off. The ears use a long hold keyframe, resting for most of the cycle and flicking only near the end, so the movement reads as an idle twitch rather than a steady wag. Reduced motion fallback included. Pure CSS. Closes #45574.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a capybara half submerged in a hot spring with a yuzu and leaf balanced on its head, ripples around it and steam rising.
