### PR TITLE
ease-transform-sticky-stack

### DIFF
--- a/submissions/docs/ease-transform-sticky-stack-sp/README.md
+++ b/submissions/docs/ease-transform-sticky-stack-sp/README.md
@@ -1,0 +1,72 @@
+# Transform Animation vs Sticky / Fixed Stacking Bug
+
+A documentation showcase that reproduces how a parent with **`ease-fade-in`** (transform-based entrance) breaks a **`position: sticky`** child, explains the containing-block gotcha, and provides safe markup patterns.
+
+> Submission track: `submissions/docs/ease-transform-sticky-stack-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue [#46194](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46194)
+
+---
+
+## What does this do?
+
+Many EaseMotion entrance utilities animate with `transform`. A transformed ancestor creates a new containing block, so sticky/fixed descendants no longer stick to the viewport as beginners expect.
+
+This lab shows:
+
+| Panel | Parent | Sticky result |
+|-------|--------|---------------|
+| Broken | `ease-fade-in` + transform ancestor | Fails to pin |
+| Safe | Entrance on content child only | Sticky works |
+
+---
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Scroll the left and right panels.
+3. Click **Replay entrance** to re-run `ease-fade-in`.
+4. Copy the safe HTML structure snippet.
+
+Example safe pattern:
+
+```html
+<section>
+  <aside class="sticky-sidebar">…</aside>
+  <div class="content ease-fade-in">…</div>
+</section>
+```
+
+---
+
+## Why is it useful?
+
+- Documents a classic CSS gotcha in an EaseMotion context
+- Prevents false “sticky broken” bug reports
+- Freeze-safe: only new files under `submissions/docs/`
+- Teaches structure, not a new motion class
+
+---
+
+## Folder structure
+
+```text
+submissions/docs/ease-transform-sticky-stack-sp/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Policy notes
+
+- Does **not** modify `core/`, `components/`, workflows, or the README
+- Compatible with the contribution freeze (new submission folder only)
+- Local chrome uses `ts-*` prefixes only
+
+---
+
+## License
+
+Same as EaseMotion CSS (MIT).

