### PR TITLE
Add lychee component

### DIFF
--- a/submissions/examples/lychee-as/README.md
+++ b/submissions/examples/lychee-as/README.md
@@ -1,0 +1,22 @@
+# Lychee
+
+### What does this do?
+
+It shows two lychees hanging from a branch. They swing on their stems, light glints off the red rind, and sparkles pop around them. Hovering or focusing the front fruit peels it: two flaps of rind swing away and the pearly white flesh and dark seed fade in underneath. Under reduced motion it hangs still and stays whole.
+
+### How is it used?
+
+```html
+<div class="lychee" tabindex="0">
+  <span class="rindL"></span>
+  <span class="bumps"></span>
+  <span class="peelL pl1"></span>
+  <span class="fleshL"></span>
+</div>
+```
+
+The lychee's knobbly skin is two gradients on one element: a `repeating-conic-gradient` cuts the radial ridges and a `repeating-radial-gradient` lays concentric rings across them, and where the two cross they read as the scaly bumps a lychee actually has. Building the texture from crossing gradients rather than dozens of little elements keeps the whole rind to a single node. The peel flaps each keep their lean in a `--pl2` custom property, and the open state multiplies it eightfold, so they swing away in opposite directions from one shared rule.
+
+### Why is it useful?
+
+Fruit, tropical, and reveal or "unwrap" themes use a lychee. This builds one with pure CSS gradients and a transition driven hover, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/lychee-as/demo.html
+++ b/submissions/examples/lychee-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lychee</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="branchL2"></span>
+    <div class="lychee" tabindex="0">
+      <span class="rindL"></span>
+      <span class="bumps"></span>
+      <span class="peelL pl1"></span>
+      <span class="peelL pl2"></span>
+      <span class="fleshL"></span>
+      <span class="seedL"></span>
+      <span class="glossL"></span>
+      <span class="stemL"></span>
+    </div>
+    <div class="lychee2">
+      <span class="rindL"></span>
+      <span class="bumps"></span>
+      <span class="stemL"></span>
+    </div>
+    <span class="leafL2 ll1"></span>
+    <span class="leafL2 ll2"></span>
+    <span class="sparkL sl4"></span>
+    <span class="sparkL sl5"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/lychee-as/style.css
+++ b/submissions/examples/lychee-as/style.css
@@ -1,0 +1,272 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #3f4a34, #12160c 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 320px;
+}
+
+.branchL2 {
+  position: absolute;
+  top: 30px;
+  left: -50vw;
+  right: 30%;
+  height: 12px;
+  border-radius: 0 6px 6px 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(40, 26, 8, 0.35) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(180deg, #6f5230, #3f2d16);
+  z-index: 3;
+}
+
+.leafL2 {
+  position: absolute;
+  top: 36px;
+  width: 62px;
+  height: 24px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #5fa84a, #2b5f26);
+  transform-origin: 0 0;
+  transform: rotate(var(--ll, 0deg));
+  z-index: 4;
+  animation: swayL2 4.6s ease-in-out infinite;
+}
+
+.ll1 {
+  left: 40px;
+
+  --ll: 10deg;
+}
+
+.ll2 {
+  left: 100px;
+
+  --ll: -12deg;
+
+  animation-delay: 1.8s;
+}
+
+.lychee {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 160px;
+  height: 200px;
+  margin-left: -110px;
+  outline: none;
+  transform-origin: 50% 4%;
+  z-index: 5;
+  animation: hangL 4.4s ease-in-out infinite;
+}
+
+.lychee2 {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 130px;
+  height: 170px;
+  margin-left: 20px;
+  transform-origin: 50% 4%;
+  z-index: 4;
+  animation: hangL 4.4s ease-in-out infinite;
+  animation-delay: 1.4s;
+}
+
+.stemL {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 8px;
+  height: 30px;
+  margin-left: -4px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6f5230, #3f2d16);
+  z-index: 3;
+}
+
+.rindL {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 118px;
+  height: 118px;
+  margin-left: -59px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #e8556a, #98172f 74%);
+  box-shadow:
+    inset -10px -10px 22px rgba(90, 8, 22, 0.5),
+    0 12px 26px rgba(0, 0, 0, 0.35);
+  z-index: 4;
+}
+
+.bumps {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 118px;
+  height: 118px;
+  margin-left: -59px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(120, 12, 30, 0.35) 0 5deg,
+      transparent 5deg 14deg
+    ),
+    repeating-radial-gradient(
+      circle,
+      rgba(255, 160, 170, 0.22) 0 2px,
+      transparent 2px 12px
+    );
+  z-index: 5;
+}
+
+.peelL {
+  position: absolute;
+  top: 82px;
+  left: 50%;
+  width: 48px;
+  height: 40px;
+  border-radius: 50% 50% 20% 20% / 70% 70% 30% 30%;
+  background: radial-gradient(circle at 36% 32%, #e8556a, #98172f 74%);
+  box-shadow: inset 0 -4px 8px rgba(70, 6, 16, 0.4);
+  transform-origin: 50% 0;
+  transform: rotate(var(--pl2, 0deg));
+  transition: transform 0.5s ease;
+  z-index: 4;
+}
+
+.pl1 {
+  margin-left: -50px;
+
+  --pl2: 10deg;
+}
+
+.pl2 {
+  margin-left: 2px;
+
+  --pl2: -10deg;
+}
+
+.lychee:hover .peelL,
+.lychee:focus-visible .peelL {
+  transform: rotate(calc(var(--pl2, 0deg) * 8)) translateY(6px);
+}
+
+.fleshL {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 84px;
+  height: 84px;
+  margin-left: -42px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 34%, #fdfdf8, #ded8cc 78%);
+  box-shadow: inset 0 -5px 10px rgba(150, 140, 120, 0.35);
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  z-index: 5;
+}
+
+.seedL {
+  position: absolute;
+  top: 68px;
+  left: 50%;
+  width: 34px;
+  height: 38px;
+  margin-left: -17px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #7d5230, #2f1c0c 74%);
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  z-index: 6;
+}
+
+.lychee:hover .fleshL,
+.lychee:focus-visible .fleshL,
+.lychee:hover .seedL,
+.lychee:focus-visible .seedL {
+  opacity: 1;
+}
+
+.glossL {
+  position: absolute;
+  top: 46px;
+  left: 50%;
+  width: 24px;
+  height: 34px;
+  margin-left: -40px;
+  border-radius: 50%;
+  background: rgba(255, 220, 220, 0.45);
+  filter: blur(4px);
+  z-index: 7;
+  animation: glintL 3.6s ease-in-out infinite;
+}
+
+.sparkL {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #fff2f4;
+  box-shadow: 0 0 10px rgba(255, 220, 230, 0.9);
+  z-index: 7;
+  animation: twinkleL 2.8s ease-in-out infinite;
+}
+
+.sl4 { top: 130px; left: 46px; }
+
+.sl5 {
+  top: 90px;
+  right: 40px;
+  animation-delay: 1.4s;
+}
+
+@keyframes hangL {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes glintL {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 0.8; }
+}
+
+@keyframes swayL2 {
+  0%, 100% { transform: rotate(var(--ll, 0deg)); }
+  50% { transform: rotate(calc(var(--ll, 0deg) + 6deg)); }
+}
+
+@keyframes twinkleL {
+  0%, 100% { opacity: 0.3; transform: scale(0.7); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lychee,
+  .lychee2,
+  .glossL,
+  .leafL2,
+  .sparkL {
+    animation: none;
+  }
+
+  .peelL,
+  .fleshL,
+  .seedL {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a lychee built for #45931. The knobbly skin is two gradients on one element: a repeating conic gradient cuts the radial ridges and a repeating radial gradient lays concentric rings across them, and where the two cross they read as the scaly bumps a lychee actually has, so the whole rind stays a single node. The peel flaps sit beneath that texture layer, which hides them completely while the fruit is closed, and each keeps its lean in a `--pl2` custom property that the open state multiplies eightfold, so they swing away in opposite directions from one shared rule to reveal the flesh and seed. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45931.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with screenshots of both states: closed, two knobbly red lychees hanging from a branch; peeled on hover, the rind flaps swung aside to show white flesh and a dark seed.
