### PR TITLE
feat: add swipe card dismiss example

### DIFF
--- a/submissions/examples/swipe-card-dismiss/README.md
+++ b/submissions/examples/swipe-card-dismiss/README.md
@@ -1,0 +1,14 @@
+# Swipe Card Dismiss
+
+A notification card pattern that previews a swipe-away action and reveals a dismiss affordance.
+
+## Files
+
+- `demo.html` - focusable notification card markup.
+- `style.css` - swipe preview, dismiss reveal, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Shows the dismiss action without shifting surrounding layout.
+- Mirrors hover behavior on keyboard focus.
+- Keeps motion minimal for reduced-motion users.

--- a/submissions/examples/swipe-card-dismiss/demo.html
+++ b/submissions/examples/swipe-card-dismiss/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Swipe Card Dismiss</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion card</p>
+    <h1 id="demo-title">Swipe card dismiss</h1>
+    <p class="intro">A notification card that previews a swipe-away motion on hover or keyboard focus.</p>
+
+    <article class="dismiss-card" tabindex="0">
+      <span class="status">New</span>
+      <strong>Design review ready</strong>
+      <span>Hover or focus to preview the dismiss motion.</span>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/swipe-card-dismiss/style.css
+++ b/submissions/examples/swipe-card-dismiss/style.css
@@ -1,0 +1,107 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #182033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 52%, #f0fdfa 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(234, 88, 12, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.dismiss-card {
+  position: relative;
+  display: grid;
+  gap: 0.7rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.12);
+  overflow: hidden;
+  transition: transform 260ms ease, opacity 260ms ease, box-shadow 260ms ease;
+}
+
+.dismiss-card::after {
+  content: "Dismiss";
+  position: absolute;
+  inset: 0 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 6rem;
+  color: #ffffff;
+  background: #ea580c;
+  font-weight: 900;
+  transform: translateX(100%);
+  transition: transform 260ms ease;
+}
+
+.dismiss-card:hover,
+.dismiss-card:focus-visible {
+  opacity: 0.96;
+  transform: translateX(-1.1rem) rotate(-1deg);
+  box-shadow: 0 1.3rem 2.5rem rgba(234, 88, 12, 0.18);
+}
+
+.dismiss-card:hover::after,
+.dismiss-card:focus-visible::after {
+  transform: translateX(0);
+}
+
+.dismiss-card:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.25rem;
+}
+
+.status {
+  width: max-content;
+  padding: 0.28rem 0.68rem;
+  border-radius: 999px;
+  color: #9a3412;
+  background: #ffedd5;
+  font-weight: 900;
+}
+
+.dismiss-card span:last-child {
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a swipe card dismiss motion example
- include hover and focus-visible preview states
- document the card motion and reduced-motion fallback

## Verification
- git diff --cached --check