### PR TITLE
Add okapi component

### DIFF
--- a/submissions/examples/okapi-as/README.md
+++ b/submissions/examples/okapi-as/README.md
@@ -1,0 +1,22 @@
+# Okapi
+
+### What does this do?
+
+It shows an okapi standing in the rainforest understory. It shifts its weight, its legs step in sequence, its tail flicks, its head lowers and lifts as it browses, its ears swivel, and leaves fall through the canopy light. Under reduced motion it stands still.
+
+### How is it used?
+
+```html
+<div class="okapi">
+  <span class="bodyO"></span>
+  <span class="stripeO so1"></span>
+  <span class="neckO"></span>
+  <div class="headO"><span class="muzzleO"></span></div>
+</div>
+```
+
+The zebra striping on the hind legs, which is the okapi's signature marking, is one `repeating-linear-gradient` per leg, so a whole banded limb costs a single property rather than a stack of bars. The head browses from `transform-origin: 84% 100%`, the base of the neck, so the long muzzle swings down toward the floor while the poll stays put, which is what makes it read as reaching for leaves rather than nodding. The four legs share one rule and one keyframe, each offset by a quarter of the cycle, so the gait cascades instead of marching in lockstep.
+
+### Why is it useful?
+
+Wildlife, rainforest, and rare animal themes use an okapi. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/okapi-as/demo.html
+++ b/submissions/examples/okapi-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Okapi</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="canopy"></span>
+    <span class="trunkO to1"></span>
+    <span class="trunkO to2"></span>
+    <div class="okapi">
+      <span class="tailO"></span>
+      <span class="bodyO"></span>
+      <span class="legO lo1"></span>
+      <span class="legO lo2"></span>
+      <span class="legO lo3"></span>
+      <span class="legO lo4"></span>
+      <span class="stripeO so1"></span>
+      <span class="stripeO so2"></span>
+      <span class="neckO"></span>
+      <div class="headO">
+        <span class="skullO"></span>
+        <span class="muzzleO"></span>
+        <span class="earO eol"></span>
+        <span class="earO eor"></span>
+        <span class="eyeO"></span>
+        <span class="hornO"></span>
+      </div>
+    </div>
+    <span class="leafO lo5"></span>
+    <span class="leafO lo6"></span>
+    <span class="floorO"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/okapi-as/style.css
+++ b/submissions/examples/okapi-as/style.css
@@ -1,0 +1,304 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #3f5e3a, #10190f 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 350px;
+  height: 320px;
+}
+
+.canopy {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 66px);
+  background:
+    radial-gradient(circle at 18% 100%, #35682f 0 60px, transparent 60px),
+    radial-gradient(circle at 46% 100%, #2c5a2a 0 74px, transparent 74px),
+    radial-gradient(circle at 78% 100%, #35682f 0 56px, transparent 56px),
+    linear-gradient(180deg, #1c3a1c, #24451f);
+  z-index: 2;
+}
+
+.trunkO {
+  position: absolute;
+  top: 40px;
+  width: 26px;
+  height: 210px;
+  border-radius: 4px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(30, 20, 6, 0.35) 0 2px,
+      transparent 2px 12px
+    ),
+    linear-gradient(90deg, #6b4d2c, #3d2b16);
+  z-index: 3;
+}
+
+.to1 { left: 22px; }
+.to2 { right: 26px; }
+
+.floorO {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 44px);
+  background: linear-gradient(180deg, #4d4326, #241f10);
+  z-index: 6;
+}
+
+.okapi {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 260px;
+  height: 240px;
+  margin-left: -130px;
+  z-index: 5;
+  animation: swayO 5s ease-in-out infinite;
+}
+
+.bodyO {
+  position: absolute;
+  bottom: 64px;
+  left: 62px;
+  width: 150px;
+  height: 82px;
+  border-radius: 40% 44% 36% 36% / 54% 54% 46% 46%;
+  background: linear-gradient(180deg, #6f3f26, #43230f);
+  box-shadow: inset 0 -8px 16px rgba(30, 14, 4, 0.45);
+  z-index: 4;
+}
+
+.stripeO {
+  position: absolute;
+  bottom: 4px;
+  width: 18px;
+  height: 58px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #f4efe2 0 5px,
+      transparent 5px 13px
+    );
+  z-index: 4;
+}
+
+.so1 { right: 66px; }
+.so2 { right: 94px; }
+
+.legO {
+  position: absolute;
+  bottom: 0;
+  width: 18px;
+  height: 70px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #5c3620, #2f1a0c);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: stepO 1.8s ease-in-out infinite;
+}
+
+.lo1 { left: 72px; }
+
+.lo2 {
+  left: 100px;
+  animation-delay: 0.45s;
+}
+
+.lo3 {
+  right: 66px;
+  animation-delay: 0.9s;
+}
+
+.lo4 {
+  right: 94px;
+  animation-delay: 1.35s;
+}
+
+.tailO {
+  position: absolute;
+  bottom: 96px;
+  right: 44px;
+  width: 8px;
+  height: 54px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #5c3620, #2f1a0c);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: flickO 3.2s ease-in-out infinite;
+}
+
+.neckO {
+  position: absolute;
+  bottom: 120px;
+  left: 62px;
+  width: 42px;
+  height: 86px;
+  border-radius: 14px 18px 6px 6px;
+  background: linear-gradient(90deg, #7a472a, #4a2712);
+  transform: rotate(-10deg);
+  transform-origin: 50% 100%;
+  z-index: 4;
+}
+
+.headO {
+  position: absolute;
+  bottom: 186px;
+  left: 20px;
+  width: 110px;
+  height: 74px;
+  transform-origin: 84% 100%;
+  z-index: 5;
+  animation: grazeO 5s ease-in-out infinite;
+}
+
+.skullO {
+  position: absolute;
+  bottom: 0;
+  right: 6px;
+  width: 66px;
+  height: 54px;
+  border-radius: 46% 50% 40% 40% / 50% 52% 48% 48%;
+  background: linear-gradient(180deg, #85502f, #4f2b14);
+  z-index: 3;
+}
+
+.muzzleO {
+  position: absolute;
+  bottom: 0;
+  left: 6px;
+  width: 58px;
+  height: 34px;
+  border-radius: 44% 26% 26% 44% / 50% 44% 44% 50%;
+  background: linear-gradient(180deg, #4a3020, #2a1a0e);
+  z-index: 4;
+}
+
+.earO {
+  position: absolute;
+  bottom: 44px;
+  width: 26px;
+  height: 22px;
+  border-radius: 50% 50% 40% 40%;
+  background: #5c3620;
+  z-index: 2;
+  animation: earO 4s ease-in-out infinite;
+}
+
+.eol { right: 44px; }
+
+.eor {
+  right: 12px;
+  animation-delay: 2s;
+}
+
+.eyeO {
+  position: absolute;
+  bottom: 30px;
+  right: 34px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #1a0f06;
+  box-shadow: inset -2px 2px 0 -1px rgba(255, 255, 255, 0.7);
+  z-index: 5;
+  animation: blinkO 5.4s ease-in-out infinite;
+}
+
+.hornO {
+  position: absolute;
+  bottom: 56px;
+  right: 30px;
+  width: 6px;
+  height: 18px;
+  border-radius: 3px;
+  background: #3f2412;
+  z-index: 4;
+}
+
+.leafO {
+  position: absolute;
+  width: 30px;
+  height: 16px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #5fae52, #2c6b31);
+  opacity: 0;
+  z-index: 6;
+  animation: fallO 6s linear infinite;
+}
+
+.lo5 { top: 60px; left: 130px; }
+
+.lo6 {
+  top: 40px;
+  right: 110px;
+  animation-delay: 3s;
+
+  --ox: -40px;
+}
+
+@keyframes swayO {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+@keyframes stepO {
+  0%, 100% { transform: rotate(-8deg); }
+  50% { transform: rotate(8deg); }
+}
+
+@keyframes flickO {
+  0%, 100% { transform: rotate(-8deg); }
+  50% { transform: rotate(10deg); }
+}
+
+@keyframes grazeO {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(8deg); }
+}
+
+@keyframes earO {
+  0%, 88%, 100% { transform: rotate(0deg); }
+  94% { transform: rotate(-16deg); }
+}
+
+@keyframes blinkO {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes fallO {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { transform: translate(var(--ox, 40px), 220px) rotate(280deg); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .okapi,
+  .legO,
+  .tailO,
+  .headO,
+  .earO,
+  .eyeO,
+  .leafO {
+    animation: none;
+  }
+
+  .leafO {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an okapi built for #45584. The zebra striping on the hind legs, the animal's signature marking, is one repeating gradient per leg, so a banded limb costs a single property rather than a stack of bars. The head browses from a `transform-origin` at the base of the neck, so the long muzzle swings toward the floor while the poll stays put, which is what makes it read as reaching for leaves rather than nodding, and the four legs share one keyframe offset by a quarter cycle each so the gait cascades instead of marching in lockstep. Reduced motion fallback included. Pure CSS. Closes #45584.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an okapi with a long neck, dark muzzle, swivelling ears and white banded hind legs, standing among rainforest trunks with leaves falling.
