### PR TITLE
color-scheme: light dark Auto Token Behavior Demo

### DIFF
--- a/submissions/docs/ease-color-scheme-auto-sp/README.md
+++ b/submissions/docs/ease-color-scheme-auto-sp/README.md
@@ -1,0 +1,71 @@
+# color-scheme: light dark Auto Token Behavior Demo
+
+An interactive documentation showcase that toggles / simulates light and dark `color-scheme` conditions and shows how they interact with EaseMotion surfaces — **without** treating `color-scheme` as a full dark-token theme remap.
+
+> Submission track: `submissions/docs/ease-color-scheme-auto-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46189](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46189)
+
+---
+
+## What does this do?
+
+EaseMotion sets `color-scheme: light dark` on `:root` and has limited `prefers-color-scheme` / `[data-theme]` awareness. Beginners often assume that means a complete dark theme.
+
+This lab compares:
+
+| Lab | Meaning |
+|-----|---------|
+| **Scheme-only** | Change `color-scheme` while keeping light tokens locked — see UA chrome (inputs, scrollbars) vs unchanged surfaces |
+| **Full remap** | Rewrite surface tokens + `color-scheme` — closer to a real dark theme expectation |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Switch **Auto / Scheme light / Scheme dark / Full dark remap**.
+3. Compare the left (scheme-only) and right (token remap) sandboxes.
+4. Read the checklist and copy the guidance snippet.
+
+Example baseline:
+
+```css
+:root {
+  color-scheme: light dark;
+}
+```
+
+---
+
+## Why is it useful?
+
+- Separates browser auto `color-scheme` behavior from a dark-mode token switcher
+- Reduces false “dark mode is broken” reports
+- Freeze-safe: only new files under `submissions/docs/`
+- Fits EaseMotion’s education-first contribution model
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-color-scheme-auto-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Demo uses existing EaseMotion classes for illustration; local chrome uses `cs-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-color-scheme-auto-sp/demo.html
+++ b/submissions/docs/ease-color-scheme-auto-sp/demo.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>color-scheme Auto Token Behavior Demo — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Toggle light/dark color-scheme and see how it affects EaseMotion surfaces and native UI without a full dark-token remap."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body data-lab="scheme-auto">
+  <header class="cs-header">
+    <p class="cs-eyebrow">EaseMotion CSS · Token Behavior Showcase</p>
+    <h1><code>color-scheme: light dark</code> Auto Token Behavior</h1>
+    <p class="cs-subtitle">
+      EaseMotion sets <code>color-scheme: light dark</code> on <code>:root</code>.
+      That is <strong>not</strong> the same as a full dark-token theme switcher.
+      Toggle modes below and compare browser auto UI vs a full remapped surface.
+    </p>
+    <a
+      class="cs-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46189"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46189
+    </a>
+  </header>
+
+  <main class="cs-main">
+    <aside class="cs-callout" role="note">
+      <strong>Different from a dark-mode switcher:</strong>
+      <code>color-scheme</code> mainly tells the browser how to paint
+      <em>native</em> controls (inputs, scrollbars, form widgets). A full theme
+      remap changes EaseMotion tokens like <code>--ease-color-bg</code>. This lab
+      separates those ideas.
+    </aside>
+
+    <section class="cs-card" aria-labelledby="mode-title">
+      <h2 class="cs-card-title" id="mode-title">Simulate preference / scheme</h2>
+      <p>
+        Choose a lab mode. Left sandbox focuses on <code>color-scheme</code> alone
+        (tokens stay light on purpose). Right sandbox shows a full token remap
+        expectation.
+      </p>
+      <div class="cs-modes" role="group" aria-label="color-scheme lab modes">
+        <button type="button" class="cs-mode is-active" data-mode="scheme-auto" aria-pressed="true">
+          <strong>Auto</strong>
+          <span>color-scheme: light dark</span>
+        </button>
+        <button type="button" class="cs-mode" data-mode="scheme-light" aria-pressed="false">
+          <strong>Scheme light</strong>
+          <span>UA light chrome only</span>
+        </button>
+        <button type="button" class="cs-mode" data-mode="scheme-dark" aria-pressed="false">
+          <strong>Scheme dark</strong>
+          <span>UA dark chrome · light tokens</span>
+        </button>
+        <button type="button" class="cs-mode" data-mode="full-dark" aria-pressed="false">
+          <strong>Full dark remap</strong>
+          <span>tokens + color-scheme</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="cs-card" aria-labelledby="live-title">
+      <h2 class="cs-card-title" id="live-title">Live comparison</h2>
+      <div class="cs-verdict" aria-live="polite">
+        <span class="cs-badge cs-badge-info" id="verdict-badge">Auto</span>
+        <p id="verdict-text">
+          Using <code>color-scheme: light dark</code>. Native controls follow the
+          OS; locked light tokens show that surfaces do not auto-flip by scheme
+          alone.
+        </p>
+      </div>
+
+      <div class="cs-compare">
+        <!-- Scheme-only sandbox -->
+        <article class="cs-sandbox cs-sandbox--scheme">
+          <div class="cs-sandbox-head">
+            Scheme-only lab
+            <span class="cs-badge cs-badge-warn">No full token remap</span>
+          </div>
+          <div class="cs-sandbox-body">
+            <div class="cs-sample-grid">
+              <div class="cs-surface">
+                <h4>EaseMotion surface</h4>
+                <p>
+                  Uses locked light <code>--ease-color-*</code> tokens so you can
+                  see what <em>doesn’t</em> flip from <code>color-scheme</code> alone.
+                </p>
+              </div>
+
+              <div class="cs-glass">Glass / frosted strip</div>
+
+              <div class="ease-center" style="gap: 0.5rem; flex-wrap: wrap; justify-content: flex-start;">
+                <button type="button" class="ease-btn ease-btn-primary ease-btn-sm">Primary</button>
+                <button type="button" class="ease-btn ease-btn-outline ease-btn-sm">Outline</button>
+              </div>
+
+              <div class="cs-native">
+                <div>
+                  <label for="scheme-text">Native text input</label>
+                  <input id="scheme-text" type="text" value="Watch UA chrome" />
+                </div>
+                <div>
+                  <label for="scheme-select">Native select</label>
+                  <select id="scheme-select">
+                    <option>Option A</option>
+                    <option>Option B</option>
+                  </select>
+                </div>
+                <label>
+                  <input type="checkbox" checked /> Checkbox (UA themed)
+                </label>
+                <div class="cs-scroll" tabindex="0">
+                  Scroll this box — scrollbar chrome often follows
+                  <code>color-scheme</code> even when EaseMotion surfaces stay light.
+                  Keep scrolling to see more lines of sample content for the
+                  overflow region.
+                </div>
+              </div>
+            </div>
+            <p class="cs-note">
+              Tip: in <strong>Scheme dark</strong>, inputs/scrollbars can look dark
+              while the card text/surface stays light — that’s the teaching point.
+            </p>
+          </div>
+        </article>
+
+        <!-- Full remap sandbox -->
+        <article class="cs-sandbox cs-sandbox--full">
+          <div class="cs-sandbox-head">
+            Full theme expectation
+            <span class="cs-badge cs-badge-ok">Token remap</span>
+          </div>
+          <div class="cs-sandbox-body">
+            <div class="cs-sample-grid">
+              <div class="cs-surface">
+                <h4>Remapped EaseMotion surface</h4>
+                <p>
+                  Here <code>--ease-color-bg</code>, surface, text, and muted are
+                  rewritten — closer to <code>[data-theme="dark"]</code> /
+                  <code>prefers-color-scheme</code> token behavior.
+                </p>
+              </div>
+
+              <div class="cs-glass">Glass / frosted strip</div>
+
+              <div class="ease-center" style="gap: 0.5rem; flex-wrap: wrap; justify-content: flex-start;">
+                <button type="button" class="ease-btn ease-btn-primary ease-btn-sm">Primary</button>
+                <button type="button" class="ease-btn ease-btn-outline ease-btn-sm">Outline</button>
+              </div>
+
+              <div class="cs-native">
+                <div>
+                  <label for="full-text">Native text input</label>
+                  <input id="full-text" type="text" value="Full dark tokens" />
+                </div>
+                <div>
+                  <label for="full-select">Native select</label>
+                  <select id="full-select">
+                    <option>Option A</option>
+                    <option>Option B</option>
+                  </select>
+                </div>
+                <label>
+                  <input type="checkbox" checked /> Checkbox (UA themed)
+                </label>
+                <div class="cs-scroll" tabindex="0">
+                  With a full remap, surfaces and text invert too — not just native
+                  widgets. This is what people usually mean by “dark mode.”
+                </div>
+              </div>
+            </div>
+            <p class="cs-note">
+              Framework already supports limited remaps via
+              <code>prefers-color-scheme</code> and <code>[data-theme]</code> — still
+              not every component token is a complete design-system dark theme.
+            </p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="cs-card" aria-labelledby="changes-title">
+      <h2 class="cs-card-title" id="changes-title">What changes / what doesn’t</h2>
+      <ul class="cs-check">
+        <li>
+          <span class="cs-check-icon" aria-hidden="true">✓</span>
+          <span>
+            <strong>Changes with <code>color-scheme</code>:</strong>
+            many native controls, scrollbars, form widgets, selection in some UAs.
+          </span>
+        </li>
+        <li>
+          <span class="cs-check-icon is-warn" aria-hidden="true">~</span>
+          <span>
+            <strong>Partial with preferences:</strong>
+            EaseMotion remaps some tokens under
+            <code>prefers-color-scheme: dark</code> / <code>[data-theme="dark"]</code>
+            (bg, surface, text, shadows, glass) — not every accent/component recipe.
+          </span>
+        </li>
+        <li>
+          <span class="cs-check-icon is-no" aria-hidden="true">✕</span>
+          <span>
+            <strong>Does not mean:</strong>
+            “all UI auto becomes a curated dark theme” from
+            <code>color-scheme: light dark</code> alone.
+          </span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="cs-card" aria-labelledby="why-title">
+      <h2 class="cs-card-title" id="why-title">Why this distinction matters</h2>
+      <ul class="cs-list">
+        <li>
+          <h3>
+            Browser auto behavior
+            <span class="cs-badge cs-badge-info">UA</span>
+          </h3>
+          <p>
+            <code>color-scheme</code> is a hint to the user agent. It’s cheap and
+            important for forms/scrollbars, but it isn’t a design-token engine.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Token remap is intentional CSS
+            <span class="cs-badge cs-badge-ok">Tokens</span>
+          </h3>
+          <p>
+            Flipping <code>--ease-color-bg</code> / surface / text is a theme
+            layer. That’s what <code>[data-theme="dark"]</code> (and some preference
+            media) provide — still not a full component-by-component dark system.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Avoid false bug reports
+            <span class="cs-badge cs-badge-warn">Docs</span>
+          </h3>
+          <p>
+            If OS is dark but a card still looks light, check whether you only have
+            auto <code>color-scheme</code> vs an actual token remap.
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section class="cs-card" aria-labelledby="table-title">
+      <h2 class="cs-card-title" id="table-title">Quick reference</h2>
+      <div class="cs-table-wrap">
+        <table class="cs-table">
+          <thead>
+            <tr>
+              <th>Approach</th>
+              <th>What it does</th>
+              <th>Use when</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>color-scheme: light dark</code></td>
+              <td>UA may theme native chrome automatically</td>
+              <td>Default / baseline (EaseMotion <code>:root</code>)</td>
+            </tr>
+            <tr>
+              <td><code>color-scheme: dark</code> only</td>
+              <td>Native dark widgets; tokens may stay light</td>
+              <td>Teaching / isolating UA behavior</td>
+            </tr>
+            <tr>
+              <td><code>[data-theme="dark"]</code></td>
+              <td>Remaps key EaseMotion surface tokens</td>
+              <td>Explicit app theme toggle</td>
+            </tr>
+            <tr>
+              <td>Full design-system dark</td>
+              <td>Every component/recipe curated for dark</td>
+              <td>Future / product-level theming work</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="cs-card cs-reco" aria-labelledby="snip-title">
+      <h2 class="cs-card-title" id="snip-title">Copy-paste guidance</h2>
+      <div class="cs-snippet-label">
+        <span class="cs-badge cs-badge-ok">Baseline</span>
+        What EaseMotion already ships
+      </div>
+      <div class="cs-snippet-block">
+        <pre
+          class="cs-snippet"
+          id="snip-base"
+          aria-label="color-scheme baseline snippet"
+>:root {
+  color-scheme: light dark; /* UA-aware native controls */
+}
+
+/* Explicit theme when you need token remap (framework supports this) */
+[data-theme="dark"] {
+  color-scheme: dark;
+  /* --ease-color-bg / surface / text remapped by EaseMotion */
+}
+
+/* Remember: color-scheme alone ≠ complete dark design system */</pre>
+        <button type="button" class="cs-copy" data-copy="snip-base">Copy</button>
+      </div>
+      <p class="cs-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <aside class="cs-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-color-scheme-auto-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46189"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46189</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var MODES = {
+        "scheme-auto": {
+          badge: "Auto",
+          badgeClass: "cs-badge-info",
+          text:
+            'Using color-scheme: light dark. Native controls follow the OS; locked light tokens show that surfaces do not auto-flip by scheme alone.',
+        },
+        "scheme-light": {
+          badge: "Scheme light",
+          badgeClass: "cs-badge-ok",
+          text:
+            "Forced color-scheme: light on the left sandbox. Expect light UA chrome. Surfaces stay on locked light tokens.",
+        },
+        "scheme-dark": {
+          badge: "Scheme dark",
+          badgeClass: "cs-badge-warn",
+          text:
+            "Forced color-scheme: dark with light tokens locked on the left — native widgets may darken while EaseMotion surfaces stay light. Right panel still shows full remap for contrast.",
+        },
+        "full-dark": {
+          badge: "Full remap",
+          badgeClass: "cs-badge-ok",
+          text:
+            "Full dark token remap on the right (and dark scheme). This is closer to what people expect from a dark theme — not color-scheme alone.",
+        },
+      };
+
+      var badge = document.getElementById("verdict-badge");
+      var text = document.getElementById("verdict-text");
+
+      function applyMode(mode) {
+        var cfg = MODES[mode] || MODES["scheme-auto"];
+        document.body.dataset.lab = mode;
+
+        document.querySelectorAll(".cs-mode").forEach(function (btn) {
+          var active = btn.getAttribute("data-mode") === mode;
+          btn.classList.toggle("is-active", active);
+          btn.setAttribute("aria-pressed", String(active));
+        });
+
+        badge.className = "cs-badge " + cfg.badgeClass;
+        badge.textContent = cfg.badge;
+        text.textContent = cfg.text;
+      }
+
+      document.querySelectorAll(".cs-mode").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          applyMode(btn.getAttribute("data-mode"));
+        });
+      });
+
+      function fallbackCopy(value) {
+        var ta = document.createElement("textarea");
+        ta.value = value;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var value = pre.textContent.trim();
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(value).then(done).catch(function () {
+              fallbackCopy(value);
+              done();
+            });
+          } else {
+            fallbackCopy(value);
+            done();
+          }
+        });
+      });
+
+      applyMode("scheme-auto");
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-color-scheme-auto-sp/style.css
+++ b/submissions/docs/ease-color-scheme-auto-sp/style.css
@@ -1,0 +1,638 @@
+/* ============================================================
+   color-scheme: light dark Auto Token Behavior Demo
+   submissions/docs/ease-color-scheme-auto-sp/style.css
+   ============================================================ */
+
+:root {
+  --cs-ink: #0f172a;
+  --cs-muted: #475569;
+  --cs-line: #e2e8f0;
+  --cs-surface: #ffffff;
+  --cs-page: #f4f7fb;
+  --cs-accent: #0f766e;
+  --cs-accent-soft: #ccfbf1;
+  --cs-warn: #b45309;
+  --cs-warn-soft: #ffedd5;
+  --cs-danger: #b91c1c;
+  --cs-danger-soft: #fee2e2;
+  --cs-ok: #15803d;
+  --cs-ok-soft: #dcfce7;
+  --cs-info: #1d4ed8;
+  --cs-info-soft: #dbeafe;
+  --cs-mono: "JetBrains Mono", ui-monospace, monospace;
+  --cs-radius: 14px;
+  --cs-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--cs-ink);
+  background:
+    radial-gradient(ellipse 75% 45% at 8% -10%, #ccfbf1 0%, transparent 55%),
+    radial-gradient(ellipse 55% 40% at 100% 0%, #e0e7ff 0%, transparent 50%),
+    var(--cs-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--cs-mono);
+}
+
+.cs-header {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.cs-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--cs-accent);
+}
+
+.cs-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.cs-subtitle {
+  margin: 0;
+  max-width: 66ch;
+  color: var(--cs-muted);
+  font-size: 1.02rem;
+}
+
+.cs-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--cs-info-soft);
+  color: var(--cs-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.cs-issue:hover,
+.cs-issue:focus-visible {
+  outline: 2px solid var(--cs-info);
+  outline-offset: 2px;
+}
+
+.cs-main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.cs-card {
+  background: var(--cs-surface);
+  border: 1px solid var(--cs-line);
+  border-radius: var(--cs-radius);
+  box-shadow: var(--cs-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.cs-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.cs-card p {
+  margin: 0 0 0.75rem;
+  color: var(--cs-muted);
+}
+
+.cs-callout {
+  border: 1px solid var(--cs-line);
+  border-left: 4px solid var(--cs-warn);
+  border-radius: 0 var(--cs-radius) var(--cs-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.cs-callout strong {
+  color: var(--cs-warn);
+}
+
+.cs-modes {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+@media (max-width: 900px) {
+  .cs-modes {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .cs-modes {
+    grid-template-columns: 1fr;
+  }
+}
+
+.cs-mode {
+  appearance: none;
+  border: 1px solid var(--cs-line);
+  border-radius: 12px;
+  padding: 0.8rem 0.85rem;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.cs-mode strong {
+  display: block;
+  font-size: 0.9rem;
+  margin-bottom: 0.2rem;
+  color: var(--cs-ink);
+}
+
+.cs-mode span {
+  display: block;
+  font-size: 0.74rem;
+  color: var(--cs-muted);
+}
+
+.cs-mode.is-active {
+  border-color: var(--cs-accent);
+  background: var(--cs-accent-soft);
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.25);
+}
+
+.cs-mode.is-active[data-mode="full-dark"],
+.cs-mode.is-active[data-mode="scheme-dark"] {
+  border-color: #64748b;
+  background: #0f172a;
+  color: #e2e8f0;
+  box-shadow: none;
+}
+
+.cs-mode.is-active[data-mode="full-dark"] strong,
+.cs-mode.is-active[data-mode="scheme-dark"] strong,
+.cs-mode.is-active[data-mode="full-dark"] span,
+.cs-mode.is-active[data-mode="scheme-dark"] span {
+  color: #e2e8f0;
+}
+
+.cs-mode.is-active[data-mode="scheme-dark"] span,
+.cs-mode.is-active[data-mode="full-dark"] span {
+  color: #94a3b8;
+}
+
+.cs-mode:focus-visible {
+  outline: 2px solid var(--cs-accent);
+  outline-offset: 2px;
+}
+
+.cs-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.cs-badge-ok {
+  background: var(--cs-ok-soft);
+  color: var(--cs-ok);
+}
+
+.cs-badge-warn {
+  background: var(--cs-warn-soft);
+  color: var(--cs-warn);
+}
+
+.cs-badge-info {
+  background: var(--cs-info-soft);
+  color: var(--cs-info);
+}
+
+.cs-badge-danger {
+  background: var(--cs-danger-soft);
+  color: var(--cs-danger);
+}
+
+.cs-verdict {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--cs-line);
+  margin-bottom: 0.85rem;
+  background: #f8fafc;
+}
+
+.cs-verdict p {
+  margin: 0;
+  flex: 1;
+  min-width: 200px;
+  color: var(--cs-ink);
+  font-size: 0.92rem;
+}
+
+.cs-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 820px) {
+  .cs-compare {
+    grid-template-columns: 1fr;
+  }
+}
+
+.cs-sandbox {
+  border: 1px solid var(--cs-line);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.cs-sandbox-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.7rem 0.85rem;
+  background: #f8fafc;
+  border-bottom: 1px solid var(--cs-line);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.cs-sandbox-body {
+  padding: 1rem 0.95rem 1.1rem;
+  /* Locked "light token baseline" for scheme-only demos */
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #1e293b;
+  --ease-color-muted: #475569;
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  color-scheme: light dark;
+}
+
+/* Mode-driven color-scheme / theme on sandboxes via data attrs on body */
+body[data-lab="scheme-light"] .cs-sandbox--scheme .cs-sandbox-body {
+  color-scheme: light;
+}
+
+body[data-lab="scheme-dark"] .cs-sandbox--scheme .cs-sandbox-body {
+  color-scheme: dark;
+  /* Keep EaseMotion-like tokens LIGHT intentionally */
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #1e293b;
+  --ease-color-muted: #475569;
+}
+
+body[data-lab="scheme-auto"] .cs-sandbox--scheme .cs-sandbox-body {
+  color-scheme: light dark;
+}
+
+body[data-lab="full-light"] .cs-sandbox--full .cs-sandbox-body,
+body[data-lab="scheme-light"] .cs-sandbox--full .cs-sandbox-body,
+body[data-lab="scheme-auto"] .cs-sandbox--full .cs-sandbox-body {
+  color-scheme: light;
+  --ease-color-bg: #f8fafc;
+  --ease-color-surface: #ffffff;
+  --ease-color-text: #1e293b;
+  --ease-color-muted: #475569;
+  --ease-glass-bg: rgba(255, 255, 255, 0.55);
+  --ease-glass-border: rgba(15, 23, 42, 0.12);
+}
+
+body[data-lab="full-dark"] .cs-sandbox--full .cs-sandbox-body,
+body[data-lab="scheme-dark"] .cs-sandbox--full .cs-sandbox-body {
+  color-scheme: dark;
+  --ease-color-bg: #0b1121;
+  --ease-color-surface: #141e33;
+  --ease-color-text: #e2e8f0;
+  --ease-color-muted: #94a3b8;
+  --ease-glass-bg: rgba(15, 23, 42, 0.45);
+  --ease-glass-border: rgba(255, 255, 255, 0.08);
+}
+
+body[data-lab="full-dark"] .cs-sandbox--scheme .cs-sandbox-body {
+  color-scheme: dark;
+}
+
+.cs-sample-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.cs-surface {
+  background: var(--ease-color-surface);
+  color: var(--ease-color-text);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 10px;
+  padding: 0.85rem 0.9rem;
+}
+
+.cs-surface h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
+}
+
+.cs-surface p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--ease-color-muted);
+}
+
+.cs-glass {
+  background: var(--ease-glass-bg, rgba(255, 255, 255, 0.4));
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.3));
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 10px;
+  padding: 0.75rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.cs-native {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.cs-native label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--ease-color-muted);
+}
+
+.cs-native input[type="text"],
+.cs-native select,
+.cs-native textarea {
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  font: inherit;
+  background: Field;
+  color: FieldText;
+}
+
+.cs-scroll {
+  max-height: 4.5rem;
+  overflow: auto;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.8rem;
+  background: var(--ease-color-surface);
+  color: var(--ease-color-text);
+}
+
+.cs-note {
+  margin: 0.65rem 0 0;
+  font-size: 0.78rem;
+  color: var(--cs-muted);
+}
+
+.cs-sandbox .cs-note {
+  color: var(--ease-color-muted);
+}
+
+.cs-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cs-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--cs-line);
+  font-size: 0.9rem;
+}
+
+.cs-check li:last-child {
+  border-bottom: none;
+}
+
+.cs-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--cs-ok);
+  margin-top: 0.1rem;
+}
+
+.cs-check-icon.is-no {
+  background: var(--cs-danger);
+}
+
+.cs-check-icon.is-warn {
+  background: var(--cs-warn);
+}
+
+.cs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.cs-list li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--cs-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.cs-list h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.cs-list p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--cs-muted);
+}
+
+.cs-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--cs-line);
+  border-radius: 12px;
+}
+
+.cs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 600px;
+}
+
+.cs-table th,
+.cs-table td {
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid var(--cs-line);
+  vertical-align: top;
+}
+
+.cs-table th {
+  background: #f8fafc;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--cs-muted);
+}
+
+.cs-table tr:last-child td {
+  border-bottom: none;
+}
+
+.cs-table code {
+  font-size: 0.78rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+.cs-reco {
+  border-left: 4px solid var(--cs-ok);
+  background: linear-gradient(135deg, #f0fdf4, #ffffff);
+}
+
+.cs-snippet-block {
+  position: relative;
+}
+
+.cs-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.cs-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.cs-copy {
+  position: absolute;
+  top: 2rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.cs-copy:hover,
+.cs-copy:focus-visible {
+  background: var(--cs-accent);
+  outline: none;
+}
+
+.cs-copy[data-copied="true"] {
+  background: var(--cs-ok);
+}
+
+.cs-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--cs-ok);
+  font-weight: 600;
+}
+
+.cs-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--cs-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--cs-muted);
+}
+
+.cs-footer strong {
+  color: var(--cs-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .cs-mode {
+    transition: none;
+  }
+}


### PR DESCRIPTION
# #46189 issue resolved

## Description

This PR adds a beginner-friendly **color-scheme: light dark Auto Token Behavior Demo** under `submissions/docs/ease-color-scheme-auto-sp/`.

It shows how `color-scheme` on `:root` affects EaseMotion surfaces and native UI without treating it as a full dark-token theme remap.

## Features

- Interactive Auto / Scheme light / Scheme dark / Full dark remap toggles
- Side-by-side lab: scheme-only vs full token remap
- Live samples for surfaces, glass, buttons, inputs, selects, checkboxes, and scrollbars
- Clear callouts: browser UA theming vs missing full dark design system
- “What changes / what doesn’t” checklist and reference table
- Copy-paste ready `color-scheme` guidance snippets
- Self-contained docs lab — open `demo.html` directly (no build step)