### PR TITLE
Add coconut component

### DIFF
--- a/submissions/examples/coconut-as/README.md
+++ b/submissions/examples/coconut-as/README.md
@@ -1,0 +1,22 @@
+# Coconut
+
+### What does this do?
+
+It shows a coconut drink on the beach with a striped straw, a paper umbrella and a wedge of pineapple. The coconut sways, the liquid inside sloshes, the umbrella twirls, and bubbles rise from the straw. Hovering or focusing it tips the whole drink faster, as if someone picked it up. Under reduced motion it sits still.
+
+### How is it used?
+
+```html
+<div class="coco" tabindex="0">
+  <span class="shellC"></span>
+  <span class="fibre"></span>
+  <span class="straw"></span>
+  <span class="umbrella"></span>
+</div>
+```
+
+The paper umbrella is a `repeating-conic-gradient` anchored at `50% 100%`, the point of the parasol, so the alternating red and white panels fan out from the tip exactly as they would on a real one, in a single element. The coir husk is a `repeating-linear-gradient` clipped by the shell's own `border-radius`, so the fibres curve around the nut instead of running flat across it. The wedge of fruit is a plain `conic-gradient` limited to 60 degrees, which cuts a slice shape without a clip path.
+
+### Why is it useful?
+
+Beach, tropical, and summer drink themes use a coconut. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/coconut-as/demo.html
+++ b/submissions/examples/coconut-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Coconut</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunC2"></span>
+    <div class="coco" tabindex="0">
+      <span class="shellC"></span>
+      <span class="fibre"></span>
+      <span class="eyeC ec1"></span>
+      <span class="eyeC ec2"></span>
+      <span class="eyeC ec3"></span>
+      <span class="straw"></span>
+      <span class="drinkC"></span>
+      <span class="umbrella"></span>
+      <span class="wedge"></span>
+    </div>
+    <span class="sipC s1"></span>
+    <span class="sipC s2"></span>
+    <span class="sandC"></span>
+    <span class="shadowC"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/coconut-as/style.css
+++ b/submissions/examples/coconut-as/style.css
@@ -1,0 +1,253 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #6fd0e8, #f2c78a 66%, #d99a55);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 330px;
+}
+
+.sunC2 {
+  position: absolute;
+  top: 26px;
+  left: 26px;
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe0, #ffdc6a 68%);
+  box-shadow: 0 0 60px rgba(255, 225, 120, 0.85);
+  animation: pulseC2 5s ease-in-out infinite;
+}
+
+.sandC {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 62px);
+  background:
+    radial-gradient(circle at 24% 0, rgba(255, 255, 255, 0.22) 0 12px, transparent 12px),
+    linear-gradient(180deg, #eed6a4, #c49f61);
+}
+
+.shadowC {
+  position: absolute;
+  bottom: 48px;
+  left: 50%;
+  width: 190px;
+  height: 24px;
+  margin-left: -95px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(120, 80, 20, 0.4), transparent 70%);
+  filter: blur(3px);
+  z-index: 3;
+}
+
+.coco {
+  position: absolute;
+  bottom: 58px;
+  left: 50%;
+  width: 220px;
+  height: 240px;
+  margin-left: -110px;
+  outline: none;
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: swayC2 4.6s ease-in-out infinite;
+}
+
+.coco:hover,
+.coco:focus-visible {
+  animation: tipC 1.4s ease-in-out infinite;
+}
+
+.shellC {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 170px;
+  height: 158px;
+  margin-left: -85px;
+  border-radius: 46% 46% 50% 50% / 40% 40% 60% 60%;
+  background: radial-gradient(circle at 36% 30%, #7d5533, #3f2716 74%);
+  box-shadow:
+    inset -10px -10px 24px rgba(30, 16, 6, 0.55),
+    0 12px 26px rgba(0, 0, 0, 0.35);
+  z-index: 4;
+}
+
+.fibre {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 170px;
+  height: 158px;
+  margin-left: -85px;
+  border-radius: 46% 46% 50% 50% / 40% 40% 60% 60%;
+  background:
+    repeating-linear-gradient(
+      86deg,
+      rgba(30, 16, 4, 0.35) 0 2px,
+      transparent 2px 11px
+    );
+  z-index: 5;
+}
+
+.eyeC {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #4a2f1a, #22150a 72%);
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.6);
+  z-index: 6;
+}
+
+.ec1 { bottom: 116px; left: 76px; }
+.ec2 { bottom: 116px; right: 76px; }
+.ec3 { bottom: 96px; left: 50%; margin-left: -7px; }
+
+.drinkC {
+  position: absolute;
+  bottom: 128px;
+  left: 50%;
+  width: 74px;
+  height: 22px;
+  margin-left: -37px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 40% 34%, #fdfaf0, #dcd2ba 76%);
+  box-shadow: inset 0 3px 6px rgba(120, 100, 60, 0.4);
+  z-index: 6;
+  animation: slosh 4.6s ease-in-out infinite;
+}
+
+.straw {
+  position: absolute;
+  bottom: 130px;
+  left: 50%;
+  width: 12px;
+  height: 110px;
+  margin-left: -22px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      160deg,
+      #f05a72 0 8px,
+      #fdfaf0 8px 16px
+    );
+  transform-origin: 50% 100%;
+  transform: rotate(16deg);
+  z-index: 7;
+}
+
+.umbrella {
+  position: absolute;
+  bottom: 196px;
+  right: 30px;
+  width: 74px;
+  height: 34px;
+  border-radius: 40px 40px 0 0;
+  background:
+    repeating-conic-gradient(
+      from 180deg at 50% 100%,
+      #f0f0f0 0 24deg,
+      #ff6b6b 24deg 48deg
+    );
+  transform: rotate(-14deg);
+  transform-origin: 50% 100%;
+  z-index: 7;
+  animation: twirl 5s ease-in-out infinite;
+}
+
+.wedge {
+  position: absolute;
+  bottom: 146px;
+  right: 34px;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background:
+    conic-gradient(
+      from 200deg,
+      #ffd34a 0 60deg,
+      transparent 60deg 360deg
+    );
+  z-index: 7;
+}
+
+.sipC {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  opacity: 0;
+  z-index: 8;
+  animation: fizz 3.4s ease-out infinite;
+}
+
+.s1 {
+  bottom: 250px;
+  left: 128px;
+  width: 10px;
+  height: 10px;
+}
+
+.s2 {
+  bottom: 268px;
+  left: 146px;
+  width: 7px;
+  height: 7px;
+  animation-delay: 1.7s;
+}
+
+@keyframes swayC2 {
+  0%, 100% { transform: rotate(-1.6deg); }
+  50% { transform: rotate(1.6deg); }
+}
+
+@keyframes tipC {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes slosh {
+  0%, 100% { transform: scaleX(1) translateX(0); }
+  50% { transform: scaleX(1.04) translateX(3px); }
+}
+
+@keyframes twirl {
+  0%, 100% { transform: rotate(-14deg); }
+  50% { transform: rotate(-4deg); }
+}
+
+@keyframes fizz {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translateY(-40px) translateX(10px) scale(1.1); opacity: 0; }
+}
+
+@keyframes pulseC2 {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .coco,
+  .drinkC,
+  .umbrella,
+  .sipC,
+  .sunC2 {
+    animation: none;
+  }
+
+  .sipC {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a coconut built for #45588. The paper umbrella is a repeating conic gradient anchored at `50% 100%`, the point of the parasol, so the alternating panels fan from the tip exactly as they would on a real one, in one element. The coir husk is a repeating gradient clipped by the shell's own border-radius, so the fibres curve around the nut instead of running flat across it, and the fruit wedge is a plain conic gradient limited to 60 degrees, which cuts a slice with no clip path. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45588.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a coconut with a fibrous husk and three eyes, opened at the top with a striped straw, a red and white paper umbrella and a fruit wedge on the rim, on the beach.
