### PR TITLE
Add zoetrope component

### DIFF
--- a/submissions/examples/zoetrope-as/README.md
+++ b/submissions/examples/zoetrope-as/README.md
@@ -1,0 +1,19 @@
+# Zoetrope
+
+A pure CSS and HTML zoetrope: a slitted drum spinning on its spindle with a strip of running figures inside.
+
+## What it shows
+
+- Figure strip built entirely from tiled gradient layers, one layer each for heads, bodies and legs
+- Slitted drum wall from a repeating linear gradient
+- steps() timing so the drum advances frame by frame like the real thing
+- A crank that turns in sync with the drum
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/zoetrope-as/demo.html
+++ b/submissions/examples/zoetrope-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zoetrope</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="glowZ"></span>
+    <div class="drumZ">
+      <span class="stripZ"></span>
+      <span class="slitsZ"></span>
+      <span class="shadeZ"></span>
+    </div>
+    <span class="rimTopZ"></span>
+    <span class="rimBotZ"></span>
+    <div class="crankZ">
+      <span class="armZ"></span>
+      <span class="knobZ"></span>
+    </div>
+    <span class="spindleZ"></span>
+    <span class="baseZ"></span>
+    <span class="tableZ"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/zoetrope-as/style.css
+++ b/submissions/examples/zoetrope-as/style.css
@@ -1,0 +1,213 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #3a3140, #14101a 76%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.glowZ {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  width: 300px;
+  height: 240px;
+  margin-left: -150px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 190, 120, 0.28), transparent 68%);
+  z-index: 1;
+  animation: flickerZ 3s ease-in-out infinite;
+}
+
+.tableZ {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 48px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(30, 16, 8, 0.35) 0 3px,
+      transparent 3px 34px
+    ),
+    linear-gradient(180deg, #6b4a2c, #2f1d10);
+  z-index: 9;
+}
+
+.baseZ {
+  position: absolute;
+  bottom: 48px;
+  left: 50%;
+  width: 170px;
+  height: 22px;
+  margin-left: -85px;
+  border-radius: 11px;
+  background: linear-gradient(180deg, #7a5330, #3a2412);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.spindleZ {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 16px;
+  height: 60px;
+  margin-left: -8px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #6b5423, #d8b45c 40%, #6b5423);
+  z-index: 2;
+}
+
+.drumZ {
+  position: absolute;
+  bottom: 118px;
+  left: 50%;
+  width: 264px;
+  height: 130px;
+  margin-left: -132px;
+  overflow: hidden;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #b8402e, #6d2113);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.45);
+  z-index: 4;
+}
+
+.stripZ {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  width: 200%;
+  height: 74px;
+  background:
+    radial-gradient(circle at 20px 16px, #23232c 0 7px, transparent 7px),
+    linear-gradient(90deg, transparent 0 14px, #23232c 14px 26px, transparent 26px),
+    linear-gradient(90deg, transparent 0 11px, #23232c 11px 15px, transparent 15px 25px, #23232c 25px 29px, transparent 29px),
+    linear-gradient(180deg, #f2e3c2, #d3bd90);
+  background-size: 40px 74px, 40px 30px, 40px 20px, 100% 100%;
+  background-position: 0 0, 0 30px, 0 54px, 0 0;
+  background-repeat: repeat-x, repeat-x, repeat-x, no-repeat;
+  animation: rollZ 2.4s steps(10) infinite;
+}
+
+.slitsZ {
+  position: absolute;
+  inset: 0;
+  width: 200%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      transparent 0 32px,
+      #1b1b22 32px 40px
+    );
+  animation: rollZ 2.4s steps(10) infinite;
+}
+
+.shadeZ {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.6),
+      rgba(0, 0, 0, 0) 24%,
+      rgba(255, 255, 255, 0.08) 46%,
+      rgba(0, 0, 0, 0) 74%,
+      rgba(0, 0, 0, 0.6)
+    );
+}
+
+.rimTopZ {
+  position: absolute;
+  bottom: 236px;
+  left: 50%;
+  width: 274px;
+  height: 26px;
+  margin-left: -137px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, #24141a 0 58%, #a8452e 62%, #64240f);
+  box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.5);
+  z-index: 6;
+}
+
+.rimBotZ {
+  position: absolute;
+  bottom: 106px;
+  left: 50%;
+  width: 274px;
+  height: 26px;
+  margin-left: -137px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #8e3320, #45170c);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
+  z-index: 3;
+}
+
+.crankZ {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 56px;
+  height: 56px;
+  margin-left: 84px;
+  z-index: 7;
+  animation: spinZ 2.4s linear infinite;
+}
+
+.armZ {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 30px;
+  height: 7px;
+  margin-top: -3px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #d8b45c, #7a5f26);
+}
+
+.knobZ {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 15px;
+  height: 15px;
+  margin-top: -7px;
+  margin-left: 26px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #f0d38a, #8a6a2a 74%);
+}
+
+@keyframes rollZ {
+  from { transform: translateX(0); }
+  to { transform: translateX(-400px); }
+}
+
+@keyframes spinZ {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes flickerZ {
+  0%, 100% { opacity: 0.85; }
+  40% { opacity: 1; }
+  70% { opacity: 0.78; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stripZ,
+  .slitsZ,
+  .crankZ,
+  .glowZ {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML zoetrope with a slitted drum and a strip of running figures.

## Details

- Figure strip tiled from gradient layers alone, one layer each for heads, bodies and legs
- Slitted drum wall from a repeating linear gradient, with rim ellipses and edge shading for the cylinder illusion
- steps() timing advances the drum frame by frame, and the crank turns on the same cycle
- Warm lamp glow flickers behind the drum
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/zoetrope-as/demo.html`
- `submissions/examples/zoetrope-as/style.css`
- `submissions/examples/zoetrope-as/README.md`

Closes #46065
