### PR TITLE
Duration Keyword Mapper

### DIFF
--- a/submissions/docs/ease-duration-keyword-map-sp/README.md
+++ b/submissions/docs/ease-duration-keyword-map-sp/README.md
@@ -1,0 +1,73 @@
+# Duration Keyword Mapper
+
+An interactive documentation tool that maps duration keywords (`fast` / `medium` / `slow`) and class helpers (`ease-duration-*`) to the matching CSS tokens (`--ease-speed-*` → **150ms / 300ms / 600ms**), with a live button + fade preview.
+
+> Submission track: `submissions/docs/ease-duration-keyword-map-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46187](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46187)
+
+---
+
+## What does this do?
+
+EaseMotion documents duration in three places — Animate props, utility classes, and design tokens. Beginners often treat them as separate APIs. This bridge tool shows they are one timing system:
+
+| Keyword | Class | Token | ms |
+|---------|-------|-------|----|
+| `fast` | `ease-duration-fast` | `--ease-speed-fast` | 150 |
+| `medium` | `ease-duration-medium` | `--ease-speed-medium` | 300 |
+| `slow` | `ease-duration-slow` | `--ease-speed-slow` | 600 |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (network needed for EaseMotion CDN).
+2. Pick **fast / medium / slow**.
+3. Watch the live API bridge, mapping table, and preview update.
+4. Click **Replay motion** or **Cycle next keyword**.
+5. Copy HTML / CSS / Animate snippets for the selected duration.
+
+Example:
+
+```html
+<div class="ease-slide-up ease-duration-fast">Timed entrance</div>
+```
+
+```jsx
+<Animate type="fade-in" duration="fast">…</Animate>
+```
+
+---
+
+## Why is it useful?
+
+- Bridges README sections that document duration APIs separately
+- Stops guessing milliseconds for keywords
+- Freeze-safe: only new files under `submissions/docs/`
+- Fits EaseMotion’s readable, education-first contribution model
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-duration-keyword-map-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Demo uses existing duration utilities for illustration; local chrome uses `dk-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-duration-keyword-map-sp/demo.html
+++ b/submissions/docs/ease-duration-keyword-map-sp/demo.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Duration Keyword Mapper — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Map fast / medium / slow keywords to ease-duration-* classes and --ease-speed-* tokens (150 / 300 / 600ms) with a live preview."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="dk-header">
+    <p class="dk-eyebrow">EaseMotion CSS · Animation Documentation Tool</p>
+    <h1>Duration Keyword Mapper</h1>
+    <p class="dk-subtitle">
+      Bridge the three duration APIs: Animate props (<code>duration="fast"</code>),
+      utility classes (<code>ease-duration-fast</code>), and tokens
+      (<code>--ease-speed-fast: 150ms</code>). One timing system — pick a keyword
+      and see them all.
+    </p>
+    <a
+      class="dk-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46187"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46187
+    </a>
+  </header>
+
+  <main class="dk-main">
+    <aside class="dk-callout" role="note">
+      <strong>One mental model:</strong>
+      <code>fast</code> / <code>medium</code> / <code>slow</code> always mean
+      <strong>150ms / 300ms / 600ms</strong> via <code>--ease-speed-*</code>,
+      whether you write an Animate prop, a class, or a CSS variable.
+    </aside>
+
+    <section class="dk-card" aria-labelledby="pick-title">
+      <h2 class="dk-card-title" id="pick-title">Pick a duration keyword</h2>
+      <p>Select a keyword to update the live map, preview, and copy snippets.</p>
+      <div class="dk-keys" role="group" aria-label="Duration keywords">
+        <button type="button" class="dk-key is-active" data-key="fast" aria-pressed="true">
+          <strong>fast</strong>
+          <span>150ms</span>
+        </button>
+        <button type="button" class="dk-key" data-key="medium" aria-pressed="false">
+          <strong>medium</strong>
+          <span>300ms · default</span>
+        </button>
+        <button type="button" class="dk-key" data-key="slow" aria-pressed="false">
+          <strong>slow</strong>
+          <span>600ms</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="dk-card" aria-labelledby="map-title">
+      <h2 class="dk-card-title" id="map-title">Live API bridge</h2>
+      <div class="dk-map" aria-live="polite">
+        <div class="dk-map-cell">
+          <span class="dk-map-label">Keyword / Animate prop</span>
+          <div class="dk-map-value" id="map-prop">duration="fast"</div>
+        </div>
+        <div class="dk-map-cell">
+          <span class="dk-map-label">Class helper</span>
+          <div class="dk-map-value" id="map-class">ease-duration-fast</div>
+        </div>
+        <div class="dk-map-cell">
+          <span class="dk-map-label">Design token</span>
+          <div class="dk-map-value" id="map-token">--ease-speed-fast: 150ms</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="dk-card" aria-labelledby="preview-title">
+      <h2 class="dk-card-title" id="preview-title">Live preview</h2>
+      <p>
+        Button uses <code>ease-hover-grow</code> + the selected
+        <code>ease-duration-*</code>. Card uses <code>ease-fade-in</code> with the
+        same duration — click Replay to feel the timing.
+      </p>
+      <div class="dk-stage">
+        <div class="dk-stage-row">
+          <button
+            type="button"
+            id="preview-btn"
+            class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow ease-duration-fast"
+          >
+            Hover me
+          </button>
+          <div
+            id="preview-box"
+            class="dk-preview-box ease-fade-in ease-duration-fast"
+          >
+            fade-in preview
+          </div>
+        </div>
+        <div class="dk-controls">
+          <button type="button" class="dk-btn" id="replay-btn">Replay motion</button>
+          <button type="button" class="dk-btn dk-btn-ghost" id="cycle-btn">
+            Cycle next keyword
+          </button>
+        </div>
+        <p class="dk-stage-meta" id="preview-meta">
+          using ease-duration-fast · --ease-speed-fast (150ms)
+        </p>
+      </div>
+    </section>
+
+    <section class="dk-card" aria-labelledby="table-title">
+      <h2 class="dk-card-title" id="table-title">Full mapping table</h2>
+      <div class="dk-table-wrap">
+        <table class="dk-table" id="map-table">
+          <thead>
+            <tr>
+              <th>Keyword</th>
+              <th>Class</th>
+              <th>Token</th>
+              <th>Milliseconds</th>
+              <th>Animate prop</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-row="fast" class="is-active">
+              <td><code>fast</code></td>
+              <td><code>ease-duration-fast</code></td>
+              <td><code>--ease-speed-fast</code></td>
+              <td>150ms</td>
+              <td><code>duration="fast"</code> or <code>150</code></td>
+            </tr>
+            <tr data-row="medium">
+              <td><code>medium</code></td>
+              <td><code>ease-duration-medium</code></td>
+              <td><code>--ease-speed-medium</code></td>
+              <td>300ms</td>
+              <td><code>duration="medium"</code> or <code>300</code></td>
+            </tr>
+            <tr data-row="slow">
+              <td><code>slow</code></td>
+              <td><code>ease-duration-slow</code></td>
+              <td><code>--ease-speed-slow</code></td>
+              <td>600ms</td>
+              <td><code>duration="slow"</code> or <code>600</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="dk-card" aria-labelledby="snip-title">
+      <h2 class="dk-card-title" id="snip-title">Copy-paste snippets</h2>
+      <p>Snippets update with your selected keyword.</p>
+      <div class="dk-snippet-grid">
+        <div class="dk-snippet-block">
+          <div class="dk-snippet-label">
+            <span class="dk-badge dk-badge-ok">HTML</span>
+            Class helper
+          </div>
+          <pre class="dk-snippet" id="snip-html" aria-label="HTML class snippet"></pre>
+          <button type="button" class="dk-copy" data-copy="snip-html">Copy</button>
+        </div>
+        <div class="dk-snippet-block">
+          <div class="dk-snippet-label">
+            <span class="dk-badge dk-badge-info">CSS</span>
+            Token override
+          </div>
+          <pre class="dk-snippet" id="snip-css" aria-label="CSS token snippet"></pre>
+          <button type="button" class="dk-copy" data-copy="snip-css">Copy</button>
+        </div>
+        <div class="dk-snippet-block">
+          <div class="dk-snippet-label">
+            <span class="dk-badge dk-badge-warn">React</span>
+            Animate prop
+          </div>
+          <pre class="dk-snippet" id="snip-react" aria-label="Animate prop snippet"></pre>
+          <button type="button" class="dk-copy" data-copy="snip-react">Copy</button>
+        </div>
+      </div>
+      <p class="dk-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <section class="dk-card" aria-labelledby="why-title">
+      <h2 class="dk-card-title" id="why-title">Why this bridge matters</h2>
+      <ul class="dk-list">
+        <li>
+          <h3>README shows APIs separately</h3>
+          <p>
+            Duration helpers, Customize tokens, and Animate props are documented
+            in different sections. This mapper is the missing bridge tool.
+          </p>
+        </li>
+        <li>
+          <h3>Same three speeds everywhere</h3>
+          <p>
+            Whether you write a class or an Animate keyword, you’re resolving to
+            <code>--ease-speed-fast|medium|slow</code>.
+          </p>
+        </li>
+        <li>
+          <h3>Theme once, keep names</h3>
+          <p>
+            Override the tokens in <code>:root</code> and every keyword + class
+            that references them updates together.
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <aside class="dk-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-duration-keyword-map-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46187"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46187</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var MAP = {
+        fast: {
+          ms: 150,
+          className: "ease-duration-fast",
+          token: "--ease-speed-fast",
+          prop: 'duration="fast"',
+        },
+        medium: {
+          ms: 300,
+          className: "ease-duration-medium",
+          token: "--ease-speed-medium",
+          prop: 'duration="medium"',
+        },
+        slow: {
+          ms: 600,
+          className: "ease-duration-slow",
+          token: "--ease-speed-slow",
+          prop: 'duration="slow"',
+        },
+      };
+
+      var ORDER = ["fast", "medium", "slow"];
+      var current = "fast";
+
+      var mapProp = document.getElementById("map-prop");
+      var mapClass = document.getElementById("map-class");
+      var mapToken = document.getElementById("map-token");
+      var previewBtn = document.getElementById("preview-btn");
+      var previewBox = document.getElementById("preview-box");
+      var previewMeta = document.getElementById("preview-meta");
+      var snipHtml = document.getElementById("snip-html");
+      var snipCss = document.getElementById("snip-css");
+      var snipReact = document.getElementById("snip-react");
+      var rows = document.querySelectorAll("#map-table tbody tr");
+
+      function stripDuration(el) {
+        ORDER.forEach(function (k) {
+          el.classList.remove(MAP[k].className);
+        });
+      }
+
+      function replayBox() {
+        previewBox.classList.remove("ease-fade-in");
+        void previewBox.offsetWidth;
+        previewBox.classList.add("ease-fade-in");
+      }
+
+      function applyKey(key) {
+        if (!MAP[key]) return;
+        current = key;
+        var item = MAP[key];
+
+        document.querySelectorAll(".dk-key").forEach(function (btn) {
+          var active = btn.getAttribute("data-key") === key;
+          btn.classList.toggle("is-active", active);
+          btn.setAttribute("aria-pressed", String(active));
+        });
+
+        rows.forEach(function (row) {
+          row.classList.toggle(
+            "is-active",
+            row.getAttribute("data-row") === key
+          );
+        });
+
+        mapProp.textContent = item.prop;
+        mapClass.textContent = item.className;
+        mapToken.textContent = item.token + ": " + item.ms + "ms";
+
+        stripDuration(previewBtn);
+        stripDuration(previewBox);
+        previewBtn.classList.add(item.className);
+        previewBox.classList.add(item.className);
+
+        previewMeta.textContent =
+          "using " +
+          item.className +
+          " · " +
+          item.token +
+          " (" +
+          item.ms +
+          "ms)";
+
+        snipHtml.textContent =
+          '<div class="ease-slide-up ' +
+          item.className +
+          '">\n  Timed entrance\n</div>\n\n' +
+          '<button class="ease-btn ease-btn-primary ease-hover-grow ' +
+          item.className +
+          '">\n  Hover me\n</button>';
+
+        snipCss.textContent =
+          ":root {\n  " +
+          item.token +
+          ": " +
+          item.ms +
+          "ms; /* keep keyword + class in sync */\n}\n\n" +
+          ".my-cta {\n  transition-duration: var(" +
+          item.token +
+          ");\n}";
+
+        snipReact.textContent =
+          '<Animate type="fade-in" ' +
+          item.prop +
+          ">\n" +
+          "  <Button>Get Started</Button>\n" +
+          "</Animate>\n\n" +
+          "// or milliseconds: duration={" +
+          item.ms +
+          "}";
+
+        replayBox();
+      }
+
+      document.querySelectorAll(".dk-key").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          applyKey(btn.getAttribute("data-key"));
+        });
+      });
+
+      document.getElementById("replay-btn").addEventListener("click", function () {
+        applyKey(current);
+      });
+
+      document.getElementById("cycle-btn").addEventListener("click", function () {
+        var i = ORDER.indexOf(current);
+        applyKey(ORDER[(i + 1) % ORDER.length]);
+      });
+
+      function decodeEntities(html) {
+        var ta = document.createElement("textarea");
+        ta.innerHTML = html;
+        return ta.value;
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = pre.textContent.trim();
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+
+      applyKey("fast");
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-duration-keyword-map-sp/style.css
+++ b/submissions/docs/ease-duration-keyword-map-sp/style.css
@@ -1,0 +1,495 @@
+/* ============================================================
+   Duration Keyword Mapper
+   submissions/docs/ease-duration-keyword-map-sp/style.css
+   ============================================================ */
+
+:root {
+  --dk-ink: #0f172a;
+  --dk-muted: #475569;
+  --dk-line: #e2e8f0;
+  --dk-surface: #ffffff;
+  --dk-page: #f5f7fb;
+  --dk-accent: #5b4dff;
+  --dk-accent-soft: #eceaff;
+  --dk-ok: #15803d;
+  --dk-ok-soft: #dcfce7;
+  --dk-info: #1d4ed8;
+  --dk-info-soft: #dbeafe;
+  --dk-warn: #b45309;
+  --dk-warn-soft: #ffedd5;
+  --dk-mono: "JetBrains Mono", ui-monospace, monospace;
+  --dk-radius: 14px;
+  --dk-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--dk-ink);
+  background:
+    radial-gradient(ellipse 70% 45% at 5% -10%, #eceaff 0%, transparent 55%),
+    radial-gradient(ellipse 50% 35% at 100% 0%, #dbeafe 0%, transparent 50%),
+    var(--dk-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--dk-mono);
+}
+
+.dk-header {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.dk-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dk-accent);
+}
+
+.dk-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.45rem, 3vw, 2.05rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.dk-subtitle {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--dk-muted);
+  font-size: 1.02rem;
+}
+
+.dk-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--dk-info-soft);
+  color: var(--dk-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.dk-issue:hover,
+.dk-issue:focus-visible {
+  outline: 2px solid var(--dk-info);
+  outline-offset: 2px;
+}
+
+.dk-main {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.dk-card {
+  background: var(--dk-surface);
+  border: 1px solid var(--dk-line);
+  border-radius: var(--dk-radius);
+  box-shadow: var(--dk-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.dk-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.dk-card p {
+  margin: 0 0 0.75rem;
+  color: var(--dk-muted);
+}
+
+.dk-callout {
+  border: 1px solid var(--dk-line);
+  border-left: 4px solid var(--dk-accent);
+  border-radius: 0 var(--dk-radius) var(--dk-radius) 0;
+  background: linear-gradient(135deg, #f5f3ff, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.dk-callout strong {
+  color: var(--dk-accent);
+}
+
+.dk-keys {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.55rem;
+}
+
+@media (max-width: 640px) {
+  .dk-keys {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dk-key {
+  appearance: none;
+  border: 1px solid var(--dk-line);
+  border-radius: 12px;
+  padding: 0.9rem 0.95rem;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.dk-key strong {
+  display: block;
+  font-size: 1rem;
+  margin-bottom: 0.2rem;
+  color: var(--dk-ink);
+}
+
+.dk-key span {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--dk-muted);
+  font-family: var(--dk-mono);
+}
+
+.dk-key.is-active {
+  border-color: var(--dk-accent);
+  background: var(--dk-accent-soft);
+  box-shadow: inset 0 0 0 1px rgba(91, 77, 255, 0.25);
+}
+
+.dk-key:focus-visible {
+  outline: 2px solid var(--dk-accent);
+  outline-offset: 2px;
+}
+
+.dk-map {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+@media (max-width: 760px) {
+  .dk-map {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dk-map-cell {
+  border: 1px solid var(--dk-line);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  background: #f8fafc;
+}
+
+.dk-map-label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--dk-muted);
+  margin-bottom: 0.35rem;
+}
+
+.dk-map-value {
+  font-family: var(--dk-mono);
+  font-size: 0.88rem;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.dk-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.dk-badge-ok {
+  background: var(--dk-ok-soft);
+  color: var(--dk-ok);
+}
+
+.dk-badge-info {
+  background: var(--dk-info-soft);
+  color: var(--dk-info);
+}
+
+.dk-badge-warn {
+  background: var(--dk-warn-soft);
+  color: var(--dk-warn);
+}
+
+.dk-stage {
+  border: 1px solid var(--dk-line);
+  border-radius: 12px;
+  padding: 1.5rem 1rem;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(91, 77, 255, 0.08), transparent 55%),
+    #fff;
+  text-align: center;
+}
+
+.dk-stage-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  min-height: 5.5rem;
+}
+
+.dk-preview-box {
+  width: min(220px, 80%);
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid var(--dk-line);
+  background: #fff;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  font-weight: 600;
+}
+
+.dk-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.dk-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--dk-accent);
+  color: #fff;
+}
+
+.dk-btn:hover {
+  background: #4a3fe0;
+}
+
+.dk-btn:focus-visible {
+  outline: 2px solid var(--dk-accent);
+  outline-offset: 2px;
+}
+
+.dk-btn-ghost {
+  background: #fff;
+  border-color: var(--dk-line);
+  color: var(--dk-ink);
+}
+
+.dk-btn-ghost:hover {
+  border-color: var(--dk-accent);
+  color: var(--dk-accent);
+}
+
+.dk-stage-meta {
+  margin: 0.85rem 0 0;
+  font-size: 0.82rem;
+  color: var(--dk-muted);
+  font-family: var(--dk-mono);
+}
+
+.dk-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--dk-line);
+  border-radius: 12px;
+}
+
+.dk-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 620px;
+}
+
+.dk-table th,
+.dk-table td {
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid var(--dk-line);
+  vertical-align: top;
+}
+
+.dk-table th {
+  background: #f8fafc;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--dk-muted);
+}
+
+.dk-table tr:last-child td {
+  border-bottom: none;
+}
+
+.dk-table tr.is-active td {
+  background: var(--dk-accent-soft);
+}
+
+.dk-table code {
+  font-size: 0.78rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+.dk-snippet-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .dk-snippet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dk-snippet-block {
+  position: relative;
+}
+
+.dk-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.dk-snippet {
+  margin: 0;
+  padding: 0.85rem 0.9rem;
+  padding-right: 4.5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.7rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 6.5rem;
+}
+
+.dk-copy {
+  position: absolute;
+  top: 2rem;
+  right: 0.5rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.3rem 0.55rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.dk-copy:hover,
+.dk-copy:focus-visible {
+  background: var(--dk-accent);
+  outline: none;
+}
+
+.dk-copy[data-copied="true"] {
+  background: var(--dk-ok);
+}
+
+.dk-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--dk-ok);
+  font-weight: 600;
+}
+
+.dk-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.dk-list li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--dk-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.dk-list h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+}
+
+.dk-list p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--dk-muted);
+}
+
+.dk-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--dk-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--dk-muted);
+}
+
+.dk-footer strong {
+  color: var(--dk-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .dk-key {
+    transition: none;
+  }
+}


### PR DESCRIPTION
# #46187 issue resolved

## Description

This PR adds a beginner-friendly **Duration Keyword Mapper** under `submissions/docs/ease-duration-keyword-map-sp/`.

It maps duration keywords (`fast` / `medium` / `slow`) and class helpers (`ease-duration-*`) to the matching CSS tokens (`--ease-speed-*` → 150ms / 300ms / 600ms), with a live button preview.

## Features

- Interactive map: keywords ↔ `ease-duration-*` ↔ `--ease-speed-*` (150 / 300 / 600)
- Live button / fade-in preview for each selected duration
- Full mapping table for class, token, ms, and Animate props
- Copy-paste snippets for HTML classes, CSS variables, and Animate `duration` props
- Clear “one timing system” mental model bridging README APIs
- Self-contained docs lab — open `demo.html` directly (no build step)