### PR TITLE
Modular Import Order Violation Demo

### DIFF
--- a/submissions/docs/ease-modular-import-order-sp/README.md
+++ b/submissions/docs/ease-modular-import-order-sp/README.md
@@ -1,0 +1,73 @@
+# Modular Import Order Violation Demo
+
+An interactive documentation lab that shows what happens when `fade.css` is loaded before / without `easemotion/variables.css` versus the correct README Option 4 order — with a side-by-side broken vs working comparison and copy-paste snippets.
+
+> Submission track: `submissions/docs/ease-modular-import-order-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46175](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46175)
+
+---
+
+## What does this do?
+
+README Option 4 warns that `easemotion/variables.css` must load before modular animation files, but a one-line warning is easy to miss. This showcase makes the failure visible: missing tokens (`--ease-speed-medium`, `--ease-ease`) invalidate the `ease-fade-in` animation shorthand, so speeds/easings look broken next to a correct import.
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (no build step).
+2. Compare the **Wrong order** and **Correct order** iframe panels.
+3. Click **Replay animation** on each side and read the computed duration/easing readout.
+4. Copy the green Option 4 snippet for real projects.
+
+Example of the correct HTML pattern this demo teaches:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion/variables.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion/fade.css"
+/>
+```
+
+---
+
+## Why is it useful?
+
+- Turns a static README warning into a hands-on “wrong order” lab
+- Prevents false “fade animation is broken” bug reports caused by import order
+- Freeze-safe: only new files under `submissions/docs/`
+- Matches EaseMotion’s readable, education-first philosophy
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-modular-import-order-sp/
+├── demo.html           ← main lab + snippets
+├── style.css           ← page layout (mio-* classes)
+├── panel-wrong.html    ← fade.css without variables first
+├── panel-correct.html  ← variables.css then fade.css
+└── README.md
+```
+
+`panel-*.html` files isolate each cascade so the correct panel cannot “fix” the wrong one.
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Demo classes in panels use existing framework utilities (`ease-fade-in`) for illustration; local chrome uses `mio-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-modular-import-order-sp/demo.html
+++ b/submissions/docs/ease-modular-import-order-sp/demo.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modular Import Order Violation Demo — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Side-by-side lab: load fade.css before variables.css vs the correct Option 4 order. See broken speeds/easings and copy the fix."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="mio-header">
+    <p class="mio-eyebrow">EaseMotion CSS · Documentation Showcase</p>
+    <h1>Modular Import Order Violation Demo</h1>
+    <p class="mio-subtitle">
+      README Option 4 lets you load only the animation modules you need — but
+      <code>easemotion/variables.css</code> <strong>must</strong> come first.
+      This lab shows broken vs working speeds/easings side by side, with
+      copy-paste correct snippets.
+    </p>
+    <a
+      class="mio-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46175"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46175
+    </a>
+  </header>
+
+  <main class="mio-main mio-stack">
+    <aside class="mio-callout" role="note">
+      <strong>Rule:</strong>
+      <code>easemotion/variables.css</code> must always load before modular
+      animation files (<code>fade.css</code>, <code>slide.css</code>, …).
+      Those modules use tokens like
+      <code>--ease-speed-medium</code> and <code>--ease-ease</code>. Without
+      them, the animation shorthand becomes invalid and the fade never looks
+      right.
+    </aside>
+
+    <!-- ── Live comparison ─────────────────────────────── -->
+    <section class="mio-card" aria-labelledby="lab-title">
+      <h2 class="mio-card-title" id="lab-title">Live lab: wrong vs correct</h2>
+      <p>
+        Same class (<code>ease-fade-in</code>). Left panel loads
+        <code>fade.css</code> without variables first (wrong / incomplete order).
+        Right panel follows Option 4. Each panel is an isolated iframe so the
+        cascade cannot “leak” across demos.
+      </p>
+
+      <div class="mio-compare">
+        <article class="mio-panel mio-panel--wrong">
+          <div class="mio-panel-head">
+            <h3>Wrong order</h3>
+            <span class="mio-badge mio-badge-danger">Broken</span>
+          </div>
+          <p class="mio-panel-meta">
+            Loads <code>fade.css</code> <strong>before</strong>
+            <code>variables.css</code> is available (variables omitted here to
+            show the failure mode Option 4 warns about).
+          </p>
+          <iframe
+            class="mio-frame"
+            id="frame-wrong"
+            title="Wrong modular import order demo"
+            src="./panel-wrong.html"
+          ></iframe>
+          <div class="mio-panel-actions">
+            <button type="button" class="mio-btn" data-replay="wrong">
+              Replay animation
+            </button>
+          </div>
+        </article>
+
+        <article class="mio-panel mio-panel--correct">
+          <div class="mio-panel-head">
+            <h3>Correct order</h3>
+            <span class="mio-badge mio-badge-ok">Working</span>
+          </div>
+          <p class="mio-panel-meta">
+            Loads <code>variables.css</code> <strong>then</strong>
+            <code>fade.css</code> — README Option 4.
+          </p>
+          <iframe
+            class="mio-frame"
+            id="frame-correct"
+            title="Correct modular import order demo"
+            src="./panel-correct.html"
+          ></iframe>
+          <div class="mio-panel-actions">
+            <button type="button" class="mio-btn" data-replay="correct">
+              Replay animation
+            </button>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <!-- ── Copy-paste snippets ──────────────────────────── -->
+    <section class="mio-card" aria-labelledby="snip-title">
+      <h2 class="mio-card-title" id="snip-title">Copy-paste snippets</h2>
+      <p>
+        Wrong pattern (fade first) vs correct Option 4 pattern. Prefer the green
+        snippet in real projects.
+      </p>
+
+      <div class="mio-snippet-grid">
+        <div class="mio-snippet-block">
+          <div class="mio-snippet-label">
+            <span class="mio-badge mio-badge-danger">Avoid</span>
+            Wrong — fade before variables
+          </div>
+          <pre
+            class="mio-snippet mio-snippet--wrong"
+            id="snip-wrong"
+            aria-label="Wrong import order snippet"
+>&lt;link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion/fade.css"
+/&gt;
+&lt;link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion/variables.css"
+/&gt;
+&lt;!-- ❌ variables must come first --&gt;</pre>
+          <button
+            type="button"
+            class="mio-copy"
+            data-copy="snip-wrong"
+            data-copied="false"
+          >
+            Copy
+          </button>
+        </div>
+
+        <div class="mio-snippet-block">
+          <div class="mio-snippet-label">
+            <span class="mio-badge mio-badge-ok">Use this</span>
+            Correct — README Option 4
+          </div>
+          <pre
+            class="mio-snippet mio-snippet--correct"
+            id="snip-correct"
+            aria-label="Correct import order snippet"
+>&lt;link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion/variables.css"
+/&gt;
+&lt;link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion/fade.css"
+/&gt;
+&lt;link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion/slide.css"
+/&gt;
+&lt;!-- ✅ Add only the animation categories you need --&gt;</pre>
+          <button
+            type="button"
+            class="mio-copy"
+            data-copy="snip-correct"
+            data-copied="false"
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+      <p class="mio-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <!-- ── Why ──────────────────────────────────────────── -->
+    <section class="mio-card" aria-labelledby="why-title">
+      <h2 class="mio-card-title" id="why-title">Why variables must load first</h2>
+      <ul class="mio-why">
+        <li>
+          <h3>
+            Tokens power the utilities
+            <span class="mio-badge mio-badge-warn">Tokens</span>
+          </h3>
+          <p>
+            <code>fade.css</code> declares
+            <code>animation: ease-kf-fade-in var(--ease-speed-medium) var(--ease-ease) both</code>.
+            Those custom properties live in <code>variables.css</code>.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Missing vars invalidate the shorthand
+            <span class="mio-badge mio-badge-danger">Broken</span>
+          </h3>
+          <p>
+            If <code>--ease-speed-medium</code> / <code>--ease-ease</code> are
+            undefined, the whole <code>animation</code> declaration becomes
+            invalid — so you get no (or wrong) duration and easing, even though
+            the keyframes file loaded.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Option 4 is modular, not magic
+            <span class="mio-badge mio-badge-ok">Docs</span>
+          </h3>
+          <p>
+            Loading only <code>fade.css</code> is fine for tree-shaking size —
+            but every modular setup still needs <code>variables.css</code> once,
+            at the top of the list.
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <!-- ── Recommendation ──────────────────────────────── -->
+    <section class="mio-card mio-reco" aria-labelledby="reco-title">
+      <h2 class="mio-card-title" id="reco-title">Recommended pattern</h2>
+      <p>
+        Always start modular imports with variables, then add only the animation
+        categories you need — same order as README Option 4.
+      </p>
+      <ul class="mio-check">
+        <li>
+          <span class="mio-check-icon" aria-hidden="true">✓</span>
+          <span>Put <code>easemotion/variables.css</code> first.</span>
+        </li>
+        <li>
+          <span class="mio-check-icon" aria-hidden="true">✓</span>
+          <span>Then add <code>fade.css</code>, <code>slide.css</code>, etc.</span>
+        </li>
+        <li>
+          <span class="mio-check-icon" aria-hidden="true">✓</span>
+          <span>Replay both panels above to compare computed duration/easing.</span>
+        </li>
+        <li>
+          <span class="mio-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Do not ship animation modules without the variables sheet.</span>
+        </li>
+        <li>
+          <span class="mio-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Do not assume a blank fade means EaseMotion keyframes are “broken.”</span>
+        </li>
+      </ul>
+    </section>
+
+    <aside class="mio-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-modular-import-order-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46175"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46175</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      function decodeEntities(html) {
+        var ta = document.createElement("textarea");
+        ta.innerHTML = html;
+        return ta.value;
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = decodeEntities(pre.innerHTML.trim());
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+
+      document.querySelectorAll("[data-replay]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var which = btn.getAttribute("data-replay");
+          var frame =
+            which === "wrong"
+              ? document.getElementById("frame-wrong")
+              : document.getElementById("frame-correct");
+          if (!frame || !frame.contentWindow) return;
+          try {
+            if (typeof frame.contentWindow.replay === "function") {
+              frame.contentWindow.replay();
+            } else {
+              frame.contentWindow.location.reload();
+            }
+          } catch (e) {
+            frame.src = frame.src;
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-modular-import-order-sp/panel-correct.html
+++ b/submissions/docs/ease-modular-import-order-sp/panel-correct.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Correct import order</title>
+  <!--
+    CORRECT modular order (README Option 4):
+    variables.css first, then fade.css.
+  -->
+  <link rel="stylesheet" href="../../../easemotion/variables.css" />
+  <link rel="stylesheet" href="../../../easemotion/fade.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.85rem;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      background: #f0fdf4;
+      color: #0f172a;
+    }
+    .box {
+      width: min(220px, 80%);
+      padding: 1.1rem 1rem;
+      border: 1px solid #86efac;
+      border-radius: 12px;
+      background: #fff;
+      text-align: center;
+      font-weight: 600;
+      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+    }
+    .note {
+      margin: 0;
+      font-size: 0.75rem;
+      color: #15803d;
+      text-align: center;
+      max-width: 28ch;
+    }
+    .readout {
+      margin: 0;
+      font-size: 0.7rem;
+      font-family: ui-monospace, monospace;
+      color: #64748b;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="demo" class="box ease-fade-in">ease-fade-in</div>
+  <p class="note">Tokens present → medium speed + EaseMotion easing applied</p>
+  <p class="readout" id="readout">checking…</p>
+  <script>
+    (function () {
+      var el = document.getElementById("demo");
+      var out = document.getElementById("readout");
+      function report() {
+        var cs = getComputedStyle(el);
+        var dur = cs.animationDuration || "(none)";
+        var easing = cs.animationTimingFunction || "(none)";
+        out.textContent =
+          "computed: duration=" + dur + " · easing=" + easing;
+      }
+      report();
+      window.replay = function () {
+        el.classList.remove("ease-fade-in");
+        void el.offsetWidth;
+        el.classList.add("ease-fade-in");
+        report();
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-modular-import-order-sp/panel-wrong.html
+++ b/submissions/docs/ease-modular-import-order-sp/panel-wrong.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wrong import order</title>
+  <!--
+    WRONG / incomplete modular order:
+    fade.css is loaded without variables.css first.
+    --ease-speed-medium and --ease-ease are missing → animation shorthand is invalid.
+  -->
+  <link rel="stylesheet" href="../../../easemotion/fade.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.85rem;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      background: #fff7f7;
+      color: #0f172a;
+    }
+    .box {
+      width: min(220px, 80%);
+      padding: 1.1rem 1rem;
+      border: 1px dashed #fca5a5;
+      border-radius: 12px;
+      background: #fff;
+      text-align: center;
+      font-weight: 600;
+    }
+    .note {
+      margin: 0;
+      font-size: 0.75rem;
+      color: #b91c1c;
+      text-align: center;
+      max-width: 28ch;
+    }
+    .readout {
+      margin: 0;
+      font-size: 0.7rem;
+      font-family: ui-monospace, monospace;
+      color: #64748b;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="demo" class="box ease-fade-in">ease-fade-in</div>
+  <p class="note">Variables missing → duration/easing invalid → little or no fade</p>
+  <p class="readout" id="readout">checking…</p>
+  <script>
+    (function () {
+      var el = document.getElementById("demo");
+      var out = document.getElementById("readout");
+      function report() {
+        var cs = getComputedStyle(el);
+        var dur = cs.animationDuration || "(none)";
+        var easing = cs.animationTimingFunction || "(none)";
+        out.textContent =
+          "computed: duration=" + dur + " · easing=" + easing;
+      }
+      report();
+      window.replay = function () {
+        el.classList.remove("ease-fade-in");
+        void el.offsetWidth;
+        el.classList.add("ease-fade-in");
+        report();
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-modular-import-order-sp/style.css
+++ b/submissions/docs/ease-modular-import-order-sp/style.css
@@ -1,0 +1,467 @@
+/* ============================================================
+   Modular Import Order Violation Demo
+   submissions/docs/ease-modular-import-order-sp/style.css
+   ============================================================ */
+
+:root {
+  --mio-ink: #0f172a;
+  --mio-muted: #475569;
+  --mio-line: #e2e8f0;
+  --mio-surface: #ffffff;
+  --mio-page: #f4f7fb;
+  --mio-accent: #0f766e;
+  --mio-accent-soft: #ccfbf1;
+  --mio-warn: #b45309;
+  --mio-warn-soft: #ffedd5;
+  --mio-danger: #b91c1c;
+  --mio-danger-soft: #fee2e2;
+  --mio-ok: #15803d;
+  --mio-ok-soft: #dcfce7;
+  --mio-info: #1d4ed8;
+  --mio-info-soft: #dbeafe;
+  --mio-mono: "JetBrains Mono", ui-monospace, monospace;
+  --mio-radius: 14px;
+  --mio-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--mio-ink);
+  background:
+    radial-gradient(ellipse 80% 50% at 10% -10%, #ccfbf1 0%, transparent 55%),
+    radial-gradient(ellipse 60% 40% at 100% 0%, #e0e7ff 0%, transparent 50%),
+    var(--mio-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--mio-mono);
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.mio-header {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.mio-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mio-accent);
+}
+
+.mio-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.mio-subtitle {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--mio-muted);
+  font-size: 1.02rem;
+}
+
+.mio-issue {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--mio-info-soft);
+  color: var(--mio-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.mio-issue:hover,
+.mio-issue:focus-visible {
+  outline: 2px solid var(--mio-info);
+  outline-offset: 2px;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+
+.mio-main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+}
+
+.mio-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.mio-card {
+  background: var(--mio-surface);
+  border: 1px solid var(--mio-line);
+  border-radius: var(--mio-radius);
+  box-shadow: var(--mio-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.mio-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.mio-card p {
+  margin: 0 0 0.75rem;
+  color: var(--mio-muted);
+}
+
+.mio-card p:last-child {
+  margin-bottom: 0;
+}
+
+.mio-callout {
+  border-left: 4px solid var(--mio-warn);
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+  border-radius: 0 var(--mio-radius) var(--mio-radius) 0;
+  border: 1px solid var(--mio-line);
+  border-left-width: 4px;
+  border-left-color: var(--mio-warn);
+}
+
+.mio-callout strong {
+  color: var(--mio-warn);
+}
+
+/* ── Side-by-side lab ────────────────────────────────────── */
+
+.mio-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 820px) {
+  .mio-compare {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mio-panel {
+  border: 1px solid var(--mio-line);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.mio-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid var(--mio-line);
+  background: #f8fafc;
+}
+
+.mio-panel-head h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.mio-panel--wrong .mio-panel-head {
+  background: var(--mio-danger-soft);
+}
+
+.mio-panel--correct .mio-panel-head {
+  background: var(--mio-ok-soft);
+}
+
+.mio-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.mio-badge-danger {
+  background: var(--mio-danger-soft);
+  color: var(--mio-danger);
+}
+
+.mio-badge-ok {
+  background: var(--mio-ok-soft);
+  color: var(--mio-ok);
+}
+
+.mio-badge-warn {
+  background: var(--mio-warn-soft);
+  color: var(--mio-warn);
+}
+
+.mio-panel-meta {
+  padding: 0.65rem 0.9rem 0;
+  font-size: 0.8rem;
+  color: var(--mio-muted);
+}
+
+.mio-panel-meta code {
+  font-size: 0.72rem;
+  background: #f1f5f9;
+  padding: 0.08rem 0.3rem;
+  border-radius: 4px;
+}
+
+.mio-frame {
+  width: 100%;
+  height: 280px;
+  border: 0;
+  border-top: 1px solid var(--mio-line);
+  margin-top: 0.65rem;
+  background: #fafafa;
+}
+
+.mio-panel-actions {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 0.9rem 0.9rem;
+}
+
+.mio-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--mio-accent);
+  color: #fff;
+}
+
+.mio-btn:hover {
+  background: #0d9488;
+}
+
+.mio-btn:focus-visible {
+  outline: 2px solid var(--mio-accent);
+  outline-offset: 2px;
+}
+
+.mio-btn-ghost {
+  background: #fff;
+  border-color: var(--mio-line);
+  color: var(--mio-ink);
+}
+
+.mio-btn-ghost:hover {
+  border-color: var(--mio-accent);
+  color: var(--mio-accent);
+}
+
+/* ── Snippets ────────────────────────────────────────────── */
+
+.mio-snippet-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 820px) {
+  .mio-snippet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mio-snippet-block {
+  position: relative;
+}
+
+.mio-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.mio-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.75rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 8.5rem;
+}
+
+.mio-snippet--wrong {
+  box-shadow: inset 0 0 0 2px rgba(185, 28, 28, 0.45);
+}
+
+.mio-snippet--correct {
+  box-shadow: inset 0 0 0 2px rgba(21, 128, 61, 0.45);
+}
+
+.mio-copy {
+  position: absolute;
+  top: 2.15rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.mio-copy:hover,
+.mio-copy:focus-visible {
+  background: var(--mio-accent);
+  outline: none;
+}
+
+.mio-copy[data-copied="true"] {
+  background: var(--mio-ok);
+}
+
+/* ── Why / checklist ─────────────────────────────────────── */
+
+.mio-why {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.mio-why li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--mio-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.mio-why h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.mio-why p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--mio-muted);
+}
+
+.mio-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mio-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--mio-line);
+  font-size: 0.9rem;
+}
+
+.mio-check li:last-child {
+  border-bottom: none;
+}
+
+.mio-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--mio-ok);
+  margin-top: 0.1rem;
+}
+
+.mio-check-icon.is-no {
+  background: var(--mio-danger);
+}
+
+.mio-reco {
+  border-left: 4px solid var(--mio-ok);
+  background: linear-gradient(135deg, #f0fdf4, #ffffff);
+}
+
+.mio-footer {
+  margin-top: 0.5rem;
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--mio-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--mio-muted);
+}
+
+.mio-footer strong {
+  color: var(--mio-ink);
+}
+
+.mio-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--mio-ok);
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
# #46175 issue resolved

## Description

This PR adds a beginner-friendly **Modular Import Order Violation Demo** under `submissions/docs/ease-modular-import-order-sp/`.

It shows side-by-side what happens when `fade.css` loads before / without `easemotion/variables.css` versus the correct README Option 4 order, with live fade demos and copy-paste snippets.

## Features

- Side-by-side **Wrong order** vs **Correct order** comparison (isolated iframe panels)
- Live `ease-fade-in` demos showing broken vs working speeds/easings
- Clear explanation of why `variables.css` must load first
- Copy-paste ready Option 4 `<link>` snippets
- Self-contained docs lab — open `demo.html` directly (no build step)
- Responsive, educational UI for easy review