### PR TITLE
docs: add RTL slide direction auto-flipping fix for issue #44669

### DIFF
--- a/submissions/docs/core_changes-issue-44669/README.md
+++ b/submissions/docs/core_changes-issue-44669/README.md
@@ -1,0 +1,38 @@
+# Issue #44669 — RTL Slide Direction Auto-Flipping Fix
+
+## What does this do?
+This submission fixes issue #44669, where horizontal slide animations (`ease-slide-in-left`, `ease-slide-in-right`, etc.) move in the wrong direction when used in Right-to-Left (RTL) layouts (`dir="rtl"`). 
+
+Instead of adding duplicate keyframes or extensive override queries, it introduces a CSS custom variable `--ease-slide-dir` which automatically flips translation coordinates in RTL layouts.
+
+## How is it used?
+
+1. **Variables Addition (`core/variables.css`):**
+   ```css
+   :root {
+     --ease-slide-dir: 1;
+   }
+   [dir="rtl"] {
+     --ease-slide-dir: -1;
+   }
+   ```
+
+2. **Keyframe Update (`core/animations.css`):**
+   Slide animations multiply their horizontal translation offset by `var(--ease-slide-dir, 1)`:
+   ```css
+   @keyframes ease-kf-slide-in-left {
+     from {
+       opacity: 0;
+       transform: translate3d(calc(-32px * var(--ease-slide-dir, 1)), 0, 0);
+     }
+     to {
+       opacity: 1;
+       transform: translate3d(0, 0, 0);
+     }
+   }
+   ```
+
+## Why is it useful?
+- **RTL Language Accessibility:** Ensures Hebrew, Arabic, and Urdu layouts receive layout-relative sliding entries, maintaining consistent motion flow across layout directions.
+- **Maintainable & Compact:** Leverages a single CSS Custom Property to mirror all horizontal sliding animations (standard slides, diagonal slides, slide-from-left/right) without adding lines of duplicated `@keyframes` or class overrides.
+- **Backwards-Compatible:** Defaults to `1` so LTR environments remain completely unaffected and perform normally.

