### PR TITLE
Add lithops component

### DIFF
--- a/submissions/examples/lithops-as/README.md
+++ b/submissions/examples/lithops-as/README.md
@@ -1,0 +1,19 @@
+# Lithops
+
+A pure CSS and HTML clump of lithops, the living stone plants, cracking open to push up a daisy like bloom.
+
+## What it shows
+
+- Each pair of fleshy lobes drawn as two rounded halves that rotate apart from a shared fissure
+- Mottled translucent windows on top of each lobe from stacked hard stop radial gradients via ::after
+- A ray flower built from a repeating conic gradient masked to a ring, scaling up out of the fissure on cue
+- Grit and pebbles blending the plants into the desert so they read as camouflaged stones
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/lithops-as/demo.html
+++ b/submissions/examples/lithops-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lithops</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunL"></span>
+    <div class="stoneL slA">
+      <span class="lobeL lll"></span>
+      <span class="lobeL llr"></span>
+      <span class="fissL"></span>
+      <span class="bloomL"></span>
+    </div>
+    <div class="stoneL slB">
+      <span class="lobeL lll"></span>
+      <span class="lobeL llr"></span>
+      <span class="fissL"></span>
+    </div>
+    <div class="stoneL slC">
+      <span class="lobeL lll"></span>
+      <span class="lobeL llr"></span>
+      <span class="fissL"></span>
+    </div>
+    <span class="pebL pb1"></span>
+    <span class="pebL pb2"></span>
+    <span class="pebL pb3"></span>
+    <span class="gritL"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/lithops-as/style.css
+++ b/submissions/examples/lithops-as/style.css
@@ -1,0 +1,224 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #e8cfa0, #cba86e 60%, #a2814e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.sunL {
+  position: absolute;
+  top: 14px;
+  right: 40px;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff4d4, #f7d488 60%, #eeb45a);
+  box-shadow: 0 0 54px 20px rgba(250, 210, 130, 0.4);
+  z-index: 1;
+  animation: glowL 6s ease-in-out infinite;
+}
+
+.gritL {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 132px);
+  background:
+    radial-gradient(circle at 12% 6%, rgba(255, 255, 255, 0.3) 0 5px, transparent 6px),
+    radial-gradient(circle at 30% 12%, rgba(90, 60, 30, 0.25) 0 7px, transparent 8px),
+    radial-gradient(circle at 54% 4%, rgba(255, 255, 255, 0.24) 0 6px, transparent 7px),
+    radial-gradient(circle at 74% 14%, rgba(90, 60, 30, 0.22) 0 8px, transparent 9px),
+    radial-gradient(circle at 92% 6%, rgba(255, 255, 255, 0.26) 0 5px, transparent 6px),
+    linear-gradient(180deg, #c9a86c, #8a6d42);
+  z-index: 8;
+}
+
+.pebL {
+  position: absolute;
+  bottom: 70px;
+  border-radius: 50% 50% 46% 44%;
+  background: linear-gradient(180deg, #d8c49a, #9a8258);
+  box-shadow: inset -3px -4px 6px rgba(80, 60, 30, 0.35);
+  z-index: 7;
+}
+
+.pb1 {
+  left: 26px;
+  width: 42px;
+  height: 26px;
+}
+
+.pb2 {
+  right: 40px;
+  width: 34px;
+  height: 22px;
+}
+
+.pb3 {
+  left: 96px;
+  bottom: 60px;
+  width: 26px;
+  height: 18px;
+}
+
+.stoneL {
+  position: absolute;
+  bottom: 72px;
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: breatheL 7s ease-in-out infinite;
+}
+
+.slA {
+  left: 40px;
+  width: 116px;
+  height: 96px;
+}
+
+.slB {
+  right: 44px;
+  width: 92px;
+  height: 78px;
+  z-index: 5;
+  animation-delay: 2.4s;
+}
+
+.slC {
+  left: 152px;
+  bottom: 74px;
+  width: 74px;
+  height: 64px;
+  z-index: 6;
+  animation-delay: 4.6s;
+  filter: brightness(0.96);
+}
+
+.lobeL {
+  position: absolute;
+  bottom: 0;
+  width: 50%;
+  height: 100%;
+  background: radial-gradient(circle at 50% 8%, #b7a86e, #8a9a5e 60%, #5f6a3a);
+  box-shadow: inset 0 -10px 18px rgba(50, 60, 24, 0.4);
+}
+
+.lll {
+  left: 0;
+  border-radius: 60% 20% 40% 60% / 90% 40% 60% 90%;
+  transform-origin: 100% 100%;
+  animation: partL 7s ease-in-out infinite;
+}
+
+.llr {
+  right: 0;
+  border-radius: 20% 60% 60% 40% / 40% 90% 90% 60%;
+  transform-origin: 0 100%;
+  animation: partRL 7s ease-in-out infinite;
+}
+
+.lobeL::after {
+  content: "";
+  position: absolute;
+  inset: 12% 14% 40% 14%;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 26%, rgba(60, 74, 30, 0.5) 0 4px, transparent 5px),
+    radial-gradient(circle at 58% 18%, rgba(60, 74, 30, 0.4) 0 3px, transparent 4px),
+    radial-gradient(circle at 44% 44%, rgba(60, 74, 30, 0.45) 0 4px, transparent 5px),
+    radial-gradient(circle at 70% 40%, rgba(60, 74, 30, 0.4) 0 3px, transparent 4px),
+    radial-gradient(circle at 24% 54%, rgba(60, 74, 30, 0.4) 0 3px, transparent 4px);
+}
+
+.fissL {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 5px;
+  height: 46%;
+  margin-left: -2px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, rgba(20, 26, 8, 0.7), rgba(20, 26, 8, 0.15));
+  z-index: 4;
+}
+
+.bloomL {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  width: 70px;
+  height: 70px;
+  margin-left: -35px;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      #ffffff 0 6deg,
+      #f4e4b0 6deg 12deg
+    );
+  mask-image: radial-gradient(circle, #000 0 20%, #000 24% 48%, transparent 54%);
+  border-radius: 50%;
+  transform-origin: 50% 100%;
+  transform: scale(0);
+  z-index: 6;
+  animation: openL 7s ease-in-out infinite;
+}
+
+.bloomL::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin: -10px 0 0 -10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #f7d06a, #d89a2e 76%);
+}
+
+@keyframes breatheL {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.02); }
+}
+
+@keyframes partL {
+  0%, 60%, 100% { transform: rotate(0deg); }
+  80% { transform: rotate(-7deg); }
+}
+
+@keyframes partRL {
+  0%, 60%, 100% { transform: rotate(0deg); }
+  80% { transform: rotate(7deg); }
+}
+
+@keyframes openL {
+  0%, 58%, 100% { transform: scale(0); }
+  82%, 92% { transform: scale(1); }
+}
+
+@keyframes glowL {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stoneL,
+  .lobeL,
+  .bloomL,
+  .sunL {
+    animation: none;
+  }
+
+  .bloomL {
+    transform: scale(0);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML clump of lithops cracking open to bloom.

## Details

- Each pair of fleshy lobes is two rounded halves that rotate apart from a shared fissure
- Mottled windows on the lobe tops from stacked hard stop radial gradients via ::after
- The flower is a repeating conic gradient masked to a ring, scaling up out of the fissure with a golden centre
- Grit and pebbles blend the plants into the desert so they read as camouflaged stones
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/lithops-as/demo.html`
- `submissions/examples/lithops-as/style.css`
- `submissions/examples/lithops-as/README.md`

Closes #46732
