### PR TITLE
feat: add copy button spark example

### DIFF
--- a/submissions/examples/copy-button-spark/README.md
+++ b/submissions/examples/copy-button-spark/README.md
@@ -1,0 +1,14 @@
+# Copy Button Spark
+
+A copy action button with small spark accents that appear on hover or keyboard focus.
+
+## Files
+
+- `demo.html` - copy button markup with decorative spark spans.
+- `style.css` - button lift, spark animation, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Uses decorative spans marked with `aria-hidden`.
+- Mirrors hover feedback on keyboard focus.
+- Removes motion for reduced-motion users.

--- a/submissions/examples/copy-button-spark/demo.html
+++ b/submissions/examples/copy-button-spark/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Copy Button Spark</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion feedback</p>
+    <h1 id="demo-title">Copy button spark</h1>
+    <p class="intro">A copy action button that lifts and emits small spark accents on hover or focus.</p>
+
+    <button class="copy-button" type="button">
+      Copy link
+      <span class="spark one" aria-hidden="true"></span>
+      <span class="spark two" aria-hidden="true"></span>
+      <span class="spark three" aria-hidden="true"></span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/copy-button-spark/style.css
+++ b/submissions/examples/copy-button-spark/style.css
@@ -1,0 +1,132 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #fefce8 0%, #ffffff 48%, #f0f9ff 100%);
+}
+
+.panel {
+  width: min(92vw, 30rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(202, 138, 4, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ca8a04;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.copy-button {
+  position: relative;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.95rem 1.45rem;
+  color: #172033;
+  background: #facc15;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  box-shadow: 0 1rem 2rem rgba(202, 138, 4, 0.2);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.copy-button:hover,
+.copy-button:focus-visible {
+  transform: translateY(-0.2rem);
+  box-shadow: 0 1.25rem 2.4rem rgba(202, 138, 4, 0.28);
+}
+
+.copy-button:focus-visible {
+  outline: 0.18rem solid #fef08a;
+  outline-offset: 0.25rem;
+}
+
+.spark {
+  position: absolute;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: #0284c7;
+  opacity: 0;
+  transform: scale(0.4);
+}
+
+.spark.one {
+  top: -0.25rem;
+  right: 1.2rem;
+}
+
+.spark.two {
+  top: 0.35rem;
+  right: -0.25rem;
+  background: #16a34a;
+}
+
+.spark.three {
+  bottom: -0.2rem;
+  right: 1.8rem;
+  background: #ea580c;
+}
+
+.copy-button:hover .spark,
+.copy-button:focus-visible .spark {
+  animation: spark-pop 720ms ease-in-out infinite;
+}
+
+.copy-button:hover .spark.two,
+.copy-button:focus-visible .spark.two {
+  animation-delay: 120ms;
+}
+
+.copy-button:hover .spark.three,
+.copy-button:focus-visible .spark.three {
+  animation-delay: 240ms;
+}
+
+@keyframes spark-pop {
+  0%,
+  100% {
+    opacity: 0;
+    transform: translateY(0) scale(0.4);
+  }
+
+  45% {
+    opacity: 1;
+    transform: translateY(-0.35rem) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a copy button spark feedback example
- include hover and focus-visible spark states
- document the decorative spark and reduced-motion fallback

## Verification
- git diff --cached --check