### PR TITLE
Add terrarium component

### DIFF
--- a/submissions/examples/terrarium-as/README.md
+++ b/submissions/examples/terrarium-as/README.md
@@ -1,0 +1,22 @@
+# Terrarium
+
+### What does this do?
+
+It shows a glass terrarium on a table. Ferns sway inside it, the succulent's leaves breathe, condensation runs down the inside of the glass, and light catches the curve of the jar. Hovering or focusing it makes the condensation run faster, as if the glass just fogged up. Under reduced motion everything is still.
+
+### How is it used?
+
+```html
+<div class="terr" tabindex="0">
+  <span class="glassT"></span>
+  <span class="soilT"></span>
+  <span class="fernT ft1"></span>
+  <span class="succLeaf sc1"></span>
+</div>
+```
+
+The glass is a single translucent element layered on top of everything with `pointer-events: none`, so it tints the plants beneath it without blocking hover on the container. The succulent is four copies of one leaf shape, each pivoting from `transform-origin: 100% 100%` at the base of the plant with its own angle in a `--sc2` custom property, so a rosette falls out of one rule. The pebble layer and the moss are both stacks of hard stop `radial-gradient` circles painted into single elements, so the gravel and the cushion of moss cost two nodes rather than twenty.
+
+### Why is it useful?
+
+Plant, cosy, and desk object themes use a terrarium. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/terrarium-as/demo.html
+++ b/submissions/examples/terrarium-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terrarium</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="terr" tabindex="0">
+      <span class="glassT"></span>
+      <span class="soilT"></span>
+      <span class="pebbleT"></span>
+      <span class="mossT"></span>
+      <span class="fernT ft1"></span>
+      <span class="fernT ft2"></span>
+      <span class="fernT ft3"></span>
+      <span class="succ"></span>
+      <span class="succLeaf sc1"></span>
+      <span class="succLeaf sc2"></span>
+      <span class="succLeaf sc3"></span>
+      <span class="succLeaf sc4"></span>
+      <span class="mushT"></span>
+      <span class="dropT dt1"></span>
+      <span class="dropT dt2"></span>
+      <span class="dropT dt3"></span>
+      <span class="shineT"></span>
+      <span class="corkT"></span>
+    </div>
+    <span class="tableT"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/terrarium-as/style.css
+++ b/submissions/examples/terrarium-as/style.css
@@ -1,0 +1,299 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #3d4450, #12151b 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 330px;
+}
+
+.tableT {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 300px;
+  height: 24px;
+  margin-left: -150px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 38, 16, 0.28) 0 2px,
+      transparent 2px 30px
+    ),
+    linear-gradient(180deg, #a97b4a, #6b4a26);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.55);
+}
+
+.terr {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 230px;
+  height: 250px;
+  margin-left: -115px;
+  outline: none;
+  z-index: 4;
+}
+
+.glassT {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 230px;
+  height: 220px;
+  border-radius: 46% 46% 40% 40% / 44% 44% 56% 56%;
+  border: 3px solid rgba(220, 245, 255, 0.35);
+  box-sizing: border-box;
+  background: linear-gradient(160deg, rgba(200, 240, 255, 0.14), rgba(140, 200, 230, 0.05));
+  box-shadow:
+    inset 0 -14px 30px rgba(140, 210, 240, 0.12),
+    0 16px 34px rgba(0, 0, 0, 0.45);
+  z-index: 7;
+  pointer-events: none;
+}
+
+.shineT {
+  position: absolute;
+  bottom: 96px;
+  left: 32px;
+  width: 34px;
+  height: 88px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  filter: blur(5px);
+  z-index: 8;
+  animation: glintT 4.4s ease-in-out infinite;
+}
+
+.corkT {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 74px;
+  height: 26px;
+  margin-left: -37px;
+  border-radius: 8px 8px 4px 4px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 60, 20, 0.25) 0 2px,
+      transparent 2px 10px
+    ),
+    linear-gradient(180deg, #d9a55e, #a3763a);
+  z-index: 9;
+}
+
+.soilT {
+  position: absolute;
+  bottom: 6px;
+  left: 14px;
+  width: 202px;
+  height: 52px;
+  border-radius: 0 0 40% 40% / 0 0 70% 70%;
+  background: linear-gradient(180deg, #5b432c, #2f2216);
+  z-index: 3;
+}
+
+.pebbleT {
+  position: absolute;
+  bottom: 6px;
+  left: 14px;
+  width: 202px;
+  height: 24px;
+  border-radius: 0 0 40% 40% / 0 0 70% 70%;
+  background:
+    radial-gradient(circle at 16% 40%, #9aa2ac 0 9px, transparent 9px),
+    radial-gradient(circle at 38% 60%, #7f8892 0 8px, transparent 8px),
+    radial-gradient(circle at 58% 42%, #9aa2ac 0 9px, transparent 9px),
+    radial-gradient(circle at 80% 58%, #7f8892 0 8px, transparent 8px),
+    transparent;
+  z-index: 4;
+}
+
+.mossT {
+  position: absolute;
+  bottom: 50px;
+  left: 26px;
+  width: 178px;
+  height: 26px;
+  border-radius: 20px;
+  background:
+    radial-gradient(circle at 18% 50%, #5fa84a 0 14px, transparent 14px),
+    radial-gradient(circle at 44% 40%, #4a8f3c 0 15px, transparent 15px),
+    radial-gradient(circle at 70% 52%, #5fa84a 0 14px, transparent 14px),
+    radial-gradient(circle at 90% 44%, #4a8f3c 0 12px, transparent 12px),
+    transparent;
+  z-index: 4;
+}
+
+.fernT {
+  position: absolute;
+  bottom: 62px;
+  width: 14px;
+  height: 96px;
+  border-radius: 7px 7px 2px 2px;
+  background:
+    repeating-linear-gradient(
+      160deg,
+      #6fbf55 0 5px,
+      #35762c 5px 10px
+    );
+  transform-origin: 50% 100%;
+  transform: rotate(var(--ft2, 0deg));
+  z-index: 5;
+  animation: swayT2 5s ease-in-out infinite;
+}
+
+.ft1 {
+  left: 46px;
+
+  --ft2: -14deg;
+}
+
+.ft2 {
+  left: 72px;
+
+  --ft2: -4deg;
+
+  animation-delay: 1.2s;
+}
+
+.ft3 {
+  left: 98px;
+
+  --ft2: 8deg;
+
+  animation-delay: 2.4s;
+}
+
+.succ {
+  position: absolute;
+  bottom: 60px;
+  right: 44px;
+  width: 30px;
+  height: 26px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #8fd06a, #3f7a34 74%);
+  z-index: 6;
+}
+
+.succLeaf {
+  position: absolute;
+  bottom: 62px;
+  right: 58px;
+  width: 40px;
+  height: 18px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #86c95e, #3d7530);
+  transform-origin: 100% 100%;
+  transform: rotate(var(--sc2, 0deg));
+  z-index: 5;
+  animation: breatheT 5s ease-in-out infinite;
+}
+
+.sc1 {
+  --sc2: -40deg;
+}
+
+.sc2 {
+  --sc2: -14deg;
+
+  animation-delay: 0.4s;
+}
+
+.sc3 {
+  --sc2: 14deg;
+
+  animation-delay: 0.8s;
+}
+
+.sc4 {
+  --sc2: 40deg;
+
+  animation-delay: 1.2s;
+}
+
+.mushT {
+  position: absolute;
+  bottom: 60px;
+  left: 130px;
+  width: 26px;
+  height: 16px;
+  border-radius: 50% 50% 20% 20%;
+  background: radial-gradient(circle at 36% 32%, #f0808a, #b83c48 74%);
+  box-shadow: 0 8px 0 -8px #e8e2d0;
+  z-index: 6;
+}
+
+.dropT {
+  position: absolute;
+  width: 8px;
+  height: 11px;
+  border-radius: 50% 50% 60% 60%;
+  background: rgba(220, 245, 255, 0.8);
+  opacity: 0;
+  z-index: 8;
+  animation: runT 5s ease-in infinite;
+}
+
+.dt1 { top: 60px; left: 52px; }
+
+.dt2 {
+  top: 40px;
+  right: 60px;
+  animation-delay: 1.7s;
+}
+
+.dt3 {
+  top: 90px;
+  right: 44px;
+  animation-delay: 3.4s;
+}
+
+.terr:hover .dropT,
+.terr:focus-visible .dropT {
+  animation-duration: 2s;
+}
+
+@keyframes swayT2 {
+  0%, 100% { transform: rotate(var(--ft2, 0deg)); }
+  50% { transform: rotate(calc(var(--ft2, 0deg) + 5deg)); }
+}
+
+@keyframes breatheT {
+  0%, 100% { transform: rotate(var(--sc2, 0deg)) scale(1); }
+  50% { transform: rotate(var(--sc2, 0deg)) scale(1.06); }
+}
+
+@keyframes glintT {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 0.7; }
+}
+
+@keyframes runT {
+  0% { transform: translateY(0); opacity: 0; }
+  20% { opacity: 0.9; }
+  100% { transform: translateY(120px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fernT,
+  .succLeaf,
+  .shineT,
+  .dropT {
+    animation: none;
+  }
+
+  .dropT {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a terrarium built for #45935. The glass is a single translucent element layered over everything with `pointer-events: none`, so it tints the plants beneath it without blocking hover on the container. The succulent is four copies of one leaf shape, each pivoting from a shared origin at the base of the plant with its own angle in a `--sc2` custom property, so a rosette falls out of one rule, and the pebbles and moss are stacks of hard stop radial gradients painted into single elements, so the gravel and the cushion of moss cost two nodes rather than twenty. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45935.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a corked glass terrarium on a table, holding soil, pebbles, swaying ferns, a succulent rosette and a small mushroom, with condensation on the glass.
