### PR TITLE
feat: add step card flip example

### DIFF
--- a/submissions/examples/step-card-flip/README.md
+++ b/submissions/examples/step-card-flip/README.md
@@ -1,0 +1,14 @@
+# Step Card Flip
+
+A setup step card that tilts and reveals a completed-looking state on hover or keyboard focus.
+
+## Files
+
+- `demo.html` - focusable setup step card markup.
+- `style.css` - 3D tilt, status color change, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Uses `perspective` for a lightweight card flip feel.
+- Mirrors hover behavior on keyboard focus.
+- Falls back to a simple lift for reduced-motion users.

--- a/submissions/examples/step-card-flip/demo.html
+++ b/submissions/examples/step-card-flip/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Step Card Flip</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion steps</p>
+    <h1 id="demo-title">Step card flip</h1>
+    <p class="intro">A setup step card that tilts and reveals its completion state on interaction.</p>
+
+    <article class="step-card" tabindex="0">
+      <span class="step">Step 2</span>
+      <strong>Connect workspace</strong>
+      <span class="hint">Hover or focus to preview completion.</span>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/step-card-flip/style.css
+++ b/submissions/examples/step-card-flip/style.css
@@ -1,0 +1,100 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  perspective: 56rem;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 50%, #eef2ff 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(234, 88, 12, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.step-card {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.12);
+  transform-style: preserve-3d;
+  transition: transform 260ms ease, box-shadow 260ms ease, background 260ms ease;
+}
+
+.step {
+  width: max-content;
+  padding: 0.28rem 0.68rem;
+  border-radius: 999px;
+  color: #9a3412;
+  background: #ffedd5;
+  font-size: 0.8rem;
+  font-weight: 900;
+}
+
+.hint {
+  color: #64748b;
+}
+
+.step-card:hover,
+.step-card:focus-visible {
+  background: #fff7ed;
+  transform: rotateX(5deg) translateY(-0.35rem);
+  box-shadow: 0 1.4rem 2.7rem rgba(234, 88, 12, 0.2);
+}
+
+.step-card:hover .step,
+.step-card:focus-visible .step {
+  color: #ffffff;
+  background: #16a34a;
+}
+
+.step-card:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+
+  .step-card:hover,
+  .step-card:focus-visible {
+    transform: translateY(-0.2rem);
+  }
+}


### PR DESCRIPTION
## Summary
- add a step card flip motion example
- include hover and focus-visible completion preview
- document the step card and reduced-motion fallback

## Verification
- git diff --cached --check