### PR TITLE
Add tarantula component

### DIFF
--- a/submissions/examples/tarantula-as/README.md
+++ b/submissions/examples/tarantula-as/README.md
@@ -1,0 +1,19 @@
+# Tarantula
+
+A pure CSS and HTML tarantula seen from above, its eight hairy legs twitching as it sits in its burrow beside a tattered web.
+
+## What it shows
+
+- Eight two segment legs, each parking its own splay angle in a custom property so one twitch keyframe can drive them all, with the knee joint drawn on ::after
+- A bristly abdomen from a fine repeating conic gradient over the body
+- The four pairs of eyes from stacked radial gradients, plus articulated pedipalps and fangs
+- A corner web from a masked conic and radial gradient pair
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/tarantula-as/demo.html
+++ b/submissions/examples/tarantula-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tarantula</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="tarT">
+      <span class="legT lg1"></span>
+      <span class="legT lg2"></span>
+      <span class="legT lg3"></span>
+      <span class="legT lg4"></span>
+      <span class="legT lg5"></span>
+      <span class="legT lg6"></span>
+      <span class="legT lg7"></span>
+      <span class="legT lg8"></span>
+      <span class="abdT"></span>
+      <span class="hairT"></span>
+      <span class="cephT"></span>
+      <span class="palpT ppl"></span>
+      <span class="palpT ppr"></span>
+      <span class="fangT ftl"></span>
+      <span class="fangT ftr"></span>
+      <span class="eyesT"></span>
+    </div>
+    <span class="pebT pt1"></span>
+    <span class="pebT pt2"></span>
+    <span class="webT"></span>
+    <span class="floorT"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tarantula-as/style.css
+++ b/submissions/examples/tarantula-as/style.css
@@ -1,0 +1,233 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 40%, #3a2f26, #14100b 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.floorT {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  background:
+    radial-gradient(circle at 24% 20%, rgba(255, 240, 210, 0.06) 0 40px, transparent 60px),
+    radial-gradient(circle at 76% 78%, rgba(0, 0, 0, 0.3) 0 50px, transparent 70px),
+    linear-gradient(180deg, #4a3d30, #241c14);
+  box-shadow: inset 0 0 60px rgba(0, 0, 0, 0.5);
+  z-index: 1;
+}
+
+.webT {
+  position: absolute;
+  top: 20px;
+  right: 24px;
+  width: 120px;
+  height: 120px;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 100% 0,
+      rgba(220, 220, 210, 0.12) 0 0.4deg,
+      transparent 0.4deg 12deg
+    ),
+    repeating-radial-gradient(
+      circle at 100% 0,
+      transparent 0 16px,
+      rgba(220, 220, 210, 0.1) 16px 17px
+    );
+  mask-image: radial-gradient(circle at 100% 0, #000 0 70%, transparent 100%);
+  z-index: 2;
+}
+
+.pebT {
+  position: absolute;
+  border-radius: 50% 50% 46% 44%;
+  background: linear-gradient(180deg, #6a5946, #362b20);
+  box-shadow: inset -3px -4px 6px rgba(10, 8, 4, 0.4);
+  z-index: 3;
+}
+
+.pt1 { bottom: 40px; left: 30px; width: 44px; height: 26px; }
+.pt2 { top: 50px; left: 60px; width: 30px; height: 18px; }
+
+.tarT {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 220px;
+  height: 220px;
+  margin: -110px 0 0 -110px;
+  z-index: 5;
+  animation: creepT 6s ease-in-out infinite;
+}
+
+.abdT {
+  position: absolute;
+  top: 108px;
+  left: 50%;
+  width: 108px;
+  height: 118px;
+  margin-left: -54px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 32%, #6a4326, #2c1a0e 78%);
+  box-shadow: inset -10px -10px 26px rgba(10, 6, 2, 0.6);
+  z-index: 5;
+}
+
+.hairT {
+  position: absolute;
+  top: 108px;
+  left: 50%;
+  width: 108px;
+  height: 118px;
+  margin-left: -54px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 40%,
+      rgba(180, 120, 60, 0.4) 0 1.4deg,
+      transparent 1.4deg 5deg
+    );
+  z-index: 6;
+}
+
+.cephT {
+  position: absolute;
+  top: 74px;
+  left: 50%;
+  width: 78px;
+  height: 74px;
+  margin-left: -39px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 34%, #7a4e2c, #351f10 78%);
+  box-shadow: inset -6px -6px 14px rgba(10, 6, 2, 0.5);
+  z-index: 7;
+}
+
+.eyesT {
+  position: absolute;
+  top: 80px;
+  left: 50%;
+  width: 22px;
+  height: 12px;
+  margin-left: -11px;
+  background:
+    radial-gradient(circle at 20% 40%, #d8c89a 0 2px, transparent 3px),
+    radial-gradient(circle at 44% 26%, #d8c89a 0 2px, transparent 3px),
+    radial-gradient(circle at 60% 26%, #d8c89a 0 2px, transparent 3px),
+    radial-gradient(circle at 82% 40%, #d8c89a 0 2px, transparent 3px);
+  z-index: 8;
+}
+
+.palpT {
+  position: absolute;
+  top: 70px;
+  width: 12px;
+  height: 34px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #7a4e2c, #3a220f);
+  transform-origin: 50% 0;
+  z-index: 8;
+  animation: palpT 3s ease-in-out infinite;
+}
+
+.ppl { left: 50%; margin-left: -30px; transform: rotate(-20deg); --pa: -20deg; }
+.ppr { left: 50%; margin-left: 18px; transform: rotate(20deg); --pa: 20deg; }
+
+.fangT {
+  position: absolute;
+  top: 96px;
+  width: 8px;
+  height: 18px;
+  border-radius: 0 0 50% 50%;
+  background: linear-gradient(180deg, #1a120a, #4a2e18);
+  transform-origin: 50% 0;
+  z-index: 9;
+  animation: fangT 4s ease-in-out infinite;
+}
+
+.ftl { left: 50%; margin-left: -12px; transform: rotate(-8deg); --fa: -8deg; }
+.ftr { left: 50%; margin-left: 4px; transform: rotate(8deg); --fa: 8deg; }
+
+.legT {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 100px;
+  height: 12px;
+  transform-origin: 6px 50%;
+  transform: rotate(var(--la, 0deg));
+  z-index: 4;
+  animation: legTwitchT 3.2s ease-in-out infinite;
+}
+
+.legT::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 4px;
+  width: 58px;
+  height: 10px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #6a4326, #4a2e18);
+}
+
+.legT::after {
+  content: "";
+  position: absolute;
+  top: -18px;
+  left: 52px;
+  width: 52px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #5a3820, #2c1a0e);
+  transform-origin: 0 90%;
+  transform: rotate(-38deg);
+}
+
+.lg1 { --la: -58deg; margin-left: -6px; }
+.lg2 { --la: -26deg; margin-left: -6px; animation-delay: 0.4s; }
+.lg3 { --la: -4deg; margin-left: -6px; animation-delay: 0.8s; }
+.lg4 { --la: 20deg; margin-left: -6px; animation-delay: 1.2s; }
+.lg5 { --la: -122deg; margin-left: -6px; animation-delay: 0.2s; }
+.lg6 { --la: -154deg; margin-left: -6px; animation-delay: 0.6s; }
+.lg7 { --la: -176deg; margin-left: -6px; animation-delay: 1s; }
+.lg8 { --la: 160deg; margin-left: -6px; animation-delay: 1.4s; }
+
+@keyframes creepT {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  50% { transform: translate(0, -8px) rotate(2deg); }
+}
+
+@keyframes legTwitchT {
+  0%, 100% { transform: rotate(var(--la, 0deg)); }
+  50% { transform: rotate(calc(var(--la, 0deg) + 6deg)); }
+}
+
+@keyframes palpT {
+  0%, 100% { transform: rotate(var(--pa, -20deg)); }
+  50% { transform: rotate(var(--pa, -20deg)) translateY(3px); }
+}
+
+@keyframes fangT {
+  0%, 80%, 100% { transform: rotate(var(--fa, 0deg)); }
+  88% { transform: rotate(var(--fa, 0deg)) translateY(3px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tarT,
+  .legT,
+  .palpT,
+  .fangT {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML tarantula seen from above in its burrow.

## Details

- Eight two segment legs, each parking its own splay angle in a custom property so one twitch keyframe drives them all, with the knee joint on ::after
- A bristly abdomen from a fine repeating conic gradient over the body
- Four pairs of eyes from stacked radial gradients, plus articulated pedipalps and fangs
- A corner web from a masked conic and radial gradient pair
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/tarantula-as/demo.html`
- `submissions/examples/tarantula-as/style.css`
- `submissions/examples/tarantula-as/README.md`

Closes #47097
