### PR TITLE
feat: add kanban lane progress pulse demo

### DIFF
--- a/submissions/examples/kanban-lane-progress-pulse-sm/README.md
+++ b/submissions/examples/kanban-lane-progress-pulse-sm/README.md
@@ -1,0 +1,40 @@
+# Kanban Lane Progress Pulse
+
+## What does this do?
+
+Kanban Lane Progress Pulse is a self-contained HTML and CSS board pattern that shows delivery status with animated lanes, progress bars, pulsing progress markers, and hoverable task cards.
+
+## How is it used?
+
+Create a `kanban-board` wrapper and add `kanban-lane` sections with lane modifier classes such as `lane-backlog`, `lane-progress`, `lane-review`, or `lane-done`.
+
+```html
+<article class="kanban-lane lane-progress">
+  <header class="lane-header">
+    <div>
+      <p>In Progress</p>
+      <h2>Being built</h2>
+    </div>
+    <span class="lane-count">04</span>
+  </header>
+  <div class="progress-track" aria-hidden="true">
+    <span></span>
+  </div>
+  <article class="task-card">
+    <span class="task-tag">Frontend</span>
+    <h3>Refine dashboard filters</h3>
+    <p>Add tighter spacing, clearer active states, and predictable wrapping.</p>
+  </article>
+</article>
+```
+
+Available lane classes:
+
+- `lane-backlog`
+- `lane-progress`
+- `lane-review`
+- `lane-done`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using animation to communicate state: lanes enter gently, progress bars reveal their completion level, pulse markers draw attention without JavaScript, and hover states make each task feel interactive. The demo is standalone and works by opening `demo.html` directly in a browser.

