### PR TITLE
Add gramophone component

### DIFF
--- a/submissions/examples/gramophone-as/README.md
+++ b/submissions/examples/gramophone-as/README.md
@@ -1,0 +1,23 @@
+# Gramophone
+
+### What does this do?
+
+It shows a wind-up gramophone playing a record. The platter spins, the tone arm tracks slowly inward across the disc as it plays, the crank turns, and notes drift out of the horn. Hovering or focusing it spins the record up to two and a half times the speed. Under reduced motion everything stops.
+
+### How is it used?
+
+```html
+<div class="gramo" tabindex="0">
+  <div class="platter">
+    <span class="discG"></span>
+    <span class="grooves"></span>
+  </div>
+  <div class="toneArm"><span class="headG"></span></div>
+</div>
+```
+
+The record's grooves are a `repeating-radial-gradient` of hairline rings, which gives hundreds of concentric grooves from one property, and because they sit inside the spinning platter they turn with the disc. The tone arm's motion is the detail worth copying: rather than swinging back and forth, it rotates from `transform-origin: 92% 50%`, its pivot at the far end, through a slow twelve second sweep that only ever moves inward. A record arm that oscillates looks wrong; one that creeps steadily toward the label looks like it is playing.
+
+### Why is it useful?
+
+Vintage, music, and nostalgic themes use a gramophone. This builds one with pure CSS gradients and animation, no images and no JavaScript, with a reduced motion fallback.

