### PR TITLE
feat: add menu item stagger example

### DIFF
--- a/submissions/examples/menu-item-stagger/README.md
+++ b/submissions/examples/menu-item-stagger/README.md
@@ -1,0 +1,14 @@
+# Menu Item Stagger
+
+A compact menu reveal where each action item slides and fades into place with a small delay.
+
+## Files
+
+- `demo.html` - action menu markup.
+- `style.css` - staggered item reveal, hover/focus states, and reduced-motion fallback.
+
+## Highlights
+
+- Uses simple nth-child delays for a sequential menu entrance.
+- Keeps hover and keyboard focus states visible.
+- Falls back to a static menu for reduced-motion users.

--- a/submissions/examples/menu-item-stagger/demo.html
+++ b/submissions/examples/menu-item-stagger/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Menu Item Stagger</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion menu</p>
+    <h1 id="demo-title">Menu item stagger</h1>
+    <p class="intro">A compact action menu where each item slides and fades in with a small delay.</p>
+
+    <nav class="action-menu" aria-label="Demo actions">
+      <a href="#">Create task</a>
+      <a href="#">Assign owner</a>
+      <a href="#">Set deadline</a>
+      <a href="#">Archive list</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/menu-item-stagger/style.css
+++ b/submissions/examples/menu-item-stagger/style.css
@@ -1,0 +1,104 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #f8fafc 0%, #f5f3ff 52%, #ecfeff 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(109, 40, 217, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #6d28d9;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.action-menu {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(109, 40, 217, 0.12);
+}
+
+.action-menu a {
+  display: block;
+  padding: 0.8rem 0.95rem;
+  border-radius: 0.75rem;
+  color: #334155;
+  font-weight: 850;
+  text-decoration: none;
+  opacity: 0;
+  transform: translateX(-0.65rem);
+  animation: item-in 520ms ease forwards;
+  transition: color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+
+.action-menu a:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.action-menu a:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.action-menu a:nth-child(4) {
+  animation-delay: 270ms;
+}
+
+.action-menu a:hover,
+.action-menu a:focus-visible {
+  color: #4c1d95;
+  background: #ede9fe;
+  transform: translateX(0.2rem);
+}
+
+.action-menu a:focus-visible {
+  outline: 0.18rem solid #a78bfa;
+  outline-offset: 0.2rem;
+}
+
+@keyframes item-in {
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .action-menu a {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a staggered action menu reveal example
- include hover and focus-visible states
- document the staggered motion and reduced-motion fallback

## Verification
- git diff --cached --check