### PR TITLE
Add cassowary component

### DIFF
--- a/submissions/examples/cassowary-as/README.md
+++ b/submissions/examples/cassowary-as/README.md
@@ -1,0 +1,19 @@
+# Cassowary
+
+A pure CSS and HTML cassowary striding through the rainforest, casque high and blue neck bright.
+
+## What it shows
+
+- Glossy black plumage from a repeating conic gradient laid over the body silhouette
+- A vivid blue neck and head with a horny brown casque and twin red wattles that waggle on the peck
+- The neck, head and wattles sharing a peck keyframe so they dip together
+- Three toed feet cut from a clip-path sawtooth on each leg via ::after
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/cassowary-as/demo.html
+++ b/submissions/examples/cassowary-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cassowary</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="frondK fk1"></span>
+    <span class="frondK fk2"></span>
+    <div class="cassC">
+      <span class="bodyC"></span>
+      <span class="plumeC"></span>
+      <span class="legC lcb"></span>
+      <span class="legC lcf"></span>
+      <span class="neckC"></span>
+      <span class="wattleC"></span>
+      <div class="headC">
+        <span class="caskC"></span>
+        <span class="skullC"></span>
+        <span class="beakC"></span>
+        <span class="eyeC"></span>
+      </div>
+    </div>
+    <span class="stoneC sc1"></span>
+    <span class="stoneC sc2"></span>
+    <span class="floorC"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cassowary-as/style.css
+++ b/submissions/examples/cassowary-as/style.css
@@ -1,0 +1,275 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #2f6a4a, #17402c 66%, #0d2a1c);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.frondK {
+  position: absolute;
+  top: -20px;
+  width: 24px;
+  height: 210px;
+  background:
+    repeating-linear-gradient(
+      76deg,
+      rgba(10, 40, 20, 0.4) 0 4px,
+      transparent 4px 16px
+    ),
+    linear-gradient(180deg, #3f7a45, #1d4326);
+  border-radius: 12px 12px 0 0;
+  transform-origin: 50% 0;
+  z-index: 1;
+  animation: swayK 8s ease-in-out infinite;
+}
+
+.fk1 {
+  left: 24px;
+  transform: rotate(-8deg);
+}
+
+.fk2 {
+  right: 30px;
+  height: 170px;
+  animation-delay: 2.6s;
+}
+
+.floorC {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 46px);
+  background:
+    radial-gradient(circle at 18% 8%, #4a6a3a 0 20px, transparent 20px),
+    radial-gradient(circle at 58% 2%, #3c5730 0 24px, transparent 24px),
+    radial-gradient(circle at 90% 10%, #4a6a3a 0 18px, transparent 18px),
+    linear-gradient(180deg, #37502c, #172414);
+  z-index: 8;
+}
+
+.stoneC {
+  position: absolute;
+  bottom: 34px;
+  border-radius: 50% 50% 44% 44%;
+  background: linear-gradient(180deg, #7c7466, #45403a);
+  z-index: 7;
+}
+
+.sc1 {
+  left: 22px;
+  width: 60px;
+  height: 30px;
+}
+
+.sc2 {
+  right: 30px;
+  width: 44px;
+  height: 24px;
+}
+
+.cassC {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 230px;
+  height: 280px;
+  margin-left: -115px;
+  z-index: 6;
+  animation: strideC 5s ease-in-out infinite;
+}
+
+.bodyC {
+  position: absolute;
+  bottom: 44px;
+  left: 40px;
+  width: 168px;
+  height: 130px;
+  border-radius: 54% 50% 46% 50% / 62% 58% 42% 42%;
+  background: radial-gradient(circle at 40% 30%, #22201f, #050505 78%);
+  box-shadow: inset -14px -10px 30px rgba(0, 0, 0, 0.6);
+  z-index: 5;
+}
+
+.plumeC {
+  position: absolute;
+  bottom: 44px;
+  left: 40px;
+  width: 168px;
+  height: 130px;
+  border-radius: 54% 50% 46% 50% / 62% 58% 42% 42%;
+  background:
+    repeating-conic-gradient(
+      from 210deg at 30% 20%,
+      rgba(80, 78, 74, 0.4) 0 1.2deg,
+      transparent 1.2deg 5deg
+    );
+  z-index: 6;
+}
+
+.legC {
+  position: absolute;
+  bottom: 0;
+  width: 18px;
+  height: 92px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #4a4038, #8a7c6a 45%, #4a4038);
+  z-index: 4;
+}
+
+.legC::after {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: -8px;
+  width: 34px;
+  height: 12px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6a5c4c, #3a3128);
+  clip-path: polygon(0 0, 24% 100%, 40% 0, 60% 100%, 76% 0, 100% 100%, 100% 0);
+}
+
+.lcb {
+  left: 118px;
+  filter: brightness(0.7);
+  z-index: 3;
+  transform-origin: 50% 0;
+  animation: stepC 5s ease-in-out infinite reverse;
+}
+
+.lcf {
+  left: 84px;
+  transform-origin: 50% 0;
+  animation: stepC 5s ease-in-out infinite;
+}
+
+.neckC {
+  position: absolute;
+  bottom: 150px;
+  left: 128px;
+  width: 40px;
+  height: 96px;
+  border-radius: 44% 44% 30% 30%;
+  background: linear-gradient(90deg, #1e63b0 0 42%, #2f86d4 60%, #6a3ca8);
+  transform-origin: 50% 100%;
+  transform: rotate(-8deg);
+  z-index: 5;
+  animation: peckC 4.4s ease-in-out infinite;
+}
+
+.wattleC {
+  position: absolute;
+  bottom: 158px;
+  left: 132px;
+  width: 20px;
+  height: 44px;
+  border-radius: 10px 10px 12px 12px;
+  background: linear-gradient(180deg, #e04530, #a01c14);
+  transform-origin: 50% 0;
+  z-index: 6;
+  animation: waggleC 4.4s ease-in-out infinite;
+}
+
+.headC {
+  position: absolute;
+  bottom: 226px;
+  left: 120px;
+  width: 74px;
+  height: 68px;
+  transform-origin: 20% 100%;
+  z-index: 7;
+  animation: peckC 4.4s ease-in-out infinite;
+}
+
+.skullC {
+  position: absolute;
+  bottom: 0;
+  left: 10px;
+  width: 46px;
+  height: 42px;
+  border-radius: 50% 54% 42% 46% / 54% 54% 46% 46%;
+  background: linear-gradient(180deg, #2f8ad8, #1a5aa0);
+  z-index: 5;
+}
+
+.caskC {
+  position: absolute;
+  bottom: 30px;
+  left: 16px;
+  width: 30px;
+  height: 44px;
+  border-radius: 46% 46% 20% 20% / 70% 70% 30% 30%;
+  background: linear-gradient(90deg, #6a4a1e, #b78a3e 50%, #5a3e18);
+  z-index: 4;
+}
+
+.beakC {
+  position: absolute;
+  bottom: 6px;
+  left: 44px;
+  width: 46px;
+  height: 18px;
+  border-radius: 20% 60% 60% 20% / 40% 60% 50% 40%;
+  background: linear-gradient(180deg, #cbb072, #7c5a24);
+  clip-path: polygon(0 0, 100% 34%, 100% 66%, 0 100%);
+  z-index: 6;
+}
+
+.eyeC {
+  position: absolute;
+  bottom: 26px;
+  left: 30px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #a86a2a, #140a04 66%);
+  box-shadow: 0 0 0 2px rgba(20, 40, 70, 0.5);
+  z-index: 7;
+}
+
+@keyframes strideC {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(6px, -2px); }
+}
+
+@keyframes stepC {
+  0%, 100% { transform: rotate(7deg); }
+  50% { transform: rotate(-9deg); }
+}
+
+@keyframes peckC {
+  0%, 60%, 100% { transform: rotate(0deg); }
+  78% { transform: rotate(16deg); }
+}
+
+@keyframes waggleC {
+  0%, 60%, 100% { transform: rotate(0deg); }
+  70% { transform: rotate(-8deg); }
+  84% { transform: rotate(8deg); }
+}
+
+@keyframes swayK {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cassC,
+  .neckC,
+  .headC,
+  .wattleC,
+  .legC,
+  .frondK {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML cassowary striding through the rainforest.

## Details

- Glossy black plumage from a repeating conic gradient over the body silhouette
- Blue neck and head with a horny casque and a red wattle that waggles as the head dips
- Neck, head and wattle share a peck keyframe so they move together
- Three toed feet cut from a clip-path sawtooth on each leg via ::after, far leg stepping in reverse and dimmed for depth
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/cassowary-as/demo.html`
- `submissions/examples/cassowary-as/style.css`
- `submissions/examples/cassowary-as/README.md`

Closes #46724
