### PR TITLE
Freeze Boundary Visual Map

### DIFF
--- a/submissions/docs/ease-freeze-boundary-map-sp/README.md
+++ b/submissions/docs/ease-freeze-boundary-map-sp/README.md
@@ -1,0 +1,70 @@
+# Freeze Boundary Visual Map (What PRs May Touch)
+
+An interactive documentation map that shows a clickable repo tree where **`core/`**, **`components/`**, and **workflows/configs** are **blocked**, while **`submissions/{examples,react,scss,docs}`** are **OK** — tied to the temporary freeze notice and issue [#13244](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/13244).
+
+> Submission track: `submissions/docs/ease-freeze-boundary-map-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46192](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46192)
+
+---
+
+## What does this do?
+
+During the contribution freeze, many GSSoC beginners still PR against frozen paths and get closed without review. This map is **policy UX** — not a PR checklist generator — so contributors can answer “what may I touch?” in seconds.
+
+| Zone | Paths | Status |
+|------|-------|--------|
+| Blocked | `core/`, `components/`, `.github/workflows/`, configs, engine, live `docs/` | Do not edit |
+| OK | `submissions/examples/`, `react/`, `scss/`, `docs/` | Add your folder here |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (no build step, no CDN required).
+2. Expand / click folders in the tree.
+3. Read the reason panel and the “put your work here” path.
+4. Follow the allowed-track cards for required files.
+
+Example safe path:
+
+```text
+submissions/docs/your-feature/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Why is it useful?
+
+- Makes the freeze boundary obvious for GSSoC onboarding
+- Links to the freeze notice and integrity policy #13244
+- Freeze-safe: only new files under `submissions/docs/`
+- Different from claim simulators or checklist bots — visual policy map
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-freeze-boundary-map-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Local chrome uses `fb-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-freeze-boundary-map-sp/demo.html
+++ b/submissions/docs/ease-freeze-boundary-map-sp/demo.html
@@ -1,0 +1,491 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Freeze Boundary Visual Map — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Clickable repo tree showing which paths PRs may touch during the contribution freeze. Blocked: core, components, workflows. OK: submissions tracks."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="fb-header">
+    <p class="fb-eyebrow">EaseMotion CSS · GSSoC Policy UX</p>
+    <h1>Freeze Boundary Visual Map</h1>
+    <p class="fb-subtitle">
+      What may your PR touch right now? Click a folder in the tree.
+      <strong>Blocked</strong> paths get closed without review during the freeze.
+      <strong>OK</strong> paths live under <code>submissions/</code> only.
+    </p>
+    <div class="fb-links">
+      <a
+        class="fb-issue fb-issue--warn"
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css#readme"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Freeze notice (README)
+      </a>
+      <a
+        class="fb-issue"
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/13244"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Policy #13244
+      </a>
+      <a
+        class="fb-issue"
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46192"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Issue #46192
+      </a>
+    </div>
+  </header>
+
+  <main class="fb-main">
+    <aside class="fb-callout" role="note">
+      <strong>Not a PR checklist generator.</strong>
+      This is a policy map for the temporary freeze: put new work only under
+      <code>submissions/{examples,react,scss,docs}/</code>. Do not edit
+      <code>core/</code>, <code>components/</code>, workflows, or shared configs.
+    </aside>
+
+    <section class="fb-card" aria-labelledby="map-title">
+      <h2 class="fb-card-title" id="map-title">Clickable boundary tree</h2>
+      <p>
+        Expand nodes, select a path, and read why it is OK or blocked. Safe zones
+        open under <code>submissions/</code>.
+      </p>
+
+      <div class="fb-layout">
+        <nav class="fb-tree" aria-label="Repository freeze boundary tree">
+          <ul>
+            <li class="fb-node">
+              <button
+                type="button"
+                class="fb-node-btn"
+                data-id="root"
+                data-expandable="true"
+                aria-expanded="true"
+              >
+                <span class="fb-chevron" aria-hidden="true">▼</span>
+                <span class="fb-name">easemotion-css/</span>
+                <span class="fb-badge fb-badge-neutral">repo</span>
+              </button>
+              <ul class="fb-children">
+                <li class="fb-node">
+                  <button
+                    type="button"
+                    class="fb-node-btn is-blocked"
+                    data-id="core"
+                  >
+                    <span class="fb-chevron" aria-hidden="true">·</span>
+                    <span class="fb-name">core/</span>
+                    <span class="fb-badge fb-badge-blocked">Blocked</span>
+                  </button>
+                </li>
+                <li class="fb-node">
+                  <button
+                    type="button"
+                    class="fb-node-btn is-blocked"
+                    data-id="components"
+                  >
+                    <span class="fb-chevron" aria-hidden="true">·</span>
+                    <span class="fb-name">components/</span>
+                    <span class="fb-badge fb-badge-blocked">Blocked</span>
+                  </button>
+                </li>
+                <li class="fb-node">
+                  <button
+                    type="button"
+                    class="fb-node-btn is-blocked"
+                    data-id="workflows"
+                  >
+                    <span class="fb-chevron" aria-hidden="true">·</span>
+                    <span class="fb-name">.github/workflows/</span>
+                    <span class="fb-badge fb-badge-blocked">Blocked</span>
+                  </button>
+                </li>
+                <li class="fb-node">
+                  <button
+                    type="button"
+                    class="fb-node-btn is-blocked"
+                    data-id="configs"
+                  >
+                    <span class="fb-chevron" aria-hidden="true">·</span>
+                    <span class="fb-name">configs / package / shared</span>
+                    <span class="fb-badge fb-badge-blocked">Blocked</span>
+                  </button>
+                </li>
+                <li class="fb-node">
+                  <button
+                    type="button"
+                    class="fb-node-btn is-blocked"
+                    data-id="easemotion"
+                  >
+                    <span class="fb-chevron" aria-hidden="true">·</span>
+                    <span class="fb-name">easemotion/ (engine)</span>
+                    <span class="fb-badge fb-badge-blocked">Blocked</span>
+                  </button>
+                </li>
+                <li class="fb-node">
+                  <button
+                    type="button"
+                    class="fb-node-btn is-blocked"
+                    data-id="docs-site"
+                  >
+                    <span class="fb-chevron" aria-hidden="true">·</span>
+                    <span class="fb-name">docs/ (site)</span>
+                    <span class="fb-badge fb-badge-blocked">Blocked</span>
+                  </button>
+                </li>
+                <li class="fb-node">
+                  <button
+                    type="button"
+                    class="fb-node-btn is-ok"
+                    data-id="submissions"
+                    data-expandable="true"
+                    aria-expanded="true"
+                  >
+                    <span class="fb-chevron" aria-hidden="true">▼</span>
+                    <span class="fb-name">submissions/</span>
+                    <span class="fb-badge fb-badge-ok">OK zone</span>
+                  </button>
+                  <ul class="fb-children">
+                    <li class="fb-node">
+                      <button
+                        type="button"
+                        class="fb-node-btn is-ok"
+                        data-id="examples"
+                      >
+                        <span class="fb-chevron" aria-hidden="true">·</span>
+                        <span class="fb-name">examples/</span>
+                        <span class="fb-badge fb-badge-ok">OK</span>
+                      </button>
+                    </li>
+                    <li class="fb-node">
+                      <button
+                        type="button"
+                        class="fb-node-btn is-ok"
+                        data-id="react"
+                      >
+                        <span class="fb-chevron" aria-hidden="true">·</span>
+                        <span class="fb-name">react/</span>
+                        <span class="fb-badge fb-badge-ok">OK</span>
+                      </button>
+                    </li>
+                    <li class="fb-node">
+                      <button
+                        type="button"
+                        class="fb-node-btn is-ok"
+                        data-id="scss"
+                      >
+                        <span class="fb-chevron" aria-hidden="true">·</span>
+                        <span class="fb-name">scss/</span>
+                        <span class="fb-badge fb-badge-ok">OK</span>
+                      </button>
+                    </li>
+                    <li class="fb-node">
+                      <button
+                        type="button"
+                        class="fb-node-btn is-ok is-selected"
+                        data-id="docs-track"
+                      >
+                        <span class="fb-chevron" aria-hidden="true">·</span>
+                        <span class="fb-name">docs/</span>
+                        <span class="fb-badge fb-badge-ok">OK</span>
+                      </button>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+
+          <div class="fb-legend" aria-hidden="true">
+            <span><span class="fb-badge fb-badge-ok">OK</span> PR may add here</span>
+            <span><span class="fb-badge fb-badge-blocked">Blocked</span> freeze closed</span>
+          </div>
+        </nav>
+
+        <aside class="fb-detail" id="detail" aria-live="polite">
+          <!-- filled by JS -->
+        </aside>
+      </div>
+    </section>
+
+    <section class="fb-card" aria-labelledby="tracks-title">
+      <h2 class="fb-card-title" id="tracks-title">Put your work here</h2>
+      <div class="fb-tracks">
+        <article class="fb-track">
+          <h3>
+            Standard
+            <span class="fb-badge fb-badge-ok">OK</span>
+          </h3>
+          <p>
+            <code>submissions/examples/your-feature/</code><br />
+            Needs <code>demo.html</code> + <code>style.css</code> + <code>README.md</code>
+          </p>
+        </article>
+        <article class="fb-track">
+          <h3>
+            React
+            <span class="fb-badge fb-badge-ok">OK</span>
+          </h3>
+          <p>
+            <code>submissions/react/your-component/</code><br />
+            Needs JSX + <code>README.md</code> (optional CSS)
+          </p>
+        </article>
+        <article class="fb-track">
+          <h3>
+            SCSS
+            <span class="fb-badge fb-badge-ok">OK</span>
+          </h3>
+          <p>
+            <code>submissions/scss/your-mixin/</code><br />
+            Needs <code>_mixin.scss</code> + <code>README.md</code>
+          </p>
+        </article>
+        <article class="fb-track">
+          <h3>
+            Docs / core showcase
+            <span class="fb-badge fb-badge-ok">OK</span>
+          </h3>
+          <p>
+            <code>submissions/docs/your-feature/</code><br />
+            Needs <code>demo.html</code> + <code>style.css</code> + <code>README.md</code>
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section class="fb-card" aria-labelledby="rules-title">
+      <h2 class="fb-card-title" id="rules-title">Freeze checklist</h2>
+      <ul class="fb-check">
+        <li>
+          <span class="fb-check-icon" aria-hidden="true">✓</span>
+          <span>Add a new folder only under an allowed <code>submissions/</code> track.</span>
+        </li>
+        <li>
+          <span class="fb-check-icon" aria-hidden="true">✓</span>
+          <span>Keep PRs self-contained — don’t touch frozen framework files.</span>
+        </li>
+        <li>
+          <span class="fb-check-icon" aria-hidden="true">✓</span>
+          <span>
+            Follow integrity / quality policy
+            <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/13244" target="_blank" rel="noopener noreferrer">#13244</a>.
+          </span>
+        </li>
+        <li>
+          <span class="fb-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Do not edit <code>core/</code>, <code>components/</code>, workflows, or shared configs.</span>
+        </li>
+        <li>
+          <span class="fb-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Do not create feature folders directly under <code>submissions/</code> root.</span>
+        </li>
+      </ul>
+    </section>
+
+    <aside class="fb-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-freeze-boundary-map-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46192"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46192</a>
+      and policy
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/13244"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#13244</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var NODES = {
+        root: {
+          status: "info",
+          badge: "Repo root",
+          badgeClass: "fb-badge-neutral",
+          title: "easemotion-css/",
+          reason:
+            "Repository root. Your PR should almost never change files here during the freeze — add work under submissions/ instead.",
+          path: "Put new folders under submissions/{examples|react|scss|docs}/your-feature/",
+        },
+        core: {
+          status: "blocked",
+          badge: "Blocked",
+          badgeClass: "fb-badge-blocked",
+          title: "core/",
+          reason:
+            "Maintainer-only during the freeze. Tokens, base, animations, and utilities live here. PRs that edit core/ are closed without review.",
+          path: "Do not touch. Demo ideas → submissions/docs/ or submissions/examples/",
+        },
+        components: {
+          status: "blocked",
+          badge: "Blocked",
+          badgeClass: "fb-badge-blocked",
+          title: "components/",
+          reason:
+            "Shared component CSS (buttons, navbar, cards, …). Freeze-blocked to stop merge conflicts and overwrites.",
+          path: "Do not touch. Propose components as a self-contained submission first.",
+        },
+        workflows: {
+          status: "blocked",
+          badge: "Blocked",
+          badgeClass: "fb-badge-blocked",
+          title: ".github/workflows/",
+          reason:
+            "CI / automation. Restricted by the freeze notice and integrity policy (#13244). Not a beginner contribution target.",
+          path: "Do not touch workflows, bots, or action YAML in community PRs.",
+        },
+        configs: {
+          status: "blocked",
+          badge: "Blocked",
+          badgeClass: "fb-badge-blocked",
+          title: "Configs / package / shared framework files",
+          reason:
+            "package.json, linters, husky, root CSS entry points, and similar shared files are freeze-restricted.",
+          path: "Do not edit package.json, stylelint, prettier, or easemotion.css in submission PRs.",
+        },
+        easemotion: {
+          status: "blocked",
+          badge: "Blocked",
+          badgeClass: "fb-badge-blocked",
+          title: "easemotion/ (engine + modular CSS)",
+          reason:
+            "Motion engine and modular CSS are framework architecture. Freeze-blocked for community drive-by edits.",
+          path: "Engine ideas can be showcased under submissions/docs/ — not patched directly here.",
+        },
+        "docs-site": {
+          status: "blocked",
+          badge: "Blocked",
+          badgeClass: "fb-badge-blocked",
+          title: "docs/ (deployed documentation site)",
+          reason:
+            "The live docs site is shared framework surface. Use submissions/docs/ for educational showcases instead.",
+          path: "submissions/docs/your-feature/{demo.html,style.css,README.md}",
+        },
+        submissions: {
+          status: "ok",
+          badge: "OK zone",
+          badgeClass: "fb-badge-ok",
+          title: "submissions/",
+          reason:
+            "The only community contribution area during the freeze. Must use one of the four track folders — never invent folders at submissions/ root.",
+          path: "submissions/examples/ · submissions/react/ · submissions/scss/ · submissions/docs/",
+        },
+        examples: {
+          status: "ok",
+          badge: "OK",
+          badgeClass: "fb-badge-ok",
+          title: "submissions/examples/",
+          reason:
+            "Standard HTML/CSS track. Ship a self-contained demo the maintainer can review without changing core.",
+          path: "submissions/examples/your-feature-name/\n├── demo.html\n├── style.css\n└── README.md",
+        },
+        react: {
+          status: "ok",
+          badge: "OK",
+          badgeClass: "fb-badge-ok",
+          title: "submissions/react/",
+          reason:
+            "React integration track. Add a component folder with JSX + README (optional style.css).",
+          path: "submissions/react/your-component/\n├── YourComponent.jsx\n├── README.md\n└── style.css (optional)",
+        },
+        scss: {
+          status: "ok",
+          badge: "OK",
+          badgeClass: "fb-badge-ok",
+          title: "submissions/scss/",
+          reason:
+            "SCSS mixins / tokens track. Keep submissions as partials + README.",
+          path: "submissions/scss/your-mixin/\n├── _your-mixin.scss\n└── README.md",
+        },
+        "docs-track": {
+          status: "ok",
+          badge: "OK",
+          badgeClass: "fb-badge-ok",
+          title: "submissions/docs/",
+          reason:
+            "Docs & core-showcase track (this map belongs here). Perfect for educational labs without editing the real docs site.",
+          path: "submissions/docs/your-feature/\n├── demo.html\n├── style.css\n└── README.md",
+        },
+      };
+
+      var detail = document.getElementById("detail");
+
+      function renderDetail(id) {
+        var node = NODES[id] || NODES["docs-track"];
+        detail.innerHTML =
+          '<div class="fb-detail-status">' +
+          '<span class="fb-badge ' +
+          node.badgeClass +
+          '">' +
+          node.badge +
+          "</span>" +
+          (node.status === "blocked"
+            ? '<span class="fb-badge fb-badge-warn">Freeze</span>'
+            : "") +
+          "</div>" +
+          "<h3><code>" +
+          node.title +
+          "</code></h3>" +
+          "<p>" +
+          node.reason +
+          "</p>" +
+          '<div class="fb-path-box"><strong>Put your work here</strong>' +
+          node.path.replace(/\n/g, "<br>") +
+          "</div>";
+      }
+
+      function selectNode(btn) {
+        document.querySelectorAll(".fb-node-btn").forEach(function (el) {
+          el.classList.remove("is-selected");
+        });
+        btn.classList.add("is-selected");
+        renderDetail(btn.getAttribute("data-id"));
+      }
+
+      document.querySelectorAll(".fb-node-btn").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          if (btn.getAttribute("data-expandable") === "true") {
+            var expanded = btn.getAttribute("aria-expanded") === "true";
+            var next = !expanded;
+            btn.setAttribute("aria-expanded", String(next));
+            var chevron = btn.querySelector(".fb-chevron");
+            if (chevron) chevron.textContent = next ? "▼" : "▶";
+            var children = btn.parentElement.querySelector(":scope > .fb-children");
+            if (children) children.hidden = !next;
+          }
+          selectNode(btn);
+        });
+      });
+
+      renderDetail("docs-track");
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-freeze-boundary-map-sp/style.css
+++ b/submissions/docs/ease-freeze-boundary-map-sp/style.css
@@ -1,0 +1,457 @@
+/* ============================================================
+   Freeze Boundary Visual Map (What PRs May Touch)
+   submissions/docs/ease-freeze-boundary-map-sp/style.css
+   ============================================================ */
+
+:root {
+  --fb-ink: #0f172a;
+  --fb-muted: #475569;
+  --fb-line: #e2e8f0;
+  --fb-surface: #ffffff;
+  --fb-page: #f4f7fb;
+  --fb-accent: #0f766e;
+  --fb-accent-soft: #ccfbf1;
+  --fb-ok: #15803d;
+  --fb-ok-soft: #dcfce7;
+  --fb-danger: #b91c1c;
+  --fb-danger-soft: #fee2e2;
+  --fb-warn: #b45309;
+  --fb-warn-soft: #ffedd5;
+  --fb-info: #1d4ed8;
+  --fb-info-soft: #dbeafe;
+  --fb-mono: "JetBrains Mono", ui-monospace, monospace;
+  --fb-radius: 14px;
+  --fb-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--fb-ink);
+  background:
+    radial-gradient(ellipse 75% 45% at 8% -10%, #ccfbf1 0%, transparent 55%),
+    radial-gradient(ellipse 50% 40% at 100% 0%, #e0e7ff 0%, transparent 50%),
+    var(--fb-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--fb-mono);
+}
+
+.fb-header {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.fb-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fb-accent);
+}
+
+.fb-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.fb-subtitle {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--fb-muted);
+  font-size: 1.02rem;
+}
+
+.fb-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.fb-issue {
+  display: inline-flex;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--fb-info-soft);
+  color: var(--fb-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.fb-issue:hover,
+.fb-issue:focus-visible {
+  outline: 2px solid var(--fb-info);
+  outline-offset: 2px;
+}
+
+.fb-issue--warn {
+  background: var(--fb-warn-soft);
+  color: var(--fb-warn);
+}
+
+.fb-issue--warn:hover,
+.fb-issue--warn:focus-visible {
+  outline-color: var(--fb-warn);
+}
+
+.fb-main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.fb-card {
+  background: var(--fb-surface);
+  border: 1px solid var(--fb-line);
+  border-radius: var(--fb-radius);
+  box-shadow: var(--fb-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.fb-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.fb-card p {
+  margin: 0 0 0.75rem;
+  color: var(--fb-muted);
+}
+
+.fb-callout {
+  border: 1px solid var(--fb-line);
+  border-left: 4px solid var(--fb-warn);
+  border-radius: 0 var(--fb-radius) var(--fb-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.fb-callout strong {
+  color: var(--fb-warn);
+}
+
+.fb-layout {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (max-width: 860px) {
+  .fb-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.fb-tree {
+  border: 1px solid var(--fb-line);
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 0.85rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.fb-tree ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fb-tree ul ul {
+  margin-left: 1.05rem;
+  padding-left: 0.65rem;
+  border-left: 1px dashed #cbd5e1;
+}
+
+.fb-node {
+  margin: 0.15rem 0;
+}
+
+.fb-node-btn {
+  appearance: none;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 0.4rem 0.5rem;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.88rem;
+  cursor: pointer;
+  color: var(--fb-ink);
+}
+
+.fb-node-btn:hover {
+  background: #fff;
+  border-color: var(--fb-line);
+}
+
+.fb-node-btn:focus-visible {
+  outline: 2px solid var(--fb-accent);
+  outline-offset: 1px;
+}
+
+.fb-node-btn.is-selected {
+  background: #fff;
+  border-color: var(--fb-accent);
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.2);
+}
+
+.fb-node-btn.is-blocked.is-selected {
+  border-color: var(--fb-danger);
+  box-shadow: inset 0 0 0 1px rgba(185, 28, 28, 0.2);
+}
+
+.fb-node-btn.is-ok.is-selected {
+  border-color: var(--fb-ok);
+  box-shadow: inset 0 0 0 1px rgba(21, 128, 61, 0.2);
+}
+
+.fb-chevron {
+  width: 1rem;
+  display: inline-flex;
+  justify-content: center;
+  color: var(--fb-muted);
+  font-size: 0.7rem;
+}
+
+.fb-name {
+  font-family: var(--fb-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.fb-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.12rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.fb-badge-ok {
+  background: var(--fb-ok-soft);
+  color: var(--fb-ok);
+}
+
+.fb-badge-blocked {
+  background: var(--fb-danger-soft);
+  color: var(--fb-danger);
+}
+
+.fb-badge-info {
+  background: var(--fb-info-soft);
+  color: var(--fb-info);
+}
+
+.fb-badge-warn {
+  background: var(--fb-warn-soft);
+  color: var(--fb-warn);
+}
+
+.fb-badge-neutral {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.fb-children[hidden] {
+  display: none;
+}
+
+.fb-detail {
+  border: 1px solid var(--fb-line);
+  border-radius: 12px;
+  padding: 1rem 1.05rem;
+  background: #fff;
+  min-height: 280px;
+}
+
+.fb-detail-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.65rem;
+}
+
+.fb-detail h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1.05rem;
+  word-break: break-word;
+}
+
+.fb-detail h3 code {
+  font-size: 0.95rem;
+}
+
+.fb-detail p {
+  margin: 0 0 0.75rem;
+  color: var(--fb-muted);
+  font-size: 0.92rem;
+}
+
+.fb-path-box {
+  margin: 0.85rem 0 0;
+  padding: 0.75rem 0.85rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: var(--fb-mono);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  word-break: break-all;
+}
+
+.fb-path-box strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #94a3b8;
+  font-family: Inter, system-ui, sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fb-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+  margin-top: 0.85rem;
+  font-size: 0.85rem;
+  color: var(--fb-muted);
+}
+
+.fb-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.fb-tracks {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+@media (max-width: 700px) {
+  .fb-tracks {
+    grid-template-columns: 1fr;
+  }
+}
+
+.fb-track {
+  border: 1px solid var(--fb-line);
+  border-radius: 10px;
+  padding: 0.85rem 0.95rem;
+  background: #fff;
+}
+
+.fb-track h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.fb-track p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--fb-muted);
+}
+
+.fb-track code {
+  font-size: 0.72rem;
+  background: #f1f5f9;
+  padding: 0.08rem 0.3rem;
+  border-radius: 4px;
+}
+
+.fb-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fb-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--fb-line);
+  font-size: 0.9rem;
+}
+
+.fb-check li:last-child {
+  border-bottom: none;
+}
+
+.fb-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--fb-ok);
+  margin-top: 0.1rem;
+}
+
+.fb-check-icon.is-no {
+  background: var(--fb-danger);
+}
+
+.fb-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--fb-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--fb-muted);
+}
+
+.fb-footer strong {
+  color: var(--fb-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
# #46192 issue resolved

## Description

This PR adds a beginner-friendly **Freeze Boundary Visual Map (What PRs May Touch)** under `submissions/docs/ease-freeze-boundary-map-sp/`.

It shows a clickable repo tree with blocked vs OK paths during the contribution freeze, tied to the freeze notice and issue #13244.

## Features

- Clickable visual map of freeze boundaries
- Blocked zones: `core/`, `components/`, workflows/configs, shared framework code
- Allowed zones: `submissions/examples/`, `react/`, `scss/`, `docs/`
- Clear OK / Blocked badges with plain-English reasons
- Per-track “put your work here” path examples
- Links to the freeze notice and integrity policy #13244
- Self-contained docs lab — open `demo.html` directly (no build step)