### PR TITLE
Add kelp forest component

### DIFF
--- a/submissions/examples/kelp-forest-as/README.md
+++ b/submissions/examples/kelp-forest-as/README.md
@@ -1,0 +1,19 @@
+# Kelp Forest
+
+A pure CSS and HTML kelp forest: five stipes swaying in the swell under drifting light shafts.
+
+## What it shows
+
+- Blades and gas bladders tiled down each stipe with background-size and repeat-y, so one element carries the whole frond
+- A rotate plus skew sway with staggered delays so the forest moves out of phase, not in lockstep
+- Blurred light shafts that widen and fade
+- Fish threading between the stipes on a three stage path
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/kelp-forest-as/demo.html
+++ b/submissions/examples/kelp-forest-as/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kelp Forest</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="shaftK sk1"></span>
+    <span class="shaftK sk2"></span>
+    <span class="shaftK sk3"></span>
+    <div class="kelpK kk1">
+      <span class="frondK"></span>
+      <span class="stipeK"></span>
+      <span class="holdK"></span>
+    </div>
+    <div class="kelpK kk2">
+      <span class="frondK"></span>
+      <span class="stipeK"></span>
+      <span class="holdK"></span>
+    </div>
+    <div class="kelpK kk3">
+      <span class="frondK"></span>
+      <span class="stipeK"></span>
+      <span class="holdK"></span>
+    </div>
+    <div class="kelpK kk4">
+      <span class="frondK"></span>
+      <span class="stipeK"></span>
+      <span class="holdK"></span>
+    </div>
+    <div class="kelpK kk5">
+      <span class="frondK"></span>
+      <span class="stipeK"></span>
+      <span class="holdK"></span>
+    </div>
+    <span class="fishK fk1"></span>
+    <span class="fishK fk2"></span>
+    <span class="fishK fk3"></span>
+    <span class="floorK"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/kelp-forest-as/style.css
+++ b/submissions/examples/kelp-forest-as/style.css
@@ -1,0 +1,206 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #2f8a8f, #0d3f52 58%, #06202e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.shaftK {
+  position: absolute;
+  top: -40px;
+  width: 60px;
+  height: 320px;
+  background: linear-gradient(180deg, rgba(210, 245, 230, 0.22), transparent 84%);
+  filter: blur(8px);
+  transform-origin: 50% 0;
+  z-index: 1;
+  animation: shimK 9s ease-in-out infinite;
+}
+
+.sk1 { left: 26px; }
+
+.sk2 {
+  left: 150px;
+  width: 42px;
+  animation-delay: 2.4s;
+}
+
+.sk3 {
+  right: 20px;
+  width: 54px;
+  animation-delay: 4.8s;
+}
+
+.floorK {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 54px);
+  background:
+    radial-gradient(circle at 14% 20%, #4c5a4a 0 22px, transparent 22px),
+    radial-gradient(circle at 48% 8%, #3f4c3e 0 26px, transparent 26px),
+    radial-gradient(circle at 82% 18%, #4c5a4a 0 20px, transparent 20px),
+    linear-gradient(180deg, #3a463a, #16201a);
+  z-index: 8;
+}
+
+.kelpK {
+  position: absolute;
+  bottom: 30px;
+  width: 64px;
+  transform-origin: 50% 100%;
+  animation: swayK 8s ease-in-out infinite;
+}
+
+.stipeK {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 9px;
+  height: 100%;
+  margin-left: -4px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #3f5c1c, #86a83c 40%, #40601e);
+  z-index: 4;
+}
+
+.frondK {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(ellipse 13px 25px at 19px 30px, #4f8c2c 0 96%, transparent 98%),
+    radial-gradient(ellipse 13px 25px at 45px 62px, #3e7423 0 96%, transparent 98%),
+    radial-gradient(circle at 28px 8px, #c2cf74 0 5px, transparent 6px),
+    radial-gradient(circle at 37px 40px, #c2cf74 0 5px, transparent 6px);
+  background-size: 64px 64px;
+  background-repeat: repeat-y;
+  z-index: 5;
+  animation: rippleK 5s ease-in-out infinite;
+}
+
+.holdK {
+  position: absolute;
+  bottom: -14px;
+  left: 50%;
+  width: 40px;
+  height: 22px;
+  margin-left: -20px;
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 40% 30%, #6a5a2c, #2e2a12 78%);
+  z-index: 6;
+}
+
+.kk1 {
+  left: 4px;
+  height: 250px;
+}
+
+.kk2 {
+  left: 74px;
+  height: 300px;
+  animation-delay: 1.4s;
+}
+
+.kk3 {
+  left: 146px;
+  height: 220px;
+  animation-delay: 2.8s;
+  filter: brightness(0.82);
+}
+
+.kk4 {
+  left: 214px;
+  height: 290px;
+  animation-delay: 4.2s;
+}
+
+.kk5 {
+  left: 282px;
+  height: 240px;
+  animation-delay: 5.6s;
+  filter: brightness(0.88);
+}
+
+.fishK {
+  position: absolute;
+  width: 26px;
+  height: 12px;
+  border-radius: 50% 40% 40% 50%;
+  background: linear-gradient(180deg, #f2f6f8, #9fb3bd);
+  box-shadow: inset -3px -2px 4px rgba(60, 80, 90, 0.4);
+  z-index: 7;
+  animation: swimK 13s linear infinite;
+}
+
+.fishK::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: -8px;
+  width: 10px;
+  height: 10px;
+  clip-path: polygon(100% 50%, 0 0, 0 100%);
+  background: #9fb3bd;
+}
+
+.fk1 { top: 86px; }
+
+.fk2 {
+  top: 132px;
+  animation-delay: 3.5s;
+  animation-duration: 16s;
+
+  --fk: 0.8;
+}
+
+.fk3 {
+  top: 190px;
+  animation-delay: 7s;
+  animation-duration: 11s;
+
+  --fk: 1.1;
+}
+
+@keyframes swayK {
+  0%, 100% { transform: rotate(-2deg) skewX(4deg); }
+  50% { transform: rotate(2deg) skewX(-4deg); }
+}
+
+@keyframes rippleK {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(1.06); }
+}
+
+@keyframes swimK {
+  0% { transform: translate(-40px, 0) scale(var(--fk, 1)); }
+  50% { transform: translate(180px, -22px) scale(var(--fk, 1)); }
+  100% { transform: translate(400px, 8px) scale(var(--fk, 1)); }
+}
+
+@keyframes shimK {
+  0%, 100% { opacity: 0.5; transform: rotate(4deg) scaleX(1); }
+  50% { opacity: 0.95; transform: rotate(8deg) scaleX(1.25); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kelpK,
+  .frondK,
+  .fishK,
+  .shaftK {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML kelp forest swaying under drifting light shafts.

## Details

- Each frond is one element: blades and gas bladders are tiled down the stipe with background-size and repeat-y
- Rotate plus skew sway on staggered delays so the five stipes move out of phase
- Blurred light shafts widen and fade overhead
- Fish thread between the stipes on a three stage path
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/kelp-forest-as/demo.html`
- `submissions/examples/kelp-forest-as/style.css`
- `submissions/examples/kelp-forest-as/README.md`

Closes #46083
