### PR TITLE
Add toad component

### DIFF
--- a/submissions/examples/toad-as/README.md
+++ b/submissions/examples/toad-as/README.md
@@ -1,0 +1,22 @@
+# Toad
+
+### What does this do?
+
+It shows a toad sitting on a lily pad at night, watching a fly circle overhead. Its body breathes, its throat balloons out as it croaks, its eyelids drop and open, and the pad bobs under it. Under reduced motion it sits still with its eyes open.
+
+### How is it used?
+
+```html
+<div class="toad">
+  <span class="bodyTo"></span>
+  <span class="throat"></span>
+  <span class="eyeTo etl"></span>
+  <span class="lidTo ltl"></span>
+</div>
+```
+
+The croak is a two-axis squash: the throat scales to `scaleY(1.5) scaleX(1.12)` from `transform-origin: 50% 20%`, its top edge, so it balloons downward and outward from where it joins the jaw rather than inflating around its own centre. The blink is inverted from the usual approach: the eyelid sits at `scaleY(0.06)`, a thin line hidden at the top of the eye, and briefly scales to full size, so the closed state is the animated one and the eye is open by default. That also makes the reduced motion fallback a one-liner, since pinning the lid at its resting scale leaves the toad wide-eyed.
+
+### Why is it useful?
+
+Pond, night, and creature themes use a toad. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/toad-as/demo.html
+++ b/submissions/examples/toad-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toad</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moonTo"></span>
+    <div class="toad">
+      <span class="hindTo htl"></span>
+      <span class="hindTo htr"></span>
+      <span class="bodyTo"></span>
+      <span class="wart wt1"></span>
+      <span class="wart wt2"></span>
+      <span class="wart wt3"></span>
+      <span class="throat"></span>
+      <span class="eyeTo etl"></span>
+      <span class="eyeTo etr"></span>
+      <span class="lidTo ltl"></span>
+      <span class="lidTo ltr"></span>
+      <span class="mouthTo"></span>
+      <span class="footTo ftl"></span>
+      <span class="footTo ftr"></span>
+    </div>
+    <span class="flyTo"></span>
+    <span class="lily"></span>
+    <span class="pondTo"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/toad-as/style.css
+++ b/submissions/examples/toad-as/style.css
@@ -1,0 +1,258 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #2c3a4a, #0b1118 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 310px;
+}
+
+.moonTo {
+  position: absolute;
+  top: 24px;
+  right: 40px;
+  width: 62px;
+  height: 62px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #fdfaf0, #d6d0b4 74%);
+  box-shadow: 0 0 56px rgba(240, 235, 200, 0.5);
+  animation: glowTo 6s ease-in-out infinite;
+}
+
+.pondTo {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 60px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.06) 0 3px,
+      transparent 3px 26px
+    ),
+    linear-gradient(180deg, #2c5866, #10262f);
+  z-index: 5;
+}
+
+.lily {
+  position: absolute;
+  bottom: 42px;
+  left: 50%;
+  width: 210px;
+  height: 44px;
+  margin-left: -105px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #4f9b52, #2b6135);
+  box-shadow: 0 -4px 12px rgba(20, 60, 30, 0.4);
+  z-index: 4;
+  animation: bobLy 5s ease-in-out infinite;
+}
+
+.toad {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  width: 220px;
+  height: 140px;
+  margin-left: -110px;
+  z-index: 6;
+  animation: breatheTo 3s ease-in-out infinite;
+}
+
+.bodyTo {
+  position: absolute;
+  bottom: 0;
+  left: 30px;
+  width: 160px;
+  height: 100px;
+  border-radius: 50% 50% 38% 38% / 62% 62% 38% 38%;
+  background: linear-gradient(180deg, #7d9a4c, #3f5b25);
+  box-shadow: inset 0 -10px 18px rgba(24, 40, 10, 0.45);
+  z-index: 3;
+}
+
+.wart {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #93b25c, #5c7a32 72%);
+  z-index: 4;
+}
+
+.wt1 {
+  bottom: 44px;
+  left: 52px;
+  width: 16px;
+  height: 14px;
+}
+
+.wt2 {
+  bottom: 30px;
+  left: 96px;
+  width: 20px;
+  height: 16px;
+}
+
+.wt3 {
+  bottom: 48px;
+  right: 48px;
+  width: 15px;
+  height: 13px;
+}
+
+.throat {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 92px;
+  height: 46px;
+  margin-left: -46px;
+  border-radius: 50% 50% 44% 44% / 70% 70% 30% 30%;
+  background: linear-gradient(180deg, #c9d98a, #92aa53);
+  transform-origin: 50% 20%;
+  z-index: 5;
+  animation: croak 3s ease-in-out infinite;
+}
+
+.eyeTo {
+  position: absolute;
+  bottom: 84px;
+  width: 40px;
+  height: 36px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #f2d34a, #a87c10 74%);
+  box-shadow: inset 0 -4px 8px rgba(80, 50, 4, 0.4);
+  z-index: 5;
+}
+
+.etl { left: 44px; }
+.etr { right: 44px; }
+
+.lidTo {
+  position: absolute;
+  bottom: 84px;
+  width: 40px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #6d8a42, #4a6529);
+  transform-origin: 50% 0;
+  z-index: 6;
+  animation: blinkTo 4.4s ease-in-out infinite;
+}
+
+.ltl { left: 44px; }
+
+.ltr {
+  right: 44px;
+  animation-delay: 0.08s;
+}
+
+.mouthTo {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 84px;
+  height: 20px;
+  margin-left: -42px;
+  border-radius: 0 0 40px 40px;
+  border-bottom: 4px solid #33481c;
+  z-index: 6;
+}
+
+.footTo {
+  position: absolute;
+  bottom: -6px;
+  width: 44px;
+  height: 16px;
+  border-radius: 8px 12px 8px 8px;
+  background: linear-gradient(180deg, #6d8a42, #405c22);
+  z-index: 2;
+}
+
+.ftl { left: 20px; }
+
+.ftr {
+  right: 20px;
+  border-radius: 12px 8px 8px 8px;
+}
+
+.hindTo {
+  position: absolute;
+  bottom: 6px;
+  width: 56px;
+  height: 44px;
+  border-radius: 50% 50% 40% 40%;
+  background: linear-gradient(180deg, #6d8a42, #3d5822);
+  z-index: 2;
+}
+
+.htl { left: 14px; }
+.htr { right: 14px; }
+
+.flyTo {
+  position: absolute;
+  top: 84px;
+  left: 84px;
+  width: 12px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2a2a30;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+  z-index: 7;
+  animation: buzzTo 4s ease-in-out infinite;
+}
+
+@keyframes breatheTo {
+  0%, 100% { transform: scaleY(1) translateY(0); }
+  50% { transform: scaleY(1.03) translateY(-2px); }
+}
+
+@keyframes croak {
+  0%, 60%, 100% { transform: scaleY(1) scaleX(1); }
+  80% { transform: scaleY(1.5) scaleX(1.12); }
+}
+
+@keyframes blinkTo {
+  0%, 88%, 100% { transform: scaleY(0.06); }
+  94% { transform: scaleY(1); }
+}
+
+@keyframes bobLy {
+  0%, 100% { transform: translateY(0) rotate(-0.6deg); }
+  50% { transform: translateY(-3px) rotate(0.6deg); }
+}
+
+@keyframes buzzTo {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(24px, 16px); }
+  50% { transform: translate(-14px, 30px); }
+  75% { transform: translate(18px, 8px); }
+}
+
+@keyframes glowTo {
+  0%, 100% { opacity: 0.9; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.04); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toad,
+  .throat,
+  .lidTo,
+  .lily,
+  .flyTo,
+  .moonTo {
+    animation: none;
+  }
+
+  .lidTo {
+    transform: scaleY(0.06);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a toad built for #45582. The croak is a two axis squash: the throat scales from a `transform-origin` at its top edge, so it balloons downward and outward from where it joins the jaw rather than inflating around its own centre. The blink is inverted from the usual approach: the eyelid rests at `scaleY(0.06)`, a thin line hidden at the top of the eye, and briefly scales to full size, so the closed state is the animated one and the eye is open by default, which also makes the reduced motion fallback a single line. Pure CSS. Closes #45582.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a warty toad with bulging golden eyes, a wide mouth and a pale throat sac, sitting on a lily pad under the moon with a fly circling.
