### PR TITLE
feat: add cyberpunk spotlight rich text toolbar component with neon hover overlays (#41489)

### DIFF
--- a/submissions/examples/spotlight-rich-text-toolbar-agy/README.md
+++ b/submissions/examples/spotlight-rich-text-toolbar-agy/README.md
@@ -1,0 +1,82 @@
+# Cyberpunk Spotlight Rich Text Toolbar Component
+
+A rich text editor formatting toolbar themed around cyberpunk design patterns, featuring mouse-tracking neon spotlight hover transitions.
+
+---
+
+## 💡 Quick Overview
+
+### 1. What does this do?
+
+This component provides a text-formatting toolbar where buttons reveal a glowing, cursor-following neon spotlight gradient background on mouse hover, and active states highlight with a solid glowing border using pure CSS.
+
+### 2. How is it used?
+
+Incorporate the state checkboxes and editor container structure in your layout markup:
+
+```html
+<!-- 1. Pure CSS Formatting Checkboxes -->
+<input type="checkbox" id="format-bold" class="toolbar-state-checkbox" />
+<input type="checkbox" id="format-italic" class="toolbar-state-checkbox" />
+
+<!-- 2. Editor Container Frame -->
+<div class="cyber-editor-wrap">
+  <!-- Toolbar Header -->
+  <div class="cyber-toolbar" id="toolbar-container">
+    <label for="format-bold" class="toolbar-btn btn-bold" tabindex="0">B</label>
+    <label for="format-italic" class="toolbar-btn btn-italic" tabindex="0"
+      >I</label
+    >
+  </div>
+
+  <!-- Content Textarea Workspace -->
+  <div class="editor-workspace">
+    <textarea class="editor-textarea">Content editing area...</textarea>
+  </div>
+</div>
+```
+
+Then hook up the cursor spotlight coordinator in your script block:
+
+```javascript
+const buttons = document.querySelectorAll(".toolbar-btn");
+buttons.forEach((btn) => {
+  btn.addEventListener("mousemove", (e) => {
+    const rect = btn.getBoundingClientRect();
+    btn.style.setProperty("--mouse-x", `${e.clientX - rect.left}px`);
+    btn.style.setProperty("--mouse-y", `${e.clientY - rect.top}px`);
+  });
+});
+```
+
+### 3. Why is it useful?
+
+Markdown and rich text toolbars are standard building blocks inside note apps and dev consoles. This component applies high-contrast cyan/magenta styling and interactive spotlights to enhance focus target visuals. It handles format selections and active highlight switches entirely in pure CSS, preventing script locks or page reflows.
+
+---
+
+## 🎨 Theme & Customization Guide
+
+Override these variables in your root element to adjust styling colors and glowing properties:
+
+```css
+:root {
+  /* Void Terminal Palette colors */
+  --cyber-bg: #050508; /* Page base canvas void color */
+  --cyber-surface: #0e0e13; /* Editor container background */
+  --cyber-border: #1a1a24; /* Button boundary separator line */
+
+  /* Neon Glow highlights */
+  --cyber-cyan: #00f0ff; /* Neon Cyan active accent */
+  --cyber-magenta: #ff0055; /* Neon Magenta alternate accent */
+  --cyber-yellow: #f0e600; /* Highlight telemetry color */
+}
+```
+
+---
+
+## ♿ Accessibility Specifications
+
+1. **Focus Controls**: Highlight focus rings style themselves in glowing neon outlines for keyboard tab navigation.
+2. **Keyboard Traversal**: Monospace buttons have keyboard listeners mapping Space and Enter keys directly into formatting checkbox click inputs.
+3. **Motion settings**: Bypasses heavy glitch distortion keyframes when `@media (prefers-reduced-motion: reduce)` matches, keeping editing states stable.

--- a/submissions/examples/spotlight-rich-text-toolbar-agy/demo.html
+++ b/submissions/examples/spotlight-rich-text-toolbar-agy/demo.html
@@ -1,0 +1,319 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyber-Editor v9.0 — Decrypted Terminal Text Workspace</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- 
+    Cyberpunk Rich Text Editor Frame
+    - Contains formatting checkbox states followed by the editor card body.
+  -->
+    <div class="cyber-editor-wrap">
+      <!-- Active formatting state checkbox toggles -->
+      <input type="checkbox" id="format-bold" class="toolbar-state-checkbox" />
+      <input
+        type="checkbox"
+        id="format-italic"
+        class="toolbar-state-checkbox"
+      />
+      <input
+        type="checkbox"
+        id="format-underline"
+        class="toolbar-state-checkbox"
+      />
+      <input
+        type="checkbox"
+        id="format-strike"
+        class="toolbar-state-checkbox"
+      />
+      <input type="checkbox" id="format-code" class="toolbar-state-checkbox" />
+
+      <!-- Alignment radio states toggles -->
+      <input
+        type="radio"
+        name="align-option"
+        id="align-left"
+        class="toolbar-state-checkbox"
+        checked
+      />
+      <input
+        type="radio"
+        name="align-option"
+        id="align-center"
+        class="toolbar-state-checkbox"
+      />
+      <input
+        type="radio"
+        name="align-option"
+        id="align-right"
+        class="toolbar-state-checkbox"
+      />
+
+      <!-- Terminal Header Info -->
+      <header class="cyber-editor-header">
+        <div class="cyber-editor-title"><span>⚡</span> cyber-editor.sys</div>
+        <div class="cyber-editor-status">decryption active</div>
+      </header>
+
+      <!-- Rich Text Formatting Toolbar -->
+      <div class="cyber-toolbar" id="toolbar-container">
+        <!-- Group 1: Font formatting styles -->
+        <div class="toolbar-group">
+          <label
+            for="format-bold"
+            class="toolbar-btn btn-bold"
+            title="Toggle Bold format"
+            tabindex="0"
+          >
+            B
+          </label>
+
+          <label
+            for="format-italic"
+            class="toolbar-btn btn-italic"
+            title="Toggle Italic format"
+            tabindex="0"
+          >
+            I
+          </label>
+
+          <label
+            for="format-underline"
+            class="toolbar-btn btn-underline"
+            title="Toggle Underline format"
+            tabindex="0"
+          >
+            U
+          </label>
+
+          <label
+            for="format-strike"
+            class="toolbar-btn btn-strike"
+            title="Toggle Strikethrough format"
+            tabindex="0"
+          >
+            S
+          </label>
+        </div>
+
+        <!-- Group 2: Advanced Blocks styles -->
+        <div class="toolbar-group">
+          <label
+            for="format-code"
+            class="toolbar-btn"
+            title="Toggle Code block format"
+            tabindex="0"
+          >
+            &lt;/&gt;
+          </label>
+
+          <button
+            class="toolbar-btn"
+            id="btn-link"
+            title="Insert Web Hyperlink"
+            tabindex="0"
+          >
+            🔗
+          </button>
+
+          <button
+            class="toolbar-btn"
+            id="btn-image"
+            title="Embed Terminal Image"
+            tabindex="0"
+          >
+            🖼️
+          </button>
+        </div>
+
+        <!-- Group 3: Text Alignment actions -->
+        <div class="toolbar-group">
+          <label
+            for="align-left"
+            class="toolbar-btn"
+            title="Align text left"
+            tabindex="0"
+          >
+            ◀
+          </label>
+
+          <label
+            for="align-center"
+            class="toolbar-btn"
+            title="Center align text"
+            tabindex="0"
+          >
+            ▼
+          </label>
+
+          <label
+            for="align-right"
+            class="toolbar-btn"
+            title="Align text right"
+            tabindex="0"
+          >
+            ▶
+          </label>
+        </div>
+
+        <!-- Group 4: Save & Utilities -->
+        <div class="toolbar-group" style="margin-left: auto">
+          <button
+            class="toolbar-btn"
+            id="btn-decrypt"
+            title="Decrypt File"
+            style="
+              color: var(--cyber-yellow);
+              border-color: var(--cyber-yellow);
+            "
+            tabindex="0"
+          >
+            🔓
+          </button>
+          <button
+            class="toolbar-btn"
+            id="btn-save"
+            title="Save Workspace File"
+            style="color: var(--cyber-cyan); border-color: var(--cyber-cyan)"
+            tabindex="0"
+          >
+            💾
+          </button>
+        </div>
+      </div>
+
+      <!-- Texteditor textarea workspace area -->
+      <div class="editor-workspace">
+        <textarea
+          class="editor-textarea"
+          id="editor-field"
+          placeholder="// start decrypting contents..."
+          aria-label="Terminal editor workspace"
+        >
+Welcome to cyber-editor.sys. All telemetry clusters are operational. Use the spotlight format buttons above to toggle inline text styles in pure CSS.</textarea
+        >
+      </div>
+
+      <!-- Live Telemetry Status Footer -->
+      <footer
+        class="cyber-editor-header"
+        style="
+          border-top: 2px solid var(--cyber-border);
+          border-bottom: none;
+          font-size: var(--cyber-font-xs);
+          background-color: rgba(14, 14, 19, 0.9);
+        "
+      >
+        <div style="color: var(--cyber-muted)">
+          LINES:
+          <span id="telemetry-lines" style="color: var(--cyber-cyan)">3</span> |
+          CHARS:
+          <span id="telemetry-chars" style="color: var(--cyber-cyan)">136</span>
+        </div>
+        <div id="telemetry-alert" style="color: var(--cyber-yellow)">
+          CONNECTION SECURE // MOCKED ENDPOINT
+        </div>
+      </footer>
+    </div>
+
+    <!-- Micro coordination interactive handlers -->
+    <script>
+      const toolbar = document.getElementById("toolbar-container");
+      const buttons = toolbar.querySelectorAll(".toolbar-btn");
+      const editor = document.getElementById("editor-field");
+      const lineCounter = document.getElementById("telemetry-lines");
+      const charCounter = document.getElementById("telemetry-chars");
+      const telemetryAlert = document.getElementById("telemetry-alert");
+
+      // 1. Mouse coordinates tracker: Sets coordinates variables dynamically on hover
+      buttons.forEach((btn) => {
+        btn.addEventListener("mousemove", (e) => {
+          const rect = btn.getBoundingClientRect();
+          const x = e.clientX - rect.left; // X position inside button
+          const y = e.clientY - rect.top; // Y position inside button
+          btn.style.setProperty("--mouse-x", `${x}px`);
+          btn.style.setProperty("--mouse-y", `${y}px`);
+        });
+      });
+
+      // 2. Keyboard accessibility trigger helper mapping on labels
+      buttons.forEach((btn) => {
+        btn.addEventListener("keydown", (e) => {
+          if (e.key === " " || e.key === "Enter") {
+            e.preventDefault();
+
+            // Map to checkboxes if clicking a label
+            if (btn.tagName.toLowerCase() === "label") {
+              const targetInput = document.getElementById(
+                btn.getAttribute("for")
+              );
+              if (targetInput) {
+                targetInput.click();
+              }
+            } else {
+              btn.click();
+            }
+          }
+        });
+      });
+
+      // 3. Telemetry values live updates
+      const updateTelemetry = () => {
+        const text = editor.value;
+        charCounter.textContent = text.length;
+        lineCounter.textContent = text.split("\n").length;
+      };
+      editor.addEventListener("input", updateTelemetry);
+
+      // Action routers for direct button elements (e.g. Link and Image)
+      document.getElementById("btn-link").addEventListener("click", () => {
+        const url = prompt("Enter Cyber Hyperlink url:");
+        if (url) {
+          telemetryAlert.textContent = `LINK ATTACHED: ${url}`;
+          setTimeout(
+            () =>
+              (telemetryAlert.textContent =
+                "CONNECTION SECURE // MOCKED ENDPOINT"),
+            3000
+          );
+        }
+      });
+
+      document.getElementById("btn-image").addEventListener("click", () => {
+        const imgUrl = prompt("Enter image endpoint url:");
+        if (imgUrl) {
+          telemetryAlert.textContent = `IMAGE ATTACHED: ${imgUrl}`;
+          setTimeout(
+            () =>
+              (telemetryAlert.textContent =
+                "CONNECTION SECURE // MOCKED ENDPOINT"),
+            3000
+          );
+        }
+      });
+
+      document.getElementById("btn-save").addEventListener("click", () => {
+        telemetryAlert.textContent = "SAVING FILE... SUCCESS";
+        setTimeout(
+          () =>
+            (telemetryAlert.textContent =
+              "CONNECTION SECURE // MOCKED ENDPOINT"),
+          3000
+        );
+      });
+
+      document.getElementById("btn-decrypt").addEventListener("click", () => {
+        telemetryAlert.textContent = "DECRYPTING BUFFER... COMPLETION: 100%";
+        setTimeout(
+          () =>
+            (telemetryAlert.textContent =
+              "CONNECTION SECURE // MOCKED ENDPOINT"),
+          3000
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/spotlight-rich-text-toolbar-agy/style.css
+++ b/submissions/examples/spotlight-rich-text-toolbar-agy/style.css
@@ -1,0 +1,359 @@
+/* ==========================================================================
+   EaseMotion CSS - Spotlight Rich Text Toolbar (Cyberpunk Variant)
+   ========================================================================== */
+
+/* ── 1. Cyberpunk Design Tokens & Variables ────────────────────────────── */
+:root {
+  /* Neon Void Color Scheme */
+  --cyber-bg: #050508;
+  --cyber-surface: #0e0e13;
+  --cyber-border: #1a1a24;
+
+  /* Cyber Highlights */
+  --cyber-cyan: #00f0ff;
+  --cyber-magenta: #ff0055;
+  --cyber-yellow: #f0e600;
+  --cyber-text: #d1d5db;
+  --cyber-muted: #6b7280;
+
+  /* Glowing Shadows */
+  --glow-cyan: 0 0 10px rgba(0, 240, 255, 0.4);
+  --glow-magenta: 0 0 10px rgba(255, 0, 85, 0.4);
+
+  /* Animation Timings */
+  --ease-elastic-duration: 0.5s;
+  --ease-fade-duration: 0.2s;
+  --ease-spring-curve: cubic-bezier(0.25, 1.25, 0.5, 1);
+  --ease-smooth-curve: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Monospace Typography */
+  --cyber-font: "Fira Code", "Courier New", Courier, monospace;
+  --cyber-font-xs: 0.72rem;
+  --cyber-font-sm: 0.85rem;
+  --cyber-font-base: 0.95rem;
+  --cyber-font-lg: 1.2rem;
+}
+
+/* Base resets & layouts */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--cyber-bg);
+  color: var(--cyber-text);
+  font-family: var(--cyber-font);
+  line-height: 1.5;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  background-image:
+    linear-gradient(rgba(255, 0, 85, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 240, 255, 0.02) 1px, transparent 1px);
+  background-size: 20px 20px;
+}
+
+/* Hide checkbox inputs used for active state hacks */
+.toolbar-state-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── 2. Editor Console Container ────────────────────────────────────────── */
+.cyber-editor-wrap {
+  width: 100%;
+  max-width: 800px;
+  background-color: var(--cyber-surface);
+  border: 2px solid var(--cyber-border);
+  border-radius: 12px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Glowing top accent strip */
+.cyber-editor-wrap::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(90deg, var(--cyber-cyan), var(--cyber-magenta));
+}
+
+/* Editor Console Header */
+.cyber-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 2px solid var(--cyber-border);
+  background-color: rgba(14, 14, 19, 0.8);
+}
+
+.cyber-editor-title {
+  font-size: var(--cyber-font-sm);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--cyber-cyan);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cyber-editor-status {
+  font-size: var(--cyber-font-xs);
+  color: var(--cyber-magenta);
+  text-transform: uppercase;
+  animation: cyber-blink 1.5s infinite;
+}
+
+/* ── 3. Rich Text Toolbar Layout ────────────────────────────────────────── */
+.cyber-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.8rem 1.2rem;
+  background-color: rgba(26, 26, 36, 0.4);
+  border-bottom: 2px solid var(--cyber-border);
+  align-items: center;
+}
+
+.toolbar-group {
+  display: flex;
+  gap: 0.25rem;
+  border-right: 1px solid var(--cyber-border);
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+}
+
+.toolbar-group:last-of-type {
+  border-right: none;
+  padding-right: 0;
+  margin-right: 0;
+}
+
+/* Toolbar Format Button Styling */
+.toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background-color: transparent;
+  border: 1px solid var(--cyber-border);
+  border-radius: 6px;
+  color: var(--cyber-text);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  user-select: none;
+  transition:
+    border-color var(--ease-fade-duration),
+    color var(--ease-fade-duration);
+}
+
+/* Inner label font weight mapping */
+.toolbar-btn.btn-bold {
+  font-weight: 800;
+}
+.toolbar-btn.btn-italic {
+  font-style: italic;
+}
+.toolbar-btn.btn-underline {
+  text-decoration: underline;
+}
+.toolbar-btn.btn-strike {
+  text-decoration: line-through;
+}
+
+/* ── 4. Neon Spotlight Physics Engine ───────────────────────────────────── */
+
+/* 
+  Spotlight Glow Layer Inside The Button
+  - Sweeps a glowing gradient across on hover.
+  - Keeps a static backdrop centered gradient tracking coordinates on cursor mousemove.
+*/
+.toolbar-btn::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  background: radial-gradient(
+    20px circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
+    rgba(0, 240, 255, 0.3),
+    transparent 60%
+  );
+  opacity: 0;
+  z-index: 1;
+  transition: opacity 0.3s var(--ease-smooth-curve);
+  pointer-events: none;
+}
+
+/* Cyber magenta override on even child categories */
+.toolbar-btn:nth-child(even)::before {
+  background: radial-gradient(
+    20px circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
+    rgba(255, 0, 85, 0.3),
+    transparent 60%
+  );
+}
+
+/* Show spotlight coordinate gradient on hover */
+.toolbar-btn:hover::before {
+  opacity: 1;
+}
+
+.toolbar-btn:hover {
+  border-color: var(--cyber-cyan);
+  color: #ffffff;
+  box-shadow: var(--glow-cyan);
+}
+
+.toolbar-btn:nth-child(even):hover {
+  border-color: var(--cyber-magenta);
+  box-shadow: var(--glow-magenta);
+}
+
+/* Active formats state check styles */
+.toolbar-state-checkbox:checked + .toolbar-btn {
+  background-color: var(--cyber-border);
+  border-color: var(--cyber-cyan);
+  color: var(--cyber-cyan);
+  box-shadow: var(--glow-cyan);
+}
+
+.toolbar-state-checkbox:checked + .toolbar-btn:nth-child(even) {
+  border-color: var(--cyber-magenta);
+  color: var(--cyber-magenta);
+  box-shadow: var(--glow-magenta);
+}
+
+/* ── 5. Editor Workspace Area ───────────────────────────────────────────── */
+.editor-workspace {
+  position: relative;
+  padding: 1.5rem;
+  min-height: 280px;
+}
+
+.editor-textarea {
+  width: 100%;
+  min-height: 250px;
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  font-family: inherit;
+  font-size: var(--cyber-font-base);
+  color: var(--cyber-text);
+  line-height: 1.6;
+}
+
+/* ── 6. State Trigger Formatting Rules (Pure CSS Selector hacks) ────────── */
+
+/* Bold toggle mapping */
+#format-bold:checked ~ .editor-workspace .editor-textarea {
+  font-weight: bold;
+}
+
+/* Italic toggle mapping */
+#format-italic:checked ~ .editor-workspace .editor-textarea {
+  font-style: italic;
+}
+
+/* Underline toggle mapping */
+#format-underline:checked ~ .editor-workspace .editor-textarea {
+  text-decoration: underline;
+}
+
+/* Strikethrough toggle mapping */
+#format-strike:checked ~ .editor-workspace .editor-textarea {
+  text-decoration: line-through;
+}
+
+/* Mono code format toggle */
+#format-code:checked ~ .editor-workspace .editor-textarea {
+  color: var(--cyber-cyan);
+  background-color: rgba(0, 240, 255, 0.02);
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+
+/* Align mappings */
+#align-left:checked ~ .editor-workspace .editor-textarea {
+  text-align: left;
+}
+
+#align-center:checked ~ .editor-workspace .editor-textarea {
+  text-align: center;
+}
+
+#align-right:checked ~ .editor-workspace .editor-textarea {
+  text-align: right;
+}
+
+/* ── 7. Cyberpunk animations ────────────────────────────────────────────── */
+@keyframes cyber-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+@keyframes glitch-shake {
+  0% {
+    transform: translate(0);
+  }
+  20% {
+    transform: translate(-2px, 2px);
+  }
+  40% {
+    transform: translate(-2px, -2px);
+  }
+  60% {
+    transform: translate(2px, 2px);
+  }
+  80% {
+    transform: translate(2px, -2px);
+  }
+  100% {
+    transform: translate(0);
+  }
+}
+
+.toolbar-btn:active {
+  animation: glitch-shake 0.15s linear;
+}
+
+/* ── 8. Responsive Styles ────────────────────────────────────────────────── */
+@media (max-width: 680px) {
+  body {
+    padding: 1rem;
+  }
+
+  .cyber-editor-wrap {
+    max-width: 100%;
+  }
+
+  .cyber-toolbar {
+    padding: 0.6rem;
+  }
+
+  .toolbar-group {
+    border-right: none;
+    padding-right: 0;
+    margin-right: 0;
+  }
+}


### PR DESCRIPTION
Fixes #41489.

Adds the new Cyberpunk Spotlight Rich Text Toolbar component under submissions/examples/spotlight-rich-text-toolbar-agy/.

### Changes Included
- **demo.html**: Showcase page featuring 'cyber-editor.sys' decrypted text workspace, formatting tools toolbar, terminal telemetry footer, and script mapping mousemove coordinates.
- **style.css**: Theme styling using neon void color schemes, dark surfaces, and cursor-following radial neon spotlight glow animations.
- **README.md**: Detailed guides answering what it does, how it is used, and why it is useful, with style configurations reference.