### PR TITLE
feat: add compare plan slider demo

### DIFF
--- a/submissions/examples/compare-plan-slider-sm/README.md
+++ b/submissions/examples/compare-plan-slider-sm/README.md
@@ -1,0 +1,36 @@
+# Compare Plan Slider
+
+## What does this do?
+
+Compare Plan Slider is a self-contained HTML and CSS pricing comparison surface with animated plan cards, a segmented billing switch, progress meters, feature lists, and hover-lift actions.
+
+## How is it used?
+
+Create a `plan-grid` wrapper and add `plan-card` items with plan modifier classes such as `plan-starter`, `plan-growth`, or `plan-scale`.
+
+```html
+<article class="plan-card plan-growth featured">
+  <div class="plan-header">
+    <p class="plan-kicker">Growth</p>
+    <span class="plan-badge">Popular</span>
+  </div>
+  <div class="plan-price">
+    <span>$29</span>
+    <small>/ month</small>
+  </div>
+  <div class="meter" aria-hidden="true">
+    <span></span>
+  </div>
+  <button type="button">Choose Growth</button>
+</article>
+```
+
+Available plan classes:
+
+- `plan-starter`
+- `plan-growth`
+- `plan-scale`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to help comparison: cards enter softly, meters reveal relative value, the segmented switch provides lightweight movement, and hover states clarify each action. The demo is standalone and works by opening `demo.html` directly in a browser.

--- a/submissions/examples/compare-plan-slider-sm/demo.html
+++ b/submissions/examples/compare-plan-slider-sm/demo.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Compare Plan Slider Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="compare-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Compare Plan Slider</h1>
+        <p>
+          A CSS-only pricing comparison surface with animated plan cards, a
+          segmented billing switch, progress meters, and hover-lift details.
+        </p>
+      </section>
+
+      <section class="billing-toggle" aria-label="Billing period preview">
+        <span class="toggle-option active">Monthly</span>
+        <span class="toggle-option">Annual</span>
+        <span class="toggle-pill" aria-hidden="true"></span>
+      </section>
+
+      <section class="plan-grid" aria-label="Pricing plan comparison">
+        <article class="plan-card plan-starter">
+          <div class="plan-header">
+            <p class="plan-kicker">Starter</p>
+            <span class="plan-badge">Solo</span>
+          </div>
+          <div class="plan-price">
+            <span>$12</span>
+            <small>/ month</small>
+          </div>
+          <p class="plan-copy">
+            For small projects that need polished motion, clean defaults, and
+            predictable component behavior.
+          </p>
+          <div class="meter" aria-hidden="true">
+            <span></span>
+          </div>
+          <ul class="feature-list">
+            <li>6 active workspaces</li>
+            <li>Reusable animation snippets</li>
+            <li>Basic review history</li>
+          </ul>
+          <button type="button">Choose Starter</button>
+        </article>
+
+        <article class="plan-card plan-growth featured">
+          <div class="plan-header">
+            <p class="plan-kicker">Growth</p>
+            <span class="plan-badge">Popular</span>
+          </div>
+          <div class="plan-price">
+            <span>$29</span>
+            <small>/ month</small>
+          </div>
+          <p class="plan-copy">
+            For teams shipping dashboards, onboarding flows, and repeated
+            product surfaces with consistent motion language.
+          </p>
+          <div class="meter" aria-hidden="true">
+            <span></span>
+          </div>
+          <ul class="feature-list">
+            <li>Unlimited workspaces</li>
+            <li>Advanced motion presets</li>
+            <li>Shared component notes</li>
+          </ul>
+          <button type="button">Choose Growth</button>
+        </article>
+
+        <article class="plan-card plan-scale">
+          <div class="plan-header">
+            <p class="plan-kicker">Scale</p>
+            <span class="plan-badge">Teams</span>
+          </div>
+          <div class="plan-price">
+            <span>$64</span>
+            <small>/ month</small>
+          </div>
+          <p class="plan-copy">
+            For larger systems that need stronger governance, rollout controls,
+            and clear visual standards across product teams.
+          </p>
+          <div class="meter" aria-hidden="true">
+            <span></span>
+          </div>
+          <ul class="feature-list">
+            <li>Release approval lanes</li>
+            <li>Design token guidance</li>
+            <li>Priority support queue</li>
+          </ul>
+          <button type="button">Choose Scale</button>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/compare-plan-slider-sm/style.css
+++ b/submissions/examples/compare-plan-slider-sm/style.css
@@ -1,0 +1,383 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.compare-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 740px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.billing-toggle {
+  position: relative;
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(104px, 1fr));
+  gap: 4px;
+  min-height: 48px;
+  margin-bottom: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 28px rgba(23, 32, 51, 0.08);
+  padding: 4px;
+}
+
+.toggle-option {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-height: 38px;
+  place-items: center;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 850;
+}
+
+.toggle-option.active {
+  color: #ffffff;
+}
+
+.toggle-pill {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: calc(50% - 6px);
+  height: calc(100% - 8px);
+  border-radius: 7px;
+  background: var(--blue);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.24);
+  animation: toggle-slide 2.8s ease-in-out infinite alternate;
+}
+
+.plan-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  align-items: stretch;
+}
+
+.plan-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 520px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  padding: 24px;
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  animation: plan-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.plan-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.plan-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.plan-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.featured::after {
+  position: absolute;
+  top: 18px;
+  right: -40px;
+  width: 150px;
+  padding: 7px 0;
+  color: #ffffff;
+  background: var(--accent);
+  content: "Best Fit";
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-align: center;
+  text-transform: uppercase;
+  transform: rotate(38deg);
+}
+
+.plan-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.plan-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.plan-kicker {
+  margin-bottom: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.plan-badge {
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 850;
+}
+
+.plan-price {
+  display: flex;
+  align-items: end;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.plan-price span {
+  font-size: 3rem;
+  font-weight: 950;
+  line-height: 1;
+}
+
+.plan-price small {
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.plan-copy {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.meter {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 10px 0 22px;
+}
+
+.meter span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--fill);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: meter-fill 1s 260ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.feature-list {
+  display: grid;
+  gap: 12px;
+  margin: 0 0 24px;
+  padding: 0;
+  list-style: none;
+}
+
+.feature-list li {
+  position: relative;
+  padding-left: 28px;
+  color: #40506a;
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.feature-list li::before {
+  position: absolute;
+  top: 2px;
+  left: 0;
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--accent);
+  content: "✓";
+  font-size: 0.68rem;
+  font-weight: 900;
+}
+
+.plan-card button {
+  min-height: 44px;
+  margin-top: auto;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.plan-card button:hover,
+.plan-card button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.plan-starter {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --fill: 56%;
+}
+
+.plan-growth {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --fill: 82%;
+}
+
+.plan-scale {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --fill: 72%;
+}
+
+@keyframes plan-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes meter-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes toggle-slide {
+  to {
+    transform: translateX(calc(100% + 8px));
+  }
+}
+
+@media (max-width: 860px) {
+  .compare-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .plan-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .plan-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #47184



**PR Text**

Title: `feat: add compare plan slider demo`

```md
## Pull Request Description
Adds a self-contained Compare Plan Slider demo under `submissions/examples/`, featuring animated pricing cards, a billing toggle, progress meters, feature lists, and hover-lift buttons.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only pricing comparison pattern for plan selection surfaces.

**How does a developer use it?**
Use a `plan-grid` wrapper with `plan-card` items and plan classes like `plan-starter`, `plan-growth`, or `plan-scale`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to make plan comparison easier while staying standalone, readable, and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The class names, plan labels, colors, and animation timing can be standardized during framework integration.