### PR TITLE
Add spinning wheel component

### DIFF
--- a/submissions/examples/spinning-wheel-as/README.md
+++ b/submissions/examples/spinning-wheel-as/README.md
@@ -1,0 +1,23 @@
+# Spinning Wheel
+
+### What does this do?
+
+It shows a spinning wheel at work. The great wheel turns, the flyer whirls, the bobbin fills, the treadle rocks, the thread pulls taut, and wisps of wool float away. Hovering or focusing it drives the wheel four times faster, as if someone leaned into the treadle. Under reduced motion everything stops.
+
+### How is it used?
+
+```html
+<div class="swheel" tabindex="0">
+  <div class="rimWrap">
+    <span class="rimSw"></span>
+    <span class="spokesSw"></span>
+  </div>
+  <span class="flyer"></span>
+</div>
+```
+
+The wheel's sixteen spokes are a single `repeating-conic-gradient`, so the whole spoked disc is one element rather than a fan of bars, and the rim around it is just a thick `border` on a circle. Everything that rotates lives inside the `rimWrap`, so hovering only has to shorten one `animation-duration` to speed the entire wheel up. The wool is a stack of hard stop `radial-gradient` puffs painted into one rounded element, so the fleece clips to its own outline for free.
+
+### Why is it useful?
+
+Craft, fairytale, and cottage themes use a spinning wheel. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/spinning-wheel-as/demo.html
+++ b/submissions/examples/spinning-wheel-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spinning Wheel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="swheel" tabindex="0">
+      <div class="rimWrap">
+        <span class="rimSw"></span>
+        <span class="spokesSw"></span>
+        <span class="hubSw"></span>
+      </div>
+      <span class="legSw ls1"></span>
+      <span class="legSw ls2"></span>
+      <span class="benchSw"></span>
+      <span class="postSw"></span>
+      <span class="bobbinSw"></span>
+      <span class="threadSw"></span>
+      <span class="flyer"></span>
+      <span class="woolSw"></span>
+      <span class="pedal"></span>
+    </div>
+    <span class="fluff fl1"></span>
+    <span class="fluff fl2"></span>
+    <span class="floorSw"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/spinning-wheel-as/style.css
+++ b/submissions/examples/spinning-wheel-as/style.css
@@ -1,0 +1,279 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #5a4636, #1c1510 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.floorSw {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 48px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(50, 30, 12, 0.3) 0 2px,
+      transparent 2px 40px
+    ),
+    linear-gradient(180deg, #7d5a35, #3d2a16);
+}
+
+.swheel {
+  position: absolute;
+  bottom: 42px;
+  left: 50%;
+  width: 300px;
+  height: 280px;
+  margin-left: -150px;
+  outline: none;
+  z-index: 4;
+}
+
+.rimWrap {
+  position: absolute;
+  bottom: 30px;
+  left: 6px;
+  width: 200px;
+  height: 200px;
+  z-index: 4;
+  animation: turnSw 6s linear infinite;
+}
+
+.swheel:hover .rimWrap,
+.swheel:focus-visible .rimWrap {
+  animation-duration: 1.4s;
+}
+
+.rimSw {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 12px solid #8a5f34;
+  box-sizing: border-box;
+  background: transparent;
+  box-shadow:
+    inset 0 0 0 3px rgba(60, 34, 10, 0.5),
+    0 0 0 3px rgba(60, 34, 10, 0.45),
+    0 12px 26px rgba(0, 0, 0, 0.45);
+}
+
+.spokesSw {
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      #a9763f 0 3deg,
+      transparent 3deg 22.5deg
+    );
+}
+
+.hubSw {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  margin: -15px 0 0 -15px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #d9a55e, #7d5220 74%);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+}
+
+.benchSw {
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  width: 290px;
+  height: 16px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #9c6c3d, #5f3f1e);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
+  z-index: 6;
+}
+
+.legSw {
+  position: absolute;
+  bottom: 0;
+  width: 14px;
+  height: 22px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #8a5f34, #4f351a);
+  z-index: 5;
+}
+
+.ls1 { left: 30px; }
+.ls2 { right: 30px; }
+
+.postSw {
+  position: absolute;
+  bottom: 30px;
+  right: 54px;
+  width: 14px;
+  height: 150px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #9c6c3d, #5f3f1e);
+  z-index: 6;
+}
+
+.flyer {
+  position: absolute;
+  bottom: 168px;
+  right: 30px;
+  width: 62px;
+  height: 34px;
+  border-radius: 30px 30px 6px 6px;
+  border: 5px solid #b98c4a;
+  border-bottom-color: transparent;
+  box-sizing: border-box;
+  z-index: 7;
+  animation: whirl 1.6s linear infinite;
+  transform-origin: 50% 100%;
+}
+
+.bobbinSw {
+  position: absolute;
+  bottom: 146px;
+  right: 44px;
+  width: 34px;
+  height: 30px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #f0e0c0 0 4px,
+      #d9c199 4px 8px
+    );
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  z-index: 8;
+  animation: windSw 1.6s linear infinite;
+}
+
+.threadSw {
+  position: absolute;
+  bottom: 86px;
+  left: 74px;
+  width: 160px;
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(245, 235, 210, 0.9), rgba(245, 235, 210, 0.5));
+  transform: rotate(-14deg);
+  transform-origin: 0 50%;
+  z-index: 7;
+  animation: tugSw 1.6s ease-in-out infinite;
+}
+
+.woolSw {
+  position: absolute;
+  bottom: 30px;
+  left: 12px;
+  width: 74px;
+  height: 62px;
+  border-radius: 50% 50% 46% 46%;
+  background:
+    radial-gradient(circle at 30% 30%, #fdfaf2 0 16px, transparent 16px),
+    radial-gradient(circle at 66% 36%, #f2ece0 0 15px, transparent 15px),
+    radial-gradient(circle at 44% 66%, #fdfaf2 0 16px, transparent 16px),
+    #ece5d6;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  z-index: 7;
+  animation: breatheSw 3.4s ease-in-out infinite;
+}
+
+.pedal {
+  position: absolute;
+  bottom: 4px;
+  left: 60px;
+  width: 70px;
+  height: 10px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #a9763f, #6b4522);
+  transform-origin: 0 50%;
+  z-index: 7;
+  animation: treadle 1.5s ease-in-out infinite;
+}
+
+.fluff {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.75);
+  filter: blur(1px);
+  opacity: 0;
+  z-index: 8;
+  animation: floatSw 5s ease-out infinite;
+}
+
+.fl1 { bottom: 170px; left: 70px; }
+
+.fl2 {
+  bottom: 200px;
+  left: 120px;
+  animation-delay: 2.5s;
+
+  --fx: 30px;
+}
+
+@keyframes turnSw {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes whirl {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes windSw {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(1.08); }
+}
+
+@keyframes tugSw {
+  0%, 100% { transform: rotate(-14deg) scaleX(1); }
+  50% { transform: rotate(-12deg) scaleX(1.02); }
+}
+
+@keyframes treadle {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes breatheSw {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(0.97); }
+}
+
+@keyframes floatSw {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.9; }
+  100% { transform: translate(var(--fx, -26px), -70px) scale(1.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rimWrap,
+  .flyer,
+  .bobbinSw,
+  .threadSw,
+  .pedal,
+  .woolSw,
+  .fluff {
+    animation: none;
+  }
+
+  .fluff {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a spinning wheel built for #45600. The sixteen spokes are a single repeating conic gradient, so the spoked disc is one element rather than a fan of bars, and the rim around it is just a thick border on a circle. Everything that rotates lives inside one wrapper, so hovering only has to shorten a single animation-duration to speed the whole wheel up. The fleece is a stack of hard stop radial gradient puffs painted into one rounded element, so the wool clips to its own outline for free. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45600.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a spinning wheel with a spoked rim on a bench, a fleece beside it, thread running up to a bobbin on the flyer, and a treadle below.
