### PR TITLE
Add origami boat component

### DIFF
--- a/submissions/examples/origami-boat-as/README.md
+++ b/submissions/examples/origami-boat-as/README.md
@@ -1,0 +1,21 @@
+# Origami Boat
+
+### What does this do?
+
+It shows a folded paper boat riding a puddle in the rain. It rocks on the water, its two paper sails luff against each other, rings spread out from the hull, and rain falls past. Hovering or focusing it rocks the boat harder, as if the water got choppy. Under reduced motion it floats still.
+
+### How is it used?
+
+```html
+<div class="obot" tabindex="0">
+  <span class="hullOb"></span>
+  <span class="sailL"></span>
+  <span class="sailR"></span>
+</div>
+```
+
+The hull is a `clip-path` trapezoid and each sail a `clip-path` triangle, because folded paper is all straight edges and a `border-radius` cannot produce a crease. The two sails run opposite phases of the same luff: the left is at full width while the right is squeezed, then they swap. That counter-motion is what makes the paper look like it is catching air on alternating sides rather than pulsing as one lump. The centre fold is a three pixel bar, and it is the single line that makes the whole thing read as folded rather than cut out.
+
+### Why is it useful?
+
+Origami, childhood, and rainy day themes use a paper boat. This builds one with pure CSS clip paths and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/origami-boat-as/demo.html
+++ b/submissions/examples/origami-boat-as/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Origami Boat</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="rainOb ro1"></span>
+    <span class="rainOb ro2"></span>
+    <span class="rainOb ro3"></span>
+    <span class="rainOb ro4"></span>
+    <div class="obot" tabindex="0">
+      <span class="hullOb"></span>
+      <span class="deckOb"></span>
+      <span class="sailL"></span>
+      <span class="sailR"></span>
+      <span class="foldOb"></span>
+    </div>
+    <span class="ringOb rb3"></span>
+    <span class="ringOb rb4"></span>
+    <span class="puddleOb"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/origami-boat-as/style.css
+++ b/submissions/examples/origami-boat-as/style.css
@@ -1,0 +1,198 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #8d99ad, #4f5c72 66%, #2a3346);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.puddleOb {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 96px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.09) 0 3px,
+      transparent 3px 26px
+    ),
+    linear-gradient(180deg, #6f86a5, #2c3a52);
+  z-index: 5;
+}
+
+.obot {
+  position: absolute;
+  bottom: 88px;
+  left: 50%;
+  width: 240px;
+  height: 150px;
+  margin-left: -120px;
+  outline: none;
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: rockOb 4s ease-in-out infinite;
+}
+
+.obot:hover,
+.obot:focus-visible {
+  animation-duration: 1.4s;
+}
+
+.hullOb {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 220px;
+  height: 60px;
+  margin-left: -110px;
+  clip-path: polygon(0 0, 100% 0, 82% 100%, 18% 100%);
+  background: linear-gradient(180deg, #fdfaf2, #cfc7bb);
+  z-index: 5;
+}
+
+.deckOb {
+  position: absolute;
+  bottom: 56px;
+  left: 50%;
+  width: 220px;
+  height: 10px;
+  margin-left: -110px;
+  background: linear-gradient(180deg, #e6dfd2, #b9b1a4);
+  z-index: 6;
+}
+
+.sailL {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 108px;
+  height: 84px;
+  margin-left: -108px;
+  clip-path: polygon(100% 0, 100% 100%, 0 100%);
+  background: linear-gradient(160deg, #fffdf8, #d6cec2);
+  z-index: 5;
+  animation: luffL 4s ease-in-out infinite;
+  transform-origin: 100% 100%;
+}
+
+.sailR {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 108px;
+  height: 84px;
+  clip-path: polygon(0 0, 100% 100%, 0 100%);
+  background: linear-gradient(200deg, #f2ece2, #c2bab0);
+  z-index: 5;
+  animation: luffR 4s ease-in-out infinite;
+  transform-origin: 0 100%;
+}
+
+.foldOb {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 3px;
+  height: 84px;
+  margin-left: -1.5px;
+  background: rgba(120, 112, 100, 0.6);
+  z-index: 7;
+}
+
+.ringOb {
+  position: absolute;
+  bottom: 76px;
+  left: 50%;
+  width: 190px;
+  height: 22px;
+  margin-left: -95px;
+  border-radius: 50%;
+  border: 2px solid rgba(230, 245, 255, 0.5);
+  opacity: 0;
+  z-index: 6;
+  animation: spreadOb 4s ease-out infinite;
+}
+
+.rb4 { animation-delay: 2s; }
+
+.rainOb {
+  position: absolute;
+  width: 2px;
+  height: 22px;
+  border-radius: 1px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7), transparent);
+  z-index: 7;
+  animation: fallRain 1.2s linear infinite;
+}
+
+.ro1 { top: -20px; left: 50px; }
+
+.ro2 {
+  top: -20px;
+  left: 130px;
+  animation-delay: 0.3s;
+}
+
+.ro3 {
+  top: -20px;
+  right: 90px;
+  animation-delay: 0.6s;
+}
+
+.ro4 {
+  top: -20px;
+  right: 30px;
+  animation-delay: 0.9s;
+}
+
+@keyframes rockOb {
+  0%, 100% { transform: rotate(-5deg) translateY(0); }
+  50% { transform: rotate(5deg) translateY(-5px); }
+}
+
+@keyframes luffL {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(0.88); }
+}
+
+@keyframes luffR {
+  0%, 100% { transform: scaleX(0.88); }
+  50% { transform: scaleX(1); }
+}
+
+@keyframes spreadOb {
+  0% { transform: scale(0.5); opacity: 0.7; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+@keyframes fallRain {
+  0% { transform: translateY(0); opacity: 0; }
+  20% { opacity: 0.8; }
+  100% { transform: translateY(280px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .obot,
+  .sailL,
+  .sailR,
+  .ringOb,
+  .rainOb {
+    animation: none;
+  }
+
+  .ringOb,
+  .rainOb {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an origami boat built for #45953. The hull is a clip-path trapezoid and each sail a clip-path triangle, because folded paper is all straight edges and a border-radius cannot produce a crease. The two sails run opposite phases of the same luff, so the left is at full width while the right is squeezed and then they swap: that counter motion is what makes the paper look like it is catching air on alternating sides rather than pulsing as one lump. The centre fold is a three pixel bar, and it is the single line that makes the whole thing read as folded rather than cut out. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #45953.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a folded paper boat with a creased twin sail and a trapezoid hull, floating on a puddle with ripple rings and rain falling.
