### PR TITLE
Add fig component

### DIFF
--- a/submissions/examples/fig-as/README.md
+++ b/submissions/examples/fig-as/README.md
@@ -1,0 +1,23 @@
+# Fig
+
+### What does this do?
+
+It shows a fig cut in two on a plate. It bobs gently and a drop of juice runs off each half. Hovering or focusing it swings the halves apart, showing the pink pulp and its radiating seeds. Under reduced motion it sits still.
+
+### How is it used?
+
+```html
+<div class="figw" tabindex="0">
+  <div class="halfF hfl">
+    <span class="skinF"></span>
+    <span class="pulp"></span>
+    <span class="seedsF"></span>
+  </div>
+</div>
+```
+
+The seeds are the interesting bit. A fig's seeds radiate from the centre of the fruit, so they are drawn with a `repeating-conic-gradient` whose origin sits at `50% 62%`, the heart of the pulp, then masked with a `radial-gradient` so they only appear inside the pink core and stop at its edge. That gives dozens of fine radiating strands from one element and one mask, instead of a scatter of nodes. Only the left half is designed: the right reuses the same markup flipped with `scaleX(-1)`, which is why its hover rule reads `translateX(-34px)` yet moves it right on screen.
+
+### Why is it useful?
+
+Fruit, Mediterranean, and cut-open reveal themes use a fig. This builds one with pure CSS gradients and a transition driven hover, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/fig-as/demo.html
+++ b/submissions/examples/fig-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fig</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="figw" tabindex="0">
+      <div class="halfF hfl">
+        <span class="skinF"></span>
+        <span class="pulp"></span>
+        <span class="seedsF"></span>
+        <span class="stemF"></span>
+      </div>
+      <div class="halfF hfr">
+        <span class="skinF"></span>
+        <span class="pulp"></span>
+        <span class="seedsF"></span>
+        <span class="stemF"></span>
+      </div>
+    </div>
+    <span class="leafF lf3"></span>
+    <span class="leafF lf4"></span>
+    <span class="plateF"></span>
+    <span class="dropF df1"></span>
+    <span class="dropF df2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fig-as/style.css
+++ b/submissions/examples/fig-as/style.css
@@ -1,0 +1,192 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #4a3f52, #16111c 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 300px;
+}
+
+.plateF {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 280px;
+  height: 26px;
+  margin-left: -140px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #e8e2d4, #98917f);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+}
+
+.leafF {
+  position: absolute;
+  bottom: 62px;
+  width: 76px;
+  height: 34px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #5f9a3c, #2c5c22);
+  transform: rotate(var(--lf2, 0deg));
+  z-index: 3;
+}
+
+.lf3 {
+  left: 20px;
+
+  --lf2: -12deg;
+}
+
+.lf4 {
+  right: 22px;
+
+  --lf2: 168deg;
+}
+
+.figw {
+  position: absolute;
+  bottom: 64px;
+  left: 50%;
+  width: 280px;
+  height: 190px;
+  margin-left: -140px;
+  outline: none;
+  z-index: 5;
+  animation: bobF 4.4s ease-in-out infinite;
+}
+
+.halfF {
+  position: absolute;
+  bottom: 0;
+  width: 130px;
+  height: 178px;
+  transition: transform 0.5s ease;
+}
+
+.hfl {
+  left: 12px;
+  transform: rotate(-4deg);
+}
+
+.hfr {
+  right: 12px;
+  transform: rotate(4deg) scaleX(-1);
+}
+
+.figw:hover .hfl,
+.figw:focus-visible .hfl {
+  transform: rotate(-13deg) translateX(-34px);
+}
+
+.figw:hover .hfr,
+.figw:focus-visible .hfr {
+  transform: rotate(13deg) scaleX(-1) translateX(-34px);
+}
+
+.skinF {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 130px;
+  height: 140px;
+  border-radius: 46% 46% 44% 44% / 30% 30% 70% 70%;
+  background: linear-gradient(180deg, #7a5a86, #3f2b4d);
+  box-shadow:
+    inset -8px -8px 18px rgba(30, 16, 40, 0.5),
+    0 12px 26px rgba(0, 0, 0, 0.4);
+}
+
+.pulp {
+  position: absolute;
+  bottom: 8px;
+  left: 10px;
+  width: 110px;
+  height: 122px;
+  border-radius: 46% 46% 44% 44% / 30% 30% 70% 70%;
+  background:
+    radial-gradient(circle at 50% 62%, #f0577a 0 34%, transparent 34%),
+    radial-gradient(circle at 50% 62%, #f7b0b8 0 52%, transparent 52%),
+    #fdf3ea;
+  z-index: 2;
+}
+
+.seedsF {
+  position: absolute;
+  bottom: 8px;
+  left: 10px;
+  width: 110px;
+  height: 122px;
+  border-radius: 46% 46% 44% 44% / 30% 30% 70% 70%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 62%,
+      rgba(160, 30, 60, 0.7) 0 1.4deg,
+      transparent 1.4deg 9deg
+    );
+  mask-image: radial-gradient(circle at 50% 62%, #000 0 34%, transparent 36%);
+  z-index: 3;
+}
+
+.stemF {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 10px;
+  height: 34px;
+  margin-left: -5px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #6f8a3e, #3f5620);
+  z-index: 4;
+}
+
+.dropF {
+  position: absolute;
+  bottom: 76px;
+  width: 10px;
+  height: 12px;
+  border-radius: 50% 50% 60% 60%;
+  background: #f0577a;
+  opacity: 0;
+  z-index: 6;
+  animation: dripF 4s ease-in infinite;
+}
+
+.df1 { left: 108px; }
+
+.df2 {
+  right: 112px;
+  animation-delay: 2s;
+}
+
+@keyframes bobF {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@keyframes dripF {
+  0% { transform: translateY(0) scale(0.5); opacity: 0; }
+  30% { opacity: 1; }
+  100% { transform: translateY(28px) scale(1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .figw,
+  .dropF {
+    animation: none;
+  }
+
+  .halfF {
+    transition: none;
+  }
+
+  .dropF {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a fig built for #45933. A fig's seeds radiate from the centre of the fruit, so they are drawn with a repeating conic gradient anchored at the heart of the pulp and masked with a radial gradient so they appear only inside the pink core and stop at its edge: that gives dozens of fine radiating strands from one element and one mask instead of a scatter of nodes. Only the left half is designed; the right reuses the same markup flipped with `scaleX(-1)`, which is why its hover rule reads `translateX(-34px)` yet moves it right on screen. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45933.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a fig halved on a plate, purple skin, pale rind and a pink core filled with fine radiating seed strands.
