### PR TITLE
Add thorny devil component

### DIFF
--- a/submissions/examples/thorny-devil-as/README.md
+++ b/submissions/examples/thorny-devil-as/README.md
@@ -1,0 +1,19 @@
+# Thorny Devil
+
+A pure CSS and HTML thorny devil, the spiky desert lizard, creeping over the sand licking up a line of ants.
+
+## What it shows
+
+- Dozens of conical spikes built from CSS border triangles with a lighter tip triangle on each ::after, scattered across the body, head and tail
+- The false head hump on the neck drawn as a spiked knob, the trademark decoy
+- Concentric ridge patterning on the back from stacked hard stop radial gradients
+- A slow rocking gait with clawed feet, tracking a marching column of ants
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/thorny-devil-as/demo.html
+++ b/submissions/examples/thorny-devil-as/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Thorny Devil</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunD"></span>
+    <div class="devilD">
+      <span class="tailD"></span>
+      <span class="legD ldbl"></span>
+      <span class="legD ldbr"></span>
+      <span class="bodyD"></span>
+      <span class="spikeD sd1"></span>
+      <span class="spikeD sd2"></span>
+      <span class="spikeD sd3"></span>
+      <span class="spikeD sd4"></span>
+      <span class="spikeD sd5"></span>
+      <span class="spikeD sd6"></span>
+      <span class="spikeD sd7"></span>
+      <span class="spikeD sd8"></span>
+      <span class="spikeD sd9"></span>
+      <span class="spikeD sd10"></span>
+      <span class="patternD"></span>
+      <span class="legD ldfl"></span>
+      <span class="legD ldfr"></span>
+      <span class="humpD"></span>
+      <span class="headD"></span>
+      <span class="hornD hdl"></span>
+      <span class="hornD hdr"></span>
+      <span class="eyeD"></span>
+    </div>
+    <span class="antD"></span>
+    <span class="antTrail at1"></span>
+    <span class="antTrail at2"></span>
+    <span class="pebD pd1"></span>
+    <span class="sandD"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/thorny-devil-as/style.css
+++ b/submissions/examples/thorny-devil-as/style.css
@@ -1,0 +1,342 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #e7b06a, #d4894a 56%, #b3672e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.sunD {
+  position: absolute;
+  top: 22px;
+  right: 40px;
+  width: 86px;
+  height: 86px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff2cc, #f7ce7e 60%, #ee9e4c);
+  box-shadow: 0 0 52px 20px rgba(250, 210, 130, 0.4);
+  z-index: 1;
+  animation: glowD 6s ease-in-out infinite;
+}
+
+.sandD {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 60px);
+  background:
+    radial-gradient(circle at 16% 8%, rgba(255, 240, 210, 0.2) 0 6px, transparent 7px),
+    radial-gradient(circle at 56% 2%, rgba(120, 70, 30, 0.24) 0 8px, transparent 9px),
+    linear-gradient(180deg, #cf9a5a, #9a6c38);
+  z-index: 8;
+}
+
+.pebD {
+  position: absolute;
+  border-radius: 50% 50% 46% 44%;
+  background: linear-gradient(180deg, #b08858, #6a4c2c);
+  box-shadow: inset -3px -4px 6px rgba(60, 40, 18, 0.4);
+  z-index: 7;
+}
+
+.pd1 { bottom: 44px; right: 40px; width: 40px; height: 22px; }
+
+.antD {
+  position: absolute;
+  bottom: 54px;
+  left: 40px;
+  width: 8px;
+  height: 6px;
+  border-radius: 50%;
+  background: #2a1c12;
+  z-index: 7;
+  animation: marchD 5s linear infinite;
+}
+
+.antTrail {
+  position: absolute;
+  bottom: 54px;
+  width: 5px;
+  height: 4px;
+  border-radius: 50%;
+  background: #3a2818;
+  z-index: 6;
+  animation: marchD 5s linear infinite;
+}
+
+.at1 { left: 40px; animation-delay: 0.6s; }
+.at2 { left: 40px; animation-delay: 1.2s; }
+
+.devilD {
+  position: absolute;
+  bottom: 58px;
+  left: 50%;
+  width: 220px;
+  height: 150px;
+  margin-left: -96px;
+  z-index: 6;
+  animation: creepD 5s ease-in-out infinite;
+}
+
+.bodyD {
+  position: absolute;
+  bottom: 20px;
+  left: 40px;
+  width: 120px;
+  height: 74px;
+  border-radius: 50% 46% 44% 50% / 60% 56% 44% 44%;
+  background: radial-gradient(circle at 40% 32%, #d8a862, #9a6a34 78%);
+  box-shadow: inset -8px -6px 16px rgba(90, 56, 20, 0.4);
+  z-index: 4;
+}
+
+.patternD {
+  position: absolute;
+  bottom: 20px;
+  left: 40px;
+  width: 120px;
+  height: 74px;
+  border-radius: 50% 46% 44% 50% / 60% 56% 44% 44%;
+  background:
+    radial-gradient(circle at 40% 40%, transparent 0 10px, rgba(90, 56, 20, 0.4) 11px 13px, transparent 14px),
+    radial-gradient(circle at 40% 40%, transparent 0 22px, rgba(90, 56, 20, 0.34) 23px 25px, transparent 26px),
+    radial-gradient(circle at 66% 54%, rgba(210, 180, 130, 0.4) 0 8px, transparent 10px),
+    linear-gradient(90deg, rgba(120, 80, 36, 0.24) 0 3px, transparent 3px 20px);
+  z-index: 5;
+}
+
+.humpD {
+  position: absolute;
+  bottom: 60px;
+  left: 46px;
+  width: 34px;
+  height: 30px;
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 40% 34%, #caa056, #86602c 78%);
+  z-index: 6;
+}
+
+.humpD::after {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  margin-left: -8px;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 16px solid #7a5628;
+}
+
+.spikeD {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-bottom: 22px solid #a2743a;
+  transform-origin: 50% 100%;
+  z-index: 3;
+}
+
+.spikeD::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: -4px;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-bottom: 10px solid #d8b06a;
+}
+
+.sd1 { bottom: 78px; left: 60px; transform: rotate(-24deg); }
+.sd2 { bottom: 82px; left: 88px; transform: rotate(-6deg); }
+.sd3 { bottom: 80px; left: 116px; transform: rotate(14deg); }
+.sd4 { bottom: 40px; left: 46px; transform: rotate(-108deg); }
+.sd5 { bottom: 30px; left: 140px; transform: rotate(96deg); }
+.sd6 { bottom: 74px; left: 140px; transform: rotate(40deg); }
+.sd7 { bottom: 84px; left: 74px; transform: rotate(-16deg); border-bottom-width: 18px; }
+.sd8 { bottom: 84px; left: 102px; transform: rotate(4deg); border-bottom-width: 18px; }
+.sd9 { bottom: 46px; left: 70px; transform: rotate(-124deg); border-bottom-width: 16px; }
+.sd10 { bottom: 44px; left: 118px; transform: rotate(120deg); border-bottom-width: 16px; }
+
+.headD {
+  position: absolute;
+  bottom: 34px;
+  left: 150px;
+  width: 44px;
+  height: 38px;
+  border-radius: 46% 54% 40% 40% / 50% 54% 46% 44%;
+  background: radial-gradient(circle at 40% 36%, #caa056, #7a5426 80%);
+  transform-origin: 20% 60%;
+  z-index: 6;
+  animation: nodD 5s ease-in-out infinite;
+}
+
+.hornD {
+  position: absolute;
+  bottom: 62px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 28px solid #b0824a;
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: nodHornD 5s ease-in-out infinite;
+}
+
+.hornD::after {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: -4px;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-bottom: 12px solid #e0bc7a;
+}
+
+.hdl { left: 168px; transform: rotate(-22deg); --h: -22deg; }
+.hdr { left: 182px; transform: rotate(18deg); --h: 18deg; }
+
+.eyeD {
+  position: absolute;
+  bottom: 52px;
+  left: 178px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #4a3a1e, #100c06 66%);
+  box-shadow: 0 0 0 1.5px rgba(50, 32, 12, 0.5);
+  z-index: 7;
+  animation: blinkD 5s ease-in-out infinite;
+}
+
+.legD {
+  position: absolute;
+  width: 12px;
+  height: 34px;
+  border-radius: 6px 6px 4px 4px;
+  background: linear-gradient(180deg, #b0824a, #6a4826);
+  transform-origin: 50% 0;
+  z-index: 3;
+}
+
+.legD::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -5px;
+  width: 22px;
+  height: 8px;
+  background: linear-gradient(180deg, #8a6034, #4a3018);
+  clip-path: polygon(0 0, 24% 100%, 44% 0, 64% 100%, 84% 0, 100% 100%, 100% 0);
+}
+
+.ldfl { bottom: 0; left: 132px; animation: stepD 3s ease-in-out infinite; }
+.ldfr { bottom: 0; left: 148px; filter: brightness(0.8); z-index: 2; }
+.ldbl { bottom: 0; left: 58px; animation: stepD 3s ease-in-out infinite reverse; }
+.ldbr { bottom: 0; left: 74px; filter: brightness(0.8); z-index: 2; }
+
+.tailD {
+  position: absolute;
+  bottom: 24px;
+  left: -6px;
+  width: 74px;
+  height: 20px;
+  border-radius: 50% 0 0 50%;
+  background: linear-gradient(90deg, #6a4826, #b0824a);
+  clip-path: polygon(0 44%, 100% 0, 100% 100%, 0 56%);
+  transform-origin: 100% 50%;
+  z-index: 3;
+  animation: tailD 4s ease-in-out infinite;
+}
+
+.tailD::after {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: 20px;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 12px solid #96662f;
+}
+
+@keyframes creepD {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-6px, 0); }
+}
+
+@keyframes stepD {
+  0%, 100% { transform: rotate(8deg); }
+  50% { transform: rotate(-10deg); }
+}
+
+@keyframes nodD {
+  0%, 60%, 100% { transform: rotate(0deg); }
+  72% { transform: rotate(8deg); }
+}
+
+@keyframes nodHornD {
+  0%, 60%, 100% { transform: rotate(var(--h, 0deg)); }
+  72% { transform: rotate(var(--h, 0deg)) translateY(3px); }
+}
+
+@keyframes blinkD {
+  0%, 90%, 100% { transform: scaleY(1); }
+  95% { transform: scaleY(0.1); }
+}
+
+@keyframes tailD {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes marchD {
+  0% { transform: translateX(0); opacity: 0; }
+  8% { opacity: 1; }
+  86% { opacity: 1; }
+  100% { transform: translateX(126px); opacity: 0; }
+}
+
+@keyframes glowD {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .devilD,
+  .headD,
+  .hornD,
+  .eyeD,
+  .ldfl,
+  .ldbl,
+  .tailD,
+  .antD,
+  .antTrail,
+  .sunD {
+    animation: none;
+  }
+
+  .antD,
+  .antTrail {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML thorny devil creeping over the sand after ants.

## Details

- Conical spikes built from CSS border triangles with a lighter tip triangle on each ::after, scattered across body, head and tail
- The false head hump on the neck as a spiked knob, the trademark decoy
- Concentric ridge patterning on the back from stacked hard stop radial gradients
- A slow rocking gait with clawed feet, tracking a marching column of ants
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/thorny-devil-as/demo.html`
- `submissions/examples/thorny-devil-as/style.css`
- `submissions/examples/thorny-devil-as/README.md`

Closes #47105
