### PR TITLE
feat: add accessibility score meter demo

### DIFF
--- a/submissions/examples/accessibility-score-meter-sm/README.md
+++ b/submissions/examples/accessibility-score-meter-sm/README.md
@@ -1,0 +1,5 @@
+# Accessibility Score Meter
+
+1. What does this do? Adds responsive accessibility score cards with animated meter fills, staggered entrance motion, focus states, and scannable review notes.
+2. How is it used? Apply `.score-grid` to the wrapper and use `.score-card` with state classes like `.excellent`, `.good`, or `.review` for each score.
+3. Why is it useful? It helps teams compare accessibility health at a glance with purposeful CSS-only motion and keyboard-friendly focus treatment.

--- a/submissions/examples/accessibility-score-meter-sm/demo.html
+++ b/submissions/examples/accessibility-score-meter-sm/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accessibility Score Meter</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="score-panel" aria-labelledby="score-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Accessibility review</p>
+        <h1 id="score-title">Animated score meters for interface health</h1>
+        <p>
+          Score cards use staggered entry, animated meter fills, and keyboard focus states to make
+          accessibility review results easy to compare at a glance.
+        </p>
+      </div>
+
+      <div class="score-grid" aria-label="Accessibility score cards">
+        <article class="score-card excellent" tabindex="0">
+          <div class="score-topline">
+            <span class="score-label">Focus visibility</span>
+            <strong>96</strong>
+          </div>
+          <div class="meter-track" aria-hidden="true">
+            <span class="meter-fill"></span>
+          </div>
+          <p>Focus rings are visible, offset correctly, and maintain contrast across surfaces.</p>
+          <div class="score-notes">
+            <span>Keyboard ready</span>
+            <span>High contrast</span>
+          </div>
+        </article>
+
+        <article class="score-card good" tabindex="0">
+          <div class="score-topline">
+            <span class="score-label">Motion comfort</span>
+            <strong>88</strong>
+          </div>
+          <div class="meter-track" aria-hidden="true">
+            <span class="meter-fill"></span>
+          </div>
+          <p>Most transitions respect reduced-motion preferences and avoid distracting loops.</p>
+          <div class="score-notes">
+            <span>Reduced motion</span>
+            <span>Short timing</span>
+          </div>
+        </article>
+
+        <article class="score-card review" tabindex="0">
+          <div class="score-topline">
+            <span class="score-label">Text contrast</span>
+            <strong>72</strong>
+          </div>
+          <div class="meter-track" aria-hidden="true">
+            <span class="meter-fill"></span>
+          </div>
+          <p>Muted labels need review on tinted cards before the component is ready to ship.</p>
+          <div class="score-notes">
+            <span>Review muted text</span>
+            <span>Token check</span>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/accessibility-score-meter-sm/style.css
+++ b/submissions/examples/accessibility-score-meter-sm/style.css
@@ -1,0 +1,268 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --excellent: #12805c;
+  --excellent-soft: #e7f7ef;
+  --good: #3158e8;
+  --good-soft: #e9eeff;
+  --review: #a95d00;
+  --review-soft: #fff5e5;
+  --track: #e8edf4;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(18, 128, 92, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 82%, rgba(49, 88, 232, 0.12), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.score-panel {
+  width: min(100%, 1060px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--excellent);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.score-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.score-card {
+  --tone: var(--good);
+  --tone-soft: var(--good-soft);
+  --score: 80%;
+  position: relative;
+  overflow: hidden;
+  min-height: 20rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1.15rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  animation: score-card-enter 580ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.score-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--tone-soft), transparent 62%);
+  opacity: 0.78;
+}
+
+.score-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.score-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.score-card:hover,
+.score-card:focus-visible {
+  border-color: color-mix(in srgb, var(--tone) 42%, var(--line));
+  box-shadow: var(--shadow);
+  transform: translateY(-5px);
+}
+
+.score-card:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  outline-offset: 5px;
+}
+
+.excellent {
+  --tone: var(--excellent);
+  --tone-soft: var(--excellent-soft);
+  --score: 96%;
+}
+
+.good {
+  --tone: var(--good);
+  --tone-soft: var(--good-soft);
+  --score: 88%;
+}
+
+.review {
+  --tone: var(--review);
+  --tone-soft: var(--review-soft);
+  --score: 72%;
+}
+
+.score-topline,
+.meter-track,
+.score-card p,
+.score-notes {
+  position: relative;
+  z-index: 1;
+}
+
+.score-topline {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.score-label {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 0.32rem 0.7rem;
+  color: var(--tone);
+  background: color-mix(in srgb, var(--tone-soft) 78%, #ffffff);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.score-topline strong {
+  color: var(--tone);
+  font-size: clamp(2.6rem, 7vw, 4.5rem);
+  line-height: 0.9;
+}
+
+.score-topline strong::after {
+  content: "%";
+  font-size: 1rem;
+  vertical-align: super;
+}
+
+.meter-track {
+  height: 0.9rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--track);
+}
+
+.meter-fill {
+  display: block;
+  width: var(--score);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--tone) 68%, #ffffff), var(--tone));
+  animation: meter-fill 850ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: left center;
+}
+
+.score-card p {
+  margin: 1rem 0 1.15rem;
+  color: var(--muted);
+  line-height: 1.58;
+}
+
+.score-notes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.score-notes span {
+  border: 1px solid color-mix(in srgb, var(--tone) 22%, var(--line));
+  border-radius: 999px;
+  padding: 0.32rem 0.68rem;
+  color: var(--tone);
+  background: rgba(255, 255, 255, 0.72);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+@keyframes score-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes meter-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .score-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .score-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .score-card,
+  .meter-fill {
+    animation: none;
+    transition: none;
+  }
+
+  .score-card:hover,
+  .score-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #47187
## Pull Request Description

Adds a self-contained Accessibility Score Meter demo with animated score cards, meter fills, staggered entrance motion, keyboard focus states, scannable review notes, responsive layout, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Responsive accessibility score cards with animated meter fills, staggered card entry, state-based colors, review notes, and keyboard focus treatment.

**How does a developer use it?**

```html
<div class="score-grid">
  <article class="score-card excellent" tabindex="0">
    <div class="score-topline">
      <span class="score-label">Focus visibility</span>
      <strong>96</strong>
    </div>
    <div class="meter-track" aria-hidden="true">
      <span class="meter-fill"></span>
    </div>
  </article>
</div>