--- a/submissions/docs/ease-transform-sticky-stack-sp/demo.html
+++ b/submissions/docs/ease-transform-sticky-stack-sp/demo.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Transform Animation vs Sticky / Fixed Stacking Bug — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Reproduce how ease-fade-in (transform) on a parent breaks position:sticky children, and copy safe markup patterns."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="ts-header">
+    <p class="ts-eyebrow">EaseMotion CSS · Layout + Motion Bug Showcase</p>
+    <h1>Transform Animation vs Sticky / Fixed Stacking</h1>
+    <p class="ts-subtitle">
+      A parent with <code>ease-fade-in</code> (transform-based entrance) can break a
+      <code>position: sticky</code> child. Scroll both panels — left sticks fail,
+      right works. Classic CSS gotcha, EaseMotion-shaped.
+    </p>
+    <a
+      class="ts-issue"
+      href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46194"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Issue #46194
+    </a>
+  </header>
+
+  <main class="ts-main">
+    <aside class="ts-callout" role="note">
+      <strong>Why:</strong>
+      Transformed ancestors create a new containing block. Sticky / fixed
+      positioning is then resolved against that ancestor — not the viewport — so
+      “sticky stops working” even though the class is fine in isolation.
+    </aside>
+
+    <section class="ts-card" aria-labelledby="lab-title">
+      <h2 class="ts-card-title" id="lab-title">Live scroll lab</h2>
+      <p>
+        Scroll each panel independently. The purple bar is
+        <code>position: sticky; top: 0</code>. Same sticky CSS — different parents.
+      </p>
+      <div class="ts-controls">
+        <button type="button" class="ts-btn" id="replay-fade">Replay entrance</button>
+        <button type="button" class="ts-btn ts-btn-ghost" id="scroll-both">
+          Jump both panels to top
+        </button>
+      </div>
+
+      <div class="ts-compare">
+        <!-- BROKEN -->
+        <article class="ts-panel ts-panel--broken">
+          <div class="ts-panel-head">
+            Broken
+            <span class="ts-badge ts-badge-danger">Transform parent</span>
+          </div>
+          <div class="ts-scroll" id="scroll-broken">
+            <div
+              class="ts-broken-parent ease-fade-in ts-force-transform"
+              id="broken-parent"
+            >
+              <div class="ts-block">
+                Parent has <code>ease-fade-in</code> + lingering
+                <code>transform</code>. Scroll down…
+              </div>
+              <aside class="ts-sticky">
+                Sticky sidebar / header
+                <small>Won’t stick to the viewport</small>
+              </aside>
+              <div class="ts-block">Content block A — keep scrolling.</div>
+              <div class="ts-block">Content block B — sticky should pin but fails.</div>
+              <div class="ts-block">Content block C — still scrolling under parent.</div>
+              <div class="ts-block">Content block D — same containing-block trap.</div>
+              <div class="ts-block">Content block E — end of broken runway.</div>
+              <div class="ts-spacer"></div>
+            </div>
+          </div>
+        </article>
+
+        <!-- SAFE -->
+        <article class="ts-panel ts-panel--safe">
+          <div class="ts-panel-head">
+            Safe
+            <span class="ts-badge ts-badge-ok">No transform ancestor</span>
+          </div>
+          <div class="ts-scroll" id="scroll-safe">
+            <div class="ts-safe-parent">
+              <div class="ts-block ease-fade-in ts-animated-child" id="safe-animated">
+                Entrance motion is on <em>this</em> content node — not the sticky’s
+                ancestor. Scroll down…
+              </div>
+              <aside class="ts-sticky">
+                Sticky sidebar / header
+                <small>Pins while you scroll this panel</small>
+              </aside>
+              <div class="ts-block">Content block A — sticky stays put.</div>
+              <div class="ts-block">Content block B — expected behavior.</div>
+              <div class="ts-block">Content block C — still sticky.</div>
+              <div class="ts-block">Content block D — structure is the fix.</div>
+              <div class="ts-block">Content block E — end of safe runway.</div>
+              <div class="ts-spacer"></div>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="ts-card" aria-labelledby="why-title">
+      <h2 class="ts-card-title" id="why-title">What happens</h2>
+      <ul class="ts-list">
+        <li>
+          <h3>
+            <code>ease-fade-in</code> uses <code>transform</code>
+            <span class="ts-badge ts-badge-info">Motion</span>
+          </h3>
+          <p>
+            Entrance keyframes scale/translate. With
+            <code>animation-fill-mode: both</code>, a transform often remains —
+            enough to create a containing block.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Sticky needs an untransformed scrollport chain
+            <span class="ts-badge ts-badge-danger">Gotcha</span>
+          </h3>
+          <p>
+            If any ancestor between sticky and the scroll container has a
+            transform (or filter/perspective), sticky sticks to <em>that</em>
+            box instead of scrolling with the page/panel as expected.
+          </p>
+        </li>
+        <li>
+          <h3>
+            Fixed can be affected too
+            <span class="ts-badge ts-badge-warn">Related</span>
+          </h3>
+          <p>
+            <code>position: fixed</code> is also containing-block sensitive when
+            ancestors use transform. Same rule: don’t wrap sticky/fixed chrome
+            in entrance-transformed parents.
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section class="ts-card" aria-labelledby="rules-title">
+      <h2 class="ts-card-title" id="rules-title">Do / don’t</h2>
+      <ul class="ts-check">
+        <li>
+          <span class="ts-check-icon" aria-hidden="true">✓</span>
+          <span>Animate content children — leave sticky/fixed ancestors transform-free.</span>
+        </li>
+        <li>
+          <span class="ts-check-icon" aria-hidden="true">✓</span>
+          <span>Put <code>ease-fade-in</code> / <code>ease-slide-up</code> on the section body, not the sticky shell.</span>
+        </li>
+        <li>
+          <span class="ts-check-icon" aria-hidden="true">✓</span>
+          <span>Prefer opacity-only motion on wrappers that must contain sticky UI.</span>
+        </li>
+        <li>
+          <span class="ts-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Don’t put sticky nav/sidebar inside a parent that uses transform entrance classes.</span>
+        </li>
+        <li>
+          <span class="ts-check-icon is-no" aria-hidden="true">✕</span>
+          <span>Don’t assume “sticky is broken in EaseMotion” — check containing blocks first.</span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="ts-card" aria-labelledby="snip-title">
+      <h2 class="ts-card-title" id="snip-title">Copy-paste structures</h2>
+      <div class="ts-snippet-grid">
+        <div class="ts-snippet-block">
+          <div class="ts-snippet-label">
+            <span class="ts-badge ts-badge-danger">Don’t</span>
+            Transformed parent
+          </div>
+          <pre
+            class="ts-snippet ts-snippet--bad"
+            id="snip-bad"
+            aria-label="Broken sticky structure"
+>&lt;!-- ❌ Sticky dies under transformed ancestor --&gt;
+&lt;section class="ease-fade-in"&gt;
+  &lt;aside class="sticky-sidebar"&gt;…&lt;/aside&gt;
+  &lt;div class="content"&gt;…&lt;/div&gt;
+&lt;/section&gt;</pre>
+          <button type="button" class="ts-copy" data-copy="snip-bad">Copy</button>
+        </div>
+        <div class="ts-snippet-block">
+          <div class="ts-snippet-label">
+            <span class="ts-badge ts-badge-ok">Do</span>
+            Animate the child
+          </div>
+          <pre
+            class="ts-snippet ts-snippet--good"
+            id="snip-good"
+            aria-label="Safe sticky structure"
+>&lt;!-- ✅ Sticky ancestor stays transform-free --&gt;
+&lt;section&gt;
+  &lt;aside class="sticky-sidebar"&gt;…&lt;/aside&gt;
+  &lt;div class="content ease-fade-in"&gt;…&lt;/div&gt;
+&lt;/section&gt;</pre>
+          <button type="button" class="ts-copy" data-copy="snip-good">Copy</button>
+        </div>
+      </div>
+      <p class="ts-status" id="copy-status" role="status" aria-live="polite"></p>
+    </section>
+
+    <aside class="ts-footer">
+      <strong>Submission note:</strong>
+      Freeze-safe docs showcase —
+      <code>submissions/docs/ease-transform-sticky-stack-sp/</code>.
+      Does not modify <code>core/</code>, <code>components/</code>, or README.
+      Relates to issue
+      <a
+        href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46194"
+        target="_blank"
+        rel="noopener noreferrer"
+      >#46194</a>.
+    </aside>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      var brokenParent = document.getElementById("broken-parent");
+      var safeAnimated = document.getElementById("safe-animated");
+      var scrollBroken = document.getElementById("scroll-broken");
+      var scrollSafe = document.getElementById("scroll-safe");
+
+      function replay(el) {
+        if (!el) return;
+        el.classList.remove("ease-fade-in");
+        void el.offsetWidth;
+        el.classList.add("ease-fade-in");
+      }
+
+      document.getElementById("replay-fade").addEventListener("click", function () {
+        replay(brokenParent);
+        replay(safeAnimated);
+      });
+
+      document.getElementById("scroll-both").addEventListener("click", function () {
+        if (scrollBroken) scrollBroken.scrollTop = 0;
+        if (scrollSafe) scrollSafe.scrollTop = 0;
+      });
+
+      function decodeEntities(html) {
+        var ta = document.createElement("textarea");
+        ta.innerHTML = html;
+        return ta.value;
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+        } catch (e) {
+          /* ignore */
+        }
+        document.body.removeChild(ta);
+      }
+
+      var statusEl = document.getElementById("copy-status");
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          if (!pre) return;
+          var text = decodeEntities(pre.innerHTML.trim());
+
+          function done() {
+            btn.dataset.copied = "true";
+            btn.textContent = "Copied!";
+            if (statusEl) statusEl.textContent = "Snippet copied to clipboard.";
+            window.setTimeout(function () {
+              btn.dataset.copied = "false";
+              btn.textContent = "Copy";
+              if (statusEl) statusEl.textContent = "";
+            }, 1400);
+          }
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              fallbackCopy(text);
+              done();
+            });
+          } else {
+            fallbackCopy(text);
+            done();
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-transform-sticky-stack-sp/style.css
+++ b/submissions/docs/ease-transform-sticky-stack-sp/style.css
@@ -1,0 +1,475 @@
+/* ============================================================
+   Transform Animation vs Sticky / Fixed Stacking Bug
+   submissions/docs/ease-transform-sticky-stack-sp/style.css
+   ============================================================ */
+
+:root {
+  --ts-ink: #0f172a;
+  --ts-muted: #475569;
+  --ts-line: #e2e8f0;
+  --ts-surface: #ffffff;
+  --ts-page: #f4f7fb;
+  --ts-accent: #0f766e;
+  --ts-accent-soft: #ccfbf1;
+  --ts-ok: #15803d;
+  --ts-ok-soft: #dcfce7;
+  --ts-danger: #b91c1c;
+  --ts-danger-soft: #fee2e2;
+  --ts-warn: #b45309;
+  --ts-warn-soft: #ffedd5;
+  --ts-info: #1d4ed8;
+  --ts-info-soft: #dbeafe;
+  --ts-mono: "JetBrains Mono", ui-monospace, monospace;
+  --ts-radius: 14px;
+  --ts-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--ts-ink);
+  background:
+    radial-gradient(ellipse 75% 45% at 8% -10%, #ccfbf1 0%, transparent 55%),
+    radial-gradient(ellipse 50% 40% at 100% 0%, #e0e7ff 0%, transparent 50%),
+    var(--ts-page);
+  line-height: 1.55;
+}
+
+code,
+pre {
+  font-family: var(--ts-mono);
+}
+
+.ts-header {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.25rem;
+}
+
+.ts-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ts-accent);
+}
+
+.ts-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.ts-subtitle {
+  margin: 0;
+  max-width: 66ch;
+  color: var(--ts-muted);
+  font-size: 1.02rem;
+}
+
+.ts-issue {
+  display: inline-flex;
+  margin-top: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--ts-info-soft);
+  color: var(--ts-info);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ts-issue:hover,
+.ts-issue:focus-visible {
+  outline: 2px solid var(--ts-info);
+  outline-offset: 2px;
+}
+
+.ts-main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.ts-card {
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-line);
+  border-radius: var(--ts-radius);
+  box-shadow: var(--ts-shadow);
+  padding: 1.2rem 1.25rem;
+}
+
+.ts-card-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.ts-card p {
+  margin: 0 0 0.75rem;
+  color: var(--ts-muted);
+}
+
+.ts-callout {
+  border: 1px solid var(--ts-line);
+  border-left: 4px solid var(--ts-warn);
+  border-radius: 0 var(--ts-radius) var(--ts-radius) 0;
+  background: linear-gradient(135deg, #fff7ed, #ffffff);
+  padding: 0.95rem 1.1rem;
+}
+
+.ts-callout strong {
+  color: var(--ts-warn);
+}
+
+.ts-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.ts-badge-ok {
+  background: var(--ts-ok-soft);
+  color: var(--ts-ok);
+}
+
+.ts-badge-danger {
+  background: var(--ts-danger-soft);
+  color: var(--ts-danger);
+}
+
+.ts-badge-info {
+  background: var(--ts-info-soft);
+  color: var(--ts-info);
+}
+
+.ts-badge-warn {
+  background: var(--ts-warn-soft);
+  color: var(--ts-warn);
+}
+
+.ts-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 860px) {
+  .ts-compare {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ts-panel {
+  border: 1px solid var(--ts-line);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.ts-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--ts-line);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.ts-panel--broken .ts-panel-head {
+  background: var(--ts-danger-soft);
+}
+
+.ts-panel--safe .ts-panel-head {
+  background: var(--ts-ok-soft);
+}
+
+.ts-scroll {
+  height: 360px;
+  overflow: auto;
+  background: #f8fafc;
+}
+
+.ts-spacer {
+  height: 1.25rem;
+}
+
+.ts-block {
+  margin: 0.85rem;
+  padding: 0.9rem 1rem;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid var(--ts-line);
+  font-size: 0.88rem;
+  color: var(--ts-muted);
+}
+
+.ts-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  margin: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  background: #4f46e5;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.88rem;
+  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.35);
+}
+
+.ts-sticky small {
+  display: block;
+  font-weight: 500;
+  opacity: 0.9;
+  font-size: 0.75rem;
+  margin-top: 0.15rem;
+}
+
+/* Broken parent: transform/entrance on ancestor */
+.ts-broken-parent {
+  /* ease-fade-in applied in HTML; keep fill transform alive for demo */
+}
+
+/* Force containing block even after animation for reliable repro */
+.ts-force-transform {
+  transform: scale(1);
+}
+
+.ts-safe-parent {
+  /* no transform on the sticky's ancestor */
+}
+
+.ts-animated-child {
+  /* entrance motion lives here, NOT on sticky ancestor */
+}
+
+.ts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.ts-list li {
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--ts-line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.ts-list h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.ts-list p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--ts-muted);
+}
+
+.ts-check {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ts-check li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--ts-line);
+  font-size: 0.9rem;
+}
+
+.ts-check li:last-child {
+  border-bottom: none;
+}
+
+.ts-check-icon {
+  flex-shrink: 0;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--ts-ok);
+  margin-top: 0.1rem;
+}
+
+.ts-check-icon.is-no {
+  background: var(--ts-danger);
+}
+
+.ts-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+.ts-btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--ts-accent);
+  color: #fff;
+}
+
+.ts-btn:hover {
+  background: #0d9488;
+}
+
+.ts-btn:focus-visible {
+  outline: 2px solid var(--ts-accent);
+  outline-offset: 2px;
+}
+
+.ts-btn-ghost {
+  background: #fff;
+  border-color: var(--ts-line);
+  color: var(--ts-ink);
+}
+
+.ts-snippet-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 820px) {
+  .ts-snippet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ts-snippet-block {
+  position: relative;
+}
+
+.ts-snippet-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.ts-snippet {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  padding-right: 5rem;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.7rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 9rem;
+}
+
+.ts-snippet--bad {
+  box-shadow: inset 0 0 0 2px rgba(185, 28, 28, 0.45);
+}
+
+.ts-snippet--good {
+  box-shadow: inset 0 0 0 2px rgba(21, 128, 61, 0.45);
+}
+
+.ts-copy {
+  position: absolute;
+  top: 2rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: #334155;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.ts-copy:hover,
+.ts-copy:focus-visible {
+  background: var(--ts-accent);
+  outline: none;
+}
+
+.ts-copy[data-copied="true"] {
+  background: var(--ts-ok);
+}
+
+.ts-status {
+  min-height: 1.25rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--ts-ok);
+  font-weight: 600;
+}
+
+.ts-footer {
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--ts-line);
+  background: #fff;
+  font-size: 0.85rem;
+  color: var(--ts-muted);
+}
+
+.ts-footer strong {
+  color: var(--ts-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
# #46194 issue resolved

## Description

This PR adds a beginner-friendly **Transform Animation vs Sticky / Fixed Stacking Bug** documentation showcase under `submissions/docs/ease-transform-sticky-stack-sp/`.

It reproduces how a parent with `ease-fade-in` (transform-based entrance) breaks a `position: sticky` child, explains the containing-block gotcha, and shows safe markup patterns.

## Features

- Side-by-side live scroll labs: broken vs safe sticky behavior
- Sticky child under `ease-fade-in` / transformed parent vs transform-free ancestor
- Plain-English explanation: transform → containing block → sticky fails
- Notes covering sticky and fixed stacking behavior
- Do / don’t markup patterns for entrance classes + sticky UI
- Copy-paste ready safe HTML structure snippets
- Self-contained docs lab — open `demo.html` directly (no build step)