### PR TITLE
feat(submission): add typewriter-image-gallery component (#41495)

### DIFF
--- a/submissions/examples/typewriter-image-gallery-ksk/README.md
+++ b/submissions/examples/typewriter-image-gallery-ksk/README.md
@@ -1,0 +1,13 @@
+# Typewriter Image Gallery (`typewriter-image-gallery-ksk`)
+
+1. What does this do?  
+Displays a glassmorphism image gallery where each card's title animates in using a CSS typewriter effect (`steps()` width expansion with a blinking cursor), staggered across cards so they type one after another.
+
+2. How is it used?  
+Place `.tw-card` items inside a `.tw-gallery` grid. Each `.tw-title` uses CSS custom properties `--tw-chars`, `--tw-duration`, and `--tw-delay` to control per-card typewriter timing. Card images go inside `.tw-img-wrap`.
+
+3. Why is it useful?  
+Provides a polished, attention-directing gallery reveal pattern with zero JavaScript — using CSS `steps()` timing, `overflow: hidden`, and `border-right` cursor blinking to simulate realistic character-by-character typing.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #41495.*

--- a/submissions/examples/typewriter-image-gallery-ksk/demo.html
+++ b/submissions/examples/typewriter-image-gallery-ksk/demo.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typewriter Image Gallery — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #080a18;
+      /* glassmorphism needs a vivid background to show through */
+      background-image:
+        radial-gradient(ellipse at 20% 30%, rgba(108, 99, 255, 0.25) 0%, transparent 55%),
+        radial-gradient(ellipse at 80% 70%, rgba(236, 72, 153, 0.2) 0%, transparent 55%),
+        radial-gradient(ellipse at 55% 10%, rgba(56, 189, 248, 0.15) 0%, transparent 45%);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 0;
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding: 0 20px;
+    }
+    .page-header h1 {
+      font-size: 2rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, #6c63ff, #38bdf8);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin: 0 0 0.5rem;
+    }
+    .page-header p {
+      color: rgba(255,255,255,0.35);
+      font-size: 0.92rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="page-header">
+    <h1>Typewriter Image Gallery</h1>
+    <p>Glassmorphism cards with staggered typewriter titles — pure CSS, no JavaScript.</p>
+  </div>
+
+  <div class="tw-gallery">
+
+    <!-- Card 1: Aurora Landscape -->
+    <div class="tw-card">
+      <div class="tw-img-wrap">
+        <svg viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="sky1" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#0a0a2e"/>
+              <stop offset="100%" stop-color="#1a1060"/>
+            </linearGradient>
+            <linearGradient id="aurora1" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#00f2fe" stop-opacity="0.7"/>
+              <stop offset="50%" stop-color="#7f00ff" stop-opacity="0.5"/>
+              <stop offset="100%" stop-color="#00f2fe" stop-opacity="0"/>
+            </linearGradient>
+          </defs>
+          <rect width="320" height="200" fill="url(#sky1)"/>
+          <!-- Stars -->
+          <circle cx="30" cy="20" r="1" fill="white" opacity="0.8"/>
+          <circle cx="80" cy="10" r="1.2" fill="white" opacity="0.6"/>
+          <circle cx="150" cy="30" r="0.8" fill="white" opacity="0.9"/>
+          <circle cx="220" cy="15" r="1" fill="white" opacity="0.7"/>
+          <circle cx="290" cy="25" r="1.2" fill="white" opacity="0.5"/>
+          <circle cx="60" cy="45" r="0.8" fill="white" opacity="0.6"/>
+          <circle cx="180" cy="8" r="1" fill="white" opacity="0.8"/>
+          <circle cx="260" cy="50" r="0.7" fill="white" opacity="0.5"/>
+          <!-- Aurora waves -->
+          <path d="M0 80 Q80 40 160 70 Q240 100 320 60 L320 110 Q240 140 160 110 Q80 80 0 120Z" fill="url(#aurora1)" opacity="0.6"/>
+          <path d="M0 100 Q80 60 160 90 Q240 120 320 80 L320 130 Q240 160 160 130 Q80 100 0 140Z" fill="#00ff88" opacity="0.15"/>
+          <!-- Mountains -->
+          <path d="M0 200 L0 130 L40 90 L80 130 L110 100 L160 140 L200 110 L240 140 L270 115 L320 145 L320 200Z" fill="#0d0f24"/>
+          <!-- Snow caps -->
+          <path d="M40 90 L30 110 L50 110Z" fill="rgba(255,255,255,0.3)"/>
+          <path d="M110 100 L100 118 L120 118Z" fill="rgba(255,255,255,0.25)"/>
+          <path d="M200 110 L190 125 L210 125Z" fill="rgba(255,255,255,0.2)"/>
+          <path d="M270 115 L260 130 L280 130Z" fill="rgba(255,255,255,0.2)"/>
+        </svg>
+        <span class="tw-badge">Landscape</span>
+      </div>
+      <div class="tw-body">
+        <h3 class="tw-title">Aurora Highlands Vista</h3>
+        <p class="tw-desc">A breathtaking mountain range under shimmering northern lights, captured in motion.</p>
+        <div class="tw-meta">
+          <div class="tw-meta-author">
+            <svg class="tw-avatar-dot" viewBox="0 0 24 24"><circle cx="12" cy="12" r="12" fill="#6c63ff"/><circle cx="12" cy="10" r="4" fill="#c4b5fd"/><path d="M4 22c0-4.4 3.6-8 8-8s8 3.6 8 8" fill="#6c63ff"/></svg>
+            <span>@polarframe</span>
+          </div>
+          <div class="tw-likes">
+            <svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+            2.4k
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Card 2: Deep Ocean -->
+    <div class="tw-card">
+      <div class="tw-img-wrap">
+        <svg viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="ocean1" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#001f3f"/>
+              <stop offset="100%" stop-color="#000a14"/>
+            </linearGradient>
+            <radialGradient id="glow1" cx="50%" cy="60%" r="40%">
+              <stop offset="0%" stop-color="#00d4ff" stop-opacity="0.3"/>
+              <stop offset="100%" stop-color="transparent"/>
+            </radialGradient>
+          </defs>
+          <rect width="320" height="200" fill="url(#ocean1)"/>
+          <rect width="320" height="200" fill="url(#glow1)"/>
+          <!-- Bubbles -->
+          <circle cx="60" cy="160" r="4" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1"/>
+          <circle cx="80" cy="140" r="2.5" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>
+          <circle cx="100" cy="120" r="3" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1"/>
+          <circle cx="240" cy="170" r="3.5" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>
+          <circle cx="260" cy="150" r="2" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1"/>
+          <!-- Jellyfish body -->
+          <path d="M130 70 Q140 50 160 55 Q180 50 190 70 Q185 90 160 92 Q135 90 130 70Z" fill="rgba(0,212,255,0.4)" stroke="rgba(0,212,255,0.6)" stroke-width="1"/>
+          <!-- Tentacles -->
+          <path d="M140 90 Q138 110 135 130 Q132 150 136 165" fill="none" stroke="rgba(0,212,255,0.4)" stroke-width="1.5"/>
+          <path d="M150 92 Q148 115 146 135 Q144 155 148 170" fill="none" stroke="rgba(0,212,255,0.35)" stroke-width="1.5"/>
+          <path d="M160 92 Q160 115 160 135 Q160 155 162 172" fill="none" stroke="rgba(0,212,255,0.4)" stroke-width="1.5"/>
+          <path d="M170 92 Q172 115 174 135 Q176 155 174 170" fill="none" stroke="rgba(0,212,255,0.35)" stroke-width="1.5"/>
+          <path d="M180 90 Q182 110 185 130 Q188 150 185 165" fill="none" stroke="rgba(0,212,255,0.4)" stroke-width="1.5"/>
+          <!-- Glow center -->
+          <ellipse cx="160" cy="72" rx="15" ry="10" fill="rgba(255,255,255,0.15)"/>
+          <!-- Coral bottom -->
+          <rect x="0" y="178" width="320" height="22" fill="#001226"/>
+          <path d="M20 178 Q25 160 30 178" fill="#0d3b2e" stroke="#155740" stroke-width="1"/>
+          <path d="M50 178 Q60 155 70 178" fill="#0d3b2e" stroke="#155740" stroke-width="1"/>
+          <path d="M280 178 Q285 162 290 178" fill="#0d3b2e" stroke="#155740" stroke-width="1"/>
+          <path d="M250 178 Q262 158 274 178" fill="#0d3b2e" stroke="#155740" stroke-width="1"/>
+        </svg>
+        <span class="tw-badge">Ocean</span>
+      </div>
+      <div class="tw-body">
+        <h3 class="tw-title">Midnight Jellyfish Drift</h3>
+        <p class="tw-desc">Bioluminescent creatures navigate the deep, their glow lighting the abyss.</p>
+        <div class="tw-meta">
+          <div class="tw-meta-author">
+            <svg class="tw-avatar-dot" viewBox="0 0 24 24"><circle cx="12" cy="12" r="12" fill="#0891b2"/><circle cx="12" cy="10" r="4" fill="#7dd3fc"/><path d="M4 22c0-4.4 3.6-8 8-8s8 3.6 8 8" fill="#0891b2"/></svg>
+            <span>@dephlens</span>
+          </div>
+          <div class="tw-likes">
+            <svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+            3.8k
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Card 3: Neon City -->
+    <div class="tw-card">
+      <div class="tw-img-wrap">
+        <svg viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="night1" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#0a0010"/>
+              <stop offset="100%" stop-color="#1a0030"/>
+            </linearGradient>
+          </defs>
+          <rect width="320" height="200" fill="url(#night1)"/>
+          <!-- Moon -->
+          <circle cx="270" cy="30" r="18" fill="#fff9e6" opacity="0.9"/>
+          <circle cx="278" cy="24" r="14" fill="#1a0030"/>
+          <!-- Buildings -->
+          <rect x="0"   y="110" width="30" height="90" fill="#0d001a"/>
+          <rect x="25"  y="80"  width="25" height="120" fill="#120022"/>
+          <rect x="45"  y="100" width="20" height="100" fill="#0d001a"/>
+          <rect x="60"  y="60"  width="35" height="140" fill="#16002e"/>
+          <rect x="90"  y="90"  width="22" height="110" fill="#0d001a"/>
+          <rect x="108" y="70"  width="30" height="130" fill="#120022"/>
+          <rect x="133" y="85"  width="25" height="115" fill="#0d001a"/>
+          <rect x="153" y="55"  width="40" height="145" fill="#16002e"/>
+          <rect x="188" y="95"  width="22" height="105" fill="#0d001a"/>
+          <rect x="205" y="65"  width="32" height="135" fill="#120022"/>
+          <rect x="232" y="80"  width="25" height="120" fill="#0d001a"/>
+          <rect x="252" y="50"  width="38" height="150" fill="#16002e"/>
+          <rect x="285" y="90"  width="22" height="110" fill="#0d001a"/>
+          <rect x="302" y="75"  width="18" height="125" fill="#120022"/>
+          <!-- Neon window lights -->
+          <rect x="65"  y="70"  width="4" height="3" fill="#ff00ff" opacity="0.9"/>
+          <rect x="75"  y="80"  width="4" height="3" fill="#00ffff" opacity="0.8"/>
+          <rect x="65"  y="85"  width="4" height="3" fill="#ff00ff" opacity="0.7"/>
+          <rect x="160" y="65"  width="4" height="3" fill="#ff00ff" opacity="0.9"/>
+          <rect x="170" y="75"  width="4" height="3" fill="#00ffff" opacity="0.8"/>
+          <rect x="160" y="85"  width="4" height="3" fill="#ffff00" opacity="0.7"/>
+          <rect x="255" y="60"  width="4" height="3" fill="#00ffff" opacity="0.9"/>
+          <rect x="265" y="70"  width="4" height="3" fill="#ff00ff" opacity="0.8"/>
+          <rect x="255" y="80"  width="4" height="3" fill="#ff6600" opacity="0.7"/>
+          <rect x="112" y="80"  width="4" height="3" fill="#ffff00" opacity="0.8"/>
+          <rect x="112" y="92"  width="4" height="3" fill="#ff00ff" opacity="0.7"/>
+          <rect x="207" y="75"  width="4" height="3" fill="#00ffff" opacity="0.9"/>
+          <rect x="207" y="87"  width="4" height="3" fill="#ff00ff" opacity="0.8"/>
+          <!-- Neon sign glow bar -->
+          <rect x="0" y="150" width="320" height="2" fill="#ff00ff" opacity="0.15"/>
+          <!-- Reflection on wet road -->
+          <rect x="0" y="175" width="320" height="25" fill="#0a0010" opacity="0.8"/>
+          <rect x="50"  y="178" width="40" height="2" fill="#ff00ff" opacity="0.3"/>
+          <rect x="150" y="178" width="40" height="2" fill="#00ffff" opacity="0.3"/>
+          <rect x="240" y="178" width="40" height="2" fill="#ff00ff" opacity="0.25"/>
+        </svg>
+        <span class="tw-badge">Cityscape</span>
+      </div>
+      <div class="tw-body">
+        <h3 class="tw-title">Neon Metropolis After Rain</h3>
+        <p class="tw-desc">Cyberpunk skyline reflections blur in puddles beneath a violet-lit sky.</p>
+        <div class="tw-meta">
+          <div class="tw-meta-author">
+            <svg class="tw-avatar-dot" viewBox="0 0 24 24"><circle cx="12" cy="12" r="12" fill="#7c3aed"/><circle cx="12" cy="10" r="4" fill="#ddd6fe"/><path d="M4 22c0-4.4 3.6-8 8-8s8 3.6 8 8" fill="#7c3aed"/></svg>
+            <span>@neonframe</span>
+          </div>
+          <div class="tw-likes">
+            <svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+            5.1k
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/typewriter-image-gallery-ksk/style.css
+++ b/submissions/examples/typewriter-image-gallery-ksk/style.css
@@ -1,0 +1,190 @@
+/* ============================================================
+   EaseMotion CSS — Typewriter Image Gallery (Glassmorphism)
+   submissions/examples/typewriter-image-gallery-ksk/style.css
+   ============================================================ */
+
+/* ponytail: CSS steps() typewriter, glassmorphism cards, staggered entry keyframes */
+
+/* ── Gallery Grid ───────────────────────────────────────── */
+.tw-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 20px;
+  box-sizing: border-box;
+}
+
+/* ── Glass Card ─────────────────────────────────────────── */
+.tw-card {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  transition: transform 0.35s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+              box-shadow 0.35s ease;
+  /* staggered entry */
+  opacity: 0;
+  animation: card-rise 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.tw-card:nth-child(1) { animation-delay: 0.1s; }
+.tw-card:nth-child(2) { animation-delay: 0.25s; }
+.tw-card:nth-child(3) { animation-delay: 0.4s; }
+
+.tw-card:hover {
+  transform: translateY(-8px) scale(1.02);
+  box-shadow:
+    0 20px 48px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+}
+
+/* ── Image Thumbnail Area ───────────────────────────────── */
+.tw-img-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+}
+
+.tw-img-wrap svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  transition: transform 0.5s ease;
+}
+
+.tw-card:hover .tw-img-wrap svg {
+  transform: scale(1.06);
+}
+
+/* Glass overlay shimmer on image */
+.tw-img-wrap::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    160deg,
+    rgba(255, 255, 255, 0.06) 0%,
+    transparent 60%
+  );
+  pointer-events: none;
+}
+
+/* ── Category Badge ─────────────────────────────────────── */
+.tw-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  padding: 4px 10px;
+  border-radius: 99px;
+  background: rgba(108, 99, 255, 0.75);
+  backdrop-filter: blur(6px);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ── Card Body ──────────────────────────────────────────── */
+.tw-body {
+  padding: 1.25rem 1.4rem 1.5rem;
+}
+
+/* ── Typewriter Title ───────────────────────────────────── */
+.tw-title {
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 800;
+  margin: 0 0 0.6rem;
+  white-space: nowrap;
+  overflow: hidden;
+  border-right: 2px solid #6c63ff; /* cursor */
+  width: 0;
+  /* typewriter: expand width char by char, then blink cursor */
+  animation:
+    tw-type var(--tw-duration, 1.8s) steps(var(--tw-chars, 20), end) forwards,
+    tw-blink 0.75s step-end infinite;
+  animation-delay: var(--tw-delay, 0.5s), calc(var(--tw-delay, 0.5s) + var(--tw-duration, 1.8s));
+}
+
+/* freeze cursor blink until typing starts */
+.tw-card:nth-child(1) .tw-title { --tw-delay: 0.5s;  --tw-chars: 22; --tw-duration: 1.6s; }
+.tw-card:nth-child(2) .tw-title { --tw-delay: 1.8s;  --tw-chars: 19; --tw-duration: 1.4s; }
+.tw-card:nth-child(3) .tw-title { --tw-delay: 3s;    --tw-chars: 24; --tw-duration: 1.8s; }
+
+/* ── Description ────────────────────────────────────────── */
+.tw-desc {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  margin: 0 0 1.1rem;
+}
+
+/* ── Meta Row ───────────────────────────────────────────── */
+.tw-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.tw-meta-author {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.tw-avatar-dot {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.tw-likes {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.tw-likes svg {
+  width: 13px;
+  height: 13px;
+  fill: #ec4899;
+}
+
+/* ── Keyframes ──────────────────────────────────────────── */
+
+/* Typewriter expand */
+@keyframes tw-type {
+  from { width: 0; }
+  to   { width: 100%; }
+}
+
+/* Cursor blink */
+@keyframes tw-blink {
+  0%, 100% { border-color: #6c63ff; }
+  50%       { border-color: transparent; }
+}
+
+/* Card staggered entry */
+@keyframes card-rise {
+  from {
+    opacity: 0;
+    transform: translateY(30px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}


### PR DESCRIPTION
Closes #41495

Adds a self-contained Typewriter Image Gallery under `submissions/examples/typewriter-image-gallery-ksk/`.

#### Key Features

1. **CSS Typewriter Effect** — Card titles animate character-by-character using `steps()` timing with `width: 0 → 100%` expansion and `overflow: hidden`. A `border-right` cursor blinks after typing completes using `tw-blink` keyframes.
2. **Staggered Sequencing** — Each card's typewriter starts after the previous one finishes via CSS custom properties (`--tw-delay`, `--tw-chars`, `--tw-duration`) — no JavaScript needed.
3. **Glassmorphism Cards** — `backdrop-filter: blur(14px)`, semi-transparent backgrounds, and layered inset highlights create a frosted glass aesthetic over vivid gradient backgrounds.
4. **Staggered Entry Animation** — Cards rise from below with a springy `card-rise` keyframe, each delayed by 150ms for a sequential reveal.
5. **CSS SVG Art** — Three fully hand-crafted inline SVG illustrations (Aurora Highlands, Deep Ocean Jellyfish, Neon Cityscape) — no external image dependencies.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Typewriter keyframes, glassmorphism card styles, gallery grid |
| `demo.html` | Full showcase with 3 cards and vivid gradient background |
| `README.md` | Usage guide referencing issue `#41495` |