### PR TITLE
Add fennec fox component

### DIFF
--- a/submissions/examples/fennec-fox-as/README.md
+++ b/submissions/examples/fennec-fox-as/README.md
@@ -1,0 +1,23 @@
+# Fennec Fox
+
+### What does this do?
+
+It shows a fennec fox in the desert at night, its huge ears swivelling to catch a sound. The fox perks up, its head turns, its ears swivel, its brush tail swishes, and it blinks under the moon. Under reduced motion it sits still.
+
+### How is it used?
+
+```html
+<div class="fennec">
+  <div class="headF2">
+    <span class="earF2 efl"></span>
+    <span class="innerF2 ifl"></span>
+    <span class="faceF2"></span>
+  </div>
+</div>
+```
+
+Each ear is two elements, the outer shell and the pink inner, and both read the same `--ef` custom property for their angle and run the same `swivelF2` keyframe. Because the keyframe steps to `rotate(calc(var(--ef) + 8deg))`, the inner ear turns with the outer one instead of sliding out of it, and each ear still keeps its own splay. The tail's dark tip is an inset `box-shadow` rather than an extra element, so the two tone brush costs nothing extra.
+
+### Why is it useful?
+
+Desert, wildlife, and night themes use a fennec fox. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/fennec-fox-as/demo.html
+++ b/submissions/examples/fennec-fox-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fennec Fox</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moonF2"></span>
+    <span class="duneF"></span>
+    <div class="fennec">
+      <span class="tailF2"></span>
+      <span class="bodyF2"></span>
+      <span class="legF2 lf1"></span>
+      <span class="legF2 lf2"></span>
+      <div class="headF2">
+        <span class="earF2 efl"></span>
+        <span class="earF2 efr"></span>
+        <span class="innerF2 ifl"></span>
+        <span class="innerF2 ifr"></span>
+        <span class="faceF2"></span>
+        <span class="eyeF2 eyf1"></span>
+        <span class="eyeF2 eyf2"></span>
+        <span class="muzzleF2"></span>
+        <span class="noseF2"></span>
+        <span class="whiskF2 wf1"></span>
+        <span class="whiskF2 wf2"></span>
+      </div>
+    </div>
+    <span class="starF2 sf1"></span>
+    <span class="starF2 sf2"></span>
+    <span class="starF2 sf3"></span>
+    <span class="sandF2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fennec-fox-as/style.css
+++ b/submissions/examples/fennec-fox-as/style.css
@@ -1,0 +1,312 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #3a4166, #0c0e1a 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 310px;
+}
+
+.moonF2 {
+  position: absolute;
+  top: 26px;
+  right: 40px;
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #fdfaf0, #d8d2b8 74%);
+  box-shadow: 0 0 60px rgba(240, 235, 205, 0.6);
+  z-index: 2;
+  animation: glowF2 6s ease-in-out infinite;
+}
+
+.starF2 {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff;
+  z-index: 2;
+  animation: twinkleF2 3s ease-in-out infinite;
+}
+
+.sf1 { top: 44px; left: 40px; }
+
+.sf2 {
+  top: 90px;
+  left: 96px;
+  animation-delay: 1s;
+}
+
+.sf3 {
+  top: 60px;
+  right: 130px;
+  animation-delay: 2s;
+}
+
+.duneF {
+  position: absolute;
+  bottom: 44px;
+  left: -50vw;
+  right: -50vw;
+  height: 70px;
+  background:
+    radial-gradient(circle at 28% 100%, #a98a5c 0 90px, transparent 90px),
+    radial-gradient(circle at 74% 100%, #97794c 0 70px, transparent 70px);
+  z-index: 3;
+}
+
+.sandF2 {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 48px);
+  background: linear-gradient(180deg, #c2a06a, #6b5730);
+  z-index: 6;
+}
+
+.fennec {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 240px;
+  height: 230px;
+  margin-left: -120px;
+  z-index: 5;
+  animation: perkF2 4.4s ease-in-out infinite;
+}
+
+.bodyF2 {
+  position: absolute;
+  bottom: 0;
+  left: 66px;
+  width: 106px;
+  height: 96px;
+  border-radius: 46% 46% 40% 40% / 52% 52% 48% 48%;
+  background: linear-gradient(180deg, #f0d9a8, #c9a86e);
+  box-shadow: inset -6px -6px 14px rgba(140, 110, 60, 0.35);
+  z-index: 4;
+}
+
+.legF2 {
+  position: absolute;
+  bottom: -6px;
+  width: 22px;
+  height: 20px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #e0c793, #b3925c);
+  z-index: 3;
+}
+
+.lf1 { left: 76px; }
+.lf2 { left: 120px; }
+
+.tailF2 {
+  position: absolute;
+  bottom: 4px;
+  right: 20px;
+  width: 76px;
+  height: 34px;
+  border-radius: 20px 30px 30px 20px;
+  background: linear-gradient(90deg, #e6cd9a, #b8955e);
+  box-shadow: inset -10px 0 0 -4px #4a3c20;
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: swishF2 3.6s ease-in-out infinite;
+}
+
+.headF2 {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 150px;
+  height: 150px;
+  margin-left: -75px;
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: listenF2 4.4s ease-in-out infinite;
+}
+
+.earF2 {
+  position: absolute;
+  bottom: 56px;
+  width: 44px;
+  height: 84px;
+  border-radius: 50% 50% 20% 20% / 62% 62% 38% 38%;
+  background: linear-gradient(180deg, #ecd3a2, #bf9c64);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--ef, 0deg));
+  z-index: 2;
+  animation: swivelF2 4s ease-in-out infinite;
+}
+
+.efl {
+  left: 8px;
+
+  --ef: -20deg;
+}
+
+.efr {
+  right: 8px;
+
+  --ef: 20deg;
+
+  animation-delay: 2s;
+}
+
+.innerF2 {
+  position: absolute;
+  bottom: 66px;
+  width: 24px;
+  height: 58px;
+  border-radius: 50% 50% 20% 20% / 62% 62% 38% 38%;
+  background: linear-gradient(180deg, #e8a89a, #c07f70);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--ef, 0deg));
+  z-index: 3;
+  animation: swivelF2 4s ease-in-out infinite;
+}
+
+.ifl {
+  left: 18px;
+
+  --ef: -20deg;
+}
+
+.ifr {
+  right: 18px;
+
+  --ef: 20deg;
+
+  animation-delay: 2s;
+}
+
+.faceF2 {
+  position: absolute;
+  bottom: 0;
+  left: 34px;
+  width: 82px;
+  height: 76px;
+  border-radius: 46% 46% 44% 44% / 50% 50% 50% 50%;
+  background: linear-gradient(180deg, #f4e2bc, #cfae78);
+  z-index: 4;
+}
+
+.eyeF2 {
+  position: absolute;
+  bottom: 40px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #241708;
+  box-shadow: inset -3px 3px 0 -1px rgba(255, 255, 255, 0.85);
+  z-index: 6;
+  animation: blinkF2 5s ease-in-out infinite;
+}
+
+.eyf1 { left: 46px; }
+.eyf2 { right: 46px; }
+
+.muzzleF2 {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 40px;
+  height: 30px;
+  margin-left: -20px;
+  border-radius: 50% 50% 44% 44%;
+  background: linear-gradient(180deg, #fdf4e2, #ddc9a4);
+  z-index: 5;
+}
+
+.noseF2 {
+  position: absolute;
+  bottom: 22px;
+  left: 50%;
+  width: 14px;
+  height: 10px;
+  margin-left: -7px;
+  border-radius: 50% 50% 60% 60%;
+  background: #2a1a0a;
+  z-index: 7;
+}
+
+.whiskF2 {
+  position: absolute;
+  bottom: 14px;
+  width: 30px;
+  height: 2px;
+  border-radius: 1px;
+  background: rgba(255, 248, 230, 0.8);
+  z-index: 7;
+  transform: rotate(var(--wf2, 0deg));
+}
+
+.wf1 {
+  left: 26px;
+
+  --wf2: 8deg;
+}
+
+.wf2 {
+  right: 26px;
+
+  --wf2: -8deg;
+}
+
+@keyframes perkF2 {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+@keyframes listenF2 {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes swivelF2 {
+  0%, 100% { transform: rotate(var(--ef, 0deg)); }
+  50% { transform: rotate(calc(var(--ef, 0deg) + 8deg)); }
+}
+
+@keyframes swishF2 {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(8deg); }
+}
+
+@keyframes blinkF2 {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes twinkleF2 {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.2; }
+}
+
+@keyframes glowF2 {
+  0%, 100% { opacity: 0.9; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.04); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fennec,
+  .headF2,
+  .earF2,
+  .innerF2,
+  .tailF2,
+  .eyeF2,
+  .starF2,
+  .moonF2 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a fennec fox built for #45915. Each ear is two elements, the outer shell and the pink inner, and both read the same `--ef` custom property for their angle and run the same keyframe. Because the keyframe steps to `rotate(calc(var(--ef) + 8deg))`, the inner ear turns with the outer instead of sliding out of it, and each ear still keeps its own splay. The tail's dark tip is an inset box-shadow rather than an extra element, so the two tone brush costs nothing extra. Reduced motion fallback included. Pure CSS. Closes #45915.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a fennec fox with oversized ears and pink inners, a pale muzzle, whiskers and a dark tipped brush tail, on moonlit dunes.
