### PR TITLE
Add astrolabe component

### DIFF
--- a/submissions/examples/astrolabe-as/README.md
+++ b/submissions/examples/astrolabe-as/README.md
@@ -1,0 +1,24 @@
+# Astrolabe
+
+### What does this do?
+
+It shows a brass astrolabe against a starfield. The rete, the openwork star map, turns slowly over the plate; the alidade, the sighting rule across the face, swings back and forth as if taking a reading; and the stars twinkle. Hovering or focusing the instrument spins the rete five times faster. Under reduced motion everything holds position.
+
+### How is it used?
+
+```html
+<div class="astro" tabindex="0">
+  <span class="mater"></span>
+  <span class="ticks"></span>
+  <div class="rete">
+    <span class="ringA ra1"></span>
+    <span class="pointerA pa1"></span>
+  </div>
+</div>
+```
+
+The degree scale around the rim is a `repeating-conic-gradient` masked to a thin ring: the mask is a `radial-gradient` that is transparent in the middle and opaque only between 44 and 47 percent, so the tick marks appear as a band around the edge instead of spokes across the whole disc. The plate's altitude circles come from a `repeating-radial-gradient`, so the concentric grid is one property. The rete's star pointers each keep their bearing in a `--pa2` custom property, and the rotation lives on the rete wrapper, so the pointers hold their relative positions as the whole star map turns.
+
+### Why is it useful?
+
+Astronomy, antique instrument, and navigation themes use an astrolabe. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/astrolabe-as/demo.html
+++ b/submissions/examples/astrolabe-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Astrolabe</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="astro" tabindex="0">
+      <span class="mater"></span>
+      <span class="ticks"></span>
+      <span class="plate2"></span>
+      <div class="rete">
+        <span class="ringA ra1"></span>
+        <span class="ringA ra2"></span>
+        <span class="pointerA pa1"></span>
+        <span class="pointerA pa2"></span>
+        <span class="pointerA pa3"></span>
+      </div>
+      <div class="alidade">
+        <span class="ruleA"></span>
+        <span class="sightA sa1"></span>
+        <span class="sightA sa2"></span>
+      </div>
+      <span class="pinA"></span>
+      <span class="throne"></span>
+      <span class="ringHang"></span>
+    </div>
+    <span class="starA st1"></span>
+    <span class="starA st2"></span>
+    <span class="starA st3"></span>
+    <span class="starA st4"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/astrolabe-as/style.css
+++ b/submissions/examples/astrolabe-as/style.css
@@ -1,0 +1,251 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #24304a, #080b14 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 340px;
+}
+
+.starA {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff8e0;
+  box-shadow: 0 0 8px rgba(255, 245, 210, 0.9);
+  animation: twinkleA 3.2s ease-in-out infinite;
+}
+
+.st1 { top: 30px; left: 34px; }
+
+.st2 {
+  top: 60px;
+  right: 40px;
+  animation-delay: 0.8s;
+}
+
+.st3 {
+  bottom: 44px;
+  left: 54px;
+  animation-delay: 1.6s;
+}
+
+.st4 {
+  bottom: 70px;
+  right: 46px;
+  animation-delay: 2.4s;
+}
+
+.astro {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 250px;
+  height: 250px;
+  margin: -120px 0 0 -125px;
+  outline: none;
+  z-index: 4;
+}
+
+.throne {
+  position: absolute;
+  top: -26px;
+  left: 50%;
+  width: 34px;
+  height: 30px;
+  margin-left: -17px;
+  border-radius: 8px 8px 0 0;
+  background: linear-gradient(180deg, #d9b45e, #8a6a1e);
+  z-index: 3;
+}
+
+.ringHang {
+  position: absolute;
+  top: -50px;
+  left: 50%;
+  width: 26px;
+  height: 26px;
+  margin-left: -13px;
+  border-radius: 50%;
+  border: 5px solid #d9b45e;
+  box-sizing: border-box;
+  background: transparent;
+  z-index: 3;
+}
+
+.mater {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 14px solid #c9a24a;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 36% 30%, #3f4a66, #1a2134 76%);
+  box-shadow:
+    inset 0 0 0 3px rgba(90, 70, 20, 0.6),
+    0 0 0 3px rgba(90, 70, 20, 0.5),
+    0 16px 34px rgba(0, 0, 0, 0.55);
+  z-index: 4;
+}
+
+.ticks {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(255, 235, 170, 0.85) 0 1deg,
+      transparent 1deg 15deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 42%, #000 44%, #000 47%, transparent 49%);
+  z-index: 6;
+}
+
+.plate2 {
+  position: absolute;
+  inset: 34px;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(
+      circle,
+      rgba(180, 200, 240, 0.16) 0 1px,
+      transparent 1px 18px
+    );
+  z-index: 5;
+}
+
+.rete {
+  position: absolute;
+  inset: 34px;
+  border-radius: 50%;
+  z-index: 6;
+  animation: turnA 20s linear infinite;
+}
+
+.astro:hover .rete,
+.astro:focus-visible .rete {
+  animation-duration: 4s;
+}
+
+.ringA {
+  position: absolute;
+  border-radius: 50%;
+  border: 3px solid #e8c96a;
+  box-sizing: border-box;
+  background: transparent;
+}
+
+.ra1 {
+  top: 12%;
+  left: 12%;
+  width: 76%;
+  height: 76%;
+}
+
+.ra2 {
+  top: 34%;
+  left: 26%;
+  width: 46%;
+  height: 46%;
+}
+
+.pointerA {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 62px;
+  margin: -62px 0 0 -4px;
+  border-radius: 4px 4px 0 0;
+  background: linear-gradient(180deg, #ffe9a0, #c9a24a);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--pa2, 0deg));
+}
+
+.pa1 {
+  --pa2: 20deg;
+}
+
+.pa2 {
+  --pa2: 140deg;
+}
+
+.pa3 {
+  --pa2: 260deg;
+}
+
+.alidade {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 220px;
+  height: 12px;
+  margin: -6px 0 0 -110px;
+  transform-origin: 50% 50%;
+  z-index: 7;
+  animation: sightA 9s ease-in-out infinite;
+}
+
+.ruleA {
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #f0d789, #a9843a);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+}
+
+.sightA {
+  position: absolute;
+  top: -8px;
+  width: 12px;
+  height: 26px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #f0d789, #8a6a1e);
+}
+
+.sa1 { left: 26px; }
+.sa2 { right: 26px; }
+
+.pinA {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 22px;
+  height: 22px;
+  margin: -11px 0 0 -11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #fff0be, #b8923a 74%);
+  box-shadow: 0 0 12px rgba(255, 230, 160, 0.8);
+  z-index: 8;
+}
+
+@keyframes turnA {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes sightA {
+  0%, 100% { transform: rotate(-24deg); }
+  50% { transform: rotate(22deg); }
+}
+
+@keyframes twinkleA {
+  0%, 100% { opacity: 0.3; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(1.25); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rete,
+  .alidade,
+  .starA {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an astrolabe built for #45612. The degree scale is a repeating conic gradient masked to a thin ring: the mask is a radial gradient transparent in the middle and opaque only between 44 and 47 percent, so the ticks band the rim instead of spoking across the whole disc. The plate's altitude circles come from a single repeating radial gradient, and the rete's star pointers each keep their bearing in a `--pa2` custom property with the rotation on the rete wrapper, so the pointers hold their relative positions as the star map turns. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45612.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a brass astrolabe with a hanging ring and throne, a ticked rim, altitude circles, a rotating rete with star pointers and a sighting rule across the face, under a starfield.
