### PR TITLE
Add puppet theater component

### DIFF
--- a/submissions/examples/puppet-theater-as/README.md
+++ b/submissions/examples/puppet-theater-as/README.md
@@ -1,0 +1,19 @@
+# Puppet Theater
+
+A pure CSS and HTML Punch and Judy puppet theater: the striped curtains sweep open, a spotlight falls and two hand puppets bob and wave through their show.
+
+## What it shows
+
+- Curtains that draw open and closed by animating scaleX from the edges, framed by a scalloped valance masked with a radial gradient
+- Two hand puppets built from a head, body and waving arms, bobbing out of phase, each in its own costume and hat
+- A painted backdrop of stars and a moon glow from stacked radial gradients, with a pulsing spotlight
+- An ornate gilded proscenium arch around the stage
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`, leaving the curtains open.

--- a/submissions/examples/puppet-theater-as/demo.html
+++ b/submissions/examples/puppet-theater-as/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Puppet Theater</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="stageT">
+      <span class="backdropT"></span>
+      <span class="spotT"></span>
+      <div class="puppetT ptL">
+        <span class="pHead"></span>
+        <span class="pHat"></span>
+        <span class="pEye pel"></span>
+        <span class="pEye per"></span>
+        <span class="pNose"></span>
+        <span class="pBody"></span>
+        <span class="pArm palL"></span>
+        <span class="pArm palR"></span>
+      </div>
+      <div class="puppetT ptR">
+        <span class="pHead"></span>
+        <span class="pHat"></span>
+        <span class="pEye pel"></span>
+        <span class="pEye per"></span>
+        <span class="pNose"></span>
+        <span class="pBody"></span>
+        <span class="pArm palL"></span>
+        <span class="pArm palR"></span>
+      </div>
+      <span class="curtainT ctL"></span>
+      <span class="curtainT ctR"></span>
+      <span class="valanceT"></span>
+    </div>
+    <span class="prosceniumT"></span>
+    <span class="noteT nt1"></span>
+    <span class="noteT nt2"></span>
+    <span class="floorStageT"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/puppet-theater-as/style.css
+++ b/submissions/examples/puppet-theater-as/style.css
@@ -1,0 +1,337 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #2c1a3a, #120a1c 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.floorStageT {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 40px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 10, 30, 0.4) 0 2px,
+      transparent 2px 40px
+    ),
+    linear-gradient(180deg, #2c1e3a, #140c1e);
+  z-index: 9;
+}
+
+.prosceniumT {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 300px;
+  height: 250px;
+  margin-left: -150px;
+  border-radius: 14px 14px 6px 6px;
+  background: linear-gradient(180deg, #8a5a2a, #4a2f14);
+  box-shadow:
+    inset 0 0 0 6px rgba(210, 170, 90, 0.4),
+    0 16px 30px rgba(0, 0, 0, 0.4);
+  z-index: 5;
+}
+
+.stageT {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 256px;
+  height: 200px;
+  margin-left: -128px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #1a2440, #0c1428);
+  z-index: 6;
+}
+
+.backdropT {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 24%, #f0e6a0 0 2px, transparent 3px),
+    radial-gradient(circle at 44% 16%, #f0e6a0 0 2px, transparent 3px),
+    radial-gradient(circle at 72% 26%, #f0e6a0 0 2px, transparent 3px),
+    radial-gradient(circle at 88% 14%, #f0e6a0 0 2px, transparent 3px),
+    radial-gradient(circle at 60% 60%, rgba(180, 150, 210, 0.3) 0 40px, transparent 60px),
+    linear-gradient(180deg, #2a3a62, #16223e 60%, #3a2a3e);
+  z-index: 1;
+}
+
+.spotT {
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  width: 180px;
+  height: 200px;
+  margin-left: -90px;
+  background: radial-gradient(ellipse at 50% 0, rgba(255, 240, 190, 0.28), transparent 66%);
+  z-index: 2;
+  animation: spotPulseT 5s ease-in-out infinite;
+}
+
+.puppetT {
+  position: absolute;
+  bottom: -6px;
+  width: 90px;
+  height: 130px;
+  z-index: 4;
+}
+
+.ptL {
+  left: 26px;
+  transform-origin: 50% 100%;
+  animation: bounceLT 2.6s ease-in-out infinite;
+}
+
+.ptR {
+  right: 26px;
+  transform-origin: 50% 100%;
+  animation: bounceRT 2.6s ease-in-out infinite 0.4s;
+}
+
+.pBody {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 60px;
+  height: 66px;
+  margin-left: -30px;
+  border-radius: 46% 46% 20% 20% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #c83a5a, #8a1f38);
+  box-shadow: inset -4px -4px 12px rgba(80, 12, 30, 0.4);
+  z-index: 3;
+}
+
+.ptR .pBody {
+  background: linear-gradient(180deg, #3a7ac2, #1f4d86);
+}
+
+.pHead {
+  position: absolute;
+  bottom: 56px;
+  left: 50%;
+  width: 50px;
+  height: 50px;
+  margin-left: -25px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #f2d0a8, #d0966a 80%);
+  box-shadow: inset -3px -3px 8px rgba(150, 100, 60, 0.4);
+  z-index: 4;
+}
+
+.pHat {
+  position: absolute;
+  bottom: 94px;
+  left: 50%;
+  width: 46px;
+  height: 24px;
+  margin-left: -23px;
+  border-radius: 50% 50% 8% 8%;
+  background: linear-gradient(180deg, #e0b83a, #a5820f);
+  z-index: 5;
+}
+
+.ptR .pHat {
+  border-radius: 8px 8px 0 0;
+  clip-path: polygon(30% 100%, 46% 10%, 54% 10%, 70% 100%);
+  background: linear-gradient(180deg, #6a3ca8, #3a1f6a);
+}
+
+.pEye {
+  position: absolute;
+  bottom: 72px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #1a140c;
+  z-index: 6;
+}
+
+.pel { left: 50%; margin-left: -13px; }
+.per { left: 50%; margin-left: 6px; }
+
+.pNose {
+  position: absolute;
+  bottom: 64px;
+  left: 50%;
+  width: 9px;
+  height: 8px;
+  margin-left: -4px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ff8a6a, #c23a2a 74%);
+  z-index: 6;
+}
+
+.pArm {
+  position: absolute;
+  bottom: 40px;
+  width: 30px;
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #c83a5a, #8a1f38);
+  z-index: 5;
+}
+
+.ptR .pArm {
+  background: linear-gradient(90deg, #3a7ac2, #1f4d86);
+}
+
+.palL {
+  left: -4px;
+  transform-origin: 100% 50%;
+  animation: waveArmLT 1.6s ease-in-out infinite;
+}
+
+.palR {
+  right: -4px;
+  transform-origin: 0 50%;
+  animation: waveArmRT 1.6s ease-in-out infinite;
+}
+
+.palL::after,
+.palR::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f2d0a8, #d0966a 78%);
+}
+
+.palL::after { left: -8px; }
+.palR::after { right: -8px; }
+
+.curtainT {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 70px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #a01f32 0 6px,
+      #d8425a 6px 14px,
+      #7a1526 14px 20px
+    );
+  z-index: 7;
+}
+
+.ctL {
+  left: 0;
+  border-radius: 0 0 40% 0;
+  transform-origin: 0 0;
+  animation: openCurtainLT 6s ease-in-out infinite;
+}
+
+.ctR {
+  right: 0;
+  border-radius: 0 0 0 40%;
+  transform-origin: 100% 0;
+  animation: openCurtainRT 6s ease-in-out infinite;
+}
+
+.valanceT {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 34px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #a01f32 0 6px,
+      #d8425a 6px 14px,
+      #7a1526 14px 20px
+    );
+  border-radius: 0 0 10px 10px;
+  mask-image: radial-gradient(circle 16px at 16px 100%, transparent 0 14px, #000 15px);
+  z-index: 8;
+}
+
+.noteT {
+  position: absolute;
+  color: rgba(250, 240, 200, 0.7);
+  font-size: 20px;
+  z-index: 6;
+  animation: floatNoteT 4s ease-in infinite;
+}
+
+.noteT::before { content: "\266A"; }
+.nt1 { bottom: 200px; left: 90px; }
+.nt2 { bottom: 220px; right: 100px; font-size: 16px; animation-delay: 2s; }
+
+@keyframes bounceLT {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-10px) rotate(2deg); }
+}
+
+@keyframes bounceRT {
+  0%, 100% { transform: translateY(-6px) rotate(2deg); }
+  50% { transform: translateY(2px) rotate(-2deg); }
+}
+
+@keyframes waveArmLT {
+  0%, 100% { transform: rotate(-16deg); }
+  50% { transform: rotate(20deg); }
+}
+
+@keyframes waveArmRT {
+  0%, 100% { transform: rotate(16deg); }
+  50% { transform: rotate(-20deg); }
+}
+
+@keyframes openCurtainLT {
+  0%, 12% { transform: translateX(0) scaleX(1); }
+  30%, 88% { transform: translateX(-6px) scaleX(0.34); }
+  100% { transform: translateX(0) scaleX(1); }
+}
+
+@keyframes openCurtainRT {
+  0%, 12% { transform: translateX(0) scaleX(1); }
+  30%, 88% { transform: translateX(6px) scaleX(0.34); }
+  100% { transform: translateX(0) scaleX(1); }
+}
+
+@keyframes spotPulseT {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+@keyframes floatNoteT {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  30% { opacity: 1; }
+  100% { transform: translate(-16px, -40px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .puppetT,
+  .pArm,
+  .curtainT,
+  .spotT,
+  .noteT {
+    animation: none;
+  }
+
+  .ctL { transform: translateX(-6px) scaleX(0.34); }
+  .ctR { transform: translateX(6px) scaleX(0.34); }
+
+  .noteT {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML puppet theater with curtains and two hand puppets.

## Details

- Curtains draw open and closed by animating scaleX from the edges, framed by a scalloped valance masked with a radial gradient
- Two hand puppets built from a head, body and waving arms bob out of phase, each in its own costume and hat
- A painted backdrop of stars and a moon glow from stacked radial gradients, with a pulsing spotlight
- An ornate gilded proscenium arch around the stage
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/puppet-theater-as/demo.html`
- `submissions/examples/puppet-theater-as/style.css`
- `submissions/examples/puppet-theater-as/README.md`

Closes #47131
