### PR TITLE
Add pangolin component

### DIFF
--- a/submissions/examples/pangolin-as/README.md
+++ b/submissions/examples/pangolin-as/README.md
@@ -1,0 +1,21 @@
+# Pangolin
+
+### What does this do?
+
+It shows a pangolin snuffling along an anthill, flicking out its long tongue while ants scurry away. It waddles, its tail sways, its legs step in turn, and it blinks. Hovering or focusing it makes every armour scale lift and flare outward. Under reduced motion it stands still with its scales flat.
+
+### How is it used?
+
+```html
+<div class="pang" tabindex="0">
+  <span class="bodyPa"></span>
+  <span class="scalePa spa1"></span>
+  <div class="headPa"><span class="tongue"></span></div>
+</div>
+```
+
+Each scale keeps its own lean in a `--pa2` custom property, and the flare multiplies it with `calc(var(--pa2) * 2.2)`, so every plate opens further along the direction it already points rather than snapping to a shared angle. The tongue is the other trick: it sits at `scaleX(0.1)` by default and shoots to full length from `transform-origin: 100% 50%`, its root at the mouth, so it extends forward out of the snout instead of growing from its own middle. Because it returns to a tenth of its width, the retracted tongue is effectively invisible without needing a second state.
+
+### Why is it useful?
+
+Wildlife, conservation, and unusual animal themes use a pangolin. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/pangolin-as/demo.html
+++ b/submissions/examples/pangolin-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pangolin</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="pang" tabindex="0">
+      <span class="tailPa"></span>
+      <span class="bodyPa"></span>
+      <span class="scalePa spa1"></span>
+      <span class="scalePa spa2"></span>
+      <span class="scalePa spa3"></span>
+      <span class="scalePa spa4"></span>
+      <span class="scalePa spa5"></span>
+      <span class="scalePa spa6"></span>
+      <span class="legPa lpa1"></span>
+      <span class="legPa lpa2"></span>
+      <div class="headPa">
+        <span class="snoutPa"></span>
+        <span class="eyePa"></span>
+        <span class="tongue"></span>
+      </div>
+    </div>
+    <span class="antPa ap1"></span>
+    <span class="antPa ap2"></span>
+    <span class="antPa ap3"></span>
+    <span class="moundPa"></span>
+    <span class="groundPa"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pangolin-as/style.css
+++ b/submissions/examples/pangolin-as/style.css
@@ -1,0 +1,287 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #6b5a3c, #211a0f 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.groundPa {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 58px);
+  background:
+    radial-gradient(circle at 22% 0, rgba(255, 235, 190, 0.12) 0 12px, transparent 12px),
+    linear-gradient(180deg, #9c7c4a, #543f20);
+}
+
+.moundPa {
+  position: absolute;
+  bottom: 52px;
+  right: 30px;
+  width: 90px;
+  height: 46px;
+  border-radius: 50% 50% 10% 10% / 70% 70% 30% 30%;
+  background: linear-gradient(180deg, #8a6a3c, #55401e);
+  z-index: 3;
+}
+
+.pang {
+  position: absolute;
+  bottom: 52px;
+  left: 30px;
+  width: 260px;
+  height: 160px;
+  outline: none;
+  z-index: 5;
+  animation: waddle 3.4s ease-in-out infinite;
+}
+
+.bodyPa {
+  position: absolute;
+  bottom: 18px;
+  left: 60px;
+  width: 150px;
+  height: 84px;
+  border-radius: 46% 50% 34% 34% / 62% 62% 38% 38%;
+  background: linear-gradient(180deg, #8f7444, #57411f);
+  z-index: 3;
+}
+
+.scalePa {
+  position: absolute;
+  width: 52px;
+  height: 34px;
+  border-radius: 50% 50% 20% 20% / 70% 70% 30% 30%;
+  background: linear-gradient(180deg, #c9a45c, #7d5c26);
+  box-shadow:
+    inset 0 -4px 6px rgba(50, 34, 6, 0.4),
+    0 2px 4px rgba(30, 20, 4, 0.4);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--pa2, 0deg));
+  transition: transform 0.45s ease;
+  z-index: 5;
+}
+
+.spa1 {
+  bottom: 66px;
+  left: 68px;
+
+  --pa2: -22deg;
+}
+
+.spa2 {
+  bottom: 74px;
+  left: 104px;
+
+  --pa2: -8deg;
+}
+
+.spa3 {
+  bottom: 74px;
+  left: 142px;
+
+  --pa2: 8deg;
+}
+
+.spa4 {
+  bottom: 62px;
+  left: 176px;
+
+  --pa2: 22deg;
+}
+
+.spa5 {
+  bottom: 40px;
+  left: 84px;
+
+  --pa2: -14deg;
+}
+
+.spa6 {
+  bottom: 40px;
+  left: 156px;
+
+  --pa2: 14deg;
+}
+
+.pang:hover .scalePa,
+.pang:focus-visible .scalePa {
+  transform: rotate(calc(var(--pa2, 0deg) * 2.2)) translateY(-4px);
+}
+
+.tailPa {
+  position: absolute;
+  bottom: 16px;
+  right: 0;
+  width: 96px;
+  height: 34px;
+  border-radius: 10px 40% 40% 10px / 10px 60% 60% 10px;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(60, 42, 10, 0.45) 0 3px,
+      transparent 3px 14px
+    ),
+    linear-gradient(90deg, #8f7444, #4e3a1c);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: swayPa 3.4s ease-in-out infinite;
+}
+
+.legPa {
+  position: absolute;
+  bottom: 0;
+  width: 24px;
+  height: 26px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #6f5730, #3f2f14);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: stepPa 0.9s ease-in-out infinite;
+}
+
+.lpa1 { left: 84px; }
+
+.lpa2 {
+  left: 158px;
+  animation-delay: 0.45s;
+}
+
+.headPa {
+  position: absolute;
+  bottom: 26px;
+  left: 4px;
+  width: 90px;
+  height: 66px;
+  transform-origin: 92% 80%;
+  z-index: 4;
+  animation: sniff 3.4s ease-in-out infinite;
+}
+
+.snoutPa {
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  width: 84px;
+  height: 40px;
+  border-radius: 50% 24% 24% 50% / 60% 40% 40% 60%;
+  background: linear-gradient(180deg, #a08048, #6b5127);
+  z-index: 3;
+}
+
+.eyePa {
+  position: absolute;
+  bottom: 30px;
+  left: 52px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #1e1408;
+  box-shadow: inset -2px 2px 0 -1px rgba(255, 255, 255, 0.7);
+  z-index: 5;
+  animation: blinkPa 5s ease-in-out infinite;
+}
+
+.tongue {
+  position: absolute;
+  bottom: 14px;
+  left: -46px;
+  width: 54px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #e88ba0, #c9536e);
+  transform-origin: 100% 50%;
+  transform: scaleX(0.1);
+  z-index: 2;
+  animation: lick 2.6s ease-in-out infinite;
+}
+
+.antPa {
+  position: absolute;
+  bottom: 62px;
+  width: 7px;
+  height: 5px;
+  border-radius: 3px;
+  background: #2e1f10;
+  z-index: 6;
+  animation: scurry 2.6s ease-in-out infinite;
+}
+
+.ap1 { right: 96px; }
+
+.ap2 {
+  right: 118px;
+  animation-delay: 0.6s;
+}
+
+.ap3 {
+  right: 140px;
+  animation-delay: 1.2s;
+}
+
+@keyframes waddle {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-4px) rotate(1deg); }
+}
+
+@keyframes swayPa {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes stepPa {
+  0%, 100% { transform: rotate(-12deg); }
+  50% { transform: rotate(12deg); }
+}
+
+@keyframes sniff {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes lick {
+  0%, 60%, 100% { transform: scaleX(0.1); }
+  30% { transform: scaleX(1); }
+}
+
+@keyframes blinkPa {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes scurry {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-14px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pang,
+  .tailPa,
+  .legPa,
+  .headPa,
+  .eyePa,
+  .tongue,
+  .antPa {
+    animation: none;
+  }
+
+  .scalePa {
+    transition: none;
+  }
+
+  .tongue {
+    transform: scaleX(0.1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pangolin built for #45576. Each scale keeps its lean in a `--pa2` custom property and the flare multiplies it with `calc(var(--pa2) * 2.2)`, so every plate opens further along the direction it already points rather than snapping to a shared angle. The tongue sits at `scaleX(0.1)` and shoots to full length from a `transform-origin: 100% 50%` at its root in the mouth, so it extends forward out of the snout instead of growing from its own middle, and because it returns to a tenth of its width the retracted tongue is effectively invisible without needing a second state. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45576.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a pangolin with overlapping armour scales, a long snout with its tongue flicked out, a ringed tail and ants scurrying beside an anthill.
