### PR TITLE
Add trebuchet component

### DIFF
--- a/submissions/examples/trebuchet-as/README.md
+++ b/submissions/examples/trebuchet-as/README.md
@@ -1,0 +1,23 @@
+# Trebuchet
+
+### What does this do?
+
+It shows a trebuchet loosing a stone at a castle wall. The counterweight drops, the arm whips over, the rock flies in an arc across the scene, and dust kicks up where it lands. Under reduced motion the machine sits loaded and still.
+
+### How is it used?
+
+```html
+<div class="treb">
+  <span class="frameT ft1"></span>
+  <div class="armT">
+    <span class="beam"></span>
+    <span class="counter"></span>
+  </div>
+</div>
+```
+
+The arm rotates around a zero-sized wrapper pinned at `transform-origin: 0 0` exactly on the axle, with the beam and counterweight hung off it at negative offsets. Because the pivot is a point rather than the centre of a box, the long end of the beam sweeps a wide arc while the counterweight drops on the short end, which is what a real trebuchet does. The rock runs its own keyframe on the same four second clock and only leaves the sling at 46 percent, the exact moment the arm reaches the top of its swing, so the release lines up without any JavaScript. The dust waits until 84 percent, when the stone lands.
+
+### Why is it useful?
+
+Medieval, siege, and physics or launch themes use a trebuchet. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/trebuchet-as/demo.html
+++ b/submissions/examples/trebuchet-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Trebuchet</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="castle"></span>
+    <div class="treb">
+      <span class="frameT ft1"></span>
+      <span class="frameT ft2"></span>
+      <span class="axle"></span>
+      <div class="armT">
+        <span class="beam"></span>
+        <span class="counter"></span>
+        <span class="slingT"></span>
+      </div>
+      <span class="baseT2"></span>
+    </div>
+    <span class="rockT"></span>
+    <span class="dustT dt1"></span>
+    <span class="dustT dt2"></span>
+    <span class="groundT"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/trebuchet-as/style.css
+++ b/submissions/examples/trebuchet-as/style.css
@@ -1,0 +1,218 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #8fa6c0, #c9b48d 66%, #7d6a45);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 320px;
+}
+
+.groundT {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 56px);
+  background:
+    repeating-linear-gradient(
+      98deg,
+      rgba(90, 70, 30, 0.22) 0 3px,
+      transparent 3px 22px
+    ),
+    linear-gradient(180deg, #9b8a5c, #5c4f2c);
+}
+
+.castle {
+  position: absolute;
+  bottom: 56px;
+  right: 6px;
+  width: 92px;
+  height: 130px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #8d94a0 0 18px,
+      transparent 18px 30px
+    ),
+    linear-gradient(180deg, #7d848f, #4f555e);
+  box-shadow: inset -6px 0 12px rgba(20, 24, 30, 0.4);
+  z-index: 3;
+}
+
+.treb {
+  position: absolute;
+  bottom: 52px;
+  left: 40px;
+  width: 240px;
+  height: 240px;
+  z-index: 5;
+}
+
+.baseT2 {
+  position: absolute;
+  bottom: 0;
+  left: 20px;
+  width: 170px;
+  height: 16px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #8a5f34, #4f351a);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.frameT {
+  position: absolute;
+  bottom: 10px;
+  width: 16px;
+  height: 130px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #9c6c3d, #5f3f1e);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--fr2, 0deg));
+  z-index: 4;
+}
+
+.ft1 {
+  left: 56px;
+
+  --fr2: 16deg;
+}
+
+.ft2 {
+  left: 116px;
+
+  --fr2: -16deg;
+}
+
+.axle {
+  position: absolute;
+  bottom: 126px;
+  left: 78px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #cfd6dd, #6f7681 74%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  z-index: 6;
+}
+
+.armT {
+  position: absolute;
+  bottom: 139px;
+  left: 91px;
+  width: 0;
+  height: 0;
+  transform-origin: 0 0;
+  z-index: 5;
+  animation: fling 4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+.beam {
+  position: absolute;
+  top: -6px;
+  left: -74px;
+  width: 210px;
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #6f4a24, #b98c4a);
+  box-shadow: 0 3px 6px rgba(40, 24, 6, 0.4);
+}
+
+.counter {
+  position: absolute;
+  top: -22px;
+  left: -100px;
+  width: 44px;
+  height: 44px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #5f6a76, #2f363d);
+  box-shadow: inset 0 -6px 10px rgba(10, 14, 18, 0.5);
+}
+
+.slingT {
+  position: absolute;
+  top: 0;
+  left: 128px;
+  width: 4px;
+  height: 44px;
+  border-radius: 2px;
+  background: #c9b48d;
+  transform-origin: 50% 0;
+  transform: rotate(12deg);
+}
+
+.rockT {
+  position: absolute;
+  bottom: 176px;
+  left: 214px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #a9b0b8, #575e66 74%);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.4);
+  z-index: 6;
+  animation: hurl 4s cubic-bezier(0.2, 0.6, 0.4, 1) infinite;
+}
+
+.dustT {
+  position: absolute;
+  bottom: 54px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(200, 180, 140, 0.6);
+  filter: blur(4px);
+  opacity: 0;
+  z-index: 4;
+  animation: puffT 4s ease-out infinite;
+}
+
+.dt1 { left: 90px; }
+
+.dt2 {
+  left: 130px;
+  animation-delay: 0.2s;
+
+  --tx: 26px;
+}
+
+@keyframes fling {
+  0%, 30% { transform: rotate(0deg); }
+  46% { transform: rotate(-116deg); }
+  60% { transform: rotate(-104deg); }
+  100% { transform: rotate(0deg); }
+}
+
+@keyframes hurl {
+  0%, 34% { transform: translate(0, 0) rotate(0deg); opacity: 1; }
+  46% { transform: translate(-40px, -70px) rotate(90deg); opacity: 1; }
+  70% { transform: translate(110px, -120px) rotate(320deg); opacity: 1; }
+  85% { transform: translate(190px, -40px) rotate(520deg); opacity: 0.9; }
+  90%, 100% { transform: translate(200px, -10px) rotate(560deg); opacity: 0; }
+}
+
+@keyframes puffT {
+  0%, 84% { transform: translate(0, 0) scale(0.4); opacity: 0; }
+  90% { opacity: 0.7; }
+  100% { transform: translate(var(--tx, -20px), -30px) scale(2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .armT,
+  .rockT,
+  .dustT {
+    animation: none;
+  }
+
+  .dustT {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a trebuchet built for #45598. The arm rotates around a zero sized wrapper pinned at `transform-origin: 0 0` exactly on the axle, with the beam and counterweight hung off it at negative offsets, so the long end sweeps a wide arc while the counterweight drops on the short end, which is what a real trebuchet does. The rock runs its own keyframe on the same four second clock and leaves the sling at 46 percent, the exact moment the arm tops out, and the dust holds until 84 percent when the stone lands, so release and impact stay in sync with no JavaScript. Reduced motion fallback included. Pure CSS. Closes #45598.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a trebuchet with an A frame, axle, counterweighted beam and sling, a stone loaded, and a castle wall in range.
