### PR TITLE
Add manatee component

### DIFF
--- a/submissions/examples/manatee-as/README.md
+++ b/submissions/examples/manatee-as/README.md
@@ -1,0 +1,21 @@
+# Manatee
+
+### What does this do?
+
+It shows a manatee drifting slowly through a seagrass bed. It moves diagonally as it swims rather than just bobbing, its paddle tail sweeps, its flippers row, its head nods, its whiskers twitch, and it blinks. Under reduced motion it hangs still in the water.
+
+### How is it used?
+
+```html
+<div class="manatee">
+  <span class="paddle"></span>
+  <span class="bodyMa"></span>
+  <div class="headMa"><span class="muzzleMa"></span></div>
+</div>
+```
+
+The drift keyframe moves the animal on both axes at once, `translate(14px, -12px)`, which is what separates a slow swim from a bob in place: it actually travels while it rises. The tail sweeps from `transform-origin: 0 50%` where it joins the body, so it hinges at the hips rather than pivoting around its own centre. The skin folds are one `repeating-linear-gradient` angled across the body and clipped by the same `border-radius`, so they curve with the animal for free.
+
+### Why is it useful?
+
+Ocean, wildlife, and calm or gentle themes use a manatee. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/manatee-as/demo.html
+++ b/submissions/examples/manatee-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manatee</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="raysM"></span>
+    <div class="manatee">
+      <span class="paddle"></span>
+      <span class="bodyMa"></span>
+      <span class="wrinkles"></span>
+      <span class="flipperMa fml"></span>
+      <span class="flipperMa fmr"></span>
+      <div class="headMa">
+        <span class="skullMa"></span>
+        <span class="muzzleMa"></span>
+        <span class="nostrilMa"></span>
+        <span class="eyeMa"></span>
+        <span class="whiskMa wm1"></span>
+        <span class="whiskMa wm2"></span>
+      </div>
+    </div>
+    <span class="grassM gm1"></span>
+    <span class="grassM gm2"></span>
+    <span class="bubM bm1"></span>
+    <span class="bubM bm2"></span>
+    <span class="bedM"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/manatee-as/style.css
+++ b/submissions/examples/manatee-as/style.css
@@ -1,0 +1,305 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #2f93a8, #062b3a 84%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 350px;
+  height: 320px;
+}
+
+.raysM {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 240px);
+  background:
+    repeating-linear-gradient(
+      96deg,
+      rgba(200, 250, 255, 0.06) 0 26px,
+      transparent 26px 96px
+    );
+  pointer-events: none;
+}
+
+.bedM {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 54px);
+  background:
+    radial-gradient(circle at 26% 0, rgba(255, 245, 210, 0.14) 0 20px, transparent 20px),
+    linear-gradient(180deg, #46666b, #1c3238);
+  z-index: 5;
+}
+
+.grassM {
+  position: absolute;
+  bottom: 44px;
+  width: 14px;
+  height: 96px;
+  border-radius: 7px 7px 0 0;
+  background: linear-gradient(180deg, #57a86a, #1f5c37);
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: swayM 5s ease-in-out infinite;
+}
+
+.gm1 { left: 30px; }
+
+.gm2 {
+  right: 36px;
+  height: 74px;
+  animation-delay: 2.2s;
+}
+
+.manatee {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 300px;
+  height: 140px;
+  margin-left: -150px;
+  z-index: 4;
+  animation: driftM 6s ease-in-out infinite;
+}
+
+.bodyMa {
+  position: absolute;
+  bottom: 10px;
+  left: 62px;
+  width: 176px;
+  height: 96px;
+  border-radius: 44% 40% 40% 44% / 52% 50% 50% 52%;
+  background: linear-gradient(180deg, #9aa7ac, #5f6c73);
+  box-shadow: inset 0 -10px 20px rgba(30, 44, 50, 0.45);
+  z-index: 3;
+}
+
+.wrinkles {
+  position: absolute;
+  bottom: 14px;
+  left: 74px;
+  width: 152px;
+  height: 84px;
+  border-radius: 44% 40% 40% 44% / 52% 50% 50% 52%;
+  background:
+    repeating-linear-gradient(
+      80deg,
+      rgba(40, 56, 62, 0.18) 0 3px,
+      transparent 3px 22px
+    );
+  z-index: 4;
+}
+
+.paddle {
+  position: absolute;
+  bottom: 12px;
+  right: 4px;
+  width: 90px;
+  height: 60px;
+  border-radius: 10px 50% 50% 10px / 10px 50% 50% 10px;
+  background: linear-gradient(90deg, #8c989e, #56636a);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: sweepM 6s ease-in-out infinite;
+}
+
+.flipperMa {
+  position: absolute;
+  width: 54px;
+  height: 26px;
+  border-radius: 40% 60% 50% 50% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #8c989e, #5a666d);
+  transform-origin: 10% 30%;
+  z-index: 5;
+  animation: paddleM 4s ease-in-out infinite;
+}
+
+.fml {
+  bottom: 8px;
+  left: 92px;
+}
+
+.fmr {
+  bottom: 30px;
+  left: 78px;
+  z-index: 2;
+  animation-delay: 2s;
+}
+
+.headMa {
+  position: absolute;
+  bottom: 26px;
+  left: 6px;
+  width: 110px;
+  height: 96px;
+  transform-origin: 90% 70%;
+  z-index: 4;
+  animation: nodM 6s ease-in-out infinite;
+}
+
+.skullMa {
+  position: absolute;
+  bottom: 0;
+  left: 22px;
+  width: 84px;
+  height: 80px;
+  border-radius: 46% 40% 40% 46% / 52% 50% 50% 52%;
+  background: linear-gradient(180deg, #a2aeb3, #66737a);
+  z-index: 3;
+}
+
+.muzzleMa {
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  width: 62px;
+  height: 52px;
+  border-radius: 46% 34% 34% 46% / 50% 46% 46% 50%;
+  background: linear-gradient(180deg, #b3bfc4, #7a878e);
+  box-shadow: inset -4px -4px 10px rgba(40, 56, 62, 0.3);
+  z-index: 4;
+}
+
+.nostrilMa {
+  position: absolute;
+  bottom: 34px;
+  left: 8px;
+  width: 9px;
+  height: 7px;
+  border-radius: 50%;
+  background: #33424a;
+  box-shadow: 14px 2px 0 -1px #33424a;
+  z-index: 6;
+}
+
+.eyeMa {
+  position: absolute;
+  bottom: 50px;
+  left: 48px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #1a2429;
+  box-shadow: inset -2px 2px 0 -1px rgba(255, 255, 255, 0.7);
+  z-index: 6;
+  animation: blinkM 5.6s ease-in-out infinite;
+}
+
+.whiskMa {
+  position: absolute;
+  bottom: 22px;
+  left: 4px;
+  width: 30px;
+  height: 2px;
+  border-radius: 1px;
+  background: rgba(240, 250, 255, 0.7);
+  transform-origin: 100% 50%;
+  transform: rotate(var(--wm, 0deg));
+  z-index: 6;
+  animation: twitchM 4s ease-in-out infinite;
+}
+
+.wm1 {
+  --wm: -14deg;
+}
+
+.wm2 {
+  bottom: 14px;
+
+  --wm: 12deg;
+
+  animation-delay: 1.4s;
+}
+
+.bubM {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 250, 255, 0.7);
+  opacity: 0;
+  z-index: 6;
+  animation: upM 6s ease-in infinite;
+}
+
+.bm1 {
+  bottom: 190px;
+  left: 74px;
+  width: 11px;
+  height: 11px;
+}
+
+.bm2 {
+  bottom: 206px;
+  left: 54px;
+  width: 8px;
+  height: 8px;
+  animation-delay: 3s;
+}
+
+@keyframes driftM {
+  0%, 100% { transform: translate(0, 0) rotate(-1deg); }
+  50% { transform: translate(14px, -12px) rotate(1deg); }
+}
+
+@keyframes sweepM {
+  0%, 100% { transform: rotate(-7deg); }
+  50% { transform: rotate(8deg); }
+}
+
+@keyframes paddleM {
+  0%, 100% { transform: rotate(-8deg); }
+  50% { transform: rotate(12deg); }
+}
+
+@keyframes nodM {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes twitchM {
+  0%, 100% { transform: rotate(var(--wm, 0deg)); }
+  50% { transform: rotate(calc(var(--wm, 0deg) + 8deg)); }
+}
+
+@keyframes blinkM {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes swayM {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes upM {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translateY(-160px) translateX(20px) scale(1.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .manatee,
+  .paddle,
+  .flipperMa,
+  .headMa,
+  .whiskMa,
+  .eyeMa,
+  .grassM,
+  .bubM {
+    animation: none;
+  }
+
+  .bubM {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a manatee built for #45580. The drift keyframe moves the animal on both axes at once, which is what separates a slow swim from a bob in place: it actually travels while it rises. The tail sweeps from a `transform-origin: 0 50%` where it joins the body, so it hinges at the hips rather than pivoting around its own centre, and the skin folds are one angled repeating gradient clipped by the same border-radius as the body, so they curve with the animal for free. Reduced motion fallback included. Pure CSS. Closes #45580.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a grey manatee with a broad paddle tail, rowing flippers, a whiskered muzzle and skin folds curving along its body, drifting over a seagrass bed under light rays.
