### PR TITLE
feat: add nature scale command palette component with spring pop transitions (#41488)

### DIFF
--- a/submissions/examples/scale-command-palette-agy/README.md
+++ b/submissions/examples/scale-command-palette-agy/README.md
@@ -1,0 +1,89 @@
+# Scale Command Palette Component (Nature Theme)
+
+A centered modal command palette overlay that expands with a springy scale-up entrance transition, themed around natural forest and garden design patterns.
+
+---
+
+## 💡 Quick Overview
+
+### 1. What does this do?
+
+This component provides a centered search command palette modal dialog triggered via keyboard shortcuts (`Ctrl+K` / `Cmd+K`) that pops into view using a springy scale-up bounce animation (`scale(0.85)` to `scale(1)`).
+
+### 2. How is it used?
+
+Incorporate the state-controlling checkbox and modal layouts in your layout markup:
+
+```html
+<!-- 1. Pure CSS State Checkbox -->
+<input
+  type="checkbox"
+  id="palette-state-toggle"
+  class="palette-state-checkbox"
+/>
+
+<!-- 2. Overlay Wrapper Layer -->
+<div class="palette-overlay">
+  <!-- Outer wrapper receiving scale transition rules -->
+  <div class="palette-panel-wrap">
+    <!-- Inner Card Container -->
+    <div class="palette-card">
+      <!-- Input Panel -->
+      <div class="palette-search-wrapper">
+        <input
+          type="text"
+          class="palette-input"
+          placeholder="Search actions..."
+        />
+      </div>
+
+      <!-- Action Items list -->
+      <div class="palette-content">
+        <div class="palette-group-title">Telemetry View</div>
+        <a href="#" class="palette-item" data-action="view-soil">
+          <span class="palette-item-text">Check Soil Moisture Stats</span>
+          <kbd>⌥S</kbd>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### 3. Why is it useful?
+
+Command palettes centralize dashboard shortcuts for quick operations. This component incorporates natural earth tones and forest greens to soften dashboard screens, while the spring scale entrance animation guides reader attention directly onto the search input fields without layout reflows or scripts.
+
+---
+
+## 🎨 Theme & Customization Guide
+
+Override these variables in your root element to adjust styling colors and transition speeds:
+
+```css
+:root {
+  /* Biophilic light theme colors */
+  --nature-canvas: #fbf9f4; /* Backdrop background */
+  --nature-surface: #ffffff; /* Search panel body color */
+  --nature-border: #e6e2da; /* Card separator lines */
+  --nature-primary: #1e3f20; /* Primary forest green branding accent */
+  --nature-accent: #2e6f40; /* Secondary leaf green accent color */
+
+  /* Timing Configuration */
+  --ease-elastic-duration: 0.55s; /* Duration of the spring scale pop */
+  --ease-spring-curve: cubic-bezier(
+    0.34,
+    1.56,
+    0.64,
+    1
+  ); /* Custom elastic bezier curve */
+}
+```
+
+---
+
+## ♿ Accessibility Specifications
+
+1. **Focus Controls**: Focuses the main search input field automatically when opened. Trigger labels have `tabindex="0"` for accessibility.
+2. **Keyboard Traversal**: Includes full keyboard listeners mapping `ArrowUp`/`ArrowDown` to traverse items and `Enter` to submit. Pressing `Escape` closes the panel instantly.
+3. **Motion settings**: Respects user browser preferences, completely disabling keyframe animations when `@media (prefers-reduced-motion: reduce)` matches.

--- a/submissions/examples/scale-command-palette-agy/demo.html
+++ b/submissions/examples/scale-command-palette-agy/demo.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flora — Plant Telemetry & Garden Workspace</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- 
+    Pure CSS State Trigger Checkbox
+    - The checked state controls the command palette visibility overlay.
+    - Keyboard shortcut listener toggles this state.
+  -->
+    <input
+      type="checkbox"
+      id="palette-state-toggle"
+      class="palette-state-checkbox"
+    />
+
+    <!-- Flora Viewport Container -->
+    <div class="flora-viewport">
+      <!-- Navigation Header -->
+      <header class="flora-header">
+        <div class="flora-brand">FLORA.</div>
+
+        <!-- Label trigger to open the command palette -->
+        <label
+          for="palette-state-toggle"
+          class="flora-nav-trigger"
+          tabindex="0"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+          <span>Search garden...</span>
+          <kbd>⌘K</kbd>
+        </label>
+      </header>
+
+      <!-- Main Workspace Dashboard Mock -->
+      <main class="flora-main">
+        <div class="flora-hero">
+          <h1>Welcome to Flora Workspace</h1>
+          <p>
+            Your garden telemetry center is fully operational. Monitor moisture
+            levels, adjust greenhouse light cycles, and log soil reports. Open
+            the command palette to execute actions quickly.
+          </p>
+
+          <label
+            for="palette-state-toggle"
+            class="flora-nav-trigger"
+            style="
+              display: inline-flex;
+              font-size: 1rem;
+              padding: 0.8rem 1.6rem;
+              border-radius: 12px;
+              margin: 0 auto;
+            "
+            tabindex="0"
+          >
+            Open Command Palette
+          </label>
+        </div>
+      </main>
+    </div>
+
+    <!-- 
+    Command Palette Overlay
+    - Centered positioning and background blur effect.
+  -->
+    <div class="palette-overlay">
+      <!-- Outer wrapper that receives scaling animation rules -->
+      <div class="palette-panel-wrap">
+        <!-- Natural Biophilic Command Card -->
+        <div class="palette-card">
+          <!-- Search bar input panel -->
+          <div class="palette-search-wrapper">
+            <svg
+              class="palette-search-icon"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <circle cx="11" cy="11" r="8"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            <input
+              type="text"
+              class="palette-input"
+              id="palette-search-field"
+              placeholder="Search garden operations..."
+              autocomplete="off"
+              aria-label="Command search input"
+            />
+          </div>
+
+          <!-- Scrolling commands list view -->
+          <div class="palette-content" id="palette-options-list">
+            <!-- Group 1: Telemetry View -->
+            <div class="palette-group-title">Telemetry View</div>
+
+            <a href="#" class="palette-item active" data-action="view-soil">
+              <div class="palette-item-left">
+                <span class="palette-item-icon">🌱</span>
+                <span class="palette-item-text">Check Soil Moisture Stats</span>
+              </div>
+              <div class="palette-item-hotkey"><kbd>⌥S</kbd></div>
+            </a>
+
+            <a href="#" class="palette-item" data-action="view-temp">
+              <div class="palette-item-left">
+                <span class="palette-item-icon">🌡️</span>
+                <span class="palette-item-text">View Ambient Temperature</span>
+              </div>
+              <div class="palette-item-hotkey"><kbd>⌥T</kbd></div>
+            </a>
+
+            <a href="#" class="palette-item" data-action="view-humidity">
+              <div class="palette-item-left">
+                <span class="palette-item-icon">💧</span>
+                <span class="palette-item-text">Open Humidity Telemetry</span>
+              </div>
+              <div class="palette-item-hotkey"><kbd>⌥H</kbd></div>
+            </a>
+
+            <!-- Group 2: Greenhouse Control -->
+            <div class="palette-group-title">Greenhouse Control</div>
+
+            <a href="#" class="palette-item" data-action="ctrl-irrigation">
+              <div class="palette-item-left">
+                <span class="palette-item-icon">🚿</span>
+                <span class="palette-item-text"
+                  >Toggle Irrigation Sprinklers</span
+                >
+              </div>
+              <div class="palette-item-hotkey"><kbd>⇧⌘I</kbd></div>
+            </a>
+
+            <a href="#" class="palette-item" data-action="ctrl-lighting">
+              <div class="palette-item-left">
+                <span class="palette-item-icon">💡</span>
+                <span class="palette-item-text"
+                  >Adjust Grow Light Intensity</span
+                >
+              </div>
+              <div class="palette-item-hotkey"><kbd>⇧⌘L</kbd></div>
+            </a>
+
+            <!-- Group 3: Gardener Actions -->
+            <div class="palette-group-title">Gardener Actions</div>
+
+            <a href="#" class="palette-item" data-action="act-logs">
+              <div class="palette-item-left">
+                <span class="palette-item-icon">📝</span>
+                <span class="palette-item-text">Export Soil Quality Logs</span>
+              </div>
+              <div class="palette-item-hotkey"><kbd>⌥L</kbd></div>
+            </a>
+
+            <a href="#" class="palette-item" data-action="act-settings">
+              <div class="palette-item-left">
+                <span class="palette-item-icon">⚙️</span>
+                <span class="palette-item-text"
+                  >Access Greenhouse Configurations</span
+                >
+              </div>
+              <div class="palette-item-hotkey"><kbd>⌘,</kbd></div>
+            </a>
+          </div>
+
+          <!-- Status bar and key guides footer -->
+          <div class="palette-footer">
+            <span>Flora Telemetry v1.4.0</span>
+            <div class="palette-footer-guide">
+              <span><kbd>↑↓</kbd> Navigate</span>
+              <span><kbd>↵</kbd> Select</span>
+              <span><kbd>esc</kbd> Dismiss</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Interactive JavaScript Enhancements -->
+    <script>
+      const checkbox = document.getElementById("palette-state-toggle");
+      const searchField = document.getElementById("palette-search-field");
+      const optionsList = document.getElementById("palette-options-list");
+      let activeIndex = 0;
+
+      // 1. Keyboard shortcut trigger (Ctrl+K or Cmd+K)
+      window.addEventListener("keydown", (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+          e.preventDefault();
+          checkbox.checked = !checkbox.checked;
+          if (checkbox.checked) {
+            setTimeout(() => searchField.focus(), 100);
+          }
+        }
+        if (e.key === "Escape" && checkbox.checked) {
+          checkbox.checked = false;
+          searchField.blur();
+        }
+      });
+
+      // Handle button label keydown maps
+      document.querySelectorAll(".flora-nav-trigger").forEach((btn) => {
+        btn.addEventListener("keydown", (e) => {
+          if (e.key === " " || e.key === "Enter") {
+            e.preventDefault();
+            checkbox.checked = !checkbox.checked;
+            if (checkbox.checked) {
+              setTimeout(() => searchField.focus(), 100);
+            }
+          }
+        });
+      });
+
+      // 2. Arrow key item navigation list
+      const getVisibleItems = () =>
+        Array.from(optionsList.querySelectorAll(".palette-item"));
+
+      window.addEventListener("keydown", (e) => {
+        if (!checkbox.checked) return;
+
+        const items = getVisibleItems();
+        if (items.length === 0) return;
+
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          items[activeIndex].classList.remove("active");
+          activeIndex = (activeIndex + 1) % items.length;
+          items[activeIndex].classList.add("active");
+          items[activeIndex].scrollIntoView({ block: "nearest" });
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          items[activeIndex].classList.remove("active");
+          activeIndex = (activeIndex - 1 + items.length) % items.length;
+          items[activeIndex].classList.add("active");
+          items[activeIndex].scrollIntoView({ block: "nearest" });
+        } else if (e.key === "Enter") {
+          e.preventDefault();
+          const activeItem = items[activeIndex];
+          if (activeItem) {
+            triggerAction(activeItem.getAttribute("data-action"));
+          }
+        }
+      });
+
+      // Action Execution router
+      function triggerAction(action) {
+        console.log(`Executing: ${action}`);
+        alert(`Executed action: ${action}`);
+        checkbox.checked = false;
+      }
+
+      // Dynamic search filtering
+      searchField.addEventListener("input", (e) => {
+        const filter = e.target.value.toLowerCase();
+        const items = optionsList.querySelectorAll(".palette-item");
+        let firstMatchIndex = -1;
+
+        items.forEach((item, index) => {
+          const text = item
+            .querySelector(".palette-item-text")
+            .innerText.toLowerCase();
+          if (text.includes(filter)) {
+            item.style.display = "flex";
+            if (firstMatchIndex === -1) {
+              firstMatchIndex = index;
+            }
+          } else {
+            item.style.display = "none";
+          }
+          item.classList.remove("active");
+        });
+
+        const visibleItems = getVisibleItems();
+        if (visibleItems.length > 0) {
+          activeIndex = 0;
+          visibleItems[activeIndex].classList.add("active");
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/scale-command-palette-agy/style.css
+++ b/submissions/examples/scale-command-palette-agy/style.css
@@ -1,0 +1,411 @@
+/* ==========================================================================
+   EaseMotion CSS - Scale Command Palette (Nature Design Variant)
+   ========================================================================== */
+
+/* ── 1. Design Tokens & CSS Variables ────────────────────────────────────── */
+:root {
+  /* Biophilic Light Theme Palette (Default) */
+  --nature-canvas: #fbf9f4;
+  --nature-surface: #ffffff;
+  --nature-border: #e6e2da;
+  --nature-primary: #1e3f20; /* Forest Green */
+  --nature-primary-hover: #132b15;
+  --nature-accent: #2e6f40; /* Leaf Green */
+  --nature-accent-light: #f1f8f3;
+  --nature-text: #2f3531;
+  --nature-muted: #7c8880;
+  --nature-hotkey-bg: #f4f1ea;
+  --nature-shadow: rgba(30, 63, 32, 0.04);
+  --nature-overlay: rgba(30, 63, 32, 0.3);
+
+  /* Animation Timings */
+  --ease-elastic-duration: 0.55s;
+  --ease-fade-duration: 0.25s;
+  --ease-spring-curve: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-smooth-curve: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Typography scale */
+  --nature-font: "Outfit", "Inter", system-ui, sans-serif;
+  --nature-font-xs: 0.72rem;
+  --nature-font-sm: 0.86rem;
+  --nature-font-base: 0.96rem;
+  --nature-font-lg: 1.15rem;
+}
+
+/* Biophilic Dark Theme Palette Overrides */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --nature-canvas: #0e120f;
+    --nature-surface: #151b17;
+    --nature-border: #262f29;
+    --nature-primary: #a7c957;
+    --nature-primary-hover: #bddb77;
+    --nature-accent: #38b000;
+    --nature-accent-light: #1b261e;
+    --nature-text: #f1f5f2;
+    --nature-muted: #828c85;
+    --nature-hotkey-bg: #1c241f;
+    --nature-shadow: rgba(0, 0, 0, 0.2);
+    --nature-overlay: rgba(5, 8, 6, 0.7);
+  }
+}
+
+/* Force dark theme overrides by selector */
+[data-theme="dark"] {
+  --nature-canvas: #0e120f;
+  --nature-surface: #151b17;
+  --nature-border: #262f29;
+  --nature-primary: #a7c957;
+  --nature-primary-hover: #bddb77;
+  --nature-accent: #38b000;
+  --nature-accent-light: #1b261e;
+  --nature-text: #f1f5f2;
+  --nature-muted: #828c85;
+  --nature-hotkey-bg: #1c241f;
+  --nature-shadow: rgba(0, 0, 0, 0.2);
+  --nature-overlay: rgba(5, 8, 6, 0.7);
+}
+
+/* ── 2. Reset and Base Layout ────────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--nature-canvas);
+  color: var(--nature-text);
+  font-family: var(--nature-font);
+  line-height: 1.6;
+}
+
+/* Hide checkbox used for pure CSS state control */
+.palette-state-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── 3. Flora Dashboard Viewport Layout ──────────────────────────────────── */
+.flora-viewport {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-image:
+    radial-gradient(at 0% 0%, rgba(46, 111, 64, 0.03) 0px, transparent 50%),
+    radial-gradient(at 100% 100%, rgba(167, 201, 87, 0.03) 0px, transparent 50%);
+}
+
+.flora-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 2rem;
+  border-bottom: 1px solid var(--nature-border);
+  background-color: var(--nature-surface);
+}
+
+.flora-brand {
+  font-weight: 800;
+  font-size: var(--nature-font-lg);
+  color: var(--nature-primary);
+  letter-spacing: -0.02em;
+}
+
+.flora-nav-trigger {
+  padding: 0.6rem 1.2rem;
+  background-color: var(--nature-surface);
+  border: 1px solid var(--nature-border);
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: var(--nature-font-sm);
+  font-weight: 600;
+  color: var(--nature-text);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  transition:
+    border-color 0.2s,
+    background-color 0.2s;
+  user-select: none;
+}
+
+.flora-nav-trigger:hover {
+  border-color: var(--nature-accent);
+  background-color: var(--nature-accent-light);
+}
+
+.flora-nav-trigger kbd {
+  font-size: 0.72rem;
+  background: var(--nature-hotkey-bg);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid var(--nature-border);
+}
+
+/* Dashboard Mock Content */
+.flora-main {
+  flex-grow: 1;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  text-align: center;
+}
+
+.flora-hero {
+  max-width: 600px;
+}
+
+.flora-hero h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: var(--nature-primary);
+  margin-bottom: 1rem;
+  letter-spacing: -0.03em;
+}
+
+.flora-hero p {
+  color: var(--nature-muted);
+  font-size: var(--nature-font-base);
+  margin-bottom: 2rem;
+}
+
+/* ── 4. Scale Command Palette Structure ────────────────────────────────── */
+.palette-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: var(--nature-overlay);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  justify-content: center;
+  padding-top: 15vh;
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--ease-fade-duration) var(--ease-smooth-curve);
+}
+
+.palette-panel-wrap {
+  width: 100%;
+  max-width: 640px;
+  transform: scale3d(0.85, 0.85, 1);
+  transition: transform var(--ease-fade-duration) var(--ease-smooth-curve);
+}
+
+.palette-card {
+  background-color: var(--nature-surface);
+  border: 1px solid var(--nature-border);
+  border-radius: 20px;
+  box-shadow: 0 20px 50px var(--nature-shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Search bar styling */
+.palette-search-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--nature-border);
+}
+
+.palette-search-icon {
+  color: var(--nature-muted);
+  flex-shrink: 0;
+}
+
+.palette-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: var(--nature-font-base);
+  color: var(--nature-text);
+  font-family: inherit;
+}
+
+.palette-input::placeholder {
+  color: var(--nature-muted);
+}
+
+/* Scrollable command list view */
+.palette-content {
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 0.8rem;
+}
+
+.palette-group-title {
+  font-size: var(--nature-font-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--nature-muted);
+  letter-spacing: 0.05em;
+  padding: 0.8rem 0.8rem 0.4rem;
+}
+
+.palette-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--nature-text);
+  transition:
+    background-color 0.2s var(--ease-smooth-curve),
+    border-color 0.2s;
+  user-select: none;
+  margin-bottom: 0.15rem;
+  border: 1px solid transparent;
+}
+
+.palette-item:hover,
+.palette-item.active {
+  background-color: var(--nature-accent-light);
+  border-color: rgba(46, 111, 64, 0.08);
+}
+
+.palette-item:hover .palette-item-icon,
+.palette-item.active .palette-item-icon {
+  transform: scale(1.1);
+}
+
+.palette-item-left {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.palette-item-icon {
+  color: var(--nature-accent);
+  flex-shrink: 0;
+  transition: transform var(--ease-elastic-duration) var(--ease-spring-curve);
+}
+
+.palette-item-text {
+  font-size: var(--nature-font-sm);
+  font-weight: 500;
+}
+
+.palette-item-hotkey {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.palette-item-hotkey kbd {
+  font-size: 0.72rem;
+  background-color: var(--nature-hotkey-bg);
+  border: 1px solid var(--nature-border);
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  color: var(--nature-muted);
+  font-family: inherit;
+}
+
+/* Palette Footer status information */
+.palette-footer {
+  padding: 0.8rem 1.5rem;
+  border-top: 1px solid var(--nature-border);
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--nature-font-xs);
+  color: var(--nature-muted);
+}
+
+.palette-footer-guide {
+  display: flex;
+  gap: 1rem;
+}
+
+.palette-footer-guide span {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.palette-footer kbd {
+  background-color: var(--nature-hotkey-bg);
+  border: 1px solid var(--nature-border);
+  padding: 0.05rem 0.25rem;
+  border-radius: 3px;
+  font-size: 0.65rem;
+}
+
+/* ── 5. State Trigger Rules (Pure CSS Checkbox Mechanism) ────────────────── */
+.palette-state-checkbox:checked ~ .palette-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.palette-state-checkbox:checked ~ .palette-overlay .palette-panel-wrap {
+  transform: scale3d(1, 1, 1);
+}
+
+/* ── 6. Animation Keyframes for springy scale-up ────────────────────────── */
+@keyframes cmd-scale-spring {
+  0% {
+    transform: scale3d(0.85, 0.85, 1);
+    opacity: 0;
+  }
+  50% {
+    transform: scale3d(1.03, 1.03, 1);
+    opacity: 0.7;
+  }
+  75% {
+    transform: scale3d(0.98, 0.98, 1);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale3d(1, 1, 1);
+    opacity: 1;
+  }
+}
+
+.palette-state-checkbox:checked ~ .palette-overlay .palette-panel-wrap {
+  animation: cmd-scale-spring var(--ease-elastic-duration)
+    var(--ease-spring-curve) forwards;
+}
+
+/* Accessibility settings for users with motion sensitivity */
+@media (prefers-reduced-motion: reduce) {
+  .palette-state-checkbox:checked ~ .palette-overlay .palette-panel-wrap {
+    animation: none;
+    transform: scale(1);
+  }
+}
+
+/* ── 7. Responsive Styles ────────────────────────────────────────────────── */
+@media (max-width: 680px) {
+  .palette-overlay {
+    padding-top: 5vh;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .palette-panel-wrap {
+    max-width: 100%;
+  }
+
+  .palette-footer {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+    text-align: center;
+  }
+
+  .flora-header {
+    padding: 1rem;
+  }
+
+  .flora-hero h1 {
+    font-size: 1.75rem;
+  }
+}


### PR DESCRIPTION
Fixes #41488.

Adds the new Nature Scale Command Palette component under submissions/examples/scale-command-palette-agy/.

### Changes Included
- **demo.html**: Showcase page featuring 'Flora Workspace' garden telemetry center dashboard, command palette input panel, list group configurations, and keyboard listeners mapping.
- **style.css**: Theme styling using warm biophilic cream & forest greens, card center alignment overlays, and spring scale-up pop entrance transition keyframes.
- **README.md**: Detailed guides answering what it does, how it is used, and why it is useful, with style configurations reference.