### PR TITLE
fix(scss): correct cubic bezier easing aliases (#46211)

### DIFF
--- a/submissions/scss/issue-46211-easing-fix/README.md
+++ b/submissions/scss/issue-46211-easing-fix/README.md
@@ -1,0 +1,11 @@
+# Fix SCSS Easing Aliases (Issue #46211)
+
+This submission fixes a bug in the core SCSS architecture where `$ease-out-cubic` and `$ease-in-cubic` incorrectly resolved to the default `$ease-ease` curve instead of their respective directional curves.
+
+## What changed
+- Added `$ease-out` resolving to `cubic-bezier(0, 0, 0.2, 1)`
+- Added `$ease-in` resolving to `cubic-bezier(0.4, 0, 1, 1)`
+- Mapped `$ease-out-cubic` and `$ease-in-cubic` to these correct values.
+
+## How to integrate
+Maintainer: Please replace the contents of the core `scss/_variables.scss` file with the patched `_variables.scss` provided in this directory.

--- a/submissions/scss/issue-46211-easing-fix/_variables.scss
+++ b/submissions/scss/issue-46211-easing-fix/_variables.scss
@@ -1,0 +1,33 @@
+// ============================================
+// EaseMotion-css - SCSS Animation Tokens
+// Fixes #1116: DRY refactor of repetitive CSS
+// Fixes #46211: Resolve correct cubic easing aliases
+// ============================================
+
+// Duration tokens (matching --ease-speed-* CSS vars)
+$speed-fast:        var(--ease-speed-fast);
+$speed-medium:      var(--ease-speed-medium);
+$speed-slow:        var(--ease-speed-slow);
+
+// Alias duration tokens (backward compat)
+$duration-fast:     $speed-fast;
+$duration-normal:   $speed-medium;
+$duration-slow:     $speed-slow;
+
+// Easing curves (matching existing CSS vars)
+$ease-ease:         cubic-bezier(0.4, 0, 0.2, 1);
+$ease-out:          cubic-bezier(0, 0, 0.2, 1);
+$ease-in:           cubic-bezier(0.4, 0, 1, 1);
+$ease-bounce:       cubic-bezier(0.34, 1.56, 0.64, 1);
+$ease-in-out:       cubic-bezier(0, 0, 0.2, 1);
+$ease-ping:         cubic-bezier(0, 0, 0.2, 1);
+
+// Named easing aliases
+$ease-in-out-cubic: $ease-ease;
+$ease-out-cubic:    $ease-out;
+$ease-in-cubic:     $ease-in;
+$ease-elastic:      $ease-bounce;
+
+// Delay and fill defaults
+$delay-none: 0s;
+$fill-both: both;


### PR DESCRIPTION
## Description
Fixes #46211  - `[BUG] SCSS easing aliases $ease-in-out-cubic, $ease-out-cubic, $ease-in-cubic all resolve to identical value`

This PR fixes an architecture bug in the SCSS implementation where directional easing aliases all defaulted to `$ease-ease`.

Because core modification is currently restricted, the updated `_variables.scss` is submitted via the `submissions/scss/issue-46211-easing-fix/` path for the maintainer to manually integrate into the core SCSS folder.

### What's Changed:
- Added `$ease-out` resolving to `cubic-bezier(0, 0, 0.2, 1)`
- Added `$ease-in` resolving to `cubic-bezier(0.4, 0, 1, 1)`
- Mapped `$ease-out-cubic` and `$ease-in-cubic` to these correct values so they behave identically to their CSS custom property counterparts.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Framework core update (Maintainers only)

## Submission Track
- [ ] `submissions/examples/` (Standard HTML/CSS)
- [ ] `submissions/react/` (React Integration)
- [x] `submissions/scss/` (SCSS Integration)
- [ ] `submissions/docs/` (Core Framework Fixes & Showcases)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have placed my files in the correct `submissions/` subdirectory.
- [x] I have included all required files (`_variables.scss`, `README.md`).
- [x] My code follows the repository's naming and formatting rules.
- [x] I have tested my changes locally and they work as expected.
- [x] I have squashed my commits into a single descriptive commit.