### PR TITLE
feat: add action center priority ribbons demo

### DIFF
--- a/submissions/examples/action-center-priority-ribbons-sm/README.md
+++ b/submissions/examples/action-center-priority-ribbons-sm/README.md
@@ -1,0 +1,38 @@
+# Action Center Priority Ribbons
+
+## What does this do?
+
+Action Center Priority Ribbons is a self-contained HTML and CSS dashboard alert board that highlights notification priority with animated entry cards, angled ribbons, status icons, and compact action buttons.
+
+## How is it used?
+
+Place the shared `action-card` class on each notification card and combine it with one priority modifier class. The card can include a `priority-ribbon`, `card-icon`, `card-copy`, and `card-footer` block.
+
+```html
+<article class="action-card action-critical">
+  <div class="priority-ribbon" aria-hidden="true">
+    <span>Critical</span>
+  </div>
+  <div class="card-icon" aria-hidden="true">!</div>
+  <div class="card-copy">
+    <p class="card-topic">Security review</p>
+    <h2>Unusual sign-in attempt</h2>
+    <p>Review the session details before the approval window expires.</p>
+  </div>
+  <footer class="card-footer">
+    <span>2 min ago</span>
+    <button type="button">Review</button>
+  </footer>
+</article>
+```
+
+Available priority classes:
+
+- `action-critical`
+- `action-high`
+- `action-medium`
+- `action-low`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by making motion functional instead of decorative: cards enter softly, ribbons make urgency easy to scan, hover states provide quick feedback, and the reduced-motion media query keeps the experience accessible. The demo is completely standalone and works by opening `demo.html` directly in a browser.

