### PR TITLE
feat: add empty inbox sweep example

### DIFF
--- a/submissions/examples/empty-inbox-sweep/README.md
+++ b/submissions/examples/empty-inbox-sweep/README.md
@@ -1,0 +1,14 @@
+# Empty Inbox Sweep
+
+An empty inbox state with a subtle sweep highlight and calm tray motion.
+
+## Files
+
+- `demo.html` - empty inbox state markup.
+- `style.css` - sweep highlight, tray motion, and reduced-motion fallback.
+
+## Highlights
+
+- Keeps the empty-state copy visible during the sweep.
+- Uses pseudo-elements for decorative motion.
+- Stops all animation for reduced-motion users.

--- a/submissions/examples/empty-inbox-sweep/demo.html
+++ b/submissions/examples/empty-inbox-sweep/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Empty Inbox Sweep</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion empty state</p>
+    <h1 id="demo-title">Empty inbox sweep</h1>
+    <p class="intro">An empty inbox card with a gentle sweep highlight and calm icon motion.</p>
+
+    <section class="empty-state" aria-label="Empty inbox">
+      <span class="tray" aria-hidden="true"></span>
+      <strong>Inbox is clear</strong>
+      <span>No unread updates waiting right now.</span>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/empty-inbox-sweep/style.css
+++ b/submissions/examples/empty-inbox-sweep/style.css
@@ -1,0 +1,113 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #ecfeff 50%, #eef2ff 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(8, 145, 178, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #0891b2;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.empty-state {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+  padding: 1.4rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  text-align: center;
+  box-shadow: 0 1rem 2rem rgba(8, 145, 178, 0.12);
+  overflow: hidden;
+}
+
+.empty-state::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent, rgba(103, 232, 249, 0.35), transparent);
+  transform: translateX(-100%);
+  animation: inbox-sweep 2400ms ease-in-out infinite;
+}
+
+.empty-state strong,
+.empty-state span {
+  position: relative;
+}
+
+.tray {
+  width: 4rem;
+  height: 2.6rem;
+  border: 0.22rem solid #0891b2;
+  border-top: 0;
+  border-radius: 0.35rem 0.35rem 1rem 1rem;
+  animation: tray-breathe 1800ms ease-in-out infinite;
+}
+
+.empty-state span:last-child {
+  color: #64748b;
+}
+
+@keyframes inbox-sweep {
+  0%,
+  35% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes tray-breathe {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-0.18rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an empty inbox sweep motion example
- include calm tray and highlight animations
- document the empty state and reduced-motion fallback

## Verification
- git diff --cached --check