### PR TITLE
feat: add liquid rating stars component

### DIFF
--- a/submissions/examples/liquid-rating-stars/README.md
+++ b/submissions/examples/liquid-rating-stars/README.md
@@ -1,0 +1,43 @@
+# Ease Liquid Rating Stars
+
+## Description
+A star rating component where each selected star fills with an animated liquid wave (gradient motion), rather than a flat color swap. Pure CSS — driven entirely by radio inputs, `:checked`, `:hover`, and the general sibling combinator (`~`). Zero JavaScript.
+
+## How it works
+- Stars are drawn via `clip-path: polygon(...)` on a `.star-shape` element — no icon font/SVG file needed.
+- A second layer, `.star-liquid`, shares the exact same clip-path and contains the animated wave gradient. It scales from `scaleY(0)` to `scaleY(1)` (bottom-anchored) to reveal the liquid fill.
+- The component markup is **reversed visually** (`flex-direction: row-reverse`, radios listed 5→1 in the DOM) so the CSS `~` (general sibling) selector can select "this star and all stars after it in the DOM" to mean "this star and all stars before it visually" — the standard trick for pure-CSS star ratings.
+- Hovering any star previews the fill up to that star; leaving reverts to the `:checked` selection.
+
+## Usage
+```html
+<fieldset class="ease-liquid-rating">
+  <legend class="sr-only">Rate this item</legend>
+
+  <input type="radio" name="rating" id="star5" class="star-input" value="5" />
+  <label for="star5" class="star-label" aria-label="5 stars">
+    <span class="star-shape"></span>
+    <span class="star-liquid"></span>
+  </label>
+  <!-- repeat for star4 down to star1, in that DOM order -->
+</fieldset>
+```
+Add `checked` to whichever radio represents the current/default rating.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--star-size` | `44px` | Star width/height |
+| `--liquid-color` | `#38bdf8` | Primary liquid fill color |
+| `--liquid-color-2` | `#a78bfa` | Secondary liquid highlight color |
+| `--wave-duration` | `2.2s` | Liquid wave motion cycle speed |
+| `--fill-duration` | `0.5s` | Fill/unfill transition speed |
+| `--fill-easing` | `cubic-bezier(0.34, 1.2, 0.64, 1)` | Fill timing function |
+
+## Accessibility
+Built on native radio inputs inside a `<fieldset>`/`<legend>`, so it's fully keyboard operable (arrow keys move selection) and screen-reader friendly out of the box. Each label has an `aria-label` stating the star count. Respects `prefers-reduced-motion` by disabling the wave animation and fill transitions.
+
+## Files
+- `demo.html` — live working example
+- `style.css` — component styles and liquid wave animation
+- `README.md` — this file

--- a/submissions/examples/liquid-rating-stars/demo.html
+++ b/submissions/examples/liquid-rating-stars/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Liquid Rating Stars — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0f172a;
+    }
+  </style>
+</head>
+<body>
+
+  <fieldset class="ease-liquid-rating" style="border: none; padding: 0; margin: 0;">
+    <legend style="position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0);">
+      Rate this course
+    </legend>
+
+    <input type="radio" name="rating" id="star5" class="star-input" value="5" />
+    <label for="star5" class="star-label" aria-label="5 stars">
+      <span class="star-shape"></span>
+      <span class="star-liquid"></span>
+    </label>
+
+    <input type="radio" name="rating" id="star4" class="star-input" value="4" />
+    <label for="star4" class="star-label" aria-label="4 stars">
+      <span class="star-shape"></span>
+      <span class="star-liquid"></span>
+    </label>
+
+    <input type="radio" name="rating" id="star3" class="star-input" value="3" checked />
+    <label for="star3" class="star-label" aria-label="3 stars">
+      <span class="star-shape"></span>
+      <span class="star-liquid"></span>
+    </label>
+
+    <input type="radio" name="rating" id="star2" class="star-input" value="2" />
+    <label for="star2" class="star-label" aria-label="2 stars">
+      <span class="star-shape"></span>
+      <span class="star-liquid"></span>
+    </label>
+
+    <input type="radio" name="rating" id="star1" class="star-input" value="1" />
+    <label for="star1" class="star-label" aria-label="1 star">
+      <span class="star-shape"></span>
+      <span class="star-liquid"></span>
+    </label>
+  </fieldset>
+
+</body>
+</html>

