### PR TITLE
Add venus flytrap component

### DIFF
--- a/submissions/examples/venus-flytrap-as/README.md
+++ b/submissions/examples/venus-flytrap-as/README.md
@@ -1,0 +1,22 @@
+# Venus Flytrap
+
+### What does this do?
+
+It shows a venus flytrap in a pot, its two traps open and waiting while a fly buzzes above them. Hovering or focusing the plant snaps both traps shut on a fast easing curve and the fly disappears. Under reduced motion the traps stay open and nothing moves.
+
+### How is it used?
+
+```html
+<div class="trapPlant" tabindex="0">
+  <div class="trapA">
+    <span class="lobeV lvl"></span>
+    <span class="lobeV lvr"></span>
+  </div>
+</div>
+```
+
+The interlocking teeth are a `::after` pseudo-element on each lobe with a sawtooth `clip-path`, so a comb of nine spikes costs no extra markup. Each lobe keeps its open angle in a `--lv` custom property and pivots from the hinge where the two halves meet; the snap multiplies that angle by 0.08, collapsing it to almost closed while still respecting which way each lobe leans. The closing `cubic-bezier(0.2, 0, 0.1, 1)` over 0.28 seconds is the whole effect: a trap that eases shut is unconvincing, and a trap that snaps is not.
+
+### Why is it useful?
+
+Botanical, carnivorous plant, and trap or "gotcha" themes use a flytrap. This builds one with pure CSS clip paths and a transition driven hover, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/venus-flytrap-as/demo.html
+++ b/submissions/examples/venus-flytrap-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Venus Flytrap</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="trapPlant" tabindex="0">
+      <span class="potV"></span>
+      <span class="soilV"></span>
+      <span class="stalkV sv1"></span>
+      <span class="stalkV sv2"></span>
+      <div class="trapA">
+        <span class="lobeV lvl"></span>
+        <span class="lobeV lvr"></span>
+        <span class="throatV"></span>
+      </div>
+      <div class="trapB">
+        <span class="lobeV lvl"></span>
+        <span class="lobeV lvr"></span>
+        <span class="throatV"></span>
+      </div>
+      <span class="flyV"></span>
+    </div>
+    <span class="tableV"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/venus-flytrap-as/style.css
+++ b/submissions/examples/venus-flytrap-as/style.css
@@ -1,0 +1,238 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #3f4a34, #12160c 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 330px;
+}
+
+.tableV {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 300px;
+  height: 24px;
+  margin-left: -150px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 38, 16, 0.28) 0 2px,
+      transparent 2px 30px
+    ),
+    linear-gradient(180deg, #a97b4a, #6b4a26);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.55);
+}
+
+.trapPlant {
+  position: absolute;
+  bottom: 58px;
+  left: 50%;
+  width: 260px;
+  height: 260px;
+  margin-left: -130px;
+  outline: none;
+  z-index: 4;
+}
+
+.potV {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 130px;
+  height: 78px;
+  margin-left: -65px;
+  border-radius: 6px 6px 16px 16px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 40, 20, 0.18) 0 3px,
+      transparent 3px 22px
+    ),
+    linear-gradient(180deg, #c96f4a, #8a4324);
+  box-shadow: inset -8px 0 16px rgba(70, 30, 10, 0.4);
+  z-index: 5;
+}
+
+.soilV {
+  position: absolute;
+  bottom: 70px;
+  left: 50%;
+  width: 122px;
+  height: 18px;
+  margin-left: -61px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #4a3a24, #241b10);
+  z-index: 6;
+}
+
+.stalkV {
+  position: absolute;
+  bottom: 80px;
+  left: 50%;
+  width: 12px;
+  height: 90px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #6fa63f, #35611f);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--sv3, 0deg));
+  z-index: 4;
+  animation: swayV 5s ease-in-out infinite;
+}
+
+.sv1 {
+  margin-left: -46px;
+
+  --sv3: -14deg;
+}
+
+.sv2 {
+  margin-left: 32px;
+
+  --sv3: 12deg;
+
+  animation-delay: 1.6s;
+}
+
+.trapA,
+.trapB {
+  position: absolute;
+  width: 110px;
+  height: 90px;
+  z-index: 5;
+  transform-origin: 50% 100%;
+  animation: breatheV 5s ease-in-out infinite;
+}
+
+.trapA {
+  bottom: 158px;
+  left: 50%;
+  margin-left: -104px;
+  transform: rotate(var(--tv, 0deg));
+
+  --tv: -14deg;
+}
+
+.trapB {
+  bottom: 152px;
+  left: 50%;
+  margin-left: -6px;
+  transform: rotate(var(--tv, 0deg));
+  animation-delay: 1.6s;
+
+  --tv: 12deg;
+}
+
+.lobeV {
+  position: absolute;
+  bottom: 0;
+  width: 54px;
+  height: 78px;
+  border-radius: 60% 30% 20% 40% / 70% 40% 30% 60%;
+  background: linear-gradient(160deg, #8fc45a, #3f7a2c);
+  box-shadow: inset 0 -6px 12px rgba(30, 50, 12, 0.4);
+  transform-origin: 100% 100%;
+  transform: rotate(var(--lv, 0deg));
+  transition: transform 0.28s cubic-bezier(0.2, 0, 0.1, 1);
+}
+
+.lvl {
+  left: 0;
+
+  --lv: -26deg;
+}
+
+.lvr {
+  right: 0;
+  border-radius: 30% 60% 40% 20% / 40% 70% 60% 30%;
+  transform-origin: 0 100%;
+
+  --lv: 26deg;
+}
+
+.lobeV::after {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 4px;
+  width: 46px;
+  height: 22px;
+  clip-path: polygon(0 100%, 8% 0, 20% 100%, 32% 0, 44% 100%, 56% 0, 68% 100%, 80% 0, 92% 100%, 100% 20%, 100% 100%);
+  background: linear-gradient(180deg, #d95f6a, #8f2f38);
+}
+
+.throatV {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  width: 52px;
+  height: 46px;
+  margin-left: -26px;
+  border-radius: 50% 50% 30% 30%;
+  background: radial-gradient(circle at 50% 80%, #e0566a, #7d1f2c 76%);
+  z-index: -1;
+}
+
+.trapPlant:hover .lobeV,
+.trapPlant:focus-visible .lobeV {
+  transform: rotate(calc(var(--lv, 0deg) * 0.08));
+}
+
+.flyV {
+  position: absolute;
+  bottom: 236px;
+  left: 50%;
+  width: 14px;
+  height: 9px;
+  margin-left: -76px;
+  border-radius: 50%;
+  background: #2a2a30;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.18);
+  z-index: 7;
+  animation: buzzV 4s ease-in-out infinite;
+  transition: opacity 0.2s ease 0.2s;
+}
+
+.trapPlant:hover .flyV,
+.trapPlant:focus-visible .flyV {
+  opacity: 0;
+}
+
+@keyframes breatheV {
+  0%, 100% { transform: rotate(var(--tv, 0deg)) translateY(0); }
+  50% { transform: rotate(var(--tv, 0deg)) translateY(-4px); }
+}
+
+@keyframes swayV {
+  0%, 100% { transform: rotate(var(--sv3, 0deg)); }
+  50% { transform: rotate(calc(var(--sv3, 0deg) + 5deg)); }
+}
+
+@keyframes buzzV {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(22px, 14px); }
+  50% { transform: translate(6px, 30px); }
+  75% { transform: translate(26px, 8px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trapA,
+  .trapB,
+  .stalkV,
+  .flyV {
+    animation: none;
+  }
+
+  .lobeV {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a venus flytrap built for #46045. The interlocking teeth are a `::after` pseudo-element on each lobe with a sawtooth clip-path, so a comb of nine spikes costs no extra markup. Each lobe keeps its open angle in a `--lv` custom property and pivots from the hinge where the halves meet; the snap multiplies that angle by 0.08, collapsing it to almost closed while still respecting which way each lobe leans. The closing cubic-bezier over 0.28 seconds is the whole effect, because a trap that eases shut is unconvincing and one that snaps is not. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #46045.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a potted venus flytrap with two toothed traps gaping open over red throats, a fly buzzing above them.
