### PR TITLE
fix(submission): demonstrate optimizer regex spacing fix (#40061)

### DIFF
--- a/submissions/scripts/optimizer-regex-fix-ksk/README.md
+++ b/submissions/scripts/optimizer-regex-fix-ksk/README.md
@@ -1,0 +1,68 @@
+# Optimizer Regex Spacing Fix (`optimizer-regex-fix-ksk`)
+
+> Bug fix demonstration for issue #40061
+
+## Problem
+
+`extractEaseClasses()` and `extractEmAttributes()` in `easemotion/engine/optimizer.js` use regexes that require no whitespace around `=`. HTML allows spaces around `=`, so valid markup is silently skipped:
+
+```html
+<!-- Matched ✅ -->
+<div class="ease-fade-in"></div>
+<div em="fade-in"></div>
+
+<!-- Missed ❌ — currently ignored by the optimizer -->
+<div class = "ease-fade-in"></div>
+<div em = "fade-in"></div>
+```
+
+## Root Cause
+
+```js
+// optimizer.js line 24 — extractEmAttributes()
+const re = /\bem=(['"])([^"']+)\1/g;       // ← no \s* around =
+
+// optimizer.js line 40 — extractEaseClasses()
+const classRe = /class=(['"])([^"']+)\1/g; // ← no \s* around =
+```
+
+## Fix (2-line change)
+
+```diff
+// extractEmAttributes() — line 24
+- const re = /\bem=(['"])([^"']+)\1/g;
++ const re = /\bem\s*=\s*(['"])([^"']+)\1/g;
+
+// extractEaseClasses() — line 40
+- const classRe = /class=(['"])([^"']+)\1/g;
++ const classRe = /class\s*=\s*(['"])([^"']+)\1/g;
+```
+
+`\s*` means "zero or more whitespace characters" — matching both `class="..."` and `class = "..."` without breaking existing behaviour.
+
+## Demonstration
+
+Run the included script to see the before/after test results:
+
+```bash
+node submissions/scripts/optimizer-regex-fix-ksk/optimizer-regex-fix.js
+```
+
+Expected output:
+
+```
+── BUGGY (current optimizer.js) ──────────────────
+  [✅ PASS] class standard (no space)
+  [❌ FAIL] class spaced   (space around =)
+  [✅ PASS] em    standard (no space)
+  [❌ FAIL] em    spaced   (space around =)
+
+── FIXED (\s* added around =) ────────────────────
+  [✅ PASS] class standard (no space)
+  [✅ PASS] class spaced   (space around =)
+  [✅ PASS] em    standard (no space)
+  [✅ PASS] em    spaced   (space around =)
+```
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #40061.*

--- a/submissions/scripts/optimizer-regex-fix-ksk/optimizer-regex-fix.js
+++ b/submissions/scripts/optimizer-regex-fix-ksk/optimizer-regex-fix.js
@@ -1,0 +1,114 @@
+/**
+ * EaseMotion CSS — Bug Fix Demonstration: #40061
+ * submissions/scripts/optimizer-regex-fix-ksk/optimizer-regex-fix.js
+ *
+ * Problem:
+ *   extractEaseClasses() and extractEmAttributes() in
+ *   easemotion/engine/optimizer.js use regexes that require the `=`
+ *   sign to have no surrounding whitespace. HTML allows spaces around `=`,
+ *   so valid markup like:
+ *     <div class = "ease-fade-in">
+ *     <div em = "fade-in">
+ *   is silently missed by the optimizer.
+ *
+ * Root Cause (from optimizer.js):
+ *   Line 24:  /\bem=(['"])([^"']+)\1/g          ← no \s* around =
+ *   Line 40:  /class=(['"])([^"']+)\1/g          ← no \s* around =
+ *
+ * Fix:
+ *   Add \s* before and after = in both patterns.
+ *
+ * Run this file to see a before/after demonstration:
+ *   node optimizer-regex-fix.js
+ */
+
+'use strict';
+
+// ── BUGGY implementations (current in optimizer.js) ─────────────────────────
+
+function extractEmAttributes_BUGGY(html) {
+  const values = [];
+  const re = /\bem=(['"])([^"']+)\1/g;
+  let m;
+  while ((m = re.exec(html)) !== null) values.push(m[2]);
+  return values;
+}
+
+function extractEaseClasses_BUGGY(html) {
+  const found = new Set();
+  const classRe = /class=(['"])([^"']+)\1/g;
+  let m;
+  while ((m = classRe.exec(html)) !== null) {
+    m[2].split(/\s+/).forEach(cls => { if (cls.startsWith('ease-')) found.add(cls); });
+  }
+  return found;
+}
+
+// ── FIXED implementations ────────────────────────────────────────────────────
+// Change: add \s* around the = in both patterns
+
+function extractEmAttributes_FIXED(html) {
+  const values = [];
+  const re = /\bem\s*=\s*(['"])([^"']+)\1/g;   // ← \s* added
+  let m;
+  while ((m = re.exec(html)) !== null) values.push(m[2]);
+  return values;
+}
+
+function extractEaseClasses_FIXED(html) {
+  const found = new Set();
+  const classRe = /class\s*=\s*(['"])([^"']+)\1/g;  // ← \s* added
+  let m;
+  while ((m = classRe.exec(html)) !== null) {
+    m[2].split(/\s+/).forEach(cls => { if (cls.startsWith('ease-')) found.add(cls); });
+  }
+  return found;
+}
+
+// ── Test Cases ───────────────────────────────────────────────────────────────
+const TEST_HTML_CLASS_STANDARD = '<div class="ease-fade-in ease-hover-grow"></div>';
+const TEST_HTML_CLASS_SPACED   = '<div class = "ease-fade-in ease-hover-grow"></div>';
+const TEST_HTML_EM_STANDARD    = '<div em="fade-in"></div>';
+const TEST_HTML_EM_SPACED      = '<div em = "fade-in"></div>';
+
+// ── Runner ───────────────────────────────────────────────────────────────────
+function run() {
+  const pass = (label, got, expected) => {
+    const ok = JSON.stringify([...got]) === JSON.stringify(expected);
+    console.log(`  [${ok ? '✅ PASS' : '❌ FAIL'}] ${label}`);
+    if (!ok) {
+      console.log(`         Expected: ${JSON.stringify(expected)}`);
+      console.log(`         Got     : ${JSON.stringify([...got])}`);
+    }
+  };
+
+  console.log('\n══════════════════════════════════════════════════');
+  console.log('  Bug Fix Demo — Issue #40061');
+  console.log('  Spaced = in HTML attributes not matched');
+  console.log('══════════════════════════════════════════════════\n');
+
+  console.log('── BUGGY (current optimizer.js) ──────────────────');
+  pass('class standard (no space)', extractEaseClasses_BUGGY(TEST_HTML_CLASS_STANDARD), ['ease-fade-in', 'ease-hover-grow']);
+  pass('class spaced   (space around =)', extractEaseClasses_BUGGY(TEST_HTML_CLASS_SPACED),   ['ease-fade-in', 'ease-hover-grow']); // ← fails
+  pass('em    standard (no space)', extractEmAttributes_BUGGY(TEST_HTML_EM_STANDARD), ['fade-in']);
+  pass('em    spaced   (space around =)', extractEmAttributes_BUGGY(TEST_HTML_EM_SPACED),   ['fade-in']); // ← fails
+
+  console.log('\n── FIXED (\\s* added around =) ────────────────────');
+  pass('class standard (no space)', extractEaseClasses_FIXED(TEST_HTML_CLASS_STANDARD), ['ease-fade-in', 'ease-hover-grow']);
+  pass('class spaced   (space around =)', extractEaseClasses_FIXED(TEST_HTML_CLASS_SPACED),   ['ease-fade-in', 'ease-hover-grow']); // ← now passes
+  pass('em    standard (no space)', extractEmAttributes_FIXED(TEST_HTML_EM_STANDARD), ['fade-in']);
+  pass('em    spaced   (space around =)', extractEmAttributes_FIXED(TEST_HTML_EM_SPACED),   ['fade-in']); // ← now passes
+
+  console.log('\n── Minimal Diff to apply to optimizer.js ─────────');
+  console.log(`
+  Line 24  (extractEmAttributes):
+  - const re = /\\bem=(['"])([^"']+)\\1/g;
+  + const re = /\\bem\\s*=\\s*(['"])([^"']+)\\1/g;
+
+  Line 40  (extractEaseClasses):
+  - const classRe = /class=(['"])([^"']+)\\1/g;
+  + const classRe = /class\\s*=\\s*(['"])([^"']+)\\1/g;
+  `);
+}
+
+run();


### PR DESCRIPTION
Closes #40061

Adds a verified bug fix demonstration under `submissions/scripts/optimizer-regex-fix-ksk/`.

#### Root Cause

Two regex patterns in `easemotion/engine/optimizer.js` don't allow whitespace around `=`, missing valid HTML like `class = "ease-fade-in"`:

```diff
// Line 24 — extractEmAttributes()
- const re = /\bem=(['"])([^"']+)\1/g;
+ const re = /\bem\s*=\s*(['"])([^"']+)\1/g;

// Line 40 — extractEaseClasses()
- const classRe = /class=(['"])([^"']+)\1/g;
+ const classRe = /class\s*=\s*(['"])([^"']+)\1/g;