### PR TITLE
Add cuttlefish component

### DIFF
--- a/submissions/examples/cuttlefish-as/README.md
+++ b/submissions/examples/cuttlefish-as/README.md
@@ -1,0 +1,21 @@
+# Cuttlefish
+
+### What does this do?
+
+It shows a cuttlefish hovering in open water. Its skirt fins ripple continuously, colour bands pulse and travel across its mantle the way chromatophores do, its W-shaped pupil narrows, its arms sway, and its feeding tentacle stretches. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="cuttle">
+  <span class="mantle"></span>
+  <span class="chroma"></span>
+  <span class="finC fcl"></span>
+</div>
+```
+
+The colour display is one element: a `repeating-linear-gradient` of purple bands whose `opacity` and `background-position` both animate, so the bands brighten and slide sideways at the same time. Animating the background position rather than the element is what makes the pattern appear to travel across the skin while the body stays put, which is exactly how a cuttlefish's chromatophores read. The fins undulate with `scaleX` plus a small `skewY`, and each pivots from the edge nearest the body so they ripple outward rather than shrinking toward their own middles.
+
+### Why is it useful?
+
+Ocean, camouflage, and hypnotic or shifting themes use a cuttlefish. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/cuttlefish-as/demo.html
+++ b/submissions/examples/cuttlefish-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cuttlefish</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="raysC2"></span>
+    <div class="cuttle">
+      <span class="mantle"></span>
+      <span class="chroma"></span>
+      <span class="finC fcl"></span>
+      <span class="finC fcr"></span>
+      <span class="eyeC2"></span>
+      <span class="pupilC"></span>
+      <span class="armC ac1"></span>
+      <span class="armC ac2"></span>
+      <span class="armC ac3"></span>
+      <span class="armC ac4"></span>
+      <span class="tentC"></span>
+    </div>
+    <span class="bubC2 bc1"></span>
+    <span class="bubC2 bc2"></span>
+    <span class="floorC2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cuttlefish-as/style.css
+++ b/submissions/examples/cuttlefish-as/style.css
@@ -1,0 +1,270 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #157a8e, #041c26 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.raysC2 {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 250px);
+  background:
+    repeating-linear-gradient(
+      96deg,
+      rgba(190, 245, 255, 0.06) 0 22px,
+      transparent 22px 90px
+    );
+  pointer-events: none;
+}
+
+.floorC2 {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 46px);
+  background:
+    radial-gradient(circle at 26% 0, rgba(255, 245, 210, 0.12) 0 16px, transparent 16px),
+    linear-gradient(180deg, #2f5560, #12252c);
+}
+
+.cuttle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 260px;
+  height: 240px;
+  margin: -120px 0 0 -130px;
+  z-index: 4;
+  animation: hoverC2 5s ease-in-out infinite;
+}
+
+.mantle {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 118px;
+  height: 156px;
+  margin-left: -59px;
+  border-radius: 50% 50% 40% 40% / 42% 42% 58% 58%;
+  background: linear-gradient(180deg, #d9b98e, #8a6a4e);
+  box-shadow:
+    inset -10px -10px 22px rgba(70, 50, 30, 0.45),
+    0 12px 28px rgba(0, 0, 0, 0.35);
+  z-index: 4;
+}
+
+.chroma {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 118px;
+  height: 156px;
+  margin-left: -59px;
+  border-radius: 50% 50% 40% 40% / 42% 42% 58% 58%;
+  background:
+    repeating-linear-gradient(
+      100deg,
+      rgba(90, 40, 120, 0.4) 0 8px,
+      transparent 8px 22px
+    );
+  z-index: 5;
+  animation: flashC2 3.4s ease-in-out infinite;
+}
+
+.finC {
+  position: absolute;
+  top: 26px;
+  width: 30px;
+  height: 140px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, rgba(160, 220, 235, 0.75), rgba(80, 150, 175, 0.5));
+  z-index: 3;
+  animation: undulate 1.6s ease-in-out infinite;
+}
+
+.fcl {
+  left: 50%;
+  margin-left: -84px;
+  transform-origin: 100% 50%;
+}
+
+.fcr {
+  left: 50%;
+  margin-left: 54px;
+  transform-origin: 0 50%;
+  animation-delay: 0.2s;
+}
+
+.eyeC2 {
+  position: absolute;
+  top: 52px;
+  left: 50%;
+  width: 40px;
+  height: 24px;
+  margin-left: -20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #f6fbff, #7fa2b0 76%);
+  box-shadow: inset 0 -3px 6px rgba(20, 50, 60, 0.4);
+  z-index: 6;
+}
+
+.pupilC {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 26px;
+  height: 8px;
+  margin-left: -13px;
+  border-radius: 6px 6px 10px 10px;
+  background: #10161c;
+  z-index: 7;
+  animation: dilate 5s ease-in-out infinite;
+}
+
+.armC {
+  position: absolute;
+  top: 156px;
+  left: 50%;
+  width: 12px;
+  height: 74px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #c9a179, #7d5f42);
+  transform-origin: 50% 0;
+  transform: rotate(var(--ca, 0deg));
+  z-index: 3;
+  animation: swayArm 2.8s ease-in-out infinite;
+}
+
+.ac1 {
+  margin-left: -38px;
+
+  --ca: -16deg;
+}
+
+.ac2 {
+  margin-left: -14px;
+
+  --ca: -5deg;
+
+  animation-delay: 0.3s;
+}
+
+.ac3 {
+  margin-left: 6px;
+
+  --ca: 6deg;
+
+  animation-delay: 0.6s;
+}
+
+.ac4 {
+  margin-left: 28px;
+
+  --ca: 17deg;
+
+  animation-delay: 0.9s;
+}
+
+.tentC {
+  position: absolute;
+  top: 158px;
+  left: 50%;
+  width: 7px;
+  height: 110px;
+  margin-left: -3px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #b98f66, #6b4f34);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: reachC2 4.4s ease-in-out infinite;
+}
+
+.bubC2 {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(220, 250, 255, 0.7);
+  opacity: 0;
+  z-index: 6;
+  animation: upC2 5.4s ease-in infinite;
+}
+
+.bc1 {
+  bottom: 160px;
+  left: 96px;
+  width: 11px;
+  height: 11px;
+}
+
+.bc2 {
+  bottom: 190px;
+  right: 92px;
+  width: 8px;
+  height: 8px;
+  animation-delay: 2.7s;
+}
+
+@keyframes hoverC2 {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-12px) rotate(1deg); }
+}
+
+@keyframes undulate {
+  0%, 100% { transform: scaleX(1) skewY(0deg); }
+  50% { transform: scaleX(0.82) skewY(4deg); }
+}
+
+@keyframes flashC2 {
+  0%, 100% { opacity: 0.25; background-position: 0 0; }
+  50% { opacity: 0.8; background-position: 22px 0; }
+}
+
+@keyframes dilate {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.7); }
+}
+
+@keyframes swayArm {
+  0%, 100% { transform: rotate(var(--ca, 0deg)); }
+  50% { transform: rotate(calc(var(--ca, 0deg) + 9deg)); }
+}
+
+@keyframes reachC2 {
+  0%, 100% { transform: rotate(-3deg) scaleY(1); }
+  50% { transform: rotate(4deg) scaleY(1.12); }
+}
+
+@keyframes upC2 {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translateY(-150px) translateX(16px) scale(1.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cuttle,
+  .finC,
+  .chroma,
+  .pupilC,
+  .armC,
+  .tentC,
+  .bubC2 {
+    animation: none;
+  }
+
+  .bubC2 {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a cuttlefish built for #45922. The colour display is one element: a repeating gradient of bands whose opacity and background-position both animate, so the bands brighten and slide sideways at once. Animating the background position rather than the element is what makes the pattern travel across the skin while the body stays put, which is exactly how chromatophores read. The fins undulate with a scaleX plus a small skewY, each pivoting from the edge nearest the body so they ripple outward rather than shrinking toward their own middles. Reduced motion fallback included. Pure CSS. Closes #45922.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a cuttlefish with a banded mantle, rippling skirt fins either side, a W shaped pupil, four arms and a long feeding tentacle.