--- a/submissions/examples/kanban-lane-progress-pulse-sm/demo.html
+++ b/submissions/examples/kanban-lane-progress-pulse-sm/demo.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kanban Lane Progress Pulse Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="kanban-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Kanban Lane Progress Pulse</h1>
+        <p>
+          A self-contained Kanban board pattern with animated lane progress
+          bars, task cards, and pulse markers that make delivery status easier
+          to scan.
+        </p>
+      </section>
+
+      <section class="board-summary" aria-label="Sprint summary">
+        <article>
+          <span class="summary-number">18</span>
+          <span class="summary-text">Tasks in sprint</span>
+        </article>
+        <article>
+          <span class="summary-number">7</span>
+          <span class="summary-text">In review</span>
+        </article>
+        <article>
+          <span class="summary-number">83%</span>
+          <span class="summary-text">Delivery confidence</span>
+        </article>
+      </section>
+
+      <section class="kanban-board" aria-label="Animated Kanban lanes">
+        <article class="kanban-lane lane-backlog">
+          <header class="lane-header">
+            <div>
+              <p>Backlog</p>
+              <h2>Ready to refine</h2>
+            </div>
+            <span class="lane-count">05</span>
+          </header>
+          <div class="progress-track" aria-hidden="true">
+            <span></span>
+          </div>
+          <div class="task-list">
+            <article class="task-card">
+              <span class="task-tag">Research</span>
+              <h3>Map empty-state variants</h3>
+              <p>
+                Compare tone, density, and action hierarchy for low-data states.
+              </p>
+            </article>
+            <article class="task-card">
+              <span class="task-tag">UX</span>
+              <h3>Audit onboarding hints</h3>
+              <p>
+                Reduce repeated helper text and keep first-run guidance
+                contextual.
+              </p>
+            </article>
+          </div>
+        </article>
+
+        <article class="kanban-lane lane-progress">
+          <header class="lane-header">
+            <div>
+              <p>In Progress</p>
+              <h2>Being built</h2>
+            </div>
+            <span class="lane-count">04</span>
+          </header>
+          <div class="progress-track" aria-hidden="true">
+            <span></span>
+          </div>
+          <div class="task-list">
+            <article class="task-card">
+              <span class="task-tag">Frontend</span>
+              <h3>Refine dashboard filters</h3>
+              <p>
+                Add tighter spacing, clearer active states, and predictable
+                wrapping.
+              </p>
+            </article>
+            <article class="task-card">
+              <span class="task-tag">Motion</span>
+              <h3>Smooth lane transitions</h3>
+              <p>
+                Keep cards readable while status changes animate between
+                columns.
+              </p>
+            </article>
+          </div>
+        </article>
+
+        <article class="kanban-lane lane-review">
+          <header class="lane-header">
+            <div>
+              <p>Review</p>
+              <h2>Needs feedback</h2>
+            </div>
+            <span class="lane-count">07</span>
+          </header>
+          <div class="progress-track" aria-hidden="true">
+            <span></span>
+          </div>
+          <div class="task-list">
+            <article class="task-card">
+              <span class="task-tag">QA</span>
+              <h3>Validate keyboard paths</h3>
+              <p>
+                Check focus order, escape flows, and visible focus for every
+                action.
+              </p>
+            </article>
+            <article class="task-card">
+              <span class="task-tag">Docs</span>
+              <h3>Update release notes</h3>
+              <p>
+                Summarize user-facing changes with migration notes and examples.
+              </p>
+            </article>
+          </div>
+        </article>
+
+        <article class="kanban-lane lane-done">
+          <header class="lane-header">
+            <div>
+              <p>Done</p>
+              <h2>Ready to ship</h2>
+            </div>
+            <span class="lane-count">02</span>
+          </header>
+          <div class="progress-track" aria-hidden="true">
+            <span></span>
+          </div>
+          <div class="task-list">
+            <article class="task-card">
+              <span class="task-tag">Design</span>
+              <h3>Polish status badges</h3>
+              <p>
+                Align colors and label lengths across the issue detail surfaces.
+              </p>
+            </article>
+            <article class="task-card">
+              <span class="task-tag">Build</span>
+              <h3>Remove stale snapshots</h3>
+              <p>
+                Clean test artifacts and keep the release branch easier to
+                review.
+              </p>
+            </article>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/kanban-lane-progress-pulse-sm/style.css
+++ b/submissions/examples/kanban-lane-progress-pulse-sm/style.css
@@ -1,0 +1,383 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #182033;
+  --muted: #637083;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(24, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.kanban-shell {
+  width: min(1240px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 46px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.75rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.board-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.board-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(24, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(24, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-number {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-text {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.kanban-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.kanban-lane {
+  position: relative;
+  isolation: isolate;
+  min-height: 520px;
+  overflow: hidden;
+  border: 1px solid rgba(24, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: var(--shadow);
+  padding: 18px;
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  animation: lane-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.kanban-lane:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.kanban-lane:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.kanban-lane:nth-child(4) {
+  animation-delay: 270ms;
+}
+
+.kanban-lane::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.74)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.lane-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.lane-header p {
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.lane-header h2 {
+  margin-bottom: 0;
+  font-size: 1.18rem;
+  line-height: 1.25;
+}
+
+.lane-count {
+  display: grid;
+  min-width: 44px;
+  min-height: 34px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.progress-track {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin-bottom: 18px;
+}
+
+.progress-track span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--progress);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: progress-fill 1s 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.progress-track span::after {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  width: 18px;
+  height: 18px;
+  border: 4px solid #ffffff;
+  border-radius: 50%;
+  content: "";
+  background: var(--accent);
+  box-shadow: 0 0 0 0 var(--accent-soft);
+  transform: translate(50%, -50%);
+  animation: progress-pulse 1.8s ease-out infinite;
+}
+
+.task-list {
+  display: grid;
+  gap: 12px;
+}
+
+.task-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 16px;
+  transform: translateY(0);
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.task-card::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  content: "";
+  background: var(--accent);
+  transform: scaleY(0.35);
+  transition: transform 180ms ease;
+}
+
+.task-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 14px 28px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.task-card:hover::before {
+  transform: scaleY(1);
+}
+
+.task-tag {
+  display: inline-flex;
+  margin-bottom: 12px;
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.task-card h3 {
+  margin-bottom: 8px;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.task-card p {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.lane-backlog {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --progress: 42%;
+}
+
+.lane-progress {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --progress: 62%;
+}
+
+.lane-review {
+  --accent: var(--red);
+  --accent-light: #fb7185;
+  --accent-soft: rgba(220, 38, 38, 0.14);
+  --progress: 76%;
+}
+
+.lane-done {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --progress: 88%;
+}
+
+@keyframes lane-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes progress-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes progress-pulse {
+  0% {
+    box-shadow: 0 0 0 0 var(--accent-soft);
+  }
+
+  70% {
+    box-shadow: 0 0 0 12px rgba(255, 255, 255, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+  }
+}
+
+@media (max-width: 1040px) {
+  .kanban-board {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .kanban-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .board-summary,
+  .kanban-board {
+    grid-template-columns: 1fr;
+  }
+
+  .kanban-lane {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
#46053


**PR Text**

Title: `feat: add kanban lane progress pulse demo`

```md
## Pull Request Description
Adds a self-contained Kanban Lane Progress Pulse demo under `submissions/examples/`, featuring animated lanes, progress bars, pulsing markers, and hoverable task cards.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only Kanban board pattern for visualizing lane progress and task status.

**How does a developer use it?**
Use `kanban-board` with `kanban-lane` sections and lane classes like `lane-backlog`, `lane-progress`, `lane-review`, or `lane-done`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate progress, stays readable, includes reduced-motion support, and works as a standalone browser demo.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The lane naming, color tokens, and animation timing can be standardized during framework integration.