### PR TITLE
ease-safari-backdrop-fallback-sp

### DIFF
--- a/submissions/docs/ease-safari-backdrop-fallback-sp/README.md
+++ b/submissions/docs/ease-safari-backdrop-fallback-sp/README.md
@@ -1,0 +1,71 @@
+# Safari `-webkit-backdrop-filter` Glass Fallback Showcase
+
+An interactive documentation lab that compares glass cards **with / without** `-webkit-backdrop-filter`, lets users mimic unsupported engines (solid fallback), and aligns guidance with the README browser compatibility table for Safari.
+
+> Submission track: `submissions/docs/ease-safari-backdrop-fallback-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46191](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46191)
+
+---
+
+## What does this do?
+
+The README notes that Safari needs `-webkit-backdrop-filter` for glass effects. Static tables are easy to miss. This showcase makes the requirement visible:
+
+| Variant | CSS | Risk |
+|---------|-----|------|
+| Without prefix | `backdrop-filter` only | Fragile on Safari / older WebKit |
+| With prefix | `backdrop-filter` + `-webkit-backdrop-filter` | Safari-safe (EaseMotion glass pattern) |
+| Unsupported mimic | Filters forced off → opaque background | Documents solid `@supports` fallback |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Compare the two glass cards / nav strips on the busy background.
+3. Click **Mimic unsupported engine** to force the solid fallback.
+4. Copy the Safari-safe snippet (with `@supports` fallback).
+
+Example:
+
+```css
+.glass {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+```
+
+---
+
+## Why is it useful?
+
+- Turns a README compatibility row into a hands-on lab
+- Prevents “glass broken on Safari” reports from missing `-webkit-`
+- Freeze-safe: only new files under `submissions/docs/`
+- Matches EaseMotion’s own navbar glass dual-declaration pattern
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-safari-backdrop-fallback-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Local chrome uses `sf-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-safari-backdrop-fallback-sp/demo.html
+++ b/submissions/docs/ease-safari-backdrop-fallback-sp/demo.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Safari -webkit-backdrop-filter Glass Fallback Showcase — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Compare glass cards with and without -webkit-backdrop-filter, mimic unsupported engines, and match the README Safari browser table."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="sf-header">
+    <p class="sf-eyebrow">EaseMotion CSS · Browser Compatibility Showcase</p>
+    <h1>Safari <code>-webkit-backdrop-filter</code> Glass Fallback</h1>
+    <p class="sf-subtitle">
+      The README browser table says Safari needs
+      <code>-webkit-backdrop-filter</code> for glass effects. This lab shows cards
+      <strong>with / without</strong> the prefix, and a mimic-unsupported mode
+      for the solid fallback path.
+    </p>
+    <a
+      class="sf-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46191"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46191
+    </a>
+  </header>
+
+  <main class="sf-main">
+    <aside class="sf-callout" role="note">
+      <strong>README note:</strong>
+      Safari 9.1+ supports <code>backdrop-filter</code>
+      <em>with</em> a <code>-webkit-backdrop-filter</code> fallback.
+      EaseMotion glass (e.g. <code>ease-navbar-glass</code>) ships both on purpose.
+    </aside>
+
+    <section class="sf-card" aria-labelledby="mode-title">
+      <h2 class="sf-card-title" id="mode-title">Engine mode</h2>
+      <p>
+        On Chromium/Firefox, unprefixed blur often still works — so use
+        <strong>Mimic unsupported</strong> to force the opaque fallback everyone
+        should ship for engines without blur.
+      </p>
+      <div class="sf-controls">
+        <button type="button" class="sf-btn is-active" id="btn-normal" aria-pressed="true">
+          Normal rendering
+        </button>
+        <button type="button" class="sf-btn sf-btn-ghost" id="btn-mimic" aria-pressed="false">
+          Mimic unsupported engine
+        </button>
+        <span class="sf-mode-label" id="mode-label" data-mode="normal">
+          Mode: Normal (real blur where supported)
+        </span>
+      </div>
+    </section>
+
+    <section class="sf-card" aria-labelledby="lab-title">
+      <h2 class="sf-card-title" id="lab-title">Live glass lab</h2>
+      <p>
+        Busy background behind the cards makes blur obvious when it works — and
+        makes the solid fallback obvious when it doesn’t.
+      </p>
+
+      <div class="sf-stage">
+        <div class="sf-stage-grid">
+          <div class="sf-glass-wrap">
+            <div class="sf-glass-label">
+              Without <code>-webkit-</code>
+              <span class="sf-badge sf-badge-danger">Risky on Safari</span>
+            </div>
+            <div class="sf-glass-noid">
+              <h3>Unprefixed only</h3>
+              <p>
+                Uses <code>backdrop-filter</code> alone. Fine in many modern
+                engines — fragile for older WebKit / Safari paths.
+              </p>
+            </div>
+          </div>
+
+          <div class="sf-glass-wrap">
+            <div class="sf-glass-label">
+              With <code>-webkit-</code>
+              <span class="sf-badge sf-badge-ok">Safari-safe</span>
+            </div>
+            <div class="sf-glass-ok">
+              <h3>Prefixed + standard</h3>
+              <p>
+                Matches EaseMotion glass:
+                <code>backdrop-filter</code> and
+                <code>-webkit-backdrop-filter</code> together.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="sf-nav-row">
+          <div class="sf-nav-noid" aria-label="Navbar glass without webkit">
+            <span>Nav · no webkit</span>
+            <a href="#snippets">Snippets</a>
+          </div>
+          <div class="sf-nav-ok" aria-label="Navbar glass with webkit">
+            <span>Nav · with webkit</span>
+            <a href="#snippets">Snippets</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="sf-card" aria-labelledby="supports-title">
+      <h2 class="sf-card-title" id="supports-title">@supports solid fallback</h2>
+      <p>
+        When neither filter works, ship an opaque / translucent solid background
+        (same idea as EaseMotion’s <code>@supports not (backdrop-filter…)</code>
+        path on glass navbar).
+      </p>
+      <div
+        class="sf-fallback-demo"
+        style="
+          background-image: linear-gradient(120deg, #c7d2fe, #fbcfe8);
+          background-size: cover;
+        "
+      >
+        <strong>@supports-aware glass</strong>
+        <p style="margin: 0.35rem 0 0; font-size: 0.88rem; color: #334155;">
+          Blurs when possible; snaps to solid white ~94% when blur is unavailable.
+        </p>
+      </div>
+    </section>
+
+    <section class="sf-card" aria-labelledby="table-title">
+      <h2 class="sf-card-title" id="table-title">README browser table (glass column)</h2>
+      <div class="sf-table-wrap">
+        <table class="sf-table">
+          <thead>
+            <tr>
+              <th>Browser</th>
+              <th>Min</th>
+              <th><code>backdrop-filter</code></th>
+              <th>Notes for this lab</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Chrome</td>
+              <td>49+</td>
+              <td>Supported</td>
+              <td>Unprefixed often enough — still ship <code>-webkit-</code></td>
+            </tr>
+            <tr>
+              <td>Firefox</td>
+              <td>31+</td>
+              <td>Supported</td>
+              <td>Same: dual declaration is cheap insurance</td>
+            </tr>
+            <tr class="is-focus">
+              <td><strong>Safari</strong></td>
+              <td>9.1+</td>
+              <td>
+                Supported with
+                <code>-webkit-backdrop-filter</code> fallback
+              </td>
+              <td>This lab’s focus row — match README guidance</td>
+            </tr>
+            <tr>
+              <td>Edge</td>
+              <td>15+</td>
+              <td>Supported</td>
+              <td>Dual declaration still recommended</td>
+            </tr>
+            <tr>
+              <td>Opera</td>
+              <td>36+</td>
+              <td>Supported</td>
+              <td>Dual declaration still recommended</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="sf-card" aria-labelledby="why-title">
+      <h2 class="sf-card-title" id="why-title">Why Safari needs the prefix</h2>
+      <ul class="sf-list">
+        <li>
+          <h3>
+            WebKit shipped the prefixed name first
+            <span class="sf-badge sf-badge-info">History</span>
+          </h3>
+          <p>
+            Older Safari builds recognize
+            <code>-webkit-backdrop-filter</code> even when the unprefixed
+            property alone isn’t enough for your target matrix.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Missing prefix → “glass is broken”
+            <span class="sf-badge sf-badge-danger">Bug lookalike</span>
+          </h3>
+          <p>
+            Authors often report broken EaseMotion glass on Safari when they
+            copy only <code>backdrop-filter</code> into custom CSS.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Always pair with a solid fallback
+            <span class="sf-badge sf-badge-ok">Resilience</span>
+          </h3>
+          <p>
+            Use <code>@supports not ((backdrop-filter) or (-webkit-backdrop-filter))</code>
+            (or mimic mode above) so unsupported engines still get readable UI.
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section class="sf-card sf-reco" id="snippets" aria-labelledby="snip-title">
+      <h2 class="sf-card-title" id="snip-title">Copy-paste snippets</h2>
+
+      <div class="sf-snippet-label">
+        <span class="sf-badge sf-badge-danger">Avoid</span>
+        Unprefixed only
+      </div>
+      <div class="sf-snippet-block">
+        <pre
+          class="sf-snippet sf-snippet--bad"
+          id="snip-bad"
+          aria-label="Risky glass CSS without webkit"
+>.glass {
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(16px);
+  /* ❌ No -webkit-backdrop-filter — fragile on Safari */
+}</pre>
+        <button type="button" class="sf-copy" data-copy="snip-bad">Copy</button>
+      </div>
+
+      <div class="sf-snippet-label">
+        <span class="sf-badge sf-badge-ok">Use this</span>
+        Safari-safe + @supports fallback
+      </div>
+      <div class="sf-snippet-block">
+        <pre
+          class="sf-snippet sf-snippet--good"
+          id="snip-good"
+          aria-label="Safari-safe glass CSS"
+>.glass {
+  background: rgba(255, 255, 255, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px); /* Safari / WebKit */
+}
+
+@supports not ((backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))) {
+  .glass {
+    background: rgba(255, 255, 255, 0.94);
+    border-color: rgba(15, 23, 42, 0.12);
+  }
+}
+
+/* EaseMotion already does this pattern on .ease-navbar-glass */</pre>
+        <button type="button" class="sf-copy" data-copy="snip-good">Copy</button>
+      </div>
+      <p class="sf-status" id="copy-status" role="status" aria-live="polite"></p>
+
+      <ul class="sf-check" style="margin-top: 0.75rem;">
+        <li>
+          <span class="sf-check-icon" aria-hidden="true">✓</span>
+          <span>Always declare both <code>backdrop-filter</code> and <code>-webkit-backdrop-filter</code>.</span>
+        </li>
+        <li>
+          <span class="sf-check-icon" aria-hidden="true">✓</span>
+          <span>Provide an opaque fallback when blur isn’t supported.</span>
+        </li>
+        <li>
+          <span class="sf-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Don’t assume Chrome-looking glass means Safari is covered.</span>
+        </li>
+      </ul>
+    </section>
+
+    <aside class="sf-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-safari-backdrop-fallback-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46191"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46191</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var btnNormal = document.getElementById("btn-normal");
+      var btnMimic = document.getElementById("btn-mimic");
+      var modeLabel = document.getElementById("mode-label");
+
+      function setMimic(on) {
+        document.body.classList.toggle("is-mimic", on);
+        btnNormal.classList.toggle("is-active", !on);
+        btnMimic.classList.toggle("is-active", on);
+        btnNormal.setAttribute("aria-pressed", String(!on));
+        btnMimic.setAttribute("aria-pressed", String(on));
+        modeLabel.dataset.mode = on ? "mimic" : "normal";
+        modeLabel.textContent = on
+          ? "Mode: Mimic unsupported (solid fallback forced)"
+          : "Mode: Normal (real blur where supported)";
+      }
+
+      btnNormal.addEventListener("click", function () {
+        setMimic(false);
+      });
+      btnMimic.addEventListener("click", function () {
+        setMimic(true);
+      });
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = pre.textContent.trim();
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-safari-backdrop-fallback-sp/style.css
+++ b/submissions/docs/ease-safari-backdrop-fallback-sp/style.css
@@ -1,0 +1,607 @@
+/* ============================================================
+   Safari -webkit-backdrop-filter Glass Fallback Showcase
+   submissions/docs/ease-safari-backdrop-fallback-sp/style.css
+   ============================================================ */
+
+:root {
+  --sf-ink: #0f172a;
+  --sf-muted: #475569;
+  --sf-line: #e2e8f0;
+  --sf-surface: #ffffff;
+  --sf-page: #eef2ff;
+  --sf-accent: #4f46e5;
+  --sf-accent-soft: #e0e7ff;
+  --sf-warn: #b45309;
+  --sf-warn-soft: #ffedd5;
+  --sf-danger: #b91c1c;
+  --sf-danger-soft: #fee2e2;
+  --sf-ok: #15803d;
+  --sf-ok-soft: #dcfce7;
+  --sf-info: #1d4ed8;
+  --sf-info-soft: #dbeafe;
+  --sf-mono: "JetBrains Mono", ui-monospace, monospace;
+  --sf-radius: 14px;
+  --sf-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  --sf-glass-blur: 16px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--sf-ink);
+  background: var(--sf-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--sf-mono);
+}
+
+.sf-header {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.sf-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sf-accent);
+}
+
+.sf-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.sf-subtitle {
+  margin: 0;
+  max-width: 66ch;
+  color: var(--sf-muted);
+  font-size: 1.02rem;
+}
+
+.sf-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--sf-info-soft);
+  color: var(--sf-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.sf-issue:hover,
+.sf-issue:focus-visible {
+  outline: 2px solid var(--sf-info);
+  outline-offset: 2px;
+}
+
+.sf-main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.sf-card {
+  background: var(--sf-surface);
+  border: 1px solid var(--sf-line);
+  border-radius: var(--sf-radius);
+  box-shadow: var(--sf-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.sf-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.sf-card p {
+  margin: 0 0 0.75rem;
+  color: var(--sf-muted);
+}
+
+.sf-callout {
+  border: 1px solid var(--sf-line);
+  border-left: 4px solid var(--sf-warn);
+  border-radius: 0 var(--sf-radius) var(--sf-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.sf-callout strong {
+  color: var(--sf-warn);
+}
+
+.sf-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.sf-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--sf-accent);
+  color: #fff;
+}
+
+.sf-btn:hover {
+  background: #4338ca;
+}
+
+.sf-btn:focus-visible {
+  outline: 2px solid var(--sf-accent);
+  outline-offset: 2px;
+}
+
+.sf-btn-ghost {
+  background: #fff;
+  border-color: var(--sf-line);
+  color: var(--sf-ink);
+}
+
+.sf-btn-ghost:hover {
+  border-color: var(--sf-accent);
+  color: var(--sf-accent);
+}
+
+.sf-btn.is-active {
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.35);
+}
+
+.sf-mode-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--sf-muted);
+}
+
+.sf-mode-label[data-mode="mimic"] {
+  color: var(--sf-danger);
+}
+
+.sf-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.sf-badge-ok {
+  background: var(--sf-ok-soft);
+  color: var(--sf-ok);
+}
+
+.sf-badge-warn {
+  background: var(--sf-warn-soft);
+  color: var(--sf-warn);
+}
+
+.sf-badge-danger {
+  background: var(--sf-danger-soft);
+  color: var(--sf-danger);
+}
+
+.sf-badge-info {
+  background: var(--sf-info-soft);
+  color: var(--sf-info);
+}
+
+/* Busy background so blur is visible */
+.sf-stage {
+  position: relative;
+  border: 1px solid var(--sf-line);
+  border-radius: var(--sf-radius);
+  overflow: hidden;
+  min-height: 320px;
+  padding: 1.25rem;
+  background:
+    linear-gradient(135deg, #c7d2fe 0%, #fce7f3 40%, #bae6fd 70%, #ddd6fe 100%);
+}
+
+.sf-stage::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(244, 114, 182, 0.55), transparent 28%),
+    radial-gradient(circle at 80% 20%, rgba(56, 189, 248, 0.5), transparent 30%),
+    radial-gradient(circle at 50% 80%, rgba(129, 140, 248, 0.55), transparent 32%);
+  animation: sf-drift 12s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+
+@keyframes sf-drift {
+  from {
+    transform: translate3d(-2%, -1%, 0) scale(1);
+  }
+  to {
+    transform: translate3d(2%, 2%, 0) scale(1.05);
+  }
+}
+
+.sf-stage-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 760px) {
+  .sf-stage-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sf-glass-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.sf-glass-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--sf-ink);
+}
+
+/* Card WITHOUT -webkit- (unprefixed only) */
+.sf-glass-noid {
+  border-radius: 1rem;
+  padding: 1.1rem 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--sf-ink);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(var(--sf-glass-blur));
+  /* intentionally NO -webkit-backdrop-filter */
+  min-height: 7.5rem;
+}
+
+/* Card WITH -webkit- (Safari-safe) */
+.sf-glass-ok {
+  border-radius: 1rem;
+  padding: 1.1rem 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--sf-ink);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(var(--sf-glass-blur));
+  -webkit-backdrop-filter: blur(var(--sf-glass-blur));
+  min-height: 7.5rem;
+}
+
+.sf-glass-ok h3,
+.sf-glass-noid h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.sf-glass-ok p,
+.sf-glass-noid p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+/* Navbar-ish strip with / without prefix */
+.sf-nav-row {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 760px) {
+  .sf-nav-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sf-nav-noid,
+.sf-nav-ok {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.sf-nav-noid {
+  backdrop-filter: blur(var(--sf-glass-blur));
+}
+
+.sf-nav-ok {
+  backdrop-filter: blur(var(--sf-glass-blur));
+  -webkit-backdrop-filter: blur(var(--sf-glass-blur));
+}
+
+.sf-nav-noid a,
+.sf-nav-ok a {
+  color: #4338ca;
+  text-decoration: none;
+  font-size: 0.8rem;
+}
+
+/* Mimic unsupported engines: kill blur, use solid fallback */
+body.is-mimic .sf-glass-noid,
+body.is-mimic .sf-glass-ok,
+body.is-mimic .sf-nav-noid,
+body.is-mimic .sf-nav-ok {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  background: rgba(255, 255, 255, 0.94) !important;
+  border-color: rgba(15, 23, 42, 0.12) !important;
+}
+
+/* Real @supports fallback example (opaque glass) */
+.sf-fallback-demo {
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(var(--sf-glass-blur));
+  -webkit-backdrop-filter: blur(var(--sf-glass-blur));
+}
+
+@supports not ((backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))) {
+  .sf-fallback-demo {
+    background: rgba(255, 255, 255, 0.94);
+    border-color: rgba(15, 23, 42, 0.12);
+  }
+}
+
+.sf-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--sf-line);
+  border-radius: 12px;
+}
+
+.sf-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  min-width: 640px;
+}
+
+.sf-table th,
+.sf-table td {
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid var(--sf-line);
+  vertical-align: top;
+}
+
+.sf-table th {
+  background: #f8fafc;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--sf-muted);
+}
+
+.sf-table tr:last-child td {
+  border-bottom: none;
+}
+
+.sf-table tr.is-focus td {
+  background: #eef2ff;
+}
+
+.sf-table code {
+  font-size: 0.78rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+.sf-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.sf-list li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--sf-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.sf-list h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.sf-list p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--sf-muted);
+}
+
+.sf-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sf-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--sf-line);
+  font-size: 0.9rem;
+}
+
+.sf-check li:last-child {
+  border-bottom: none;
+}
+
+.sf-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--sf-ok);
+  margin-top: 0.1rem;
+}
+
+.sf-check-icon.is-no {
+  background: var(--sf-danger);
+}
+
+.sf-reco {
+  border-left: 4px solid var(--sf-ok);
+  background: linear-gradient(135deg, #f0fdf4, #ffffff);
+}
+
+.sf-snippet-block {
+  position: relative;
+}
+
+.sf-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.sf-snippet {
+  margin: 0 0 1rem;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.7rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.sf-snippet--bad {
+  box-shadow: inset 0 0 0 2px rgba(185, 28, 28, 0.45);
+}
+
+.sf-snippet--good {
+  box-shadow: inset 0 0 0 2px rgba(21, 128, 61, 0.45);
+}
+
+.sf-copy {
+  position: absolute;
+  top: 2rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.sf-copy:hover,
+.sf-copy:focus-visible {
+  background: var(--sf-accent);
+  outline: none;
+}
+
+.sf-copy[data-copied="true"] {
+  background: var(--sf-ok);
+}
+
+.sf-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--sf-ok);
+  font-weight: 600;
+}
+
+.sf-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--sf-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--sf-muted);
+}
+
+.sf-footer strong {
+  color: var(--sf-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .sf-stage::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
# #46191 issue resolved

## Description

This PR adds a beginner-friendly **Safari `-webkit-backdrop-filter` Glass Fallback Showcase** under `submissions/docs/ease-safari-backdrop-fallback-sp/`.

It compares glass cards with and without the WebKit prefix, lets users mimic unsupported engines, and aligns guidance with the README Safari browser table.

## Features

- Side-by-side glass cards: with / without `-webkit-backdrop-filter`
- Mimic unsupported engine mode (solid / opaque fallback)
- Live glass card and navbar-style strips on a busy background
- README browser compatibility table focus for Safari
- Copy-paste ready CSS snippets (`backdrop-filter` + `-webkit-` + `@supports` fallback)
- Plain-English explanation of why Safari needs the prefix
- Self-contained docs lab — open `demo.html` directly (no build step)