### PR TITLE
Enhance reduced‑motion fallback to fully disable animations & transitions

### DIFF
--- a/easemotion.css
+++ b/easemotion.css
@@ -63,14 +63,11 @@
 @import "./components/forms.css";
 
 
-/* Accessibility: Respect user's reduced motion preference */
+/* Accessibility: Completely disable animations & transitions when reduced motion is preferred */
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
     scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
This PR replaces the previous reduced‑motion rule with a robust fallback that completely disables CSS animations, transitions, and scroll‑behaviour when the user prefers reduced motion.

Closes #45670
