### PR TITLE
Add quetzal component

### DIFF
--- a/submissions/examples/quetzal-as/README.md
+++ b/submissions/examples/quetzal-as/README.md
@@ -1,0 +1,19 @@
+# Quetzal
+
+A pure CSS and HTML resplendent quetzal perched in the cloud forest, its two long emerald tail streamers trailing and swaying below the branch.
+
+## What it shows
+
+- The two famous tail streamers as long rounded bars with a repeating linear gradient sheen, swaying out of phase
+- A spiky green crest from a repeating conic gradient masked to a fan
+- Iridescent wing coverts textured with a diagonal repeating linear gradient over an emerald base
+- A crimson belly and gold beak set against a drifting bank of cloud forest mist
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/quetzal-as/demo.html
+++ b/submissions/examples/quetzal-as/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quetzal</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="mistQ"></span>
+    <div class="quetzalQ">
+      <span class="streamerQ sqA"></span>
+      <span class="streamerQ sqB"></span>
+      <span class="covertQ"></span>
+      <span class="wingQ"></span>
+      <span class="bellyQ"></span>
+      <span class="backQ"></span>
+      <span class="crestQ"></span>
+      <span class="headQ"></span>
+      <span class="beakQ"></span>
+      <span class="eyeQ"></span>
+      <span class="footQ"></span>
+    </div>
+    <span class="branchQ"></span>
+    <span class="leafQ lq1"></span>
+    <span class="leafQ lq2"></span>
+    <span class="canopyQ"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/quetzal-as/style.css
+++ b/submissions/examples/quetzal-as/style.css
@@ -1,0 +1,294 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #b7d8d0, #7fb0a6 56%, #4f8478);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.mistQ {
+  position: absolute;
+  top: 40px;
+  left: -40px;
+  width: 240px;
+  height: 120px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 255, 255, 0.4), transparent 68%);
+  z-index: 1;
+  animation: driftMistQ 16s ease-in-out infinite;
+}
+
+.canopyQ {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 40px);
+  background:
+    radial-gradient(circle at 16% 10%, #3f6a44 0 24px, transparent 24px),
+    radial-gradient(circle at 54% 2%, #34583a 0 28px, transparent 28px),
+    radial-gradient(circle at 88% 10%, #3f6a44 0 20px, transparent 20px),
+    linear-gradient(180deg, #315431, #16281a);
+  z-index: 8;
+}
+
+.branchQ {
+  position: absolute;
+  bottom: 74px;
+  left: -50vw;
+  right: -50vw;
+  height: 22px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(30, 18, 8, 0.3) 0 3px,
+      transparent 3px 22px
+    ),
+    linear-gradient(180deg, #6a4a2c, #341f10);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+  z-index: 7;
+}
+
+.leafQ {
+  position: absolute;
+  width: 50px;
+  height: 20px;
+  border-radius: 60% 8% 60% 8%;
+  background: linear-gradient(100deg, #55923a, #2c521c);
+  transform-origin: 0 50%;
+  z-index: 6;
+  animation: nodQ 7s ease-in-out infinite;
+}
+
+.lq1 { top: 28px; right: 34px; }
+
+.lq2 {
+  top: 68px;
+  right: 82px;
+  width: 38px;
+  transform: scaleX(-1);
+  animation-delay: 2.6s;
+}
+
+.quetzalQ {
+  position: absolute;
+  bottom: 84px;
+  left: 50%;
+  width: 180px;
+  height: 250px;
+  margin-left: -70px;
+  z-index: 6;
+  animation: perchQ 5s ease-in-out infinite;
+}
+
+.streamerQ {
+  position: absolute;
+  top: 78px;
+  left: 34px;
+  width: 26px;
+  height: 210px;
+  border-radius: 0 0 60% 40%;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.16) 0 8px,
+      transparent 8px 22px
+    ),
+    linear-gradient(180deg, #1f9f6a, #12855a 60%, #0e6f4a);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: swayQ 5s ease-in-out infinite;
+}
+
+.sqA {
+  margin-left: -4px;
+  transform: rotate(4deg);
+}
+
+.sqB {
+  margin-left: 6px;
+  height: 232px;
+  animation-delay: 0.6s;
+
+  --sq: -3deg;
+
+  transform: rotate(-3deg);
+}
+
+.backQ {
+  position: absolute;
+  top: 60px;
+  left: 24px;
+  width: 74px;
+  height: 120px;
+  border-radius: 50% 44% 40% 46% / 40% 40% 60% 56%;
+  background:
+    linear-gradient(150deg, #2fd39a, #14875a 62%, #0d5f42);
+  box-shadow: inset -8px -6px 18px rgba(6, 60, 40, 0.4);
+  z-index: 4;
+}
+
+.covertQ {
+  position: absolute;
+  top: 96px;
+  left: 8px;
+  width: 96px;
+  height: 120px;
+  border-radius: 50% 20% 46% 60% / 40% 30% 70% 60%;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(255, 255, 255, 0.14) 0 4px,
+      transparent 4px 13px
+    ),
+    linear-gradient(160deg, #34c78e, #0f6f4c);
+  transform-origin: 80% 10%;
+  z-index: 4;
+  animation: ruffleQ 5s ease-in-out infinite;
+}
+
+.wingQ {
+  position: absolute;
+  top: 80px;
+  left: 58px;
+  width: 52px;
+  height: 96px;
+  border-radius: 46% 54% 50% 40% / 60% 50% 50% 40%;
+  background: linear-gradient(160deg, #189a6a, #0a5a3e);
+  box-shadow: inset 0 -6px 12px rgba(6, 50, 34, 0.4);
+  z-index: 5;
+}
+
+.bellyQ {
+  position: absolute;
+  top: 118px;
+  left: 60px;
+  width: 46px;
+  height: 78px;
+  border-radius: 40% 50% 50% 46% / 50% 40% 60% 60%;
+  background: linear-gradient(180deg, #e0453a, #a01f18);
+  box-shadow: inset -4px -4px 10px rgba(90, 12, 8, 0.4);
+  z-index: 5;
+}
+
+.headQ {
+  position: absolute;
+  top: 34px;
+  left: 30px;
+  width: 66px;
+  height: 62px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 34%, #35d69a, #12855a 78%);
+  z-index: 5;
+}
+
+.crestQ {
+  position: absolute;
+  top: 12px;
+  left: 34px;
+  width: 58px;
+  height: 34px;
+  background:
+    repeating-conic-gradient(
+      from 240deg at 50% 100%,
+      #2fd39a 0 5deg,
+      #14875a 5deg 10deg
+    );
+  mask-image: radial-gradient(ellipse 70% 100% at 50% 100%, #000 0 74%, transparent 82%);
+  transform-origin: 50% 100%;
+  z-index: 4;
+  animation: bristleQ 5s ease-in-out infinite;
+}
+
+.beakQ {
+  position: absolute;
+  top: 62px;
+  left: 20px;
+  width: 22px;
+  height: 16px;
+  border-radius: 50% 20% 30% 60%;
+  background: linear-gradient(180deg, #f4d264, #b8860f);
+  clip-path: polygon(0 40%, 100% 0, 100% 100%, 0 90%);
+  z-index: 6;
+}
+
+.eyeQ {
+  position: absolute;
+  top: 54px;
+  left: 44px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #3a3a30, #0c0c08 66%);
+  box-shadow: 0 0 0 2px rgba(240, 250, 240, 0.4);
+  z-index: 7;
+  animation: blinkQ 5.5s ease-in-out infinite;
+}
+
+.footQ {
+  position: absolute;
+  bottom: -6px;
+  left: 60px;
+  width: 26px;
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6a5238, #34261a);
+  clip-path: polygon(0 0, 24% 100%, 44% 0, 64% 100%, 84% 0, 100% 100%, 100% 0);
+  z-index: 6;
+}
+
+@keyframes perchQ {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  50% { transform: translate(0, -3px) rotate(-1deg); }
+}
+
+@keyframes swayQ {
+  0%, 100% { transform: rotate(4deg); }
+  50% { transform: rotate(-3deg); }
+}
+
+@keyframes ruffleQ {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-2deg); }
+}
+
+@keyframes bristleQ {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.08); }
+}
+
+@keyframes blinkQ {
+  0%, 92%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes nodQ {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes driftMistQ {
+  0%, 100% { transform: translateX(0); opacity: 0.7; }
+  50% { transform: translateX(40px); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quetzalQ,
+  .streamerQ,
+  .covertQ,
+  .crestQ,
+  .eyeQ,
+  .leafQ,
+  .mistQ {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML resplendent quetzal perched in the cloud forest.

## Details

- The two long tail streamers are rounded bars with a repeating linear gradient sheen, trailing past the branch and swaying out of phase
- A spiky crest from a repeating conic gradient masked to a fan
- Iridescent wing coverts from a diagonal repeating linear gradient over an emerald base
- Crimson belly, gold beak and a drifting bank of cloud forest mist
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/quetzal-as/demo.html`
- `submissions/examples/quetzal-as/style.css`
- `submissions/examples/quetzal-as/README.md`

Closes #46761
