### PR TITLE
Add dragonfruit component

### DIFF
--- a/submissions/examples/dragonfruit-as/README.md
+++ b/submissions/examples/dragonfruit-as/README.md
@@ -1,0 +1,23 @@
+# Dragonfruit
+
+### What does this do?
+
+It shows a dragonfruit cut in two on a board. It bobs gently, the green scales along its skin flutter, and sparkles pop around it. Hovering or focusing it swings the halves apart to show the speckled white flesh inside. Under reduced motion it sits closed and still.
+
+### How is it used?
+
+```html
+<div class="dragon" tabindex="0">
+  <div class="halfD dl">
+    <span class="rindD"></span>
+    <span class="fleshD"></span>
+    <span class="seedsD"></span>
+  </div>
+</div>
+```
+
+Only one half is designed: the right one reuses the same markup flipped with `scaleX(-1)`, which is why its hover rule reads `translateX(-36px)` yet moves it to the right, since that transform is written in the flipped half's own coordinate space. The seeds are ten hard stop `radial-gradient` circles painted into one element that shares the flesh's `border-radius`, so they scatter across the cut face and clip to it for free rather than needing ten elements. Each leafy scale keeps its own angle in a `--dd` custom property that the flutter keyframe reads back, so the shared animation never flattens them.
+
+### Why is it useful?
+
+Fruit, tropical, and vivid colour themes use a dragonfruit. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/dragonfruit-as/demo.html
+++ b/submissions/examples/dragonfruit-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dragonfruit</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="dragon" tabindex="0">
+      <div class="halfD dl">
+        <span class="rindD"></span>
+        <span class="fleshD"></span>
+        <span class="seedsD"></span>
+      </div>
+      <div class="halfD dr">
+        <span class="rindD"></span>
+        <span class="fleshD"></span>
+        <span class="seedsD"></span>
+      </div>
+      <span class="scaleD sd1"></span>
+      <span class="scaleD sd2"></span>
+      <span class="scaleD sd3"></span>
+      <span class="scaleD sd4"></span>
+    </div>
+    <span class="boardD"></span>
+    <span class="sparkD spd1"></span>
+    <span class="sparkD spd2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dragonfruit-as/style.css
+++ b/submissions/examples/dragonfruit-as/style.css
@@ -1,0 +1,206 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #3d2a3e, #140d16 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.boardD {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 300px;
+  height: 26px;
+  margin-left: -150px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(70, 44, 20, 0.28) 0 2px,
+      transparent 2px 26px
+    ),
+    linear-gradient(180deg, #c39a63, #8a6a3c);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+}
+
+.dragon {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  width: 300px;
+  height: 200px;
+  margin-left: -150px;
+  outline: none;
+  z-index: 4;
+  animation: bobD 4.4s ease-in-out infinite;
+}
+
+.halfD {
+  position: absolute;
+  bottom: 0;
+  width: 140px;
+  height: 190px;
+  transition: transform 0.5s ease;
+}
+
+.dl {
+  left: 12px;
+  transform: rotate(-4deg);
+}
+
+.dr {
+  right: 12px;
+  transform: rotate(4deg) scaleX(-1);
+}
+
+.dragon:hover .dl,
+.dragon:focus-visible .dl {
+  transform: rotate(-12deg) translateX(-36px);
+}
+
+.dragon:hover .dr,
+.dragon:focus-visible .dr {
+  transform: rotate(12deg) scaleX(-1) translateX(-36px);
+}
+
+.rindD {
+  position: absolute;
+  inset: 0;
+  border-radius: 44% 44% 40% 40% / 36% 36% 64% 64%;
+  background: linear-gradient(180deg, #e8407f, #a3175a);
+  box-shadow:
+    inset -8px -8px 18px rgba(90, 6, 40, 0.5),
+    0 12px 26px rgba(0, 0, 0, 0.4);
+}
+
+.fleshD {
+  position: absolute;
+  inset: 12px;
+  border-radius: 44% 44% 40% 40% / 36% 36% 64% 64%;
+  background: radial-gradient(circle at 44% 44%, #fdfdfb, #e6e2e0 76%);
+  z-index: 2;
+}
+
+.seedsD {
+  position: absolute;
+  inset: 12px;
+  border-radius: 44% 44% 40% 40% / 36% 36% 64% 64%;
+  background:
+    radial-gradient(circle at 30% 22%, #1e1a1c 0 4px, transparent 4px),
+    radial-gradient(circle at 58% 16%, #1e1a1c 0 3px, transparent 3px),
+    radial-gradient(circle at 44% 34%, #1e1a1c 0 4px, transparent 4px),
+    radial-gradient(circle at 70% 38%, #1e1a1c 0 3px, transparent 3px),
+    radial-gradient(circle at 26% 46%, #1e1a1c 0 4px, transparent 4px),
+    radial-gradient(circle at 54% 54%, #1e1a1c 0 3px, transparent 3px),
+    radial-gradient(circle at 36% 66%, #1e1a1c 0 4px, transparent 4px),
+    radial-gradient(circle at 64% 72%, #1e1a1c 0 3px, transparent 3px),
+    radial-gradient(circle at 46% 84%, #1e1a1c 0 4px, transparent 4px),
+    radial-gradient(circle at 22% 76%, #1e1a1c 0 3px, transparent 3px),
+    transparent;
+  z-index: 3;
+}
+
+.scaleD {
+  position: absolute;
+  width: 72px;
+  height: 26px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #8fd05a, #3f8a34);
+  box-shadow: 0 3px 6px rgba(20, 40, 10, 0.4);
+  transform-origin: 100% 100%;
+  transform: rotate(var(--dd, 0deg));
+  z-index: 5;
+  animation: flutterD 4s ease-in-out infinite;
+}
+
+.sd1 {
+  top: 6px;
+  left: 24px;
+
+  --dd: -18deg;
+}
+
+.sd2 {
+  top: 46px;
+  left: 6px;
+
+  --dd: 16deg;
+
+  animation-delay: 0.7s;
+}
+
+.sd3 {
+  top: 6px;
+  right: 24px;
+  transform-origin: 0 100%;
+
+  --dd: 18deg;
+
+  animation-delay: 1.4s;
+}
+
+.sd4 {
+  top: 46px;
+  right: 6px;
+  transform-origin: 0 100%;
+
+  --dd: -16deg;
+
+  animation-delay: 2.1s;
+}
+
+.sparkD {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #fff0f6;
+  box-shadow: 0 0 10px rgba(255, 200, 230, 0.9);
+  z-index: 6;
+  animation: twinkleD 2.8s ease-in-out infinite;
+}
+
+.spd1 { top: 60px; left: 44px; }
+
+.spd2 {
+  top: 110px;
+  right: 46px;
+  animation-delay: 1.4s;
+}
+
+@keyframes bobD {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-7px); }
+}
+
+@keyframes flutterD {
+  0%, 100% { transform: rotate(var(--dd, 0deg)); }
+  50% { transform: rotate(calc(var(--dd, 0deg) + 8deg)); }
+}
+
+@keyframes twinkleD {
+  0%, 100% { opacity: 0.3; transform: scale(0.7); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dragon,
+  .scaleD,
+  .sparkD {
+    animation: none;
+  }
+
+  .halfD {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dragonfruit built for #45590. Only one half is designed: the right reuses the same markup flipped with `scaleX(-1)`, which is why its hover rule reads `translateX(-36px)` yet moves it right on screen, since the transform is written in the flipped half's own coordinate space. The seeds are ten hard stop radial gradients painted into one element that shares the flesh's border-radius, so they scatter across the cut face and clip to it for free instead of needing ten elements, and each leafy scale keeps its angle in a `--dd` custom property that the flutter keyframe reads back. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45590.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a dragonfruit halved on a board, magenta rind with green scales and speckled white flesh on both cut faces.
