### PR TITLE
feat: add ripple-variant like button component (#41567)

### DIFF
--- a/examples/ripple-like-button/README.md
+++ b/examples/ripple-like-button/README.md
@@ -1,0 +1,20 @@
+# Submission Component: Ripple Like Button
+
+## Overview
+
+A compact, pure-CSS “like” toggle that uses a visually hidden checkbox and an animated ripple halo to provide polished feedback without JavaScript.
+
+## ✨ Submission Files
+
+- `demo.html` — Browser-ready preview with three responsive variants in different contexts.
+- `style.css` — Scoped component styles that reuse EaseMotion variables, timing tokens, and the shared `ease-kf-ping` animation.
+
+## 🎛️ Interaction Architecture
+
+1. **Hidden Toggle Control:** The label wraps a visually hidden checkbox so the control stays semantic, keyboard accessible, and screen-reader friendly.
+2. **Ripple Halo Animation:** When the checkbox becomes checked, a pseudo-element expands and fades using the library’s shared ping keyframe and easing tokens.
+3. **Stateful Feedback:** The icon switches from an outlined heart to a filled heart and the label turns to the danger accent to signal an active state.
+
+## ♿ Accessibility Notes
+
+The control exposes an `aria-label` and remains operable by keyboard, so assistive technologies can announce the active state clearly without requiring JavaScript.

--- a/examples/ripple-like-button/demo.html
+++ b/examples/ripple-like-button/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — Ripple Like Button</title>
+
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="./style.css">
+
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: linear-gradient(135deg, #0f172a 0%, #111827 100%);
+      color: #f8fafc;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+
+    .alm-demo-shell {
+      width: min(100%, 960px);
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .alm-demo-header {
+      text-align: center;
+      display: grid;
+      gap: 0.5rem;
+      max-width: 640px;
+      margin: 0 auto;
+    }
+
+    .alm-demo-header h1 {
+      margin: 0;
+      font-size: clamp(1.6rem, 3vw, 2.3rem);
+      line-height: 1.2;
+    }
+
+    .alm-demo-header p {
+      margin: 0;
+      color: #94a3b8;
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    .alm-demo-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .alm-demo-card {
+      display: grid;
+      gap: 1rem;
+      padding: 1.25rem;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 1rem;
+      background: rgba(255, 255, 255, 0.05);
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.2);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+    }
+
+    .alm-demo-card h2 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .alm-demo-card p {
+      margin: 0;
+      color: #cbd5e1;
+      font-size: 0.9rem;
+      line-height: 1.6;
+    }
+
+    @media (max-width: 640px) {
+      .alm-demo-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="alm-demo-shell">
+    <header class="alm-demo-header">
+      <h1>Ripple-Like Button</h1>
+      <p>These pure-CSS toggle buttons use an accessible checkbox pattern and a ripple halo to deliver tactile feedback without JavaScript.</p>
+    </header>
+
+    <section class="alm-demo-grid">
+      <article class="alm-demo-card">
+        <h2>Standard action</h2>
+        <p>A responsive default-sized button for feed and card contexts.</p>
+        <label class="alm-like-button" for="like-primary">
+          <input class="alm-like-input" type="checkbox" id="like-primary" aria-label="Like this story">
+          <span class="alm-like-icon" aria-hidden="true"></span>
+          <span class="alm-like-label">Like</span>
+        </label>
+      </article>
+
+      <article class="alm-demo-card">
+        <h2>Compact toolbar</h2>
+        <p>Same interaction, smaller footprint for dense interfaces.</p>
+        <label class="alm-like-button alm-like-button--compact" for="like-compact">
+          <input class="alm-like-input" type="checkbox" id="like-compact" aria-label="Like this note">
+          <span class="alm-like-icon" aria-hidden="true"></span>
+          <span class="alm-like-label">Like</span>
+        </label>
+      </article>
+
+      <article class="alm-demo-card">
+        <h2>Prominent action</h2>
+        <p>A wider variant for primary touch targets and hero layouts.</p>
+        <label class="alm-like-button alm-like-button--wide" for="like-wide">
+          <input class="alm-like-input" type="checkbox" id="like-wide" aria-label="Like this feature">
+          <span class="alm-like-icon" aria-hidden="true"></span>
+          <span class="alm-like-label">Like</span>
+        </label>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/examples/ripple-like-button/style.css
+++ b/examples/ripple-like-button/style.css
@@ -1,0 +1,128 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — ripple-like-button-dp/style.css
+   ============================================================ */
+
+/* Step back to the repository root from the submission folder */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+/* ── Ripple Like Button Shell ─────────────────────────────── */
+.alm-like-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55em;
+  min-height: 2.75rem;
+  padding: 0.7em 1.05em;
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.18));
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-glass-bg, rgba(255, 255, 255, 0.08));
+  color: var(--ease-color-text, #f8fafc);
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: clamp(0.9rem, 1.6vw, 1rem);
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  user-select: none;
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.08));
+  transition:
+    transform var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    box-shadow var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.alm-like-button:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--ease-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.1));
+}
+
+.alm-like-button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 0.2rem rgba(108, 99, 255, 0.35),
+    var(--ease-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.1));
+}
+
+.alm-like-button--compact {
+  min-height: 2.35rem;
+  padding: 0.55em 0.85em;
+  font-size: 0.875rem;
+}
+
+.alm-like-button--wide {
+  min-height: 3rem;
+  padding: 0.8em 1.25em;
+  font-size: 1.05rem;
+}
+
+/* ── Hidden Checkbox Control ─────────────────────────────── */
+.alm-like-input {
+  position: absolute;
+  inset: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── Icon + Label Content ───────────────────────────────── */
+.alm-like-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2em;
+  height: 1.2em;
+  font-size: 1.1em;
+  line-height: 1;
+  z-index: 1;
+  transition: transform var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.alm-like-icon::before {
+  content: "♡";
+  display: inline-block;
+  transform: translateY(-0.02em);
+}
+
+.alm-like-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2.4em;
+  height: 2.4em;
+  transform: translate(-50%, -50%) scale(0.7);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.65) 0%, rgba(239, 68, 68, 0.18) 45%, transparent 72%);
+  opacity: 0;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.alm-like-label {
+  position: relative;
+  z-index: 1;
+  transition: color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/* ── Checked State ──────────────────────────────────────── */
+.alm-like-input:checked + .alm-like-icon {
+  transform: scale(1.1);
+  color: var(--ease-color-danger, #b91c1c);
+}
+
+.alm-like-input:checked + .alm-like-icon::before {
+  content: "♥";
+}
+
+.alm-like-input:checked ~ .alm-like-label {
+  color: var(--ease-color-danger, #b91c1c);
+}
+
+.alm-like-input:checked + .alm-like-icon::after {
+  animation: ease-kf-ping var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)) forwards;
+}


### PR DESCRIPTION
Closes #41567

## What
Adds a `ripple-like-button` example — a pure-CSS like/heart toggle using a hidden checkbox + label pattern, with an expanding ripple/halo effect on activation.

## Details
- Reuses EaseMotion's existing `ease-kf-ping` keyframe and `--ease-*` custom properties (no new timing values introduced)
- Zero JavaScript
- Follows the same file structure and README format as existing examples (e.g. `media-cards`)
- Accessible: `:focus-visible` styling, keyboard operable (Tab + Enter/Space), semantic label/checkbox pairing
- Responsive sizing using rem/em units

## Testing
- Opened `demo.html` directly in browser — verified ripple animation and checked/unchecked states
- Verified keyboard navigation and focus visibility
- Tested at multiple viewport widths in DevTools