### PR TITLE
Add pocket watch component

### DIFF
--- a/submissions/examples/pocket-watch-as/README.md
+++ b/submissions/examples/pocket-watch-as/README.md
@@ -1,0 +1,21 @@
+# Pocket Watch
+
+### What does this do?
+
+It shows a brass pocket watch swinging on its chain. The second hand ticks round in discrete jumps, the minute and hour hands creep at their proper speeds, and light glints off the crystal. Hovering or focusing it swings the watch faster, as if it were being dangled. Under reduced motion it hangs still.
+
+### How is it used?
+
+```html
+<div class="watch" tabindex="0">
+  <span class="dialW"></span>
+  <span class="ticksW"></span>
+  <span class="handS"></span>
+</div>
+```
+
+The second hand uses `steps(60, end)` over 60 seconds, so it advances in sixty discrete jumps rather than sweeping smoothly, which is exactly how a mechanical tick reads. The other two hands run on real clock periods, 3600 seconds for the minute hand and 43200 for the hour, so the watch keeps honest relative time rather than spinning for show. The dial's minute ticks and the heavier hour markers are two `repeating-conic-gradient`s, each masked to its own radial band so one lands as a fine outer scale and the other as bolder markers further in.
+
+### Why is it useful?
+
+Vintage, timekeeping, and mechanical themes use a pocket watch. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/pocket-watch-as/demo.html
+++ b/submissions/examples/pocket-watch-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pocket Watch</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="chainW"></span>
+    <div class="watch" tabindex="0">
+      <span class="crownW"></span>
+      <span class="bowW"></span>
+      <span class="caseW"></span>
+      <span class="bezelW"></span>
+      <span class="dialW"></span>
+      <span class="ticksW"></span>
+      <span class="numerals"></span>
+      <span class="handH"></span>
+      <span class="handM"></span>
+      <span class="handS"></span>
+      <span class="pinW"></span>
+      <span class="crystalW"></span>
+    </div>
+    <span class="glintW gw1"></span>
+    <span class="glintW gw2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pocket-watch-as/style.css
+++ b/submissions/examples/pocket-watch-as/style.css
@@ -1,0 +1,278 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #3a3244, #100d16 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+}
+
+.chainW {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 10px;
+  height: 60px;
+  margin-left: -5px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #d9b45e 0 5px,
+      #8a6a1e 5px 10px
+    );
+  border-radius: 5px;
+  z-index: 3;
+}
+
+.watch {
+  position: absolute;
+  top: 54px;
+  left: 50%;
+  width: 230px;
+  height: 250px;
+  margin-left: -115px;
+  outline: none;
+  transform-origin: 50% 2%;
+  z-index: 4;
+  animation: swingW 5s ease-in-out infinite;
+}
+
+.watch:hover,
+.watch:focus-visible {
+  animation-duration: 1.6s;
+}
+
+.bowW {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  margin-left: -15px;
+  border-radius: 50%;
+  border: 5px solid #d9b45e;
+  box-sizing: border-box;
+  background: transparent;
+  z-index: 3;
+}
+
+.crownW {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  width: 24px;
+  height: 18px;
+  margin-left: -12px;
+  border-radius: 4px 4px 2px 2px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #e8c75e 0 3px,
+      #a3822c 3px 6px
+    );
+  z-index: 4;
+}
+
+.caseW {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 220px;
+  height: 220px;
+  margin-left: -110px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #f0d489, #a3822c 76%);
+  box-shadow:
+    inset -10px -10px 24px rgba(90, 66, 10, 0.5),
+    0 18px 36px rgba(0, 0, 0, 0.55);
+  z-index: 4;
+}
+
+.bezelW {
+  position: absolute;
+  top: 38px;
+  left: 50%;
+  width: 196px;
+  height: 196px;
+  margin-left: -98px;
+  border-radius: 50%;
+  border: 5px solid #c9a24a;
+  box-sizing: border-box;
+  background: transparent;
+  z-index: 6;
+}
+
+.dialW {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 184px;
+  height: 184px;
+  margin-left: -92px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #fdf8ea, #ddd2b8 78%);
+  box-shadow: inset 0 -6px 14px rgba(140, 120, 70, 0.3);
+  z-index: 5;
+}
+
+.ticksW {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 184px;
+  height: 184px;
+  margin-left: -92px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(60, 44, 20, 0.75) 0 1.2deg,
+      transparent 1.2deg 6deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 40%, #000 42%, #000 47%, transparent 49%);
+  z-index: 6;
+}
+
+.numerals {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 184px;
+  height: 184px;
+  margin-left: -92px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(60, 44, 20, 0.85) 0 3deg,
+      transparent 3deg 30deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 33%, #000 35%, #000 42%, transparent 44%);
+  z-index: 6;
+}
+
+.handH {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 56px;
+  margin: -56px 0 0 -5px;
+  border-radius: 5px 5px 2px 2px;
+  background: linear-gradient(180deg, #3a2f18, #17110a);
+  transform-origin: 50% 100%;
+  z-index: 7;
+  animation: turnHour 43200s linear infinite;
+}
+
+.handM {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 7px;
+  height: 78px;
+  margin: -78px 0 0 -3.5px;
+  border-radius: 4px 4px 2px 2px;
+  background: linear-gradient(180deg, #3a2f18, #17110a);
+  transform-origin: 50% 100%;
+  z-index: 7;
+  animation: turnMin 3600s linear infinite;
+}
+
+.handS {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3px;
+  height: 86px;
+  margin: -86px 0 0 -1.5px;
+  border-radius: 2px;
+  background: #b8352c;
+  transform-origin: 50% 100%;
+  z-index: 8;
+  animation: tick 60s steps(60, end) infinite;
+}
+
+.pinW {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f0d489, #8a6a1e 74%);
+  z-index: 9;
+}
+
+.crystalW {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 184px;
+  height: 184px;
+  margin-left: -92px;
+  border-radius: 50%;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.32) 0 30%, transparent 30% 46%, rgba(255, 255, 255, 0.16) 46% 54%, transparent 54%);
+  z-index: 9;
+  pointer-events: none;
+}
+
+.glintW {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #fff8dc;
+  box-shadow: 0 0 12px rgba(255, 240, 190, 0.9);
+  z-index: 10;
+  animation: sparkW 3s ease-in-out infinite;
+}
+
+.gw1 { top: 90px; left: 56px; }
+
+.gw2 {
+  bottom: 60px;
+  right: 60px;
+  animation-delay: 1.5s;
+}
+
+@keyframes swingW {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes tick {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes turnMin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes turnHour {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes sparkW {
+  0%, 100% { opacity: 0.3; transform: scale(0.7); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .watch,
+  .handS,
+  .handM,
+  .handH,
+  .glintW {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pocket watch built for #45939. The second hand uses `steps(60, end)` over sixty seconds, so it advances in sixty discrete jumps rather than sweeping smoothly, which is exactly how a mechanical tick reads, and the other two hands run on real clock periods, 3600 seconds for the minute and 43200 for the hour, so the watch keeps honest relative time rather than spinning for show. The dial's fine minute ticks and its bolder hour markers are two repeating conic gradients, each masked to its own radial band so one lands as an outer scale and the other as heavier markers further in. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45939.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a brass pocket watch on a chain with a bow and crown, a ticked dial with hour markers, black hour and minute hands and a red seconds hand.
