### PR TITLE
Add tarsier component

### DIFF
--- a/submissions/examples/tarsier-as/README.md
+++ b/submissions/examples/tarsier-as/README.md
@@ -1,0 +1,22 @@
+# Tarsier
+
+### What does this do?
+
+It shows a tarsier clinging to a branch at night, its enormous eyes tracking fireflies. Its head snaps left and right in the sudden way a tarsier's does, its pupils dart with the movement, its ears twitch, its tail curls, and it blinks. Under reduced motion it stares straight ahead.
+
+### How is it used?
+
+```html
+<div class="tars">
+  <div class="headTs">
+    <span class="eyeTs eyl2"></span>
+    <span class="pupilTs ptl"></span>
+  </div>
+</div>
+```
+
+The head swivel and the pupils share exactly the same keyframe timing: both hold, then snap at 40 percent, hold again, snap back at 65 percent. Because the pupils translate in the same direction the head turns, the gaze leads the movement rather than lagging behind it, which is what makes the look read as alert rather than mechanical. The `cubic-bezier(0.6, 0, 0.2, 1)` on the head is what gives the turn its snap: slow to leave, fast through the middle, settling hard.
+
+### Why is it useful?
+
+Nocturnal, wildlife, and watchful themes use a tarsier. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/tarsier-as/demo.html
+++ b/submissions/examples/tarsier-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tarsier</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moonTs"></span>
+    <span class="branchTs"></span>
+    <div class="tars">
+      <span class="tailTs"></span>
+      <span class="bodyTs"></span>
+      <span class="legTs lt1"></span>
+      <span class="legTs lt2"></span>
+      <span class="armTs at1"></span>
+      <span class="armTs at2"></span>
+      <div class="headTs">
+        <span class="earTs etl"></span>
+        <span class="earTs etr"></span>
+        <span class="faceTs"></span>
+        <span class="eyeTs eyl2"></span>
+        <span class="eyeTs eyr2"></span>
+        <span class="pupilTs ptl"></span>
+        <span class="pupilTs ptr"></span>
+        <span class="noseTs"></span>
+        <span class="mouthTs"></span>
+      </div>
+    </div>
+    <span class="fireflyTs ff1"></span>
+    <span class="fireflyTs ff2"></span>
+    <span class="fireflyTs ff3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tarsier-as/style.css
+++ b/submissions/examples/tarsier-as/style.css
@@ -1,0 +1,298 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #26314a, #080b12 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 320px;
+}
+
+.moonTs {
+  position: absolute;
+  top: 26px;
+  right: 38px;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 36%, #fdfaf0, #d6d0b4 74%);
+  box-shadow: 0 0 60px rgba(240, 235, 205, 0.55);
+  z-index: 2;
+  animation: glowTs 6s ease-in-out infinite;
+}
+
+.branchTs {
+  position: absolute;
+  bottom: 56px;
+  left: -50vw;
+  right: -50vw;
+  height: 26px;
+  border-radius: 10px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(40, 26, 8, 0.4) 0 3px,
+      transparent 3px 18px
+    ),
+    linear-gradient(180deg, #6f5230, #3a2915);
+  z-index: 3;
+}
+
+.tars {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 220px;
+  height: 220px;
+  margin-left: -110px;
+  z-index: 5;
+  animation: perchTs 5s ease-in-out infinite;
+}
+
+.bodyTs {
+  position: absolute;
+  bottom: 0;
+  left: 62px;
+  width: 96px;
+  height: 100px;
+  border-radius: 46% 46% 40% 40% / 52% 52% 48% 48%;
+  background: linear-gradient(180deg, #b8a184, #7d6a52);
+  box-shadow: inset -6px -6px 14px rgba(50, 40, 26, 0.35);
+  z-index: 3;
+}
+
+.tailTs {
+  position: absolute;
+  bottom: -30px;
+  right: 44px;
+  width: 10px;
+  height: 110px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #9c8a70, #5f5240);
+  transform-origin: 50% 0;
+  transform: rotate(16deg);
+  z-index: 2;
+  animation: curlTs 4.4s ease-in-out infinite;
+}
+
+.legTs {
+  position: absolute;
+  bottom: -10px;
+  width: 18px;
+  height: 34px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #a89076, #6f5f48);
+  z-index: 4;
+}
+
+.lt1 { left: 72px; }
+.lt2 { left: 122px; }
+
+.armTs {
+  position: absolute;
+  bottom: 40px;
+  width: 14px;
+  height: 40px;
+  border-radius: 7px;
+  background: linear-gradient(180deg, #ad9578, #74644c);
+  transform-origin: 50% 0;
+  transform: rotate(var(--at, 0deg));
+  z-index: 5;
+}
+
+.at1 {
+  left: 60px;
+
+  --at: 12deg;
+}
+
+.at2 {
+  right: 60px;
+
+  --at: -12deg;
+}
+
+.headTs {
+  position: absolute;
+  bottom: 78px;
+  left: 50%;
+  width: 140px;
+  height: 132px;
+  margin-left: -70px;
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: swivelTs 5s cubic-bezier(0.6, 0, 0.2, 1) infinite;
+}
+
+.faceTs {
+  position: absolute;
+  bottom: 0;
+  left: 20px;
+  width: 100px;
+  height: 106px;
+  border-radius: 48% 48% 44% 44% / 50% 50% 50% 50%;
+  background: linear-gradient(180deg, #c9b294, #8e7a5e);
+  z-index: 3;
+}
+
+.earTs {
+  position: absolute;
+  bottom: 68px;
+  width: 30px;
+  height: 36px;
+  border-radius: 50% 50% 30% 30%;
+  background: #9c8a70;
+  z-index: 2;
+  animation: earTs 4s ease-in-out infinite;
+}
+
+.etl { left: 8px; }
+
+.etr {
+  right: 8px;
+  animation-delay: 2s;
+}
+
+.eyeTs {
+  position: absolute;
+  bottom: 42px;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 34%, #ffe97e, #c98a10 76%);
+  box-shadow:
+    inset 0 -4px 8px rgba(120, 80, 6, 0.4),
+    0 0 16px rgba(255, 220, 110, 0.5);
+  z-index: 5;
+  animation: blinkTs 5.4s ease-in-out infinite;
+}
+
+.eyl2 { left: 22px; }
+.eyr2 { right: 22px; }
+
+.pupilTs {
+  position: absolute;
+  bottom: 56px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #14100a;
+  z-index: 6;
+  animation: dartTs 5s ease-in-out infinite;
+}
+
+.ptl { left: 35px; }
+.ptr { right: 35px; }
+
+.noseTs {
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  width: 12px;
+  height: 8px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: #4a3a24;
+  z-index: 6;
+}
+
+.mouthTs {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  width: 26px;
+  height: 10px;
+  margin-left: -13px;
+  border-radius: 0 0 14px 14px;
+  border-bottom: 2px solid #4a3a24;
+  z-index: 6;
+}
+
+.fireflyTs {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #d8ff8a;
+  box-shadow: 0 0 12px rgba(190, 255, 120, 0.95);
+  z-index: 7;
+  animation: blinkFly 3.4s ease-in-out infinite;
+}
+
+.ff1 { top: 90px; left: 40px; }
+
+.ff2 {
+  top: 150px;
+  right: 44px;
+  animation-delay: 1.1s;
+}
+
+.ff3 {
+  bottom: 110px;
+  left: 60px;
+  animation-delay: 2.2s;
+}
+
+@keyframes perchTs {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+@keyframes swivelTs {
+  0%, 30% { transform: rotate(0deg); }
+  40%, 55% { transform: rotate(-24deg); }
+  65%, 90% { transform: rotate(22deg); }
+  100% { transform: rotate(0deg); }
+}
+
+@keyframes dartTs {
+  0%, 30% { transform: translateX(0); }
+  40%, 55% { transform: translateX(-5px); }
+  65%, 90% { transform: translateX(5px); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes blinkTs {
+  0%, 94%, 100% { transform: scaleY(1); }
+  97% { transform: scaleY(0.08); }
+}
+
+@keyframes earTs {
+  0%, 88%, 100% { transform: rotate(0deg); }
+  94% { transform: rotate(-10deg); }
+}
+
+@keyframes curlTs {
+  0%, 100% { transform: rotate(14deg); }
+  50% { transform: rotate(22deg); }
+}
+
+@keyframes blinkFly {
+  0%, 100% { opacity: 0.15; transform: scale(0.7); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+@keyframes glowTs {
+  0%, 100% { opacity: 0.9; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.04); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tars,
+  .headTs,
+  .pupilTs,
+  .eyeTs,
+  .earTs,
+  .tailTs,
+  .fireflyTs,
+  .moonTs {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a tarsier built for #45947. The head swivel and the pupils share exactly the same keyframe timing: both hold, snap at 40 percent, hold again, and snap back at 65 percent. Because the pupils translate in the same direction the head turns, the gaze leads the movement rather than lagging behind it, which is what makes the look read as alert rather than mechanical, and the cubic-bezier on the head is what gives the turn its snap, slow to leave, fast through the middle, settling hard. Reduced motion fallback included. Pure CSS. Closes #45947.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a tarsier gripping a branch with enormous golden eyes and dark pupils, round ears and a long tail, under a moon with fireflies around it.
