### PR TITLE
ease-github-raw-cdn-pitfalls-sp

### DIFF
--- a/submissions/docs/ease-github-raw-cdn-pitfalls-sp/README.md
+++ b/submissions/docs/ease-github-raw-cdn-pitfalls-sp/README.md
@@ -1,0 +1,110 @@
+# GitHub Raw CDN CSS Pitfalls Guide
+
+An interactive documentation showcase that compares loading **EaseMotion CSS** via **jsDelivr**, **unpkg**, and **`raw.githubusercontent.com`**, and explains when the GitHub Raw CDN fails (MIME / Content-Type, caching, broken styles) with a clear production recommendation panel.
+
+> Submission track: `submissions/docs/ease-github-raw-cdn-pitfalls-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46162](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46162)
+
+---
+
+## What does this do?
+
+The EaseMotion README lists multiple CDN options, including GitHub Raw:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css"
+/>
+```
+
+Beginners often paste that Raw URL expecting it to behave like jsDelivr or unpkg. In practice, Raw responses frequently use the wrong `Content-Type` (`text/plain` instead of `text/css`), have weak caching, and can make a perfectly valid stylesheet look “broken.”
+
+This lab helps you:
+
+- Compare jsDelivr / unpkg / GitHub Raw side by side
+- Generate copy-ready `<link>` tags for the selected provider + file
+- Probe live `Content-Type` headers (when the browser allows CORS)
+- See an educational mock of unstyled UI when Raw fails
+- Leave with a clear production recommendation
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (internet required for CDN probe + EaseMotion styles).
+2. Pick a **provider** (jsDelivr, unpkg, or GitHub Raw) and a **file**.
+3. Read the **live verdict** and copy the generated snippet.
+4. Click **Probe Content-Type** to inspect response headers.
+5. Study the comparison table, pitfalls list, and recommendation panel.
+
+---
+
+## Features
+
+- Provider selector with risk badges (Recommended / Risky)
+- File toggle: `easemotion.min.css` or `easemotion.css`
+- Live verdict panel (Safe vs Risky tone)
+- Copy-to-clipboard for `<link>` tag and raw URL
+- Live header probe (`Content-Type`, HTTP status, interpretation)
+- Comparison matrix (MIME, caching, production suitability)
+- Visual “styled vs broken” preview cards
+- Pitfall explanations: MIME, cache, rate limits, false bug reports
+- Production recommendation checklist
+- Responsive, accessible UI with keyboard-friendly radio controls
+- Respects `prefers-reduced-motion`
+
+---
+
+## URL formats used in the demo
+
+| Provider | Example URL |
+|----------|-------------|
+| jsDelivr (pinned) | `https://cdn.jsdelivr.net/npm/easemotion-css@1.2.0/easemotion.min.css` |
+| unpkg (pinned) | `https://unpkg.com/easemotion-css@1.2.0/easemotion.min.css` |
+| GitHub Raw | `https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css` |
+
+---
+
+## Why is it useful?
+
+- Prevents false “EaseMotion CSS is broken” reports caused by CDN misuse
+- Documents a real README footgun without editing core or the README itself
+- Freeze-safe: only new files under `submissions/docs/`
+- Complements the CDN semver picker docs tool (this one focuses on **Raw MIME pitfalls**, not semver selection)
+
+---
+
+## Tech stack
+
+| Asset | Source |
+|-------|--------|
+| EaseMotion CSS | jsDelivr CDN (`easemotion.min.css`) for the page chrome |
+| Comparison + probe UI | Inline JS in `demo.html` |
+| Layout & visual states | `style.css` |
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-github-raw-cdn-pitfalls-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or existing files
+- Compatible with the freeze notice and #13244 (new submission folder only)
+- Educational showcase — recommended README wording changes remain maintainer-only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-github-raw-cdn-pitfalls-sp/demo.html
+++ b/submissions/docs/ease-github-raw-cdn-pitfalls-sp/demo.html
@@ -1,0 +1,655 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GitHub Raw CDN CSS Pitfalls Guide — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Compare jsDelivr, unpkg, and raw.githubusercontent.com for loading EaseMotion CSS. Learn MIME, Content-Type, caching pitfalls, and production recommendations."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="rp-header ease-fade-in">
+    <p class="rp-eyebrow">EaseMotion CSS · CDN Documentation Showcase</p>
+    <h1>GitHub Raw CDN CSS Pitfalls Guide</h1>
+    <p class="rp-subtitle">
+      Compare <strong>jsDelivr</strong>, <strong>unpkg</strong>, and
+      <strong>raw.githubusercontent.com</strong> for loading
+      <code>easemotion.min.css</code>. See why the Raw link from the README can
+      look “broken,” and pick a production-safe CDN.
+    </p>
+    <a
+      class="rp-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46162"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46162
+    </a>
+  </header>
+
+  <main class="rp-main">
+    <div class="rp-grid">
+      <!-- ── Sidebar: provider picker ───────────────────────── -->
+      <aside class="rp-panel" aria-label="CDN provider controls">
+        <h2 class="rp-panel-title">Choose a CDN</h2>
+
+        <div class="rp-field">
+          <span class="rp-field-label" id="provider-label">Provider</span>
+          <div
+            class="rp-option-list"
+            role="radiogroup"
+            aria-labelledby="provider-label"
+          >
+            <label class="rp-option is-selected" data-provider="jsdelivr">
+              <input type="radio" name="provider" value="jsdelivr" checked />
+              <strong>jsDelivr</strong>
+              <small>
+                <span class="rp-badge rp-badge-ok">Recommended</span>
+                Proper CSS MIME · global cache
+              </small>
+            </label>
+            <label class="rp-option" data-provider="unpkg">
+              <input type="radio" name="provider" value="unpkg" />
+              <strong>unpkg</strong>
+              <small>
+                <span class="rp-badge rp-badge-info">npm packages</span>
+                Good for pinned releases
+              </small>
+            </label>
+            <label class="rp-option" data-provider="raw">
+              <input type="radio" name="provider" value="raw" />
+              <strong>GitHub Raw</strong>
+              <small>
+                <span class="rp-badge rp-badge-danger">Risky</span>
+                Often <code>text/plain</code> · weak CDN
+              </small>
+            </label>
+          </div>
+        </div>
+
+        <div class="rp-field">
+          <span class="rp-field-label" id="file-label">File</span>
+          <div class="rp-option-list" role="radiogroup" aria-labelledby="file-label">
+            <label class="rp-option is-selected">
+              <input type="radio" name="file" value="easemotion.min.css" checked />
+              <strong>easemotion.min.css</strong>
+              <small>Production minified bundle</small>
+            </label>
+            <label class="rp-option">
+              <input type="radio" name="file" value="easemotion.css" />
+              <strong>easemotion.css</strong>
+              <small>Readable debug bundle</small>
+            </label>
+          </div>
+        </div>
+
+        <p style="margin: 0; font-size: 0.8rem; color: var(--rp-muted)">
+          Tip: README documents Raw for convenience, but jsDelivr is preferred
+          for production.
+        </p>
+      </aside>
+
+      <!-- ── Main content ───────────────────────────────────── -->
+      <div class="rp-stack">
+        <!-- Verdict -->
+        <section class="rp-card ease-slide-up" aria-live="polite">
+          <h2 class="rp-card-title">Live verdict</h2>
+          <div class="rp-verdict" id="verdict" data-tone="ok">
+            <span class="rp-badge rp-badge-ok" id="verdict-badge">Safe</span>
+            <p class="rp-verdict-text" id="verdict-text">
+              jsDelivr serves EaseMotion with a correct stylesheet MIME type and
+              reliable edge caching. Prefer this for production.
+            </p>
+          </div>
+
+          <div class="rp-snippet-block">
+            <pre class="rp-snippet" id="snippet" aria-label="Copy-ready link tag"></pre>
+            <button type="button" class="rp-copy" id="copy-btn" data-copied="false">
+              Copy
+            </button>
+          </div>
+
+          <div class="rp-actions">
+            <button type="button" class="rp-btn rp-btn-primary" id="probe-btn">
+              Probe Content-Type
+            </button>
+            <button type="button" class="rp-btn rp-btn-ghost" id="copy-url-btn">
+              Copy raw URL
+            </button>
+          </div>
+
+          <div class="rp-probe" id="probe" hidden>
+            <p class="rp-probe-status" id="probe-status">Checking…</p>
+            <div class="rp-probe-row">
+              <span class="rp-probe-key">URL</span>
+              <span class="rp-probe-val" id="probe-url">—</span>
+            </div>
+            <div class="rp-probe-row">
+              <span class="rp-probe-key">HTTP status</span>
+              <span class="rp-probe-val" id="probe-http">—</span>
+            </div>
+            <div class="rp-probe-row">
+              <span class="rp-probe-key">Content-Type</span>
+              <span class="rp-probe-val" id="probe-type">—</span>
+            </div>
+            <div class="rp-probe-row">
+              <span class="rp-probe-key">Interpretation</span>
+              <span class="rp-probe-val" id="probe-note">—</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Comparison matrix -->
+        <section class="rp-card ease-slide-up ease-delay-100">
+          <h2 class="rp-card-title">Provider comparison</h2>
+          <p>
+            Same file, three hosts. Highlighted row matches your current selection.
+          </p>
+          <div class="rp-table-wrap">
+            <table class="rp-table" id="compare-table">
+              <thead>
+                <tr>
+                  <th>Provider</th>
+                  <th>Typical Content-Type</th>
+                  <th>Caching</th>
+                  <th>Production?</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr data-row="jsdelivr" class="is-active">
+                  <td><strong>jsDelivr</strong></td>
+                  <td><code>text/css</code> (correct)</td>
+                  <td>Global CDN · version pins cache long-term</td>
+                  <td><span class="rp-badge rp-badge-ok">Yes</span></td>
+                </tr>
+                <tr data-row="unpkg">
+                  <td><strong>unpkg</strong></td>
+                  <td><code>text/css</code> (correct)</td>
+                  <td>npm registry CDN · pin with <code>@x.y.z</code></td>
+                  <td><span class="rp-badge rp-badge-ok">Yes</span></td>
+                </tr>
+                <tr data-row="raw">
+                  <td><strong>GitHub Raw</strong></td>
+                  <td><code>text/plain</code> (often wrong)</td>
+                  <td>No real edge CDN · short / fragile cache</td>
+                  <td><span class="rp-badge rp-badge-danger">Avoid</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- Visual outcome -->
+        <section class="rp-card ease-slide-up ease-delay-200">
+          <h2 class="rp-card-title">What “broken styles” can look like</h2>
+          <p>
+            When a browser refuses (or inconsistently accepts) a stylesheet with a
+            non-CSS MIME type, EaseMotion classes never apply — the framework
+            looks dead even though the CSS file is valid.
+          </p>
+          <div class="rp-preview-grid">
+            <article class="rp-preview-card" data-preview="jsdelivr">
+              <div class="rp-preview-head">
+                jsDelivr
+                <span class="rp-badge rp-badge-ok">Styled</span>
+              </div>
+              <div class="rp-preview-body">
+                <button type="button" class="rp-demo-btn ease-btn ease-btn-primary ease-btn-pill">
+                  Primary action
+                </button>
+                <div class="rp-demo-card ease-card ease-card-shadow">
+                  <h3>Card works</h3>
+                  <p>Tokens, radius, and shadows load correctly.</p>
+                </div>
+                <p class="rp-preview-note">Expected production result.</p>
+              </div>
+            </article>
+
+            <article class="rp-preview-card" data-preview="unpkg">
+              <div class="rp-preview-head">
+                unpkg
+                <span class="rp-badge rp-badge-ok">Styled</span>
+              </div>
+              <div class="rp-preview-body">
+                <button type="button" class="rp-demo-btn ease-btn ease-btn-primary ease-btn-pill">
+                  Primary action
+                </button>
+                <div class="rp-demo-card ease-card ease-card-shadow">
+                  <h3>Card works</h3>
+                  <p>Pinned npm URLs behave like a proper CSS CDN.</p>
+                </div>
+                <p class="rp-preview-note">Prefer a version pin for prod.</p>
+              </div>
+            </article>
+
+            <article class="rp-preview-card" data-preview="raw">
+              <div class="rp-preview-head">
+                GitHub Raw
+                <span class="rp-badge rp-badge-danger">Unstyled risk</span>
+              </div>
+              <div class="rp-preview-body rp-fake-broken">
+                <button type="button" class="rp-demo-btn">
+                  Primary action
+                </button>
+                <div class="rp-demo-card">
+                  <h3>Card “missing”</h3>
+                  <p>Looks like plain HTML if the sheet is ignored.</p>
+                </div>
+                <p class="rp-preview-note">
+                  Educational mock of failed stylesheet apply.
+                </p>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <!-- Pitfalls -->
+        <section class="rp-card ease-slide-up ease-delay-300">
+          <h2 class="rp-card-title">Pitfalls explained</h2>
+          <ul class="rp-pitfalls">
+            <li class="rp-pitfall">
+              <h3>
+                Wrong Content-Type
+                <span class="rp-badge rp-badge-danger">MIME</span>
+              </h3>
+              <p>
+                <code>raw.githubusercontent.com</code> commonly returns
+                <code>text/plain; charset=utf-8</code> instead of
+                <code>text/css</code>. Strict browsers may block or warn when a
+                stylesheet is served as plain text, so utilities like
+                <code>ease-btn</code> never paint.
+              </p>
+            </li>
+            <li class="rp-pitfall">
+              <h3>
+                Weak caching
+                <span class="rp-badge rp-badge-warn">Cache</span>
+              </h3>
+              <p>
+                Raw GitHub is not a production CSS CDN. You miss the edge network
+                and long-lived immutable caching that versioned jsDelivr/unpkg URLs
+                provide. Updates and purges feel unpredictable.
+              </p>
+            </li>
+            <li class="rp-pitfall">
+              <h3>
+                Rate limits &amp; availability
+                <span class="rp-badge rp-badge-warn">Reliability</span>
+              </h3>
+              <p>
+                Hotlinking Raw for every site visitor can hit GitHub rate limits
+                or outages. jsDelivr and unpkg are designed for high-volume
+                static asset delivery.
+              </p>
+            </li>
+            <li class="rp-pitfall">
+              <h3>
+                False “EaseMotion is broken” reports
+                <span class="rp-badge rp-badge-info">Docs</span>
+              </h3>
+              <p>
+                When beginners paste the Raw README link and see an unstyled
+                page, they often blame the framework. The CSS is fine — the
+                delivery method is the problem.
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <!-- Recommendation -->
+        <section class="rp-card rp-reco ease-slide-up">
+          <h2 class="rp-card-title">Production recommendation</h2>
+          <p>
+            Keep the Raw URL as a curiosity in docs if needed — but ship with
+            jsDelivr (or unpkg) and a <strong>pinned version</strong>.
+          </p>
+          <ul class="rp-reco-list">
+            <li>
+              <strong>Best default:</strong>
+              <code>https://cdn.jsdelivr.net/npm/easemotion-css@1.2.0/easemotion.min.css</code>
+            </li>
+            <li>
+              <strong>Also fine:</strong>
+              <code>https://unpkg.com/easemotion-css@1.2.0/easemotion.min.css</code>
+            </li>
+            <li>
+              <strong>Avoid in production:</strong>
+              <code>https://raw.githubusercontent.com/.../easemotion.min.css</code>
+            </li>
+            <li>
+              <strong>Avoid unpinned branches in prod:</strong>
+              <code>@main</code> can change under you — pin <code>@1.2.0</code>.
+            </li>
+          </ul>
+        </section>
+
+        <!-- Do / Don't -->
+        <section class="rp-card">
+          <h2 class="rp-card-title">Quick checklist</h2>
+          <ul class="rp-check">
+            <li>
+              <span class="rp-check-icon" aria-hidden="true">✓</span>
+              <span>Use jsDelivr or unpkg with a semver pin for production apps.</span>
+            </li>
+            <li>
+              <span class="rp-check-icon" aria-hidden="true">✓</span>
+              <span>Confirm <code>Content-Type</code> includes <code>text/css</code> when debugging blank styles.</span>
+            </li>
+            <li>
+              <span class="rp-check-icon" aria-hidden="true">✓</span>
+              <span>Use this page’s Probe button when a CDN looks “dead.”</span>
+            </li>
+            <li>
+              <span class="rp-check-icon is-no" aria-hidden="true">✕</span>
+              <span>Do not rely on GitHub Raw as your primary CSS CDN.</span>
+            </li>
+            <li>
+              <span class="rp-check-icon is-no" aria-hidden="true">✕</span>
+              <span>Do not assume missing styles mean EaseMotion CSS itself is broken.</span>
+            </li>
+          </ul>
+        </section>
+
+        <aside class="rp-footer">
+          <strong>Submission note:</strong>
+          Freeze-safe docs showcase only —
+          <code>submissions/docs/ease-github-raw-cdn-pitfalls-sp/</code>.
+          Does not modify <code>core/</code>, <code>components/</code>, or README.
+          Relates to issue
+          <a
+            href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46162"
+            target="_blank"
+            rel="noopener noreferrer"
+          >#46162</a>.
+        </aside>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var FILE_DEFAULT = "easemotion.min.css";
+
+      var PROVIDERS = {
+        jsdelivr: {
+          id: "jsdelivr",
+          label: "jsDelivr",
+          tone: "ok",
+          badge: "Safe",
+          badgeClass: "rp-badge-ok",
+          verdict:
+            "jsDelivr serves EaseMotion with a correct stylesheet MIME type and reliable edge caching. Prefer this for production.",
+          url: function (file) {
+            return (
+              "https://cdn.jsdelivr.net/npm/easemotion-css@1.2.0/" + file
+            );
+          },
+          expectCss: true,
+        },
+        unpkg: {
+          id: "unpkg",
+          label: "unpkg",
+          tone: "ok",
+          badge: "Safe",
+          badgeClass: "rp-badge-ok",
+          verdict:
+            "unpkg serves the npm package with a proper CSS Content-Type. Pin a version (e.g. @1.2.0) for production.",
+          url: function (file) {
+            return "https://unpkg.com/easemotion-css@1.2.0/" + file;
+          },
+          expectCss: true,
+        },
+        raw: {
+          id: "raw",
+          label: "GitHub Raw",
+          tone: "danger",
+          badge: "Risky",
+          badgeClass: "rp-badge-danger",
+          verdict:
+            "GitHub Raw often returns text/plain instead of text/css, has weak CDN caching, and can make EaseMotion look “broken.” Avoid for production.",
+          url: function (file) {
+            return (
+              "https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/" +
+              file
+            );
+          },
+          expectCss: false,
+        },
+      };
+
+      var providerInputs = document.querySelectorAll('input[name="provider"]');
+      var fileInputs = document.querySelectorAll('input[name="file"]');
+      var optionLabels = document.querySelectorAll(".rp-option");
+      var verdictEl = document.getElementById("verdict");
+      var verdictBadge = document.getElementById("verdict-badge");
+      var verdictText = document.getElementById("verdict-text");
+      var snippetEl = document.getElementById("snippet");
+      var copyBtn = document.getElementById("copy-btn");
+      var copyUrlBtn = document.getElementById("copy-url-btn");
+      var probeBtn = document.getElementById("probe-btn");
+      var probeBox = document.getElementById("probe");
+      var probeStatus = document.getElementById("probe-status");
+      var probeUrl = document.getElementById("probe-url");
+      var probeHttp = document.getElementById("probe-http");
+      var probeType = document.getElementById("probe-type");
+      var probeNote = document.getElementById("probe-note");
+      var compareRows = document.querySelectorAll("#compare-table tbody tr");
+      var previewCards = document.querySelectorAll(".rp-preview-card");
+
+      function selectedValue(inputs) {
+        for (var i = 0; i < inputs.length; i++) {
+          if (inputs[i].checked) return inputs[i].value;
+        }
+        return null;
+      }
+
+      function selectedFile() {
+        return selectedValue(fileInputs) || FILE_DEFAULT;
+      }
+
+      function selectedProvider() {
+        return PROVIDERS[selectedValue(providerInputs) || "jsdelivr"];
+      }
+
+      function linkTag(url) {
+        return (
+          '<link\n  rel="stylesheet"\n  href="' +
+          url +
+          '"\n/>'
+        );
+      }
+
+      function syncOptionSelected() {
+        optionLabels.forEach(function (label) {
+          var input = label.querySelector("input");
+          if (!input) return;
+          label.classList.toggle("is-selected", input.checked);
+        });
+      }
+
+      function syncCompare() {
+        var id = selectedProvider().id;
+        compareRows.forEach(function (row) {
+          row.classList.toggle("is-active", row.getAttribute("data-row") === id);
+        });
+        previewCards.forEach(function (card) {
+          card.classList.toggle(
+            "is-selected",
+            card.getAttribute("data-preview") === id
+          );
+        });
+      }
+
+      function updateUI() {
+        var provider = selectedProvider();
+        var file = selectedFile();
+        var url = provider.url(file);
+
+        syncOptionSelected();
+        syncCompare();
+
+        verdictEl.setAttribute("data-tone", provider.tone);
+        verdictBadge.className = "rp-badge " + provider.badgeClass;
+        verdictBadge.textContent = provider.badge;
+        verdictText.textContent = provider.verdict;
+        snippetEl.textContent = linkTag(url);
+
+        copyBtn.dataset.copied = "false";
+        copyBtn.textContent = "Copy";
+      }
+
+      function copyText(text, button, label) {
+        function done() {
+          button.dataset.copied = "true";
+          button.textContent = "Copied!";
+          window.setTimeout(function () {
+            button.dataset.copied = "false";
+            button.textContent = label;
+          }, 1400);
+        }
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {
+            fallbackCopy(text);
+            done();
+          });
+        } else {
+          fallbackCopy(text);
+          done();
+        }
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      function classifyType(type, expectCss) {
+        var t = (type || "").toLowerCase();
+        var isCss = t.indexOf("text/css") !== -1 || t.indexOf("stylesheet") !== -1;
+        if (isCss) {
+          return {
+            ok: true,
+            note: "Looks like a proper stylesheet MIME. Good for <link rel=\"stylesheet\">.",
+          };
+        }
+        if (t.indexOf("text/plain") !== -1) {
+          return {
+            ok: false,
+            note: "text/plain is the classic Raw GitHub pitfall — browsers may not apply this as CSS.",
+          };
+        }
+        if (!type) {
+          return {
+            ok: !expectCss,
+            note: "No Content-Type header exposed (CORS). Check DevTools Network panel for the real header.",
+          };
+        }
+        return {
+          ok: false,
+          note: "Unexpected type for a CSS file. Inspect Network → Response Headers.",
+        };
+      }
+
+      function setProbeVal(el, text, ok) {
+        el.textContent = text;
+        el.classList.remove("is-ok", "is-bad");
+        if (ok === true) el.classList.add("is-ok");
+        if (ok === false) el.classList.add("is-bad");
+      }
+
+      function probe() {
+        var provider = selectedProvider();
+        var url = provider.url(selectedFile());
+
+        probeBox.hidden = false;
+        probeStatus.textContent = "Fetching headers…";
+        setProbeVal(probeUrl, url, null);
+        setProbeVal(probeHttp, "…", null);
+        setProbeVal(probeType, "…", null);
+        setProbeVal(probeNote, "…", null);
+
+        fetch(url, { method: "GET", mode: "cors", cache: "no-store" })
+          .then(function (res) {
+            var type = res.headers.get("content-type") || "";
+            var verdict = classifyType(type, provider.expectCss);
+
+            setProbeVal(probeHttp, String(res.status) + " " + res.statusText, res.ok);
+            setProbeVal(probeType, type || "(empty / not readable)", verdict.ok);
+            setProbeVal(probeNote, verdict.note, verdict.ok);
+
+            if (res.ok && provider.expectCss && verdict.ok) {
+              probeStatus.textContent = "Probe complete — MIME looks good.";
+            } else if (res.ok && !verdict.ok) {
+              probeStatus.textContent = "Probe complete — MIME risk detected.";
+            } else if (res.ok) {
+              probeStatus.textContent = "Probe complete — inspect the notes below.";
+            } else {
+              probeStatus.textContent = "Probe complete — unexpected HTTP status.";
+            }
+
+            return res.text();
+          })
+          .catch(function (err) {
+            probeStatus.textContent =
+              "Probe blocked or failed (CORS / network). Use DevTools → Network instead.";
+            setProbeVal(probeHttp, "n/a", false);
+            setProbeVal(probeType, "n/a", false);
+            setProbeVal(
+              probeNote,
+              "Browser fetch error: " +
+                (err && err.message ? err.message : "unknown") +
+                ". Open the URL in a new tab and check Response Headers manually.",
+              false
+            );
+          });
+      }
+
+      providerInputs.forEach(function (input) {
+        input.addEventListener("change", updateUI);
+      });
+      fileInputs.forEach(function (input) {
+        input.addEventListener("change", updateUI);
+      });
+
+      copyBtn.addEventListener("click", function () {
+        copyText(snippetEl.textContent, copyBtn, "Copy");
+      });
+
+      copyUrlBtn.addEventListener("click", function () {
+        copyText(selectedProvider().url(selectedFile()), copyUrlBtn, "Copy raw URL");
+      });
+
+      probeBtn.addEventListener("click", probe);
+
+      updateUI();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-github-raw-cdn-pitfalls-sp/style.css
+++ b/submissions/docs/ease-github-raw-cdn-pitfalls-sp/style.css
@@ -1,0 +1,715 @@
+/* ============================================================
+   EaseMotion CSS — GitHub Raw CDN CSS Pitfalls Guide
+   submissions/docs/ease-github-raw-cdn-pitfalls-sp/style.css
+   ============================================================ */
+
+:root {
+  --rp-ink: #0f172a;
+  --rp-muted: #475569;
+  --rp-line: #e2e8f0;
+  --rp-surface: #ffffff;
+  --rp-page: #f4f7fb;
+  --rp-accent: #0f766e;
+  --rp-accent-soft: #ccfbf1;
+  --rp-warn: #b45309;
+  --rp-warn-soft: #ffedd5;
+  --rp-danger: #b91c1c;
+  --rp-danger-soft: #fee2e2;
+  --rp-ok: #15803d;
+  --rp-ok-soft: #dcfce7;
+  --rp-info: #1d4ed8;
+  --rp-info-soft: #dbeafe;
+  --rp-mono: "JetBrains Mono", ui-monospace, monospace;
+  --rp-radius: 14px;
+  --rp-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--rp-ink);
+  background:
+    radial-gradient(ellipse 80% 50% at 10% -10%, #ccfbf1 0%, transparent 55%),
+    radial-gradient(ellipse 60% 40% at 100% 0%, #e0e7ff 0%, transparent 50%),
+    var(--rp-page);
+  line-height: 1.55;
+}
+
+code,
+pre,
+.rp-mono {
+  font-family: var(--rp-mono);
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.rp-header {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.rp-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--rp-accent);
+}
+
+.rp-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.rp-subtitle {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--rp-muted);
+  font-size: 1.02rem;
+}
+
+.rp-issue {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--rp-info-soft);
+  color: var(--rp-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.rp-issue:hover,
+.rp-issue:focus-visible {
+  outline: 2px solid var(--rp-info);
+  outline-offset: 2px;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+
+.rp-main {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+}
+
+.rp-grid {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+@media (max-width: 860px) {
+  .rp-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rp-panel,
+.rp-card {
+  background: var(--rp-surface);
+  border: 1px solid var(--rp-line);
+  border-radius: var(--rp-radius);
+  box-shadow: var(--rp-shadow);
+}
+
+.rp-panel {
+  padding: 1.15rem;
+  position: sticky;
+  top: 1rem;
+}
+
+@media (max-width: 860px) {
+  .rp-panel {
+    position: static;
+  }
+}
+
+.rp-panel-title,
+.rp-card-title {
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.rp-field {
+  margin-bottom: 1.1rem;
+}
+
+.rp-field-label {
+  display: block;
+  margin-bottom: 0.45rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--rp-muted);
+}
+
+.rp-option-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.rp-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.15rem 0.65rem;
+  align-items: start;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--rp-line);
+  border-radius: 10px;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.rp-option input {
+  margin-top: 0.2rem;
+  accent-color: var(--rp-accent);
+}
+
+.rp-option strong {
+  font-size: 0.92rem;
+}
+
+.rp-option small {
+  grid-column: 2;
+  color: var(--rp-muted);
+  font-size: 0.78rem;
+}
+
+.rp-option.is-selected {
+  border-color: var(--rp-accent);
+  background: var(--rp-accent-soft);
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.25);
+}
+
+.rp-option:focus-within {
+  outline: 2px solid var(--rp-accent);
+  outline-offset: 2px;
+}
+
+.rp-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  width: fit-content;
+}
+
+.rp-badge-ok {
+  background: var(--rp-ok-soft);
+  color: var(--rp-ok);
+}
+
+.rp-badge-warn {
+  background: var(--rp-warn-soft);
+  color: var(--rp-warn);
+}
+
+.rp-badge-danger {
+  background: var(--rp-danger-soft);
+  color: var(--rp-danger);
+}
+
+.rp-badge-info {
+  background: var(--rp-info-soft);
+  color: var(--rp-info);
+}
+
+.rp-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.rp-card {
+  padding: 1.2rem 1.25rem;
+}
+
+.rp-card p {
+  margin: 0 0 0.75rem;
+  color: var(--rp-muted);
+}
+
+.rp-card p:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Verdict / status ────────────────────────────────────── */
+
+.rp-verdict {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--rp-line);
+  margin-bottom: 1rem;
+}
+
+.rp-verdict[data-tone="ok"] {
+  background: var(--rp-ok-soft);
+  border-color: #86efac;
+}
+
+.rp-verdict[data-tone="warn"] {
+  background: var(--rp-warn-soft);
+  border-color: #fdba74;
+}
+
+.rp-verdict[data-tone="danger"] {
+  background: var(--rp-danger-soft);
+  border-color: #fca5a5;
+}
+
+.rp-verdict-label {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.rp-verdict-text {
+  flex: 1;
+  min-width: 200px;
+  margin: 0;
+  color: var(--rp-ink);
+  font-size: 0.92rem;
+}
+
+/* ── Comparison table ────────────────────────────────────── */
+
+.rp-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--rp-line);
+  border-radius: 12px;
+}
+
+.rp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 640px;
+}
+
+.rp-table th,
+.rp-table td {
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid var(--rp-line);
+  vertical-align: top;
+}
+
+.rp-table th {
+  background: #f8fafc;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--rp-muted);
+}
+
+.rp-table tr:last-child td {
+  border-bottom: none;
+}
+
+.rp-table tr.is-active td {
+  background: var(--rp-accent-soft);
+}
+
+.rp-table code {
+  font-size: 0.78rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+/* ── Snippet / copy ──────────────────────────────────────── */
+
+.rp-snippet-block {
+  position: relative;
+  margin-top: 0.75rem;
+}
+
+.rp-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5.5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.rp-copy {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.rp-copy:hover,
+.rp-copy:focus-visible {
+  background: var(--rp-accent);
+  outline: none;
+}
+
+.rp-copy[data-copied="true"] {
+  background: var(--rp-ok);
+}
+
+/* ── Probe results ───────────────────────────────────────── */
+
+.rp-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin: 0.85rem 0 0.25rem;
+}
+
+.rp-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 150ms ease,
+    background-color 150ms ease,
+    border-color 150ms ease;
+}
+
+.rp-btn:active {
+  transform: scale(0.98);
+}
+
+.rp-btn:focus-visible {
+  outline: 2px solid var(--rp-accent);
+  outline-offset: 2px;
+}
+
+.rp-btn-primary {
+  background: var(--rp-accent);
+  color: #fff;
+}
+
+.rp-btn-primary:hover {
+  background: #0d9488;
+}
+
+.rp-btn-ghost {
+  background: #fff;
+  border-color: var(--rp-line);
+  color: var(--rp-ink);
+}
+
+.rp-btn-ghost:hover {
+  border-color: var(--rp-accent);
+  color: var(--rp-accent);
+}
+
+.rp-probe {
+  margin-top: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  border: 1px dashed var(--rp-line);
+  background: #f8fafc;
+  font-size: 0.88rem;
+}
+
+.rp-probe[hidden] {
+  display: none;
+}
+
+.rp-probe-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 0.35rem 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+.rp-probe-row:last-child {
+  margin-bottom: 0;
+}
+
+.rp-probe-key {
+  font-weight: 600;
+  color: var(--rp-muted);
+  font-size: 0.8rem;
+}
+
+.rp-probe-val {
+  font-family: var(--rp-mono);
+  font-size: 0.78rem;
+  word-break: break-all;
+}
+
+.rp-probe-val.is-ok {
+  color: var(--rp-ok);
+}
+
+.rp-probe-val.is-bad {
+  color: var(--rp-danger);
+}
+
+.rp-probe-status {
+  margin: 0 0 0.65rem;
+  font-weight: 600;
+}
+
+/* ── Preview frames ──────────────────────────────────────── */
+
+.rp-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .rp-preview-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rp-preview-card {
+  border: 1px solid var(--rp-line);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.rp-preview-card.is-selected {
+  border-color: var(--rp-accent);
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.2);
+}
+
+.rp-preview-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.8rem;
+  background: #f8fafc;
+  border-bottom: 1px solid var(--rp-line);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.rp-preview-body {
+  padding: 1rem 0.9rem 1.1rem;
+  min-height: 150px;
+}
+
+.rp-preview-note {
+  margin: 0.65rem 0 0;
+  font-size: 0.78rem;
+  color: var(--rp-muted);
+}
+
+.rp-fake-broken {
+  opacity: 0.55;
+  filter: grayscale(0.4);
+}
+
+.rp-fake-broken .rp-demo-btn {
+  background: #94a3b8 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.rp-demo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: #0f766e;
+  color: #fff;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: default;
+}
+
+.rp-demo-card {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+}
+
+.rp-demo-card h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.rp-demo-card p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--rp-muted);
+}
+
+/* ── Pitfall list ────────────────────────────────────────── */
+
+.rp-pitfalls {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.rp-pitfall {
+  padding: 0.85rem 0.95rem;
+  border-radius: 10px;
+  border: 1px solid var(--rp-line);
+  background: #fff;
+}
+
+.rp-pitfall h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.rp-pitfall p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--rp-muted);
+}
+
+/* ── Recommendation ──────────────────────────────────────── */
+
+.rp-reco {
+  border-left: 4px solid var(--rp-ok);
+  background: linear-gradient(135deg, #f0fdf4, #ffffff);
+}
+
+.rp-reco-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.15rem;
+  color: var(--rp-ink);
+}
+
+.rp-reco-list li {
+  margin-bottom: 0.35rem;
+}
+
+.rp-reco-list li:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Checklist ───────────────────────────────────────────── */
+
+.rp-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.rp-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--rp-line);
+  font-size: 0.9rem;
+}
+
+.rp-check li:last-child {
+  border-bottom: none;
+}
+
+.rp-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--rp-ok);
+  margin-top: 0.1rem;
+}
+
+.rp-check-icon.is-no {
+  background: var(--rp-danger);
+}
+
+/* ── Footer note ─────────────────────────────────────────── */
+
+.rp-footer {
+  margin-top: 1.5rem;
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--rp-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--rp-muted);
+}
+
+.rp-footer strong {
+  color: var(--rp-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .rp-btn,
+  .rp-option {
+    transition: none;
+  }
+}


### PR DESCRIPTION
# #46162 issue resolved

## Description

This PR adds a beginner-friendly **GitHub Raw CDN CSS Pitfalls Guide** under `submissions/docs/ease-github-raw-cdn-pitfalls-sp/`.

It is an interactive documentation showcase that compares loading `easemotion.min.css` via **jsDelivr**, **unpkg**, and **raw.githubusercontent.com**, and explains when the GitHub Raw CDN fails (MIME / Content-Type, caching, broken styles), with a clear production recommendation panel.

## Features

- Side-by-side comparison of jsDelivr / unpkg / GitHub Raw
- Live verdict panel with Safe vs Risky guidance
- Demo panel showing correct vs broken stylesheet loading outcomes
- Plain-English explanation of MIME / Content-Type / caching pitfalls
- Live **Probe Content-Type** check (when browser CORS allows)
- Production recommendation panel with pin vs `@main` notes
- Copy-ready CDN `<link>` snippets for each provider
- Responsive, educational UI aligned with EaseMotion documentation style

## Folder Structure

```text
submissions/docs/ease-github-raw-cdn-pitfalls-sp/
├── demo.html
├── style.css
└── README.md