### PR TITLE
Add pitcher plant component

### DIFF
--- a/submissions/examples/pitcher-plant-as/README.md
+++ b/submissions/examples/pitcher-plant-as/README.md
@@ -1,0 +1,21 @@
+# Pitcher Plant
+
+### What does this do?
+
+It shows two pitcher plants hanging from a vine. They sway on their tendrils, their lids tilt, the digestive fluid inside sloshes, nectar drips from the rims, and an insect follows the lure around the mouth of one pitcher before falling in and vanishing.
+
+### How is it used?
+
+```html
+<div class="pitcher pcA">
+  <span class="lidP"></span>
+  <span class="peristome"></span>
+  <span class="jugP"></span>
+</div>
+```
+
+The ribbed rim, a pitcher plant's peristome, is a `repeating-conic-gradient` laid over a warm radial base, so the fine radial ribs that guide insects inward come from one property. The insect's path is a single keyframe that walks it around the rim, tips it over the edge at 75 percent and fades it out below the rim, so a whole capture reads as one movement. Note the second pitcher: its smaller size lives in a `--ps` custom property that the sway keyframe rebuilds, because a static `transform: scale()` would have been silently wiped by the animation.
+
+### Why is it useful?
+
+Botanical, carnivorous plant, and jungle themes use a pitcher plant. This builds one with pure CSS gradients and animation, no images, with a reduced motion fallback.

