### PR TITLE
Add pika component

### DIFF
--- a/submissions/examples/pika-as/README.md
+++ b/submissions/examples/pika-as/README.md
@@ -1,0 +1,19 @@
+# Pika
+
+A pure CSS and HTML pika perched on a talus boulder with a mouthful of hay, chirping across the scree.
+
+## What it shows
+
+- A bundle of hay drawn from two crossed repeating linear gradients, masked so the middle disappears behind the muzzle
+- Both eyes from a single element: one is the box itself, the other is a box-shadow
+- Round ears that park their angle in a custom property and twitch on a shared keyframe
+- Talus boulders cut from clip-path polygons
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/pika-as/demo.html
+++ b/submissions/examples/pika-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pika</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="peakP pk1"></span>
+    <span class="peakP pk2"></span>
+    <span class="chirpP cp1"></span>
+    <span class="chirpP cp2"></span>
+    <div class="pikaP">
+      <span class="bodyP"></span>
+      <span class="furP"></span>
+      <span class="earP epl"></span>
+      <span class="earP epr"></span>
+      <span class="headP"></span>
+      <span class="hayP"></span>
+      <span class="snoutP"></span>
+      <span class="noseP"></span>
+      <span class="eyeP epe"></span>
+      <span class="pawP pwl"></span>
+      <span class="pawP pwr"></span>
+    </div>
+    <span class="rockP rp1"></span>
+    <span class="rockP rp2"></span>
+    <span class="rockP rp3"></span>
+    <span class="taluP"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pika-as/style.css
+++ b/submissions/examples/pika-as/style.css
@@ -1,0 +1,294 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #6ba4c8, #bcd9e6 62%, #e4eef2);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.peakP {
+  position: absolute;
+  bottom: 52px;
+  background:
+    linear-gradient(180deg, #f4f8fa 0 22%, #8ba3b4 24%, #5f7686);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  z-index: 1;
+}
+
+.pk1 {
+  left: -20px;
+  width: 220px;
+  height: 150px;
+}
+
+.pk2 {
+  right: -30px;
+  width: 260px;
+  height: 190px;
+  filter: brightness(0.92);
+}
+
+.taluP {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 62px);
+  background:
+    radial-gradient(circle at 12% 8%, #9d9d94 0 16px, transparent 16px),
+    radial-gradient(circle at 40% 3%, #6a6a62 0 20px, transparent 20px),
+    radial-gradient(circle at 70% 11%, #9d9d94 0 14px, transparent 14px),
+    radial-gradient(circle at 92% 5%, #63635b 0 18px, transparent 18px),
+    radial-gradient(circle at 26% 16%, #6a6a62 0 11px, transparent 11px),
+    radial-gradient(circle at 56% 18%, #93938a 0 9px, transparent 9px),
+    linear-gradient(180deg, #83837a, #3e3e38);
+  z-index: 8;
+}
+
+.rockP {
+  position: absolute;
+  background: linear-gradient(160deg, #b0b0a6, #6a6a60);
+  box-shadow: inset -6px -8px 14px rgba(30, 30, 24, 0.4);
+}
+
+.rp1 {
+  bottom: 48px;
+  left: 8px;
+  width: 110px;
+  height: 90px;
+  clip-path: polygon(16% 100%, 0 42%, 30% 4%, 78% 0, 100% 46%, 92% 100%);
+  z-index: 7;
+}
+
+.rp2 {
+  bottom: 44px;
+  left: 50%;
+  width: 190px;
+  height: 100px;
+  margin-left: -95px;
+  clip-path: polygon(10% 100%, 0 54%, 22% 8%, 74% 2%, 100% 50%, 94% 100%);
+  z-index: 5;
+}
+
+.rp3 {
+  bottom: 46px;
+  right: 4px;
+  width: 120px;
+  height: 76px;
+  clip-path: polygon(12% 100%, 0 50%, 26% 6%, 80% 0, 100% 54%, 90% 100%);
+  z-index: 7;
+}
+
+.pikaP {
+  position: absolute;
+  bottom: 136px;
+  left: 50%;
+  width: 160px;
+  height: 150px;
+  margin-left: -80px;
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: breathP 3.6s ease-in-out infinite;
+}
+
+.bodyP {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 126px;
+  height: 106px;
+  margin-left: -63px;
+  border-radius: 50% 50% 42% 42% / 58% 58% 42% 42%;
+  background: radial-gradient(circle at 38% 32%, #a8977f, #5f5344 78%);
+  box-shadow: 0 10px 20px rgba(20, 16, 10, 0.4);
+  z-index: 4;
+}
+
+.furP {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 126px;
+  height: 106px;
+  margin-left: -63px;
+  border-radius: 50% 50% 42% 42% / 58% 58% 42% 42%;
+  background:
+    radial-gradient(circle at 30% 40%, rgba(60, 50, 36, 0.35) 0 6px, transparent 6px),
+    radial-gradient(circle at 58% 30%, rgba(220, 208, 186, 0.3) 0 5px, transparent 5px),
+    radial-gradient(circle at 72% 56%, rgba(60, 50, 36, 0.3) 0 7px, transparent 7px),
+    radial-gradient(circle at 40% 72%, rgba(220, 208, 186, 0.25) 0 6px, transparent 6px);
+  z-index: 5;
+}
+
+.earP {
+  position: absolute;
+  top: 0;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 60%, #cf9a92 0 34%, #8b7a66 38%, #5f5344);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--ea, 0deg));
+  z-index: 5;
+  animation: twitchP 4.4s ease-in-out infinite;
+}
+
+.epl {
+  left: 50%;
+  margin-left: -50px;
+
+  --ea: -14deg;
+}
+
+.epr {
+  left: 50%;
+  margin-left: 12px;
+
+  --ea: 14deg;
+
+  animation-delay: 1.6s;
+}
+
+.headP {
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  width: 96px;
+  height: 84px;
+  margin-left: -48px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 32%, #b6a48c, #6d5f4c 80%);
+  z-index: 6;
+}
+
+.hayP {
+  position: absolute;
+  top: 58px;
+  left: 50%;
+  width: 150px;
+  height: 30px;
+  margin-left: -75px;
+  background:
+    repeating-linear-gradient(
+      98deg,
+      #a9c452 0 3px,
+      transparent 3px 11px
+    ),
+    repeating-linear-gradient(
+      82deg,
+      #7f9a36 0 2px,
+      transparent 2px 13px
+    );
+  mask-image: linear-gradient(90deg, #000 0 30%, transparent 38% 62%, #000 70%);
+  transform-origin: 50% 50%;
+  z-index: 6;
+  animation: hayWagP 3.6s ease-in-out infinite;
+}
+
+.snoutP {
+  position: absolute;
+  top: 52px;
+  left: 50%;
+  width: 46px;
+  height: 32px;
+  margin-left: -23px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 44% 36%, #ded0b8, #9c8c72 82%);
+  z-index: 8;
+}
+
+.noseP {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 11px;
+  height: 8px;
+  margin-left: -5px;
+  border-radius: 50%;
+  background: #3a2c22;
+  z-index: 9;
+}
+
+.eyeP {
+  position: absolute;
+  top: 38px;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -26px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #6a6050, #17120c 68%);
+  box-shadow: 40px 0 0 0 #17120c;
+  z-index: 8;
+}
+
+.pawP {
+  position: absolute;
+  bottom: -4px;
+  width: 30px;
+  height: 14px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #a8977f, #6a5c48);
+  z-index: 7;
+}
+
+.pwl { left: 50%; margin-left: -44px; }
+.pwr { left: 50%; margin-left: 14px; }
+
+.chirpP {
+  position: absolute;
+  top: 96px;
+  left: 84px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  opacity: 0;
+  z-index: 9;
+  animation: callP 3.6s ease-out infinite;
+}
+
+.cp2 { animation-delay: 0.4s; }
+
+@keyframes breathP {
+  0%, 100% { transform: scale(1, 1); }
+  50% { transform: scale(1.03, 0.98); }
+}
+
+@keyframes twitchP {
+  0%, 84%, 100% { transform: rotate(var(--ea, 0deg)); }
+  90% { transform: rotate(calc(var(--ea, 0deg) - 12deg)); }
+}
+
+@keyframes hayWagP {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@keyframes callP {
+  0% { transform: scale(0.4) translateX(0); opacity: 0; }
+  20% { opacity: 0.9; }
+  100% { transform: scale(2.2) translateX(-26px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pikaP,
+  .earP,
+  .hayP,
+  .chirpP {
+    animation: none;
+  }
+
+  .chirpP {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML pika perched on a talus boulder with a mouthful of hay.

## Details

- Hay bundle from two crossed repeating linear gradients, masked so the middle disappears behind the muzzle
- Both eyes come from a single element, the second one drawn with box-shadow
- Ear angles live in a custom property so a shared twitch keyframe can rebuild each rotation
- Boulders and peaks cut from clip-path polygons, call rings ripple across the scree
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/pika-as/demo.html`
- `submissions/examples/pika-as/style.css`
- `submissions/examples/pika-as/README.md`

Closes #46080
