### PR TITLE
feat: add keyboard focus command cards demo

### DIFF
--- a/submissions/examples/keyboard-focus-command-cards-sm/README.md
+++ b/submissions/examples/keyboard-focus-command-cards-sm/README.md
@@ -1,0 +1,5 @@
+# Keyboard Focus Command Cards
+
+1. What does this do? Adds a responsive command-card grid with staggered entrance motion, clear keyboard focus rings, shortcut badges, and hover lift feedback.
+2. How is it used? Apply `.command-grid` to a command list wrapper and `.command-card` to each actionable card link.
+3. Why is it useful? It gives keyboard and mouse users a polished way to scan frequent actions while keeping the motion purposeful and CSS-only.

--- a/submissions/examples/keyboard-focus-command-cards-sm/demo.html
+++ b/submissions/examples/keyboard-focus-command-cards-sm/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keyboard Focus Command Cards</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="command-panel" aria-labelledby="command-title">
+      <div class="panel-copy">
+        <p class="eyebrow">Keyboard friendly</p>
+        <h1 id="command-title">Command cards that feel responsive before you click</h1>
+        <p>
+          Tab through the cards to see a clear focus trail, shortcut badges, and a soft motion cue
+          for the selected command.
+        </p>
+      </div>
+
+      <div class="command-grid" aria-label="Common dashboard commands">
+        <a class="command-card primary-card" href="#new-project">
+          <span class="icon-box">+</span>
+          <span class="command-content">
+            <strong>New project</strong>
+            <span>Create a workspace with saved motion presets.</span>
+          </span>
+          <kbd>N</kbd>
+        </a>
+
+        <a class="command-card" href="#search">
+          <span class="icon-box">⌕</span>
+          <span class="command-content">
+            <strong>Search library</strong>
+            <span>Find animation utilities, snippets, and examples.</span>
+          </span>
+          <kbd>/</kbd>
+        </a>
+
+        <a class="command-card" href="#sync">
+          <span class="icon-box">↻</span>
+          <span class="command-content">
+            <strong>Sync tokens</strong>
+            <span>Refresh local colors, spacing, and timing values.</span>
+          </span>
+          <kbd>S</kbd>
+        </a>
+
+        <a class="command-card" href="#export">
+          <span class="icon-box">⇩</span>
+          <span class="command-content">
+            <strong>Export CSS</strong>
+            <span>Download the current utility bundle for review.</span>
+          </span>
+          <kbd>E</kbd>
+        </a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/keyboard-focus-command-cards-sm/style.css
+++ b/submissions/examples/keyboard-focus-command-cards-sm/style.css
@@ -1,0 +1,243 @@
+:root {
+  color-scheme: light;
+  --page: #f4f7fb;
+  --ink: #172033;
+  --muted: #637083;
+  --surface: #ffffff;
+  --line: #dbe3ee;
+  --accent: #2563eb;
+  --accent-dark: #1746a2;
+  --accent-soft: #e7efff;
+  --success: #11865b;
+  --shadow: 0 20px 55px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 20% 10%, rgba(37, 99, 235, 0.16), transparent 26rem),
+    radial-gradient(circle at 85% 80%, rgba(17, 134, 91, 0.12), transparent 24rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.command-panel {
+  width: min(100%, 1040px);
+}
+
+.panel-copy {
+  max-width: 720px;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.1rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-copy p:last-child {
+  max-width: 640px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.command-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.command-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  min-height: 8.5rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1.1rem;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  text-decoration: none;
+  animation: card-enter 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.command-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.12), transparent 55%);
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.command-card:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.command-card:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.command-card:nth-child(4) {
+  animation-delay: 240ms;
+}
+
+.command-card:hover,
+.command-card:focus-visible {
+  border-color: rgba(37, 99, 235, 0.48);
+  box-shadow: var(--shadow);
+  transform: translateY(-5px);
+}
+
+.command-card:hover::before,
+.command-card:focus-visible::before {
+  opacity: 1;
+}
+
+.command-card:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.32);
+  outline-offset: 5px;
+}
+
+.primary-card {
+  background: linear-gradient(135deg, #ffffff 0%, var(--accent-soft) 100%);
+}
+
+.icon-box,
+kbd,
+.command-content {
+  position: relative;
+  z-index: 1;
+}
+
+.icon-box {
+  display: grid;
+  width: 3.2rem;
+  height: 3.2rem;
+  place-items: center;
+  border-radius: 0.45rem;
+  color: #ffffff;
+  background: var(--accent);
+  font-size: 1.6rem;
+  font-weight: 800;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.24);
+}
+
+.command-content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.command-content strong {
+  font-size: 1.08rem;
+}
+
+.command-content span {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+kbd {
+  min-width: 2.35rem;
+  border: 1px solid rgba(23, 32, 51, 0.16);
+  border-bottom-width: 3px;
+  border-radius: 0.4rem;
+  padding: 0.32rem 0.55rem;
+  color: var(--accent-dark);
+  background: #f9fbff;
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 760px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .command-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .command-card {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .command-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  kbd {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .command-card {
+    animation: none;
+    transition: none;
+  }
+
+  .command-card::before {
+    transition: none;
+  }
+
+  .command-card:hover,
+  .command-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #45989

## Pull Request Description

Adds a self-contained Keyboard Focus Command Cards demo with staggered card entrance motion, hover lift feedback, shortcut badges, clear keyboard focus rings, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A responsive command-card grid with staggered entrance animation, keyboard-visible focus states, shortcut badges, and hover lift feedback.

**How does a developer use it?**

```html
<div class="command-grid">
  <a class="command-card" href="#search">
    <span class="icon-box">⌕</span>
    <span class="command-content">
      <strong>Search library</strong>
      <span>Find animation utilities, snippets, and examples.</span>
    </span>
    <kbd>/</kbd>
  </a>
</div>