### PR TITLE
Add hoopoe component

### DIFF
--- a/submissions/examples/hoopoe-as/README.md
+++ b/submissions/examples/hoopoe-as/README.md
@@ -1,0 +1,19 @@
+# Hoopoe
+
+A pure CSS and HTML hoopoe on the ground, raising and fanning its crown of tipped feathers as it pecks for a worm.
+
+## What it shows
+
+- A fan crest of five feathers, each parking its own angle in a custom property and tipped black with a shared linear gradient, opening and closing on a scale keyframe
+- Barred wings and tail from a two colour repeating linear gradient
+- The head, curved bill and eye all pecking down together on one timing, snatching a worm that shrinks away
+- A striped ground and warm sun behind
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/hoopoe-as/demo.html
+++ b/submissions/examples/hoopoe-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hoopoe</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunH"></span>
+    <div class="hoopoeH">
+      <div class="crestH">
+        <span class="crFeather cf1"></span>
+        <span class="crFeather cf2"></span>
+        <span class="crFeather cf3"></span>
+        <span class="crFeather cf4"></span>
+        <span class="crFeather cf5"></span>
+      </div>
+      <span class="tailH"></span>
+      <span class="wingH"></span>
+      <span class="bodyH"></span>
+      <span class="legH lhb"></span>
+      <span class="legH lhf"></span>
+      <span class="headH"></span>
+      <span class="billH"></span>
+      <span class="eyeH"></span>
+    </div>
+    <span class="wormH"></span>
+    <span class="groundH"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/hoopoe-as/style.css
+++ b/submissions/examples/hoopoe-as/style.css
@@ -1,0 +1,242 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #bfe0ea, #8fc0cf 58%, #a9c78a);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.sunH {
+  position: absolute;
+  top: 26px;
+  right: 44px;
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff6da, #f8dc96 62%, #eebe64);
+  box-shadow: 0 0 50px 20px rgba(250, 220, 140, 0.35);
+  z-index: 1;
+  animation: glowH 6s ease-in-out infinite;
+}
+
+.groundH {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 60px);
+  background:
+    radial-gradient(circle at 18% 8%, #8aa858 0 18px, transparent 18px),
+    radial-gradient(circle at 58% 2%, #7a9648 0 22px, transparent 22px),
+    radial-gradient(circle at 88% 10%, #8aa858 0 16px, transparent 16px),
+    linear-gradient(180deg, #7a9648, #46592a);
+  z-index: 8;
+}
+
+.wormH {
+  position: absolute;
+  bottom: 48px;
+  left: 74px;
+  width: 44px;
+  height: 10px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #d88a8a, #b05a5a);
+  transform-origin: 100% 50%;
+  z-index: 7;
+  animation: wriggleH 3.4s ease-in-out infinite;
+}
+
+.hoopoeH {
+  position: absolute;
+  bottom: 56px;
+  left: 50%;
+  width: 220px;
+  height: 240px;
+  margin-left: -96px;
+  z-index: 6;
+  animation: bobH 3.4s ease-in-out infinite;
+}
+
+.bodyH {
+  position: absolute;
+  bottom: 24px;
+  left: 60px;
+  width: 116px;
+  height: 74px;
+  border-radius: 54% 42% 46% 54% / 62% 56% 44% 44%;
+  background: linear-gradient(180deg, #e0a45a, #c47f38 74%, #f0e6d6);
+  box-shadow: inset -8px -6px 16px rgba(120, 70, 20, 0.35);
+  z-index: 4;
+}
+
+.wingH {
+  position: absolute;
+  bottom: 20px;
+  left: 96px;
+  width: 76px;
+  height: 66px;
+  border-radius: 40% 50% 50% 44% / 50% 40% 60% 60%;
+  background:
+    repeating-linear-gradient(
+      60deg,
+      #23201c 0 7px,
+      #f2ece0 7px 14px
+    );
+  box-shadow: inset 0 -5px 10px rgba(20, 18, 14, 0.3);
+  z-index: 5;
+}
+
+.tailH {
+  position: absolute;
+  bottom: -34px;
+  left: 150px;
+  width: 30px;
+  height: 96px;
+  border-radius: 0 0 20% 20%;
+  background: linear-gradient(180deg, #23201c 0 42%, #f2ece0 42% 60%, #23201c 60%);
+  transform-origin: 50% 0;
+  transform: rotate(24deg);
+  z-index: 3;
+}
+
+.legH {
+  position: absolute;
+  bottom: 0;
+  width: 7px;
+  height: 30px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #6a4a30, #3a2818);
+  z-index: 4;
+}
+
+.lhf { left: 96px; }
+.lhb { left: 116px; filter: brightness(0.8); z-index: 3; }
+
+.headH {
+  position: absolute;
+  bottom: 78px;
+  left: 40px;
+  width: 58px;
+  height: 56px;
+  border-radius: 54% 50% 44% 40% / 56% 54% 44% 46%;
+  background: radial-gradient(circle at 44% 36%, #e8ac62, #c47f38 78%);
+  transform-origin: 70% 100%;
+  z-index: 5;
+  animation: peckH 3.4s ease-in-out infinite;
+}
+
+.billH {
+  position: absolute;
+  bottom: 92px;
+  left: 8px;
+  width: 56px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #2a231c, #6a5240);
+  transform-origin: 100% 50%;
+  clip-path: polygon(0 30%, 100% 0, 100% 100%, 0 70%);
+  z-index: 6;
+  animation: peckBillH 3.4s ease-in-out infinite;
+}
+
+.eyeH {
+  position: absolute;
+  bottom: 108px;
+  left: 66px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #4a3a24, #100c06 66%);
+  box-shadow: 0 0 0 1.5px rgba(60, 40, 20, 0.4);
+  z-index: 7;
+  animation: eyeMoveH 3.4s ease-in-out infinite;
+}
+
+.crestH {
+  position: absolute;
+  bottom: 120px;
+  left: 66px;
+  width: 10px;
+  height: 10px;
+  z-index: 4;
+  animation: fanH 5s ease-in-out infinite;
+}
+
+.crFeather {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 12px;
+  height: 66px;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(180deg, #14110c 0 16%, #e88a2e 16% 82%, #c46a1e);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--cf, 0deg));
+}
+
+.cf1 { --cf: -44deg; height: 50px; }
+.cf2 { --cf: -22deg; height: 60px; }
+.cf3 { --cf: 0deg; height: 66px; }
+.cf4 { --cf: 22deg; height: 60px; }
+.cf5 { --cf: 44deg; height: 50px; }
+
+@keyframes bobH {
+  0%, 44%, 100% { transform: translateY(0); }
+  60% { transform: translateY(4px); }
+}
+
+@keyframes peckH {
+  0%, 44%, 100% { transform: rotate(0deg); }
+  60% { transform: rotate(30deg); }
+  72% { transform: rotate(6deg); }
+}
+
+@keyframes peckBillH {
+  0%, 44%, 100% { transform: rotate(0deg); }
+  60% { transform: rotate(30deg); }
+  72% { transform: rotate(6deg); }
+}
+
+@keyframes eyeMoveH {
+  0%, 44%, 100% { transform: translate(0, 0); }
+  60% { transform: translate(-2px, 4px); }
+}
+
+@keyframes fanH {
+  0%, 100% { transform: scaleX(0.82) scaleY(0.94); }
+  50% { transform: scaleX(1) scaleY(1); }
+}
+
+@keyframes wriggleH {
+  0%, 44%, 100% { transform: rotate(0deg) scaleX(1); }
+  20% { transform: rotate(-8deg) scaleX(0.94); }
+  56% { transform: rotate(0deg) scaleX(0.3); opacity: 1; }
+  64% { opacity: 0; }
+  99% { opacity: 0; transform: scaleX(0.3); }
+}
+
+@keyframes glowH {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hoopoeH,
+  .headH,
+  .billH,
+  .eyeH,
+  .crestH,
+  .wormH,
+  .sunH {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML hoopoe fanning its crest and pecking for a worm.

## Details

- A fan crest of five feathers, each parking its own angle in a custom property and tipped black with a shared linear gradient, opening and closing on a scale keyframe
- Barred wings and tail from a two colour repeating linear gradient
- Head, curved bill and eye peck down together on one timing, snatching a worm that shrinks away
- A striped ground and warm sun behind
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/hoopoe-as/demo.html`
- `submissions/examples/hoopoe-as/style.css`
- `submissions/examples/hoopoe-as/README.md`

Closes #47095
