### PR TITLE
feat: add compare toggle cards demo

### DIFF
--- a/submissions/examples/compare-toggle-cards-sm/README.md
+++ b/submissions/examples/compare-toggle-cards-sm/README.md
@@ -1,0 +1,5 @@
+# Compare Toggle Cards
+
+1. What does this do? Adds CSS-only comparison cards that toggle between before and after states with animated metrics, emphasis colors, helper text, and preview details.
+2. How is it used? Place `#compare-toggle` before `.compare-switch` and `.compare-grid`, then add `.compare-card` items for each comparison point.
+3. Why is it useful? It helps teams explain interface improvements clearly with purposeful motion and no JavaScript.

--- a/submissions/examples/compare-toggle-cards-sm/demo.html
+++ b/submissions/examples/compare-toggle-cards-sm/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compare Toggle Cards</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="compare-panel" aria-labelledby="compare-title">
+      <div class="panel-copy">
+        <p class="eyebrow">Before and after</p>
+        <h1 id="compare-title">Toggle cards for comparing interface improvements</h1>
+        <p>
+          Use the CSS-only switch to compare the baseline and improved states. Cards animate their
+          emphasis, metrics, and helper text without JavaScript.
+        </p>
+      </div>
+
+      <div class="compare-demo">
+        <input type="checkbox" id="compare-toggle" aria-label="Show improved state">
+
+        <label class="compare-switch" for="compare-toggle">
+          <span class="switch-label before-label">Before</span>
+          <span class="switch-label after-label">After</span>
+          <span class="switch-thumb" aria-hidden="true"></span>
+        </label>
+
+        <div class="compare-grid" aria-label="Interface comparison cards">
+          <article class="compare-card speed-card">
+            <span class="card-kicker">Motion speed</span>
+            <div class="metric-row">
+              <strong class="before-value">420ms</strong>
+              <strong class="after-value">240ms</strong>
+            </div>
+            <p class="before-copy">Slow entrance timing makes dense screens feel delayed.</p>
+            <p class="after-copy">Shorter timing keeps feedback responsive while preserving polish.</p>
+            <div class="progress-track">
+              <span class="progress-fill"></span>
+            </div>
+          </article>
+
+          <article class="compare-card focus-card">
+            <span class="card-kicker">Focus clarity</span>
+            <div class="metric-row">
+              <strong class="before-value">Low</strong>
+              <strong class="after-value">High</strong>
+            </div>
+            <p class="before-copy">Keyboard focus is present but too subtle for quick scanning.</p>
+            <p class="after-copy">A stronger outline and offset make the active target obvious.</p>
+            <div class="focus-preview">
+              <span>Save changes</span>
+            </div>
+          </article>
+
+          <article class="compare-card density-card">
+            <span class="card-kicker">Layout density</span>
+            <div class="metric-row">
+              <strong class="before-value">Loose</strong>
+              <strong class="after-value">Balanced</strong>
+            </div>
+            <p class="before-copy">Content needs extra scrolling before the next action appears.</p>
+            <p class="after-copy">Spacing stays breathable while bringing related controls closer.</p>
+            <div class="density-preview">
+              <span></span>
+              <span></span>
+              <span></span>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/compare-toggle-cards-sm/style.css
+++ b/submissions/examples/compare-toggle-cards-sm/style.css
@@ -1,0 +1,410 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #182033;
+  --muted: #667085;
+  --line: #d9e2ee;
+  --before: #8a5a00;
+  --before-soft: #fff6df;
+  --after: #176b52;
+  --after-soft: #e7f7ef;
+  --accent: #3158e8;
+  --accent-soft: #e9eeff;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(49, 88, 232, 0.14), transparent 28rem),
+    radial-gradient(circle at 86% 82%, rgba(23, 107, 82, 0.12), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.compare-panel {
+  width: min(100%, 1040px);
+}
+
+.panel-copy {
+  max-width: 760px;
+  margin-bottom: 1.4rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-copy p:last-child {
+  max-width: 660px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.compare-demo {
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow);
+}
+
+.compare-demo > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.compare-switch {
+  position: relative;
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(7rem, 1fr));
+  gap: 0.25rem;
+  isolation: isolate;
+  margin-bottom: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.28rem;
+  background: #f8fbff;
+  cursor: pointer;
+}
+
+.switch-label {
+  position: relative;
+  z-index: 2;
+  padding: 0.68rem 1rem;
+  border-radius: 999px;
+  color: var(--muted);
+  font-weight: 850;
+  text-align: center;
+  transition: color 220ms ease;
+}
+
+.switch-thumb {
+  position: absolute;
+  inset: 0.28rem auto 0.28rem 0.28rem;
+  z-index: 1;
+  width: calc(50% - 0.28rem);
+  border-radius: 999px;
+  background: var(--before-soft);
+  box-shadow: inset 0 0 0 1px rgba(138, 90, 0, 0.16);
+  transition:
+    background-color 260ms ease,
+    box-shadow 260ms ease,
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+#compare-toggle:not(:checked) ~ .compare-switch .before-label {
+  color: var(--before);
+}
+
+#compare-toggle:checked ~ .compare-switch .after-label {
+  color: var(--after);
+}
+
+#compare-toggle:focus-visible ~ .compare-switch {
+  outline: 3px solid rgba(49, 88, 232, 0.28);
+  outline-offset: 5px;
+}
+
+#compare-toggle:checked ~ .compare-switch .switch-thumb {
+  background: var(--after-soft);
+  box-shadow: inset 0 0 0 1px rgba(23, 107, 82, 0.18);
+  transform: translateX(100%);
+}
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.compare-card {
+  position: relative;
+  overflow: hidden;
+  min-height: 21rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1.15rem;
+  background: var(--surface);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  animation: card-rise 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 240ms ease,
+    box-shadow 240ms ease,
+    transform 240ms ease;
+}
+
+.compare-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--before-soft), transparent 62%);
+  opacity: 0.75;
+  transition:
+    background 260ms ease,
+    opacity 260ms ease;
+}
+
+.compare-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.compare-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.compare-card:hover {
+  border-color: rgba(49, 88, 232, 0.38);
+  box-shadow: 0 18px 44px rgba(31, 42, 68, 0.14);
+  transform: translateY(-4px);
+}
+
+.card-kicker,
+.metric-row,
+.before-copy,
+.after-copy,
+.progress-track,
+.focus-preview,
+.density-preview {
+  position: relative;
+  z-index: 1;
+}
+
+.card-kicker {
+  display: inline-flex;
+  margin-bottom: 1rem;
+  border-radius: 999px;
+  padding: 0.28rem 0.68rem;
+  color: var(--before);
+  background: var(--before-soft);
+  font-size: 0.78rem;
+  font-weight: 850;
+  transition:
+    color 260ms ease,
+    background-color 260ms ease;
+}
+
+.metric-row {
+  display: grid;
+  min-height: 4.6rem;
+}
+
+.metric-row strong {
+  grid-area: 1 / 1;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 1;
+  transition:
+    opacity 260ms ease,
+    transform 260ms ease;
+}
+
+.after-value,
+.after-copy {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.before-copy,
+.after-copy {
+  min-height: 4.8rem;
+  margin: 0.75rem 0 1rem;
+  color: var(--muted);
+  line-height: 1.55;
+  transition:
+    opacity 260ms ease,
+    transform 260ms ease;
+}
+
+.after-copy {
+  margin-top: -5.8rem;
+}
+
+#compare-toggle:checked ~ .compare-grid .compare-card::before {
+  background: linear-gradient(180deg, var(--after-soft), transparent 62%);
+}
+
+#compare-toggle:checked ~ .compare-grid .card-kicker {
+  color: var(--after);
+  background: var(--after-soft);
+}
+
+#compare-toggle:checked ~ .compare-grid .before-value,
+#compare-toggle:checked ~ .compare-grid .before-copy {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+#compare-toggle:checked ~ .compare-grid .after-value,
+#compare-toggle:checked ~ .compare-grid .after-copy {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.progress-track {
+  height: 0.75rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #edf1f7;
+}
+
+.progress-fill {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--before);
+  transition:
+    width 280ms ease,
+    background-color 280ms ease;
+}
+
+#compare-toggle:checked ~ .compare-grid .progress-fill {
+  width: 78%;
+  background: var(--after);
+}
+
+.focus-preview {
+  display: inline-flex;
+  margin-top: 0.2rem;
+  border: 1px solid var(--line);
+  border-radius: 0.45rem;
+  padding: 0.75rem 1rem;
+  background: #ffffff;
+  font-weight: 800;
+  transition:
+    border-color 260ms ease,
+    box-shadow 260ms ease,
+    transform 260ms ease;
+}
+
+#compare-toggle:checked ~ .compare-grid .focus-preview {
+  border-color: var(--after);
+  box-shadow: 0 0 0 4px rgba(23, 107, 82, 0.14);
+  transform: translateY(-2px);
+}
+
+.density-preview {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.density-preview span {
+  display: block;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: #d9e2ee;
+  transition:
+    height 260ms ease,
+    width 260ms ease,
+    background-color 260ms ease;
+}
+
+.density-preview span:nth-child(1) {
+  width: 86%;
+}
+
+.density-preview span:nth-child(2) {
+  width: 68%;
+}
+
+.density-preview span:nth-child(3) {
+  width: 76%;
+}
+
+#compare-toggle:checked ~ .compare-grid .density-preview {
+  gap: 0.55rem;
+}
+
+#compare-toggle:checked ~ .compare-grid .density-preview span {
+  height: 0.62rem;
+  background: color-mix(in srgb, var(--after) 42%, #d9e2ee);
+}
+
+@keyframes card-rise {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 820px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .compare-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .compare-card {
+    min-height: 18rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .compare-switch {
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-label,
+  .switch-thumb,
+  .compare-card,
+  .compare-card::before,
+  .card-kicker,
+  .metric-row strong,
+  .before-copy,
+  .after-copy,
+  .progress-fill,
+  .focus-preview,
+  .density-preview span {
+    transition: none;
+  }
+
+  .compare-card {
+    animation: none;
+  }
+
+  .compare-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #46034

## Pull Request Description

Adds a self-contained Compare Toggle Cards demo with CSS-only before/after states, animated metrics, emphasis colors, helper text, preview details, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A responsive comparison card layout that toggles between before and after interface states using CSS-only controls and animated card details.

**How does a developer use it?**

```html
<div class="compare-demo">
  <input type="checkbox" id="compare-toggle" aria-label="Show improved state">

  <label class="compare-switch" for="compare-toggle">
    <span class="switch-label before-label">Before</span>
    <span class="switch-label after-label">After</span>
    <span class="switch-thumb" aria-hidden="true"></span>
  </label>

  <div class="compare-grid">
    <article class="compare-card">
      <span class="card-kicker">Motion speed</span>
      <div class="metric-row">
        <strong class="before-value">420ms</strong>
        <strong class="after-value">240ms</strong>
      </div>
    </article>
  </div>
</div>