### PR TITLE
Inter Font FOIT and Entrance Animation Flash

### DIFF
--- a/submissions/docs/ease-font-foit-motion-sp/README.md
+++ b/submissions/docs/ease-font-foit-motion-sp/README.md
@@ -1,0 +1,71 @@
+# Inter Font FOIT + Entrance Animation Flash
+
+An interactive documentation showcase that reproduces text jumping when **Inter** loads mid-`ease-fade-in` / `ease-slide-up`, then documents practical fixes: `font-display`, correct `preconnect` order, and fallback font metrics.
+
+> Submission track: `submissions/docs/ease-font-foit-motion-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46176](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46176)
+
+---
+
+## What does this do?
+
+The README pushes Inter for typography, but font loading × EaseMotion entrance motion is easy to miss. When Inter finishes loading while entrance animations run, text can reflow or flash — looking like a framework bug even though motion and fonts both work.
+
+This lab shows the broken late-swap case next to a mitigated setup and gives copy-paste snippets.
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (internet needed for Google Fonts in the panels).
+2. Compare **FOIT / late Inter swap** vs **Mitigated loading**.
+3. Click **Replay flash** to force Inter to arrive mid-entrance animation.
+4. Copy the recommended preconnect + `display=swap` + fallback metrics snippet.
+
+Example of the mitigated pattern this demo teaches:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+  rel="stylesheet"
+/>
+```
+
+---
+
+## Why is it useful?
+
+- Documents a real README-adjacent footgun (Inter × entrance motion)
+- Reduces false “animation flash” bug reports
+- Freeze-safe: only new files under `submissions/docs/`
+- Fits EaseMotion’s readable, education-first contribution model
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-font-foit-motion-sp/
+├── demo.html           ← main lab + snippets + checklist
+├── style.css           ← page layout (ff-* classes)
+├── panel-problem.html  ← late Inter swap mid-motion
+├── panel-fixed.html    ← preconnect + swap + size-adjust
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Demo panels use existing framework utilities (`ease-fade-in`, `ease-slide-up`) for illustration; local chrome uses `ff-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-font-foit-motion-sp/demo.html
+++ b/submissions/docs/ease-font-foit-motion-sp/demo.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inter Font FOIT + Entrance Animation Flash — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Show text jumping when Inter loads mid ease-fade-in / ease-slide-up, and document font-display, preconnect order, and fallback metrics fixes."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="ff-header">
+    <p class="ff-eyebrow">EaseMotion CSS · Documentation Showcase</p>
+    <h1>Inter Font FOIT + Entrance Animation Flash</h1>
+    <p class="ff-subtitle">
+      The README encourages Inter for typography. When that font finishes loading
+      while <code>ease-fade-in</code> / <code>ease-slide-up</code> are running,
+      text can jump or flash — looking like a motion bug even when both systems
+      work. This lab reproduces the glitch and shows practical fixes.
+    </p>
+    <a
+      class="ff-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46176"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46176
+    </a>
+  </header>
+
+  <main class="ff-main">
+    <aside class="ff-callout" role="note">
+      <strong>What you’re seeing:</strong>
+      FOIT/FOUT happens when a webfont swaps in after first paint.
+      EaseMotion entrance utilities animate opacity/transform at the same time —
+      so a late metric change feels like a “flash” or jump mid-fade/slide.
+    </aside>
+
+    <section class="ff-card" aria-labelledby="lab-title">
+      <h2 class="ff-card-title" id="lab-title">Live lab: problem vs mitigated</h2>
+      <p>
+        Isolated iframes so each font-loading strategy stays honest. Click
+        <strong>Replay flash</strong> on the left to re-trigger a late Inter swap
+        during entrance motion.
+      </p>
+
+      <div class="ff-compare">
+        <article class="ff-panel ff-panel--problem">
+          <div class="ff-panel-head">
+            <h3>FOIT / late Inter swap</h3>
+            <span class="ff-badge ff-badge-danger">Looks buggy</span>
+          </div>
+          <p class="ff-panel-meta">
+            No preconnect · fallback Georgia · Inter injected mid
+            <code>ease-fade-in</code> / <code>ease-slide-up</code> with
+            <code>display=block</code>
+          </p>
+          <iframe
+            class="ff-frame"
+            id="frame-problem"
+            title="Problem demo: Inter loads mid entrance animation"
+            src="./panel-problem.html"
+          ></iframe>
+          <div class="ff-panel-actions">
+            <button type="button" class="ff-btn" data-replay="problem">
+              Replay flash
+            </button>
+          </div>
+        </article>
+
+        <article class="ff-panel ff-panel--fixed">
+          <div class="ff-panel-head">
+            <h3>Mitigated loading</h3>
+            <span class="ff-badge ff-badge-ok">Recommended</span>
+          </div>
+          <p class="ff-panel-meta">
+            Correct <code>preconnect</code> order ·
+            <code>display=swap</code> · fallback <code>size-adjust</code> metrics
+          </p>
+          <iframe
+            class="ff-frame"
+            id="frame-fixed"
+            title="Fixed demo: mitigated font loading with entrance animation"
+            src="./panel-fixed.html"
+          ></iframe>
+          <div class="ff-panel-actions">
+            <button type="button" class="ff-btn" data-replay="fixed">
+              Replay motion
+            </button>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="ff-card" aria-labelledby="why-title">
+      <h2 class="ff-card-title" id="why-title">Why this happens</h2>
+      <ul class="ff-list">
+        <li>
+          <h3>
+            Font metrics change mid-animation
+            <span class="ff-badge ff-badge-danger">Jump</span>
+          </h3>
+          <p>
+            Inter and Georgia (or system UI) have different widths/heights.
+            When the stack swaps during <code>ease-slide-up</code>, glyphs
+            reflow — it reads as a glitch, not a font load.
+          </p>
+        </li>
+        <li>
+          <h3>
+            FOIT vs FOUT
+            <span class="ff-badge ff-badge-warn">display</span>
+          </h3>
+          <p>
+            <code>font-display: block</code> can hide text briefly (FOIT).
+            <code>swap</code> shows fallback quickly (FOUT) but may still jump.
+            <code>optional</code> can skip late swaps on slow networks — often
+            best when entrance motion is critical above the fold.
+          </p>
+        </li>
+        <li>
+          <h3>
+            README order matters
+            <span class="ff-badge ff-badge-info">preconnect</span>
+          </h3>
+          <p>
+            Without early <code>preconnect</code> to
+            <code>fonts.googleapis.com</code> and
+            <code>fonts.gstatic.com</code>, Inter arrives later — right in the
+            middle of EaseMotion entrance timings (~150–300ms).
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section class="ff-card" aria-labelledby="table-title">
+      <h2 class="ff-card-title" id="table-title">font-display cheat sheet</h2>
+      <div class="ff-table-wrap">
+        <table class="ff-table">
+          <thead>
+            <tr>
+              <th>Value</th>
+              <th>Behavior</th>
+              <th>With entrance motion</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>block</code></td>
+              <td>Invisible text wait (FOIT), then swap</td>
+              <td>High flash risk mid-fade/slide</td>
+            </tr>
+            <tr>
+              <td><code>swap</code></td>
+              <td>Fallback immediately, then Inter</td>
+              <td>OK for most pages; pair with metrics</td>
+            </tr>
+            <tr>
+              <td><code>optional</code></td>
+              <td>May keep fallback if font is late</td>
+              <td>Best when motion must stay stable</td>
+            </tr>
+            <tr>
+              <td><code>fallback</code></td>
+              <td>Short block, then swap window</td>
+              <td>Compromise between block and swap</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="ff-card" aria-labelledby="snip-title">
+      <h2 class="ff-card-title" id="snip-title">Copy-paste snippets</h2>
+      <p>
+        Avoid late-loading Inter during first paint + entrance. Prefer the green
+        setup that matches the README’s preconnect order and adds metrics.
+      </p>
+
+      <div class="ff-snippet-grid">
+        <div class="ff-snippet-block">
+          <div class="ff-snippet-label">
+            <span class="ff-badge ff-badge-danger">Avoid</span>
+            Late / no preconnect
+          </div>
+          <pre
+            class="ff-snippet ff-snippet--bad"
+            id="snip-bad"
+            aria-label="Risky font loading snippet"
+>&lt;!-- ❌ No preconnect · display=block · loads late --&gt;
+&lt;link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=block"
+  rel="stylesheet"
+/&gt;
+&lt;h1 class="ease-fade-in"&gt;Build faster.&lt;/h1&gt;
+&lt;p class="ease-slide-up"&gt;Animation-first CSS for humans.&lt;/p&gt;</pre>
+          <button type="button" class="ff-copy" data-copy="snip-bad">Copy</button>
+        </div>
+
+        <div class="ff-snippet-block">
+          <div class="ff-snippet-label">
+            <span class="ff-badge ff-badge-ok">Use this</span>
+            Mitigated (recommended)
+          </div>
+          <pre
+            class="ff-snippet ff-snippet--good"
+            id="snip-good"
+            aria-label="Recommended font loading snippet"
+>&lt;link rel="preconnect" href="https://fonts.googleapis.com" /&gt;
+&lt;link rel="preconnect" href="https://fonts.gstatic.com" crossorigin /&gt;
+&lt;link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap"
+  rel="stylesheet"
+/&gt;
+&lt;style&gt;
+  @font-face {
+    font-family: "Inter Fallback";
+    src: local("Arial");
+    size-adjust: 107%;
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
+  }
+  body {
+    font-family: Inter, "Inter Fallback", system-ui, sans-serif;
+  }
+&lt;/style&gt;</pre>
+          <button type="button" class="ff-copy" data-copy="snip-good">Copy</button>
+        </div>
+      </div>
+      <p class="ff-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <section class="ff-card ff-reco" aria-labelledby="reco-title">
+      <h2 class="ff-card-title" id="reco-title">Production checklist</h2>
+      <ul class="ff-check">
+        <li>
+          <span class="ff-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Keep README order:
+            <code>preconnect</code> Google Fonts → <code>preconnect</code>
+            gstatic (<code>crossorigin</code>) → Inter stylesheet.
+          </span>
+        </li>
+        <li>
+          <span class="ff-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Prefer <code>display=swap</code> (README default) or
+            <code>optional</code> for hero + entrance motion.
+          </span>
+        </li>
+        <li>
+          <span class="ff-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Add fallback metrics (<code>size-adjust</code> /
+            ascent/descent overrides) so a late swap barely jumps.
+          </span>
+        </li>
+        <li>
+          <span class="ff-check-icon is-no" aria-hidden="true">✕</span>
+          <span>
+            Don’t inject Inter midway through
+            <code>ease-fade-in</code> / <code>ease-slide-up</code>.
+          </span>
+        </li>
+        <li>
+          <span class="ff-check-icon is-no" aria-hidden="true">✕</span>
+          <span>
+            Don’t blame EaseMotion first — check font timing when text “flashes.”
+          </span>
+        </li>
+      </ul>
+    </section>
+
+    <aside class="ff-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-font-foit-motion-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46176"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46176</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      function decodeEntities(html) {
+        var ta = document.createElement("textarea");
+        ta.innerHTML = html;
+        return ta.value;
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = decodeEntities(pre.innerHTML.trim());
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+
+      document.querySelectorAll("[data-replay]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var which = btn.getAttribute("data-replay");
+          var frame =
+            which === "problem"
+              ? document.getElementById("frame-problem")
+              : document.getElementById("frame-fixed");
+          if (!frame || !frame.contentWindow) return;
+          try {
+            if (typeof frame.contentWindow.replay === "function") {
+              frame.contentWindow.replay();
+            } else {
+              frame.contentWindow.location.reload();
+            }
+          } catch (e) {
+            frame.src = frame.src;
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-font-foit-motion-sp/panel-fixed.html
+++ b/submissions/docs/ease-font-foit-motion-sp/panel-fixed.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fixed — mitigated font × motion</title>
+  <!--
+    FIXED setup:
+    - Correct preconnect order
+    - Inter with font-display=swap (or optional)
+    - Fallback @font-face metrics (size-adjust) to reduce jump
+    - Then start ease-fade-in / ease-slide-up
+  -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="../../../easemotion/variables.css" />
+  <link rel="stylesheet" href="../../../easemotion/fade.css" />
+  <link rel="stylesheet" href="../../../easemotion/slide.css" />
+  <style>
+    /* Metric-friendly fallback while Inter loads */
+    @font-face {
+      font-family: "Inter Fallback";
+      src: local("Arial"), local("Helvetica Neue"), local("sans-serif");
+      size-adjust: 107%;
+      ascent-override: 90%;
+      descent-override: 22%;
+      line-gap-override: 0%;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100%;
+      padding: 1rem 1.1rem;
+      font-family: Inter, "Inter Fallback", system-ui, sans-serif;
+      background: #f0fdf4;
+      color: #0f172a;
+    }
+    .stage {
+      border: 1px solid #86efac;
+      border-radius: 12px;
+      background: #fff;
+      padding: 1rem 1.1rem;
+      min-height: 9.5rem;
+      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+    }
+    .label {
+      margin: 0 0 0.55rem;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #15803d;
+      font-family: system-ui, sans-serif;
+    }
+    h1 {
+      margin: 0 0 0.4rem;
+      font-size: 1.45rem;
+      line-height: 1.15;
+      letter-spacing: -0.02em;
+    }
+    p {
+      margin: 0;
+      font-size: 0.95rem;
+      line-height: 1.45;
+      max-width: 28ch;
+    }
+    .meta {
+      margin: 0.75rem 0 0;
+      font-size: 0.72rem;
+      color: #64748b;
+      font-family: ui-monospace, monospace;
+    }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <p class="label">preconnect + display=swap + fallback metrics</p>
+    <h1 id="title" class="ease-fade-in">Build faster.</h1>
+    <p id="sub" class="ease-slide-up">Animation-first CSS for humans.</p>
+  </div>
+  <p class="meta" id="meta">mitigated load — replay to re-run entrance motion</p>
+
+  <script>
+    (function () {
+      "use strict";
+
+      function setMeta(text) {
+        var el = document.getElementById("meta");
+        if (el) el.textContent = text;
+      }
+
+      function restartMotion() {
+        var title = document.getElementById("title");
+        var sub = document.getElementById("sub");
+        title.classList.remove("ease-fade-in");
+        sub.classList.remove("ease-slide-up");
+        void title.offsetWidth;
+        title.classList.add("ease-fade-in");
+        sub.classList.add("ease-slide-up");
+        setMeta(
+          "Entrance replayed with Inter ready (or metric-matched fallback)"
+        );
+      }
+
+      window.replay = restartMotion;
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-font-foit-motion-sp/panel-problem.html
+++ b/submissions/docs/ease-font-foit-motion-sp/panel-problem.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Problem — FOIT × entrance flash</title>
+  <!--
+    PROBLEM setup:
+    - No preconnect
+    - Start on a metric-mismatched fallback (Georgia)
+    - Start ease-fade-in / ease-slide-up immediately
+    - Inject Inter mid-animation with font-display=block (FOIT-ish swap)
+  -->
+  <link rel="stylesheet" href="../../../easemotion/variables.css" />
+  <link rel="stylesheet" href="../../../easemotion/fade.css" />
+  <link rel="stylesheet" href="../../../easemotion/slide.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100%;
+      padding: 1rem 1.1rem;
+      font-family: Georgia, "Times New Roman", serif;
+      background: #fff7f7;
+      color: #0f172a;
+    }
+    .stage {
+      border: 1px dashed #fca5a5;
+      border-radius: 12px;
+      background: #fff;
+      padding: 1rem 1.1rem;
+      min-height: 9.5rem;
+    }
+    .label {
+      margin: 0 0 0.55rem;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #b91c1c;
+      font-family: system-ui, sans-serif;
+    }
+    h1 {
+      margin: 0 0 0.4rem;
+      font-size: 1.45rem;
+      line-height: 1.15;
+      letter-spacing: -0.02em;
+    }
+    p {
+      margin: 0;
+      font-size: 0.95rem;
+      line-height: 1.45;
+      max-width: 28ch;
+    }
+    .meta {
+      margin: 0.75rem 0 0;
+      font-size: 0.72rem;
+      color: #64748b;
+      font-family: ui-monospace, monospace;
+    }
+    body.is-inter {
+      font-family: Inter, system-ui, sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <p class="label">Late Inter swap mid-motion</p>
+    <h1 id="title" class="ease-fade-in">Build faster.</h1>
+    <p id="sub" class="ease-slide-up">Animation-first CSS for humans.</p>
+  </div>
+  <p class="meta" id="meta">waiting to inject Inter…</p>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var DELAY_MS = 180;
+      var fontHref =
+        "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=block";
+
+      function setMeta(text) {
+        var el = document.getElementById("meta");
+        if (el) el.textContent = text;
+      }
+
+      function restartMotion() {
+        var title = document.getElementById("title");
+        var sub = document.getElementById("sub");
+        title.classList.remove("ease-fade-in");
+        sub.classList.remove("ease-slide-up");
+        void title.offsetWidth;
+        title.classList.add("ease-fade-in");
+        sub.classList.add("ease-slide-up");
+      }
+
+      function injectInter() {
+        var existing = document.getElementById("inter-late");
+        if (existing) existing.remove();
+
+        document.body.classList.remove("is-inter");
+        setMeta("t=0 — fallback Georgia · starting entrance motion");
+        restartMotion();
+
+        window.setTimeout(function () {
+          setMeta("t≈" + DELAY_MS + "ms — injecting Inter (display=block) mid-animation");
+          var link = document.createElement("link");
+          link.id = "inter-late";
+          link.rel = "stylesheet";
+          link.href = fontHref;
+          link.onload = function () {
+            document.body.classList.add("is-inter");
+            setMeta(
+              "Inter applied mid-ease-fade-in / ease-slide-up → text jump / flash"
+            );
+          };
+          document.head.appendChild(link);
+          /* Also flip stack quickly so jump is visible even if CSS is cached */
+          window.setTimeout(function () {
+            document.body.classList.add("is-inter");
+          }, 40);
+        }, DELAY_MS);
+      }
+
+      window.replay = injectInter;
+      injectInter();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-font-foit-motion-sp/style.css
+++ b/submissions/docs/ease-font-foit-motion-sp/style.css
@@ -1,0 +1,478 @@
+/* ============================================================
+   Inter Font FOIT + Entrance Animation Flash
+   submissions/docs/ease-font-foit-motion-sp/style.css
+   ============================================================ */
+
+:root {
+  --ff-ink: #0f172a;
+  --ff-muted: #475569;
+  --ff-line: #e2e8f0;
+  --ff-surface: #ffffff;
+  --ff-page: #f4f7fb;
+  --ff-accent: #4f46e5;
+  --ff-accent-soft: #e0e7ff;
+  --ff-warn: #b45309;
+  --ff-warn-soft: #ffedd5;
+  --ff-danger: #b91c1c;
+  --ff-danger-soft: #fee2e2;
+  --ff-ok: #15803d;
+  --ff-ok-soft: #dcfce7;
+  --ff-info: #1d4ed8;
+  --ff-info-soft: #dbeafe;
+  --ff-mono: "JetBrains Mono", ui-monospace, monospace;
+  --ff-radius: 14px;
+  --ff-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--ff-ink);
+  background:
+    radial-gradient(ellipse 80% 50% at 8% -12%, #e0e7ff 0%, transparent 55%),
+    radial-gradient(ellipse 55% 40% at 100% 0%, #fce7f3 0%, transparent 50%),
+    var(--ff-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--ff-mono);
+}
+
+.ff-header {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.ff-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ff-accent);
+}
+
+.ff-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.ff-subtitle {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--ff-muted);
+  font-size: 1.02rem;
+}
+
+.ff-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--ff-info-soft);
+  color: var(--ff-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ff-issue:hover,
+.ff-issue:focus-visible {
+  outline: 2px solid var(--ff-info);
+  outline-offset: 2px;
+}
+
+.ff-main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.ff-card {
+  background: var(--ff-surface);
+  border: 1px solid var(--ff-line);
+  border-radius: var(--ff-radius);
+  box-shadow: var(--ff-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.ff-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.ff-card p {
+  margin: 0 0 0.75rem;
+  color: var(--ff-muted);
+}
+
+.ff-callout {
+  border: 1px solid var(--ff-line);
+  border-left: 4px solid var(--ff-warn);
+  border-radius: 0 var(--ff-radius) var(--ff-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.ff-callout strong {
+  color: var(--ff-warn);
+}
+
+.ff-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 820px) {
+  .ff-compare {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ff-panel {
+  border: 1px solid var(--ff-line);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.ff-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid var(--ff-line);
+}
+
+.ff-panel-head h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.ff-panel--problem .ff-panel-head {
+  background: var(--ff-danger-soft);
+}
+
+.ff-panel--fixed .ff-panel-head {
+  background: var(--ff-ok-soft);
+}
+
+.ff-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.ff-badge-danger {
+  background: var(--ff-danger-soft);
+  color: var(--ff-danger);
+}
+
+.ff-badge-ok {
+  background: var(--ff-ok-soft);
+  color: var(--ff-ok);
+}
+
+.ff-badge-warn {
+  background: var(--ff-warn-soft);
+  color: var(--ff-warn);
+}
+
+.ff-badge-info {
+  background: var(--ff-info-soft);
+  color: var(--ff-info);
+}
+
+.ff-panel-meta {
+  padding: 0.65rem 0.9rem 0;
+  font-size: 0.8rem;
+  color: var(--ff-muted);
+}
+
+.ff-panel-meta code {
+  font-size: 0.72rem;
+  background: #f1f5f9;
+  padding: 0.08rem 0.3rem;
+  border-radius: 4px;
+}
+
+.ff-frame {
+  width: 100%;
+  height: 320px;
+  border: 0;
+  border-top: 1px solid var(--ff-line);
+  margin-top: 0.65rem;
+  background: #fafafa;
+}
+
+.ff-panel-actions {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 0.9rem 0.9rem;
+}
+
+.ff-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--ff-accent);
+  color: #fff;
+}
+
+.ff-btn:hover {
+  background: #4338ca;
+}
+
+.ff-btn:focus-visible {
+  outline: 2px solid var(--ff-accent);
+  outline-offset: 2px;
+}
+
+.ff-snippet-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 820px) {
+  .ff-snippet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ff-snippet-block {
+  position: relative;
+}
+
+.ff-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.ff-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 10rem;
+}
+
+.ff-snippet--bad {
+  box-shadow: inset 0 0 0 2px rgba(185, 28, 28, 0.45);
+}
+
+.ff-snippet--good {
+  box-shadow: inset 0 0 0 2px rgba(21, 128, 61, 0.45);
+}
+
+.ff-copy {
+  position: absolute;
+  top: 2.15rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.ff-copy:hover,
+.ff-copy:focus-visible {
+  background: var(--ff-accent);
+  outline: none;
+}
+
+.ff-copy[data-copied="true"] {
+  background: var(--ff-ok);
+}
+
+.ff-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.ff-list li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--ff-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.ff-list h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.ff-list p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--ff-muted);
+}
+
+.ff-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--ff-line);
+  border-radius: 12px;
+}
+
+.ff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 560px;
+}
+
+.ff-table th,
+.ff-table td {
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid var(--ff-line);
+  vertical-align: top;
+}
+
+.ff-table th {
+  background: #f8fafc;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ff-muted);
+}
+
+.ff-table tr:last-child td {
+  border-bottom: none;
+}
+
+.ff-table code {
+  font-size: 0.78rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+.ff-reco {
+  border-left: 4px solid var(--ff-ok);
+  background: linear-gradient(135deg, #f0fdf4, #ffffff);
+}
+
+.ff-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ff-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--ff-line);
+  font-size: 0.9rem;
+}
+
+.ff-check li:last-child {
+  border-bottom: none;
+}
+
+.ff-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--ff-ok);
+  margin-top: 0.1rem;
+}
+
+.ff-check-icon.is-no {
+  background: var(--ff-danger);
+}
+
+.ff-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--ff-ok);
+  font-weight: 600;
+}
+
+.ff-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--ff-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--ff-muted);
+}
+
+.ff-footer strong {
+  color: var(--ff-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
# #46176 issue resolved

## Description

This PR adds a beginner-friendly **Inter Font FOIT + Entrance Animation Flash** documentation showcase under `submissions/docs/ease-font-foit-motion-sp/`.

It shows text jumping when Inter loads mid-`ease-fade-in` / `ease-slide-up`, then documents fixes with `font-display`, correct `preconnect` order, and fallback font metrics.

## Features

- Side-by-side lab: FOIT / late Inter swap vs mitigated loading
- Live demos with `ease-fade-in` and `ease-slide-up` during font load
- Guidance for `font-display` (`swap` / `optional` / `block`)
- Correct `preconnect` order snippets (Google Fonts + gstatic)
- Fallback metrics / `size-adjust` tips to reduce layout jump
- Copy-paste ready snippets for real projects
- Self-contained docs lab — open `demo.html` directly (no build step)