### PR TITLE
Add lantern fish component

### DIFF
--- a/submissions/examples/lantern-fish-as/README.md
+++ b/submissions/examples/lantern-fish-as/README.md
@@ -1,0 +1,22 @@
+# Lantern Fish
+
+### What does this do?
+
+It shows an anglerfish in the deep, its glowing lure swinging in front of a mouthful of teeth. The fish drifts through the dark, its tail and fin wave, the lure and the halo around it pulse together, photophores along its flank blink, and marine snow drifts past. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="lfish">
+  <span class="glowL"></span>
+  <span class="lureL"></span>
+  <span class="rodL"></span>
+  <span class="bodyL"></span>
+</div>
+```
+
+The lure and the halo behind it run the same `pulseL` keyframe on the same four second clock, so the light and the glow it casts brighten and fade as one thing rather than drifting out of phase. The teeth are `clip-path` triangles, each flipped upside down through its own `--tt2` angle of roughly 180 degrees with a few degrees of variation, so they hang from the jaw at slightly different tilts instead of looking like a stamped row. The rod swings from `transform-origin: 0 50%`, its root on the head, so the lure arcs out in front of the fish.
+
+### Why is it useful?
+
+Deep sea, dark mode, and eerie or mysterious themes use an anglerfish. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/lantern-fish-as/demo.html
+++ b/submissions/examples/lantern-fish-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lantern Fish</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="lfish">
+      <span class="glowL"></span>
+      <span class="lureL"></span>
+      <span class="rodL"></span>
+      <span class="bodyL"></span>
+      <span class="finL"></span>
+      <span class="tailL"></span>
+      <span class="eyeL"></span>
+      <span class="jawL"></span>
+      <span class="toothL tl1"></span>
+      <span class="toothL tl2"></span>
+      <span class="toothL tl3"></span>
+      <span class="toothL tl4"></span>
+      <span class="spotL sl1"></span>
+      <span class="spotL sl2"></span>
+      <span class="spotL sl3"></span>
+    </div>
+    <span class="moteL ml1"></span>
+    <span class="moteL ml2"></span>
+    <span class="moteL ml3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/lantern-fish-as/style.css
+++ b/submissions/examples/lantern-fish-as/style.css
@@ -1,0 +1,273 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #0b2233, #01060c 72%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.lfish {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 300px;
+  height: 180px;
+  margin-left: -150px;
+  z-index: 4;
+  animation: swimL 6s ease-in-out infinite;
+}
+
+.bodyL {
+  position: absolute;
+  bottom: 0;
+  left: 56px;
+  width: 170px;
+  height: 116px;
+  border-radius: 52% 40% 40% 46% / 56% 50% 50% 44%;
+  background: linear-gradient(160deg, #2c4657, #0e1d29);
+  box-shadow:
+    inset -10px -10px 22px rgba(0, 0, 0, 0.55),
+    0 0 40px rgba(80, 200, 220, 0.12);
+  z-index: 3;
+}
+
+.finL {
+  position: absolute;
+  bottom: 96px;
+  left: 128px;
+  width: 60px;
+  height: 34px;
+  clip-path: polygon(0 100%, 40% 0, 100% 100%);
+  background: linear-gradient(180deg, #3f6a80, #1b3444);
+  z-index: 2;
+  animation: finWave 3.4s ease-in-out infinite;
+}
+
+.tailL {
+  position: absolute;
+  bottom: 24px;
+  right: 42px;
+  width: 66px;
+  height: 70px;
+  clip-path: polygon(0 50%, 100% 0, 78% 50%, 100% 100%);
+  background: linear-gradient(90deg, #2c4657, #17303f);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: tailWave 2.2s ease-in-out infinite;
+}
+
+.eyeL {
+  position: absolute;
+  bottom: 74px;
+  left: 82px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 34%, #eafcff, #16323f 74%);
+  box-shadow: 0 0 12px rgba(180, 240, 255, 0.5);
+  z-index: 6;
+  animation: starefish 5s ease-in-out infinite;
+}
+
+.jawL {
+  position: absolute;
+  bottom: 12px;
+  left: 44px;
+  width: 90px;
+  height: 34px;
+  border-radius: 40% 10% 10% 50% / 60% 20% 20% 60%;
+  background: linear-gradient(180deg, #24394a, #0c1a24);
+  z-index: 4;
+}
+
+.toothL {
+  position: absolute;
+  width: 10px;
+  height: 18px;
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  background: linear-gradient(180deg, #fdfdf5, #c9cfc4);
+  z-index: 6;
+  transform: rotate(var(--tt2, 0deg));
+}
+
+.tl1 {
+  bottom: 30px;
+  left: 52px;
+
+  --tt2: 178deg;
+}
+
+.tl2 {
+  bottom: 30px;
+  left: 70px;
+
+  --tt2: 186deg;
+}
+
+.tl3 {
+  bottom: 30px;
+  left: 88px;
+
+  --tt2: 172deg;
+}
+
+.tl4 {
+  bottom: 30px;
+  left: 106px;
+
+  --tt2: 184deg;
+}
+
+.rodL {
+  position: absolute;
+  bottom: 112px;
+  left: 86px;
+  width: 78px;
+  height: 7px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #2c4657, #4f7d92);
+  transform-origin: 0 50%;
+  transform: rotate(-42deg);
+  z-index: 5;
+  animation: dangleL 4s ease-in-out infinite;
+}
+
+.lureL {
+  position: absolute;
+  bottom: 168px;
+  left: 138px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f4ffd0, #7fe08a 62%, #2f9e5e);
+  box-shadow: 0 0 26px rgba(140, 255, 170, 0.95);
+  z-index: 6;
+  animation: pulseL 4s ease-in-out infinite;
+}
+
+.glowL {
+  position: absolute;
+  bottom: 96px;
+  left: 74px;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(120, 245, 170, 0.3), transparent 66%);
+  filter: blur(8px);
+  z-index: 2;
+  animation: pulseL 4s ease-in-out infinite;
+}
+
+.spotL {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #8ff0c4;
+  box-shadow: 0 0 10px rgba(140, 245, 200, 0.9);
+  z-index: 5;
+  animation: blinkSpot 3s ease-in-out infinite;
+}
+
+.sl1 { bottom: 46px; left: 132px; }
+
+.sl2 {
+  bottom: 64px;
+  left: 166px;
+  animation-delay: 0.8s;
+}
+
+.sl3 {
+  bottom: 40px;
+  left: 196px;
+  animation-delay: 1.6s;
+}
+
+.moteL {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgba(190, 245, 255, 0.7);
+  z-index: 3;
+  animation: driftL 9s linear infinite;
+}
+
+.ml1 { top: 60px; left: 40px; }
+
+.ml2 {
+  top: 130px;
+  right: 50px;
+  animation-delay: 3s;
+}
+
+.ml3 {
+  bottom: 40px;
+  left: 90px;
+  animation-delay: 6s;
+}
+
+@keyframes swimL {
+  0%, 100% { transform: translate(0, 0) rotate(-1deg); }
+  50% { transform: translate(-12px, -10px) rotate(1deg); }
+}
+
+@keyframes tailWave {
+  0%, 100% { transform: rotate(-10deg); }
+  50% { transform: rotate(10deg); }
+}
+
+@keyframes finWave {
+  0%, 100% { transform: skewX(0deg); }
+  50% { transform: skewX(-10deg); }
+}
+
+@keyframes dangleL {
+  0%, 100% { transform: rotate(-42deg); }
+  50% { transform: rotate(-34deg); }
+}
+
+@keyframes pulseL {
+  0%, 100% { opacity: 0.75; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.12); }
+}
+
+@keyframes blinkSpot {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 1; }
+}
+
+@keyframes starefish {
+  0%, 94%, 100% { transform: scaleY(1); }
+  97% { transform: scaleY(0.15); }
+}
+
+@keyframes driftL {
+  0% { transform: translate(0, 0); opacity: 0; }
+  20% { opacity: 1; }
+  80% { opacity: 1; }
+  100% { transform: translate(40px, -60px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lfish,
+  .tailL,
+  .finL,
+  .rodL,
+  .lureL,
+  .glowL,
+  .spotL,
+  .eyeL,
+  .moteL {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a lantern fish built for #45586. The lure and the halo behind it run the same keyframe on the same four second clock, so the light and the glow it casts brighten and fade as one thing rather than drifting out of phase. The teeth are clip-path triangles, each flipped through its own `--tt2` angle of roughly 180 degrees with a few degrees of variation, so they hang from the jaw at slightly different tilts instead of looking like a stamped row, and the rod swings from a `transform-origin` at its root on the head so the lure arcs out in front of the fish. Reduced motion fallback included. Pure CSS. Closes #45586.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a dark anglerfish with a glowing green lure on a rod, jagged teeth, a fanned tail and blinking photophores, drifting in the deep with marine snow.
