### PR TITLE
Add bamboo grove component

### DIFF
--- a/submissions/examples/bamboo-grove-as/README.md
+++ b/submissions/examples/bamboo-grove-as/README.md
@@ -1,0 +1,20 @@
+# Bamboo Grove
+
+### What does this do?
+
+It shows a stand of bamboo in the wind. Each culm sways on its own offset, the fronds rustle, leaves spiral down through the light shafts, and mist drifts along the floor. The whole grove also leans as one when a gust passes. Under reduced motion the grove stands still.
+
+### How is it used?
+
+```html
+<div class="grove">
+  <span class="culm cm1"></span>
+  <span class="frond fr1"></span>
+</div>
+```
+
+The gust is the thing worth stealing here. Each culm sways individually, but the wrapper around them also runs a slow `skewX`, and skewing a container displaces its children by an amount proportional to their height: tall stalks lean far, short ones barely move. That single property gives the grove a wind gradient that would otherwise need a different keyframe per stalk. The culm nodes are a `repeating-linear-gradient` down each stem, so the joints cost nothing extra.
+
+### Why is it useful?
+
+Zen, forest, and calm or atmospheric themes use bamboo. This builds a grove with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/bamboo-grove-as/demo.html
+++ b/submissions/examples/bamboo-grove-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bamboo Grove</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="lightBg"></span>
+    <div class="grove">
+      <span class="culm cm1"></span>
+      <span class="culm cm2"></span>
+      <span class="culm cm3"></span>
+      <span class="culm cm4"></span>
+      <span class="culm cm5"></span>
+      <span class="culm cm6"></span>
+      <span class="frond fr1"></span>
+      <span class="frond fr2"></span>
+      <span class="frond fr3"></span>
+      <span class="frond fr4"></span>
+      <span class="frond fr5"></span>
+      <span class="frond fr6"></span>
+    </div>
+    <span class="leafFall lf5"></span>
+    <span class="leafFall lf6"></span>
+    <span class="mistB"></span>
+    <span class="floorB"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bamboo-grove-as/style.css
+++ b/submissions/examples/bamboo-grove-as/style.css
@@ -1,0 +1,264 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #cfe3c0, #7fa668 62%, #3d5a34);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.lightBg {
+  position: absolute;
+  top: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 330px);
+  background:
+    repeating-linear-gradient(
+      98deg,
+      rgba(255, 255, 220, 0.12) 0 26px,
+      transparent 26px 96px
+    );
+  pointer-events: none;
+  z-index: 6;
+}
+
+.floorB {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 44px);
+  background: linear-gradient(180deg, #6d7f4a, #35401f);
+  z-index: 5;
+}
+
+.mistB {
+  position: absolute;
+  bottom: 40px;
+  left: -50vw;
+  right: -50vw;
+  height: 70px;
+  background: linear-gradient(180deg, transparent, rgba(240, 250, 235, 0.5));
+  filter: blur(6px);
+  z-index: 5;
+  animation: driftMist 8s ease-in-out infinite;
+}
+
+.grove {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 320px;
+  height: 290px;
+  margin-left: -160px;
+  z-index: 4;
+  animation: gustB 7s ease-in-out infinite;
+}
+
+.culm {
+  position: absolute;
+  bottom: 0;
+  width: 22px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(40, 70, 20, 0.45) 0 3px,
+      transparent 3px 44px
+    ),
+    linear-gradient(90deg, #a8c95e, #5f8a30 60%, #46691f);
+  box-shadow: inset -4px 0 8px rgba(30, 50, 10, 0.4);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--cm, 0deg));
+  z-index: 3;
+  animation: swayB 5s ease-in-out infinite;
+}
+
+.cm1 {
+  left: 14px;
+  height: 250px;
+
+  --cm: -3deg;
+}
+
+.cm2 {
+  left: 62px;
+  height: 285px;
+
+  --cm: 2deg;
+
+  animation-delay: 0.6s;
+}
+
+.cm3 {
+  left: 118px;
+  height: 230px;
+  width: 18px;
+
+  --cm: -2deg;
+
+  animation-delay: 1.2s;
+}
+
+.cm4 {
+  left: 168px;
+  height: 275px;
+
+  --cm: 3deg;
+
+  animation-delay: 1.8s;
+}
+
+.cm5 {
+  left: 224px;
+  height: 245px;
+  width: 18px;
+
+  --cm: -2deg;
+
+  animation-delay: 2.4s;
+}
+
+.cm6 {
+  left: 272px;
+  height: 290px;
+
+  --cm: 2deg;
+
+  animation-delay: 3s;
+}
+
+.frond {
+  position: absolute;
+  width: 90px;
+  height: 24px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #8fd056, #3f7a26);
+  transform-origin: 0 100%;
+  transform: rotate(var(--fr3, 0deg));
+  z-index: 4;
+  animation: rustleB 4.4s ease-in-out infinite;
+}
+
+.fr1 {
+  bottom: 240px;
+  left: 26px;
+
+  --fr3: -26deg;
+}
+
+.fr2 {
+  bottom: 272px;
+  left: 74px;
+
+  --fr3: 18deg;
+
+  animation-delay: 0.7s;
+}
+
+.fr3 {
+  bottom: 220px;
+  left: 126px;
+
+  --fr3: -20deg;
+
+  animation-delay: 1.4s;
+}
+
+.fr4 {
+  bottom: 262px;
+  left: 180px;
+
+  --fr3: 22deg;
+
+  animation-delay: 2.1s;
+}
+
+.fr5 {
+  bottom: 234px;
+  left: 232px;
+
+  --fr3: -18deg;
+
+  animation-delay: 2.8s;
+}
+
+.fr6 {
+  bottom: 278px;
+  left: 282px;
+
+  --fr3: 16deg;
+
+  animation-delay: 3.5s;
+}
+
+.leafFall {
+  position: absolute;
+  width: 30px;
+  height: 12px;
+  border-radius: 0 100% 0 100%;
+  background: linear-gradient(140deg, #9ed86a, #4d8a2c);
+  opacity: 0;
+  z-index: 5;
+  animation: fallB 8s linear infinite;
+}
+
+.lf5 { top: 60px; left: 90px; }
+
+.lf6 {
+  top: 30px;
+  right: 90px;
+  animation-delay: 4s;
+
+  --bx3: -60px;
+}
+
+@keyframes gustB {
+  0%, 100% { transform: skewX(0deg); }
+  50% { transform: skewX(-2deg); }
+}
+
+@keyframes swayB {
+  0%, 100% { transform: rotate(var(--cm, 0deg)); }
+  50% { transform: rotate(calc(var(--cm, 0deg) + 2deg)); }
+}
+
+@keyframes rustleB {
+  0%, 100% { transform: rotate(var(--fr3, 0deg)); }
+  50% { transform: rotate(calc(var(--fr3, 0deg) + 8deg)); }
+}
+
+@keyframes fallB {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  12% { opacity: 1; }
+  88% { opacity: 1; }
+  100% { transform: translate(var(--bx3, 70px), 260px) rotate(320deg); opacity: 0; }
+}
+
+@keyframes driftMist {
+  0%, 100% { transform: translateX(0); opacity: 0.7; }
+  50% { transform: translateX(24px); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grove,
+  .culm,
+  .frond,
+  .leafFall,
+  .mistB {
+    animation: none;
+  }
+
+  .leafFall {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bamboo grove built for #45951. Each culm sways individually, but the wrapper around them also runs a slow skewX, and skewing a container displaces its children in proportion to their height: tall stalks lean far, short ones barely move. That single property gives the grove a wind gradient that would otherwise need a different keyframe per stalk. The culm nodes are a repeating gradient down each stem, so the joints cost nothing extra. Reduced motion fallback included. Pure CSS. Closes #45951.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a stand of jointed bamboo culms of varying heights with fronds at the top, light shafts through the grove and mist along the floor.
