### PR TITLE
feat: add kanban card lift example

### DIFF
--- a/submissions/examples/kanban-card-lift/README.md
+++ b/submissions/examples/kanban-card-lift/README.md
@@ -1,0 +1,14 @@
+# Kanban Card Lift
+
+A workflow task card that lifts on interaction and expands a priority stripe.
+
+## Files
+
+- `demo.html` - focusable kanban task card markup.
+- `style.css` - lift motion, priority stripe transition, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Mirrors hover behavior on keyboard focus.
+- Uses a pseudo-element for the animated priority stripe.
+- Keeps layout stable while the card lifts.

--- a/submissions/examples/kanban-card-lift/demo.html
+++ b/submissions/examples/kanban-card-lift/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kanban Card Lift</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion workflow</p>
+    <h1 id="demo-title">Kanban card lift</h1>
+    <p class="intro">A task card that lifts, brightens its priority stripe, and keeps keyboard focus visible.</p>
+
+    <article class="task-card" tabindex="0">
+      <span class="priority">High priority</span>
+      <strong>Review motion tokens</strong>
+      <span>Update transitions before the next design sync.</span>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/kanban-card-lift/style.css
+++ b/submissions/examples/kanban-card-lift/style.css
@@ -1,0 +1,105 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 48%, #ecfeff 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(249, 115, 22, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.task-card {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem 1.25rem 1.25rem 1.45rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.11);
+  overflow: hidden;
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.task-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.35rem;
+  background: #fb923c;
+  transform: scaleY(0.55);
+  transform-origin: center;
+  transition: transform 220ms ease, background 220ms ease;
+}
+
+.priority {
+  width: max-content;
+  padding: 0.28rem 0.68rem;
+  border-radius: 999px;
+  color: #9a3412;
+  background: #ffedd5;
+  font-size: 0.8rem;
+  font-weight: 900;
+}
+
+.task-card span:last-child {
+  color: #64748b;
+}
+
+.task-card:hover,
+.task-card:focus-visible {
+  transform: translateY(-0.35rem);
+  box-shadow: 0 1.35rem 2.6rem rgba(234, 88, 12, 0.18);
+}
+
+.task-card:hover::before,
+.task-card:focus-visible::before {
+  background: #ea580c;
+  transform: scaleY(1);
+}
+
+.task-card:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a kanban card lift motion example
- include hover and focus-visible states
- document the priority stripe and reduced-motion fallback

## Verification
- git diff --cached --check