### PR TITLE
Add orrery component

### DIFF
--- a/submissions/examples/orrery-as/README.md
+++ b/submissions/examples/orrery-as/README.md
@@ -1,0 +1,22 @@
+# Orrery
+
+### What does this do?
+
+It shows a brass orrery: three planets circling a glowing sun on dashed orbit rings, with a moon orbiting the outermost planet. Each planet keeps its own year, the inner ones fast and the outer ones slow. Hovering or focusing the model spins the whole mechanism up, and every body speeds up in proportion, so the relative periods stay correct even at five times the speed. Under reduced motion the system holds its positions.
+
+### How is it used?
+
+```html
+<div class="orrery" tabindex="0">
+  <div class="armO a3">
+    <span class="planetO p3"></span>
+    <div class="moonArm"><span class="moonO"></span></div>
+  </div>
+</div>
+```
+
+Each planet hangs off a zero-sized arm pinned at the centre of the model, and it is the arm that rotates, not the planet, so a single `rotate` sweeps the body around a perfect circle without any orbital maths. The moon nests one level deeper: its own arm sits inside the outer planet's arm, so it inherits that planet's orbit and adds its own on top, which is how a real moon moves. Hovering shortens all four durations by the same factor, which is why the model speeds up without losing its relative periods.
+
+### Why is it useful?
+
+Astronomy, mechanical, and system or hierarchy themes use an orrery. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/orrery-as/demo.html
+++ b/submissions/examples/orrery-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Orrery</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="orrery" tabindex="0">
+      <span class="orbit ob1"></span>
+      <span class="orbit ob2"></span>
+      <span class="orbit ob3"></span>
+      <div class="armO a1"><span class="planetO p1"></span></div>
+      <div class="armO a2"><span class="planetO p2"></span></div>
+      <div class="armO a3">
+        <span class="planetO p3"></span>
+        <div class="moonArm"><span class="moonO"></span></div>
+      </div>
+      <span class="sunO"></span>
+      <span class="glowO"></span>
+      <span class="pillarO"></span>
+      <span class="baseO"></span>
+    </div>
+    <span class="starO so1"></span>
+    <span class="starO so2"></span>
+    <span class="starO so3"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/orrery-as/style.css
+++ b/submissions/examples/orrery-as/style.css
@@ -1,0 +1,247 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #232a44, #070911 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.starO {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff6dc;
+  box-shadow: 0 0 8px rgba(255, 245, 210, 0.9);
+  animation: twinkleO 3.2s ease-in-out infinite;
+}
+
+.so1 { top: 30px; left: 34px; }
+
+.so2 {
+  top: 66px;
+  right: 40px;
+  animation-delay: 1.1s;
+}
+
+.so3 {
+  bottom: 40px;
+  left: 60px;
+  animation-delay: 2.2s;
+}
+
+.orrery {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 280px;
+  height: 280px;
+  margin-left: -140px;
+  outline: none;
+  z-index: 4;
+}
+
+.baseO {
+  position: absolute;
+  bottom: -20px;
+  left: 50%;
+  width: 150px;
+  height: 22px;
+  margin-left: -75px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #d9b45e, #8a6a1e);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.55);
+  z-index: 3;
+}
+
+.pillarO {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 20px;
+  height: 130px;
+  margin-left: -10px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #e8c75e, #8a6a1e);
+  z-index: 3;
+}
+
+.sunO {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  margin: -22px 0 0 -22px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #fff6c0, #f0a020 74%);
+  box-shadow: 0 0 30px rgba(255, 180, 60, 0.9);
+  z-index: 7;
+  animation: pulseO 4s ease-in-out infinite;
+}
+
+.glowO {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 140px;
+  height: 140px;
+  margin: -70px 0 0 -70px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 190, 90, 0.22), transparent 66%);
+  filter: blur(8px);
+  z-index: 3;
+  animation: pulseO 4s ease-in-out infinite;
+}
+
+.orbit {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 50%;
+  border: 1px dashed rgba(232, 199, 94, 0.4);
+  box-sizing: border-box;
+  z-index: 4;
+}
+
+.ob1 {
+  width: 110px;
+  height: 110px;
+  margin: -55px 0 0 -55px;
+}
+
+.ob2 {
+  width: 176px;
+  height: 176px;
+  margin: -88px 0 0 -88px;
+}
+
+.ob3 {
+  width: 244px;
+  height: 244px;
+  margin: -122px 0 0 -122px;
+}
+
+.armO {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 5;
+}
+
+.a1 {
+  animation: spinO 6s linear infinite;
+}
+
+.a2 {
+  animation: spinO 12s linear infinite;
+}
+
+.a3 {
+  animation: spinO 22s linear infinite;
+}
+
+.planetO {
+  position: absolute;
+  border-radius: 50%;
+  box-shadow: inset -3px -3px 6px rgba(0, 0, 0, 0.5);
+}
+
+.p1 {
+  top: -63px;
+  left: -8px;
+  width: 16px;
+  height: 16px;
+  background: radial-gradient(circle at 36% 32%, #f0a86a, #a8551c 74%);
+}
+
+.p2 {
+  top: -98px;
+  left: -11px;
+  width: 22px;
+  height: 22px;
+  background: radial-gradient(circle at 36% 32%, #8fd0e8, #2f6f96 74%);
+}
+
+.p3 {
+  top: -134px;
+  left: -13px;
+  width: 26px;
+  height: 26px;
+  background: radial-gradient(circle at 36% 32%, #a8e08a, #3f7a34 74%);
+}
+
+.moonArm {
+  position: absolute;
+  top: -121px;
+  left: 0;
+  width: 0;
+  height: 0;
+  animation: spinO 3s linear infinite;
+  z-index: 6;
+}
+
+.moonO {
+  position: absolute;
+  top: -24px;
+  left: -5px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #fdfaf0, #a9a294 74%);
+}
+
+.orrery:hover .a1,
+.orrery:focus-visible .a1 {
+  animation-duration: 1.2s;
+}
+
+.orrery:hover .a2,
+.orrery:focus-visible .a2 {
+  animation-duration: 2.4s;
+}
+
+.orrery:hover .a3,
+.orrery:focus-visible .a3 {
+  animation-duration: 4.4s;
+}
+
+.orrery:hover .moonArm,
+.orrery:focus-visible .moonArm {
+  animation-duration: 0.6s;
+}
+
+@keyframes spinO {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes pulseO {
+  0%, 100% { opacity: 0.85; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.06); }
+}
+
+@keyframes twinkleO {
+  0%, 100% { opacity: 0.3; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(1.25); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .armO,
+  .moonArm,
+  .sunO,
+  .glowO,
+  .starO {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an orrery built for #46047. Each planet hangs off a zero sized arm pinned at the centre of the model, and it is the arm that rotates rather than the planet, so a single rotate sweeps each body around a perfect circle with no orbital maths. The moon nests one level deeper: its arm sits inside the outer planet's arm, so it inherits that planet's orbit and adds its own on top, which is how a real moon moves. Hovering shortens all four durations by the same factor, so the model speeds up without losing its relative periods. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #46047.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a brass orrery on a pillar with a glowing sun, three dashed orbit rings carrying planets, and a moon orbiting the outermost planet.
