### PR TITLE
ease-commit-squash-helper

### DIFF
--- a/submissions/docs/ease-commit-squash-helper-sp/README.md
+++ b/submissions/docs/ease-commit-squash-helper-sp/README.md
@@ -1,0 +1,65 @@
+# Conventional Commits + Squash Message Builder
+
+A documentation tool that lets contributors pick a commit type (`feat` / `fix` / `docs`) and a submission track, then generate **one** ready-to-use squash commit message — plus tips that discourage pushing many micro-commits.
+
+> Submission track: `submissions/docs/ease-commit-squash-helper-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46193](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46193)
+
+---
+
+## What does this do?
+
+EaseMotion asks contributors to squash commits and use Conventional Commits. Beginners still open PRs with 10–20 noisy micro-commits. This builder turns **type + track + summary** into a single squash-friendly message.
+
+Example output:
+
+```text
+docs(submissions/docs, freeze-map): add freeze boundary visual map
+
+Refs #46192
+```
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser (no build step).
+2. Pick a type and track.
+3. Optional: scope slug + issue number.
+4. Copy the generated squash message.
+5. Read the “don’t push 20 micro-commits” tips.
+
+---
+
+## Why is it useful?
+
+- Targets commit hygiene (README / CONTRIBUTING squash rule)
+- Different from a folder-name helper or claim simulator
+- Freeze-safe: only new files under `submissions/docs/`
+- Helps GSSoC contributors keep PR history reviewable
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-commit-squash-helper-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Local chrome uses `ch-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-commit-squash-helper-sp/demo.html
+++ b/submissions/docs/ease-commit-squash-helper-sp/demo.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Conventional Commits + Squash Message Builder — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Pick feat/fix/docs + a submissions track to generate one squash-friendly conventional commit message. Avoid micro-commit spam."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="ch-header">
+    <p class="ch-eyebrow">EaseMotion CSS · Commit Hygiene Tool</p>
+    <h1>Conventional Commits + Squash Message Builder</h1>
+    <p class="ch-subtitle">
+      Pick a type and track, write a short summary, and get
+      <strong>one</strong> squash-ready conventional commit message.
+      Not a folder-name helper — this targets the README squash rule.
+    </p>
+    <a
+      class="ch-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46193"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46193
+    </a>
+  </header>
+
+  <main class="ch-main">
+    <aside class="ch-callout" role="note">
+      <strong>CONTRIBUTING rule:</strong>
+      Squash into a single meaningful commit (or a few logical ones). Do not push
+      dozens of micro-commits like <code>fix</code>, <code>typo</code>, or
+      <code>update style.css</code>. Prefer Conventional Commits
+      (<code>feat:</code> / <code>fix:</code> / <code>docs:</code>).
+    </aside>
+
+    <section class="ch-card" aria-labelledby="builder-title">
+      <h2 class="ch-card-title" id="builder-title">Build your squash message</h2>
+
+      <div class="ch-field">
+        <span class="ch-label" id="type-label">Commit type</span>
+        <div class="ch-options" role="group" aria-labelledby="type-label">
+          <button type="button" class="ch-option is-active" data-type="feat" aria-pressed="true">feat</button>
+          <button type="button" class="ch-option" data-type="fix" aria-pressed="false">fix</button>
+          <button type="button" class="ch-option" data-type="docs" aria-pressed="false">docs</button>
+          <button type="button" class="ch-option" data-type="style" aria-pressed="false">style</button>
+          <button type="button" class="ch-option" data-type="chore" aria-pressed="false">chore</button>
+        </div>
+      </div>
+
+      <div class="ch-field">
+        <span class="ch-label" id="track-label">Submission track</span>
+        <div class="ch-options" role="group" aria-labelledby="track-label">
+          <button type="button" class="ch-option is-active" data-track="examples" aria-pressed="true">examples</button>
+          <button type="button" class="ch-option" data-track="react" aria-pressed="false">react</button>
+          <button type="button" class="ch-option" data-track="scss" aria-pressed="false">scss</button>
+          <button type="button" class="ch-option" data-track="docs" aria-pressed="false">docs</button>
+        </div>
+      </div>
+
+      <div class="ch-field">
+        <label class="ch-label" for="scope">Scope (optional)</label>
+        <input
+          class="ch-input"
+          id="scope"
+          type="text"
+          maxlength="40"
+          placeholder="e.g. hover-grow, freeze-map, button"
+          autocomplete="off"
+        />
+        <p class="ch-hint">Short folder or topic slug — becomes <code>type(scope):</code></p>
+      </div>
+
+      <div class="ch-field">
+        <label class="ch-label" for="summary">Summary</label>
+        <input
+          class="ch-input"
+          id="summary"
+          type="text"
+          maxlength="72"
+          placeholder="e.g. add bounce clip overflow showcase"
+          value="add documentation showcase"
+          autocomplete="off"
+        />
+        <p class="ch-hint">Imperative mood, lowercase, no period at the end.</p>
+      </div>
+
+      <div class="ch-field">
+        <label class="ch-label" for="issue">Issue number (optional)</label>
+        <input
+          class="ch-input"
+          id="issue"
+          type="text"
+          inputmode="numeric"
+          placeholder="e.g. 46193"
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="ch-field">
+        <span class="ch-label">Squash commit message</span>
+        <div class="ch-preview">
+          <pre class="ch-message" id="message" aria-live="polite"></pre>
+          <button type="button" class="ch-copy" id="copy-btn">Copy</button>
+        </div>
+        <p class="ch-status" id="copy-status" role="status" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <section class="ch-card" aria-labelledby="compare-title">
+      <h2 class="ch-card-title" id="compare-title">Good vs noisy history</h2>
+      <div class="ch-compare">
+        <article class="ch-example">
+          <h3>
+            <span class="ch-badge ch-badge-ok">Good</span>
+            One squash message
+          </h3>
+          <ul>
+            <li>docs(submissions): add freeze boundary map for #46192</li>
+          </ul>
+        </article>
+        <article class="ch-example">
+          <h3>
+            <span class="ch-badge ch-badge-danger">Avoid</span>
+            Micro-commit spam
+          </h3>
+          <ul>
+            <li>update</li>
+            <li>fix typo</li>
+            <li>asdf</li>
+            <li>update style.css</li>
+            <li>fix again</li>
+            <li>final</li>
+            <li>final final</li>
+            <li>…×20</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="ch-card" aria-labelledby="tips-title">
+      <h2 class="ch-card-title" id="tips-title">Don’t push 20 micro-commits</h2>
+      <ul class="ch-check">
+        <li>
+          <span class="ch-check-icon" aria-hidden="true">✓</span>
+          <span>Squash locally (or via GitHub “Squash and merge”) before review.</span>
+        </li>
+        <li>
+          <span class="ch-check-icon" aria-hidden="true">✓</span>
+          <span>Use one clear Conventional Commit that describes the whole PR.</span>
+        </li>
+        <li>
+          <span class="ch-check-icon" aria-hidden="true">✓</span>
+          <span>Include the track or folder in scope when it helps reviewers.</span>
+        </li>
+        <li>
+          <span class="ch-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Don’t leave a trail of <code>fix</code> / <code>typo</code> / <code>update</code> commits.</span>
+        </li>
+        <li>
+          <span class="ch-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Don’t treat this tool as a claim simulator or folder-name validator — commits only.</span>
+        </li>
+      </ul>
+    </section>
+
+    <aside class="ch-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-commit-squash-helper-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46193"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46193</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var type = "feat";
+      var track = "examples";
+
+      var summaryEl = document.getElementById("summary");
+      var scopeEl = document.getElementById("scope");
+      var issueEl = document.getElementById("issue");
+      var messageEl = document.getElementById("message");
+      var copyBtn = document.getElementById("copy-btn");
+      var statusEl = document.getElementById("copy-status");
+
+      function slug(value) {
+        return String(value || "")
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "");
+      }
+
+      function cleanSummary(value) {
+        var s = String(value || "")
+          .trim()
+          .replace(/\.+$/, "");
+        if (!s) s = "add documentation showcase";
+        s = s.charAt(0).toLowerCase() + s.slice(1);
+        return s;
+      }
+
+      function buildMessage() {
+        var scopeParts = [];
+        scopeParts.push("submissions/" + track);
+        var custom = slug(scopeEl.value);
+        if (custom) scopeParts.push(custom);
+        var scope = scopeParts.join(", ");
+
+        var summary = cleanSummary(summaryEl.value);
+        var issue = String(issueEl.value || "").replace(/\D/g, "");
+
+        var head = type + "(" + scope + "): " + summary;
+        if (issue) {
+          return head + "\n\nRefs #" + issue;
+        }
+        return head;
+      }
+
+      function refresh() {
+        messageEl.textContent = buildMessage();
+      }
+
+      function wireGroup(selector, attr, onPick) {
+        document.querySelectorAll(selector).forEach(function (btn) {
+          btn.addEventListener("click", function () {
+            document.querySelectorAll(selector).forEach(function (el) {
+              el.classList.remove("is-active");
+              el.setAttribute("aria-pressed", "false");
+            });
+            btn.classList.add("is-active");
+            btn.setAttribute("aria-pressed", "true");
+            onPick(btn.getAttribute(attr));
+            refresh();
+          });
+        });
+      }
+
+      wireGroup("[data-type]", "data-type", function (value) {
+        type = value;
+      });
+      wireGroup("[data-track]", "data-track", function (value) {
+        track = value;
+      });
+
+      ["input", "change"].forEach(function (evt) {
+        summaryEl.addEventListener(evt, refresh);
+        scopeEl.addEventListener(evt, refresh);
+        issueEl.addEventListener(evt, refresh);
+      });
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      copyBtn.addEventListener("click", function () {
+        var text = messageEl.textContent;
+
+        function done() {
+          copyBtn.dataset.copied = "true";
+          copyBtn.textContent = "Copied!";
+          statusEl.textContent = "Squash message copied to clipboard.";
+          window.setTimeout(function () {
+            copyBtn.dataset.copied = "false";
+            copyBtn.textContent = "Copy";
+            statusEl.textContent = "";
+          }, 1400);
+        }
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {
+            fallbackCopy(text);
+            done();
+          });
+        } else {
+          fallbackCopy(text);
+          done();
+        }
+      });
+
+      refresh();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-commit-squash-helper-sp/style.css
+++ b/submissions/docs/ease-commit-squash-helper-sp/style.css
@@ -1,0 +1,385 @@
+/* ============================================================
+   Conventional Commits + Squash Message Builder
+   submissions/docs/ease-commit-squash-helper-sp/style.css
+   ============================================================ */
+
+:root {
+  --ch-ink: #0f172a;
+  --ch-muted: #475569;
+  --ch-line: #e2e8f0;
+  --ch-surface: #ffffff;
+  --ch-page: #f5f7fb;
+  --ch-accent: #5b4dff;
+  --ch-accent-soft: #eceaff;
+  --ch-ok: #15803d;
+  --ch-ok-soft: #dcfce7;
+  --ch-danger: #b91c1c;
+  --ch-danger-soft: #fee2e2;
+  --ch-warn: #b45309;
+  --ch-warn-soft: #ffedd5;
+  --ch-info: #1d4ed8;
+  --ch-info-soft: #dbeafe;
+  --ch-mono: "JetBrains Mono", ui-monospace, monospace;
+  --ch-radius: 14px;
+  --ch-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--ch-ink);
+  background:
+    radial-gradient(ellipse 70% 45% at 5% -10%, #eceaff 0%, transparent 55%),
+    radial-gradient(ellipse 50% 35% at 100% 0%, #dbeafe 0%, transparent 50%),
+    var(--ch-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--ch-mono);
+}
+
+.ch-header {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.ch-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ch-accent);
+}
+
+.ch-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.ch-subtitle {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--ch-muted);
+  font-size: 1.02rem;
+}
+
+.ch-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--ch-info-soft);
+  color: var(--ch-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ch-issue:hover,
+.ch-issue:focus-visible {
+  outline: 2px solid var(--ch-info);
+  outline-offset: 2px;
+}
+
+.ch-main {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.ch-card {
+  background: var(--ch-surface);
+  border: 1px solid var(--ch-line);
+  border-radius: var(--ch-radius);
+  box-shadow: var(--ch-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.ch-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.ch-card p {
+  margin: 0 0 0.75rem;
+  color: var(--ch-muted);
+}
+
+.ch-callout {
+  border: 1px solid var(--ch-line);
+  border-left: 4px solid var(--ch-warn);
+  border-radius: 0 var(--ch-radius) var(--ch-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.ch-callout strong {
+  color: var(--ch-warn);
+}
+
+.ch-field {
+  margin-bottom: 1rem;
+}
+
+.ch-field:last-child {
+  margin-bottom: 0;
+}
+
+.ch-label {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ch-muted);
+}
+
+.ch-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.ch-option {
+  appearance: none;
+  border: 1px solid var(--ch-line);
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  background: #fff;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--ch-ink);
+}
+
+.ch-option.is-active {
+  border-color: var(--ch-accent);
+  background: var(--ch-accent-soft);
+  color: #4338ca;
+}
+
+.ch-option:focus-visible {
+  outline: 2px solid var(--ch-accent);
+  outline-offset: 2px;
+}
+
+.ch-input,
+.ch-textarea {
+  width: 100%;
+  border: 1px solid var(--ch-line);
+  border-radius: 10px;
+  padding: 0.65rem 0.8rem;
+  font: inherit;
+  background: #fff;
+  color: var(--ch-ink);
+}
+
+.ch-input:focus,
+.ch-textarea:focus {
+  outline: 2px solid var(--ch-accent);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.ch-hint {
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--ch-muted);
+}
+
+.ch-preview {
+  position: relative;
+  margin-top: 0.35rem;
+}
+
+.ch-message {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  padding-right: 5.5rem;
+  border-radius: 12px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 3.5rem;
+}
+
+.ch-copy {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.7rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.ch-copy:hover,
+.ch-copy:focus-visible {
+  background: var(--ch-accent);
+  outline: none;
+}
+
+.ch-copy[data-copied="true"] {
+  background: var(--ch-ok);
+}
+
+.ch-status {
+  min-height: 1.25rem;
+  margin: 0.45rem 0 0;
+  font-size: 0.8rem;
+  color: var(--ch-ok);
+  font-weight: 600;
+}
+
+.ch-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.ch-badge-ok {
+  background: var(--ch-ok-soft);
+  color: var(--ch-ok);
+}
+
+.ch-badge-danger {
+  background: var(--ch-danger-soft);
+  color: var(--ch-danger);
+}
+
+.ch-badge-warn {
+  background: var(--ch-warn-soft);
+  color: var(--ch-warn);
+}
+
+.ch-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  .ch-compare {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ch-example {
+  border: 1px solid var(--ch-line);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  background: #fff;
+}
+
+.ch-example h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ch-example ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--ch-muted);
+  font-size: 0.85rem;
+  font-family: var(--ch-mono);
+}
+
+.ch-example li {
+  margin-bottom: 0.25rem;
+}
+
+.ch-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ch-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--ch-line);
+  font-size: 0.9rem;
+}
+
+.ch-check li:last-child {
+  border-bottom: none;
+}
+
+.ch-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--ch-ok);
+  margin-top: 0.1rem;
+}
+
+.ch-check-icon.is-no {
+  background: var(--ch-danger);
+}
+
+.ch-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--ch-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--ch-muted);
+}
+
+.ch-footer strong {
+  color: var(--ch-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
# #46193 issue resolved

## Description

This PR adds a beginner-friendly **Conventional Commits + Squash Message Builder** under `submissions/docs/ease-commit-squash-helper-sp/`.

It lets contributors pick a commit type and submission track, then generate one squash-ready conventional commit message with tips to avoid micro-commit spam.

## Features

- Type picker (`feat` / `fix` / `docs` / `style` / `chore`)
- Track picker aligned with `submissions/{examples,react,scss,docs}`
- Optional scope and issue number fields
- Live preview of a single squash commit message
- Copy-to-clipboard for the generated message
- Good vs noisy commit history examples
- “Don’t push 20 micro-commits” tips tied to the CONTRIBUTING squash rule
- Self-contained docs lab — open `demo.html` directly (no build step)