### PR TITLE
feat: add focus mode command panel demo

### DIFF
--- a/submissions/examples/focus-mode-command-panel-sm/README.md
+++ b/submissions/examples/focus-mode-command-panel-sm/README.md
@@ -1,0 +1,31 @@
+# Focus Mode Command Panel
+
+## What does this do?
+
+Focus Mode Command Panel is a self-contained HTML and CSS command surface that presents productivity actions as animated, keyboard-friendly rows with strong focus states and a compact session summary.
+
+## How is it used?
+
+Create a `command-panel` wrapper, then add `command-item` buttons with item-specific accent classes such as `item-plan`, `item-review`, `item-note`, or `item-share`.
+
+```html
+<button class="command-item item-plan" type="button">
+  <span class="command-icon">01</span>
+  <span class="command-copy">
+    <strong>Plan next milestone</strong>
+    <small>Open planning checklist with the highest impact items.</small>
+  </span>
+  <span class="command-key">P</span>
+</button>
+```
+
+Available accent classes:
+
+- `item-plan`
+- `item-review`
+- `item-note`
+- `item-share`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to improve orientation: the panel enters gently, command rows appear in sequence, hover and focus states are clear, and the reduced-motion media query keeps the pattern accessible. The demo works directly in the browser with no JavaScript, CDNs, build tools, or external frameworks.

