### PR TITLE
Add artichoke component

### DIFF
--- a/submissions/examples/artichoke-as/README.md
+++ b/submissions/examples/artichoke-as/README.md
@@ -1,0 +1,21 @@
+# Artichoke
+
+### What does this do?
+
+It shows an artichoke on a board. It bobs gently and its crown nods. Hovering or focusing it makes every scale-like bract lift and splay outward, the way an artichoke opens when it is steamed. Under reduced motion it sits closed and still.
+
+### How is it used?
+
+```html
+<div class="choke" tabindex="0">
+  <span class="coreA"></span>
+  <span class="bractA ba1"></span>
+  <span class="tipA"></span>
+</div>
+```
+
+Each bract is placed with two custom properties at once: `--ba` for the angle it leans and `--by` for how far up the bud it sits, combined as `rotate(var(--ba)) translateY(var(--by))`. That gives nine overlapping leaves in two staggered rows from a single rule. The open state multiplies the angle and pushes the offset further out, `rotate(calc(var(--ba) * 1.6)) translateY(calc(var(--by) - 10px))`, so every bract swings further along the direction it already leans and lifts away from the core, instead of all snapping to the same pose.
+
+### Why is it useful?
+
+Vegetable, cooking, and layered or "unfolding" themes use an artichoke. This builds one with pure CSS gradients and a transition driven hover, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/artichoke-as/demo.html
+++ b/submissions/examples/artichoke-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Artichoke</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="choke" tabindex="0">
+      <span class="coreA"></span>
+      <span class="bractA ba1"></span>
+      <span class="bractA ba2"></span>
+      <span class="bractA ba3"></span>
+      <span class="bractA ba4"></span>
+      <span class="bractA ba5"></span>
+      <span class="bractA ba6"></span>
+      <span class="bractA ba7"></span>
+      <span class="bractA ba8"></span>
+      <span class="bractA ba9"></span>
+      <span class="tipA"></span>
+      <span class="stalkA"></span>
+    </div>
+    <span class="boardA2"></span>
+    <span class="crumbA2 ca3"></span>
+    <span class="crumbA2 ca4"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/artichoke-as/style.css
+++ b/submissions/examples/artichoke-as/style.css
@@ -1,0 +1,199 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 36%, #46503a, #131709 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 330px;
+}
+
+.boardA2 {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 290px;
+  height: 26px;
+  margin-left: -145px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(70, 44, 20, 0.28) 0 2px,
+      transparent 2px 26px
+    ),
+    linear-gradient(180deg, #c39a63, #8a6a3c);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+}
+
+.choke {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 240px;
+  height: 250px;
+  margin-left: -120px;
+  outline: none;
+  z-index: 4;
+  animation: bobA2 4.6s ease-in-out infinite;
+}
+
+.stalkA {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 20px;
+  height: 46px;
+  margin-left: -10px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #6f8a3e, #43571f);
+  z-index: 2;
+}
+
+.coreA {
+  position: absolute;
+  bottom: 34px;
+  left: 50%;
+  width: 130px;
+  height: 150px;
+  margin-left: -65px;
+  border-radius: 50% 50% 40% 40% / 56% 56% 44% 44%;
+  background: linear-gradient(180deg, #86a04c, #455a22);
+  box-shadow: inset 0 -8px 16px rgba(30, 40, 10, 0.5);
+  z-index: 3;
+}
+
+.bractA {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 62px;
+  height: 76px;
+  margin-left: -31px;
+  border-radius: 50% 50% 40% 40% / 62% 62% 38% 38%;
+  background: linear-gradient(180deg, #9fbb5c, #4f6a26);
+  box-shadow:
+    inset 0 -5px 10px rgba(30, 44, 8, 0.4),
+    0 2px 5px rgba(20, 30, 6, 0.4);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--ba, 0deg)) translateY(var(--by, 0px));
+  transition: transform 0.5s ease;
+  z-index: 4;
+}
+
+.ba1 {
+  --ba: -34deg;
+  --by: -56px;
+}
+
+.ba2 {
+  --ba: -17deg;
+  --by: -66px;
+}
+
+.ba3 {
+  --ba: 0deg;
+  --by: -72px;
+}
+
+.ba4 {
+  --ba: 17deg;
+  --by: -66px;
+}
+
+.ba5 {
+  --ba: 34deg;
+  --by: -56px;
+}
+
+.ba6 {
+  --ba: -26deg;
+  --by: -14px;
+}
+
+.ba7 {
+  --ba: -9deg;
+  --by: -22px;
+}
+
+.ba8 {
+  --ba: 9deg;
+  --by: -22px;
+}
+
+.ba9 {
+  --ba: 26deg;
+  --by: -14px;
+}
+
+.choke:hover .bractA,
+.choke:focus-visible .bractA {
+  transform: rotate(calc(var(--ba, 0deg) * 1.6)) translateY(calc(var(--by, 0px) - 10px));
+}
+
+.tipA {
+  position: absolute;
+  bottom: 150px;
+  left: 50%;
+  width: 44px;
+  height: 58px;
+  margin-left: -22px;
+  border-radius: 50% 50% 36% 36% / 66% 66% 34% 34%;
+  background: linear-gradient(180deg, #b8cf74, #6b8a34);
+  box-shadow: inset 0 -4px 8px rgba(40, 56, 12, 0.4);
+  z-index: 5;
+  animation: nodA2 4.6s ease-in-out infinite;
+  transform-origin: 50% 100%;
+}
+
+.crumbA2 {
+  position: absolute;
+  bottom: 74px;
+  width: 10px;
+  height: 6px;
+  border-radius: 3px;
+  background: #7f9a44;
+  z-index: 5;
+  animation: jiggleA2 3.2s ease-in-out infinite;
+}
+
+.ca3 { left: 58px; }
+
+.ca4 {
+  right: 62px;
+  animation-delay: 1.6s;
+}
+
+@keyframes bobA2 {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-6px) rotate(1deg); }
+}
+
+@keyframes nodA2 {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes jiggleA2 {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .choke,
+  .tipA,
+  .crumbA2 {
+    animation: none;
+  }
+
+  .bractA {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an artichoke built for #45929. Each bract is placed with two custom properties at once, `--ba` for the angle it leans and `--by` for how far up the bud it sits, combined as `rotate(var(--ba)) translateY(var(--by))`, which gives nine overlapping leaves in two staggered rows from a single rule. The open state multiplies the angle and pushes the offset further out, so every bract swings further along the direction it already leans and lifts away from the core rather than all snapping to the same pose. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45929.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an artichoke on a board with overlapping bracts sheathing the bud in staggered rows and a crown poking through the top.
