### PR TITLE
feat: add search result rank shift demo

### DIFF
--- a/submissions/examples/search-result-rank-shift-sm/README.md
+++ b/submissions/examples/search-result-rank-shift-sm/README.md
@@ -1,0 +1,5 @@
+# Search Result Rank Shift
+
+1. What does this do? Adds ranked search result cards with staggered entry motion, hover/focus highlighting, animated rank badges, and scannable tags.
+2. How is it used? Apply `.result-list` to the wrapper and `.result-card` with a `.rank-badge` to each focusable result item.
+3. Why is it useful? It makes search results easier to scan by using purposeful CSS-only motion to emphasize the currently active result.

--- a/submissions/examples/search-result-rank-shift-sm/demo.html
+++ b/submissions/examples/search-result-rank-shift-sm/demo.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Search Result Rank Shift</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="search-panel" aria-labelledby="search-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Search results</p>
+        <h1 id="search-title">Ranked result cards with motion cues</h1>
+        <p>
+          Result cards enter in order, highlight the active result on hover or focus, and shift the
+          rank badge to make scanning feel responsive without JavaScript.
+        </p>
+      </div>
+
+      <div class="query-bar" role="search" aria-label="Demo search query">
+        <span class="query-icon" aria-hidden="true">⌕</span>
+        <span class="query-text">motion accessibility checklist</span>
+        <span class="result-count">4 results</span>
+      </div>
+
+      <div class="result-list" aria-label="Ranked search results">
+        <article class="result-card" tabindex="0">
+          <span class="rank-badge">01</span>
+          <div class="result-body">
+            <div class="result-meta">
+              <span>Guide</span>
+              <span>Updated today</span>
+            </div>
+            <h2>Accessible Motion Checklist</h2>
+            <p>
+              A compact checklist for timing, reduced-motion preferences, focus visibility, and
+              animation interruption states.
+            </p>
+            <div class="result-tags">
+              <span>Reduced motion</span>
+              <span>Focus</span>
+              <span>Timing</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="result-card" tabindex="0">
+          <span class="rank-badge">02</span>
+          <div class="result-body">
+            <div class="result-meta">
+              <span>Pattern</span>
+              <span>5 min read</span>
+            </div>
+            <h2>Responsive Hover Feedback</h2>
+            <p>
+              Examples for hover states that support keyboard focus and avoid layout shift on
+              compact screens.
+            </p>
+            <div class="result-tags">
+              <span>Hover</span>
+              <span>Cards</span>
+              <span>Keyboard</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="result-card" tabindex="0">
+          <span class="rank-badge">03</span>
+          <div class="result-body">
+            <div class="result-meta">
+              <span>Reference</span>
+              <span>12 examples</span>
+            </div>
+            <h2>Motion Token Naming</h2>
+            <p>
+              Naming patterns for speed, easing, delay, and direction tokens in animation-first
+              systems.
+            </p>
+            <div class="result-tags">
+              <span>Tokens</span>
+              <span>Easing</span>
+              <span>Delay</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="result-card" tabindex="0">
+          <span class="rank-badge">04</span>
+          <div class="result-body">
+            <div class="result-meta">
+              <span>Audit</span>
+              <span>Template</span>
+            </div>
+            <h2>Release Motion Review</h2>
+            <p>
+              A release-ready review format for checking motion quality before shipping interface
+              changes.
+            </p>
+            <div class="result-tags">
+              <span>Release</span>
+              <span>Review</span>
+              <span>QA</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/search-result-rank-shift-sm/style.css
+++ b/submissions/examples/search-result-rank-shift-sm/style.css
@@ -1,0 +1,285 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d9e2ee;
+  --accent: #3158e8;
+  --accent-soft: #e9eeff;
+  --success: #147b5a;
+  --success-soft: #e8f7ef;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(49, 88, 232, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 80%, rgba(20, 123, 90, 0.12), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.search-panel {
+  width: min(100%, 980px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.35rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.query-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+}
+
+.query-icon {
+  display: grid;
+  width: 2.4rem;
+  height: 2.4rem;
+  place-items: center;
+  border-radius: 0.45rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 1.2rem;
+  font-weight: 900;
+}
+
+.query-text {
+  min-width: 0;
+  flex: 1;
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.result-count {
+  border-radius: 999px;
+  padding: 0.32rem 0.7rem;
+  color: var(--success);
+  background: var(--success-soft);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.result-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.result-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  animation: result-enter 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 240ms ease,
+    box-shadow 240ms ease,
+    transform 240ms ease;
+}
+
+.result-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent-soft), transparent 60%);
+  opacity: 0;
+  transition: opacity 240ms ease;
+}
+
+.result-card:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.result-card:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.result-card:nth-child(4) {
+  animation-delay: 240ms;
+}
+
+.result-card:hover,
+.result-card:focus-visible {
+  border-color: rgba(49, 88, 232, 0.42);
+  box-shadow: var(--shadow);
+  transform: translateY(-4px);
+}
+
+.result-card:hover::before,
+.result-card:focus-visible::before {
+  opacity: 1;
+}
+
+.result-card:focus-visible {
+  outline: 3px solid rgba(49, 88, 232, 0.26);
+  outline-offset: 5px;
+}
+
+.rank-badge,
+.result-body {
+  position: relative;
+  z-index: 1;
+}
+
+.rank-badge {
+  display: grid;
+  width: 3.15rem;
+  height: 3.15rem;
+  place-items: center;
+  border-radius: 0.5rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 950;
+  transition:
+    background-color 240ms ease,
+    color 240ms ease,
+    transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.result-card:hover .rank-badge,
+.result-card:focus-visible .rank-badge {
+  color: #ffffff;
+  background: var(--accent);
+  transform: translateX(0.32rem) scale(1.06);
+}
+
+.result-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+}
+
+.result-meta span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.result-body h2 {
+  margin: 0;
+  font-size: 1.18rem;
+}
+
+.result-body p {
+  margin: 0.45rem 0 0.85rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.result-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.result-tags span {
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--line));
+  border-radius: 999px;
+  padding: 0.28rem 0.62rem;
+  color: var(--accent);
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+@keyframes result-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.99);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 640px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .query-bar {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .result-card {
+    grid-template-columns: 1fr;
+  }
+
+  .result-card:hover .rank-badge,
+  .result-card:focus-visible .rank-badge {
+    transform: translateY(-0.2rem) scale(1.04);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .result-card,
+  .result-card::before,
+  .rank-badge {
+    animation: none;
+    transition: none;
+  }
+
+  .result-card:hover,
+  .result-card:focus-visible,
+  .result-card:hover .rank-badge,
+  .result-card:focus-visible .rank-badge {
+    transform: none;
+  }
+}


### PR DESCRIPTION

## Pull Request Description

Adds a self-contained Search Result Rank Shift demo with ranked result cards, staggered entry motion, hover/focus highlighting, animated rank badges, tags, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

Closes #46082

## Feature Description

**What does this add?**

A responsive ranked search result layout where each result enters in order and shifts its rank badge on hover or keyboard focus.

**How does a developer use it?**

```html
<div class="result-list">
  <article class="result-card" tabindex="0">
    <span class="rank-badge">01</span>
    <div class="result-body">
      <h2>Accessible Motion Checklist</h2>
      <p>A compact checklist for timing, reduced-motion preferences, and focus visibility.</p>
    </div>
  </article>
</div>