### PR TITLE
Add quokka component

### DIFF
--- a/submissions/examples/quokka-as/README.md
+++ b/submissions/examples/quokka-as/README.md
@@ -1,0 +1,25 @@
+# Quokka
+
+### What does this do?
+
+It shows a quokka sitting up with a leaf, wearing its famous grin. It bobs, tilts its head, nibbles the leaf, flicks its tail, twitches an ear, and blinks. Under reduced motion it sits still, still smiling.
+
+### How is it used?
+
+```html
+<div class="quok">
+  <span class="bodyQ"></span>
+  <div class="headQ">
+    <span class="faceQ"></span>
+    <span class="smileQ"></span>
+  </div>
+  <span class="armQ"></span>
+  <span class="leafQ"></span>
+</div>
+```
+
+The grin is a box with only its bottom border drawn and its bottom corners fully rounded, which curves that single line into a smile. No clip path, no second element. The arm and the leaf share the same `nibbleQ` keyframe on the same 2.2 second clock, so the leaf moves exactly with the paw holding it rather than drifting free of it. The ear uses a long-hold keyframe: it rests for 88 percent of the cycle and flicks only briefly, which reads as an idle twitch instead of a steady wag.
+
+### Why is it useful?
+
+Wildlife, cheerful, and mascot themes use a quokka. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/quokka-as/demo.html
+++ b/submissions/examples/quokka-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quokka</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="quok">
+      <span class="tailQ"></span>
+      <span class="bodyQ"></span>
+      <span class="footQ fq1"></span>
+      <span class="footQ fq2"></span>
+      <span class="armQ"></span>
+      <div class="headQ">
+        <span class="earQ eql"></span>
+        <span class="earQ eqr"></span>
+        <span class="faceQ"></span>
+        <span class="cheekQ cql"></span>
+        <span class="cheekQ cqr"></span>
+        <span class="eyeQ eyl"></span>
+        <span class="eyeQ eyr"></span>
+        <span class="snoutQ"></span>
+        <span class="noseQ"></span>
+        <span class="smileQ"></span>
+      </div>
+      <span class="leafQ"></span>
+    </div>
+    <span class="grassQ gq1"></span>
+    <span class="grassQ gq2"></span>
+    <span class="sparkQ sq1"></span>
+    <span class="sparkQ sq2"></span>
+    <span class="groundQ"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/quokka-as/style.css
+++ b/submissions/examples/quokka-as/style.css
@@ -1,0 +1,301 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #8fae62, #2c3a1a 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 310px;
+}
+
+.groundQ {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 54px);
+  background:
+    radial-gradient(circle at 24% 0, rgba(255, 250, 200, 0.16) 0 12px, transparent 12px),
+    linear-gradient(180deg, #9c8f52, #4f4622);
+}
+
+.grassQ {
+  position: absolute;
+  bottom: 48px;
+  width: 10px;
+  height: 60px;
+  border-radius: 5px 5px 0 0;
+  background: linear-gradient(180deg, #a8c25c, #4f6a26);
+  transform-origin: 50% 100%;
+  z-index: 3;
+  animation: swayQ 4.6s ease-in-out infinite;
+}
+
+.gq1 { left: 28px; }
+
+.gq2 {
+  right: 30px;
+  height: 46px;
+  animation-delay: 1.8s;
+}
+
+.quok {
+  position: absolute;
+  bottom: 48px;
+  left: 50%;
+  width: 230px;
+  height: 220px;
+  margin-left: -115px;
+  z-index: 5;
+  animation: hopQ 3.4s ease-in-out infinite;
+}
+
+.bodyQ {
+  position: absolute;
+  bottom: 0;
+  left: 56px;
+  width: 116px;
+  height: 112px;
+  border-radius: 46% 46% 40% 40% / 52% 52% 48% 48%;
+  background: linear-gradient(180deg, #a97d52, #6d4c2a);
+  box-shadow: inset -8px -8px 16px rgba(40, 26, 10, 0.4);
+  z-index: 3;
+}
+
+.tailQ {
+  position: absolute;
+  bottom: 6px;
+  right: 30px;
+  width: 66px;
+  height: 18px;
+  border-radius: 9px;
+  background: linear-gradient(90deg, #966c46, #573a1e);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: flickQ 3.4s ease-in-out infinite;
+}
+
+.footQ {
+  position: absolute;
+  bottom: -6px;
+  width: 40px;
+  height: 16px;
+  border-radius: 10px 14px 8px 8px;
+  background: linear-gradient(180deg, #8d6540, #503620);
+  z-index: 4;
+}
+
+.fq1 { left: 62px; }
+.fq2 { left: 118px; }
+
+.armQ {
+  position: absolute;
+  bottom: 52px;
+  left: 96px;
+  width: 40px;
+  height: 16px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #a97d52, #6d4c2a);
+  transform-origin: 0 50%;
+  transform: rotate(-12deg);
+  z-index: 6;
+  animation: nibbleQ 2.2s ease-in-out infinite;
+}
+
+.leafQ {
+  position: absolute;
+  bottom: 54px;
+  left: 128px;
+  width: 34px;
+  height: 16px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #7fc45a, #35702f);
+  transform: rotate(-16deg);
+  z-index: 7;
+  animation: nibbleQ 2.2s ease-in-out infinite;
+}
+
+.headQ {
+  position: absolute;
+  bottom: 92px;
+  left: 50%;
+  width: 130px;
+  height: 116px;
+  margin-left: -65px;
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: tiltQ 3.4s ease-in-out infinite;
+}
+
+.faceQ {
+  position: absolute;
+  bottom: 0;
+  left: 18px;
+  width: 94px;
+  height: 92px;
+  border-radius: 46% 46% 44% 44% / 50% 50% 50% 50%;
+  background: linear-gradient(180deg, #bd9061, #85603a);
+  z-index: 3;
+}
+
+.earQ {
+  position: absolute;
+  bottom: 74px;
+  width: 30px;
+  height: 34px;
+  border-radius: 50% 50% 40% 40%;
+  background: linear-gradient(180deg, #a97d52, #6d4c2a);
+  z-index: 2;
+  animation: earQ 4s ease-in-out infinite;
+}
+
+.eql { left: 12px; }
+
+.eqr {
+  right: 12px;
+  animation-delay: 2s;
+}
+
+.cheekQ {
+  position: absolute;
+  bottom: 22px;
+  width: 26px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(220, 140, 120, 0.45);
+  z-index: 5;
+}
+
+.cql { left: 24px; }
+.cqr { right: 24px; }
+
+.eyeQ {
+  position: absolute;
+  bottom: 50px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: #1e1207;
+  box-shadow: inset -3px 3px 0 -1px rgba(255, 255, 255, 0.85);
+  z-index: 6;
+  animation: blinkQ 5s ease-in-out infinite;
+}
+
+.eyl { left: 34px; }
+.eyr { right: 34px; }
+
+.snoutQ {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  width: 44px;
+  height: 32px;
+  margin-left: -22px;
+  border-radius: 50% 50% 44% 44%;
+  background: linear-gradient(180deg, #d3ab7c, #a17c50);
+  z-index: 5;
+}
+
+.noseQ {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  width: 16px;
+  height: 11px;
+  margin-left: -8px;
+  border-radius: 50% 50% 60% 60%;
+  background: #2e1c0c;
+  z-index: 7;
+}
+
+.smileQ {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  width: 34px;
+  height: 16px;
+  margin-left: -17px;
+  border-radius: 0 0 20px 20px;
+  border-bottom: 3px solid #3d2712;
+  z-index: 7;
+}
+
+.sparkQ {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #fffbe0;
+  box-shadow: 0 0 10px rgba(255, 250, 200, 0.9);
+  z-index: 7;
+  animation: twinkleQ 2.8s ease-in-out infinite;
+}
+
+.sq1 { top: 60px; left: 50px; }
+
+.sq2 {
+  top: 100px;
+  right: 48px;
+  animation-delay: 1.4s;
+}
+
+@keyframes hopQ {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@keyframes tiltQ {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes nibbleQ {
+  0%, 100% { transform: rotate(-12deg); }
+  50% { transform: rotate(-2deg); }
+}
+
+@keyframes flickQ {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes earQ {
+  0%, 88%, 100% { transform: rotate(0deg); }
+  94% { transform: rotate(-12deg); }
+}
+
+@keyframes blinkQ {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes swayQ {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes twinkleQ {
+  0%, 100% { opacity: 0.3; transform: scale(0.7); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quok,
+  .headQ,
+  .earQ,
+  .eyeQ,
+  .tailQ,
+  .armQ,
+  .leafQ,
+  .grassQ,
+  .sparkQ {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a quokka built for #45913. The grin is a box with only its bottom border drawn and its bottom corners fully rounded, which curves that single line into a smile with no clip path and no second element. The arm and the leaf share one keyframe on the same 2.2 second clock, so the leaf moves exactly with the paw holding it rather than drifting free of it, and the ear uses a long hold keyframe that rests for most of the cycle and flicks only briefly, which reads as an idle twitch rather than a steady wag. Reduced motion fallback included. Pure CSS. Closes #45913.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a quokka sitting up with round ears, blushed cheeks and a wide grin, holding a leaf in its paw.
