### PR TITLE
Add persimmon component

### DIFF
--- a/submissions/examples/persimmon-as/README.md
+++ b/submissions/examples/persimmon-as/README.md
@@ -1,0 +1,21 @@
+# Persimmon
+
+### What does this do?
+
+It shows a ripe persimmon hanging from an autumn twig. It swings on its stem, the four sepals of its calyx flex, light glints off the skin, the leaves sway, and stray leaves drift down. Hovering or focusing the fruit swings it three times faster, as if it were about to drop. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="persim" tabindex="0">
+  <span class="fruitP"></span>
+  <span class="sepal sp1"></span>
+  <span class="calyxP"></span>
+</div>
+```
+
+The calyx is four identical sepals placed by rotation alone: each is a leaf shape whose `border-radius` rounds two opposite corners, and each keeps its own bearing in a `--sp2` custom property set 90 degrees apart. Because they all pivot from `transform-origin: 50% 20%`, a point near the top of the fruit, four copies of one shape fan into a full star-shaped calyx with no extra geometry. The flex keyframe rebuilds `rotate(var(--sp2))` before scaling, so the sepals swell without snapping back to a single angle.
+
+### Why is it useful?
+
+Autumn, fruit, and harvest themes use a persimmon. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/persimmon-as/demo.html
+++ b/submissions/examples/persimmon-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Persimmon</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="twigP"></span>
+    <div class="persim" tabindex="0">
+      <span class="fruitP"></span>
+      <span class="glossP2"></span>
+      <span class="calyxP"></span>
+      <span class="sepal sp1"></span>
+      <span class="sepal sp2"></span>
+      <span class="sepal sp3"></span>
+      <span class="sepal sp4"></span>
+      <span class="stemP"></span>
+    </div>
+    <span class="leafP2 lp1"></span>
+    <span class="leafP2 lp2"></span>
+    <span class="fallP fp1"></span>
+    <span class="fallP fp2"></span>
+    <span class="groundP2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/persimmon-as/style.css
+++ b/submissions/examples/persimmon-as/style.css
@@ -1,0 +1,240 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #bcd6e0, #e8c99a 70%, #b98f5e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 330px;
+}
+
+.groundP2 {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 46px);
+  background: linear-gradient(180deg, #8f6f42, #4a3820);
+}
+
+.twigP {
+  position: absolute;
+  top: 24px;
+  left: -50vw;
+  right: 46%;
+  height: 12px;
+  border-radius: 0 6px 6px 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(50, 30, 8, 0.3) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(180deg, #7d5a30, #4a3418);
+  z-index: 3;
+}
+
+.leafP2 {
+  position: absolute;
+  top: 30px;
+  width: 66px;
+  height: 26px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #6fa63f, #34611f);
+  transform-origin: 0 0;
+  transform: rotate(var(--lp, 0deg));
+  z-index: 4;
+  animation: swayP2 4.6s ease-in-out infinite;
+}
+
+.lp1 {
+  left: 40px;
+
+  --lp: 8deg;
+}
+
+.lp2 {
+  left: 96px;
+
+  --lp: -14deg;
+
+  animation-delay: 1.8s;
+}
+
+.persim {
+  position: absolute;
+  top: 32px;
+  left: 50%;
+  width: 200px;
+  height: 240px;
+  margin-left: -100px;
+  outline: none;
+  transform-origin: 50% 2%;
+  z-index: 5;
+  animation: hangP 4.4s ease-in-out infinite;
+}
+
+.persim:hover,
+.persim:focus-visible {
+  animation-duration: 1.4s;
+}
+
+.stemP {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 10px;
+  height: 34px;
+  margin-left: -5px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #6f5228, #463315);
+  z-index: 3;
+}
+
+.calyxP {
+  position: absolute;
+  top: 28px;
+  left: 50%;
+  width: 66px;
+  height: 26px;
+  margin-left: -33px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #86a34a, #47611f 74%);
+  z-index: 6;
+}
+
+.sepal {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 62px;
+  height: 30px;
+  margin-left: -31px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #7f9f45, #3f5c1c);
+  box-shadow: 0 2px 4px rgba(30, 50, 10, 0.35);
+  transform-origin: 50% 20%;
+  transform: rotate(var(--sp2, 0deg));
+  z-index: 5;
+  animation: curlP 5s ease-in-out infinite;
+}
+
+.sp1 {
+  --sp2: 8deg;
+}
+
+.sp2 {
+  --sp2: 98deg;
+
+  animation-delay: 0.4s;
+}
+
+.sp3 {
+  --sp2: 188deg;
+
+  animation-delay: 0.8s;
+}
+
+.sp4 {
+  --sp2: 278deg;
+
+  animation-delay: 1.2s;
+}
+
+.fruitP {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 168px;
+  height: 140px;
+  margin-left: -84px;
+  border-radius: 46% 46% 50% 50% / 40% 40% 60% 60%;
+  background: radial-gradient(circle at 36% 32%, #ff9b3c, #d9541c 74%);
+  box-shadow:
+    inset -12px -12px 26px rgba(140, 40, 6, 0.45),
+    0 14px 30px rgba(0, 0, 0, 0.3);
+  z-index: 4;
+}
+
+.glossP2 {
+  position: absolute;
+  top: 66px;
+  left: 50%;
+  width: 34px;
+  height: 52px;
+  margin-left: -54px;
+  border-radius: 50%;
+  background: rgba(255, 240, 210, 0.5);
+  filter: blur(5px);
+  z-index: 5;
+  animation: glintP2 3.6s ease-in-out infinite;
+}
+
+.fallP {
+  position: absolute;
+  width: 30px;
+  height: 12px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #d98a3c, #a04f18);
+  opacity: 0;
+  z-index: 6;
+  animation: dropP 6s linear infinite;
+}
+
+.fp1 { top: 120px; left: 40px; }
+
+.fp2 {
+  top: 90px;
+  right: 44px;
+  animation-delay: 3s;
+
+  --px4: -40px;
+}
+
+@keyframes hangP {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes curlP {
+  0%, 100% { transform: rotate(var(--sp2, 0deg)) scale(1); }
+  50% { transform: rotate(var(--sp2, 0deg)) scale(1.08); }
+}
+
+@keyframes glintP2 {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 0.8; }
+}
+
+@keyframes swayP2 {
+  0%, 100% { transform: rotate(var(--lp, 0deg)); }
+  50% { transform: rotate(calc(var(--lp, 0deg) + 6deg)); }
+}
+
+@keyframes dropP {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { transform: translate(var(--px4, 40px), 200px) rotate(280deg); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .persim,
+  .sepal,
+  .glossP2,
+  .leafP2,
+  .fallP {
+    animation: none;
+  }
+
+  .fallP {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a persimmon built for #45926. The calyx is four identical sepals placed by rotation alone: each is a leaf shape whose border-radius rounds two opposite corners, and each keeps its bearing in a `--sp2` custom property set 90 degrees apart. Because all four pivot from a shared `transform-origin` near the top of the fruit, four copies of one shape fan into a full star shaped calyx with no extra geometry, and the flex keyframe rebuilds `rotate(var(--sp2))` before scaling so the sepals swell without snapping back to a single angle. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45926.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a glossy orange persimmon hanging from a twig with a four sepal star calyx and green leaves.