--- a/submissions/examples/action-center-priority-ribbons-sm/demo.html
+++ b/submissions/examples/action-center-priority-ribbons-sm/demo.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Action Center Priority Ribbons Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="action-center-shell">
+      <section class="intro-panel" aria-labelledby="demo-title">
+        <p class="section-label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Action Center Priority Ribbons</h1>
+        <p>
+          A CSS-only alert board for dashboards where each card enters with soft
+          motion and carries an angled ribbon for quick priority scanning.
+        </p>
+      </section>
+
+      <section class="summary-strip" aria-label="Notification summary">
+        <div>
+          <span class="summary-value">12</span>
+          <span class="summary-label">Open alerts</span>
+        </div>
+        <div>
+          <span class="summary-value">4</span>
+          <span class="summary-label">Need approval</span>
+        </div>
+        <div>
+          <span class="summary-value">98%</span>
+          <span class="summary-label">System health</span>
+        </div>
+      </section>
+
+      <section
+        class="notification-grid"
+        aria-label="Priority notification examples"
+      >
+        <article class="action-card action-critical">
+          <div class="priority-ribbon" aria-hidden="true">
+            <span>Critical</span>
+          </div>
+          <div class="card-icon" aria-hidden="true">!</div>
+          <div class="card-copy">
+            <p class="card-topic">Security review</p>
+            <h2>Unusual sign-in attempt</h2>
+            <p>
+              A new device attempted access from an untrusted region. Review the
+              session details before the approval window expires.
+            </p>
+          </div>
+          <footer class="card-footer">
+            <span>2 min ago</span>
+            <button type="button">Review</button>
+          </footer>
+        </article>
+
+        <article class="action-card action-high">
+          <div class="priority-ribbon" aria-hidden="true">
+            <span>High</span>
+          </div>
+          <div class="card-icon" aria-hidden="true">↑</div>
+          <div class="card-copy">
+            <p class="card-topic">Release queue</p>
+            <h2>Production build is ready</h2>
+            <p>
+              The deployment passed checks and is waiting for a final sign-off
+              before the staged rollout begins.
+            </p>
+          </div>
+          <footer class="card-footer">
+            <span>12 min ago</span>
+            <button type="button">Approve</button>
+          </footer>
+        </article>
+
+        <article class="action-card action-medium">
+          <div class="priority-ribbon" aria-hidden="true">
+            <span>Medium</span>
+          </div>
+          <div class="card-icon" aria-hidden="true">✓</div>
+          <div class="card-copy">
+            <p class="card-topic">Billing export</p>
+            <h2>Invoice packet generated</h2>
+            <p>
+              Monthly usage, taxes, and team allocation files are ready for
+              review before they are sent to finance.
+            </p>
+          </div>
+          <footer class="card-footer">
+            <span>34 min ago</span>
+            <button type="button">Open</button>
+          </footer>
+        </article>
+
+        <article class="action-card action-low">
+          <div class="priority-ribbon" aria-hidden="true">
+            <span>Low</span>
+          </div>
+          <div class="card-icon" aria-hidden="true">i</div>
+          <div class="card-copy">
+            <p class="card-topic">Workspace update</p>
+            <h2>Profile suggestions available</h2>
+            <p>
+              Add roles, contact preferences, and availability shortcuts to make
+              team collaboration context easier to scan.
+            </p>
+          </div>
+          <footer class="card-footer">
+            <span>1 hr ago</span>
+            <button type="button">Update</button>
+          </footer>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/action-center-priority-ribbons-sm/style.css
+++ b/submissions/examples/action-center-priority-ribbons-sm/style.css
@@ -1,0 +1,366 @@
+:root {
+  --page-bg: #f3f6fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #657286;
+  --line: #dce4ef;
+  --shadow: 0 24px 60px rgba(23, 32, 51, 0.13);
+  --critical: #dc2626;
+  --high: #f97316;
+  --medium: #2563eb;
+  --low: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.12), transparent 36%),
+    var(--page-bg);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.action-center-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 46px 0;
+}
+
+.intro-panel {
+  max-width: 720px;
+  margin-bottom: 24px;
+}
+
+.section-label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.7rem;
+  line-height: 1.05;
+}
+
+.intro-panel p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.summary-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.summary-strip div {
+  display: flex;
+  min-height: 86px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.7rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.notification-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.action-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 270px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.action-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.action-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.action-card:nth-child(4) {
+  animation-delay: 270ms;
+}
+
+.action-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      115deg,
+      rgba(255, 255, 255, 0.94),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 44%);
+}
+
+.action-card::after {
+  position: absolute;
+  right: 22px;
+  bottom: 74px;
+  width: 96px;
+  height: 96px;
+  border: 1px solid var(--accent-soft);
+  border-radius: 50%;
+  content: "";
+  opacity: 0.85;
+  transform: scale(0.78);
+  animation: pulse-ring 2.8s ease-in-out infinite;
+}
+
+.priority-ribbon {
+  position: absolute;
+  top: 19px;
+  right: -47px;
+  width: 174px;
+  padding: 8px 0;
+  color: #ffffff;
+  background: var(--accent);
+  box-shadow: 0 10px 24px var(--accent-soft);
+  text-align: center;
+  transform: rotate(38deg);
+  transform-origin: center;
+}
+
+.priority-ribbon span {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card-icon {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  margin: 28px 0 0 26px;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 1.25rem;
+  font-weight: 900;
+}
+
+.card-copy {
+  padding: 20px 86px 18px 26px;
+}
+
+.card-topic {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.card-copy h2 {
+  margin-bottom: 10px;
+  font-size: 1.28rem;
+  line-height: 1.2;
+}
+
+.card-copy p:not(.card-topic) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+  border-top: 1px solid var(--line);
+  padding: 16px 18px 16px 26px;
+}
+
+.card-footer span {
+  color: #40506a;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.card-footer button {
+  min-width: 92px;
+  min-height: 38px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.card-footer button:hover,
+.card-footer button:focus-visible {
+  box-shadow: 0 10px 22px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.action-critical {
+  --accent: var(--critical);
+  --accent-soft: rgba(220, 38, 38, 0.14);
+}
+
+.action-high {
+  --accent: var(--high);
+  --accent-soft: rgba(249, 115, 22, 0.16);
+}
+
+.action-medium {
+  --accent: var(--medium);
+  --accent-soft: rgba(37, 99, 235, 0.14);
+}
+
+.action-low {
+  --accent: var(--low);
+  --accent-soft: rgba(22, 163, 74, 0.14);
+}
+
+.action-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-4px);
+  transition:
+    border-color 220ms ease,
+    transform 220ms ease;
+}
+
+.action-card:hover .priority-ribbon {
+  animation: ribbon-breathe 700ms ease both;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes pulse-ring {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.78);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes ribbon-breathe {
+  0%,
+  100% {
+    filter: saturate(1);
+  }
+
+  50% {
+    filter: saturate(1.25) brightness(1.06);
+  }
+}
+
+@media (max-width: 820px) {
+  .action-center-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .summary-strip,
+  .notification-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .action-card {
+    min-height: 284px;
+  }
+
+  .card-copy {
+    padding-right: 74px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #46007


**PR Text**

Title: `feat: add action center priority ribbons demo`

Body:
```md
## Pull Request Description
Adds a self-contained Action Center Priority Ribbons demo under `submissions/examples/`, showing animated notification cards with priority ribbons, status icons, metadata, and action buttons.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only dashboard alert board for scanning notification priority quickly.

**How does a developer use it?**
Use `action-card` with a priority modifier such as `action-critical`, `action-high`, `action-medium`, or `action-low`.

**Why does it fit EaseMotion CSS?**
It uses readable CSS, purposeful motion, hover feedback, and reduced-motion support without JavaScript or external dependencies.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The naming and timing can be standardized during framework integration.