### PR TITLE
feat(submission): add plasma-modal-v2 SaaS enterprise variant (#41872)

### DIFF
--- a/submissions/examples/plasma-modal-v2-ksk/README.md
+++ b/submissions/examples/plasma-modal-v2-ksk/README.md
@@ -1,0 +1,13 @@
+# Plasma Modal v2 (`plasma-modal-v2-ksk`)
+
+1. What does this do?  
+A SaaS Enterprise upgrade modal with three drifting plasma blobs, an animated rainbow gradient header band, and a spring scale entry animation — all driven by a pure CSS checkbox toggle.
+
+2. How is it used?  
+Pair `<input type="checkbox" class="plasma-v2-toggle">` with `<label for="...">` buttons for open/close/dismiss. The `.plasma-v2-backdrop` and `.plasma-v2-modal` activate on `:checked`.
+
+3. Why is it useful?  
+Provides a premium-feel SaaS upgrade/upsell modal with living plasma atmosphere, feature checklist, and dual action buttons — zero JavaScript required.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #41872.*

--- a/submissions/examples/plasma-modal-v2-ksk/demo.html
+++ b/submissions/examples/plasma-modal-v2-ksk/demo.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Plasma Modal v2 — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #060813;
+      background-image:
+        radial-gradient(ellipse at 15% 25%, rgba(124, 58, 237, 0.18) 0%, transparent 50%),
+        radial-gradient(ellipse at 85% 75%, rgba(37, 99, 235, 0.15) 0%, transparent 50%);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-label {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    .page-label h1 {
+      font-size: 1.8rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, #a78bfa, #60a5fa);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin: 0 0 0.4rem;
+    }
+    .page-label p {
+      color: #334155;
+      font-size: 0.88rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-label">
+    <h1>Plasma Modal v2</h1>
+    <p>Pure CSS toggle — click the button to open, click outside or "Dismiss" to close.</p>
+  </div>
+
+  <!-- Checkbox toggle -->
+  <input type="checkbox" id="plasma-v2" class="plasma-v2-toggle">
+
+  <!-- Trigger -->
+  <label for="plasma-v2" class="plasma-v2-trigger">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M13 10V3L4 14h7v7l9-11h-7z"/>
+    </svg>
+    Open Plasma Modal
+  </label>
+
+  <!-- Backdrop -->
+  <div class="plasma-v2-backdrop">
+    <label for="plasma-v2" class="plasma-v2-backdrop-close"></label>
+
+    <div class="plasma-v2-modal">
+      <!-- Animated gradient top band -->
+      <div class="plasma-v2-header-band"></div>
+
+      <!-- Plasma blobs -->
+      <div class="plasma-v2-blobs">
+        <div class="pv2-blob pv2-blob-1"></div>
+        <div class="pv2-blob pv2-blob-2"></div>
+        <div class="pv2-blob pv2-blob-3"></div>
+      </div>
+
+      <!-- Content -->
+      <div class="plasma-v2-content">
+        <div class="plasma-v2-icon">⚡</div>
+
+        <h2 class="plasma-v2-title">Activate Plasma<br>Enterprise Plan</h2>
+        <p class="plasma-v2-desc">
+          Unlock unlimited workspaces, AI-powered insights, and 99.99% SLA uptime for your entire team.
+        </p>
+
+        <div class="plasma-v2-features">
+          <div class="plasma-v2-feature">
+            <div class="plasma-v2-feature-dot">✓</div>
+            Unlimited team members &amp; workspaces
+          </div>
+          <div class="plasma-v2-feature">
+            <div class="plasma-v2-feature-dot">✓</div>
+            AI analytics with real-time dashboards
+          </div>
+          <div class="plasma-v2-feature">
+            <div class="plasma-v2-feature-dot">✓</div>
+            Priority 24/7 support &amp; 99.99% SLA
+          </div>
+          <div class="plasma-v2-feature">
+            <div class="plasma-v2-feature-dot">✓</div>
+            Custom domain &amp; white-label branding
+          </div>
+        </div>
+
+        <div class="plasma-v2-actions">
+          <label for="plasma-v2" class="plasma-v2-btn plasma-v2-btn-ghost">Dismiss</label>
+          <label for="plasma-v2" class="plasma-v2-btn plasma-v2-btn-primary">Upgrade Now →</label>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/plasma-modal-v2-ksk/style.css
+++ b/submissions/examples/plasma-modal-v2-ksk/style.css
@@ -1,0 +1,272 @@
+/* ============================================================
+   EaseMotion CSS — Plasma Modal v2 (SaaS Dark Variant)
+   submissions/examples/plasma-modal-v2-ksk/style.css
+   ============================================================ */
+
+/* ── Toggle controller ───────────────────────────────────── */
+.plasma-v2-toggle {
+  display: none;
+}
+
+/* ── Trigger Button ─────────────────────────────────────── */
+.plasma-v2-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 28px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #7c3aed, #2563eb);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(124, 58, 237, 0.4);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.25s ease;
+  user-select: none;
+}
+
+.plasma-v2-trigger:hover {
+  transform: translateY(-3px) scale(1.02);
+  box-shadow: 0 14px 32px rgba(124, 58, 237, 0.55);
+}
+
+/* ── Backdrop ───────────────────────────────────────────── */
+.plasma-v2-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 4, 16, 0.75);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 100;
+}
+
+.plasma-v2-toggle:checked ~ .plasma-v2-backdrop {
+  opacity: 1;
+  pointer-events: all;
+}
+
+/* ── Modal Card ─────────────────────────────────────────── */
+.plasma-v2-modal {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  background: #0c0e1d;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow:
+    0 32px 64px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(124, 58, 237, 0.15);
+  transform: scale(0.88) translateY(32px);
+  opacity: 0;
+  transition:
+    transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.3s ease;
+}
+
+.plasma-v2-toggle:checked ~ .plasma-v2-backdrop .plasma-v2-modal {
+  transform: scale(1) translateY(0);
+  opacity: 1;
+}
+
+/* ── Plasma Blob Layer ──────────────────────────────────── */
+.plasma-v2-blobs {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: 24px;
+}
+
+.pv2-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(50px);
+  opacity: 0.35;
+}
+
+.pv2-blob-1 {
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, #7c3aed, transparent 70%);
+  top: -60px;
+  left: -60px;
+  animation: pv2-drift-1 8s ease-in-out infinite alternate;
+}
+
+.pv2-blob-2 {
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle, #2563eb, transparent 70%);
+  bottom: -40px;
+  right: -40px;
+  animation: pv2-drift-2 10s ease-in-out infinite alternate;
+}
+
+.pv2-blob-3 {
+  width: 140px;
+  height: 140px;
+  background: radial-gradient(circle, #db2777, transparent 70%);
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  animation: pv2-drift-3 7s ease-in-out infinite alternate;
+}
+
+/* ── Header Band ────────────────────────────────────────── */
+.plasma-v2-header-band {
+  height: 4px;
+  background: linear-gradient(90deg, #7c3aed, #2563eb, #db2777);
+  background-size: 200% 100%;
+  animation: pv2-gradient-slide 3s linear infinite;
+}
+
+/* ── Content ────────────────────────────────────────────── */
+.plasma-v2-content {
+  position: relative;
+  z-index: 2;
+  padding: 2rem;
+}
+
+.plasma-v2-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #7c3aed22, #2563eb22);
+  border: 1px solid rgba(124, 58, 237, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  font-size: 1.5rem;
+}
+
+.plasma-v2-title {
+  color: #fff;
+  font-size: 1.35rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.6rem;
+  line-height: 1.3;
+}
+
+.plasma-v2-desc {
+  color: #64748b;
+  font-size: 0.88rem;
+  line-height: 1.7;
+  margin: 0 0 1.75rem;
+}
+
+/* ── Feature List ───────────────────────────────────────── */
+.plasma-v2-features {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 2rem;
+}
+
+.plasma-v2-feature {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.86rem;
+  color: #94a3b8;
+}
+
+.plasma-v2-feature-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(124, 58, 237, 0.15);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  flex-shrink: 0;
+  color: #a78bfa;
+}
+
+/* ── Actions ────────────────────────────────────────────── */
+.plasma-v2-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.plasma-v2-btn {
+  flex: 1;
+  padding: 13px 16px;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  text-align: center;
+  user-select: none;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.2s ease;
+}
+
+.plasma-v2-btn:hover {
+  transform: translateY(-2px);
+}
+
+.plasma-v2-btn-ghost {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #64748b;
+}
+
+.plasma-v2-btn-ghost:hover {
+  color: #94a3b8;
+}
+
+.plasma-v2-btn-primary {
+  background: linear-gradient(135deg, #7c3aed, #2563eb);
+  border: none;
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(124, 58, 237, 0.35);
+}
+
+.plasma-v2-btn-primary:hover {
+  box-shadow: 0 8px 22px rgba(124, 58, 237, 0.5);
+}
+
+/* ── Backdrop click to close ────────────────────────────── */
+.plasma-v2-backdrop-close {
+  position: absolute;
+  inset: 0;
+  cursor: default;
+  z-index: 1;
+}
+
+.plasma-v2-modal { z-index: 2; }
+
+/* ── Keyframes ──────────────────────────────────────────── */
+@keyframes pv2-drift-1 {
+  from { transform: translate(0, 0) scale(1); }
+  to   { transform: translate(40px, 30px) scale(1.15); }
+}
+
+@keyframes pv2-drift-2 {
+  from { transform: translate(0, 0) scale(1); }
+  to   { transform: translate(-30px, -40px) scale(1.2); }
+}
+
+@keyframes pv2-drift-3 {
+  from { transform: translate(-50%, -50%) scale(1); }
+  to   { transform: translate(-40%, -60%) scale(1.3); }
+}
+
+@keyframes pv2-gradient-slide {
+  0%   { background-position: 0% 0; }
+  100% { background-position: 200% 0; }
+}


### PR DESCRIPTION
Closes #41872

Adds a second Plasma Modal variant under `submissions/examples/plasma-modal-v2-ksk/` — a SaaS Enterprise upgrade modal with distinct design differences from the original submission.

#### Differences from plasma-modal-ksk
- **Animated gradient header band** — rainbow linear gradient slides across the top of the card continuously
- **Feature checklist layout** — four bullet points with glowing dot indicators instead of a stats grid
- **Indigo/blue plasma palette** — `#7c3aed` + `#2563eb` + `#db2777` instead of purple/pink/cyan
- **Spring scale entry** — `cubic-bezier(0.34, 1.56, 0.64, 1)` overshoot on modal open

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Plasma blob keyframes, gradient band animation, modal scale transition |
| `demo.html` | Self-contained showcase with trigger button and full modal |
| `README.md` | Usage guide referencing issue `#41872` |