### PR TITLE
feat: add badge counter roll example

### DIFF
--- a/submissions/examples/badge-counter-roll/README.md
+++ b/submissions/examples/badge-counter-roll/README.md
@@ -1,0 +1,14 @@
+# Badge Counter Roll
+
+A compact counter badge where the number rolls upward when the action is hovered or focused.
+
+## Files
+
+- `demo.html` - counter button markup with accessible label text.
+- `style.css` - badge lift, number roll, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Keeps the numeric badge stable in size.
+- Mirrors hover feedback on keyboard focus.
+- Removes movement for reduced-motion users.

--- a/submissions/examples/badge-counter-roll/demo.html
+++ b/submissions/examples/badge-counter-roll/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Badge Counter Roll</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion counter</p>
+    <h1 id="demo-title">Badge counter roll</h1>
+    <p class="intro">A compact metric badge where the number rolls upward and the container lifts on interaction.</p>
+
+    <button class="counter-badge" type="button" aria-label="12 unread updates">
+      <span class="label">Updates</span>
+      <span class="number" aria-hidden="true">12</span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/badge-counter-roll/style.css
+++ b/submissions/examples/badge-counter-roll/style.css
@@ -1,0 +1,110 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #ecfeff 48%, #fff7ed 100%);
+}
+
+.panel {
+  width: min(92vw, 30rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(14, 116, 144, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #0e7490;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.counter-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.75rem 0.85rem 0.75rem 1rem;
+  color: #ffffff;
+  background: #0f172a;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.2);
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+.number {
+  display: grid;
+  place-items: center;
+  min-width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 50%;
+  color: #0f172a;
+  background: #67e8f9;
+  overflow: hidden;
+}
+
+.counter-badge:hover,
+.counter-badge:focus-visible {
+  background: #0e7490;
+  transform: translateY(-0.2rem);
+  box-shadow: 0 1.25rem 2.4rem rgba(14, 116, 144, 0.25);
+}
+
+.counter-badge:hover .number,
+.counter-badge:focus-visible .number {
+  animation: counter-roll 620ms ease both;
+}
+
+.counter-badge:focus-visible {
+  outline: 0.18rem solid #67e8f9;
+  outline-offset: 0.25rem;
+}
+
+@keyframes counter-roll {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+
+  45% {
+    transform: translateY(-0.35rem) scale(1.08);
+  }
+
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a badge counter roll motion example
- include hover and focus-visible states
- document the counter and reduced-motion fallback

## Verification
- git diff --cached --check