### PR TITLE
feat: add focus ring orbit example

### DIFF
--- a/submissions/examples/focus-ring-orbit/README.md
+++ b/submissions/examples/focus-ring-orbit/README.md
@@ -1,0 +1,14 @@
+# Focus Ring Orbit
+
+A keyboard-focused button effect that shows an orbiting ring when the control receives focus.
+
+## Files
+
+- `demo.html` - button demo markup.
+- `style.css` - hover lift, focus-visible orbit ring, and reduced-motion fallback.
+
+## Highlights
+
+- Keeps focus styling visible for keyboard users.
+- Uses a pseudo-element for the animated focus ring.
+- Provides a static focus state when reduced motion is requested.

--- a/submissions/examples/focus-ring-orbit/demo.html
+++ b/submissions/examples/focus-ring-orbit/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Focus Ring Orbit</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion accessibility</p>
+    <h1 id="demo-title">Focus ring orbit</h1>
+    <p class="intro">A keyboard-friendly button where the focus ring rotates gently around the control.</p>
+
+    <button class="orbit-button" type="button">
+      Save changes
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/focus-ring-orbit/style.css
+++ b/submissions/examples/focus-ring-orbit/style.css
@@ -1,0 +1,105 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #ecfeff 0%, #ffffff 50%, #fef3c7 100%);
+}
+
+.panel {
+  width: min(92vw, 30rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(14, 116, 144, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #0e7490;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.orbit-button {
+  position: relative;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.95rem 1.4rem;
+  color: #ffffff;
+  background: #0e7490;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  box-shadow: 0 1rem 2rem rgba(14, 116, 144, 0.22);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.orbit-button::before {
+  content: "";
+  position: absolute;
+  inset: -0.45rem;
+  border: 0.16rem solid transparent;
+  border-top-color: #f59e0b;
+  border-right-color: #22d3ee;
+  border-radius: inherit;
+  opacity: 0;
+  transform: rotate(0deg) scale(0.92);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.orbit-button:hover,
+.orbit-button:focus-visible {
+  transform: translateY(-0.18rem);
+  box-shadow: 0 1.25rem 2.25rem rgba(14, 116, 144, 0.28);
+}
+
+.orbit-button:focus-visible {
+  outline: 0;
+}
+
+.orbit-button:focus-visible::before {
+  opacity: 1;
+  animation: orbit-ring 1100ms linear infinite;
+}
+
+@keyframes orbit-ring {
+  to {
+    transform: rotate(360deg) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition-duration: 1ms !important;
+  }
+
+  .orbit-button:focus-visible::before {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a focus ring orbit button example
- include keyboard focus-visible animation
- document the focus state and reduced-motion fallback

## Verification
- git diff --cached --check