### PR TITLE
Add koto component

### DIFF
--- a/submissions/examples/koto-as/README.md
+++ b/submissions/examples/koto-as/README.md
@@ -1,0 +1,19 @@
+# Koto
+
+A pure CSS and HTML koto, the Japanese long zither, its silk strings shimmering over movable bridges as cherry blossom drifts down.
+
+## What it shows
+
+- The long paulownia body with grain from a repeating linear gradient over a warm wood base
+- Seven strings stretched the length of the instrument, plucked in sequence on staggered fast keyframes
+- Seven movable ji bridges cut from clip-path pillars, each propping a string
+- A tatami mat laid in perspective and falling cherry petals
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/koto-as/demo.html
+++ b/submissions/examples/koto-as/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Koto</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="petalK pk1"></span>
+    <span class="petalK pk2"></span>
+    <span class="petalK pk3"></span>
+    <div class="kotoK">
+      <span class="bodyK"></span>
+      <span class="grainK"></span>
+      <span class="stringK sk1"></span>
+      <span class="stringK sk2"></span>
+      <span class="stringK sk3"></span>
+      <span class="stringK sk4"></span>
+      <span class="stringK sk5"></span>
+      <span class="stringK sk6"></span>
+      <span class="stringK sk7"></span>
+      <span class="bridgeK bk1"></span>
+      <span class="bridgeK bk2"></span>
+      <span class="bridgeK bk3"></span>
+      <span class="bridgeK bk4"></span>
+      <span class="bridgeK bk5"></span>
+      <span class="bridgeK bk6"></span>
+      <span class="bridgeK bk7"></span>
+      <span class="capK capL"></span>
+      <span class="capK capR"></span>
+    </div>
+    <span class="matK"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/koto-as/style.css
+++ b/submissions/examples/koto-as/style.css
@@ -1,0 +1,178 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #d8c4a8, #b39a76 62%, #8a6f4e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+}
+
+.petalK {
+  position: absolute;
+  width: 16px;
+  height: 12px;
+  border-radius: 60% 10% 60% 10%;
+  background: radial-gradient(circle at 40% 34%, #ffd8e4, #f2a0bc 74%);
+  z-index: 7;
+  animation: fallPetalK 8s ease-in infinite;
+}
+
+.pk1 { top: -20px; left: 80px; }
+.pk2 { top: -20px; left: 180px; animation-delay: 2.6s; }
+.pk3 { top: -20px; left: 260px; animation-delay: 5s; }
+
+.matK {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 320px;
+  height: 120px;
+  margin-left: -160px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(120, 96, 56, 0.24) 0 3px,
+      transparent 3px 20px
+    ),
+    linear-gradient(180deg, #c2a878, #9a805a);
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.25);
+  transform: perspective(500px) rotateX(46deg);
+  transform-origin: 50% 100%;
+  z-index: 2;
+}
+
+.kotoK {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 300px;
+  height: 96px;
+  margin-left: -150px;
+  z-index: 5;
+  animation: swayK 7s ease-in-out infinite;
+}
+
+.bodyK {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 300px;
+  height: 74px;
+  border-radius: 30px 18px 20px 40px / 40px 30px 30px 50px;
+  background: linear-gradient(180deg, #b5824a, #7a5228 76%, #5a3c1c);
+  box-shadow:
+    inset -8px -8px 22px rgba(50, 30, 8, 0.4),
+    0 12px 24px rgba(0, 0, 0, 0.35);
+  z-index: 4;
+}
+
+.grainK {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 300px;
+  height: 74px;
+  border-radius: 30px 18px 20px 40px / 40px 30px 30px 50px;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(60, 34, 12, 0.22) 0 2px,
+      transparent 2px 16px
+    ),
+    radial-gradient(ellipse at 30% 30%, rgba(210, 170, 110, 0.3) 0 40px, transparent 60px);
+  z-index: 5;
+}
+
+.stringK {
+  position: absolute;
+  left: 14px;
+  width: 272px;
+  height: 1.5px;
+  background: linear-gradient(90deg, rgba(245, 240, 224, 0.5), rgba(240, 232, 210, 0.9) 20%, rgba(240, 232, 210, 0.9) 80%, rgba(245, 240, 224, 0.5));
+  transform-origin: 50% 50%;
+  z-index: 6;
+  animation: pluckK 0.26s ease-in-out infinite;
+}
+
+.sk1 { bottom: 62px; }
+.sk2 { bottom: 54px; animation-delay: 0.04s; }
+.sk3 { bottom: 46px; animation-delay: 0.08s; }
+.sk4 { bottom: 38px; animation-delay: 0.12s; }
+.sk5 { bottom: 30px; animation-delay: 0.16s; }
+.sk6 { bottom: 22px; animation-delay: 0.2s; }
+.sk7 { bottom: 14px; animation-delay: 0.24s; }
+
+.bridgeK {
+  position: absolute;
+  bottom: 12px;
+  width: 10px;
+  height: 56px;
+  background: linear-gradient(180deg, #f0e6cc, #b8a276);
+  clip-path: polygon(30% 0, 70% 0, 100% 100%, 0 100%);
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+  z-index: 7;
+}
+
+.bk1 { left: 40px; }
+.bk2 { left: 78px; }
+.bk3 { left: 116px; }
+.bk4 { left: 154px; }
+.bk5 { left: 192px; }
+.bk6 { left: 230px; }
+.bk7 { left: 262px; }
+
+.capK {
+  position: absolute;
+  bottom: 0;
+  width: 22px;
+  height: 74px;
+  background: linear-gradient(180deg, #3a2410, #1c1408);
+  z-index: 6;
+}
+
+.capL {
+  left: 0;
+  border-radius: 30px 6px 8px 40px / 40px 6px 8px 50px;
+}
+
+.capR {
+  right: 0;
+  border-radius: 6px 18px 20px 8px / 6px 30px 30px 8px;
+}
+
+@keyframes pluckK {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(0.7px); }
+}
+
+@keyframes swayK {
+  0%, 100% { transform: rotate(-0.6deg); }
+  50% { transform: rotate(0.6deg); }
+}
+
+@keyframes fallPetalK {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  12% { opacity: 1; }
+  100% { transform: translate(-40px, 250px) rotate(220deg); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kotoK,
+  .stringK,
+  .petalK {
+    animation: none;
+  }
+
+  .petalK {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML koto resting on a tatami mat.

## Details

- The long paulownia body with grain from a repeating linear gradient over a warm wood base
- Seven strings stretched the length of the instrument, plucked in sequence on staggered fast keyframes
- Seven movable ji bridges cut from clip-path pillars, each propping a string
- A tatami mat laid in perspective and falling cherry petals
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/koto-as/demo.html`
- `submissions/examples/koto-as/style.css`
- `submissions/examples/koto-as/README.md`

Closes #47117
