### PR TITLE
Add zeppelin component

### DIFF
--- a/submissions/examples/zeppelin-as/README.md
+++ b/submissions/examples/zeppelin-as/README.md
@@ -1,0 +1,24 @@
+# Zeppelin
+
+### What does this do?
+
+It shows an airship cruising through the clouds. The envelope drifts forward and upward as it flies, the propeller spins, the cabin windows glow in sequence, birds flap past, and clouds slide behind it. Under reduced motion it holds position.
+
+### How is it used?
+
+```html
+<div class="zep">
+  <span class="envelope"></span>
+  <span class="finZ fz1"></span>
+  <span class="gondola"></span>
+  <div class="propZ">
+    <span class="bladeZ bz1"></span>
+  </div>
+</div>
+```
+
+The tail fins are `clip-path` triangles, which give them the straight edges and sharp points a `border-radius` cannot. The propeller is two blades sharing one hub, each parked at its own angle in a `--zb` custom property, with the spin applied to the wrapper rather than the blades, so the 0 and 90 degree offsets survive the animation instead of being overwritten by it. The cruise keyframe translates on both axes, so the airship actually makes way rather than bobbing on the spot.
+
+### Why is it useful?
+
+Retro, travel, and sky themes use an airship. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/zeppelin-as/demo.html
+++ b/submissions/examples/zeppelin-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zeppelin</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="cloudZ cz1"></span>
+    <span class="cloudZ cz2"></span>
+    <div class="zep">
+      <span class="envelope"></span>
+      <span class="seams"></span>
+      <span class="noseZ"></span>
+      <span class="finZ fz1"></span>
+      <span class="finZ fz2"></span>
+      <span class="finZ fz3"></span>
+      <span class="gondola"></span>
+      <span class="windowZ wz1"></span>
+      <span class="windowZ wz2"></span>
+      <span class="windowZ wz3"></span>
+      <div class="propZ">
+        <span class="bladeZ bz1"></span>
+        <span class="bladeZ bz2"></span>
+        <span class="hubZ"></span>
+      </div>
+    </div>
+    <span class="birdZ bd1"></span>
+    <span class="birdZ bd2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/zeppelin-as/style.css
+++ b/submissions/examples/zeppelin-as/style.css
@@ -1,0 +1,254 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #8fd0ea, #d8e8f2 74%, #f0dcc0);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 300px;
+}
+
+.cloudZ {
+  position: absolute;
+  width: 110px;
+  height: 34px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow:
+    30px -14px 0 -4px rgba(255, 255, 255, 0.85),
+    -26px -10px 0 -8px rgba(255, 255, 255, 0.85);
+  z-index: 2;
+  animation: driftZ 14s linear infinite;
+}
+
+.cz1 { top: 40px; left: 10px; }
+
+.cz2 {
+  bottom: 46px;
+  right: 20px;
+  animation-delay: 7s;
+}
+
+.zep {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 320px;
+  height: 160px;
+  margin: -80px 0 0 -160px;
+  z-index: 4;
+  animation: cruiseZ 6s ease-in-out infinite;
+}
+
+.envelope {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  width: 260px;
+  height: 96px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #e8e2d2, #a9a294);
+  box-shadow:
+    inset 0 -12px 22px rgba(80, 74, 60, 0.35),
+    inset 0 10px 18px rgba(255, 255, 255, 0.5),
+    0 14px 30px rgba(60, 80, 100, 0.3);
+  z-index: 4;
+}
+
+.seams {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  width: 260px;
+  height: 96px;
+  border-radius: 50%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 84, 70, 0.25) 0 2px,
+      transparent 2px 34px
+    );
+  z-index: 5;
+}
+
+.noseZ {
+  position: absolute;
+  top: 54px;
+  left: 8px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #cfd6dd, #7d858f 74%);
+  z-index: 6;
+}
+
+.finZ {
+  position: absolute;
+  background: linear-gradient(180deg, #d0503f, #93261c);
+  z-index: 3;
+}
+
+.fz1 {
+  top: 26px;
+  right: 14px;
+  width: 52px;
+  height: 34px;
+  clip-path: polygon(100% 0, 100% 100%, 0 100%);
+}
+
+.fz2 {
+  bottom: 42px;
+  right: 14px;
+  width: 52px;
+  height: 34px;
+  clip-path: polygon(100% 0, 100% 100%, 0 0);
+}
+
+.fz3 {
+  top: 52px;
+  right: 4px;
+  width: 40px;
+  height: 32px;
+  clip-path: polygon(100% 20%, 100% 80%, 0 50%);
+}
+
+.gondola {
+  position: absolute;
+  top: 108px;
+  left: 50%;
+  width: 96px;
+  height: 34px;
+  margin-left: -48px;
+  border-radius: 8px 8px 16px 16px;
+  background: linear-gradient(180deg, #5f6a76, #333c45);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
+  z-index: 6;
+}
+
+.windowZ {
+  position: absolute;
+  top: 116px;
+  width: 14px;
+  height: 12px;
+  border-radius: 3px;
+  background: radial-gradient(circle at 36% 34%, #ffeeb0, #f0b93c 74%);
+  box-shadow: 0 0 8px rgba(255, 210, 90, 0.8);
+  z-index: 7;
+  animation: lampZ 3.4s ease-in-out infinite;
+}
+
+.wz1 { left: 50%; margin-left: -38px; }
+
+.wz2 {
+  left: 50%;
+  margin-left: -8px;
+  animation-delay: 1.1s;
+}
+
+.wz3 {
+  left: 50%;
+  margin-left: 22px;
+  animation-delay: 2.2s;
+}
+
+.propZ {
+  position: absolute;
+  top: 118px;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  margin-left: 44px;
+  z-index: 7;
+  animation: spinZ 0.9s linear infinite;
+}
+
+.bladeZ {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 34px;
+  margin: -17px 0 0 -4px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #9fa8b2, #5a6470);
+  transform: rotate(var(--zb, 0deg));
+}
+
+.bz1 {
+  --zb: 0deg;
+}
+
+.bz2 {
+  --zb: 90deg;
+}
+
+.hubZ {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  border-radius: 50%;
+  background: #414b55;
+}
+
+.birdZ {
+  position: absolute;
+  width: 18px;
+  height: 5px;
+  border-radius: 50%;
+  background: #3f4a56;
+  box-shadow: 12px -3px 0 -1px #3f4a56;
+  z-index: 3;
+  animation: flapZ 3.4s ease-in-out infinite;
+}
+
+.bd1 { top: 66px; right: 60px; }
+
+.bd2 {
+  top: 96px;
+  right: 26px;
+  animation-delay: 1.7s;
+}
+
+@keyframes cruiseZ {
+  0%, 100% { transform: translate(0, 0) rotate(-1deg); }
+  50% { transform: translate(10px, -10px) rotate(1deg); }
+}
+
+@keyframes spinZ {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes driftZ {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(70px); }
+}
+
+@keyframes lampZ {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+@keyframes flapZ {
+  0%, 100% { transform: translate(0, 0) scaleY(1); }
+  50% { transform: translate(-10px, 6px) scaleY(0.5); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zep,
+  .propZ,
+  .cloudZ,
+  .windowZ,
+  .birdZ {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a zeppelin built for #45596. The tail fins are clip-path triangles, which give them straight edges and sharp points a border-radius cannot. The propeller is two blades sharing one hub, each parked at its own `--zb` angle, with the spin applied to the wrapper rather than the blades, so the 0 and 90 degree offsets survive the animation instead of being overwritten by it. The cruise keyframe translates on both axes, so the airship makes way rather than bobbing on the spot. Reduced motion fallback included. Pure CSS. Closes #45596.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an airship with a seamed envelope, red tail fins, a lit gondola and a spinning propeller, cruising among clouds.
