### PR TITLE
feat: add flip onboarding tooltip component under admin panel theme (#41497)

### DIFF
--- a/submissions/examples/flip-onboarding-tooltip-agy/README.md
+++ b/submissions/examples/flip-onboarding-tooltip-agy/README.md
@@ -1,0 +1,82 @@
+# Flip Onboarding Tooltip Walkthrough Component
+
+An onboarding walkthrough tooltip themed around modern admin panels, featuring a 3D perspective Y-axis spin transition when steps switch.
+
+---
+
+## 💡 Quick Overview
+
+### 1. What does this do?
+
+This component provides an onboarding walkthrough tooltip that shifts position dynamically to target different elements in a dashboard, performing a full 3D flip rotation transition each time the step transitions.
+
+### 2. How is it used?
+
+Incorporate the state radio tags, hotspots labels, and tooltip card wrappers in your markup:
+
+```html
+<!-- 1. Pure CSS Step Radios -->
+<input
+  type="radio"
+  name="walkthrough-step"
+  id="step-1"
+  class="step-state-radio"
+  checked
+/>
+<input
+  type="radio"
+  name="walkthrough-step"
+  id="step-2"
+  class="step-state-radio"
+/>
+
+<!-- 2. Dashboard Widgets & Hotspots -->
+<div class="db-widget">
+  <label for="step-1" class="hotspot-pin hotspot-pin-1" tabindex="0"></label>
+</div>
+
+<!-- 3. Floating Tooltip -->
+<div class="onboarding-tooltip" role="dialog" aria-modal="false">
+  <div class="tooltip-card">
+    <div class="step-content step-content-1">
+      <h2>Step 1 Heading</h2>
+      <p>Instructions text content...</p>
+      <label for="step-2" class="tooltip-btn btn-primary">Next</label>
+    </div>
+  </div>
+</div>
+```
+
+### 3. Why is it useful?
+
+Walkthrough guides are essential to onboard users on new panels. This component coordinates position slides and 3D card flips entirely using sibling selectors and keyframe rules in pure CSS, ensuring maximum performance without scripting overhead.
+
+---
+
+## 🎨 Theme & Customization Guide
+
+Override these variables in your root element to adjust styling colors and transition curves:
+
+```css
+:root {
+  /* Dashboard surface colors */
+  --admin-bg: #090d16; /* Canvas void background */
+  --admin-surface: #111827; /* Card background surface */
+  --admin-border: #1f2937; /* Card edge borders */
+
+  /* Spotlight colors */
+  --admin-accent: #3b82f6; /* Primary brand color */
+  --admin-purple: #8b5cf6; /* Secondary purple color */
+
+  /* Timing Configuration */
+  --ease-elastic-duration: 0.6s; /* 3D Spin and fly transition duration */
+}
+```
+
+---
+
+## ♿ Accessibility Specifications
+
+1. **Semantic HTML**: Utilizes explicit `role="dialog"` tags and correct step progress values.
+2. **Keyboard Traversal**: Hotspot pins and action controls are tab navigable, featuring custom dashed focus outlines triggered by keyboard events.
+3. **Motion settings**: Disables 3D spin keyframes when `@media (prefers-reduced-motion: reduce)` matches, converting transitions to simple fade parameters.

--- a/submissions/examples/flip-onboarding-tooltip-agy/demo.html
+++ b/submissions/examples/flip-onboarding-tooltip-agy/demo.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Dashboard — Flip Onboarding Walkthrough Deck</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- 
+    Administrative Dashboard Shell
+    - Houses step radios, hotspots, widgets, and the onboarding tooltip.
+  -->
+    <div class="dashboard-wrap">
+      <!-- Onboarding Step Radios (CSS state hooks) -->
+      <input
+        type="radio"
+        name="walkthrough-step"
+        id="step-1"
+        class="step-state-radio"
+        checked
+      />
+      <input
+        type="radio"
+        name="walkthrough-step"
+        id="step-2"
+        class="step-state-radio"
+      />
+      <input
+        type="radio"
+        name="walkthrough-step"
+        id="step-3"
+        class="step-state-radio"
+      />
+
+      <!-- Sidebar Dashboard Navigation -->
+      <aside
+        style="
+          grid-column: span 2;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          border-bottom: 1px solid var(--admin-border);
+          padding-bottom: 1.2rem;
+          margin-bottom: 0.5rem;
+          width: 100%;
+        "
+      >
+        <div
+          style="
+            font-weight: 800;
+            font-size: var(--admin-font-lg);
+            color: #ffffff;
+            letter-spacing: -0.02em;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+          "
+        >
+          <span style="color: var(--admin-accent)">◆</span> ADMIN DECK v4.2
+        </div>
+        <div style="display: flex; gap: 1rem; align-items: center">
+          <span
+            style="font-size: var(--admin-font-xs); color: var(--admin-muted)"
+            >SYSTEM STATUS: ONLINE</span
+          >
+          <div
+            style="
+              width: 8px;
+              height: 8px;
+              border-radius: 50%;
+              background-color: #10b981;
+              box-shadow: 0 0 8px #10b981;
+            "
+          ></div>
+        </div>
+      </aside>
+
+      <!-- Column 1: Metrics Widgets -->
+      <div
+        style="display: flex; flex-direction: column; gap: 1.5rem; width: 100%"
+      >
+        <!-- Widget 1: Total Revenue -->
+        <div class="db-widget">
+          <label
+            for="step-1"
+            class="hotspot-pin hotspot-pin-1"
+            title="Revenue analytics hotspot"
+            tabindex="0"
+          ></label>
+          <div class="db-widget-header">Total Revenue</div>
+          <div class="db-widget-metric">$48,256.00</div>
+          <div
+            style="
+              font-size: var(--admin-font-xs);
+              color: var(--admin-accent);
+              font-weight: 700;
+              margin-top: 0.5rem;
+            "
+          >
+            +14.2% FROM LAST MONTH
+          </div>
+        </div>
+
+        <!-- Widget 2: Active Visitors -->
+        <div class="db-widget">
+          <label
+            for="step-2"
+            class="hotspot-pin hotspot-pin-2"
+            title="Visitors analytics hotspot"
+            tabindex="0"
+          ></label>
+          <div class="db-widget-header">Active Users</div>
+          <div class="db-widget-metric">1,482</div>
+          <div
+            style="
+              font-size: var(--admin-font-xs);
+              color: var(--admin-muted);
+              margin-top: 0.5rem;
+            "
+          >
+            78 sessions active currently
+          </div>
+        </div>
+      </div>
+
+      <!-- Column 2: Chart Widgets -->
+      <div
+        style="display: flex; flex-direction: column; gap: 1.5rem; width: 100%"
+      >
+        <!-- Widget 3: Conversion Rates -->
+        <div class="db-widget" style="min-height: 335px">
+          <label
+            for="step-3"
+            class="hotspot-pin hotspot-pin-3"
+            title="Conversion rates hotspot"
+            tabindex="0"
+          ></label>
+          <div class="db-widget-header">Conversion Rate</div>
+          <div class="db-widget-metric">3.42%</div>
+
+          <!-- Mock SVG Bar chart representation -->
+          <svg
+            style="width: 100%; height: 160px; margin-top: 1.5rem"
+            aria-label="Mock analytics graphic chart"
+          >
+            <rect
+              x="10"
+              y="80"
+              width="30"
+              height="80"
+              fill="var(--admin-border)"
+            ></rect>
+            <rect
+              x="60"
+              y="60"
+              width="30"
+              height="100"
+              fill="var(--admin-border)"
+            ></rect>
+            <rect
+              x="110"
+              y="40"
+              width="30"
+              height="120"
+              fill="var(--admin-border)"
+            ></rect>
+            <rect
+              x="160"
+              y="20"
+              width="30"
+              height="140"
+              fill="var(--admin-accent)"
+            ></rect>
+            <rect
+              x="210"
+              y="50"
+              width="30"
+              height="110"
+              fill="var(--admin-border)"
+            ></rect>
+            <rect
+              x="260"
+              y="30"
+              width="30"
+              height="130"
+              fill="var(--admin-purple)"
+            ></rect>
+          </svg>
+        </div>
+      </div>
+
+      <!-- Quick Actions Panel -->
+      <div
+        style="
+          grid-column: span 2;
+          display: flex;
+          gap: 1rem;
+          padding: 1.2rem;
+          background-color: rgba(31, 41, 55, 0.2);
+          border-radius: 16px;
+          border: 1px solid var(--admin-border);
+          width: 100%;
+          align-items: center;
+        "
+      >
+        <span
+          style="
+            font-size: var(--admin-font-xs);
+            color: var(--admin-muted);
+            font-weight: 700;
+            text-transform: uppercase;
+          "
+          >Quick Actions:</span
+        >
+        <button
+          style="
+            background-color: var(--admin-accent);
+            color: #ffffff;
+            border: none;
+            border-radius: 8px;
+            padding: 0.4rem 1rem;
+            font-size: var(--admin-font-xs);
+            font-weight: 700;
+            cursor: pointer;
+          "
+        >
+          Generate Report
+        </button>
+        <button
+          style="
+            background-color: transparent;
+            color: var(--admin-text);
+            border: 1px solid var(--admin-border);
+            border-radius: 8px;
+            padding: 0.4rem 1rem;
+            font-size: var(--admin-font-xs);
+            cursor: pointer;
+          "
+          onclick="alert('Database synced.')"
+        >
+          Sync DB
+        </button>
+      </div>
+
+      <!-- Floating 3D Flip Onboarding Tooltip Card -->
+      <div
+        class="onboarding-tooltip"
+        role="dialog"
+        aria-modal="false"
+        aria-label="Onboarding walkthrough tooltip"
+      >
+        <div class="tooltip-card">
+          <!-- Step 1 Content -->
+          <div class="step-content step-content-1">
+            <div class="tooltip-header">
+              <span class="tooltip-step-label">Step 1 of 3</span>
+            </div>
+            <h2 class="tooltip-title">Revenue Analytics</h2>
+            <p class="tooltip-body">
+              This panel displays your gross earnings stats. Review percentage
+              shifts to evaluate sales spikes.
+            </p>
+            <div class="tooltip-footer">
+              <div class="tooltip-dots">
+                <div class="tooltip-dot tooltip-dot-1"></div>
+                <div class="tooltip-dot"></div>
+                <div class="tooltip-dot"></div>
+              </div>
+              <div class="tooltip-actions">
+                <label for="step-2" class="tooltip-btn btn-primary" tabindex="0"
+                  >Next</label
+                >
+              </div>
+            </div>
+          </div>
+
+          <!-- Step 2 Content -->
+          <div class="step-content step-content-2">
+            <div class="tooltip-header">
+              <span class="tooltip-step-label">Step 2 of 3</span>
+            </div>
+            <h2 class="tooltip-title">Active Visitors</h2>
+            <p class="tooltip-body">
+              Tracks real-time visitors navigating your pages. Updates sessions
+              intervals every 10 seconds.
+            </p>
+            <div class="tooltip-footer">
+              <div class="tooltip-dots">
+                <div class="tooltip-dot"></div>
+                <div class="tooltip-dot tooltip-dot-2"></div>
+                <div class="tooltip-dot"></div>
+              </div>
+              <div class="tooltip-actions">
+                <label for="step-1" class="tooltip-btn" tabindex="0"
+                  >Back</label
+                >
+                <label for="step-3" class="tooltip-btn btn-primary" tabindex="0"
+                  >Next</label
+                >
+              </div>
+            </div>
+          </div>
+
+          <!-- Step 3 Content -->
+          <div class="step-content step-content-3">
+            <div class="tooltip-header">
+              <span class="tooltip-step-label">Step 3 of 3</span>
+            </div>
+            <h2 class="tooltip-title">Conversion Graphs</h2>
+            <p class="tooltip-body">
+              Displays user conversions rates mapped in columns. Contrast blue
+              vs purple for seasonal metrics.
+            </p>
+            <div class="tooltip-footer">
+              <div class="tooltip-dots">
+                <div class="tooltip-dot"></div>
+                <div class="tooltip-dot"></div>
+                <div class="tooltip-dot tooltip-dot-3"></div>
+              </div>
+              <div class="tooltip-actions">
+                <label for="step-2" class="tooltip-btn" tabindex="0"
+                  >Back</label
+                >
+                <label
+                  for="step-1"
+                  class="tooltip-btn btn-primary"
+                  tabindex="0"
+                  onclick="alert('Tour completed! Restarting.')"
+                  >Finish</label
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Keyboard actions accessibility listeners mapping -->
+    <script>
+      // Accessibility: Map keyboard trigger options for active labels
+      const actionLabels = document.querySelectorAll("label");
+      actionLabels.forEach((btn) => {
+        btn.addEventListener("keydown", (e) => {
+          if (e.key === " " || e.key === "Enter") {
+            e.preventDefault();
+            const targetInput = document.getElementById(
+              btn.getAttribute("for")
+            );
+            if (targetInput) {
+              targetInput.click();
+            }
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/flip-onboarding-tooltip-agy/style.css
+++ b/submissions/examples/flip-onboarding-tooltip-agy/style.css
@@ -1,0 +1,384 @@
+/* ==========================================================================
+   EaseMotion CSS - Flip Onboarding Tooltip (Admin Panel Variant)
+   ========================================================================== */
+
+/* ── 1. Admin Theme Design Tokens & Variables ───────────────────────────── */
+:root {
+  /* Slate Dark Administrative Palette */
+  --admin-bg: #090d16;
+  --admin-surface: #111827;
+  --admin-border: #1f2937;
+
+  /* Luminous Focus Highlights */
+  --admin-accent: #3b82f6; /* Brand Royal Blue */
+  --admin-purple: #8b5cf6; /* Alternate Purple */
+  --admin-text: #f3f4f6;
+  --admin-muted: #9ca3af;
+  --admin-glow: rgba(59, 130, 246, 0.15);
+
+  /* Animation Timings */
+  --ease-elastic-duration: 0.6s;
+  --ease-fade-duration: 0.2s;
+  --ease-smooth-curve: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Monospace & Sans Typography */
+  --admin-font: "Inter", system-ui, -apple-system, sans-serif;
+  --admin-font-xs: 0.75rem;
+  --admin-font-sm: 0.85rem;
+  --admin-font-base: 0.95rem;
+  --admin-font-lg: 1.15rem;
+}
+
+/* Force dark theme layout alignments */
+body {
+  background-color: var(--admin-bg);
+  color: var(--admin-text);
+  font-family: var(--admin-font);
+  line-height: 1.5;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  overflow-x: hidden;
+}
+
+/* Hide checkbox inputs used for step navigation */
+.step-state-radio {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── 2. Administrative Dashboard Shell Mock ────────────────────────────── */
+.dashboard-wrap {
+  width: 100%;
+  max-width: 820px;
+  background-color: var(--admin-surface);
+  border: 1px solid var(--admin-border);
+  border-radius: 20px;
+  padding: 2rem;
+  position: relative;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+/* Dashboard Panel Widgets */
+.db-widget {
+  background-color: rgba(31, 41, 55, 0.3);
+  border: 1px solid var(--admin-border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  position: relative;
+  min-height: 160px;
+  transition: border-color 0.3s;
+}
+
+.db-widget:hover {
+  border-color: rgba(59, 130, 246, 0.3);
+}
+
+.db-widget-header {
+  font-size: var(--admin-font-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--admin-muted);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.8rem;
+}
+
+.db-widget-metric {
+  font-size: 2rem;
+  font-weight: 800;
+  color: #ffffff;
+}
+
+/* Glowing Hotspot Pins Layout */
+.hotspot-pin {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: var(--admin-accent);
+  cursor: pointer;
+  z-index: 20;
+}
+
+.hotspot-pin-1 {
+  top: 20px;
+  right: 20px;
+}
+.hotspot-pin-2 {
+  bottom: 20px;
+  right: 20px;
+}
+.hotspot-pin-3 {
+  top: 20px;
+  right: 20px;
+} /* Placed on second widget */
+
+/* Pulse ripple effect around pins */
+.hotspot-pin::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 2px solid var(--admin-accent);
+  animation: pin-pulse 1.8s infinite ease-out;
+}
+
+@keyframes pin-pulse {
+  0% {
+    transform: scale(0.8);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1.8);
+    opacity: 0;
+  }
+}
+
+/* Focus indicators on pins for keyboard traversals */
+.hotspot-pin:focus-visible {
+  outline: 2px solid var(--admin-accent);
+  outline-offset: 4px;
+}
+
+/* ── 3. Onboarding Tooltip Layout Frame ────────────────────────────────── */
+.onboarding-tooltip {
+  position: absolute;
+  width: 280px;
+  z-index: 100;
+  perspective: 1000px;
+  pointer-events: auto; /* Let mouse clicks hit links and label buttons */
+  transition:
+    top 0.6s var(--ease-smooth-curve),
+    left 0.6s var(--ease-smooth-curve);
+}
+
+.tooltip-card {
+  background-color: #1f2937;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow:
+    0 20px 25px -5px rgba(0, 0, 0, 0.3),
+    0 10px 10px -5px rgba(0, 0, 0, 0.3);
+  transform-style: preserve-3d;
+  position: relative;
+}
+
+/* Small indicator pointer arrow link border */
+.tooltip-card::after {
+  content: "";
+  position: absolute;
+  left: 20px;
+  bottom: -6px;
+  width: 12px;
+  height: 12px;
+  background-color: #1f2937;
+  transform: rotate(45deg);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* Text elements content margins */
+.tooltip-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.6rem;
+}
+
+.tooltip-step-label {
+  font-size: var(--admin-font-xs);
+  color: var(--admin-accent);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.tooltip-title {
+  font-size: var(--admin-font-sm);
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.tooltip-body {
+  font-size: var(--admin-font-xs);
+  color: var(--admin-muted);
+  line-height: 1.4;
+  margin-bottom: 1rem;
+}
+
+/* Tooltip footer controllers */
+.tooltip-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tooltip-dots {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.tooltip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.tooltip-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tooltip-btn {
+  padding: 0.3rem 0.6rem;
+  font-size: var(--admin-font-xs);
+  border-radius: 8px;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  background-color: rgba(255, 255, 255, 0.05);
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+}
+
+.tooltip-btn:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.tooltip-btn.btn-primary {
+  background-color: var(--admin-accent);
+  border-color: var(--admin-accent);
+}
+
+.tooltip-btn.btn-primary:hover {
+  background-color: #2563eb;
+}
+
+/* ── 4. Position & 3D Flip Animators mappings ──────────────────────────── */
+
+/* Step 1 checked state rules */
+#step-1:checked ~ .onboarding-tooltip {
+  top: 90px;
+  left: 20px;
+  animation: flip-step-1 var(--ease-elastic-duration) var(--ease-smooth-curve);
+}
+#step-1:checked ~ .onboarding-tooltip .tooltip-dot-1 {
+  background-color: var(--admin-accent);
+}
+#step-1:checked ~ .onboarding-tooltip .step-content-1 {
+  display: block;
+}
+#step-1:checked ~ .onboarding-tooltip .step-content-2,
+#step-1:checked ~ .onboarding-tooltip .step-content-3 {
+  display: none;
+}
+
+/* Step 2 checked state rules */
+#step-2:checked ~ .onboarding-tooltip {
+  top: 260px;
+  left: 20px;
+  animation: flip-step-2 var(--ease-elastic-duration) var(--ease-smooth-curve);
+}
+#step-2:checked ~ .onboarding-tooltip .tooltip-dot-2 {
+  background-color: var(--admin-accent);
+}
+#step-2:checked ~ .onboarding-tooltip .step-content-2 {
+  display: block;
+}
+#step-2:checked ~ .onboarding-tooltip .step-content-1,
+#step-2:checked ~ .onboarding-tooltip .step-content-3 {
+  display: none;
+}
+
+/* Step 3 checked state rules */
+#step-3:checked ~ .onboarding-tooltip {
+  top: 90px;
+  left: 420px;
+  animation: flip-step-3 var(--ease-elastic-duration) var(--ease-smooth-curve);
+}
+#step-3:checked ~ .onboarding-tooltip .tooltip-dot-3 {
+  background-color: var(--admin-accent);
+}
+#step-3:checked ~ .onboarding-tooltip .step-content-3 {
+  display: block;
+}
+#step-3:checked ~ .onboarding-tooltip .step-content-1,
+#step-3:checked ~ .onboarding-tooltip .step-content-2 {
+  display: none;
+}
+
+/* 3D Spin Rotations along Y-axis */
+@keyframes flip-step-1 {
+  0% {
+    transform: rotateY(0) scale3d(1, 1, 1);
+  }
+  50% {
+    transform: rotateY(180deg) scale3d(0.9, 0.9, 1);
+  }
+  100% {
+    transform: rotateY(360deg) scale3d(1, 1, 1);
+  }
+}
+
+@keyframes flip-step-2 {
+  0% {
+    transform: rotateY(0) scale3d(1, 1, 1);
+  }
+  50% {
+    transform: rotateY(180deg) scale3d(0.9, 0.9, 1);
+  }
+  100% {
+    transform: rotateY(360deg) scale3d(1, 1, 1);
+  }
+}
+
+@keyframes flip-step-3 {
+  0% {
+    transform: rotateY(0) scale3d(1, 1, 1);
+  }
+  50% {
+    transform: rotateY(180deg) scale3d(0.9, 0.9, 1);
+  }
+  100% {
+    transform: rotateY(360deg) scale3d(1, 1, 1);
+  }
+}
+
+/* Reduced motion fallbacks */
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-tooltip {
+    animation: none !important;
+  }
+}
+
+/* ── 5. Responsive Styles ────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .dashboard-wrap {
+    grid-template-columns: 1fr;
+    max-width: 100%;
+  }
+
+  .onboarding-tooltip {
+    position: relative;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100%;
+    margin-top: 1rem;
+  }
+
+  .tooltip-card::after {
+    display: none;
+  }
+}


### PR DESCRIPTION
Fixes #41497.

Adds the new Admin Panel Flip Onboarding Tooltip component under submissions/examples/flip-onboarding-tooltip-agy/.

### Changes Included
- **demo.html**: Showcase page featuring Admin Deck header layout, metrics dashboard, Conversion Bar chart widgets, pulsing hotspots, and the 3D flip tooltip.
- **style.css**: Theme styling using slate dark backgrounds, hotspot ripple animation keyframes, and 3D Y-axis rotation spin transitions.
- **README.md**: Detailed guides answering what it does, how it is used, and why it is useful, with style configurations reference.