### PR TITLE
feat: add 3d tilt markdown preview component under space theme (#41492)

### DIFF
--- a/submissions/examples/3d-tilt-markdown-preview-agy/README.md
+++ b/submissions/examples/3d-tilt-markdown-preview-agy/README.md
@@ -1,0 +1,85 @@
+# 3D Tilt Markdown Preview Card (Space Theme)
+
+A markdown document preview card themed around deep space logs, featuring a 3D perspective tilting effect matching mouse movement.
+
+---
+
+## 💡 Quick Overview
+
+### 1. What does this do?
+
+This component renders a structured markdown document card that tilts in 3D perspective when the mouse hovers over different sections using pure CSS hover zones.
+
+### 2. How is it used?
+
+Incorporate the grid hover zones and card layouts in your page markup:
+
+```html
+<!-- Outer wrapper setting perspective scope -->
+<div class="tilt-perspective-wrap" id="tilt-wrapper">
+  <!-- 3x3 Grid Hover Zones -->
+  <div class="tilt-zone tilt-zone-1"></div>
+  <div class="tilt-zone tilt-zone-2"></div>
+  <!-- ... Zones 3 to 8 ... -->
+  <div class="tilt-zone tilt-zone-9"></div>
+
+  <!-- Inner Card -->
+  <article class="tilt-card" id="tilt-card-body">
+    <header class="md-header">
+      <h1 class="md-title">Observatory Log</h1>
+    </header>
+    <section class="md-body">
+      <!-- Markdown elements... -->
+    </section>
+  </article>
+</div>
+```
+
+Then hook up the cursor spotlight coordinator in your script block to enable smooth tracking:
+
+```javascript
+const wrapper = document.getElementById("tilt-wrapper");
+const card = document.getElementById("tilt-card-body");
+wrapper.addEventListener("mousemove", (e) => {
+  const rect = wrapper.getBoundingClientRect();
+  const rotateY = ((e.clientX - rect.left) / rect.width - 0.5) * 20;
+  const rotateX = -((e.clientY - rect.top) / rect.height - 0.5) * 20;
+  card.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(1.02)`;
+});
+```
+
+### 3. Why is it useful?
+
+Markdown document viewers are common interfaces inside dashboards. Adding a 3D tilt effect inspired by deep space panels adds visual depth and guides focus, operating without JS layout shifts or heavy physics scripts.
+
+---
+
+## 🎨 Theme & Customization Guide
+
+Override these variables in your root element to adjust styling colors and glowing properties:
+
+```css
+:root {
+  /* Deep Space palette colors */
+  --space-bg: #04040d; /* Base background void color */
+  --space-surface: rgba(
+    13,
+    13,
+    33,
+    0.6
+  ); /* Translucent card surface background */
+  --space-border: rgba(99, 102, 241, 0.2); /* Thin card boundary separators */
+
+  /* Luminous Nebula Gradients */
+  --space-purple: #c084fc; /* Stellar Purple highlight */
+  --space-cyan: #38bdf8; /* Starlight Cyan highlight */
+}
+```
+
+---
+
+## ♿ Accessibility Specifications
+
+1. **Semantic HTML**: Built using correct ARIA landmark roles: `<article>` for container wrapping, `<blockquote/>` for quotes, and `<time/>` tags for date stamps.
+2. **Keyboard Traversal**: Elements inside the card are tab navigable and focus rings display a starlight blue aura.
+3. **Motion settings**: Bypasses 3D tilt rotations completely when `@media (prefers-reduced-motion: reduce)` matches, keeping readability stable.

--- a/submissions/examples/3d-tilt-markdown-preview-agy/demo.html
+++ b/submissions/examples/3d-tilt-markdown-preview-agy/demo.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Orion Observatory Journal — 3D Tilting Preview Portal</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Outer Perspective Wrapper -->
+    <div class="tilt-perspective-wrap" id="tilt-wrapper">
+      <!-- 
+      Pure CSS Hover zones layout
+      - Hovering over each absolute quadrant tilts the sibling card container.
+      - Grid contains a 3x3 layout.
+    -->
+      <div class="tilt-zone tilt-zone-1"></div>
+      <div class="tilt-zone tilt-zone-2"></div>
+      <div class="tilt-zone tilt-zone-3"></div>
+      <div class="tilt-zone tilt-zone-4"></div>
+      <div class="tilt-zone tilt-zone-5"></div>
+      <div class="tilt-zone tilt-zone-6"></div>
+      <div class="tilt-zone tilt-zone-7"></div>
+      <div class="tilt-zone tilt-zone-8"></div>
+      <div class="tilt-zone tilt-zone-9"></div>
+
+      <!-- Inner Tilting Markdown Card -->
+      <article class="tilt-card" id="tilt-card-body">
+        <!-- Document Header -->
+        <header class="md-header">
+          <div class="md-meta">Decrypted Log // Sector 412</div>
+          <h1 class="md-title">Orion Nebula Observation Log</h1>
+        </header>
+
+        <!-- Markdown Body Preview -->
+        <section class="md-body">
+          <p>
+            Telemetry metrics from the Hubble cluster report anomalies within
+            the core nebula rings. Soil, carbon, and hydrogen particle counts
+            are shifting dynamically.
+          </p>
+
+          <h2>1. Observation Summary</h2>
+          <p>
+            The primary core cluster is expanding. Stars within the inner ring
+            system are showing elevated light outputs. Telemetry suggests a
+            thermal shockwave is building.
+          </p>
+
+          <!-- Quote blocks -->
+          <blockquote>
+            "The core rings are luminous. Decryption algorithms are actively
+            compiling particle maps."
+            <cite
+              style="
+                display: block;
+                margin-top: 0.5rem;
+                font-size: var(--space-font-xs);
+                font-style: normal;
+                color: var(--space-cyan);
+              "
+              >— Kepler Array logs</cite
+            >
+          </blockquote>
+
+          <h2>2. Telemetry Parameters & Stellar Spectra</h2>
+          <p>
+            Current observation scopes register the following values during
+            Sector 412 scanning loops. High-resolution infrared spectrometry
+            scans show ionized helium clouds drifting near the core orbit
+            boundaries at elevated velocities.
+          </p>
+
+          <ul>
+            <li>
+              <strong>Cluster status:</strong> Active, core telemetry synced
+            </li>
+            <li>
+              <strong>Thermal threshold:</strong> 12,450K, stable inside bounds
+            </li>
+            <li>
+              <strong>Moisture levels:</strong> 0.04% density, optimal cloud
+              formations
+            </li>
+            <li>
+              <strong>Luminous Output:</strong> 4.8 L☉ (solar luminosity
+              equivalents)
+            </li>
+          </ul>
+
+          <h2>3. Target Code Configuration</h2>
+          <p>
+            Engineers can parse observation coordinates using the following json
+            packet:
+          </p>
+
+          <!-- Code block snippet -->
+          <pre class="md-code-block"><code>// Nebula compilation configurations
+const orionCluster = {
+  id: "sector-412",
+  status: "expanding",
+  particleCount: 1248500,
+  thermalLoad: 12450,
+  spectrometry: ["hydrogen", "helium", "ionized-carbon"]
+};</code></pre>
+
+          <h2>4. Core Warnings & Risks</h2>
+          <p style="color: var(--space-magenta); font-weight: 700">
+            ⚠️ SOLAR FLARE WARNING: A solar flare event is expected in Sector
+            412 within the next 48 hours. Secure telemetry channels immediately.
+          </p>
+
+          <p style="margin-top: 1.5rem">
+            For more telemetry readings, check the
+            <a
+              href="https://github.com/SAPTARSHI-coder/EaseMotion-css"
+              class="md-link"
+              target="_blank"
+              >EaseMotion CSS code repository</a
+            >.
+          </p>
+        </section>
+
+        <!-- Document Footer Actions -->
+        <footer
+          style="
+            margin-top: 2rem;
+            border-top: 1px solid var(--space-border);
+            padding-top: 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            pointer-events: auto;
+          "
+        >
+          <span
+            style="font-size: var(--space-font-xs); color: var(--space-muted)"
+            >LOG VERSION: v9.4 // ORION</span
+          >
+          <button
+            id="btn-sync"
+            style="
+              background: none;
+              border: 1px solid var(--space-cyan);
+              color: var(--space-cyan);
+              padding: 0.4rem 1rem;
+              border-radius: 8px;
+              font-size: var(--space-font-xs);
+              cursor: pointer;
+              transition: background-color 0.2s;
+            "
+            tabindex="0"
+          >
+            Sync Satellite
+          </button>
+        </footer>
+      </article>
+    </div>
+
+    <!-- Interactive JavaScript Enhancements (Mouse tracking override) -->
+    <script>
+      const wrapper = document.getElementById("tilt-wrapper");
+      const card = document.getElementById("tilt-card-body");
+      const zones = document.querySelectorAll(".tilt-zone");
+      const syncBtn = document.getElementById("btn-sync");
+
+      // 1. Mouse coordinates tracker: Overrides pure CSS zone tilts with smooth pixel-perfect movements
+      wrapper.addEventListener("mousemove", (e) => {
+        // Temporarily disable CSS zones sibling triggers on javascript cursor move
+        zones.forEach((zone) => (zone.style.pointerEvents = "none"));
+
+        const rect = wrapper.getBoundingClientRect();
+        const x = e.clientX - rect.left; // cursor x inside wrapper
+        const y = e.clientY - rect.top; // cursor y inside wrapper
+
+        const width = rect.width;
+        const height = rect.height;
+
+        // Calculate rotation offset values between -10deg and +10deg
+        const rotateY = (x / width - 0.5) * 20;
+        const rotateX = -(y / height - 0.5) * 20;
+
+        card.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale3d(1.02, 1.02, 1)`;
+      });
+
+      // 2. Reset coordinates on mouse leave
+      wrapper.addEventListener("mouseleave", () => {
+        // Re-enable pure CSS zones sibling triggers
+        zones.forEach((zone) => (zone.style.pointerEvents = "auto"));
+
+        card.style.transform = "rotateX(0deg) rotateY(0deg) scale3d(1, 1, 1)";
+      });
+
+      // Keyboard handlers mapping Enter on sync buttons
+      syncBtn.addEventListener("click", () => {
+        syncBtn.textContent = "Syncing...";
+        syncBtn.style.borderColor = "var(--space-magenta)";
+        syncBtn.style.color = "var(--space-magenta)";
+        setTimeout(() => {
+          syncBtn.textContent = "Sync Satellite";
+          syncBtn.style.borderColor = "var(--space-cyan)";
+          syncBtn.style.color = "var(--space-cyan)";
+          alert("Hubble array synchronized successfully.");
+        }, 1500);
+      });
+
+      syncBtn.addEventListener("keydown", (e) => {
+        if (e.key === " " || e.key === "Enter") {
+          e.preventDefault();
+          syncBtn.click();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/3d-tilt-markdown-preview-agy/style.css
+++ b/submissions/examples/3d-tilt-markdown-preview-agy/style.css
@@ -1,0 +1,361 @@
+/* ==========================================================================
+   EaseMotion CSS - 3D Tilt Markdown Preview (Space Design Variant)
+   ========================================================================== */
+
+/* ── 1. Cosmic Design Tokens & Variables ────────────────────────────────── */
+:root {
+  /* Deep Space Color Scheme */
+  --space-bg: #04040d;
+  --space-surface: rgba(13, 13, 33, 0.6);
+  --space-border: rgba(99, 102, 241, 0.2);
+
+  /* Luminous Nebula Gradients */
+  --space-purple: #c084fc; /* Stellar Purple */
+  --space-cyan: #38bdf8; /* Starlight Cyan */
+  --space-magenta: #f472b6; /* Nebula Magenta */
+  --space-text: #f3f4f6;
+  --space-muted: #9ca3af;
+  --space-shadow: rgba(99, 102, 241, 0.08);
+
+  /* Animation Timings */
+  --ease-elastic-duration: 0.5s;
+  --ease-fade-duration: 0.25s;
+  --ease-smooth-curve: cubic-bezier(0.25, 1, 0.5, 1);
+
+  /* Typographic Hierarchy */
+  --space-font: "Inter", system-ui, -apple-system, sans-serif;
+  --space-font-xs: 0.75rem;
+  --space-font-sm: 0.88rem;
+  --space-font-base: 0.98rem;
+  --space-font-lg: 1.25rem;
+  --space-font-xl: 1.75rem;
+}
+
+/* Force dark theme settings */
+body {
+  background-color: var(--space-bg);
+  color: var(--space-text);
+  font-family: var(--space-font);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 3rem 1.5rem;
+  overflow-x: hidden;
+  position: relative;
+}
+
+/* Nebula background glowing circles */
+body::before {
+  content: "";
+  position: absolute;
+  top: -10%;
+  left: -10%;
+  width: 50%;
+  height: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(192, 132, 252, 0.08) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+body::after {
+  content: "";
+  position: absolute;
+  bottom: -10%;
+  right: -10%;
+  width: 50%;
+  height: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(56, 189, 248, 0.08) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+/* Custom Scrollbar for code blocks */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: rgba(5, 5, 15, 0.5);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--space-border);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--space-cyan);
+}
+
+/* ── 2. 3D Perspective Wrapper Setup ───────────────────────────────────── */
+.tilt-perspective-wrap {
+  width: 100%;
+  max-width: 720px;
+  position: relative;
+  /* Define perspective scope on parent container */
+  perspective: 1000px;
+}
+
+/* ── 3. 3x3 Quadrant Hover Zones (Pure CSS Tilt Engine) ─────────────────── */
+.tilt-zone {
+  position: absolute;
+  width: 33.333%;
+  height: 33.333%;
+  z-index: 10;
+  cursor: pointer;
+}
+
+/* Layout coordinates mapping for the 9 quadrants */
+.tilt-zone-1 {
+  top: 0;
+  left: 0;
+}
+.tilt-zone-2 {
+  top: 0;
+  left: 33.333%;
+}
+.tilt-zone-3 {
+  top: 0;
+  left: 66.666%;
+}
+.tilt-zone-4 {
+  top: 33.333%;
+  left: 0;
+}
+.tilt-zone-5 {
+  top: 33.333%;
+  left: 33.333%;
+}
+.tilt-zone-6 {
+  top: 33.333%;
+  left: 66.666%;
+}
+.tilt-zone-7 {
+  top: 66.666%;
+  left: 0;
+}
+.tilt-zone-8 {
+  top: 66.666%;
+  left: 33.333%;
+}
+.tilt-zone-9 {
+  top: 66.666%;
+  left: 66.666%;
+}
+
+/* ── 4. Markdown Tilting Card Container ────────────────────────────────── */
+.tilt-card {
+  background-color: var(--space-surface);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--space-border);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.4),
+    0 0 40px var(--space-shadow);
+  transform-style: preserve-3d;
+  transition:
+    transform 0.5s var(--ease-smooth-curve),
+    box-shadow 0.5s;
+  pointer-events: none; /* Let hover events pass straight to zones underneath */
+}
+
+/* Luminous glowing border element */
+.tilt-card::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 24px;
+  padding: 1px;
+  background: linear-gradient(135deg, var(--space-purple), var(--space-cyan));
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  opacity: 0.3;
+  transition: opacity 0.5s;
+}
+
+/* ── 5. Hover Zone Sibling Selector Rotations Mappings ────────────────── */
+.tilt-zone-1:hover ~ .tilt-card {
+  transform: rotateX(8deg) rotateY(-8deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-2:hover ~ .tilt-card {
+  transform: rotateX(8deg) rotateY(0deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-3:hover ~ .tilt-card {
+  transform: rotateX(8deg) rotateY(8deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-4:hover ~ .tilt-card {
+  transform: rotateX(0deg) rotateY(-8deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-5:hover ~ .tilt-card {
+  transform: rotateX(0deg) rotateY(0deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-6:hover ~ .tilt-card {
+  transform: rotateX(0deg) rotateY(8deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-7:hover ~ .tilt-card {
+  transform: rotateX(-8deg) rotateY(-8deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-8:hover ~ .tilt-card {
+  transform: rotateX(-8deg) rotateY(0deg) scale3d(1.02, 1.02, 1);
+}
+.tilt-zone-9:hover ~ .tilt-card {
+  transform: rotateX(-8deg) rotateY(8deg) scale3d(1.02, 1.02, 1);
+}
+
+/* Enhance glowing outlines on hover state */
+.tilt-perspective-wrap:hover .tilt-card::before {
+  opacity: 0.8;
+}
+
+.tilt-perspective-wrap:hover .tilt-card {
+  box-shadow:
+    0 40px 80px rgba(0, 0, 0, 0.5),
+    0 0 50px rgba(99, 102, 241, 0.2);
+}
+
+/* ── 6. Markdown Layout Content Typography ──────────────────────────────── */
+.md-header {
+  border-bottom: 1px solid var(--space-border);
+  padding-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
+  transform: translate3d(0, 0, 20px); /* 3D layer pop */
+}
+
+.md-title {
+  font-size: var(--space-font-xl);
+  font-weight: 800;
+  color: #ffffff;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #ffffff, var(--space-muted));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.md-meta {
+  font-size: var(--space-font-xs);
+  color: var(--space-cyan);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  margin-top: 0.25rem;
+}
+
+.md-body {
+  transform: translate3d(0, 0, 10px); /* 3D layer pop */
+}
+
+.md-body h2 {
+  font-size: var(--space-font-lg);
+  font-weight: 700;
+  margin: 1.8rem 0 0.8rem;
+  color: var(--space-purple);
+  letter-spacing: -0.02em;
+}
+
+.md-body p {
+  font-size: var(--space-font-base);
+  color: var(--space-text);
+  margin-bottom: 1.2rem;
+}
+
+.md-body blockquote {
+  border-left: 3px solid var(--space-cyan);
+  padding-left: 1.25rem;
+  margin: 1.8rem 0;
+  color: var(--space-muted);
+  font-style: italic;
+  background-color: rgba(56, 189, 248, 0.02);
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.md-body ul {
+  padding-left: 1.5rem;
+  margin-bottom: 1.2rem;
+}
+
+.md-body li {
+  font-size: var(--space-font-sm);
+  color: var(--space-text);
+  margin-bottom: 0.6rem;
+}
+
+/* Code highlight blocks */
+.md-code-block {
+  background-color: rgba(5, 5, 15, 0.8);
+  border: 1px solid var(--space-border);
+  border-radius: 12px;
+  padding: 1.2rem;
+  font-family: monospace;
+  font-size: var(--space-font-xs);
+  overflow-x: auto;
+  margin: 1.8rem 0;
+  color: var(--space-cyan);
+}
+
+/* Interactive link nodes */
+.md-link {
+  color: var(--space-cyan);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--space-cyan);
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+  pointer-events: auto; /* Re-enable pointer events for links */
+}
+
+.md-link:hover {
+  color: var(--space-magenta);
+  border-bottom-color: var(--space-magenta);
+}
+
+/* Focus and active highlight states styling */
+#btn-sync:focus-visible {
+  outline: 2px solid var(--space-cyan);
+  outline-offset: 4px;
+}
+
+#btn-sync:hover {
+  background-color: rgba(56, 189, 248, 0.05);
+}
+
+/* ── 7. Responsive Styles ────────────────────────────────────────────────── */
+@media (max-width: 680px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .tilt-card {
+    padding: 1.5rem;
+  }
+
+  .md-title {
+    font-size: var(--space-font-lg);
+  }
+}
+
+/* Motion fallbacks */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-zone {
+    display: none;
+  }
+
+  .tilt-card {
+    transform: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Fixes #41492.

Adds the new Space 3D Tilt Markdown Preview component under submissions/examples/3d-tilt-markdown-preview-agy/.

### Changes Included
- **demo.html**: Showcase page featuring 'Orion Observatory Journal' logs, a 9-quadrant hover tilt grid wrapper, blockquotes, code blocks, lists, and synchronization buttons.
- **style.css**: Theme styling using space void black backgrounds, nebula gradients, and sibling selectors tilt rotations.
- **README.md**: Detailed guides answering what it does, how it is used, and why it is useful, with style configurations reference.