### PR TITLE
feat: add typewriter spinner component under neumorphism theme (#41496)

### DIFF
--- a/submissions/examples/typewriter-spinner-agy/README.md
+++ b/submissions/examples/typewriter-spinner-agy/README.md
@@ -1,0 +1,115 @@
+# Neumorphic Typewriter Spinner Component
+
+A loading status spinner styled like retro typewriter keys, featuring physics-based keypress wave transitions inside a soft neumorphic workspace deck.
+
+---
+
+## 💡 Quick Overview
+
+### 1. What does this do?
+
+This component renders a loading spinner array containing typewriter-like letter blocks spelling "L-O-A-D-I-N-G-..." that press down sequentially in a wave pattern using pure CSS transitions.
+
+### 2. How is it used?
+
+Incorporate the state-controlling checkbox and loader layout inside your dashboard:
+
+```html
+<!-- 1. Pure CSS State Checkbox -->
+<input
+  type="checkbox"
+  id="loader-active-toggle"
+  class="spinner-state-checkbox"
+  checked
+/>
+
+<!-- 2. Typewriter Keys Loader -->
+<div
+  class="typewriter-loader"
+  role="status"
+  aria-live="polite"
+  aria-label="Loading contents"
+>
+  <div class="type-key">L</div>
+  <div class="type-key">O</div>
+  <div class="type-key">A</div>
+  <div class="type-key">D</div>
+  <div class="type-key">I</div>
+  <div class="type-key">N</div>
+  <div class="type-key">G</div>
+</div>
+
+<!-- 3. Toggle Control Switches -->
+<div class="typist-controls">
+  <label for="loader-active-toggle" class="typist-btn">Start Typing</label>
+</div>
+```
+
+### 3. Why is it useful?
+
+Loading spinners are primary transition visual elements inside dashboards and portfolios. This component implements soft neumorphic extrusion borders that shift to inset bevel shadows sequentially, imitating typing actions without layout reflows or scripts.
+
+---
+
+## 🎨 Theme & Customization Guide
+
+Override these variables in your root element to adjust styling colors and transition delays:
+
+```css
+:root {
+  /* Neumorphic soft colors */
+  --neu-bg: #e0e8f6; /* Base dashboard background */
+  --neu-surface: #e0e8f6; /* Button and key faces color */
+  --neu-light: #ffffff; /* Soft light reflection highlight */
+  --neu-shadow: #b8c4d9; /* Soft dark bevel drop shadow */
+  --neu-accent: #3b82f6; /* Glowing selection key label color */
+
+  /* Timing Configuration */
+  --ease-elastic-duration: 1.5s; /* Speed of the complete wave cycle loop */
+}
+```
+
+### Custom Staggered Intervals
+
+Staggered delay intervals can be customized in the children lists to speed up or slow down the typewriter wave action:
+
+```css
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(1) {
+  animation-delay: 0s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(2) {
+  animation-delay: 0.12s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(3) {
+  animation-delay: 0.24s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(4) {
+  animation-delay: 0.36s;
+}
+```
+
+### Dark Mode Integration
+
+Neumorphism relies heavily on precise shadow contrast. The component automatically adjusts for dark mode themes using:
+
+1. Media queries searching for user-selected settings (`@media (prefers-color-scheme: dark)`).
+2. Data attributes configuration tags (`[data-theme="dark"]`).
+
+---
+
+## 📖 CSS Class Reference
+
+| Selector Class       | Visual / Layout Purpose                                            |
+| :------------------- | :----------------------------------------------------------------- |
+| `.typist-wrap`       | Main dashboard outer deck containing soft shadows.                 |
+| `.typewriter-loader` | Inset neumorphic container representing the keyboard deck.         |
+| `.type-key`          | Circular extruded keys that react to sequential wave animations.   |
+| `.typist-btn`        | Interactive button switches styling active/inactive inset shadows. |
+
+---
+
+## ♿ Accessibility Specifications
+
+1. **Focus Controls**: Highlight focus rings style themselves in dashed blue outlines for keyboard accessibility.
+2. **Keyboard Traversal**: Start/Stop labels are mapped to checkbox triggers via Space and Enter click listeners.
+3. **Motion settings**: Completely disables keypress transitions when `@media (prefers-reduced-motion: reduce)` matches, keeping readability stable.

--- a/submissions/examples/typewriter-spinner-agy/demo.html
+++ b/submissions/examples/typewriter-spinner-agy/demo.html
@@ -1,0 +1,334 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Retro Typist Hub — Neumorphic Typewriter Loader Deck</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- 
+    Typist Workspace deck wrapper
+    - Houses checkboxes, dashboard controllers, typewriter keys.
+  -->
+    <div class="typist-wrap">
+      <!-- Pure CSS State Checkbox trigger controls -->
+      <input
+        type="checkbox"
+        id="loader-active-toggle"
+        class="spinner-state-checkbox"
+        checked
+      />
+
+      <!-- Header Panel -->
+      <header class="typist-title">
+        <h1>Retro Typist Console</h1>
+        <p>Neumorphic typewriter simulation array // CSS wave engine</p>
+      </header>
+
+      <!-- 
+      Typewriter Loader Container
+      - Contains individual letter key blocks.
+      - Checked checkbox triggers sequential keypress wave.
+    -->
+      <div
+        class="typewriter-loader"
+        role="status"
+        aria-live="polite"
+        aria-label="Loading contents"
+      >
+        <div class="type-key">L</div>
+        <div class="type-key">O</div>
+        <div class="type-key">A</div>
+        <div class="type-key">D</div>
+        <div class="type-key">I</div>
+        <div class="type-key">N</div>
+        <div class="type-key">G</div>
+        <div class="type-key">.</div>
+        <div class="type-key">.</div>
+        <div class="type-key">.</div>
+      </div>
+
+      <!-- Neumorphic Control Switches Deck -->
+      <div class="typist-controls">
+        <!-- Start Button (maps checkbox checked) -->
+        <label
+          for="loader-active-toggle"
+          class="typist-btn"
+          id="btn-start"
+          tabindex="0"
+        >
+          Start Typing
+        </label>
+
+        <!-- Stop Button (maps checkbox unchecked) -->
+        <label
+          for="loader-active-toggle"
+          class="typist-btn"
+          id="btn-stop"
+          tabindex="0"
+        >
+          Stop Loader
+        </label>
+      </div>
+
+      <!-- Secondary Neumorphic Statistics Deck -->
+      <section
+        style="
+          width: 100%;
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+          gap: 1.5rem;
+          margin-top: 1rem;
+        "
+      >
+        <div
+          style="
+            background-color: var(--neu-surface);
+            padding: 1.2rem;
+            border-radius: 20px;
+            box-shadow:
+              inset 3px 3px 6px var(--neu-shadow),
+              inset -3px -3px 6px var(--neu-light);
+            text-align: center;
+          "
+        >
+          <div
+            style="
+              font-size: var(--neu-font-xs);
+              color: var(--neu-muted);
+              text-transform: uppercase;
+            "
+          >
+            Typing Speed
+          </div>
+          <div
+            style="
+              font-size: var(--neu-font-xl);
+              font-weight: 800;
+              margin: 0.25rem 0;
+            "
+            id="metric-wpm"
+          >
+            84 WPM
+          </div>
+          <div
+            style="
+              font-size: 0.65rem;
+              color: var(--neu-accent);
+              font-weight: 700;
+            "
+          >
+            OPTICAL ACCURACY
+          </div>
+        </div>
+
+        <div
+          style="
+            background-color: var(--neu-surface);
+            padding: 1.2rem;
+            border-radius: 20px;
+            box-shadow:
+              inset 3px 3px 6px var(--neu-shadow),
+              inset -3px -3px 6px var(--neu-light);
+            text-align: center;
+          "
+        >
+          <div
+            style="
+              font-size: var(--neu-font-xs);
+              color: var(--neu-muted);
+              text-transform: uppercase;
+            "
+          >
+            Keypresses
+          </div>
+          <div
+            style="
+              font-size: var(--neu-font-xl);
+              font-weight: 800;
+              margin: 0.25rem 0;
+            "
+            id="metric-hits"
+          >
+            1,482
+          </div>
+          <div
+            style="
+              font-size: 0.65rem;
+              color: var(--neu-accent);
+              font-weight: 700;
+            "
+          >
+            TOTAL STROKES
+          </div>
+        </div>
+      </section>
+
+      <!-- Speed Variation Mode -->
+      <div
+        style="
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          gap: 0.8rem;
+          background-color: var(--neu-surface);
+          padding: 1.5rem;
+          border-radius: 20px;
+          box-shadow:
+            4px 4px 8px var(--neu-shadow),
+            -4px -4px 8px var(--neu-light);
+        "
+      >
+        <h3
+          style="
+            font-size: var(--neu-font-sm);
+            color: var(--neu-text);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+          "
+        >
+          Console Mode: Overclocked
+        </h3>
+        <p style="font-size: var(--neu-font-xs); color: var(--neu-muted)">
+          Below is a secondary fast stagger indicator simulating hyper-speed
+          typing. Activate by checking the main loop switch above.
+        </p>
+
+        <!-- Hyper Speed Key Deck -->
+        <div
+          class="typewriter-loader"
+          style="margin: 0.5rem 0; gap: 0.4rem; padding: 1rem 1.2rem"
+        >
+          <div
+            class="type-key"
+            style="width: 32px; height: 32px; font-size: var(--neu-font-sm)"
+          >
+            F
+          </div>
+          <div
+            class="type-key"
+            style="width: 32px; height: 32px; font-size: var(--neu-font-sm)"
+          >
+            A
+          </div>
+          <div
+            class="type-key"
+            style="width: 32px; height: 32px; font-size: var(--neu-font-sm)"
+          >
+            S
+          </div>
+          <div
+            class="type-key"
+            style="width: 32px; height: 32px; font-size: var(--neu-font-sm)"
+          >
+            T
+          </div>
+        </div>
+      </div>
+
+      <!-- Console Logging Telemetry -->
+      <div
+        style="
+          width: 100%;
+          padding: 1rem;
+          border-radius: 15px;
+          background-color: var(--neu-surface);
+          box-shadow:
+            inset 3px 3px 6px var(--neu-shadow),
+            inset -3px -3px 6px var(--neu-light);
+          font-size: var(--neu-font-xs);
+          color: var(--neu-muted);
+          max-height: 120px;
+          overflow-y: auto;
+        "
+        id="console-logs"
+      >
+        <div style="color: var(--neu-accent); margin-bottom: 0.2rem">
+          [SYSTEM] Array initialized. Standing by.
+        </div>
+        <div style="margin-bottom: 0.2rem">
+          [TELEMETRY] delay-staggering configured to 120ms intervals.
+        </div>
+        <div>[STATUS] Press "Start Typing" to initiate wave loop.</div>
+      </div>
+
+      <!-- Technical logs telemetry footer -->
+      <footer
+        style="
+          margin-top: 1rem;
+          border-top: 1px dashed var(--neu-shadow);
+          padding-top: 1.5rem;
+          text-align: center;
+          width: 100%;
+        "
+      >
+        <span
+          style="
+            font-size: var(--neu-font-xs);
+            color: var(--neu-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+          "
+        >
+          Telemetry: Staggered delays: 0.12s intervals // Wave frequency: 1.5Hz
+        </span>
+      </footer>
+    </div>
+
+    <!-- Keyboard actions accessibility listeners mapping -->
+    <script>
+      const checkbox = document.getElementById("loader-active-toggle");
+      const startBtn = document.getElementById("btn-start");
+      const stopBtn = document.getElementById("btn-stop");
+      const consoleLogs = document.getElementById("console-logs");
+      const wpmMetric = document.getElementById("metric-wpm");
+      const hitsMetric = document.getElementById("metric-hits");
+      let hitCount = 1482;
+
+      // Helper to append log lines
+      const addLog = (msg, isAccent = false) => {
+        const logDiv = document.createElement("div");
+        logDiv.style.marginBottom = "0.2rem";
+        if (isAccent) logDiv.style.color = "var(--neu-accent)";
+        logDiv.textContent = msg;
+        consoleLogs.appendChild(logDiv);
+        consoleLogs.scrollTop = consoleLogs.scrollHeight;
+      };
+
+      // Accessibility: Map keyboard trigger options for active labels
+      document.querySelectorAll("label[for]").forEach((btn) => {
+        btn.addEventListener("keydown", (e) => {
+          if (e.key === " " || e.key === "Enter") {
+            e.preventDefault();
+            const targetInput = document.getElementById(
+              btn.getAttribute("for")
+            );
+            if (targetInput) {
+              targetInput.click();
+            }
+          }
+        });
+      });
+
+      // Logging listeners on state change
+      checkbox.addEventListener("change", () => {
+        if (checkbox.checked) {
+          addLog("[STATUS] Typewriter wave loop triggered.", true);
+          wpmMetric.textContent = "84 WPM";
+        } else {
+          addLog("[STATUS] Wave loop terminated.", false);
+          wpmMetric.textContent = "0 WPM";
+        }
+      });
+
+      // Simulate keypress counts on loading
+      setInterval(() => {
+        if (checkbox.checked) {
+          hitCount += Math.floor(Math.random() * 3);
+          hitsMetric.textContent = hitCount.toLocaleString();
+        }
+      }, 2000);
+    </script>
+  </body>
+</html>

--- a/submissions/examples/typewriter-spinner-agy/style.css
+++ b/submissions/examples/typewriter-spinner-agy/style.css
@@ -1,0 +1,334 @@
+/* ==========================================================================
+   EaseMotion CSS - Typewriter Spinner (Neumorphic Design Variant)
+   ========================================================================== */
+
+/* ── 1. Neumorphic Design Tokens & Variables ────────────────────────────── */
+:root {
+  /* Soft Blue-Gray Neumorphic Palette */
+  --neu-bg: #e0e8f6;
+  --neu-surface: #e0e8f6;
+  --neu-light: #ffffff;
+  --neu-shadow: #b8c4d9;
+  --neu-accent: #3b82f6; /* Active Indicator */
+  --neu-text: #3e4d59;
+  --neu-muted: #7d8c99;
+  --neu-border: rgba(184, 196, 217, 0.4);
+
+  /* Animation Configurations */
+  --ease-elastic-duration: 1.5s;
+  --ease-fade-duration: 0.25s;
+  --ease-smooth-curve: cubic-bezier(0.25, 1, 0.5, 1);
+
+  /* Typography Scales */
+  --neu-font: "Courier New", Courier, monospace;
+  --neu-font-xs: 0.75rem;
+  --neu-font-sm: 0.85rem;
+  --neu-font-base: 1rem;
+  --neu-font-lg: 1.25rem;
+  --neu-font-xl: 1.5rem;
+}
+
+/* Force dark neumorphic variations if user system requests dark scheme */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --neu-bg: #1e2430;
+    --neu-surface: #1e2430;
+    --neu-light: #2b3344;
+    --neu-shadow: #11151c;
+    --neu-accent: #60a5fa;
+    --neu-text: #e2e8f0;
+    --neu-muted: #64748b;
+    --neu-border: rgba(17, 21, 28, 0.4);
+  }
+}
+
+/* Force dark theme variations by selector */
+[data-theme="dark"] {
+  --neu-bg: #1e2430;
+  --neu-surface: #1e2430;
+  --neu-light: #2b3344;
+  --neu-shadow: #11151c;
+  --neu-accent: #60a5fa;
+  --neu-text: #e2e8f0;
+  --neu-muted: #64748b;
+  --neu-border: rgba(17, 21, 28, 0.4);
+}
+
+/* ── 2. Reset and Base Layout ────────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--neu-bg);
+  color: var(--neu-text);
+  font-family: var(--neu-font);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  transition:
+    background-color var(--ease-fade-duration),
+    color var(--ease-fade-duration);
+}
+
+/* Custom Scrollbar for console panels */
+#console-logs::-webkit-scrollbar {
+  width: 5px;
+}
+#console-logs::-webkit-scrollbar-track {
+  background: transparent;
+}
+#console-logs::-webkit-scrollbar-thumb {
+  background: var(--neu-shadow);
+  border-radius: 3px;
+}
+#console-logs::-webkit-scrollbar-thumb:hover {
+  background: var(--neu-accent);
+}
+
+/* Hide checkbox used for pure CSS state control */
+.spinner-state-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── 3. Typist Dashboard Console Mock Layout ──────────────────────────────── */
+.typist-wrap {
+  width: 100%;
+  max-width: 680px;
+  background-color: var(--neu-surface);
+  border-radius: 30px;
+  padding: 2.5rem;
+  box-shadow:
+    12px 12px 24px var(--neu-shadow),
+    -12px -12px 24px var(--neu-light);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  transition: box-shadow var(--ease-fade-duration);
+}
+
+.typist-title {
+  text-align: center;
+}
+
+.typist-title h1 {
+  font-size: var(--neu-font-lg);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--neu-text);
+}
+
+.typist-title p {
+  font-size: var(--neu-font-xs);
+  color: var(--neu-muted);
+  margin-top: 0.4rem;
+}
+
+/* Neumorphic control switch buttons */
+.typist-controls {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.typist-btn {
+  padding: 0.8rem 1.6rem;
+  border: none;
+  background-color: var(--neu-surface);
+  color: var(--neu-text);
+  border-radius: 15px;
+  font-family: inherit;
+  font-size: var(--neu-font-sm);
+  font-weight: 700;
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+  box-shadow:
+    4px 4px 8px var(--neu-shadow),
+    -4px -4px 8px var(--neu-light);
+  transition:
+    box-shadow var(--ease-fade-duration) var(--ease-smooth-curve),
+    transform var(--ease-fade-duration) var(--ease-smooth-curve),
+    color var(--ease-fade-duration);
+}
+
+.typist-btn:active {
+  box-shadow:
+    inset 2px 2px 5px var(--neu-shadow),
+    inset -2px -2px 5px var(--neu-light);
+  transform: translateY(1px);
+}
+
+/* Active indicator ring on focus */
+.typist-btn:focus-visible {
+  outline: 2px dashed var(--neu-accent);
+  outline-offset: 3px;
+}
+
+/* ── 4. Neumorphic Typewriter Spinner Component ────────────────────────── */
+.typewriter-loader {
+  display: flex;
+  gap: 0.6rem;
+  padding: 1.5rem 2rem;
+  background-color: var(--neu-surface);
+  border-radius: 20px;
+  box-shadow:
+    inset 4px 4px 8px var(--neu-shadow),
+    inset -4px -4px 8px var(--neu-light);
+  margin: 1rem 0;
+  position: relative;
+}
+
+/* Extruded circular typewriter keys */
+.type-key {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background-color: var(--neu-surface);
+  color: var(--neu-text);
+  font-size: var(--neu-font-base);
+  font-weight: 700;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow:
+    4px 4px 8px var(--neu-shadow),
+    -4px -4px 8px var(--neu-light);
+  user-select: none;
+  position: relative;
+  transition:
+    box-shadow 0.3s,
+    transform 0.3s,
+    color 0.3s;
+  /* Prevent browser layout jumps during transform scales */
+  backface-visibility: hidden;
+}
+
+/* Inner key circular bezel strip */
+.type-key::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  border: 1px solid var(--neu-border);
+  opacity: 0.8;
+}
+
+/* ── 5. Keypress Wave Animation System ─────────────────────────────────── */
+@keyframes keypress-wave {
+  0%,
+  100% {
+    box-shadow:
+      4px 4px 8px var(--neu-shadow),
+      -4px -4px 8px var(--neu-light);
+    transform: translateY(0) scale3d(1, 1, 1);
+  }
+  30% {
+    box-shadow:
+      inset 3px 3px 6px var(--neu-shadow),
+      inset -3px -3px 6px var(--neu-light);
+    transform: translateY(2px) scale3d(0.96, 0.96, 1);
+    color: var(--neu-accent);
+  }
+  60% {
+    box-shadow:
+      4px 4px 8px var(--neu-shadow),
+      -4px -4px 8px var(--neu-light);
+    transform: translateY(0) scale3d(1, 1, 1);
+  }
+}
+
+/* ── 6. State Trigger Rules (Pure CSS Checkbox Toggle) ──────────────────── */
+
+/* When loader is active, trigger animation wave sequentially */
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key {
+  animation: keypress-wave var(--ease-elastic-duration) infinite
+    var(--ease-smooth-curve);
+}
+
+/* Stagger animation-delays across letter keys */
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(1) {
+  animation-delay: 0s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(2) {
+  animation-delay: 0.12s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(3) {
+  animation-delay: 0.24s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(4) {
+  animation-delay: 0.36s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(5) {
+  animation-delay: 0.48s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(6) {
+  animation-delay: 0.6s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(7) {
+  animation-delay: 0.72s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(8) {
+  animation-delay: 0.84s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(9) {
+  animation-delay: 0.96s;
+}
+.spinner-state-checkbox:checked ~ .typewriter-loader .type-key:nth-child(10) {
+  animation-delay: 1.08s;
+}
+
+/* Invert start/stop buttons neumorphic styling based on state checked */
+#loader-active-toggle:checked ~ .typist-controls #btn-start {
+  box-shadow:
+    inset 3px 3px 6px var(--neu-shadow),
+    inset -3px -3px 6px var(--neu-light);
+  color: var(--neu-accent);
+}
+
+#loader-active-toggle:not(:checked) ~ .typist-controls #btn-stop {
+  box-shadow:
+    inset 3px 3px 6px var(--neu-shadow),
+    inset -3px -3px 6px var(--neu-light);
+  color: var(--neu-muted);
+}
+
+/* Accessibility settings for users with motion sensitivity */
+@media (prefers-reduced-motion: reduce) {
+  .spinner-state-checkbox:checked ~ .typewriter-loader .type-key {
+    animation: none;
+  }
+}
+
+/* ── 7. Responsive Styles ────────────────────────────────────────────────── */
+@media (max-width: 680px) {
+  .typist-wrap {
+    padding: 1.5rem;
+    border-radius: 20px;
+    gap: 1.5rem;
+  }
+
+  .typewriter-loader {
+    gap: 0.3rem;
+    padding: 1rem 0.8rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .type-key {
+    width: 32px;
+    height: 32px;
+    font-size: var(--neu-font-xs);
+  }
+}


### PR DESCRIPTION
Fixes #41496.

Adds the new Neumorphic Typewriter Spinner component under submissions/examples/typewriter-spinner-agy/.

### Changes Included
- **demo.html**: Showcase page featuring Retro Typist Console, typewriter keys deck, start/stop toggle buttons, stats cards, speed variations, and logs console.
- **style.css**: Theme styling using soft cream/gray neumorphic shadows, inset press keyframe transitions, and custom scrollbars.
- **README.md**: Detailed guides answering what it does, how it is used, and why it is useful, with style configurations reference.