--- a/submissions/examples/pitcher-plant-as/demo.html
+++ b/submissions/examples/pitcher-plant-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pitcher Plant</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="vineP"></span>
+    <div class="pitcher pcA">
+      <span class="lidP"></span>
+      <span class="peristome"></span>
+      <span class="jugP"></span>
+      <span class="veinsP"></span>
+      <span class="fluidP"></span>
+      <span class="tendril"></span>
+    </div>
+    <div class="pitcher pcB">
+      <span class="lidP"></span>
+      <span class="peristome"></span>
+      <span class="jugP"></span>
+      <span class="veinsP"></span>
+      <span class="fluidP"></span>
+      <span class="tendril"></span>
+    </div>
+    <span class="bugP"></span>
+    <span class="dropP dp3"></span>
+    <span class="dropP dp4"></span>
+    <span class="mossP"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pitcher-plant-as/style.css
+++ b/submissions/examples/pitcher-plant-as/style.css
@@ -1,0 +1,235 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #35492f, #0e130a 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 330px;
+  height: 330px;
+}
+
+.mossP {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 50px);
+  background:
+    radial-gradient(circle at 22% 0, #4f7a34 0 20px, transparent 20px),
+    radial-gradient(circle at 58% 4%, #3f6a2c 0 24px, transparent 24px),
+    radial-gradient(circle at 86% 0, #4f7a34 0 18px, transparent 18px),
+    linear-gradient(180deg, #3a5a28, #1a2a12);
+}
+
+.vineP {
+  position: absolute;
+  top: 20px;
+  left: -50vw;
+  right: -50vw;
+  height: 14px;
+  border-radius: 7px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(30, 50, 12, 0.35) 0 3px,
+      transparent 3px 18px
+    ),
+    linear-gradient(180deg, #6f9a3c, #3f5f22);
+  z-index: 3;
+}
+
+.pitcher {
+  position: absolute;
+  top: 26px;
+  width: 150px;
+  height: 250px;
+  transform-origin: 50% 2%;
+  z-index: 5;
+  animation: swingP2 5s ease-in-out infinite;
+}
+
+.pcA {
+  left: 50%;
+  margin-left: -140px;
+}
+
+.pcB {
+  left: 50%;
+  margin-left: 10px;
+  animation-delay: 1.8s;
+
+  --ps: 0.86;
+}
+
+.tendril {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 8px;
+  height: 56px;
+  margin-left: -4px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6f9a3c, #3f5f22);
+  z-index: 3;
+}
+
+.jugP {
+  position: absolute;
+  top: 68px;
+  left: 50%;
+  width: 104px;
+  height: 150px;
+  margin-left: -52px;
+  border-radius: 34% 34% 46% 46% / 22% 22% 78% 78%;
+  background: linear-gradient(160deg, #b4d06a, #5f7a2c);
+  box-shadow:
+    inset -10px -10px 24px rgba(40, 60, 10, 0.45),
+    0 12px 26px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.veinsP {
+  position: absolute;
+  top: 68px;
+  left: 50%;
+  width: 104px;
+  height: 150px;
+  margin-left: -52px;
+  border-radius: 34% 34% 46% 46% / 22% 22% 78% 78%;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(150, 30, 40, 0.35) 0 3px,
+      transparent 3px 17px
+    );
+  z-index: 5;
+}
+
+.fluidP {
+  position: absolute;
+  top: 168px;
+  left: 50%;
+  width: 88px;
+  height: 44px;
+  margin-left: -44px;
+  border-radius: 0 0 44% 44% / 0 0 90% 90%;
+  background: linear-gradient(180deg, rgba(170, 220, 210, 0.6), rgba(90, 150, 140, 0.35));
+  z-index: 6;
+  animation: sloshP 5s ease-in-out infinite;
+}
+
+.peristome {
+  position: absolute;
+  top: 56px;
+  left: 50%;
+  width: 122px;
+  height: 30px;
+  margin-left: -61px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(150, 30, 40, 0.45) 0 3deg,
+      transparent 3deg 9deg
+    ),
+    radial-gradient(circle at 40% 34%, #e8935c, #a8452c 76%);
+  box-shadow: inset 0 -4px 10px rgba(90, 20, 10, 0.45);
+  z-index: 6;
+}
+
+.lidP {
+  position: absolute;
+  top: 22px;
+  left: 50%;
+  width: 110px;
+  height: 44px;
+  margin-left: -55px;
+  border-radius: 60% 60% 20% 20% / 80% 80% 20% 20%;
+  background: linear-gradient(160deg, #c2dc78, #6a8a34);
+  box-shadow: 0 4px 10px rgba(20, 40, 6, 0.4);
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: lidP2 5s ease-in-out infinite;
+}
+
+.bugP {
+  position: absolute;
+  top: 74px;
+  left: 50%;
+  width: 13px;
+  height: 9px;
+  margin-left: -110px;
+  border-radius: 50%;
+  background: #2a2a30;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+  z-index: 7;
+  animation: lureP 6s ease-in infinite;
+}
+
+.dropP {
+  position: absolute;
+  width: 8px;
+  height: 11px;
+  border-radius: 50% 50% 60% 60%;
+  background: rgba(200, 240, 235, 0.85);
+  opacity: 0;
+  z-index: 7;
+  animation: dripP2 4.4s ease-in infinite;
+}
+
+.dp3 { top: 92px; left: 84px; }
+
+.dp4 {
+  top: 86px;
+  right: 92px;
+  animation-delay: 2.2s;
+}
+
+@keyframes swingP2 {
+  0%, 100% { transform: rotate(-2deg) scale(var(--ps, 1)); }
+  50% { transform: rotate(2deg) scale(var(--ps, 1)); }
+}
+
+@keyframes lidP2 {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes sloshP {
+  0%, 100% { transform: scaleY(1) translateX(0); }
+  50% { transform: scaleY(1.08) translateX(3px); }
+}
+
+@keyframes lureP {
+  0% { transform: translate(0, 0); opacity: 1; }
+  55% { transform: translate(48px, -14px); opacity: 1; }
+  75% { transform: translate(58px, 30px); opacity: 1; }
+  85%, 100% { transform: translate(58px, 90px); opacity: 0; }
+}
+
+@keyframes dripP2 {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  25% { opacity: 0.9; }
+  100% { transform: translateY(40px) scale(1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pitcher,
+  .lidP,
+  .fluidP,
+  .bugP,
+  .dropP {
+    animation: none;
+  }
+
+  .dropP {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pitcher plant built for #46051. The ribbed rim, a pitcher plant's peristome, is a repeating conic gradient over a warm radial base, so the fine ribs that guide insects inward come from one property. The insect's path is a single keyframe that walks it around the rim, tips it over the edge at 75 percent and fades it out below, so a whole capture reads as one movement. The second pitcher's smaller size lives in a `--ps` custom property that the sway keyframe rebuilds, because a static `transform: scale()` would have been silently wiped by the animation. Reduced motion fallback included. Pure CSS. Closes #46051.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` (self-contained, opens in browser with no server)
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Notes for Maintainer

Verified in Chromium with a screenshot: two pitcher plants hanging from a vine with ribbed orange rims, veined jugs holding fluid, lids above them and an insect at one rim.
