### PR TITLE
Add paper crane component

### DIFF
--- a/submissions/examples/paper-crane-as/README.md
+++ b/submissions/examples/paper-crane-as/README.md
@@ -1,0 +1,21 @@
+# Paper Crane
+
+### What does this do?
+
+It shows an origami crane hanging on a thread. It turns and rises on the air, its folded wings beat, and cherry petals drift past. Hovering or focusing it makes the crane bob faster, as if a breath of air caught it. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="crane" tabindex="0">
+  <span class="bodyPc"></span>
+  <span class="wingPc wpl"></span>
+  <span class="headPc"></span>
+</div>
+```
+
+Every part of the crane is a `clip-path` polygon, because origami is made of straight creases and sharp points, and no amount of `border-radius` produces a fold. The body is a diamond, each wing a triangle, the head a beak-shaped wedge. The wings beat with `scaleY` rather than rotation, each pivoting from the edge that meets the body, so they compress toward the fold line the way folded paper does instead of swinging like feathered wings. The centre crease is a `clip-path` two percent wide, which is a whole element spent on a single line, and it is what makes the body read as folded rather than flat.
+
+### Why is it useful?
+
+Origami, peace, and delicate or handmade themes use a paper crane. This builds one with pure CSS clip paths and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/paper-crane-as/demo.html
+++ b/submissions/examples/paper-crane-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Paper Crane</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunPc"></span>
+    <div class="crane" tabindex="0">
+      <span class="bodyPc"></span>
+      <span class="creasePc"></span>
+      <span class="wingPc wpl"></span>
+      <span class="wingPc wpr"></span>
+      <span class="neckPc"></span>
+      <span class="headPc"></span>
+      <span class="tailPc"></span>
+    </div>
+    <span class="threadPc"></span>
+    <span class="petalPc pp1"></span>
+    <span class="petalPc pp2"></span>
+    <span class="petalPc pp3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/paper-crane-as/style.css
+++ b/submissions/examples/paper-crane-as/style.css
@@ -1,0 +1,213 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #f2d3d8, #b98a9c 62%, #4e3b52);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.sunPc {
+  position: absolute;
+  top: 34px;
+  right: 42px;
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff2e2, #f0a8b4 70%);
+  box-shadow: 0 0 70px rgba(255, 190, 200, 0.7);
+  z-index: 2;
+  animation: glowPc 6s ease-in-out infinite;
+}
+
+.threadPc {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 2px;
+  height: 70px;
+  margin-left: -1px;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 3;
+}
+
+.crane {
+  position: absolute;
+  top: 66px;
+  left: 50%;
+  width: 260px;
+  height: 190px;
+  margin-left: -130px;
+  outline: none;
+  transform-origin: 50% 0;
+  z-index: 5;
+  animation: hoverPc 5s ease-in-out infinite;
+}
+
+.crane:hover,
+.crane:focus-visible {
+  animation-duration: 1.8s;
+}
+
+.bodyPc {
+  position: absolute;
+  top: 70px;
+  left: 50%;
+  width: 104px;
+  height: 96px;
+  margin-left: -52px;
+  clip-path: polygon(0 0, 100% 0, 54% 100%);
+  background: linear-gradient(160deg, #fdfaf6, #cfc4dc);
+  z-index: 5;
+}
+
+.creasePc {
+  position: absolute;
+  top: 70px;
+  left: 50%;
+  width: 104px;
+  height: 96px;
+  margin-left: -52px;
+  clip-path: polygon(49% 0, 52% 0, 55% 100%, 52% 100%);
+  background: rgba(140, 120, 155, 0.5);
+  z-index: 6;
+}
+
+.wingPc {
+  position: absolute;
+  top: 4px;
+  width: 112px;
+  height: 70px;
+  background: linear-gradient(160deg, #fffdfa, #d6cbe2);
+  filter: drop-shadow(0 5px 8px rgba(80, 60, 90, 0.25));
+  z-index: 4;
+  animation: flapPc 3.4s ease-in-out infinite;
+}
+
+.wpl {
+  left: 50%;
+  margin-left: -164px;
+  clip-path: polygon(100% 100%, 100% 0, 0 56%);
+  transform-origin: 100% 100%;
+}
+
+.wpr {
+  left: 50%;
+  margin-left: 52px;
+  clip-path: polygon(0 100%, 0 0, 100% 56%);
+  transform-origin: 0 100%;
+  animation-delay: 0.15s;
+}
+
+.neckPc {
+  position: absolute;
+  top: 62px;
+  left: 50%;
+  width: 72px;
+  height: 13px;
+  margin-left: -118px;
+  clip-path: polygon(0 30%, 100% 0, 100% 100%, 0 70%);
+  background: linear-gradient(90deg, #d6cbe2, #fdfaf6);
+  transform-origin: 100% 50%;
+  transform: rotate(-36deg);
+  z-index: 6;
+}
+
+.headPc {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  width: 32px;
+  height: 15px;
+  margin-left: -136px;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  background: linear-gradient(90deg, #fdfaf6, #d6cbe2);
+  transform: rotate(-16deg);
+  z-index: 7;
+}
+
+.tailPc {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 84px;
+  height: 15px;
+  margin-left: 48px;
+  clip-path: polygon(0 0, 100% 34%, 100% 66%, 0 100%);
+  background: linear-gradient(90deg, #fdfaf6, #c9bed6);
+  transform-origin: 0 50%;
+  transform: rotate(-30deg);
+  z-index: 4;
+}
+
+.petalPc {
+  position: absolute;
+  width: 18px;
+  height: 10px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #ffd6e2, #f294b4);
+  opacity: 0;
+  z-index: 6;
+  animation: driftPc 7s linear infinite;
+}
+
+.pp1 { top: 90px; left: 40px; }
+
+.pp2 {
+  top: 60px;
+  right: 60px;
+  animation-delay: 2.3s;
+
+  --pcx: -50px;
+}
+
+.pp3 {
+  top: 130px;
+  right: 30px;
+  animation-delay: 4.6s;
+
+  --pcx: -80px;
+}
+
+@keyframes hoverPc {
+  0%, 100% { transform: translateY(0) rotate(-3deg); }
+  50% { transform: translateY(-14px) rotate(3deg); }
+}
+
+@keyframes flapPc {
+  0%, 100% { transform: rotate(0deg) scaleY(1); }
+  50% { transform: rotate(0deg) scaleY(0.72); }
+}
+
+@keyframes driftPc {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { transform: translate(var(--pcx, 60px), 180px) rotate(300deg); opacity: 0; }
+}
+
+@keyframes glowPc {
+  0%, 100% { opacity: 0.9; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.04); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crane,
+  .wingPc,
+  .petalPc,
+  .sunPc {
+    animation: none;
+  }
+
+  .petalPc {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a paper crane built for #45937. Every part is a clip-path polygon, because origami is made of straight creases and sharp points and no amount of border-radius produces a fold: the body is a triangle, each wing a swept triangle, the head a beak shaped wedge. The wings beat with scaleY rather than rotation, each pivoting from the edge that meets the body, so they compress toward the fold line the way folded paper does instead of swinging like feathered wings, and the centre crease is a clip-path a couple of percent wide, which is what makes the body read as folded rather than flat. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45937.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: an origami crane hanging on a thread with swept paper wings, a creased triangular body, a beaked head and a pointed tail, with petals drifting past.
