### PR TITLE
feat: add underline draw font switcher

### DIFF
--- a/submissions/examples/underline-draw-font-switcher-jp/README.md
+++ b/submissions/examples/underline-draw-font-switcher-jp/README.md
@@ -1,0 +1,64 @@
+# Underline Draw Font Switcher
+
+## What does this do?
+
+This submission creates a responsive, accessible CSS-only font switcher with an animated underline that updates an analytics dashboard preview.
+
+## How is it used?
+
+```html
+<input
+  class="font-radio-jp"
+  type="radio"
+  name="font-style"
+  id="font-system"
+  checked
+/>
+
+<input
+  class="font-radio-jp"
+  type="radio"
+  name="font-style"
+  id="font-serif"
+/>
+
+<div class="font-switcher-jp">
+  <label for="font-system">System</label>
+  <label for="font-serif">Serif</label>
+</div>
+
+<section class="analytics-card-jp">
+  <h2>Growth dashboard</h2>
+</section>
+```
+
+Customize the component through CSS variables:
+
+```css
+:root {
+  --ease-underline-duration-jp: 420ms;
+  --ease-underline-curve-jp: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-font-accent-jp: #7867ff;
+  --ease-font-accent-2-jp: #47ddbd;
+  --ease-switch-radius-jp: 1rem;
+}
+```
+
+Native radio inputs control the selected font. The active label draws an underline from left to right, and the dashboard preview updates through sibling selectors.
+
+Open `demo.html` directly in a browser. No server, JavaScript, CDN, or external framework is required.
+
+## Why is it useful?
+
+Font switchers are useful for typography tools, analytics previews, theme editors, design systems, reading interfaces, and accessibility settings.
+
+This example fits EaseMotion CSS because it:
+
+- uses underline motion to clearly communicate the selected font;
+- keeps native radio controls for keyboard interaction;
+- provides readable labels and visible selected states;
+- exposes reusable timing and color variables;
+- updates a realistic analytics preview;
+- adapts to smaller screens;
+- respects `prefers-reduced-motion`;
+- requires zero JavaScript and zero external dependencies.

