### PR TITLE
feat: expand comparison row spotlight demo

### DIFF
--- a/submissions/examples/comparison-row-spotlight-sm/README.md
+++ b/submissions/examples/comparison-row-spotlight-sm/README.md
@@ -1,5 +1,5 @@
 # Comparison Row Spotlight
 
-1. What does this do? Adds a responsive feature comparison table with staggered row entrance animation and a subtle row spotlight on hover or keyboard focus.
-2. How is it used? Apply `.spotlight-table` to a comparison table inside a `.table-wrap` container.
+1. What does this do? Adds a responsive feature comparison table with animated plan summary cards, staggered row entrance animation, and a subtle row spotlight on hover or keyboard focus.
+2. How is it used? Place `.plan-card` items above a `.spotlight-table` inside a `.table-wrap` container.
 3. Why is it useful? It keeps dense pricing or feature matrices readable while adding human-friendly motion that draws attention to one decision row at a time.

--- a/submissions/examples/comparison-row-spotlight-sm/demo.html
+++ b/submissions/examples/comparison-row-spotlight-sm/demo.html
@@ -20,6 +20,24 @@
           </p>
         </div>
 
+        <div class="plan-strip" aria-label="Plan summary">
+          <article class="plan-card">
+            <span class="plan-label">Starter</span>
+            <strong>Small teams</strong>
+            <p>Simple motion presets for landing pages and prototypes.</p>
+          </article>
+          <article class="plan-card featured-plan">
+            <span class="plan-label">Studio</span>
+            <strong>Recommended</strong>
+            <p>More animation choices, token mapping, and rollout templates.</p>
+          </article>
+          <article class="plan-card">
+            <span class="plan-label">Scale</span>
+            <strong>Large systems</strong>
+            <p>Unlimited presets for product teams with mature design systems.</p>
+          </article>
+        </div>
+
         <div
           class="table-wrap"
           tabindex="0"
@@ -64,6 +82,12 @@
                 <td><span class="status no">No</span></td>
                 <td class="recommended">3 templates</td>
                 <td>Custom set</td>
+              </tr>
+              <tr>
+                <th scope="row">Best for</th>
+                <td>Launch pages</td>
+                <td class="recommended">Product teams</td>
+                <td>Design systems</td>
               </tr>
             </tbody>
           </table>

--- a/submissions/examples/comparison-row-spotlight-sm/style.css
+++ b/submissions/examples/comparison-row-spotlight-sm/style.css
@@ -7,9 +7,11 @@
   --surface: #ffffff;
   --accent: #2f6fed;
   --accent-soft: #e7f0ff;
+  --accent-strong: #174ea6;
   --success: #138a5b;
   --danger: #be3d3d;
   --shadow: 0 18px 48px rgba(24, 35, 58, 0.12);
+  --soft-shadow: 0 12px 28px rgba(24, 35, 58, 0.09);
 }
 
 * {
@@ -74,6 +76,70 @@ h1 {
   color: var(--muted);
   font-size: 1rem;
   line-height: 1.7;
+}
+
+.plan-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 1.5rem 0;
+}
+
+.plan-card {
+  min-height: 8.25rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: var(--soft-shadow);
+  animation: card-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.plan-card:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.plan-card:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.plan-card:hover {
+  border-color: rgba(47, 111, 237, 0.48);
+  box-shadow: 0 16px 38px rgba(24, 35, 58, 0.14);
+  transform: translateY(-4px);
+}
+
+.featured-plan {
+  background: linear-gradient(180deg, #ffffff 0%, var(--accent-soft) 100%);
+  border-color: rgba(47, 111, 237, 0.38);
+}
+
+.plan-label {
+  display: inline-flex;
+  margin-bottom: 0.8rem;
+  border-radius: 999px;
+  padding: 0.28rem 0.65rem;
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.plan-card strong {
+  display: block;
+  margin-bottom: 0.45rem;
+  font-size: 1rem;
+}
+
+.plan-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
 }
 
 .table-wrap {
@@ -142,6 +208,10 @@ h1 {
   animation-delay: 280ms;
 }
 
+.spotlight-table tbody tr:nth-child(6) {
+  animation-delay: 350ms;
+}
+
 .spotlight-table tbody tr:hover,
 .spotlight-table tbody tr:focus-within {
   background: #f7fbff;
@@ -156,10 +226,12 @@ h1 {
 
 .recommended {
   background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 750;
 }
 
 .spotlight-table thead .recommended {
-  color: #174ea6;
+  color: var(--accent-strong);
 }
 
 .status {
@@ -195,10 +267,26 @@ h1 {
   }
 }
 
+@keyframes card-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 @media (max-width: 640px) {
   .demo-shell {
     align-items: start;
     padding: 1rem;
+  }
+
+  .plan-strip {
+    grid-template-columns: 1fr;
   }
 
   .table-wrap {
@@ -211,11 +299,13 @@ h1 {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .plan-card,
   .spotlight-table tbody tr {
     animation: none;
     transition: none;
   }
 
+  .plan-card:hover,
   .spotlight-table tbody tr:hover,
   .spotlight-table tbody tr:focus-within {
     transform: none;


### PR DESCRIPTION


## Pull Request Description

Adds a self-contained Comparison Row Spotlight demo for readable pricing and feature comparison tables, including animated plan summary cards and row spotlight interactions.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

Closes #45981

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A responsive feature comparison table with animated plan summary cards, staggered row entrance motion, hover row spotlighting, and reduced-motion support.

**How does a developer use it?**

```html
<div class="plan-strip">
  <article class="plan-card">
    <span class="plan-label">Starter</span>
    <strong>Small teams</strong>
    <p>Simple motion presets for landing pages and prototypes.</p>
  </article>
</div>

<div class="table-wrap">
  <table class="spotlight-table">
    <!-- comparison rows -->
  </table>
</div>