### PR TITLE
feat(submission): add find-unused-css-vars CLI tool (#45115)

### DIFF
--- a/submissions/scripts/find-unused-css-vars-ksk/README.md
+++ b/submissions/scripts/find-unused-css-vars-ksk/README.md
@@ -1,0 +1,86 @@
+# Unused CSS Custom Properties Detector (`find-unused-css-vars-ksk`)
+
+A zero-dependency Node.js CLI that scans EaseMotion CSS source files and reports CSS custom properties that are declared but never referenced via `var(--...)`.
+
+## Requirements
+
+- Node.js ≥ 14 (uses `fs`, `path` — no external packages needed)
+
+## Usage
+
+```bash
+# From this directory, scan the repo root (default):
+node find-unused-css-vars.js
+
+# Specify a custom root path:
+node find-unused-css-vars.js --root ../../
+
+# Scan CSS + HTML files:
+node find-unused-css-vars.js --ext css,html
+
+# JSON output (for CI / tooling):
+node find-unused-css-vars.js --json
+
+# Allow-list variables to suppress false positives:
+node find-unused-css-vars.js --allow --ease-debug-bg,--ease-reserved-var
+```
+
+## Example Output
+
+```
+🔍 EaseMotion CSS — Unused Variable Detector
+   Root   : /path/to/EaseMotion-css
+   Types  : .css
+   Scanned: 42 file(s)
+
+📊 Summary
+   Declared  : 87 variable(s)
+   Referenced: 84 variable(s)
+   Unused    : 3 variable(s)
+
+⚠️  Unused CSS Custom Properties:
+
+  --ease-border-heavy
+    ↳ core/tokens.css
+  --ease-primary-light
+    ↳ core/colors.css
+  --ease-shadow-xl
+    ↳ core/tokens.css
+
+💡 Tip: Add variables to --allow to suppress false positives.
+```
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--root <path>` | `../../..` (repo root) | Directory to scan recursively |
+| `--ext <ext,...>` | `css` | Comma-separated file extensions to scan |
+| `--json` | off | Output machine-readable JSON report |
+| `--allow <var,...>` | none | Comma-separated variables to skip (allow-list) |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No unused variables found |
+| `1` | Unused variables detected (or error) |
+
+## How It Works
+
+1. Recursively walks the project directory (skipping `node_modules`, `.git`, `dist`)
+2. Strips CSS comments to avoid false positives
+3. Extracts all `--variable-name:` declarations with a regex
+4. Extracts all `var(--variable-name)` references with a regex
+5. Reports variables in the declared set but not in the referenced set
+
+## CI Integration
+
+```yaml
+# .github/workflows/css-vars-check.yml
+- name: Check unused CSS variables
+  run: node submissions/scripts/find-unused-css-vars-ksk/find-unused-css-vars.js --json
+```
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #45115.*

--- a/submissions/scripts/find-unused-css-vars-ksk/find-unused-css-vars.js
+++ b/submissions/scripts/find-unused-css-vars-ksk/find-unused-css-vars.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * EaseMotion CSS — Unused CSS Custom Properties Detector
+ * submissions/scripts/find-unused-css-vars-ksk/find-unused-css-vars.js
+ *
+ * Usage:
+ *   node find-unused-css-vars.js [--root <path>] [--ext <ext,...>] [--json] [--allow <var,...>]
+ *
+ * Examples:
+ *   node find-unused-css-vars.js
+ *   node find-unused-css-vars.js --root ../../ --ext css,html
+ *   node find-unused-css-vars.js --json
+ *   node find-unused-css-vars.js --allow --ease-debug-bg,--ease-test-var
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+// ── CLI argument parsing ─────────────────────────────────────────────────────
+const args   = process.argv.slice(2);
+const getArg = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const ROOT       = path.resolve(getArg('--root', path.join(__dirname, '../../..')));
+const EXTENSIONS = getArg('--ext', 'css').split(',').map(e => e.trim().replace(/^\./, ''));
+const JSON_MODE  = args.includes('--json');
+const ALLOW_RAW  = getArg('--allow', '');
+const ALLOW_LIST = new Set(ALLOW_RAW ? ALLOW_RAW.split(',').map(v => v.trim()) : []);
+
+// ── File discovery ───────────────────────────────────────────────────────────
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.cache']);
+
+function walk(dir, extSet, results = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+  catch { return results; }
+
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, extSet, results);
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name).replace('.', '');
+      if (extSet.has(ext)) results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+// ── Regex patterns ───────────────────────────────────────────────────────────
+// Matches:  --some-variable-name  (declaration, inside a rule block)
+const RE_DECL = /(?:^|[{;,\s])(--[\w-]+)\s*:/gm;
+// Matches:  var(--some-variable-name)  (reference, anywhere)
+const RE_REF  = /var\(\s*(--[\w-]+)/g;
+
+// ── Scan files ───────────────────────────────────────────────────────────────
+function scanFiles(files) {
+  const declared  = new Map(); // varName → [filePath, ...]
+  const referenced = new Set();
+
+  for (const file of files) {
+    let src;
+    try { src = fs.readFileSync(file, 'utf8'); }
+    catch { continue; }
+
+    // Remove comments to avoid false positives
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')  // block comments
+      .replace(/\/\/.*/g, '');            // line comments (SCSS/less)
+
+    // Collect declarations
+    for (const match of stripped.matchAll(RE_DECL)) {
+      const name = match[1];
+      if (!declared.has(name)) declared.set(name, []);
+      declared.get(name).push(file);
+    }
+
+    // Collect references
+    for (const match of stripped.matchAll(RE_REF)) {
+      referenced.add(match[1]);
+    }
+  }
+
+  return { declared, referenced };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+(function main() {
+  const extSet = new Set(EXTENSIONS);
+  const files  = walk(ROOT, extSet);
+
+  if (!JSON_MODE) {
+    console.log(`\n🔍 EaseMotion CSS — Unused Variable Detector`);
+    console.log(`   Root   : ${ROOT}`);
+    console.log(`   Types  : ${[...extSet].map(e => '.' + e).join(', ')}`);
+    console.log(`   Scanned: ${files.length} file(s)\n`);
+  }
+
+  if (files.length === 0) {
+    if (JSON_MODE) { console.log(JSON.stringify({ error: 'No files found', root: ROOT })); }
+    else { console.error('⚠️  No CSS files found. Check --root and --ext options.'); }
+    process.exit(1);
+  }
+
+  const { declared, referenced } = scanFiles(files);
+
+  // Find unused: declared but never referenced, not in allow-list
+  const unused = [...declared.entries()]
+    .filter(([name]) => !referenced.has(name) && !ALLOW_LIST.has(name))
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  // ── Output ─────────────────────────────────────────────────────────────────
+  if (JSON_MODE) {
+    const report = {
+      scanned: files.length,
+      declared: declared.size,
+      referenced: referenced.size,
+      unused: unused.map(([name, paths]) => ({
+        variable: name,
+        declaredIn: paths.map(p => path.relative(ROOT, p)),
+      })),
+    };
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(unused.length > 0 ? 1 : 0);
+  }
+
+  // Pretty output
+  console.log(`📊 Summary`);
+  console.log(`   Declared  : ${declared.size} variable(s)`);
+  console.log(`   Referenced: ${referenced.size} variable(s)`);
+  console.log(`   Unused    : ${unused.length} variable(s)`);
+  if (ALLOW_LIST.size) console.log(`   Allow-list: ${ALLOW_LIST.size} variable(s) skipped\n`);
+  else console.log('');
+
+  if (unused.length === 0) {
+    console.log('✅ No unused CSS custom properties found. All clean!\n');
+    process.exit(0);
+  }
+
+  console.log('⚠️  Unused CSS Custom Properties:\n');
+  for (const [name, paths] of unused) {
+    console.log(`  ${name}`);
+    for (const p of paths) {
+      console.log(`    ↳ ${path.relative(ROOT, p)}`);
+    }
+  }
+
+  console.log(`\n💡 Tip: Add variables to --allow to suppress false positives.`);
+  console.log(`   Example: node find-unused-css-vars.js --allow ${unused[0][0]}\n`);
+  process.exit(1);
+})();


### PR DESCRIPTION
Closes #45115

Adds a zero-dependency Node.js CLI utility under `submissions/scripts/find-unused-css-vars-ksk/`.

#### What it does

Scans EaseMotion CSS project files recursively, then reports CSS custom properties that are **declared** but never **referenced** via `var(--...)`.

#### Key Features

1. **Zero dependencies** — uses only Node.js built-ins (`fs`, `path`). No `npm install` required.
2. **Comment stripping** — strips `/* block */` and `// line` comments before scanning to avoid false positives from commented-out vars.
3. **Allow-list support** — `--allow` flag lets maintainers suppress known intentional unused vars (e.g. reserved tokens, debug vars).
4. **JSON output mode** — `--json` flag emits a machine-readable report for CI/tooling integration.
5. **Exit codes** — exits `0` (clean) or `1` (unused found), making it CI-friendly out of the box.
6. **Configurable root + extensions** — `--root` and `--ext` flags scan any directory and any file type (CSS, HTML, SCSS, etc.).

#### Usage
```bash
node submissions/scripts/find-unused-css-vars-ksk/find-unused-css-vars.js
node submissions/scripts/find-unused-css-vars-ksk/find-unused-css-vars.js --root ./ --ext css,html --json