### PR TITLE
Sticky Glass Navbar Scroll Jank Lab

### DIFF
--- a/submissions/docs/ease-navbar-glass-jank-sp/README.md
+++ b/submissions/docs/ease-navbar-glass-jank-sp/README.md
@@ -1,0 +1,69 @@
+# Sticky Glass Navbar Scroll Jank Lab
+
+An interactive documentation showcase that pairs **`ease-navbar-glass-sticky`** with heavy **`backdrop-filter` blur** on a tall page full of looping animations, then explains scroll hitching and “safe sticky” tips — without changing core CSS.
+
+> Submission track: `submissions/docs/ease-navbar-glass-jank-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46183](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46183)
+
+---
+
+## What does this do?
+
+The glass sticky navbar component already exists. What’s scarce is performance guidance for **sticky + blur + busy animated content**. Beginners paste `ease-navbar-glass-sticky` into content-heavy pages, then report mysterious scroll hitching.
+
+This lab reproduces that setup, shows live scroll signals, and teaches safer patterns (reduce blur, pause loops under the bar, opaque sticky fallback).
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (network needed for EaseMotion CDN).
+2. Scroll the colorful lab under the sticky glass navbar (Jank mode).
+3. Toggle **Safe sticky** and scroll again — feel the difference.
+4. Read the hitch panel + checklist, then copy safer snippets.
+
+Example safer usage:
+
+```html
+<nav
+  class="ease-navbar-glass ease-navbar-glass-sticky"
+  style="--ease-navbar-glass-blur: 0px; background: rgba(255,255,255,0.94);"
+>
+  <a class="ease-navbar-brand" href="/">Brand</a>
+</nav>
+```
+
+---
+
+## Why is it useful?
+
+- Documents a real component footgun without editing `components/navbar.css`
+- Separates “broken class” reports from GPU blur + motion cost
+- Freeze-safe: only new files under `submissions/docs/`
+- Fits EaseMotion’s education-first contribution model
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-navbar-glass-jank-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Demo uses existing navbar utilities for illustration; local chrome uses `nj-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-navbar-glass-jank-sp/demo.html
+++ b/submissions/docs/ease-navbar-glass-jank-sp/demo.html
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky Glass Navbar Scroll Jank Lab — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Scroll under ease-navbar-glass-sticky + blur with looping animations. Learn scroll hitch causes and safe sticky tips."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <!-- Sticky glass navbar under test -->
+  <div class="nj-nav-shell">
+    <nav
+      class="ease-navbar-glass ease-navbar-glass-sticky ease-navbar-glass-blur"
+      id="demo-nav"
+      aria-label="Demo glass navbar"
+    >
+      <a class="ease-navbar-brand" href="#top">EaseMotion Lab</a>
+      <div class="ease-navbar-menu">
+        <a class="ease-navbar-item" href="#hitch">Hitch panel</a>
+        <a class="ease-navbar-item" href="#safe">Safe sticky</a>
+        <a class="ease-navbar-item" href="#snippets">Snippets</a>
+      </div>
+    </nav>
+  </div>
+
+  <header class="nj-header" id="top">
+    <p class="nj-eyebrow">EaseMotion CSS · Component Performance Showcase</p>
+    <h1>Sticky Glass Navbar Scroll Jank Lab</h1>
+    <p class="nj-subtitle">
+      Pair <code>ease-navbar-glass-sticky</code> + heavy blur with a tall page of
+      looping animations. Scroll. Feel the hitch. Toggle
+      <strong>Safe sticky</strong> to compare a cheaper setup — without changing
+      core CSS.
+    </p>
+    <a
+      class="nj-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46183"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46183
+    </a>
+  </header>
+
+  <main class="nj-main">
+    <aside class="nj-callout" role="note">
+      <strong>Why this lab:</strong>
+      The glass navbar component already exists. What’s scarce is performance
+      guidance for <em>sticky + backdrop-filter blur + busy animated content</em>
+      underneath. That combo can make scroll feel sticky even when EaseMotion
+      utilities are “correct.”
+    </aside>
+
+    <section class="nj-card" aria-labelledby="mode-title">
+      <h2 class="nj-card-title" id="mode-title">Mode switch</h2>
+      <p>
+        Start in <strong>Jank mode</strong> (full glass blur + looping motion under
+        the bar). Switch to <strong>Safe sticky</strong> to disable blur and pause
+        heavy loops — same sticky navbar, cheaper compositing.
+      </p>
+      <div class="nj-controls">
+        <button type="button" class="nj-btn is-active" id="btn-jank" aria-pressed="true">
+          Jank mode
+        </button>
+        <button type="button" class="nj-btn nj-btn-ghost" id="btn-safe" aria-pressed="false">
+          Safe sticky
+        </button>
+        <span class="nj-mode" id="mode-label" data-mode="jank">Mode: Jank (blur + loops)</span>
+      </div>
+    </section>
+
+    <section class="nj-card" id="hitch" aria-labelledby="signal-title">
+      <h2 class="nj-card-title" id="signal-title">Scroll hitch panel</h2>
+      <p>
+        Scroll the colorful lab below. Watch these live signals while content
+        moves under the sticky glass bar.
+      </p>
+      <div class="nj-signal" aria-live="polite">
+        <div class="nj-stat">
+          <span class="nj-stat-label">Scroll Y</span>
+          <span class="nj-stat-value" id="stat-y">0px</span>
+        </div>
+        <div class="nj-stat">
+          <span class="nj-stat-label">Events / sec</span>
+          <span class="nj-stat-value" id="stat-eps">0</span>
+        </div>
+        <div class="nj-stat">
+          <span class="nj-stat-label">What to feel</span>
+          <span class="nj-stat-value" id="stat-feel" style="font-size: 0.85rem">
+            stutter under blur
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tall scroll region with looping animations -->
+    <section class="nj-scroll-lab" aria-label="Scroll lab with looping animations">
+      <div class="nj-scroll-inner">
+        <div class="nj-section">
+          <h3>1 · Busy layer under glass</h3>
+          <p>
+            These looping utilities keep painting while
+            <code>backdrop-filter</code> samples whatever scrolls behind the
+            sticky bar — expensive on low-end GPUs.
+          </p>
+          <div class="nj-orbit">
+            <div class="nj-blob nj-loop-heavy ease-bounce">bounce</div>
+            <div class="nj-blob nj-blob--alt nj-loop-heavy ease-pulse">pulse</div>
+            <div class="nj-blob nj-blob--warn nj-loop-heavy ease-ping">ping</div>
+            <div class="nj-blob nj-loop-heavy ease-float">float</div>
+            <div class="nj-blob nj-blob--alt nj-loop-heavy ease-rotate">spin</div>
+          </div>
+        </div>
+
+        <div class="nj-section">
+          <h3>2 · Cards scrolling under blur</h3>
+          <p>
+            Keep scrolling. The sticky glass bar continuously re-blurs this
+            content. That’s the hitch story — not a “broken” navbar class.
+          </p>
+          <div class="nj-cards">
+            <article class="nj-mini-card nj-loop-heavy ease-pulse">
+              <h4>Layer thrash</h4>
+              <p>Blur must resample large regions each frame while you scroll.</p>
+            </article>
+            <article class="nj-mini-card nj-loop-heavy ease-bounce">
+              <h4>Loop + scroll</h4>
+              <p>Infinite animations compete with sticky compositing work.</p>
+            </article>
+            <article class="nj-mini-card nj-loop-heavy ease-float">
+              <h4>Overdraw</h4>
+              <p>Gradients + glass + motion = more pixels than you think.</p>
+            </article>
+          </div>
+        </div>
+
+        <div class="nj-section">
+          <h3>3 · Keep going…</h3>
+          <p>
+            On mid-range devices you may still be fine. On low-power / battery
+            saver / many open tabs, this layout is a classic scroll hitch
+            repro. Toggle <strong>Safe sticky</strong> up top and scroll again.
+          </p>
+        </div>
+
+        <div class="nj-section">
+          <h3>4 · More animated chrome</h3>
+          <div class="nj-orbit">
+            <div class="nj-blob nj-loop-heavy ease-heartbeat">beat</div>
+            <div class="nj-blob nj-blob--alt nj-loop-heavy ease-wobble">wobble</div>
+            <div class="nj-blob nj-blob--warn nj-loop-heavy ease-shake">shake</div>
+          </div>
+        </div>
+
+        <div class="nj-section">
+          <h3>5 · End of lab runway</h3>
+          <p>
+            You’ve scrolled enough content under sticky glass. Next: read the
+            hitch causes and copy safer snippets for production.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="nj-card" aria-labelledby="why-title">
+      <h2 class="nj-card-title" id="why-title">Why sticky + blur hitches</h2>
+      <ul class="nj-list">
+        <li>
+          <h3>
+            <code>backdrop-filter</code> is not free
+            <span class="nj-badge nj-badge-danger">GPU</span>
+          </h3>
+          <p>
+            Every scroll frame, the browser must sample and blur whatever sits
+            behind the navbar. Busy gradients + looping elements increase that
+            work dramatically.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Sticky promotes a persistent overlay
+            <span class="nj-badge nj-badge-warn">Compositor</span>
+          </h3>
+          <p>
+            <code>ease-navbar-glass-sticky</code> keeps the bar on-screen. That
+            is good UX — and means blur never “rests” while the page moves.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Looping utilities never idle
+            <span class="nj-badge nj-badge-info">Motion</span>
+          </h3>
+          <p>
+            Classes like <code>ease-bounce</code>, <code>ease-pulse</code>, and
+            <code>ease-ping</code> keep animating under the glass, so the
+            backdrop sample region keeps changing even when you stop scrolling.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Solid / translucent is cheaper
+            <span class="nj-badge nj-badge-ok">Alt</span>
+          </h3>
+          <p>
+            A sticky bar with an opaque or lightly translucent background
+            (no blur) still feels modern and scrolls much smoother.
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section class="nj-card nj-reco" id="safe" aria-labelledby="safe-title">
+      <h2 class="nj-card-title" id="safe-title">Safe sticky checklist</h2>
+      <ul class="nj-check">
+        <li>
+          <span class="nj-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Keep sticky if you need it — drop or lower blur
+            (<code>(--ease-navbar-glass-blur)</code> on long/content-heavy pages.
+          </span>
+        </li>
+        <li>
+          <span class="nj-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Avoid infinite looping animations directly under the glass bar’s
+            blur region (hero chrome is enough).
+          </span>
+        </li>
+        <li>
+          <span class="nj-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Respect <code>prefers-reduced-motion</code> — pause loops and consider
+            disabling blur for that preference.
+          </span>
+        </li>
+        <li>
+          <span class="nj-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Prefer translucent solid backgrounds over large
+            <code>backdrop-filter</code> radii (24px+) on mobile.
+          </span>
+        </li>
+        <li>
+          <span class="nj-check-icon is-no" aria-hidden="true">✕</span>
+          <span>
+            Don’t stack sticky glass + full-page looping utilities + heavy
+            gradients without testing low-end scroll FPS.
+          </span>
+        </li>
+        <li>
+          <span class="nj-check-icon is-no" aria-hidden="true">✕</span>
+          <span>
+            Don’t assume hitch means the navbar class is “broken.” Profile blur
+            + motion cost first.
+          </span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="nj-card" id="snippets" aria-labelledby="snip-title">
+      <h2 class="nj-card-title" id="snip-title">Copy-paste snippets</h2>
+      <p>
+        Full glass sticky (lab default) vs a safer sticky bar without expensive
+        blur.
+      </p>
+
+      <p style="margin-bottom: 0.35rem; font-weight: 700; font-size: 0.9rem;">
+        Glass sticky (can hitch under busy content)
+      </p>
+      <div class="nj-snippet-block">
+        <pre
+          class="nj-snippet"
+          id="snip-jank"
+          aria-label="Glass sticky navbar snippet"
+>&lt;nav class="ease-navbar-glass ease-navbar-glass-sticky ease-navbar-glass-blur"&gt;
+  &lt;a class="ease-navbar-brand" href="/"&gt;Brand&lt;/a&gt;
+  &lt;div class="ease-navbar-menu"&gt;
+    &lt;a class="ease-navbar-item" href="#docs"&gt;Docs&lt;/a&gt;
+  &lt;/div&gt;
+&lt;/nav&gt;</pre>
+        <button type="button" class="nj-copy" data-copy="snip-jank">Copy</button>
+      </div>
+
+      <p style="margin: 1rem 0 0.35rem; font-weight: 700; font-size: 0.9rem;">
+        Safer sticky (reduce blur / use opaque fallback)
+      </p>
+      <div class="nj-snippet-block">
+        <pre
+          class="nj-snippet"
+          id="snip-safe"
+          aria-label="Safer sticky navbar snippet"
+>&lt;nav
+  class="ease-navbar-glass ease-navbar-glass-sticky"
+  style="--ease-navbar-glass-blur: 0px; background: rgba(255,255,255,0.94);"
+&gt;
+  &lt;a class="ease-navbar-brand" href="/"&gt;Brand&lt;/a&gt;
+  &lt;div class="ease-navbar-menu"&gt;
+    &lt;a class="ease-navbar-item" href="#docs"&gt;Docs&lt;/a&gt;
+  &lt;/div&gt;
+&lt;/nav&gt;
+
+&lt;!-- Tip: keep looping animations out of the strip scrolling under the bar --&gt;</pre>
+        <button type="button" class="nj-copy" data-copy="snip-safe">Copy</button>
+      </div>
+      <p class="nj-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <aside class="nj-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-navbar-glass-jank-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46183"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46183</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var btnJank = document.getElementById("btn-jank");
+      var btnSafe = document.getElementById("btn-safe");
+      var modeLabel = document.getElementById("mode-label");
+      var feel = document.getElementById("stat-feel");
+      var yEl = document.getElementById("stat-y");
+      var epsEl = document.getElementById("stat-eps");
+
+      function setMode(safe) {
+        document.body.classList.toggle("is-safe-mode", safe);
+        btnJank.classList.toggle("is-active", !safe);
+        btnSafe.classList.toggle("is-active", safe);
+        btnJank.setAttribute("aria-pressed", String(!safe));
+        btnSafe.setAttribute("aria-pressed", String(safe));
+        modeLabel.dataset.mode = safe ? "safe" : "jank";
+        modeLabel.textContent = safe
+          ? "Mode: Safe sticky (no blur · loops paused)"
+          : "Mode: Jank (blur + loops)";
+        if (feel) {
+          feel.textContent = safe
+            ? "smoother scroll"
+            : "stutter under blur";
+        }
+      }
+
+      btnJank.addEventListener("click", function () {
+        setMode(false);
+      });
+      btnSafe.addEventListener("click", function () {
+        setMode(true);
+      });
+
+      var scrollCount = 0;
+      var lastTick = performance.now();
+
+      window.addEventListener(
+        "scroll",
+        function () {
+          scrollCount += 1;
+          if (yEl) yEl.textContent = Math.round(window.scrollY) + "px";
+        },
+        { passive: true }
+      );
+
+      window.setInterval(function () {
+        var now = performance.now();
+        var dt = (now - lastTick) / 1000;
+        lastTick = now;
+        var eps = dt > 0 ? Math.round(scrollCount / dt) : 0;
+        scrollCount = 0;
+        if (epsEl) epsEl.textContent = String(eps);
+      }, 1000);
+
+      function decodeEntities(html) {
+        var ta = document.createElement("textarea");
+        ta.innerHTML = html;
+        return ta.value;
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = decodeEntities(pre.innerHTML.trim());
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-navbar-glass-jank-sp/style.css
+++ b/submissions/docs/ease-navbar-glass-jank-sp/style.css
@@ -1,0 +1,545 @@
+/* ============================================================
+   Sticky Glass Navbar Scroll Jank Lab
+   submissions/docs/ease-navbar-glass-jank-sp/style.css
+   ============================================================ */
+
+:root {
+  --nj-ink: #0f172a;
+  --nj-muted: #475569;
+  --nj-line: #e2e8f0;
+  --nj-surface: #ffffff;
+  --nj-page: #eef2ff;
+  --nj-accent: #4f46e5;
+  --nj-accent-soft: #e0e7ff;
+  --nj-warn: #b45309;
+  --nj-warn-soft: #ffedd5;
+  --nj-danger: #b91c1c;
+  --nj-danger-soft: #fee2e2;
+  --nj-ok: #15803d;
+  --nj-ok-soft: #dcfce7;
+  --nj-info: #1d4ed8;
+  --nj-info-soft: #dbeafe;
+  --nj-mono: "JetBrains Mono", ui-monospace, monospace;
+  --nj-radius: 14px;
+  --nj-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--nj-ink);
+  background: var(--nj-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--nj-mono);
+}
+
+/* Sticky glass shell — full-bleed top strip so sticky reads as a bar */
+.nj-nav-shell {
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  padding: 0.75rem 1rem;
+  background: transparent;
+}
+
+.nj-nav-shell .ease-navbar-glass {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* Safer mode: kill expensive blur, keep sticky */
+body.is-safe-mode .ease-navbar-glass {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  background: rgba(255, 255, 255, 0.94) !important;
+  border-color: rgba(15, 23, 42, 0.1) !important;
+}
+
+body.is-safe-mode .nj-loop-heavy {
+  animation: none !important;
+}
+
+.nj-header {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.75rem 1.5rem 1rem;
+}
+
+.nj-eyebrow {
+  margin: 0 0 0.45rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--nj-accent);
+}
+
+.nj-header h1 {
+  margin: 0 0 0.65rem;
+  font-size: clamp(1.45rem, 3vw, 2.05rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.nj-subtitle {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--nj-muted);
+}
+
+.nj-issue {
+  display: inline-flex;
+  margin-top: 0.9rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--nj-info-soft);
+  color: var(--nj-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.nj-issue:hover,
+.nj-issue:focus-visible {
+  outline: 2px solid var(--nj-info);
+  outline-offset: 2px;
+}
+
+.nj-main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.nj-card {
+  background: var(--nj-surface);
+  border: 1px solid var(--nj-line);
+  border-radius: var(--nj-radius);
+  box-shadow: var(--nj-shadow);
+  padding: 1.15rem 1.2rem;
+}
+
+.nj-card-title {
+  margin: 0 0 0.6rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.nj-card p {
+  margin: 0 0 0.7rem;
+  color: var(--nj-muted);
+}
+
+.nj-callout {
+  border: 1px solid var(--nj-line);
+  border-left: 4px solid var(--nj-warn);
+  border-radius: 0 var(--nj-radius) var(--nj-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.9rem 1.05rem;
+}
+
+.nj-callout strong {
+  color: var(--nj-warn);
+}
+
+.nj-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.nj-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--nj-accent);
+  color: #fff;
+}
+
+.nj-btn:hover {
+  background: #4338ca;
+}
+
+.nj-btn:focus-visible {
+  outline: 2px solid var(--nj-accent);
+  outline-offset: 2px;
+}
+
+.nj-btn-ghost {
+  background: #fff;
+  border-color: var(--nj-line);
+  color: var(--nj-ink);
+}
+
+.nj-btn-ghost:hover {
+  border-color: var(--nj-accent);
+  color: var(--nj-accent);
+}
+
+.nj-btn.is-active {
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.35);
+}
+
+.nj-mode {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--nj-muted);
+}
+
+.nj-mode[data-mode="jank"] {
+  color: var(--nj-danger);
+}
+
+.nj-mode[data-mode="safe"] {
+  color: var(--nj-ok);
+}
+
+.nj-signal {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.65rem;
+}
+
+@media (max-width: 700px) {
+  .nj-signal {
+    grid-template-columns: 1fr;
+  }
+}
+
+.nj-stat {
+  border: 1px solid var(--nj-line);
+  border-radius: 10px;
+  padding: 0.75rem 0.85rem;
+  background: #f8fafc;
+}
+
+.nj-stat-label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--nj-muted);
+  margin-bottom: 0.25rem;
+}
+
+.nj-stat-value {
+  font-family: var(--nj-mono);
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.nj-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.nj-badge-danger {
+  background: var(--nj-danger-soft);
+  color: var(--nj-danger);
+}
+
+.nj-badge-ok {
+  background: var(--nj-ok-soft);
+  color: var(--nj-ok);
+}
+
+.nj-badge-warn {
+  background: var(--nj-warn-soft);
+  color: var(--nj-warn);
+}
+
+.nj-badge-info {
+  background: var(--nj-info-soft);
+  color: var(--nj-info);
+}
+
+/* Busy animated content under the sticky glass */
+.nj-scroll-lab {
+  position: relative;
+  border: 1px solid var(--nj-line);
+  border-radius: var(--nj-radius);
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, #c7d2fe 0%, #e0e7ff 18%, #f8fafc 40%, #dbeafe 70%, #ede9fe 100%);
+  min-height: 220vh;
+  padding: 1.25rem;
+}
+
+.nj-scroll-lab::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 10%, rgba(244, 114, 182, 0.35), transparent 28%),
+    radial-gradient(circle at 80% 30%, rgba(56, 189, 248, 0.35), transparent 30%),
+    radial-gradient(circle at 40% 70%, rgba(167, 139, 250, 0.4), transparent 32%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.nj-scroll-inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.nj-section {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 12px;
+  padding: 1.1rem 1.15rem;
+  backdrop-filter: blur(4px);
+}
+
+.nj-section h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1rem;
+}
+
+.nj-section p {
+  margin: 0;
+  color: var(--nj-muted);
+  font-size: 0.92rem;
+}
+
+.nj-orbit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem 0.5rem;
+}
+
+.nj-blob {
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 1.1rem;
+  display: grid;
+  place-items: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.35);
+}
+
+.nj-blob--alt {
+  background: linear-gradient(135deg, #0ea5e9, #22c55e);
+}
+
+.nj-blob--warn {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+}
+
+.nj-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+@media (max-width: 800px) {
+  .nj-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.nj-mini-card {
+  border-radius: 12px;
+  padding: 1rem;
+  background: #fff;
+  border: 1px solid var(--nj-line);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+}
+
+.nj-mini-card h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.92rem;
+}
+
+.nj-mini-card p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--nj-muted);
+}
+
+.nj-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.nj-list li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--nj-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.nj-list h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.nj-list p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--nj-muted);
+}
+
+.nj-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nj-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--nj-line);
+  font-size: 0.9rem;
+}
+
+.nj-check li:last-child {
+  border-bottom: none;
+}
+
+.nj-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--nj-ok);
+  margin-top: 0.1rem;
+}
+
+.nj-check-icon.is-no {
+  background: var(--nj-danger);
+}
+
+.nj-reco {
+  border-left: 4px solid var(--nj-ok);
+  background: linear-gradient(135deg, #f0fdf4, #ffffff);
+}
+
+.nj-snippet-block {
+  position: relative;
+}
+
+.nj-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.nj-copy {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.nj-copy:hover,
+.nj-copy:focus-visible {
+  background: var(--nj-accent);
+  outline: none;
+}
+
+.nj-copy[data-copied="true"] {
+  background: var(--nj-ok);
+}
+
+.nj-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--nj-ok);
+  font-weight: 600;
+}
+
+.nj-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--nj-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--nj-muted);
+}
+
+.nj-footer strong {
+  color: var(--nj-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .nj-loop-heavy {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
# #46183 issue resolved

## Description

This PR adds a beginner-friendly **Sticky Glass Navbar Scroll Jank Lab** under `submissions/docs/ease-navbar-glass-jank-sp/`.

It pairs `ease-navbar-glass-sticky` with blur on a long page of looping animations, then explains scroll hitching and safer sticky patterns without changing core CSS.

## Features

- Live sticky glass navbar (`ease-navbar-glass` / `ease-navbar-glass-sticky` + blur)
- Long scrollable page with looping EaseMotion animations under the bar
- Scroll hitch panel (scroll position, events/sec, what to feel)
- Jank mode vs Safe sticky toggle
- “Safe sticky” checklist and `backdrop-filter` cost notes
- Copy-paste ready safer navbar snippets
- Self-contained docs lab — open `demo.html` directly (no build step)