--- a/submissions/examples/liquid-rating-stars/style.css
+++ b/submissions/examples/liquid-rating-stars/style.css
@@ -1,0 +1,112 @@
+/* Ease Liquid Rating Stars — pure CSS, clip-path star shapes with animated
+   wave fill. Zero JavaScript (radio inputs drive state via :checked/:hover). */
+
+.ease-liquid-rating {
+  --star-size: 44px;
+  --star-empty: #2a2a3f;
+  --liquid-color: #38bdf8;
+  --liquid-color-2: #a78bfa;
+  --wave-duration: 2.2s;
+  --fill-duration: 0.5s;
+  --fill-easing: cubic-bezier(0.34, 1.2, 0.64, 1);
+
+  display: inline-flex;
+  flex-direction: row-reverse; /* reversed so ~ sibling selector can target "previous" stars */
+  gap: 6px;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-liquid-rating .star-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+}
+
+.ease-liquid-rating .star-label {
+  position: relative;
+  width: var(--star-size);
+  height: var(--star-size);
+  cursor: pointer;
+  display: inline-block;
+}
+
+/* the star shape itself, drawn via clip-path polygon */
+.ease-liquid-rating .star-shape {
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(
+    50% 0%, 61% 35%, 98% 35%, 68% 57%,
+    79% 91%, 50% 70%, 21% 91%, 32% 57%,
+    2% 35%, 39% 35%
+  );
+  background: var(--star-empty);
+  transition: background var(--fill-duration) ease;
+}
+
+/* liquid wave fill layer, clipped to same star shape, height animates via scaleY */
+.ease-liquid-rating .star-liquid {
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(
+    50% 0%, 61% 35%, 98% 35%, 68% 57%,
+    79% 91%, 50% 70%, 21% 91%, 32% 57%,
+    2% 35%, 39% 35%
+  );
+  overflow: hidden;
+  transform: scaleY(0);
+  transform-origin: bottom;
+  transition: transform var(--fill-duration) var(--fill-easing);
+}
+
+.ease-liquid-rating .star-liquid::before {
+  content: "";
+  position: absolute;
+  inset: -20% -20%;
+  background:
+    radial-gradient(circle at 30% 30%, var(--liquid-color-2), transparent 60%),
+    linear-gradient(180deg, var(--liquid-color), var(--liquid-color-2));
+  background-size: 200% 200%, 100% 100%;
+  animation: liquid-wave var(--wave-duration) ease-in-out infinite;
+}
+
+@keyframes liquid-wave {
+  0%, 100% { background-position: 0% 0%, 0% 0%; }
+  50%      { background-position: 100% 30%, 0% 0%; }
+}
+
+/* ---- fill logic: a star fills if it's selected, or any star at-or-before it
+   (in visual order) is selected/hovered, using the row-reverse + ~ trick ---- */
+.ease-liquid-rating .star-input:checked ~ .star-label .star-liquid,
+.ease-liquid-rating .star-input:checked ~ .star-label ~ .star-label .star-liquid {
+  transform: scaleY(1);
+}
+
+/* live hover preview */
+.ease-liquid-rating:hover .star-label:hover .star-liquid,
+.ease-liquid-rating:hover .star-label:hover ~ .star-label .star-liquid {
+  transform: scaleY(1);
+}
+
+.ease-liquid-rating .star-input:focus-visible ~ .star-label .star-shape {
+  outline: 2px solid var(--liquid-color);
+  outline-offset: 3px;
+}
+
+.ease-liquid-rating .rating-value {
+  align-self: center;
+  margin-left: 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #94a3b8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-liquid-rating .star-liquid::before {
+    animation: none;
+  }
+  .ease-liquid-rating .star-liquid,
+  .ease-liquid-rating .star-shape {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #41768

## Pull Request Description
Adds a `liquid-rating-stars` component — a star rating input where each selected star fills with an animated liquid wave gradient instead of a flat color swap. Stars are drawn with pure CSS `clip-path` polygons and driven entirely by radio inputs — zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/liquid-rating-stars-savni/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Uses `ease-*` prefixed classes (`ease-liquid-rating`)
- [x] Works without JavaScript (pure CSS)
- [x] Responsive and accessible
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A star rating component (`ease-liquid-rating`) where selecting a star fills it with an animated liquid wave gradient, with live hover preview across the star range, built entirely on native radio inputs.

**How does a developer use it?**
```html
<fieldset class="ease-liquid-rating">
  <legend class="sr-only">Rate this item</legend>

  <input type="radio" name="rating" id="star5" class="star-input" value="5" />
  <label for="star5" class="star-label" aria-label="5 stars">
    <span class="star-shape"></span>
    <span class="star-liquid"></span>
  </label>
  <!-- repeat for star4 down to star1, in that DOM order -->
</fieldset>
```

**Why does it fit EaseMotion CSS?**
Stars are rendered via `clip-path: polygon()` — no icon font or SVG file dependency — with a second identically-clipped `.star-liquid` layer that reveals via `scaleY()` and contains an animated dual-gradient wave (`@keyframes` background-position shift). Fill state is driven purely by `:checked`/`:hover` and the general sibling (`~`) combinator, using the classic reversed-DOM-order trick for CSS-only star ratings — no JavaScript at all. Every visual parameter (color, size, wave speed, easing) is exposed via CSS custom properties without touching core rules, and it respects `prefers-reduced-motion`.

**Accessibility**
Built on native `<input type="radio">` inside a `<fieldset>`/`<legend>`, so arrow-key navigation and screen reader announcement work out of the box with no custom ARIA logic needed. Each label includes a descriptive `aria-label`.

---

## Demo
- [x] Demo added (`demo.html` — pre-selected 3-star default, hover to preview other ratings)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Component markup is intentionally listed 5→1 in the DOM with `flex-direction: row-reverse` for visual ordering — this is required for the pure-CSS sibling-selector fill trick to work (selecting "all stars visually before this one" via `~`), a standard, well-established pattern for CSS-only star ratings.