### PR TITLE
Add planetarium component

### DIFF
--- a/submissions/examples/planetarium-as/README.md
+++ b/submissions/examples/planetarium-as/README.md
@@ -1,0 +1,19 @@
+# Planetarium
+
+A pure CSS and HTML planetarium: a star ball projector throwing a night sky across the inside of the dome.
+
+## What it shows
+
+- The projected sky drawn from two layered fields of pinpoint radial gradients that twinkle out of phase
+- A star ball projector built from stacked spheres, each dusted with its own aperture pinholes via ::after
+- A planet gliding along its orbit inside the dome, plus an occasional shooting star
+- The dome clipped to a half circle with a soft rim glow, the projector nodding below the seam
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/planetarium-as/demo.html
+++ b/submissions/examples/planetarium-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Planetarium</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="domeP">
+      <span class="starsP"></span>
+      <span class="starsP sp2"></span>
+      <div class="orbitP">
+        <span class="planetP"></span>
+      </div>
+      <span class="shootP"></span>
+      <span class="ringP"></span>
+    </div>
+    <span class="seamP"></span>
+    <div class="projP">
+      <span class="ballP pbT"></span>
+      <span class="ballP pbM"></span>
+      <span class="ballP pbB"></span>
+      <span class="beamP beA"></span>
+      <span class="beamP beB"></span>
+      <span class="standP"></span>
+    </div>
+    <span class="floorP"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/planetarium-as/style.css
+++ b/submissions/examples/planetarium-as/style.css
@@ -1,0 +1,279 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #241f38, #0a0812 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 330px;
+}
+
+.domeP {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 300px;
+  height: 300px;
+  margin-left: -150px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 40%, #12122a, #05060f 76%);
+  box-shadow:
+    inset 0 10px 40px rgba(80, 90, 160, 0.24),
+    inset 0 -6px 20px rgba(0, 0, 0, 0.6);
+  clip-path: polygon(-10% 0, 110% 0, 110% 74%, -10% 74%);
+  z-index: 3;
+}
+
+.starsP {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 12% 20%, #fff 0 1.4px, transparent 2px),
+    radial-gradient(circle at 28% 46%, #cfe0ff 0 1.8px, transparent 2.4px),
+    radial-gradient(circle at 44% 16%, #fff 0 1.2px, transparent 1.8px),
+    radial-gradient(circle at 60% 40%, #fff4d0 0 2px, transparent 2.6px),
+    radial-gradient(circle at 74% 22%, #fff 0 1.4px, transparent 2px),
+    radial-gradient(circle at 86% 44%, #cfe0ff 0 1.6px, transparent 2.2px),
+    radial-gradient(circle at 20% 62%, #fff 0 1.6px, transparent 2.2px),
+    radial-gradient(circle at 52% 62%, #fff 0 1.2px, transparent 1.8px),
+    radial-gradient(circle at 80% 60%, #fff4d0 0 1.8px, transparent 2.4px),
+    radial-gradient(circle at 36% 70%, #fff 0 1.4px, transparent 2px);
+  z-index: 4;
+  animation: twinkleP 4s ease-in-out infinite;
+}
+
+.sp2 {
+  background:
+    radial-gradient(circle at 18% 34%, #fff 0 1.2px, transparent 1.8px),
+    radial-gradient(circle at 40% 54%, #fff 0 1.6px, transparent 2.2px),
+    radial-gradient(circle at 66% 30%, #cfe0ff 0 1.4px, transparent 2px),
+    radial-gradient(circle at 90% 52%, #fff 0 1.2px, transparent 1.8px),
+    radial-gradient(circle at 8% 50%, #fff4d0 0 1.6px, transparent 2.2px),
+    radial-gradient(circle at 56% 20%, #fff 0 1.4px, transparent 2px);
+  animation-delay: 2s;
+  animation-direction: reverse;
+}
+
+.orbitP {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 150px;
+  height: 150px;
+  margin-left: -75px;
+  z-index: 5;
+  animation: spinP 14s linear infinite;
+}
+
+.planetP {
+  position: absolute;
+  top: -5px;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffd27a, #d87a2e 76%);
+  box-shadow: 0 0 8px 2px rgba(255, 200, 120, 0.6);
+}
+
+.shootP {
+  position: absolute;
+  top: 30px;
+  left: 40px;
+  width: 70px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, transparent, #fff);
+  transform: rotate(24deg);
+  opacity: 0;
+  z-index: 5;
+  animation: shootP 7s ease-in infinite;
+}
+
+.ringP {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 220px;
+  height: 220px;
+  margin-left: -110px;
+  border-radius: 50%;
+  border: 1px dashed rgba(150, 170, 240, 0.25);
+  z-index: 4;
+}
+
+.seamP {
+  position: absolute;
+  top: 226px;
+  left: 50%;
+  width: 306px;
+  height: 12px;
+  margin-left: -153px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #3a3f5a, #1a1c2c);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+  z-index: 6;
+}
+
+.floorP {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 78px);
+  background:
+    radial-gradient(ellipse 140px 30px at 50% 0, rgba(90, 100, 160, 0.28), transparent 70%),
+    linear-gradient(180deg, #1a1b28, #0a0a12);
+  z-index: 5;
+}
+
+.projP {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 90px;
+  height: 130px;
+  margin-left: -45px;
+  z-index: 7;
+  animation: nodP 12s ease-in-out infinite;
+}
+
+.ballP {
+  position: absolute;
+  left: 50%;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 26%, #6a7290, #1c2030 74%);
+  box-shadow: inset -4px -4px 10px rgba(0, 0, 0, 0.6);
+  z-index: 6;
+}
+
+.ballP::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 30%, #ffe9a0 0 1.4px, transparent 2px),
+    radial-gradient(circle at 62% 24%, #ffe9a0 0 1.2px, transparent 1.8px),
+    radial-gradient(circle at 44% 54%, #ffe9a0 0 1.4px, transparent 2px),
+    radial-gradient(circle at 72% 62%, #ffe9a0 0 1.2px, transparent 1.8px),
+    radial-gradient(circle at 24% 68%, #ffe9a0 0 1.2px, transparent 1.8px);
+}
+
+.pbT {
+  top: 0;
+  width: 40px;
+  height: 40px;
+  margin-left: -20px;
+}
+
+.pbM {
+  top: 30px;
+  width: 30px;
+  height: 30px;
+  margin-left: -15px;
+  z-index: 5;
+}
+
+.pbB {
+  top: 54px;
+  width: 46px;
+  height: 46px;
+  margin-left: -23px;
+  z-index: 4;
+}
+
+.beamP {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  width: 150px;
+  height: 60px;
+  background: linear-gradient(90deg, rgba(180, 200, 255, 0.28), transparent 76%);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: flickerP 5s ease-in-out infinite;
+}
+
+.beA {
+  transform: rotate(-150deg);
+}
+
+.beB {
+  transform: rotate(-30deg) scaleY(-1);
+  animation-delay: 1.5s;
+}
+
+.standP {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 16px;
+  height: 40px;
+  margin-left: -8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #2a2e40, #545c78 45%, #22262f);
+  z-index: 3;
+}
+
+.standP::after {
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  left: 50%;
+  width: 60px;
+  height: 12px;
+  margin-left: -30px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 30%, #3a3f52, #16181f 76%);
+}
+
+@keyframes spinP {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes twinkleP {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+@keyframes shootP {
+  0%, 84%, 100% { opacity: 0; transform: rotate(24deg) translateX(0); }
+  88% { opacity: 1; }
+  96% { opacity: 0; transform: rotate(24deg) translateX(120px); }
+}
+
+@keyframes nodP {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes flickerP {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .starsP,
+  .orbitP,
+  .shootP,
+  .projP,
+  .beamP {
+    animation: none;
+  }
+
+  .shootP {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML planetarium projecting a night sky onto its dome.

## Details

- The projected sky is two layered fields of pinpoint radial gradients twinkling out of phase
- The star ball projector is stacked spheres, each dusted with aperture pinholes via ::after, with faint beams fanning up to the dome
- A planet glides along its orbit inside the dome and a shooting star streaks past now and then
- The dome is clipped to a half circle with a soft rim glow, the projector nodding below the seam
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/planetarium-as/demo.html`
- `submissions/examples/planetarium-as/style.css`
- `submissions/examples/planetarium-as/README.md`

Closes #46754
