### PR TITLE
Dual Stylesheet Cascade Surprise

### DIFF
--- a/submissions/docs/ease-dual-css-load-sp/README.md
+++ b/submissions/docs/ease-dual-css-load-sp/README.md
@@ -1,0 +1,68 @@
+# Dual Stylesheet Cascade Surprise
+
+An interactive documentation lab that intentionally loads both **`easemotion.css`** and **`easemotion.min.css`**, shows doubled rules / unexpected cascade wins, and teaches the **debug vs prod** rule: never ship both at once.
+
+> Submission track: `submissions/docs/ease-dual-css-load-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46185](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46185)
+
+---
+
+## What does this do?
+
+Beginners often link the readable source and the minified bundle “just to be safe.” That duplicates the framework in the cascade, doubles download cost, and can make custom overrides vanish when the later sheet wins.
+
+This showcase toggles **source only**, **min only**, and **both**, with live weight/risk stats and copy-paste correct snippets.
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (network required for CDN stylesheets).
+2. Switch load modes and watch the verdict + stats update.
+3. In **Both** mode, note the mid-cascade override tip and doubled weight.
+4. Copy the recommended single-file production snippet.
+
+Example of the correct rule:
+
+```html
+<!-- ✅ One sheet only -->
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+/>
+```
+
+---
+
+## Why is it useful?
+
+- Documents a common newbie footgun not covered clearly in existing lists
+- Prevents false “EaseMotion CSS is buggy” reports caused by dual loading
+- Freeze-safe: only new files under `submissions/docs/`
+- Fits EaseMotion’s education-first contribution model
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-dual-css-load-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Demo injects existing CDN assets for illustration; local chrome uses `dc-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-dual-css-load-sp/demo.html
+++ b/submissions/docs/ease-dual-css-load-sp/demo.html
@@ -1,0 +1,477 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dual Stylesheet Cascade Surprise — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Intentionally load easemotion.css and easemotion.min.css together. See doubled rules, cascade wins, and the debug vs prod rule."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <!-- Lab chrome only — EaseMotion sheets are injected by mode toggle -->
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body data-mode="source" data-cascade="ok">
+  <header class="dc-header">
+    <p class="dc-eyebrow">EaseMotion CSS · Cascade Documentation Showcase</p>
+    <h1>Dual Stylesheet Cascade Surprise</h1>
+    <p class="dc-subtitle">
+      Beginners often link both <code>easemotion.css</code> and
+      <code>easemotion.min.css</code> “just to be safe.” That doubles the
+      framework in the cascade. Toggle modes below and watch the surprise.
+    </p>
+    <a
+      class="dc-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46185"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46185
+    </a>
+  </header>
+
+  <main class="dc-main">
+    <aside class="dc-callout" role="note">
+      <strong>Debug vs prod rule:</strong>
+      Use <em>one</em> EaseMotion stylesheet at a time — readable source while
+      debugging, minified bundle in production. Never ship both.
+    </aside>
+
+    <section class="dc-card" aria-labelledby="mode-title">
+      <h2 class="dc-card-title" id="mode-title">Load mode</h2>
+      <p>
+        Each mode injects real CDN links into <code>&lt;head&gt;</code>. Network
+        required. Start with source, then try <strong>Both</strong>.
+      </p>
+      <div class="dc-modes" role="group" aria-label="Stylesheet load mode">
+        <button type="button" class="dc-mode is-active" data-mode="source" aria-pressed="true">
+          <strong>Source only</strong>
+          <span>easemotion.css — debug / readable</span>
+        </button>
+        <button type="button" class="dc-mode" data-mode="min" aria-pressed="false">
+          <strong>Min only</strong>
+          <span>easemotion.min.css — production</span>
+        </button>
+        <button type="button" class="dc-mode" data-mode="both" aria-pressed="false">
+          <strong>Both (mistake)</strong>
+          <span>source + min — cascade surprise</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="dc-card" aria-labelledby="verdict-title">
+      <h2 class="dc-card-title" id="verdict-title">Live verdict</h2>
+      <div class="dc-verdict" id="verdict" data-tone="ok" aria-live="polite">
+        <span class="dc-badge dc-badge-ok" id="verdict-badge">Safe</span>
+        <p id="verdict-text">
+          Only the readable source is linked. Good for local debugging — one
+          framework copy in the cascade.
+        </p>
+      </div>
+
+      <div class="dc-stats">
+        <div class="dc-stat">
+          <span class="dc-stat-label">Sheets linked</span>
+          <span class="dc-stat-value" id="stat-sheets">1</span>
+        </div>
+        <div class="dc-stat">
+          <span class="dc-stat-label">Est. CSS weight</span>
+          <span class="dc-stat-value" id="stat-weight">~178 KB</span>
+        </div>
+        <div class="dc-stat">
+          <span class="dc-stat-label">Framework copies</span>
+          <span class="dc-stat-value" id="stat-copies">1×</span>
+        </div>
+        <div class="dc-stat">
+          <span class="dc-stat-label">Cascade risk</span>
+          <span class="dc-stat-value is-ok" id="stat-risk">Low</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="dc-card" aria-labelledby="stage-title">
+      <h2 class="dc-card-title" id="stage-title">Visual stage</h2>
+      <p>
+        Same markup every mode. Utilities come from whichever EaseMotion sheet(s)
+        are currently injected. When <strong>Both</strong> is on, a mid-cascade
+        tip outline highlights: “last equal-specificity sheet tends to win.”
+      </p>
+      <div class="dc-stage">
+        <p class="dc-stage-label">Live EaseMotion controls</p>
+        <button
+          type="button"
+          id="demo-btn"
+          class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow dc-override-hint"
+        >
+          Get Started →
+        </button>
+        <p class="dc-stage-note" id="stage-note">
+          Hover the button — styles come from a single framework load.
+        </p>
+      </div>
+    </section>
+
+    <section class="dc-card" aria-labelledby="why-title">
+      <h2 class="dc-card-title" id="why-title">What goes wrong when both load</h2>
+      <ul class="dc-list">
+        <li>
+          <h3>
+            Doubled download
+            <span class="dc-badge dc-badge-danger">Bytes</span>
+          </h3>
+          <p>
+            You fetch roughly two full copies of EaseMotion (~178&nbsp;KB raw min
+            plus the readable tree of <code>@import</code>s). Users pay twice;
+            nothing new ships.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Doubled rules in the cascade
+            <span class="dc-badge dc-badge-warn">Cascade</span>
+          </h3>
+          <p>
+            Every <code>.ease-*</code> rule appears twice. Equal specificity →
+            the <em>later</em> stylesheet wins. That “last wins” surprise looks
+            like a random bug when you insert custom CSS between the two links.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Overrides get stomped
+            <span class="dc-badge dc-badge-info">Debugging</span>
+          </h3>
+          <p>
+            A tweak after <code>easemotion.css</code> but before
+            <code>.min.css</code> can disappear. DevTools looks haunted; the
+            dual load is the culprit.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Harder mental model
+            <span class="dc-badge dc-badge-warn">DX</span>
+          </h3>
+          <p>
+            Source exists for reading. Min exists for shipping. Mixing them
+            fights the “one composition” idea of a curated framework.
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section class="dc-card" aria-labelledby="table-title">
+      <h2 class="dc-card-title" id="table-title">Debug vs production</h2>
+      <div class="dc-table-wrap">
+        <table class="dc-table">
+          <thead>
+            <tr>
+              <th>Goal</th>
+              <th>Use</th>
+              <th>Don’t</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Read / debug class source</td>
+              <td><code>easemotion.css</code></td>
+              <td>Also load <code>.min.css</code></td>
+            </tr>
+            <tr>
+              <td>Ship to production / CDN demo</td>
+              <td><code>easemotion.min.css</code></td>
+              <td>Also load readable entry</td>
+            </tr>
+            <tr>
+              <td>“Just to be safe”</td>
+              <td>Pick one intentionally</td>
+              <td>Link both — never safer</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="dc-card dc-reco" aria-labelledby="reco-title">
+      <h2 class="dc-card-title" id="reco-title">Recommendation</h2>
+      <ul class="dc-check">
+        <li>
+          <span class="dc-check-icon" aria-hidden="true">✓</span>
+          <span>Production: one <code>easemotion.min.css</code> (CDN or npm).</span>
+        </li>
+        <li>
+          <span class="dc-check-icon" aria-hidden="true">✓</span>
+          <span>Local debugging: one <code>easemotion.css</code> when you need readable imports.</span>
+        </li>
+        <li>
+          <span class="dc-check-icon" aria-hidden="true">✓</span>
+          <span>Put custom overrides <em>after</em> your single EaseMotion link.</span>
+        </li>
+        <li>
+          <span class="dc-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Do not load source and min together on the same page.</span>
+        </li>
+        <li>
+          <span class="dc-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Do not blame EaseMotion first when dual-load stomps your CSS.</span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="dc-card" aria-labelledby="snip-title">
+      <h2 class="dc-card-title" id="snip-title">Copy-paste snippets</h2>
+      <div class="dc-snippet-grid">
+        <div class="dc-snippet-block">
+          <div class="dc-snippet-label">
+            <span class="dc-badge dc-badge-danger">Avoid</span>
+            Both linked
+          </div>
+          <pre
+            class="dc-snippet dc-snippet--bad"
+            id="snip-bad"
+            aria-label="Dual load mistake snippet"
+>&lt;!-- ❌ Doubles the framework — never do this --&gt;
+&lt;link rel="stylesheet" href=".../easemotion.css" /&gt;
+&lt;link rel="stylesheet" href=".../easemotion.min.css" /&gt;</pre>
+          <button type="button" class="dc-copy" data-copy="snip-bad">Copy</button>
+        </div>
+        <div class="dc-snippet-block">
+          <div class="dc-snippet-label">
+            <span class="dc-badge dc-badge-ok">Use this</span>
+            Production (preferred)
+          </div>
+          <pre
+            class="dc-snippet dc-snippet--good"
+            id="snip-good"
+            aria-label="Single min stylesheet snippet"
+>&lt;!-- ✅ One sheet only --&gt;
+&lt;link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+/&gt;</pre>
+          <button type="button" class="dc-copy" data-copy="snip-good">Copy</button>
+        </div>
+      </div>
+      <p class="dc-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <aside class="dc-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-dual-css-load-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46185"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46185</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var CDN_BASE =
+        "https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/";
+      var ID_SOURCE = "ease-lab-source";
+      var ID_MIN = "ease-lab-min";
+      var ID_MID = "ease-lab-mid-override";
+
+      /* Approximate raw sizes for education (min is ~178KB; source entry is tiny
+         but pulls the full import tree — treat dual load as ~2× min for teaching) */
+      var SIZE_MIN_KB = 178;
+      var SIZE_SOURCE_KB = 175;
+
+      var modes = {
+        source: {
+          sheets: 1,
+          weight: "~" + SIZE_SOURCE_KB + " KB (+ @imports)",
+          copies: "1×",
+          risk: "Low",
+          riskOk: true,
+          tone: "ok",
+          badge: "Safe",
+          badgeClass: "dc-badge-ok",
+          verdict:
+            "Only the readable source is linked. Good for local debugging — one framework copy in the cascade.",
+          note: "Hover the button — styles come from a single framework load.",
+          cascade: "ok",
+        },
+        min: {
+          sheets: 1,
+          weight: "~" + SIZE_MIN_KB + " KB",
+          copies: "1×",
+          risk: "Low",
+          riskOk: true,
+          tone: "ok",
+          badge: "Safe",
+          badgeClass: "dc-badge-ok",
+          verdict:
+            "Only the production min bundle is linked. Preferred for shipped pages and CDN demos.",
+          note: "Production-ready: one minified stylesheet, one cascade pass.",
+          cascade: "ok",
+        },
+        both: {
+          sheets: 2,
+          weight: "~" + (SIZE_SOURCE_KB + SIZE_MIN_KB) + " KB (≈2×)",
+          copies: "2×",
+          risk: "High",
+          riskOk: false,
+          tone: "danger",
+          badge: "Mistake",
+          badgeClass: "dc-badge-danger",
+          verdict:
+            "Both sheets are linked. Rules are duplicated; the later file usually wins. Custom CSS between them can vanish.",
+          note: "Red dashed outline = dual-load surprise mode. You’re running two copies of EaseMotion.",
+          cascade: "surprise",
+        },
+      };
+
+      var verdictEl = document.getElementById("verdict");
+      var verdictBadge = document.getElementById("verdict-badge");
+      var verdictText = document.getElementById("verdict-text");
+      var stageNote = document.getElementById("stage-note");
+      var statSheets = document.getElementById("stat-sheets");
+      var statWeight = document.getElementById("stat-weight");
+      var statCopies = document.getElementById("stat-copies");
+      var statRisk = document.getElementById("stat-risk");
+
+      function ensureLink(id, href) {
+        var el = document.getElementById(id);
+        if (!el) {
+          el = document.createElement("link");
+          el.id = id;
+          el.rel = "stylesheet";
+          document.head.appendChild(el);
+        }
+        el.href = href;
+        return el;
+      }
+
+      function removeEl(id) {
+        var el = document.getElementById(id);
+        if (el) el.remove();
+      }
+
+      function syncLinks(mode) {
+        removeEl(ID_MID);
+
+        if (mode === "source") {
+          ensureLink(ID_SOURCE, CDN_BASE + "easemotion.css");
+          removeEl(ID_MIN);
+        } else if (mode === "min") {
+          removeEl(ID_SOURCE);
+          ensureLink(ID_MIN, CDN_BASE + "easemotion.min.css");
+        } else {
+          /* both: source first, then a mid override, then min — teaches stomping */
+          ensureLink(ID_SOURCE, CDN_BASE + "easemotion.css");
+          var mid = document.createElement("style");
+          mid.id = ID_MID;
+          mid.textContent =
+            "/* Mid-cascade laboratory override — often stomped by .min.css */\n" +
+            ".ease-btn-primary.dc-override-hint { box-shadow: 0 0 0 4px rgba(185,28,28,0.35); }";
+          document.head.appendChild(mid);
+          ensureLink(ID_MIN, CDN_BASE + "easemotion.min.css");
+        }
+      }
+
+      function applyMode(mode) {
+        var cfg = modes[mode] || modes.source;
+        document.body.dataset.mode = mode;
+        document.body.dataset.cascade = cfg.cascade;
+
+        document.querySelectorAll(".dc-mode").forEach(function (btn) {
+          var active = btn.getAttribute("data-mode") === mode;
+          btn.classList.toggle("is-active", active);
+          btn.setAttribute("aria-pressed", String(active));
+        });
+
+        syncLinks(mode);
+
+        verdictEl.setAttribute("data-tone", cfg.tone);
+        verdictBadge.className = "dc-badge " + cfg.badgeClass;
+        verdictBadge.textContent = cfg.badge;
+        verdictText.textContent = cfg.verdict;
+        stageNote.textContent = cfg.note;
+
+        statSheets.textContent = String(cfg.sheets);
+        statWeight.textContent = cfg.weight;
+        statCopies.textContent = cfg.copies;
+        statRisk.textContent = cfg.risk;
+        statRisk.classList.toggle("is-ok", cfg.riskOk);
+        statRisk.classList.toggle("is-bad", !cfg.riskOk);
+      }
+
+      document.querySelectorAll(".dc-mode").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          applyMode(btn.getAttribute("data-mode"));
+        });
+      });
+
+      function decodeEntities(html) {
+        var ta = document.createElement("textarea");
+        ta.innerHTML = html;
+        return ta.value;
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = decodeEntities(pre.innerHTML.trim());
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+
+      applyMode("source");
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-dual-css-load-sp/style.css
+++ b/submissions/docs/ease-dual-css-load-sp/style.css
@@ -1,0 +1,555 @@
+/* ============================================================
+   Dual Stylesheet Cascade Surprise
+   submissions/docs/ease-dual-css-load-sp/style.css
+   ============================================================ */
+
+:root {
+  --dc-ink: #0f172a;
+  --dc-muted: #475569;
+  --dc-line: #e2e8f0;
+  --dc-surface: #ffffff;
+  --dc-page: #f4f7fb;
+  --dc-accent: #0f766e;
+  --dc-accent-soft: #ccfbf1;
+  --dc-warn: #b45309;
+  --dc-warn-soft: #ffedd5;
+  --dc-danger: #b91c1c;
+  --dc-danger-soft: #fee2e2;
+  --dc-ok: #15803d;
+  --dc-ok-soft: #dcfce7;
+  --dc-info: #1d4ed8;
+  --dc-info-soft: #dbeafe;
+  --dc-mono: "JetBrains Mono", ui-monospace, monospace;
+  --dc-radius: 14px;
+  --dc-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--dc-ink);
+  background:
+    radial-gradient(ellipse 75% 45% at 8% -10%, #ccfbf1 0%, transparent 55%),
+    radial-gradient(ellipse 55% 40% at 100% 0%, #e0e7ff 0%, transparent 50%),
+    var(--dc-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--dc-mono);
+}
+
+.dc-header {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.dc-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dc-accent);
+}
+
+.dc-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.45rem, 3vw, 2.05rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.dc-subtitle {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--dc-muted);
+  font-size: 1.02rem;
+}
+
+.dc-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--dc-info-soft);
+  color: var(--dc-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.dc-issue:hover,
+.dc-issue:focus-visible {
+  outline: 2px solid var(--dc-info);
+  outline-offset: 2px;
+}
+
+.dc-main {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.dc-card {
+  background: var(--dc-surface);
+  border: 1px solid var(--dc-line);
+  border-radius: var(--dc-radius);
+  box-shadow: var(--dc-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.dc-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.dc-card p {
+  margin: 0 0 0.75rem;
+  color: var(--dc-muted);
+}
+
+.dc-callout {
+  border: 1px solid var(--dc-line);
+  border-left: 4px solid var(--dc-warn);
+  border-radius: 0 var(--dc-radius) var(--dc-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.dc-callout strong {
+  color: var(--dc-warn);
+}
+
+.dc-modes {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.55rem;
+}
+
+@media (max-width: 700px) {
+  .dc-modes {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dc-mode {
+  appearance: none;
+  border: 1px solid var(--dc-line);
+  border-radius: 12px;
+  padding: 0.85rem 0.9rem;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.dc-mode strong {
+  display: block;
+  font-size: 0.92rem;
+  margin-bottom: 0.2rem;
+  color: var(--dc-ink);
+}
+
+.dc-mode span {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--dc-muted);
+}
+
+.dc-mode.is-active {
+  border-color: var(--dc-accent);
+  background: var(--dc-accent-soft);
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.25);
+}
+
+.dc-mode.is-active[data-mode="both"] {
+  border-color: var(--dc-danger);
+  background: var(--dc-danger-soft);
+  box-shadow: inset 0 0 0 1px rgba(185, 28, 28, 0.2);
+}
+
+.dc-mode:focus-visible {
+  outline: 2px solid var(--dc-accent);
+  outline-offset: 2px;
+}
+
+.dc-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.65rem;
+}
+
+@media (max-width: 800px) {
+  .dc-stats {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.dc-stat {
+  border: 1px solid var(--dc-line);
+  border-radius: 10px;
+  padding: 0.75rem 0.85rem;
+  background: #f8fafc;
+}
+
+.dc-stat-label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--dc-muted);
+  margin-bottom: 0.25rem;
+}
+
+.dc-stat-value {
+  font-family: var(--dc-mono);
+  font-size: 0.95rem;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.dc-stat-value.is-bad {
+  color: var(--dc-danger);
+}
+
+.dc-stat-value.is-ok {
+  color: var(--dc-ok);
+}
+
+.dc-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.dc-badge-danger {
+  background: var(--dc-danger-soft);
+  color: var(--dc-danger);
+}
+
+.dc-badge-ok {
+  background: var(--dc-ok-soft);
+  color: var(--dc-ok);
+}
+
+.dc-badge-warn {
+  background: var(--dc-warn-soft);
+  color: var(--dc-warn);
+}
+
+.dc-badge-info {
+  background: var(--dc-info-soft);
+  color: var(--dc-info);
+}
+
+.dc-stage {
+  border: 1px solid var(--dc-line);
+  border-radius: 12px;
+  padding: 1.25rem 1rem;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(15, 118, 110, 0.08), transparent 55%),
+    #fff;
+  text-align: center;
+}
+
+.dc-stage-label {
+  margin: 0 0 0.85rem;
+  font-size: 0.8rem;
+  color: var(--dc-muted);
+}
+
+.dc-stage-note {
+  margin: 0.9rem 0 0;
+  font-size: 0.85rem;
+  color: var(--dc-muted);
+}
+
+.dc-verdict {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--dc-line);
+  margin-bottom: 0.85rem;
+}
+
+.dc-verdict[data-tone="ok"] {
+  background: var(--dc-ok-soft);
+  border-color: #86efac;
+}
+
+.dc-verdict[data-tone="danger"] {
+  background: var(--dc-danger-soft);
+  border-color: #fca5a5;
+}
+
+.dc-verdict[data-tone="warn"] {
+  background: var(--dc-warn-soft);
+  border-color: #fdba74;
+}
+
+.dc-verdict p {
+  margin: 0;
+  flex: 1;
+  min-width: 200px;
+  color: var(--dc-ink);
+  font-size: 0.92rem;
+}
+
+.dc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.dc-list li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--dc-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.dc-list h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.dc-list p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--dc-muted);
+}
+
+.dc-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--dc-line);
+  border-radius: 12px;
+}
+
+.dc-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 560px;
+}
+
+.dc-table th,
+.dc-table td {
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid var(--dc-line);
+  vertical-align: top;
+}
+
+.dc-table th {
+  background: #f8fafc;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--dc-muted);
+}
+
+.dc-table tr:last-child td {
+  border-bottom: none;
+}
+
+.dc-table code {
+  font-size: 0.78rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+.dc-reco {
+  border-left: 4px solid var(--dc-ok);
+  background: linear-gradient(135deg, #f0fdf4, #ffffff);
+}
+
+.dc-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dc-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--dc-line);
+  font-size: 0.9rem;
+}
+
+.dc-check li:last-child {
+  border-bottom: none;
+}
+
+.dc-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--dc-ok);
+  margin-top: 0.1rem;
+}
+
+.dc-check-icon.is-no {
+  background: var(--dc-danger);
+}
+
+.dc-snippet-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 760px) {
+  .dc-snippet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dc-snippet-block {
+  position: relative;
+}
+
+.dc-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.dc-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 7rem;
+}
+
+.dc-snippet--bad {
+  box-shadow: inset 0 0 0 2px rgba(185, 28, 28, 0.45);
+}
+
+.dc-snippet--good {
+  box-shadow: inset 0 0 0 2px rgba(21, 128, 61, 0.45);
+}
+
+.dc-copy {
+  position: absolute;
+  top: 2.15rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.dc-copy:hover,
+.dc-copy:focus-visible {
+  background: var(--dc-accent);
+  outline: none;
+}
+
+.dc-copy[data-copied="true"] {
+  background: var(--dc-ok);
+}
+
+.dc-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--dc-ok);
+  font-weight: 600;
+}
+
+.dc-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--dc-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--dc-muted);
+}
+
+.dc-footer strong {
+  color: var(--dc-ink);
+}
+
+/* Local override demo — loses when min sheet loads after it */
+.dc-override-hint {
+  outline: 2px dashed transparent;
+  outline-offset: 4px;
+}
+
+body[data-cascade="surprise"] .dc-override-hint {
+  outline-color: var(--dc-danger);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .dc-mode {
+    transition: none;
+  }
+}


### PR DESCRIPTION
# #46185 issue resolved

## Description

This PR adds a beginner-friendly **Dual Stylesheet Cascade Surprise** documentation showcase under `submissions/docs/ease-dual-css-load-sp/`.

It intentionally loads `easemotion.css` and `easemotion.min.css` together, shows doubled rules and unexpected cascade wins, and teaches the debug vs prod rule: never ship both at once.

## Features

- Toggle modes: source only / min only / both loaded
- Live stats for sheet count, estimated CSS weight, and cascade risk
- Visual demo of cascade surprises when both files are present
- Plain-English explanation of rule duplication and “last sheet wins”
- Debug vs production recommendation panel
- Copy-paste ready correct single `<link>` snippets
- Self-contained docs lab — open `demo.html` directly (no build step)