### PR TITLE
Add cuttlefish hunt component

### DIFF
--- a/submissions/examples/cuttlefish-hunt-as/README.md
+++ b/submissions/examples/cuttlefish-hunt-as/README.md
@@ -1,0 +1,19 @@
+# Cuttlefish Hunt
+
+A pure CSS and HTML cuttlefish stalking a shrimp, flashing hypnotic bands down its mantle before its two feeding tentacles shoot out to grab.
+
+## What it shows
+
+- Passing cloud camouflage: a striped repeating linear gradient over the mantle pulses its opacity and slides, the cuttlefish's mesmerising display
+- Two feeding tentacles that fire out by animating their height, tipped with grabbing clubs, timed to the shrimp's escape dart
+- A rippling fin skirt from a fine repeating linear gradient undulating fast around the body
+- W shaped cuttlefish pupils drawn from a radial gradient iris plus a bar on ::after
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/cuttlefish-hunt-as/demo.html
+++ b/submissions/examples/cuttlefish-hunt-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cuttlefish Hunt</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="rayK rk1"></span>
+    <span class="rayK rk2"></span>
+    <div class="cuttleK">
+      <span class="finK"></span>
+      <span class="mantleK"></span>
+      <span class="bandK"></span>
+      <span class="armK ak1"></span>
+      <span class="armK ak2"></span>
+      <span class="armK ak3"></span>
+      <span class="armK ak4"></span>
+      <span class="tentK tkl">
+        <span class="clubK"></span>
+      </span>
+      <span class="tentK tkr">
+        <span class="clubK"></span>
+      </span>
+      <span class="eyeK ekl"></span>
+      <span class="eyeK ekr"></span>
+    </div>
+    <span class="shrimpK"></span>
+    <span class="bubK bk1"></span>
+    <span class="bubK bk2"></span>
+    <span class="floorK"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cuttlefish-hunt-as/style.css
+++ b/submissions/examples/cuttlefish-hunt-as/style.css
@@ -1,0 +1,278 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #1f8a9a, #0d4a5e 64%, #06303f);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+}
+
+.rayK {
+  position: absolute;
+  top: -30px;
+  width: 60px;
+  height: 300px;
+  background: linear-gradient(180deg, rgba(210, 245, 250, 0.2), transparent 82%);
+  filter: blur(8px);
+  transform-origin: 50% 0;
+  z-index: 1;
+  animation: shimK 9s ease-in-out infinite;
+}
+
+.rk1 { left: 50px; transform: rotate(8deg); }
+.rk2 { right: 60px; width: 44px; animation-delay: 3s; }
+
+.floorK {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 44px);
+  background:
+    radial-gradient(circle at 16% 8%, rgba(255, 255, 255, 0.16) 0 6px, transparent 7px),
+    radial-gradient(circle at 54% 2%, rgba(80, 60, 30, 0.24) 0 8px, transparent 9px),
+    linear-gradient(180deg, #b6a06a, #7a6640);
+  z-index: 8;
+}
+
+.shrimpK {
+  position: absolute;
+  bottom: 50px;
+  left: 176px;
+  width: 30px;
+  height: 16px;
+  border-radius: 50% 40% 40% 50%;
+  background: linear-gradient(180deg, #f2c8a0, #d89a6a);
+  box-shadow: inset -2px -2px 4px rgba(150, 90, 50, 0.4);
+  z-index: 6;
+  animation: dartK 5s ease-in-out infinite;
+}
+
+.shrimpK::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: -8px;
+  width: 12px;
+  height: 12px;
+  clip-path: polygon(100% 50%, 0 0, 0 100%);
+  background: #d89a6a;
+}
+
+.cuttleK {
+  position: absolute;
+  bottom: 70px;
+  left: 50%;
+  width: 220px;
+  height: 170px;
+  margin-left: -80px;
+  z-index: 6;
+  animation: hoverK 5s ease-in-out infinite;
+}
+
+.mantleK {
+  position: absolute;
+  top: 26px;
+  left: 60px;
+  width: 140px;
+  height: 96px;
+  border-radius: 46% 50% 46% 50% / 60% 40% 60% 50%;
+  background: radial-gradient(circle at 60% 34%, #d8c48a, #9a7c48 78%);
+  box-shadow: inset -10px -6px 22px rgba(70, 54, 20, 0.4);
+  z-index: 4;
+}
+
+.bandK {
+  position: absolute;
+  top: 26px;
+  left: 60px;
+  width: 140px;
+  height: 96px;
+  border-radius: 46% 50% 46% 50% / 60% 40% 60% 50%;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(40, 30, 12, 0.55) 0 5px,
+      transparent 5px 15px
+    );
+  z-index: 5;
+  animation: flashK 3s ease-in-out infinite;
+}
+
+.finK {
+  position: absolute;
+  top: 30px;
+  left: 52px;
+  width: 156px;
+  height: 92px;
+  border-radius: 50%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(150, 210, 220, 0.32) 0 2px,
+      transparent 2px 8px
+    ),
+    radial-gradient(ellipse at 50% 50%, rgba(120, 190, 200, 0.4), transparent 70%);
+  z-index: 3;
+  animation: undulateK 1.2s ease-in-out infinite;
+}
+
+.eyeK {
+  position: absolute;
+  top: 44px;
+  width: 22px;
+  height: 20px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 40% 40%, #f2ecd0 0 4px, transparent 5px),
+    radial-gradient(circle at 50% 54%, #1a1810 0 5px, #7a9aa0 6px 8px, #4a3a1e 10px);
+  box-shadow: 0 0 6px rgba(120, 160, 170, 0.4);
+  z-index: 7;
+}
+
+.eyeK::after {
+  content: "";
+  position: absolute;
+  top: 52%;
+  left: 50%;
+  width: 12px;
+  height: 4px;
+  margin: -2px 0 0 -6px;
+  border-radius: 2px;
+  background: #14120a;
+}
+
+.ekl { left: 84px; }
+.ekr { left: 118px; }
+
+.armK {
+  position: absolute;
+  top: 116px;
+  width: 12px;
+  height: 54px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #c2a86a, #7a6238);
+  transform-origin: 50% 0;
+  transform: rotate(var(--ak, 0deg));
+  z-index: 5;
+  animation: waveArmK 3.4s ease-in-out infinite;
+}
+
+.ak1 { left: 96px; --ak: -20deg; }
+.ak2 { left: 112px; --ak: -7deg; animation-delay: 0.3s; }
+.ak3 { left: 128px; --ak: 7deg; animation-delay: 0.6s; }
+.ak4 { left: 144px; --ak: 20deg; animation-delay: 0.9s; }
+
+.tentK {
+  position: absolute;
+  top: 120px;
+  width: 8px;
+  height: 20px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #b09a5e, #6a5630);
+  transform-origin: 50% 0;
+  z-index: 4;
+  animation: strikeK 5s ease-in-out infinite;
+}
+
+.tkl { left: 100px; }
+.tkr { left: 132px; animation-delay: 0.06s; }
+
+.clubK {
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin-left: -8px;
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 40% 34%, #d8b06a, #8a6a34 76%);
+}
+
+.bubK {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.8), rgba(150, 210, 230, 0.2) 70%);
+  border: 1px solid rgba(200, 235, 245, 0.4);
+  opacity: 0;
+  z-index: 7;
+  animation: riseK 6s ease-in infinite;
+}
+
+.bk1 { bottom: 150px; left: 200px; width: 8px; height: 8px; }
+.bk2 { bottom: 160px; left: 224px; width: 5px; height: 5px; animation-delay: 3s; }
+
+@keyframes hoverK {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  50% { transform: translate(-4px, -6px) rotate(-1deg); }
+}
+
+@keyframes flashK {
+  0%, 40% { opacity: 0.9; transform: translateX(0); }
+  55% { opacity: 0.2; transform: translateX(-4px); }
+  70% { opacity: 0.9; transform: translateX(0); }
+  100% { opacity: 0.9; }
+}
+
+@keyframes undulateK {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.08); }
+}
+
+@keyframes waveArmK {
+  0%, 100% { transform: rotate(var(--ak, 0deg)); }
+  50% { transform: rotate(calc(var(--ak, 0deg) * 0.6)); }
+}
+
+@keyframes strikeK {
+  0%, 60% { height: 20px; }
+  70% { height: 80px; }
+  76% { height: 80px; }
+  86% { height: 20px; }
+  100% { height: 20px; }
+}
+
+@keyframes dartK {
+  0%, 64% { transform: translate(0, 0); opacity: 1; }
+  72% { transform: translate(-18px, -10px); opacity: 1; }
+  80% { transform: translate(-40px, -4px); opacity: 0; }
+  100% { transform: translate(0, 0); opacity: 0; }
+}
+
+@keyframes shimK {
+  0%, 100% { opacity: 0.5; transform: rotate(6deg) scaleX(1); }
+  50% { opacity: 0.9; transform: rotate(10deg) scaleX(1.2); }
+}
+
+@keyframes riseK {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  20% { opacity: 0.9; }
+  100% { transform: translateY(-140px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cuttleK,
+  .bandK,
+  .finK,
+  .armK,
+  .tentK,
+  .shrimpK,
+  .bubK,
+  .rayK {
+    animation: none;
+  }
+
+  .bubK {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML cuttlefish flashing camouflage and striking a shrimp.

## Details

- Passing cloud camouflage: a striped repeating linear gradient over the mantle pulses its opacity and slides
- Two feeding tentacles fire out by animating their height, tipped with grabbing clubs, timed to the shrimp's escape dart
- A rippling fin skirt from a fine repeating linear gradient undulating fast around the body
- W shaped cuttlefish pupils from a radial gradient iris plus a bar on ::after
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/cuttlefish-hunt-as/demo.html`
- `submissions/examples/cuttlefish-hunt-as/style.css`
- `submissions/examples/cuttlefish-hunt-as/README.md`

Closes #47109
