### PR TITLE
ease-btn-hover vs ease-hover-grow Naming Confusion Lab

### DIFF
--- a/submissions/docs/ease-hover-class-confusion-sp/README.md
+++ b/submissions/docs/ease-hover-class-confusion-sp/README.md
@@ -1,0 +1,75 @@
+# ease-btn-hover vs ease-hover-grow Naming Confusion Lab
+
+A documentation showcase that compares **`ease-btn-hover`** and **`ease-hover-grow`** on the same button, explains API overlap, and provides a “which one when” decision table — teaching API literacy instead of shipping another hover effect.
+
+> Submission track: `submissions/docs/ease-hover-class-confusion-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46181](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46181)
+
+---
+
+## What does this do?
+
+Beginners often treat `ease-btn-hover` and `ease-hover-grow` as synonyms because both sound like “hover the button.” They are not the same:
+
+| Class | Effect | Scope |
+|-------|--------|--------|
+| `ease-btn-hover` | Lift (~3px) + shadow/glow | Button modifier (`components/buttons.css`) |
+| `ease-hover-grow` | Scale (~1.06) | Generic hover utility (`core/animations.css`) |
+
+This lab puts both on identical buttons side by side and adds a decision table for buttons, cards, icons, and CTAs.
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (needs network for EaseMotion CDN styles).
+2. Hover each button in the live A/B panel.
+3. Read the API notes and decision table.
+4. Copy the usage snippets for the class you need.
+
+Example:
+
+```html
+<button class="ease-btn ease-btn-primary ease-btn-pill ease-btn-hover">
+  Get Started →
+</button>
+
+<button class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow">
+  Get Started →
+</button>
+```
+
+---
+
+## Why is it useful?
+
+- Prevents confused class stacking (`transform` fights itself)
+- Teaches naming literacy — rare compared to “add another hover”
+- Freeze-safe: only new files under `submissions/docs/`
+- Fits EaseMotion’s readable, education-first contribution model
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-hover-class-confusion-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Demo uses existing framework classes for illustration; local chrome uses `hc-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-hover-class-confusion-sp/demo.html
+++ b/submissions/docs/ease-hover-class-confusion-sp/demo.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-btn-hover vs ease-hover-grow Naming Confusion Lab — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Side-by-side lab comparing ease-btn-hover and ease-hover-grow on the same button, with API overlap notes and a which-one-when decision table."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="hc-header">
+    <p class="hc-eyebrow">EaseMotion CSS · API Literacy Showcase</p>
+    <h1>ease-btn-hover vs ease-hover-grow</h1>
+    <p class="hc-subtitle">
+      Both names sound like “make this react on hover.” They do
+      <strong>different</strong> things. Hover each button below, then use the
+      decision table to pick the right class — API literacy, not another hover
+      effect dump.
+    </p>
+    <a
+      class="hc-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46181"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46181
+    </a>
+  </header>
+
+  <main class="hc-main">
+    <aside class="hc-callout" role="note">
+      <strong>Quick truth:</strong>
+      <code>ease-btn-hover</code> is a <em>button</em> modifier (lift + shadow/glow).
+      <code>ease-hover-grow</code> is a <em>generic</em> utility (scale up).
+      Same intent category — different API surface.
+    </aside>
+
+    <!-- Live A/B -->
+    <section class="hc-card" aria-labelledby="lab-title">
+      <h2 class="hc-card-title" id="lab-title">Live lab: same button, each class</h2>
+      <p>
+        Identical base markup (<code>ease-btn ease-btn-primary ease-btn-pill</code>).
+        Only the hover helper changes. Hover (or tab-focus if your pointer is coarse)
+        to feel the difference.
+      </p>
+
+      <div class="hc-compare">
+        <article class="hc-panel">
+          <div class="hc-panel-head">
+            <h3><code>ease-btn-hover</code></h3>
+            <span class="hc-badge hc-badge-btn">Button modifier</span>
+          </div>
+          <div class="hc-panel-body">
+            <button
+              type="button"
+              class="ease-btn ease-btn-primary ease-btn-pill ease-btn-hover"
+            >
+              Get Started →
+            </button>
+          </div>
+          <p class="hc-panel-note">
+            On hover: <strong>lifts</strong> (~3px) and grows
+            <strong>shadow / glow</strong>. Keeps button footprint size.
+          </p>
+        </article>
+
+        <article class="hc-panel">
+          <div class="hc-panel-head">
+            <h3><code>ease-hover-grow</code></h3>
+            <span class="hc-badge hc-badge-grow">Generic utility</span>
+          </div>
+          <div class="hc-panel-body">
+            <button
+              type="button"
+              class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow"
+            >
+              Get Started →
+            </button>
+          </div>
+          <p class="hc-panel-note">
+            On hover: <strong>scales</strong> to ~1.06. Works on buttons, cards,
+            icons — not button-only.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <!-- What each does -->
+    <section class="hc-card" aria-labelledby="api-title">
+      <h2 class="hc-card-title" id="api-title">API overlap explained</h2>
+      <div class="hc-fact-grid">
+        <div class="hc-fact">
+          <h3>
+            <code>ease-btn-hover</code>
+            <span class="hc-badge hc-badge-btn">components/buttons.css</span>
+          </h3>
+          <ul>
+            <li>Designed to pair with <code>ease-btn</code></li>
+            <li><code>transform: translate3d(0, -3px, 0)</code></li>
+            <li>Adds elevated <code>box-shadow</code> + button glow token</li>
+            <li>Guarded by <code>hover: hover</code> + fine pointer media</li>
+            <li>Reads as “this is a clickable CTA lift”</li>
+          </ul>
+        </div>
+        <div class="hc-fact">
+          <h3>
+            <code>ease-hover-grow</code>
+            <span class="hc-badge hc-badge-grow">core/animations.css</span>
+          </h3>
+          <ul>
+            <li>Generic hover utility (any element)</li>
+            <li><code>transform: scale(1.06)</code></li>
+            <li>No shadow — size change only</li>
+            <li>Great for chips, cards, icons, avatar tiles</li>
+            <li>Reads as “this thing gets slightly bigger”</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Decision table -->
+    <section class="hc-card" aria-labelledby="table-title">
+      <h2 class="hc-card-title" id="table-title">Decision table — which one when</h2>
+      <p>
+        Use this when two names feel interchangeable. Prefer the class whose
+        <em>effect</em> matches the UX you want — not which name sounds closer
+        to “hover button.”
+      </p>
+      <div class="hc-table-wrap">
+        <table class="hc-table">
+          <thead>
+            <tr>
+              <th>You want…</th>
+              <th>On…</th>
+              <th>Pick</th>
+              <th>Why</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>CTA lifts with depth / glow</td>
+              <td>Primary / outline buttons</td>
+              <td class="hc-pick hc-pick-btn"><code>ease-btn-hover</code></td>
+              <td>Button-specific lift + shadow API</td>
+            </tr>
+            <tr>
+              <td>Subtle enlarge on hover</td>
+              <td>Button, card, icon, badge</td>
+              <td class="hc-pick hc-pick-grow"><code>ease-hover-grow</code></td>
+              <td>Generic scale utility</td>
+            </tr>
+            <tr>
+              <td>Card feels tappable without looking “pressed up”</td>
+              <td>Cards / media tiles</td>
+              <td class="hc-pick hc-pick-grow"><code>ease-hover-grow</code></td>
+              <td>Scale reads as focus/attention</td>
+            </tr>
+            <tr>
+              <td>Marketing hero CTA with elevation</td>
+              <td><code>ease-btn</code> only</td>
+              <td class="hc-pick hc-pick-btn"><code>ease-btn-hover</code></td>
+              <td>Matches button language in docs/README</td>
+            </tr>
+            <tr>
+              <td>Icon button that shouldn’t cast a big glow</td>
+              <td>Small controls</td>
+              <td class="hc-pick hc-pick-grow"><code>ease-hover-grow</code></td>
+              <td>Scale is quieter than lift+shadow</td>
+            </tr>
+            <tr>
+              <td>Both lift and scale</td>
+              <td>Button (rare)</td>
+              <td class="hc-pick hc-pick-either">Stack carefully</td>
+              <td>Both set <code>transform</code> — last/higher specificity wins</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Stacking warning + demo -->
+    <section class="hc-card" aria-labelledby="stack-title">
+      <h2 class="hc-card-title" id="stack-title">Stacking both classes</h2>
+      <p class="hc-stack-note">
+        <strong>Usually avoid</strong> putting
+        <code>ease-btn-hover</code> and <code>ease-hover-grow</code> on the same
+        element. Both animate <code>transform</code>. You don’t get
+        lift <em>and</em> scale — one declaration fights the other. Prefer one
+        clear motion job per control.
+      </p>
+      <div class="hc-demo-stack">
+        <button
+          type="button"
+          class="ease-btn ease-btn-outline ease-btn-pill ease-btn-hover ease-hover-grow"
+        >
+          Stacked (confusing)
+        </button>
+        <button type="button" class="ease-btn ease-btn-primary ease-btn-pill ease-btn-hover">
+          Lift only
+        </button>
+        <button type="button" class="ease-btn ease-btn-secondary ease-btn-pill ease-hover-grow">
+          Scale only
+        </button>
+      </div>
+    </section>
+
+    <!-- Snippets -->
+    <section class="hc-card" aria-labelledby="snip-title">
+      <h2 class="hc-card-title" id="snip-title">Copy-paste usage</h2>
+      <div class="hc-snippet-grid">
+        <div class="hc-snippet-block">
+          <div class="hc-snippet-label">
+            <span class="hc-badge hc-badge-btn">Button lift</span>
+            <code>ease-btn-hover</code>
+          </div>
+          <pre
+            class="hc-snippet"
+            id="snip-btn"
+            aria-label="ease-btn-hover usage"
+>&lt;button class="ease-btn ease-btn-primary ease-btn-pill ease-btn-hover"&gt;
+  Get Started →
+&lt;/button&gt;</pre>
+          <button type="button" class="hc-copy" data-copy="snip-btn">Copy</button>
+        </div>
+        <div class="hc-snippet-block">
+          <div class="hc-snippet-label">
+            <span class="hc-badge hc-badge-grow">Generic scale</span>
+            <code>ease-hover-grow</code>
+          </div>
+          <pre
+            class="hc-snippet"
+            id="snip-grow"
+            aria-label="ease-hover-grow usage"
+>&lt;button class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow"&gt;
+  Get Started →
+&lt;/button&gt;
+
+&lt;!-- Also fine on non-buttons --&gt;
+&lt;div class="ease-card ease-hover-grow"&gt;…&lt;/div&gt;</pre>
+          <button type="button" class="hc-copy" data-copy="snip-grow">Copy</button>
+        </div>
+      </div>
+      <p class="hc-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <aside class="hc-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-hover-class-confusion-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46181"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46181</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      function decodeEntities(html) {
+        var ta = document.createElement("textarea");
+        ta.innerHTML = html;
+        return ta.value;
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = decodeEntities(pre.innerHTML.trim());
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-hover-class-confusion-sp/style.css
+++ b/submissions/docs/ease-hover-class-confusion-sp/style.css
@@ -1,0 +1,446 @@
+/* ============================================================
+   ease-btn-hover vs ease-hover-grow Naming Confusion Lab
+   submissions/docs/ease-hover-class-confusion-sp/style.css
+   ============================================================ */
+
+:root {
+  --hc-ink: #0f172a;
+  --hc-muted: #475569;
+  --hc-line: #e2e8f0;
+  --hc-surface: #ffffff;
+  --hc-page: #f5f7fb;
+  --hc-accent: #5b4dff;
+  --hc-accent-soft: #eceaff;
+  --hc-warn: #b45309;
+  --hc-warn-soft: #ffedd5;
+  --hc-ok: #15803d;
+  --hc-ok-soft: #dcfce7;
+  --hc-info: #1d4ed8;
+  --hc-info-soft: #dbeafe;
+  --hc-mono: "JetBrains Mono", ui-monospace, monospace;
+  --hc-radius: 14px;
+  --hc-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--hc-ink);
+  background:
+    radial-gradient(ellipse 70% 45% at 5% -10%, #eceaff 0%, transparent 55%),
+    radial-gradient(ellipse 50% 35% at 100% 0%, #e0f2fe 0%, transparent 50%),
+    var(--hc-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--hc-mono);
+}
+
+.hc-header {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.hc-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--hc-accent);
+}
+
+.hc-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.45rem, 3vw, 2.05rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.hc-subtitle {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--hc-muted);
+  font-size: 1.02rem;
+}
+
+.hc-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--hc-info-soft);
+  color: var(--hc-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hc-issue:hover,
+.hc-issue:focus-visible {
+  outline: 2px solid var(--hc-info);
+  outline-offset: 2px;
+}
+
+.hc-main {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.hc-card {
+  background: var(--hc-surface);
+  border: 1px solid var(--hc-line);
+  border-radius: var(--hc-radius);
+  box-shadow: var(--hc-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.hc-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.hc-card p {
+  margin: 0 0 0.75rem;
+  color: var(--hc-muted);
+}
+
+.hc-callout {
+  border: 1px solid var(--hc-line);
+  border-left: 4px solid var(--hc-warn);
+  border-radius: 0 var(--hc-radius) var(--hc-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.hc-callout strong {
+  color: var(--hc-warn);
+}
+
+.hc-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 760px) {
+  .hc-compare {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hc-panel {
+  border: 1px solid var(--hc-line);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.hc-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 0.9rem;
+  background: #f8fafc;
+  border-bottom: 1px solid var(--hc-line);
+}
+
+.hc-panel-head h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.hc-panel-body {
+  padding: 1.35rem 1rem 1.15rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+  min-height: 150px;
+  justify-content: center;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(91, 77, 255, 0.06), transparent 55%),
+    #fff;
+}
+
+.hc-panel-note {
+  margin: 0;
+  padding: 0 0.9rem 1rem;
+  font-size: 0.82rem;
+  color: var(--hc-muted);
+  text-align: center;
+}
+
+.hc-panel-note code {
+  font-size: 0.74rem;
+  background: #f1f5f9;
+  padding: 0.08rem 0.3rem;
+  border-radius: 4px;
+}
+
+.hc-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.hc-badge-btn {
+  background: var(--hc-accent-soft);
+  color: #4338ca;
+}
+
+.hc-badge-grow {
+  background: var(--hc-ok-soft);
+  color: var(--hc-ok);
+}
+
+.hc-badge-warn {
+  background: var(--hc-warn-soft);
+  color: var(--hc-warn);
+}
+
+.hc-badge-info {
+  background: var(--hc-info-soft);
+  color: var(--hc-info);
+}
+
+.hc-fact-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.85rem;
+}
+
+@media (max-width: 760px) {
+  .hc-fact-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hc-fact {
+  border: 1px solid var(--hc-line);
+  border-radius: 10px;
+  padding: 0.85rem 0.95rem;
+  background: #fff;
+}
+
+.hc-fact h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.hc-fact ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--hc-muted);
+  font-size: 0.88rem;
+}
+
+.hc-fact li {
+  margin-bottom: 0.25rem;
+}
+
+.hc-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--hc-line);
+  border-radius: 12px;
+}
+
+.hc-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 640px;
+}
+
+.hc-table th,
+.hc-table td {
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid var(--hc-line);
+  vertical-align: top;
+}
+
+.hc-table th {
+  background: #f8fafc;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--hc-muted);
+}
+
+.hc-table tr:last-child td {
+  border-bottom: none;
+}
+
+.hc-table code {
+  font-size: 0.78rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+.hc-pick {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.hc-pick-btn {
+  color: #4338ca;
+}
+
+.hc-pick-grow {
+  color: var(--hc-ok);
+}
+
+.hc-pick-either {
+  color: var(--hc-warn);
+}
+
+.hc-snippet-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 760px) {
+  .hc-snippet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hc-snippet-block {
+  position: relative;
+}
+
+.hc-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.hc-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.75rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 6.5rem;
+}
+
+.hc-copy {
+  position: absolute;
+  top: 2.15rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.hc-copy:hover,
+.hc-copy:focus-visible {
+  background: var(--hc-accent);
+  outline: none;
+}
+
+.hc-copy[data-copied="true"] {
+  background: var(--hc-ok);
+}
+
+.hc-stack-note {
+  border: 1px solid var(--hc-line);
+  border-radius: 10px;
+  padding: 0.85rem 0.95rem;
+  background: #f8fafc;
+  font-size: 0.9rem;
+  color: var(--hc-muted);
+}
+
+.hc-stack-note code {
+  font-size: 0.8rem;
+  background: #e2e8f0;
+  padding: 0.08rem 0.3rem;
+  border-radius: 4px;
+}
+
+.hc-demo-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  padding: 0.5rem 0 0.25rem;
+}
+
+.hc-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--hc-ok);
+  font-weight: 600;
+}
+
+.hc-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--hc-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--hc-muted);
+}
+
+.hc-footer strong {
+  color: var(--hc-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
# #46181 issue resolved

## Description

This PR adds a beginner-friendly **ease-btn-hover vs ease-hover-grow Naming Confusion Lab** under `submissions/docs/ease-hover-class-confusion-sp/`.

It compares both classes on the same button, explains the API overlap, and includes a “which one when” decision table so beginners pick the right hover utility.

## Features

- Side-by-side live comparison of `ease-btn-hover` and `ease-hover-grow`
- Same button markup on both sides for an honest visual A/B
- Clear labels: lift/shadow (button modifier) vs scale (generic utility)
- Decision table for buttons, cards, icons, and CTAs
- Notes on when stacking both classes helps vs hurts
- Copy-paste ready usage snippets
- Self-contained docs lab — open `demo.html` directly (no build step)