### PR TITLE
Add rocking horse component

### DIFF
--- a/submissions/examples/rocking-horse-as/README.md
+++ b/submissions/examples/rocking-horse-as/README.md
@@ -1,0 +1,21 @@
+# Rocking Horse
+
+### What does this do?
+
+It shows a wooden rocking horse tipping back and forth in a nursery. The whole horse rocks on its curved skid, its head nods with the motion, its tail swishes, and it blinks. Hovering or focusing it rocks twice as fast, as if a child climbed on. Under reduced motion it stands still.
+
+### How is it used?
+
+```html
+<div class="rocker" tabindex="0">
+  <span class="skid"></span>
+  <span class="bodyR"></span>
+  <div class="headR"><span class="skullR"></span></div>
+</div>
+```
+
+The whole horse rocks from `transform-origin: 50% 96%`, a point near the bottom of the curved skid rather than the centre of the horse. That is the entire trick: pivoting low makes the body swing through an arc that traces the curve of the rocker, so it reads as rolling on the skid instead of spinning in place. The skid itself is a bordered box with its top border removed, which leaves the bare curve. The head nods on its own pivot at the neck and runs the same three second clock as the rock, so it lags into the motion rather than moving independently.
+
+### Why is it useful?
+
+Nursery, toy, and nostalgic themes use a rocking horse. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/rocking-horse-as/demo.html
+++ b/submissions/examples/rocking-horse-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rocking Horse</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="rocker" tabindex="0">
+      <span class="tailR"></span>
+      <span class="bodyR"></span>
+      <span class="saddle"></span>
+      <span class="legR lr1"></span>
+      <span class="legR lr2"></span>
+      <span class="legR lr3"></span>
+      <span class="legR lr4"></span>
+      <span class="neckR"></span>
+      <div class="headR">
+        <span class="skullR"></span>
+        <span class="earR"></span>
+        <span class="eyeR"></span>
+        <span class="muzzleR"></span>
+        <span class="maneR"></span>
+      </div>
+      <span class="dot dr1"></span>
+      <span class="dot dr2"></span>
+      <span class="dot dr3"></span>
+      <span class="skid"></span>
+    </div>
+    <span class="starR sr1"></span>
+    <span class="starR sr2"></span>
+    <span class="starR sr3"></span>
+    <span class="rugR"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/rocking-horse-as/style.css
+++ b/submissions/examples/rocking-horse-as/style.css
@@ -1,0 +1,294 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #46405e, #14111c 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 310px;
+}
+
+.starR {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #fff6d8;
+  box-shadow: 0 0 8px rgba(255, 240, 190, 0.9);
+  animation: twinkleR 3s ease-in-out infinite;
+}
+
+.sr1 { top: 40px; left: 46px; }
+
+.sr2 {
+  top: 70px;
+  right: 54px;
+  animation-delay: 1s;
+}
+
+.sr3 {
+  top: 118px;
+  left: 90px;
+  animation-delay: 2s;
+}
+
+.rugR {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 44px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 60, 100, 0.35) 0 12px,
+      transparent 12px 30px
+    ),
+    linear-gradient(180deg, #6f5588, #38294a);
+}
+
+.rocker {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 280px;
+  height: 240px;
+  margin-left: -140px;
+  outline: none;
+  transform-origin: 50% 96%;
+  z-index: 4;
+  animation: rockR 3s ease-in-out infinite;
+}
+
+.rocker:hover,
+.rocker:focus-visible {
+  animation-duration: 1.2s;
+}
+
+.skid {
+  position: absolute;
+  bottom: 0;
+  left: 26px;
+  width: 230px;
+  height: 40px;
+  border-radius: 0 0 120px 120px / 0 0 40px 40px;
+  border: 10px solid #b26a2c;
+  border-top: 0;
+  box-sizing: border-box;
+  z-index: 6;
+}
+
+.bodyR {
+  position: absolute;
+  bottom: 88px;
+  left: 66px;
+  width: 150px;
+  height: 82px;
+  border-radius: 44% 46% 40% 40% / 54% 54% 46% 46%;
+  background: linear-gradient(180deg, #f0eae0, #c6bdae);
+  box-shadow: inset 0 -8px 16px rgba(110, 100, 84, 0.35);
+  z-index: 4;
+}
+
+.saddle {
+  position: absolute;
+  bottom: 148px;
+  left: 116px;
+  width: 62px;
+  height: 26px;
+  border-radius: 10px 10px 6px 6px;
+  background: linear-gradient(180deg, #e0523f, #a3251a);
+  box-shadow: 0 3px 6px rgba(60, 10, 6, 0.4);
+  z-index: 6;
+}
+
+.dot {
+  position: absolute;
+  width: 14px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(150, 120, 90, 0.5);
+  z-index: 5;
+}
+
+.dr1 { bottom: 112px; left: 92px; }
+.dr2 { bottom: 132px; left: 130px; }
+.dr3 { bottom: 108px; left: 176px; }
+
+.legR {
+  position: absolute;
+  bottom: 34px;
+  width: 20px;
+  height: 62px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #ddd5c8, #a89f90);
+  transform-origin: 50% 0;
+  z-index: 3;
+  transform: rotate(var(--lr2, 0deg));
+}
+
+.lr1 {
+  left: 76px;
+
+  --lr2: 12deg;
+}
+
+.lr2 {
+  left: 104px;
+
+  --lr2: 4deg;
+}
+
+.lr3 {
+  right: 84px;
+
+  --lr2: -4deg;
+}
+
+.lr4 {
+  right: 58px;
+
+  --lr2: -12deg;
+}
+
+.tailR {
+  position: absolute;
+  bottom: 116px;
+  right: 42px;
+  width: 20px;
+  height: 74px;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #d9c98a, #a8944e);
+  transform-origin: 50% 0;
+  transform: rotate(18deg);
+  z-index: 3;
+  animation: swishR 3s ease-in-out infinite;
+}
+
+.neckR {
+  position: absolute;
+  bottom: 150px;
+  left: 74px;
+  width: 40px;
+  height: 60px;
+  border-radius: 14px;
+  background: linear-gradient(90deg, #e8e0d4, #c2b8a8);
+  transform: rotate(-12deg);
+  transform-origin: 50% 100%;
+  z-index: 4;
+}
+
+.headR {
+  position: absolute;
+  bottom: 194px;
+  left: 30px;
+  width: 100px;
+  height: 70px;
+  transform-origin: 84% 100%;
+  z-index: 5;
+  animation: nodR 3s ease-in-out infinite;
+}
+
+.skullR {
+  position: absolute;
+  bottom: 0;
+  right: 8px;
+  width: 62px;
+  height: 54px;
+  border-radius: 46% 50% 40% 40% / 50% 52% 48% 48%;
+  background: linear-gradient(180deg, #f2ece2, #cfc6b6);
+  z-index: 3;
+}
+
+.muzzleR {
+  position: absolute;
+  bottom: 2px;
+  left: 4px;
+  width: 52px;
+  height: 30px;
+  border-radius: 44% 26% 26% 44% / 50% 44% 44% 50%;
+  background: linear-gradient(180deg, #e6dccc, #bdb2a0);
+  z-index: 4;
+}
+
+.earR {
+  position: absolute;
+  bottom: 46px;
+  right: 22px;
+  width: 16px;
+  height: 20px;
+  border-radius: 50% 50% 30% 30%;
+  background: #d9cfbe;
+  z-index: 2;
+}
+
+.eyeR {
+  position: absolute;
+  bottom: 28px;
+  right: 34px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #2a2018;
+  box-shadow: inset -2px 2px 0 -1px rgba(255, 255, 255, 0.8);
+  z-index: 5;
+  animation: blinkR 5s ease-in-out infinite;
+}
+
+.maneR {
+  position: absolute;
+  bottom: 18px;
+  right: 0;
+  width: 22px;
+  height: 62px;
+  border-radius: 10px 4px 4px 10px;
+  background:
+    repeating-linear-gradient(
+      170deg,
+      #e8c05a 0 6px,
+      #c39a2c 6px 12px
+    );
+  z-index: 2;
+}
+
+@keyframes rockR {
+  0%, 100% { transform: rotate(-7deg); }
+  50% { transform: rotate(7deg); }
+}
+
+@keyframes nodR {
+  0%, 100% { transform: rotate(3deg); }
+  50% { transform: rotate(-4deg); }
+}
+
+@keyframes swishR {
+  0%, 100% { transform: rotate(14deg); }
+  50% { transform: rotate(24deg); }
+}
+
+@keyframes blinkR {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes twinkleR {
+  0%, 100% { opacity: 0.3; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rocker,
+  .headR,
+  .tailR,
+  .eyeR,
+  .starR {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a rocking horse built for #45602. The whole horse rocks from a `transform-origin: 50% 96%`, a point near the bottom of the curved skid rather than the centre of the body: pivoting low is the entire trick, because it makes the horse swing through an arc that traces the curve of the rocker so it reads as rolling on the skid instead of spinning in place. The skid itself is a bordered box with its top border removed, which leaves the bare curve, and the head nods on its own pivot at the neck on the same three second clock so it lags into the motion rather than moving independently. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45602.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a dappled wooden rocking horse with a red saddle, golden mane and tail, standing on a curved skid in a nursery.
