### PR TITLE
feat: add dropdown caret turn example

### DIFF
--- a/submissions/examples/dropdown-caret-turn/README.md
+++ b/submissions/examples/dropdown-caret-turn/README.md
@@ -1,0 +1,14 @@
+# Dropdown Caret Turn
+
+A native details dropdown with a rotating caret and softly revealed menu options.
+
+## Files
+
+- `demo.html` - native `details` dropdown markup.
+- `style.css` - caret rotation, menu reveal, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Uses semantic browser dropdown behavior.
+- Rotates the caret when the dropdown is open.
+- Keeps menu links keyboard accessible.

--- a/submissions/examples/dropdown-caret-turn/demo.html
+++ b/submissions/examples/dropdown-caret-turn/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dropdown Caret Turn</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion dropdown</p>
+    <h1 id="demo-title">Dropdown caret turn</h1>
+    <p class="intro">A native details dropdown with a rotating caret and soft option reveal.</p>
+
+    <details class="dropdown" open>
+      <summary>
+        Sort by priority
+        <span aria-hidden="true"></span>
+      </summary>
+      <div class="menu">
+        <a href="#">Highest first</a>
+        <a href="#">Recently updated</a>
+        <a href="#">Oldest first</a>
+      </div>
+    </details>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dropdown-caret-turn/style.css
+++ b/submissions/examples/dropdown-caret-turn/style.css
@@ -1,0 +1,128 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 50%, #f0fdfa 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(234, 88, 12, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.dropdown {
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.12);
+  overflow: hidden;
+}
+
+.dropdown summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  color: #172033;
+  font-weight: 900;
+  cursor: pointer;
+  list-style: none;
+}
+
+.dropdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.dropdown summary span {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-right: 0.18rem solid #ea580c;
+  border-bottom: 0.18rem solid #ea580c;
+  transform: rotate(45deg);
+  transition: transform 220ms ease;
+}
+
+.dropdown[open] summary span {
+  transform: rotate(225deg);
+}
+
+.menu {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0 0.75rem 0.75rem;
+  animation: menu-reveal 260ms ease both;
+}
+
+.menu a {
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  color: #475569;
+  font-weight: 850;
+  text-decoration: none;
+  transition: color 180ms ease, background 180ms ease;
+}
+
+.menu a:hover,
+.menu a:focus-visible {
+  color: #9a3412;
+  background: #ffedd5;
+}
+
+.dropdown summary:focus-visible,
+.menu a:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.2rem;
+}
+
+@keyframes menu-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-0.35rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dropdown caret turn motion example
- include native details menu behavior
- document the caret rotation and reduced-motion fallback

## Verification
- git diff --cached --check