--- a/submissions/docs/core_changes-issue-44669/demo.html
+++ b/submissions/docs/core_changes-issue-44669/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Core Changes Issue #44669 Demo — RTL Slide direction</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <div class="demo-header">
+      <h1 class="demo-title">Issue #44669 — RTL Slide Direction Auto-Flipping Fix</h1>
+      <p class="demo-desc">
+        This showcase demonstrates how the updated keyframes use the CSS design token <code>--ease-slide-dir</code> to automatically mirror horizontal slide animations in Right-to-Left (RTL) mode.
+      </p>
+    </div>
+
+    <div class="layout-grid">
+      <!-- LTR Section -->
+      <div class="layout-pane" id="pane-ltr">
+        <div class="pane-badge">LTR</div>
+        <h2 class="pane-title">English / Left-to-Right layout</h2>
+        
+        <div class="card-stack">
+          <div class="demo-card ease-slide-in-left">
+            <strong>Slide In Left (From Start)</strong><br>
+            Entering from left margin.
+          </div>
+          
+          <div class="demo-card ease-slide-in-right">
+            <strong>Slide In Right (From End)</strong><br>
+            Entering from right margin.
+          </div>
+        </div>
+      </div>
+
+      <!-- RTL Section -->
+      <div class="layout-pane" id="pane-rtl" dir="rtl">
+        <div class="pane-badge">RTL</div>
+        <h2 class="pane-title">العربية / Right-to-Left layout</h2>
+        
+        <div class="card-stack">
+          <div class="demo-card ease-slide-in-left">
+            <strong>شريحة في اليسار (من النهاية)</strong><br>
+            Entering from left margin (logical end in RTL).
+          </div>
+          
+          <div class="demo-card ease-slide-in-right">
+            <strong>شريحة في اليمين (من البداية)</strong><br>
+            Entering from right margin (logical start in RTL).
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="text-align: center;">
+      <button class="btn-trigger" onclick="replayAnimations()">Replay Animations 🔁</button>
+    </div>
+  </div>
+
+  <script>
+    function replayAnimations() {
+      const cards = document.querySelectorAll('.demo-card');
+      cards.forEach(card => {
+        const cls = Array.from(card.classList).find(c => c.startsWith('ease-slide-'));
+        if (cls) {
+          card.classList.remove(cls);
+          // Trigger reflow to restart animation
+          void card.offsetWidth;
+          card.classList.add(cls);
+        }
+      });
+    }
+  </script>
+
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-44669/style.css
+++ b/submissions/docs/core_changes-issue-44669/style.css
@@ -1,0 +1,211 @@
+/* ============================================================
+   Core Changes Issue #44669 — RTL Slide Direction Fix
+   ============================================================ */
+
+/* ── Proposed Design Token Additions ── */
+:root {
+  --ease-slide-dir: 1;
+}
+
+[dir="rtl"] {
+  --ease-slide-dir: -1;
+}
+
+/* ── Proposed Composable Keyframes Updates ── */
+@keyframes ease-kf-slide-in-left {
+  from {
+    opacity: 0;
+    transform: translate3d(calc(-32px * var(--ease-slide-dir, 1)), 0, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes ease-kf-slide-in-right {
+  from {
+    opacity: 0;
+    transform: translate3d(calc(32px * var(--ease-slide-dir, 1)), 0, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes ease-kf-slide-in-from-left {
+  from {
+    opacity: 0;
+    transform: translate3d(calc(-100% * var(--ease-slide-dir, 1)), 0, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes ease-kf-slide-in-from-right {
+  from {
+    opacity: 0;
+    transform: translate3d(calc(100% * var(--ease-slide-dir, 1)), 0, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+/* Composable Diagonal Slides */
+@keyframes ease-kf-slide-in-from-top-left {
+  from {
+    opacity: 0;
+    transform: translate3d(calc(-100% * var(--ease-slide-dir, 1)), -100%, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes ease-kf-slide-in-from-top-right {
+  from {
+    opacity: 0;
+    transform: translate3d(calc(100% * var(--ease-slide-dir, 1)), -100%, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+/* ── Composable Animation Utility Classes ── */
+.ease-slide-in-left {
+  animation: ease-kf-slide-in-left 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ease-slide-in-right {
+  animation: ease-kf-slide-in-right 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ease-slide-in-from-left {
+  animation: ease-kf-slide-in-from-left 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ease-slide-in-from-right {
+  animation: ease-kf-slide-in-from-right 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* ── Demo Page Styles ── */
+.demo-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 30px;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 12px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+}
+
+.demo-header {
+  border-bottom: 1px solid #334155;
+  padding-bottom: 20px;
+}
+
+.demo-title {
+  font-size: 24px;
+  font-weight: 800;
+  margin: 0 0 10px 0;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.demo-desc {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+}
+
+@media (max-width: 768px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.layout-pane {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 24px;
+  position: relative;
+}
+
+.pane-badge {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: bold;
+  background: #475569;
+  border-radius: 4px;
+}
+
+[dir="rtl"] .pane-badge {
+  right: auto;
+  left: 15px;
+}
+
+.pane-title {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 20px 0;
+}
+
+.card-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.demo-card {
+  padding: 16px;
+  background: #0f172a;
+  border-left: 4px solid #38bdf8;
+  border-radius: 6px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+[dir="rtl"] .demo-card {
+  border-left: none;
+  border-right: 4px solid #38bdf8;
+}
+
+.btn-trigger {
+  margin-top: 15px;
+  padding: 10px 20px;
+  background: #38bdf8;
+  border: none;
+  border-radius: 6px;
+  color: #0f172a;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-trigger:hover {
+  background: #7dd3fc;
+}


### PR DESCRIPTION
## Problem

When a page is rendered with `dir="rtl"` (e.g., Arabic, Hebrew, Urdu sites), the horizontal slide utilities:

- `.ease-slide-left`
- `.ease-slide-right`
- `.ease-slide-in-left`
- `.ease-slide-in-right`
- any other slide‑in‑from‑* utilities that move horizontally

behave incorrectly – they slide in the opposite direction of what the visual writing direction dictates. This breaks the intended motion experience for RTL users.

## Reproduction Steps
1. Add `dir="rtl"` to the `<html>` element.  
2. Apply `.ease-slide-left` (or any horizontal slide class) to an element.  
3. The element slides **from the wrong side** (mirrored behavior).

## Expected Behaviour
Slide‑in animations should respect the document’s writing direction, sliding from the logical start when `dir="rtl"`.

## Fix Overview

We introduce a single CSS custom property `--ease-slide-dir` that controls the sign of horizontal translations:

```css
/* Design token – defaults to normal LTR direction */
:root { --ease-slide-dir: 1; }

/* Flip for RTL layouts */
[dir="rtl"] { --ease-slide-dir: -1; }


Closes  #45786