### PR TITLE
Add sitar component

### DIFF
--- a/submissions/examples/sitar-as/README.md
+++ b/submissions/examples/sitar-as/README.md
@@ -1,0 +1,19 @@
+# Sitar
+
+A pure CSS and HTML sitar, the Indian long necked lute, its strings shimmering as musical notes drift up.
+
+## What it shows
+
+- The resonating gourd from a warm radial gradient with a fine ribbed overlay, and a rosette sound hole from a repeating conic gradient
+- The long neck laid with curved frets and three shimmering strings that vibrate on a very fast keyframe
+- The carved peg box with tuning pegs, the whole instrument tilted and gently swaying
+- Musical notes as unicode glyphs through ::before content, floating up and fading
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/sitar-as/demo.html
+++ b/submissions/examples/sitar-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sitar</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="noteS ns1"></span>
+    <span class="noteS ns2"></span>
+    <span class="noteS ns3"></span>
+    <div class="sitarS">
+      <span class="gourdS"></span>
+      <span class="roseS"></span>
+      <span class="bridgeS"></span>
+      <span class="neckS"></span>
+      <span class="fretS f1"></span>
+      <span class="fretS f2"></span>
+      <span class="fretS f3"></span>
+      <span class="fretS f4"></span>
+      <span class="fretS f5"></span>
+      <span class="fretS f6"></span>
+      <span class="stringS str1"></span>
+      <span class="stringS str2"></span>
+      <span class="stringS str3"></span>
+      <span class="pegboxS"></span>
+      <span class="pegS pg1"></span>
+      <span class="pegS pg2"></span>
+      <span class="pegS pg3"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sitar-as/style.css
+++ b/submissions/examples/sitar-as/style.css
@@ -1,0 +1,197 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #4a2f52, #1c1024 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+}
+
+.noteS {
+  position: absolute;
+  color: rgba(245, 220, 250, 0.7);
+  font-size: 22px;
+  z-index: 1;
+  animation: floatNoteS 6s ease-in infinite;
+}
+
+.noteS::before { content: "\266B"; }
+.ns1 { bottom: 120px; left: 60px; }
+.ns2 { bottom: 150px; left: 40px; font-size: 18px; animation-delay: 2s; }
+.ns3 { bottom: 130px; left: 96px; font-size: 26px; animation-delay: 4s; }
+
+.sitarS {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  width: 300px;
+  height: 320px;
+  margin-left: -150px;
+  transform: rotate(28deg);
+  transform-origin: 62% 78%;
+  z-index: 5;
+  animation: swayS 6s ease-in-out infinite;
+}
+
+.gourdS {
+  position: absolute;
+  bottom: 20px;
+  left: 130px;
+  width: 150px;
+  height: 150px;
+  border-radius: 50% 50% 46% 46% / 54% 54% 46% 46%;
+  background: radial-gradient(circle at 38% 30%, #d89a4a, #7a4a1e 78%);
+  box-shadow:
+    inset -16px -12px 34px rgba(60, 30, 8, 0.5),
+    0 14px 28px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.gourdS::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 30, 8, 0.22) 0 1px,
+      transparent 1px 20px
+    );
+}
+
+.roseS {
+  position: absolute;
+  bottom: 84px;
+  left: 168px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(40, 20, 6, 0.7) 0 10deg,
+      transparent 10deg 20deg
+    ),
+    radial-gradient(circle, #3a2410, #1c1408 72%);
+  box-shadow: inset 0 0 6px rgba(20, 12, 4, 0.7);
+  z-index: 5;
+}
+
+.bridgeS {
+  position: absolute;
+  bottom: 58px;
+  left: 176px;
+  width: 30px;
+  height: 12px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #e8d0a0, #a5885a);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  z-index: 6;
+}
+
+.neckS {
+  position: absolute;
+  bottom: 150px;
+  left: 176px;
+  width: 34px;
+  height: 180px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #5a3a1c, #a5764a 46%, #4a3016);
+  box-shadow: inset -4px 0 8px rgba(30, 18, 8, 0.4);
+  transform-origin: 50% 100%;
+  z-index: 3;
+}
+
+.fretS {
+  position: absolute;
+  left: 176px;
+  width: 34px;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #c8a86a, #8a6a3a);
+  z-index: 5;
+}
+
+.f1 { bottom: 176px; }
+.f2 { bottom: 202px; }
+.f3 { bottom: 228px; }
+.f4 { bottom: 254px; }
+.f5 { bottom: 280px; }
+.f6 { bottom: 306px; }
+
+.stringS {
+  position: absolute;
+  bottom: 62px;
+  width: 1.5px;
+  height: 264px;
+  background: linear-gradient(180deg, rgba(240, 235, 220, 0.9), rgba(200, 200, 180, 0.5));
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: vibrateS 0.24s ease-in-out infinite;
+}
+
+.str1 { left: 186px; }
+.str2 { left: 192px; animation-delay: 0.06s; }
+.str3 { left: 198px; animation-delay: 0.12s; }
+
+.pegboxS {
+  position: absolute;
+  bottom: 300px;
+  left: 168px;
+  width: 50px;
+  height: 34px;
+  border-radius: 8px 8px 6px 6px;
+  background: linear-gradient(180deg, #6a4626, #3a2410);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.pegS {
+  position: absolute;
+  width: 16px;
+  height: 8px;
+  border-radius: 4px;
+  background: radial-gradient(circle at 34% 34%, #e0c078, #8a6230 76%);
+  z-index: 7;
+}
+
+.pg1 { bottom: 322px; left: 152px; }
+.pg2 { bottom: 310px; left: 150px; }
+.pg3 { bottom: 322px; left: 216px; }
+
+@keyframes vibrateS {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(0.8px); }
+}
+
+@keyframes swayS {
+  0%, 100% { transform: rotate(27deg); }
+  50% { transform: rotate(29deg); }
+}
+
+@keyframes floatNoteS {
+  0% { transform: translate(0, 0) scale(0.7); opacity: 0; }
+  25% { opacity: 1; }
+  100% { transform: translate(-24px, -60px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sitarS,
+  .stringS,
+  .noteS {
+    animation: none;
+  }
+
+  .noteS {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML sitar with shimmering strings and drifting notes.

## Details

- The resonating gourd from a warm radial gradient with a fine ribbed overlay, and a rosette sound hole from a repeating conic gradient
- The long neck laid with curved frets and three shimmering strings that vibrate on a very fast keyframe
- The carved peg box with tuning pegs, the whole instrument tilted and gently swaying
- Musical notes as unicode glyphs through ::before content, floating up and fading
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/sitar-as/demo.html`
- `submissions/examples/sitar-as/style.css`
- `submissions/examples/sitar-as/README.md`

Closes #47115