--- a/submissions/examples/gramophone-as/demo.html
+++ b/submissions/examples/gramophone-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gramophone</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="gramo" tabindex="0">
+      <span class="hornG"></span>
+      <span class="hornLip"></span>
+      <span class="hornRibs"></span>
+      <span class="neckG"></span>
+      <span class="boxG"></span>
+      <span class="boxTrim"></span>
+      <div class="platter">
+        <span class="discG"></span>
+        <span class="grooves"></span>
+        <span class="labelG"></span>
+      </div>
+      <div class="toneArm">
+        <span class="armG"></span>
+        <span class="headG"></span>
+      </div>
+      <span class="crankG"></span>
+    </div>
+    <span class="noteG ng1"></span>
+    <span class="noteG ng2"></span>
+    <span class="noteG ng3"></span>
+    <span class="tableG"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gramophone-as/style.css
+++ b/submissions/examples/gramophone-as/style.css
@@ -1,0 +1,293 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 32%, #4a3b2e, #16100b 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.tableG {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 310px;
+  height: 24px;
+  margin-left: -155px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 38, 16, 0.28) 0 2px,
+      transparent 2px 30px
+    ),
+    linear-gradient(180deg, #a97b4a, #6b4a26);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.55);
+}
+
+.gramo {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 290px;
+  height: 260px;
+  margin-left: -145px;
+  outline: none;
+  z-index: 4;
+}
+
+.boxG {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 190px;
+  height: 62px;
+  margin-left: -95px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(70, 40, 14, 0.25) 0 2px,
+      transparent 2px 16px
+    ),
+    linear-gradient(180deg, #8a5a30, #4f3418);
+  box-shadow: inset 0 -6px 12px rgba(40, 22, 6, 0.5);
+  z-index: 5;
+}
+
+.boxTrim {
+  position: absolute;
+  bottom: 56px;
+  left: 50%;
+  width: 200px;
+  height: 12px;
+  margin-left: -100px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #e8c75e, #a3822c);
+  z-index: 6;
+}
+
+.platter {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 130px;
+  height: 130px;
+  margin-left: -80px;
+  z-index: 5;
+  animation: spinG 3.6s linear infinite;
+}
+
+.gramo:hover .platter,
+.gramo:focus-visible .platter {
+  animation-duration: 1.4s;
+}
+
+.discG {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 34%, #3a3a44, #14141a 78%);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.5);
+}
+
+.grooves {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(
+      circle,
+      rgba(220, 220, 235, 0.14) 0 1px,
+      transparent 1px 5px
+    );
+  z-index: 2;
+}
+
+.labelG {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 42px;
+  height: 42px;
+  margin: -21px 0 0 -21px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #e8a04a, #a3521c 74%);
+  box-shadow: inset 0 0 0 3px rgba(240, 220, 180, 0.35);
+  z-index: 3;
+}
+
+.toneArm {
+  position: absolute;
+  bottom: 118px;
+  left: 50%;
+  width: 130px;
+  height: 20px;
+  margin-left: 6px;
+  transform-origin: 92% 50%;
+  transform: rotate(18deg);
+  z-index: 7;
+  animation: trackG 12s ease-in-out infinite;
+}
+
+.armG {
+  position: absolute;
+  top: 6px;
+  left: 0;
+  width: 130px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #cfd6dd, #8b929c);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.headG {
+  position: absolute;
+  top: 0;
+  left: -6px;
+  width: 24px;
+  height: 20px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #e8c75e, #8a6a1e);
+}
+
+.neckG {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 22px;
+  height: 60px;
+  margin-left: 52px;
+  border-radius: 10px;
+  background: linear-gradient(90deg, #e8c75e, #8a6a1e);
+  transform: rotate(-16deg);
+  transform-origin: 50% 100%;
+  z-index: 5;
+}
+
+.hornG {
+  position: absolute;
+  bottom: 128px;
+  left: 50%;
+  width: 170px;
+  height: 130px;
+  margin-left: -6px;
+  clip-path: polygon(0 88%, 22% 96%, 100% 100%, 100% 0, 22% 8%);
+  background: linear-gradient(120deg, #f0d489, #a3822c 70%, #7d6318);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.hornRibs {
+  position: absolute;
+  bottom: 128px;
+  left: 50%;
+  width: 170px;
+  height: 130px;
+  margin-left: -6px;
+  clip-path: polygon(0 88%, 22% 96%, 100% 100%, 100% 0, 22% 8%);
+  background:
+    repeating-linear-gradient(
+      86deg,
+      rgba(90, 66, 10, 0.28) 0 2px,
+      transparent 2px 20px
+    );
+  z-index: 5;
+}
+
+.hornLip {
+  position: absolute;
+  bottom: 122px;
+  left: 50%;
+  width: 26px;
+  height: 142px;
+  margin-left: 148px;
+  border-radius: 50%;
+  background: linear-gradient(90deg, #fff0bc, #b8923a);
+  box-shadow: inset -4px 0 8px rgba(90, 66, 10, 0.4);
+  z-index: 6;
+}
+
+.crankG {
+  position: absolute;
+  bottom: 22px;
+  left: 50%;
+  width: 54px;
+  height: 8px;
+  margin-left: 92px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #b8923a, #e8c75e);
+  transform-origin: 0 50%;
+  z-index: 6;
+  animation: windG 3.6s linear infinite;
+}
+
+.noteG {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fdf6e6;
+  box-shadow: 9px -12px 0 -3px #fdf6e6;
+  opacity: 0;
+  z-index: 8;
+  animation: floatG 3.4s ease-out infinite;
+}
+
+.ng1 { top: 60px; right: 40px; }
+
+.ng2 {
+  top: 30px;
+  right: 78px;
+  animation-delay: 1.1s;
+
+  --gx: 26px;
+}
+
+.ng3 {
+  top: 96px;
+  right: 24px;
+  animation-delay: 2.2s;
+
+  --gx: -18px;
+}
+
+@keyframes spinG {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes windG {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes trackG {
+  0% { transform: rotate(18deg); }
+  100% { transform: rotate(30deg); }
+}
+
+@keyframes floatG {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translate(var(--gx, 18px), -70px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .platter,
+  .toneArm,
+  .crankG,
+  .noteG {
+    animation: none;
+  }
+
+  .noteG {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a gramophone built for #46049. The record's grooves are a repeating radial gradient of hairline rings, which gives hundreds of concentric grooves from one property, and because they sit inside the spinning platter they turn with the disc. The tone arm is the detail worth copying: rather than swinging back and forth it rotates from a pivot at its far end through a slow twelve second sweep that only ever moves inward, because an arm that oscillates looks wrong while one that creeps steadily toward the label looks like it is playing. Reduced motion fallback included. Pure CSS, no JavaScript. Closes #46049.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: a wind-up gramophone with a flared ribbed horn, a grooved record with an orange label, a tone arm and a crank on a wooden box.
