### PR TITLE
Add tardigrade component

### DIFF
--- a/submissions/examples/tardigrade-as/README.md
+++ b/submissions/examples/tardigrade-as/README.md
@@ -1,0 +1,19 @@
+# Tardigrade
+
+A pure CSS and HTML tardigrade, the microscopic water bear, lumbering across a mossy droplet under the microscope.
+
+## What it shows
+
+- Eight stubby legs, each parking its own angle in a custom property so one paddle keyframe can rebuild the rotation
+- Claws drawn as three tiny radial gradients on every leg via ::after
+- A segmented cuticle from a repeating linear gradient over the plump body
+- A round scene with an inset shadow to read as a microscope field, with cells drifting through it
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/tardigrade-as/demo.html
+++ b/submissions/examples/tardigrade-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tardigrade</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="cellT ct1"></span>
+    <span class="cellT ct2"></span>
+    <span class="cellT ct3"></span>
+    <div class="tardT">
+      <span class="legT lt1"></span>
+      <span class="legT lt2"></span>
+      <span class="legT lt3"></span>
+      <span class="legT lt4"></span>
+      <span class="bodyT"></span>
+      <span class="segT"></span>
+      <span class="gutT"></span>
+      <span class="headT"></span>
+      <span class="snoutT"></span>
+      <span class="eyeT etl"></span>
+      <span class="eyeT etr"></span>
+      <span class="legT front lt5"></span>
+      <span class="legT front lt6"></span>
+      <span class="legT front lt7"></span>
+      <span class="legT front lt8"></span>
+    </div>
+    <span class="mossT mt1"></span>
+    <span class="mossT mt2"></span>
+    <span class="dropT"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tardigrade-as/style.css
+++ b/submissions/examples/tardigrade-as/style.css
@@ -1,0 +1,250 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 42% 34%, #cfe7ef, #6aa2b8 66%, #3a6f88);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  border-radius: 50%;
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 60px rgba(20, 60, 80, 0.4),
+    0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.cellT {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  background: radial-gradient(circle at 36% 32%, rgba(255, 255, 255, 0.28), transparent 70%);
+  z-index: 1;
+  animation: floatT 12s ease-in-out infinite;
+}
+
+.ct1 {
+  top: 26px;
+  left: 40px;
+  width: 84px;
+  height: 84px;
+}
+
+.ct2 {
+  bottom: 30px;
+  right: 44px;
+  width: 110px;
+  height: 110px;
+  animation-delay: 3s;
+}
+
+.ct3 {
+  top: 60px;
+  right: 70px;
+  width: 56px;
+  height: 56px;
+  animation-delay: 6s;
+}
+
+.mossT {
+  position: absolute;
+  bottom: -14px;
+  width: 70px;
+  height: 100px;
+  border-radius: 50% 50% 40% 40%;
+  background:
+    radial-gradient(circle at 30% 20%, #6fae52 0 14px, transparent 15px),
+    radial-gradient(circle at 62% 12%, #588f42 0 18px, transparent 19px),
+    radial-gradient(circle at 44% 40%, #7cbc5c 0 16px, transparent 17px),
+    linear-gradient(180deg, #4f8038, #2c4a20);
+  z-index: 7;
+}
+
+.mt1 { left: -12px; }
+
+.mt2 {
+  right: -16px;
+  width: 90px;
+  height: 84px;
+  filter: brightness(0.9);
+}
+
+.dropT {
+  position: absolute;
+  top: 34px;
+  right: 30px;
+  width: 26px;
+  height: 30px;
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  background: radial-gradient(circle at 34% 28%, rgba(255, 255, 255, 0.8), rgba(150, 210, 230, 0.4) 72%);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  z-index: 8;
+  animation: floatT 9s ease-in-out infinite;
+}
+
+.tardT {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 250px;
+  height: 130px;
+  margin-left: -125px;
+  z-index: 5;
+  animation: lumberT 4s ease-in-out infinite;
+}
+
+.bodyT {
+  position: absolute;
+  top: 24px;
+  left: 20px;
+  width: 190px;
+  height: 92px;
+  border-radius: 42% 48% 50% 46% / 54% 54% 46% 46%;
+  background: radial-gradient(circle at 32% 30%, #f2d9a8, #c79a5e 72%, #a87c40);
+  box-shadow: inset -12px -12px 26px rgba(130, 90, 40, 0.4);
+  z-index: 4;
+}
+
+.segT {
+  position: absolute;
+  top: 24px;
+  left: 20px;
+  width: 190px;
+  height: 92px;
+  border-radius: 42% 48% 50% 46% / 54% 54% 46% 46%;
+  background:
+    repeating-linear-gradient(
+      86deg,
+      rgba(150, 110, 56, 0.32) 0 2px,
+      transparent 2px 34px
+    );
+  z-index: 5;
+}
+
+.gutT {
+  position: absolute;
+  top: 52px;
+  left: 60px;
+  width: 96px;
+  height: 34px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(120, 160, 90, 0.55), transparent 72%);
+  z-index: 5;
+}
+
+.headT {
+  position: absolute;
+  top: 34px;
+  left: 186px;
+  width: 62px;
+  height: 66px;
+  border-radius: 46% 54% 50% 50% / 50% 50% 50% 50%;
+  background: radial-gradient(circle at 36% 32%, #f0d6a2, #bd925a 76%);
+  z-index: 4;
+}
+
+.snoutT {
+  position: absolute;
+  top: 58px;
+  left: 238px;
+  width: 22px;
+  height: 20px;
+  border-radius: 40% 60% 60% 40%;
+  background: radial-gradient(circle at 60% 50%, #3a2a18 0 5px, #c79a5e 6px);
+  box-shadow: inset -3px 0 4px rgba(90, 60, 24, 0.5);
+  z-index: 5;
+}
+
+.eyeT {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #4a4038, #100c08 68%);
+  box-shadow: 0 0 0 2px rgba(255, 245, 220, 0.4);
+  z-index: 6;
+}
+
+.etl {
+  top: 46px;
+  left: 214px;
+}
+
+.etr {
+  top: 62px;
+  left: 226px;
+  width: 8px;
+  height: 8px;
+}
+
+.legT {
+  position: absolute;
+  bottom: 4px;
+  width: 26px;
+  height: 44px;
+  border-radius: 12px 12px 8px 8px;
+  background: linear-gradient(180deg, #d9b071, #9a7038);
+  transform-origin: 50% 0;
+  transform: rotate(var(--lt, 0deg));
+  z-index: 3;
+  animation: paddleT 1.4s ease-in-out infinite;
+}
+
+.legT::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: 50%;
+  width: 16px;
+  height: 8px;
+  margin-left: -8px;
+  background:
+    radial-gradient(circle at 3px 2px, #3a2a18 0 2px, transparent 2px),
+    radial-gradient(circle at 8px 3px, #3a2a18 0 2px, transparent 2px),
+    radial-gradient(circle at 13px 2px, #3a2a18 0 2px, transparent 2px);
+}
+
+.legT.front {
+  background: linear-gradient(180deg, #e6c184, #b0824a);
+  z-index: 6;
+}
+
+.lt1 { left: 34px; --lt: 8deg; }
+.lt2 { left: 78px; --lt: 4deg; animation-delay: 0.35s; }
+.lt3 { left: 118px; --lt: -4deg; animation-delay: 0.7s; }
+.lt4 { left: 158px; --lt: -8deg; animation-delay: 1.05s; }
+
+.lt5 { left: 46px; --lt: 10deg; animation-delay: 0.7s; }
+.lt6 { left: 90px; --lt: 5deg; animation-delay: 1.05s; }
+.lt7 { left: 130px; --lt: -5deg; animation-delay: 0s; }
+.lt8 { left: 170px; --lt: -10deg; animation-delay: 0.35s; }
+
+@keyframes paddleT {
+  0%, 100% { transform: rotate(var(--lt, 0deg)); }
+  50% { transform: rotate(calc(var(--lt, 0deg) + 16deg)); }
+}
+
+@keyframes lumberT {
+  0%, 100% { transform: translate(0, 0) rotate(-1deg); }
+  50% { transform: translate(-8px, 3px) rotate(1deg); }
+}
+
+@keyframes floatT {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-10px, -14px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tardT,
+  .legT,
+  .cellT,
+  .dropT {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML tardigrade lumbering across a mossy droplet under the microscope.

## Details

- Eight stubby legs paddle in sequence, each keeping its own angle through a custom property so one keyframe drives them all
- Every leg ends in claws drawn as three tiny radial gradients on its ::after
- Segmented cuticle from a repeating linear gradient, with a faint gut showing through
- The scene is clipped to a circle with an inset shadow to read as a microscope field, cells drifting past
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/tardigrade-as/demo.html`
- `submissions/examples/tardigrade-as/style.css`
- `submissions/examples/tardigrade-as/README.md`

Closes #46716
