### PR TITLE
feat(submission): add scale-progress-bar component (#41555)

### DIFF
--- a/submissions/examples/scale-progress-bar-ksk/README.md
+++ b/submissions/examples/scale-progress-bar-ksk/README.md
@@ -1,0 +1,22 @@
+# Scale Progress Bar (`scale-progress-bar-ksk`)
+
+1. What does this do?  
+Displays dark-mode progress bars that animate from `scaleX(0)` to `scaleX(1)` with a springy overshoot effect, a shimmer sweep, and a glowing tip dot that pops in once the fill completes.
+
+2. How is it used?  
+Add a `.progress-fill` div inside a `.progress-track`. Set the per-bar width and color via CSS custom properties on a modifier class (e.g. `.bar-purple`):
+
+```css
+.bar-purple {
+  --bar-width: 85%;
+  --bar-delay: 0.2s;
+  --bar-color: #6c63ff;
+  --bar-gradient: linear-gradient(90deg, #6c63ff, #a78bfa);
+}
+```
+
+3. Why is it useful?  
+Provides an animated skill/stats section component with no JavaScript. Five pre-built colour variants (purple, cyan, pink, green, amber) are ready to use out of the box.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #41555.*

--- a/submissions/examples/scale-progress-bar-ksk/demo.html
+++ b/submissions/examples/scale-progress-bar-ksk/demo.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scale Progress Bar — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #060813;
+      color: #f8fafc;
+      font-family: system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+    }
+
+    .panel {
+      background: #0f111a;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 24px;
+      padding: 2.5rem;
+      width: 100%;
+      max-width: 560px;
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+      box-sizing: border-box;
+    }
+
+    .panel-header {
+      margin-bottom: 2rem;
+    }
+
+    .panel-header h1 {
+      font-size: 1.4rem;
+      font-weight: 800;
+      color: #fff;
+      margin: 0 0 0.35rem;
+      letter-spacing: -0.02em;
+    }
+
+    .panel-header p {
+      color: #475569;
+      font-size: 0.85rem;
+      margin: 0;
+    }
+
+    .panel-divider {
+      height: 1px;
+      background: rgba(255,255,255,0.05);
+      border: none;
+      margin: 0 0 2rem;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="panel">
+    <div class="panel-header">
+      <h1>Skill Proficiency</h1>
+      <p>Scale progress bars animate from 0 with a springy overshoot, then settle with a glowing tip pulse.</p>
+    </div>
+    <hr class="panel-divider">
+
+    <div class="progress-list">
+
+      <!-- 1. CSS / HTML -->
+      <div class="progress-item">
+        <div class="progress-label-row">
+          <span class="progress-label">CSS &amp; HTML</span>
+          <span class="progress-value bar-purple">85%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill bar-purple"></div>
+        </div>
+      </div>
+
+      <!-- 2. JavaScript -->
+      <div class="progress-item">
+        <div class="progress-label-row">
+          <span class="progress-label">JavaScript</span>
+          <span class="progress-value bar-cyan">70%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill bar-cyan"></div>
+        </div>
+      </div>
+
+      <!-- 3. UI / UX Design -->
+      <div class="progress-item">
+        <div class="progress-label-row">
+          <span class="progress-label">UI / UX Design</span>
+          <span class="progress-value bar-pink">92%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill bar-pink"></div>
+        </div>
+      </div>
+
+      <!-- 4. React -->
+      <div class="progress-item">
+        <div class="progress-label-row">
+          <span class="progress-label">React</span>
+          <span class="progress-value bar-green">58%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill bar-green"></div>
+        </div>
+      </div>
+
+      <!-- 5. Python -->
+      <div class="progress-item">
+        <div class="progress-label-row">
+          <span class="progress-label">Python</span>
+          <span class="progress-value bar-amber">45%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill bar-amber"></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/scale-progress-bar-ksk/style.css
+++ b/submissions/examples/scale-progress-bar-ksk/style.css
@@ -1,0 +1,184 @@
+/* ============================================================
+   EaseMotion CSS — Scale Progress Bar (Dark Mode)
+   submissions/examples/scale-progress-bar-ksk/style.css
+   ============================================================ */
+
+/* ponytail: CSS custom properties for per-bar values, scale + fill keyframes, no JS */
+
+/* ── Progress Bar Wrapper ───────────────────────────────── */
+.progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+/* ── Single Bar Row ─────────────────────────────────────── */
+.progress-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  opacity: 0;
+  animation: bar-entry 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.progress-item:nth-child(1) { animation-delay: 0.1s; }
+.progress-item:nth-child(2) { animation-delay: 0.25s; }
+.progress-item:nth-child(3) { animation-delay: 0.4s; }
+.progress-item:nth-child(4) { animation-delay: 0.55s; }
+.progress-item:nth-child(5) { animation-delay: 0.7s; }
+
+/* ── Label Row ──────────────────────────────────────────── */
+.progress-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.progress-label {
+  color: #e2e8f0;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.progress-value {
+  font-size: 0.8rem;
+  font-weight: 800;
+  color: var(--bar-color, #6c63ff);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Track (background rail) ────────────────────────────── */
+.progress-track {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  background: #1e2235;
+  border-radius: 99px;
+  overflow: visible; /* allow scale pop above track */
+}
+
+/* ── Fill Bar ───────────────────────────────────────────── */
+.progress-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: 99px;
+  width: var(--bar-width, 50%);
+  background: var(--bar-gradient, linear-gradient(90deg, #6c63ff, #38dbff));
+  transform-origin: left center;
+
+  /* Scale animation: squish then spring to full width */
+  animation:
+    bar-scale-in 1s cubic-bezier(0.34, 1.56, 0.64, 1) forwards,
+    bar-shimmer 2.5s linear infinite;
+  animation-delay: var(--bar-delay, 0.3s), var(--bar-delay, 0.3s);
+  transform: scaleX(0);
+}
+
+/* ── Glowing Tip Dot ────────────────────────────────────── */
+.progress-fill::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  transform: translateY(-50%) scale(0);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bar-color, #6c63ff);
+  box-shadow: 0 0 10px var(--bar-color, #6c63ff), 0 0 4px var(--bar-color, #6c63ff);
+  animation: tip-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation-delay: calc(var(--bar-delay, 0.3s) + 0.85s);
+}
+
+/* ── Shimmer sweep ──────────────────────────────────────── */
+.progress-fill::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 99px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.25) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: bar-shimmer 2.5s linear infinite;
+  animation-delay: var(--bar-delay, 0.3s);
+}
+
+/* ── Per-bar CSS custom property configs ────────────────── */
+.bar-purple {
+  --bar-width: 85%;
+  --bar-delay: 0.2s;
+  --bar-color: #6c63ff;
+  --bar-gradient: linear-gradient(90deg, #6c63ff, #a78bfa);
+}
+
+.bar-cyan {
+  --bar-width: 70%;
+  --bar-delay: 0.4s;
+  --bar-color: #38bdf8;
+  --bar-gradient: linear-gradient(90deg, #0ea5e9, #38bdf8);
+}
+
+.bar-pink {
+  --bar-width: 92%;
+  --bar-delay: 0.6s;
+  --bar-color: #ec4899;
+  --bar-gradient: linear-gradient(90deg, #db2777, #ec4899);
+}
+
+.bar-green {
+  --bar-width: 58%;
+  --bar-delay: 0.8s;
+  --bar-color: #22c55e;
+  --bar-gradient: linear-gradient(90deg, #16a34a, #22c55e);
+}
+
+.bar-amber {
+  --bar-width: 45%;
+  --bar-delay: 1s;
+  --bar-color: #f59e0b;
+  --bar-gradient: linear-gradient(90deg, #d97706, #fbbf24);
+}
+
+/* ── Keyframes ──────────────────────────────────────────── */
+
+/* Bar entry: slide in from left and pop */
+@keyframes bar-entry {
+  from {
+    opacity: 0;
+    transform: translateX(-16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Scale X spring from 0 to full width */
+@keyframes bar-scale-in {
+  0%   { transform: scaleX(0); }
+  65%  { transform: scaleX(1.04); } /* slight overshoot */
+  80%  { transform: scaleX(0.98); }
+  100% { transform: scaleX(1); }
+}
+
+/* Glowing tip dot pops in */
+@keyframes tip-pop {
+  from { transform: translateY(-50%) scale(0); }
+  60%  { transform: translateY(-50%) scale(1.4); }
+  100% { transform: translateY(-50%) scale(1); }
+}
+
+/* Shimmer sweep left to right */
+@keyframes bar-shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}


### PR DESCRIPTION
Closes #41555

Adds a self-contained Scale Progress Bar under `submissions/examples/scale-progress-bar-ksk/`.

#### Key Features

1. **Scale Spring Animation** — Fill bars animate from `scaleX(0)` to `scaleX(1)` with a `cubic-bezier(0.34, 1.56, 0.64, 1)` overshoot, bouncing slightly past 100% then settling — giving physical spring-like feel.
2. **Glowing Tip Dot** — A `::after` pseudo-element pops in at the right edge of the fill with a box-shadow glow matching the bar colour, timed to appear after the fill completes.
3. **Shimmer Sweep** — A `::before` highlight sweeps left-to-right infinitely over the fill using `background-position` animation.
4. **CSS Custom Properties** — Each bar variant sets `--bar-width`, `--bar-delay`, `--bar-color`, and `--bar-gradient` for zero-duplication configuration.
5. **Staggered Row Entry** — Each `.progress-item` slides in from the left with a `bar-entry` keyframe and sequential delays.
6. **Five Built-in Variants** — Purple, Cyan, Pink, Green, Amber — drop-in ready.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Scale keyframes, shimmer, tip dot, custom property