--- a/submissions/examples/focus-mode-command-panel-sm/demo.html
+++ b/submissions/examples/focus-mode-command-panel-sm/demo.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Focus Mode Command Panel Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="focus-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Focus Mode Command Panel</h1>
+        <p>
+          A self-contained command surface that turns common productivity
+          actions into animated, keyboard-friendly rows with clear focus and
+          hover states.
+        </p>
+      </section>
+
+      <section
+        class="command-layout"
+        aria-label="Focus mode command panel preview"
+      >
+        <aside class="session-card" aria-label="Current focus session">
+          <div class="session-ring" aria-hidden="true">
+            <span>42</span>
+          </div>
+          <p class="session-label">Minutes focused</p>
+          <h2>Deep Work Sprint</h2>
+          <p>
+            Batch similar actions, reduce context switching, and keep the next
+            decision visible without opening a full dashboard.
+          </p>
+          <div class="session-stats">
+            <span>3 tasks queued</span>
+            <span>1 blocker</span>
+          </div>
+        </aside>
+
+        <section class="command-panel" aria-labelledby="panel-title">
+          <div class="panel-header">
+            <div>
+              <p class="panel-kicker">Command Center</p>
+              <h2 id="panel-title">Choose the next action</h2>
+            </div>
+            <span class="shortcut">Ctrl K</span>
+          </div>
+
+          <div class="command-search" aria-hidden="true">
+            <span></span>
+            <p>Search tasks, docs, or shortcuts</p>
+          </div>
+
+          <div class="command-list">
+            <button class="command-item item-plan" type="button">
+              <span class="command-icon">01</span>
+              <span class="command-copy">
+                <strong>Plan next milestone</strong>
+                <small
+                  >Open planning checklist with the highest impact items.</small
+                >
+              </span>
+              <span class="command-key">P</span>
+            </button>
+
+            <button class="command-item item-review" type="button">
+              <span class="command-icon">02</span>
+              <span class="command-copy">
+                <strong>Review active blocker</strong>
+                <small>Surface unresolved notes and owner context.</small>
+              </span>
+              <span class="command-key">R</span>
+            </button>
+
+            <button class="command-item item-note" type="button">
+              <span class="command-icon">03</span>
+              <span class="command-copy">
+                <strong>Capture quick note</strong>
+                <small
+                  >Save an idea without leaving the current workflow.</small
+                >
+              </span>
+              <span class="command-key">N</span>
+            </button>
+
+            <button class="command-item item-share" type="button">
+              <span class="command-icon">04</span>
+              <span class="command-copy">
+                <strong>Share focus summary</strong>
+                <small
+                  >Generate a short update for teammates and handoffs.</small
+                >
+              </span>
+              <span class="command-key">S</span>
+            </button>
+          </div>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/focus-mode-command-panel-sm/style.css
+++ b/submissions/examples/focus-mode-command-panel-sm/style.css
@@ -1,0 +1,395 @@
+:root {
+  --page: #f4f7fb;
+  --surface: #ffffff;
+  --surface-soft: #eef3f9;
+  --ink: #172033;
+  --muted: #637083;
+  --line: #d9e2ee;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --red: #dc2626;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 32%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 35%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.focus-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.label,
+.panel-kicker,
+.session-label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.75rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.command-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.82fr) minmax(0, 1.4fr);
+  gap: 22px;
+  align-items: stretch;
+}
+
+.session-card,
+.command-panel {
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: var(--shadow);
+}
+
+.session-card {
+  position: relative;
+  overflow: hidden;
+  padding: 28px;
+  animation: panel-enter 640ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.session-card::before {
+  position: absolute;
+  inset: auto -80px -110px auto;
+  width: 250px;
+  height: 250px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 50%;
+  content: "";
+  animation: orbit-soft 7s linear infinite;
+}
+
+.session-ring {
+  display: grid;
+  width: 128px;
+  height: 128px;
+  margin-bottom: 28px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--blue) 0 74%, #dce7f8 74% 100%), var(--surface);
+  box-shadow:
+    inset 0 0 0 12px var(--surface),
+    0 18px 38px rgba(37, 99, 235, 0.18);
+}
+
+.session-ring span {
+  display: grid;
+  width: 84px;
+  height: 84px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--blue);
+  background: var(--surface);
+  font-size: 2.2rem;
+  font-weight: 900;
+}
+
+.session-card h2 {
+  margin-bottom: 12px;
+  font-size: 1.45rem;
+}
+
+.session-card p:not(.session-label) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.session-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.session-stats span {
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: #40506a;
+  background: rgba(255, 255, 255, 0.74);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.command-panel {
+  padding: 22px;
+  animation: panel-enter 640ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.panel-header h2 {
+  margin-bottom: 0;
+  font-size: 1.45rem;
+}
+
+.shortcut,
+.command-key {
+  display: inline-grid;
+  min-width: 48px;
+  min-height: 34px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-bottom-width: 3px;
+  border-radius: 7px;
+  color: #40506a;
+  background: var(--surface-soft);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.command-search {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 54px;
+  margin-bottom: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 0 16px;
+}
+
+.command-search span {
+  width: 13px;
+  height: 13px;
+  border: 2px solid var(--muted);
+  border-radius: 50%;
+  box-shadow: 7px 7px 0 -5px var(--muted);
+}
+
+.command-search p {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.command-list {
+  display: grid;
+  gap: 12px;
+}
+
+.command-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  width: 100%;
+  min-height: 86px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--surface);
+  padding: 14px;
+  text-align: left;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(12px);
+  animation: item-enter 520ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.command-item:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.command-item:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.command-item:nth-child(4) {
+  animation-delay: 240ms;
+}
+
+.command-item::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+  content: "";
+  background: var(--accent);
+  transform: scaleY(0.35);
+  transition: transform 180ms ease;
+}
+
+.command-icon {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.8rem;
+  font-weight: 950;
+}
+
+.command-copy {
+  display: grid;
+  gap: 5px;
+}
+
+.command-copy strong {
+  font-size: 1rem;
+}
+
+.command-copy small {
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.command-item:hover,
+.command-item:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 14px 28px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.command-item:hover::before,
+.command-item:focus-visible::before {
+  transform: scaleY(1);
+}
+
+.item-plan {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.14);
+}
+
+.item-review {
+  --accent: var(--red);
+  --accent-soft: rgba(220, 38, 38, 0.14);
+}
+
+.item-note {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.15);
+}
+
+.item-share {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.14);
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes item-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes orbit-soft {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 820px) {
+  .focus-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .command-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .command-item {
+    grid-template-columns: 48px minmax(0, 1fr);
+  }
+
+  .command-key {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #46039


**PR Text**

Title: `feat: add focus mode command panel demo`

```md
## Pull Request Description
Adds a self-contained Focus Mode Command Panel demo under `submissions/examples/`, featuring animated command rows, shortcut labels, focus states, and a session summary card.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only command panel pattern for focus-mode and productivity dashboards.

**How does a developer use it?**
Use `command-item` buttons with accent classes like `item-plan`, `item-review`, `item-note`, or `item-share`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion, readable CSS, keyboard-friendly focus styling, and reduced-motion support while staying fully standalone.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The class names and timing can be standardized during framework integration.