### PR TITLE
Add frilled lizard component

### DIFF
--- a/submissions/examples/frilled-lizard-as/README.md
+++ b/submissions/examples/frilled-lizard-as/README.md
@@ -1,0 +1,19 @@
+# Frilled Lizard
+
+A pure CSS and HTML frilled lizard flaring its great neck frill and gaping its jaws in a threat display on a sunny log.
+
+## What it shows
+
+- The neck frill from a banded repeating conic gradient masked into a ring, snapping open from a small disc to full spread
+- The head, jaw and frill all firing on one timing so the gape and the flare happen together
+- Scaly hide from a repeating conic gradient plus mottling over the body
+- Clawed feet from clip-path sawtooths, the far leg dimmed with filter for depth
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/frilled-lizard-as/demo.html
+++ b/submissions/examples/frilled-lizard-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Frilled Lizard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunF"></span>
+    <div class="lizF">
+      <span class="tailF"></span>
+      <span class="legF lfb"></span>
+      <span class="frillF"></span>
+      <span class="bodyF"></span>
+      <span class="scaleF"></span>
+      <span class="legF lff"></span>
+      <span class="neckF"></span>
+      <div class="headF">
+        <span class="skullF"></span>
+        <span class="jawF"></span>
+        <span class="eyeF"></span>
+      </div>
+    </div>
+    <span class="logF"></span>
+    <span class="grassF gf1"></span>
+    <span class="grassF gf2"></span>
+    <span class="dirtF"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/frilled-lizard-as/style.css
+++ b/submissions/examples/frilled-lizard-as/style.css
@@ -1,0 +1,300 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #e9b56a, #d98f4a 54%, #b56a30);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 310px;
+}
+
+.sunF {
+  position: absolute;
+  top: 22px;
+  left: 40px;
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff2cc, #f7ce7e 60%, #ee9e4c);
+  box-shadow: 0 0 54px 20px rgba(250, 210, 130, 0.4);
+  z-index: 1;
+  animation: glowF 6s ease-in-out infinite;
+}
+
+.dirtF {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 52px);
+  background:
+    radial-gradient(circle at 18% 10%, rgba(255, 240, 210, 0.16) 0 8px, transparent 9px),
+    radial-gradient(circle at 60% 4%, rgba(90, 50, 20, 0.24) 0 10px, transparent 12px),
+    linear-gradient(180deg, #b07a44, #6a4622);
+  z-index: 8;
+}
+
+.logF {
+  position: absolute;
+  bottom: 40px;
+  left: -30px;
+  width: 200px;
+  height: 34px;
+  border-radius: 17px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(40, 24, 10, 0.3) 0 3px,
+      transparent 3px 22px
+    ),
+    linear-gradient(180deg, #7a5a38, #3c2a16);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+  z-index: 7;
+}
+
+.grassF {
+  position: absolute;
+  bottom: 36px;
+  width: 30px;
+  height: 56px;
+  background:
+    repeating-linear-gradient(
+      80deg,
+      #b89a44 0 3px,
+      transparent 3px 9px
+    );
+  mask-image: linear-gradient(180deg, transparent 0 8%, #000 40%);
+  transform-origin: 50% 100%;
+  z-index: 9;
+  animation: swayGrassF 5s ease-in-out infinite;
+}
+
+.gf1 { right: 40px; }
+.gf2 { right: 12px; height: 44px; animation-delay: 2s; }
+
+.lizF {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  width: 260px;
+  height: 210px;
+  margin-left: -120px;
+  z-index: 6;
+  animation: breatheF 4s ease-in-out infinite;
+}
+
+.frillF {
+  position: absolute;
+  bottom: 72px;
+  left: 120px;
+  width: 150px;
+  height: 150px;
+  margin-left: -14px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      #c8501e 0 8deg,
+      #e8853a 8deg 16deg,
+      #a83814 16deg 24deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 22%, #000 26% 96%, transparent 100%);
+  transform-origin: 30% 60%;
+  transform: scale(var(--fs, 1));
+  z-index: 4;
+  animation: flareF 5s ease-in-out infinite;
+}
+
+.bodyF {
+  position: absolute;
+  bottom: 34px;
+  left: 40px;
+  width: 130px;
+  height: 52px;
+  border-radius: 40% 30% 30% 50% / 60% 50% 50% 70%;
+  background: linear-gradient(180deg, #b0813f, #6a4a24 76%, #d8c49a);
+  box-shadow: inset 0 -5px 10px rgba(50, 30, 10, 0.4);
+  z-index: 5;
+}
+
+.scaleF {
+  position: absolute;
+  bottom: 34px;
+  left: 40px;
+  width: 130px;
+  height: 52px;
+  border-radius: 40% 30% 30% 50% / 60% 50% 50% 70%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 40% 20%,
+      rgba(60, 36, 12, 0.28) 0 3deg,
+      transparent 3deg 10deg
+    ),
+    radial-gradient(circle at 30% 40%, rgba(40, 24, 8, 0.4) 0 4px, transparent 6px);
+  z-index: 6;
+}
+
+.neckF {
+  position: absolute;
+  bottom: 60px;
+  left: 132px;
+  width: 46px;
+  height: 40px;
+  border-radius: 40% 50% 30% 40%;
+  background: linear-gradient(180deg, #b0813f, #7a5228);
+  transform-origin: 20% 100%;
+  transform: rotate(-16deg);
+  z-index: 5;
+}
+
+.headF {
+  position: absolute;
+  bottom: 92px;
+  left: 156px;
+  width: 78px;
+  height: 46px;
+  transform-origin: 10% 60%;
+  z-index: 7;
+  animation: gapeHeadF 5s ease-in-out infinite;
+}
+
+.skullF {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  width: 70px;
+  height: 34px;
+  border-radius: 40% 60% 50% 30% / 60% 60% 40% 40%;
+  background: radial-gradient(circle at 36% 34%, #b88a4a, #6a4a24 80%);
+  z-index: 5;
+}
+
+.jawF {
+  position: absolute;
+  bottom: 0;
+  left: 24px;
+  width: 54px;
+  height: 16px;
+  border-radius: 20% 50% 40% 20%;
+  background: linear-gradient(180deg, #8a6234, #4a3018);
+  transform-origin: 0 30%;
+  clip-path: polygon(0 0, 100% 30%, 96% 100%, 0 80%);
+  z-index: 4;
+  animation: jawF 5s ease-in-out infinite;
+}
+
+.eyeF {
+  position: absolute;
+  bottom: 24px;
+  left: 14px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f0d060, #2a1c08 66%);
+  box-shadow: 0 0 0 2px rgba(50, 32, 12, 0.5);
+  z-index: 6;
+}
+
+.legF {
+  position: absolute;
+  width: 16px;
+  height: 44px;
+  border-radius: 8px 8px 5px 5px;
+  background: linear-gradient(180deg, #9a6e38, #5a3c1e);
+  transform-origin: 50% 0;
+  z-index: 4;
+}
+
+.legF::after {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: -6px;
+  width: 28px;
+  height: 10px;
+  background: linear-gradient(180deg, #7a5228, #3a260f);
+  clip-path: polygon(0 0, 20% 100%, 38% 0, 56% 100%, 74% 0, 92% 100%, 100% 0);
+}
+
+.lff { bottom: 22px; left: 150px; animation: stepF 3s ease-in-out infinite; }
+.lfb { bottom: 22px; left: 66px; filter: brightness(0.82); z-index: 3; }
+
+.tailF {
+  position: absolute;
+  bottom: 44px;
+  left: -30px;
+  width: 110px;
+  height: 20px;
+  border-radius: 50% 0 0 50%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 36, 12, 0.34) 0 4px,
+      transparent 4px 16px
+    ),
+    linear-gradient(90deg, #6a4a24, #b0813f);
+  clip-path: polygon(0 40%, 100% 0, 100% 100%, 0 60%);
+  transform-origin: 100% 50%;
+  z-index: 4;
+  animation: tailF 3s ease-in-out infinite;
+}
+
+@keyframes breatheF {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-2px) scale(1.01); }
+}
+
+@keyframes flareF {
+  0%, 40%, 100% { --fs: 0.42; transform: scale(0.42); }
+  56%, 84% { --fs: 1; transform: scale(1); }
+}
+
+@keyframes gapeHeadF {
+  0%, 40%, 100% { transform: rotate(0deg); }
+  56%, 84% { transform: rotate(-10deg); }
+}
+
+@keyframes jawF {
+  0%, 40%, 100% { transform: rotate(0deg); }
+  56%, 84% { transform: rotate(22deg); }
+}
+
+@keyframes stepF {
+  0%, 100% { transform: rotate(6deg); }
+  50% { transform: rotate(-8deg); }
+}
+
+@keyframes tailF {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes swayGrassF {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes glowF {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lizF,
+  .frillF,
+  .headF,
+  .jawF,
+  .lff,
+  .tailF,
+  .grassF,
+  .sunF {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML frilled lizard flaring its neck frill in a threat display.

## Details

- The neck frill is a banded repeating conic gradient masked into a ring, snapping open from a small disc to full spread
- Head, jaw and frill fire on one timing so the gape and the flare happen together
- Scaly hide from a repeating conic gradient plus mottling over the body
- Clawed feet from clip-path sawtooths, the far leg dimmed with filter for depth
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/frilled-lizard-as/demo.html`
- `submissions/examples/frilled-lizard-as/style.css`
- `submissions/examples/frilled-lizard-as/README.md`

Closes #47103