--- a/submissions/examples/underline-draw-font-switcher-jp/demo.html
+++ b/submissions/examples/underline-draw-font-switcher-jp/demo.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="description"
+    content="Accessible pure-CSS underline draw font switcher inspired by analytics dashboards."
+  />
+  <title>Underline Draw Font Switcher</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page-shell-jp">
+    <section class="intro-jp" aria-labelledby="page-title">
+      <p class="eyebrow-jp">EaseMotion CSS submission</p>
+      <h1 id="page-title">Underline Draw Font Switcher</h1>
+      <p class="lead-jp">
+        A CSS-only analytics preview that switches between system, serif,
+        monospace, and rounded font styles with animated underline feedback.
+      </p>
+    </section>
+
+    <section class="font-demo-jp" aria-labelledby="font-demo-title">
+      <input
+        class="font-radio-jp"
+        type="radio"
+        name="font-style"
+        id="font-system"
+        checked
+      />
+      <input
+        class="font-radio-jp"
+        type="radio"
+        name="font-style"
+        id="font-serif"
+      />
+      <input
+        class="font-radio-jp"
+        type="radio"
+        name="font-style"
+        id="font-mono"
+      />
+      <input
+        class="font-radio-jp"
+        type="radio"
+        name="font-style"
+        id="font-rounded"
+      />
+
+      <div class="font-switcher-jp" role="radiogroup" aria-label="Choose preview font">
+        <label for="font-system">
+          <span>System</span>
+        </label>
+        <label for="font-serif">
+          <span>Serif</span>
+        </label>
+        <label for="font-mono">
+          <span>Mono</span>
+        </label>
+        <label for="font-rounded">
+          <span>Rounded</span>
+        </label>
+      </div>
+
+      <section class="analytics-card-jp" aria-labelledby="font-demo-title">
+        <header class="card-header-jp">
+          <div>
+            <p class="card-kicker-jp">Typography preview</p>
+            <h2 id="font-demo-title">Growth dashboard</h2>
+          </div>
+          <span class="status-badge-jp">
+            <span aria-hidden="true"></span>
+            Updated now
+          </span>
+        </header>
+
+        <div class="preview-copy-jp">
+          <p class="preview-label-jp">Monthly recurring revenue</p>
+          <strong class="preview-value-jp">$184,320</strong>
+          <p class="preview-description-jp">
+            Revenue increased across enterprise and professional subscriptions.
+          </p>
+        </div>
+
+        <div class="metric-grid-jp">
+          <article>
+            <span>Conversion</span>
+            <strong>8.6%</strong>
+            <small>↗ 1.4%</small>
+          </article>
+
+          <article>
+            <span>Active teams</span>
+            <strong>2,481</strong>
+            <small>↗ 126</small>
+          </article>
+
+          <article>
+            <span>Churn</span>
+            <strong>1.9%</strong>
+            <small>↘ 0.3%</small>
+          </article>
+        </div>
+
+        <div class="activity-jp">
+          <div>
+            <span class="activity-dot-jp" aria-hidden="true"></span>
+            <p>
+              <strong>Enterprise plan</strong>
+              <small>Generated 42% of new revenue</small>
+            </p>
+          </div>
+
+          <div>
+            <span class="activity-dot-jp second-dot-jp" aria-hidden="true"></span>
+            <p>
+              <strong>Professional plan</strong>
+              <small>Added 318 active workspaces</small>
+            </p>
+          </div>
+        </div>
+      </section>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/underline-draw-font-switcher-jp/style.css
+++ b/submissions/examples/underline-draw-font-switcher-jp/style.css
@@ -1,0 +1,358 @@
+:root {
+  color-scheme: dark;
+
+  --ease-underline-duration-jp: 420ms;
+  --ease-underline-curve-jp: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-font-accent-jp: #7867ff;
+  --ease-font-accent-2-jp: #47ddbd;
+  --ease-switch-radius-jp: 1rem;
+
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  background: #070910;
+  color: #f7f8ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 12% 12%, rgb(120 103 255 / 16%), transparent 28rem),
+    radial-gradient(circle at 88% 84%, rgb(71 221 189 / 10%), transparent 24rem),
+    #070910;
+}
+
+.page-shell-jp {
+  width: min(100% - 2rem, 76rem);
+  margin-inline: auto;
+  padding: clamp(2.5rem, 7vw, 6rem) 0;
+}
+
+.intro-jp {
+  max-width: 49rem;
+  margin-bottom: 2rem;
+}
+
+.eyebrow-jp {
+  margin: 0 0 0.75rem;
+  color: #b2aaff;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 11ch;
+  margin: 0;
+  font-size: clamp(2.9rem, 8vw, 6.3rem);
+  line-height: 0.93;
+  letter-spacing: -0.06em;
+}
+
+.lead-jp {
+  max-width: 45rem;
+  margin: 1.2rem 0 0;
+  color: #9ca7ba;
+  line-height: 1.7;
+}
+
+.font-demo-jp {
+  position: relative;
+}
+
+.font-radio-jp {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.font-switcher-jp {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.4rem;
+  width: min(100%, 36rem);
+  margin-bottom: 1rem;
+  padding: 0.35rem;
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: calc(var(--ease-switch-radius-jp) + 0.2rem);
+  background: rgb(255 255 255 / 4%);
+  box-shadow: inset 0 1px rgb(255 255 255 / 6%);
+}
+
+.font-switcher-jp label {
+  position: relative;
+  display: grid;
+  min-height: 3rem;
+  place-items: center;
+  overflow: hidden;
+  border-radius: var(--ease-switch-radius-jp);
+  color: #909bad;
+  font-size: 0.75rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.font-switcher-jp label::after {
+  content: "";
+  position: absolute;
+  right: 0.8rem;
+  bottom: 0.45rem;
+  left: 0.8rem;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    var(--ease-font-accent-jp),
+    var(--ease-font-accent-2-jp)
+  );
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--ease-underline-duration-jp)
+    var(--ease-underline-curve-jp);
+}
+
+.font-switcher-jp label:hover {
+  color: #d9deea;
+  background: rgb(255 255 255 / 4%);
+}
+
+#font-system:checked ~ .font-switcher-jp label[for="font-system"],
+#font-serif:checked ~ .font-switcher-jp label[for="font-serif"],
+#font-mono:checked ~ .font-switcher-jp label[for="font-mono"],
+#font-rounded:checked ~ .font-switcher-jp label[for="font-rounded"] {
+  color: white;
+  background: rgb(120 103 255 / 10%);
+}
+
+#font-system:checked ~ .font-switcher-jp label[for="font-system"]::after,
+#font-serif:checked ~ .font-switcher-jp label[for="font-serif"]::after,
+#font-mono:checked ~ .font-switcher-jp label[for="font-mono"]::after,
+#font-rounded:checked ~ .font-switcher-jp label[for="font-rounded"]::after {
+  transform: scaleX(1);
+}
+
+.font-radio-jp:focus-visible ~ .font-switcher-jp {
+  outline: 3px solid rgb(178 170 255 / 40%);
+  outline-offset: 4px;
+}
+
+.analytics-card-jp {
+  padding: clamp(1rem, 4vw, 2rem);
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 1.6rem;
+  background:
+    radial-gradient(circle at 100% 0%, rgb(120 103 255 / 13%), transparent 16rem),
+    linear-gradient(145deg, rgb(255 255 255 / 5%), transparent),
+    #101521;
+  box-shadow:
+    inset 0 1px rgb(255 255 255 / 7%),
+    0 2rem 5rem rgb(0 0 0 / 30%);
+  transition: font-family 240ms ease;
+}
+
+#font-system:checked ~ .analytics-card-jp {
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+
+#font-serif:checked ~ .analytics-card-jp {
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+#font-mono:checked ~ .analytics-card-jp {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+#font-rounded:checked ~ .analytics-card-jp {
+  font-family:
+    "Trebuchet MS", "Arial Rounded MT Bold", ui-rounded, system-ui, sans-serif;
+}
+
+.card-header-jp {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.card-kicker-jp {
+  margin: 0 0 0.35rem;
+  color: #9f96ff;
+  font-size: 0.67rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.card-header-jp h2 {
+  margin: 0;
+  font-size: clamp(1.45rem, 4vw, 2.15rem);
+  letter-spacing: -0.035em;
+}
+
+.status-badge-jp {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.48rem 0.62rem;
+  border-radius: 999px;
+  background: rgb(71 221 189 / 11%);
+  color: #71e4c7;
+  font-size: 0.66rem;
+  font-weight: 800;
+}
+
+.status-badge-jp span {
+  width: 0.45rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--ease-font-accent-2-jp);
+  box-shadow: 0 0 0 0.2rem rgb(71 221 189 / 12%);
+}
+
+.preview-copy-jp {
+  padding: 1.1rem;
+  border: 1px solid rgb(255 255 255 / 8%);
+  border-radius: 1.1rem;
+  background: rgb(255 255 255 / 3.5%);
+}
+
+.preview-label-jp {
+  margin: 0 0 0.45rem;
+  color: #7f8a9d;
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.preview-value-jp {
+  display: block;
+  font-size: clamp(2.6rem, 7vw, 5rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+}
+
+.preview-description-jp {
+  max-width: 40rem;
+  margin: 0.7rem 0 0;
+  color: #8d98ac;
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.metric-grid-jp {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.metric-grid-jp article {
+  display: grid;
+  gap: 0.28rem;
+  padding: 0.9rem;
+  border: 1px solid rgb(255 255 255 / 7%);
+  border-radius: 0.95rem;
+  background: rgb(255 255 255 / 3%);
+}
+
+.metric-grid-jp span,
+.metric-grid-jp small {
+  color: #7d899c;
+}
+
+.metric-grid-jp span {
+  font-size: 0.67rem;
+  font-weight: 750;
+}
+
+.metric-grid-jp strong {
+  font-size: 1.45rem;
+}
+
+.metric-grid-jp small {
+  color: #62dcbc;
+  font-size: 0.65rem;
+}
+
+.activity-jp {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+.activity-jp > div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid rgb(255 255 255 / 7%);
+}
+
+.activity-dot-jp {
+  width: 0.65rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--ease-font-accent-jp);
+  box-shadow: 0 0 0 0.25rem rgb(120 103 255 / 11%);
+}
+
+.second-dot-jp {
+  background: var(--ease-font-accent-2-jp);
+  box-shadow: 0 0 0 0.25rem rgb(71 221 189 / 11%);
+}
+
+.activity-jp p {
+  margin: 0;
+}
+
+.activity-jp strong,
+.activity-jp small {
+  display: block;
+}
+
+.activity-jp strong {
+  font-size: 0.76rem;
+}
+
+.activity-jp small {
+  margin-top: 0.18rem;
+  color: #7f899c;
+  font-size: 0.66rem;
+}
+
+@media (max-width: 680px) {
+  .font-switcher-jp {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric-grid-jp {
+    grid-template-columns: 1fr;
+  }
+
+  .card-header-jp {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .font-switcher-jp label,
+  .font-switcher-jp label::after,
+  .analytics-card-jp {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an **Underline Draw Font Switcher** component for Issue #41551.

This submission provides a responsive, pure-CSS font switcher inspired by analytics-dashboard design patterns. It uses native radio controls, animated underline feedback, four font styles, a synchronized dashboard preview, keyboard interaction, and reduced-motion support.

**Closes #41551**

---

## Type of Change

* [x] New animation / interaction effect
* [x] New component
* [ ] Documentation improvement
* [ ] Bug fix
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside `submissions/examples/underline-draw-font-switcher-jp/`
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] Demo works when opened directly in a browser
* [x] Uses native radio inputs
* [x] Works without JavaScript
* [x] Includes four font options
* [x] Includes animated underline feedback
* [x] Includes visible selected and focus states
* [x] Includes responsive behavior
* [x] Includes reduced-motion support
* [x] Uses no external dependencies
* [x] No shared framework files were modified
* [x] No unrelated changes are included

---

## Feature Description

### What does this add?

A reusable font-switcher component suitable for:

* typography tools;
* analytics previews;
* theme editors;
* design systems;
* reading interfaces;
* accessibility settings.

The demo includes four options:

* System
* Serif
* Mono
* Rounded

### How does it work?

```html
<input
  class="font-radio-jp"
  type="radio"
  name="font-style"
  id="font-system"
  checked
/>

<input
  class="font-radio-jp"
  type="radio"
  name="font-style"
  id="font-serif"
/>

<div class="font-switcher-jp">
  <label for="font-system">
    System
  </label>

  <label for="font-serif">
    Serif
  </label>
</div>

<section class="analytics-card-jp">
  <h2>Growth dashboard</h2>
</section>
```

Native radio inputs store the selected font state. CSS sibling selectors update the dashboard preview and draw an underline beneath the active label.

### Customizable variables

```css
:root {
  --ease-underline-duration-jp: 420ms;
  --ease-underline-curve-jp:
    cubic-bezier(0.22, 1, 0.36, 1);
  --ease-font-accent-jp: #7867ff;
  --ease-font-accent-2-jp: #47ddbd;
  --ease-switch-radius-jp: 1rem;
}
```

### Accessibility

* Uses native radio inputs.
* Every option has a visible text label.
* Keyboard users can switch options with arrow keys.
* Selected state is communicated with color, background, and underline.
* The preview remains readable without animation.
* Reduced-motion users receive immediate state changes without transitions.

---

## Files Added

```text
submissions/examples/underline-draw-font-switcher-jp/
├── demo.html
├── style.css
└── README.md
```

---

## Browser Testing

Check only browsers personally tested:

* [ ] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari

---

## Notes for Maintainer

The implementation is fully isolated inside the approved Standard Track submission folder.

It uses semantic HTML, native radio controls, CSS sibling selectors, custom properties, responsive media queries, and reduced-motion handling.

No JavaScript, CDN, external fonts, framework, or dependency is included.
