### PR TITLE
feat: add standalone ease-shimmer-loading-card component demo

### DIFF
--- a/submissions/examples/ease-shimmer-loading-card/demo.html
+++ b/submissions/examples/ease-shimmer-loading-card/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Shimmer Loading Card Component</title>
+    <style>
+        body { font-family: 'Segoe UI', sans-serif; background-color: #f8fafc; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; }
+        @keyframes ease-kf-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+        .ease-skeleton-shimmer { background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 50%, #e2e8f0 75%); background-size: 200% 100%; animation: ease-kf-shimmer 1.5s ease-in-out infinite; }
+        .ease-shimmer-loading-card { display: flex; flex-direction: column; gap: 1.25rem; padding: 1.25rem; border: 1px solid #e2e8f0; border-radius: 0.75rem; background-color: #ffffff; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); width: 100%; max-width: 340px; }
+        .ease-shimmer-card-header { display: flex; align-items: center; gap: 1rem; }
+        .ease-skeleton-avatar { width: 48px; height: 48px; border-radius: 50%; flex-shrink: 0; }
+        .ease-shimmer-card-body { display: flex; flex-direction: column; gap: 0.6rem; width: 100%; }
+        .ease-skeleton-text { height: 0.85rem; border-radius: 0.25rem; width: 100%; }
+        .ease-skeleton-text.short { width: 65%; }
+    </style>
+</head>
+<body>
+    <div class="ease-shimmer-loading-card">
+        <div class="ease-shimmer-card-header">
+            <div class="ease-skeleton-avatar ease-skeleton-shimmer"></div>
+            <div class="ease-skeleton-text ease-skeleton-shimmer"></div>
+        </div>
+        <div class="ease-shimmer-card-body">
+            <div class="ease-skeleton-text ease-skeleton-shimmer short"></div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Pull Request Description

I have successfully implemented the standalone demo layout for the requested shimmer loading card component under the correct submissions directory.

Closes #45086

Type of Change

- [ ] ✈️ New animation / hover effect

- [x] 🧩 New component

- [ ] 📝 Documentation improvement

- [ ] 🐛 Bug fix in an existing submission

- [ ] Other (describe below)

Submission Checklist

⚠️ PRs that fail this checklist will be closed without review.

[x] All changes are inside submissions/ (e.g., submissions/examples/your-feature-name/)

[x] Includes demo.html — self-contained, opens in browser with no server

[x] No changes to core/

[x] No changes to components/

[x] One feature per PR (no bundled unrelated changes)

Feature Description

What does this add?
This adds a standalone component demo for the .ease-shimmer-loading-card component inside submissions/examples/ with a continuous linear-gradient shimmer animation.