### PR TITLE
Add nautilus component

### DIFF
--- a/submissions/examples/nautilus-as/README.md
+++ b/submissions/examples/nautilus-as/README.md
@@ -1,0 +1,21 @@
+# Nautilus
+
+### What does this do?
+
+It shows a nautilus drifting through deep water. It moves diagonally as it swims, its six tentacles ripple in sequence, its eye blinks, and bubbles rise past its shell. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="naut">
+  <span class="shellN"></span>
+  <span class="stripesN"></span>
+  <span class="tent tn1"></span>
+</div>
+```
+
+The shell's radiating stripes are a `repeating-conic-gradient` anchored off-centre, at `42% 58%`, and masked so nothing shows within the inner 26 percent. Putting the gradient's origin away from the middle is what makes the bands sweep round the spiral rather than radiating evenly like a pie chart, and the mask keeps the centre of the coil clear. The tentacles fan from `transform-origin: 100% 50%` at the hood, each with its own angle in a `--tn` custom property that the ripple keyframe reads back, so they wave without collapsing onto one bearing.
+
+### Why is it useful?
+
+Ocean, fossil, and spiral or geometry themes use a nautilus. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/nautilus-as/demo.html
+++ b/submissions/examples/nautilus-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nautilus</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="raysN"></span>
+    <div class="naut">
+      <span class="shellN"></span>
+      <span class="stripesN"></span>
+      <span class="chamber ch1"></span>
+      <span class="chamber ch2"></span>
+      <span class="chamber ch3"></span>
+      <span class="hoodN"></span>
+      <span class="eyeN"></span>
+      <span class="tent tn1"></span>
+      <span class="tent tn2"></span>
+      <span class="tent tn3"></span>
+      <span class="tent tn4"></span>
+      <span class="tent tn5"></span>
+      <span class="tent tn6"></span>
+    </div>
+    <span class="bubN bn1"></span>
+    <span class="bubN bn2"></span>
+    <span class="bedN"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/nautilus-as/style.css
+++ b/submissions/examples/nautilus-as/style.css
@@ -1,0 +1,244 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #14607d, #04141f 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.raysN {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 250px);
+  background:
+    repeating-linear-gradient(
+      98deg,
+      rgba(190, 245, 255, 0.05) 0 24px,
+      transparent 24px 96px
+    );
+  pointer-events: none;
+}
+
+.bedN {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 50px);
+  background:
+    radial-gradient(circle at 24% 0, rgba(255, 245, 210, 0.12) 0 18px, transparent 18px),
+    linear-gradient(180deg, #33555e, #14282f);
+}
+
+.naut {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 250px;
+  height: 220px;
+  margin: -110px 0 0 -125px;
+  z-index: 4;
+  animation: driftN 6s ease-in-out infinite;
+}
+
+.shellN {
+  position: absolute;
+  top: 0;
+  left: 40px;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #fdf6e6, #c9a86a 74%);
+  box-shadow:
+    inset -12px -12px 26px rgba(120, 90, 40, 0.4),
+    0 14px 30px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.stripesN {
+  position: absolute;
+  top: 0;
+  left: 40px;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 42% 58%,
+      rgba(160, 60, 30, 0.55) 0 4deg,
+      transparent 4deg 16deg
+    );
+  mask-image: radial-gradient(circle at 42% 58%, transparent 0 22%, #000 26%);
+  z-index: 5;
+}
+
+.chamber {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(150, 100, 50, 0.45);
+  box-sizing: border-box;
+  z-index: 6;
+}
+
+.ch1 {
+  top: 34px;
+  left: 74px;
+  width: 116px;
+  height: 116px;
+}
+
+.ch2 {
+  top: 62px;
+  left: 92px;
+  width: 78px;
+  height: 78px;
+}
+
+.ch3 {
+  top: 84px;
+  left: 106px;
+  width: 48px;
+  height: 48px;
+}
+
+.hoodN {
+  position: absolute;
+  bottom: 26px;
+  left: 26px;
+  width: 78px;
+  height: 58px;
+  border-radius: 50% 20% 30% 50% / 60% 30% 40% 60%;
+  background: linear-gradient(180deg, #d9714e, #9c3a24);
+  box-shadow: inset -4px -4px 10px rgba(90, 26, 10, 0.4);
+  z-index: 5;
+}
+
+.eyeN {
+  position: absolute;
+  bottom: 58px;
+  left: 46px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f2f8ff, #16323f 72%);
+  box-shadow: 0 0 8px rgba(200, 240, 255, 0.6);
+  z-index: 7;
+  animation: blinkN 5.4s ease-in-out infinite;
+}
+
+.tent {
+  position: absolute;
+  bottom: 30px;
+  left: 34px;
+  width: 60px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #e08a66, #a04a2c);
+  transform-origin: 100% 50%;
+  transform: rotate(var(--tn, 0deg));
+  z-index: 4;
+  animation: waveN 3s ease-in-out infinite;
+}
+
+.tn1 {
+  --tn: 172deg;
+}
+
+.tn2 {
+  --tn: 190deg;
+
+  animation-delay: 0.2s;
+}
+
+.tn3 {
+  --tn: 208deg;
+
+  animation-delay: 0.4s;
+}
+
+.tn4 {
+  --tn: 226deg;
+
+  animation-delay: 0.6s;
+}
+
+.tn5 {
+  --tn: 152deg;
+
+  animation-delay: 0.8s;
+}
+
+.tn6 {
+  --tn: 134deg;
+
+  animation-delay: 1s;
+}
+
+.bubN {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 250, 255, 0.7);
+  opacity: 0;
+  z-index: 6;
+  animation: upN 5.6s ease-in infinite;
+}
+
+.bn1 {
+  bottom: 150px;
+  left: 70px;
+  width: 11px;
+  height: 11px;
+}
+
+.bn2 {
+  bottom: 170px;
+  left: 46px;
+  width: 8px;
+  height: 8px;
+  animation-delay: 2.8s;
+}
+
+@keyframes driftN {
+  0%, 100% { transform: translate(0, 0) rotate(-2deg); }
+  50% { transform: translate(-14px, -12px) rotate(2deg); }
+}
+
+@keyframes waveN {
+  0%, 100% { transform: rotate(var(--tn, 0deg)); }
+  50% { transform: rotate(calc(var(--tn, 0deg) + 10deg)); }
+}
+
+@keyframes blinkN {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.15); }
+}
+
+@keyframes upN {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translateY(-140px) translateX(18px) scale(1.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .naut,
+  .tent,
+  .eyeN,
+  .bubN {
+    animation: none;
+  }
+
+  .bubN {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a nautilus built for #45917. The shell's radiating stripes are a repeating conic gradient anchored off centre at `42% 58%` and masked so nothing shows within the inner quarter: putting the gradient's origin away from the middle is what makes the bands sweep round the spiral rather than radiating evenly like a pie chart, and the mask keeps the centre of the coil clear. The tentacles fan from a `transform-origin: 100% 50%` at the hood, each with its own angle in a `--tn` custom property that the ripple keyframe reads back, so they wave without collapsing onto one bearing. Reduced motion fallback included. Pure CSS. Closes #45917.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a nautilus with a striped spiral shell, chamber rings, an orange hood with an eye and six rippling tentacles, drifting in deep water.
