### PR TITLE
feat: add data table row focus demo

### DIFF
--- a/submissions/examples/data-table-row-focus-sm/README.md
+++ b/submissions/examples/data-table-row-focus-sm/README.md
@@ -1,0 +1,35 @@
+# Data Table Row Focus
+
+## What does this do?
+
+Data Table Row Focus is a self-contained HTML and CSS table pattern with animated row entry, visible keyboard focus states, status chips, score meters, and compact row actions.
+
+## How is it used?
+
+Create a `table-card` wrapper with a regular HTML table, then add row modifier classes such as `row-high`, `row-medium`, `row-good`, or `row-new` to control row accent color and score meter styling.
+
+```html
+<tr class="row-high" tabindex="0">
+  <td>
+    <strong>Northstar Labs</strong>
+    <span>Enterprise renewal</span>
+  </td>
+  <td><span class="status-chip">At risk</span></td>
+  <td>
+    <div class="score-meter" aria-hidden="true">
+      <span></span>
+    </div>
+  </td>
+</tr>
+```
+
+Available row classes:
+
+- `row-high`
+- `row-medium`
+- `row-good`
+- `row-new`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to improve scanning in dense interfaces: rows enter in sequence, score meters fill to communicate health, and hover plus focus states make the active row obvious. The demo is standalone and works by opening `demo.html` directly in a browser.

--- a/submissions/examples/data-table-row-focus-sm/demo.html
+++ b/submissions/examples/data-table-row-focus-sm/demo.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Data Table Row Focus Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="table-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Data Table Row Focus</h1>
+        <p>
+          A self-contained data table pattern with animated row entry, focus
+          rings, hover highlights, status chips, and compact action buttons.
+        </p>
+      </section>
+
+      <section class="metric-strip" aria-label="Table summary">
+        <article>
+          <span class="metric-value">248</span>
+          <span class="metric-label">Accounts tracked</span>
+        </article>
+        <article>
+          <span class="metric-value">37</span>
+          <span class="metric-label">Need review</span>
+        </article>
+        <article>
+          <span class="metric-value">94%</span>
+          <span class="metric-label">Data quality</span>
+        </article>
+      </section>
+
+      <section class="table-card" aria-label="Customer account review table">
+        <header class="table-toolbar">
+          <div>
+            <p class="toolbar-kicker">Review Queue</p>
+            <h2>Priority accounts</h2>
+          </div>
+          <button type="button">Export</button>
+        </header>
+
+        <div class="responsive-table">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Account</th>
+                <th scope="col">Owner</th>
+                <th scope="col">Status</th>
+                <th scope="col">Score</th>
+                <th scope="col">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="row-high" tabindex="0">
+                <td>
+                  <strong>Northstar Labs</strong>
+                  <span>Enterprise renewal</span>
+                </td>
+                <td>Aarav S.</td>
+                <td><span class="status-chip">At risk</span></td>
+                <td>
+                  <div class="score-meter" aria-hidden="true">
+                    <span></span>
+                  </div>
+                </td>
+                <td><button type="button">Review</button></td>
+              </tr>
+              <tr class="row-medium" tabindex="0">
+                <td>
+                  <strong>Pixel Harbor</strong>
+                  <span>Usage expansion</span>
+                </td>
+                <td>Mira K.</td>
+                <td><span class="status-chip">Watching</span></td>
+                <td>
+                  <div class="score-meter" aria-hidden="true">
+                    <span></span>
+                  </div>
+                </td>
+                <td><button type="button">Open</button></td>
+              </tr>
+              <tr class="row-good" tabindex="0">
+                <td>
+                  <strong>Orbit Works</strong>
+                  <span>Healthy adoption</span>
+                </td>
+                <td>Dev P.</td>
+                <td><span class="status-chip">Healthy</span></td>
+                <td>
+                  <div class="score-meter" aria-hidden="true">
+                    <span></span>
+                  </div>
+                </td>
+                <td><button type="button">View</button></td>
+              </tr>
+              <tr class="row-new" tabindex="0">
+                <td>
+                  <strong>BrightLayer AI</strong>
+                  <span>New onboarding</span>
+                </td>
+                <td>Neha R.</td>
+                <td><span class="status-chip">New</span></td>
+                <td>
+                  <div class="score-meter" aria-hidden="true">
+                    <span></span>
+                  </div>
+                </td>
+                <td><button type="button">Assign</button></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/data-table-row-focus-sm/style.css
+++ b/submissions/examples/data-table-row-focus-sm/style.css
@@ -1,0 +1,343 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.table-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.toolbar-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.metric-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.metric-strip article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.metric-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.metric-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.table-card {
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+  padding: 22px;
+}
+
+.table-toolbar h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.table-toolbar button,
+td button {
+  min-height: 38px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--blue);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.table-toolbar button {
+  min-width: 96px;
+}
+
+.table-toolbar button:hover,
+.table-toolbar button:focus-visible,
+td button:hover,
+td button:focus-visible {
+  box-shadow: 0 12px 26px rgba(37, 99, 235, 0.18);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.responsive-table {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 18px 22px;
+  text-align: left;
+}
+
+th {
+  color: #40506a;
+  background: #f8fafc;
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+tbody tr {
+  position: relative;
+  border-top: 1px solid var(--line);
+  outline: 0;
+  opacity: 0;
+  transform: translateY(12px);
+  animation: row-enter 560ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    background 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+tbody tr:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+tbody tr:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+tbody tr:nth-child(4) {
+  animation-delay: 270ms;
+}
+
+tbody tr:hover,
+tbody tr:focus-visible {
+  background: var(--accent-soft);
+  box-shadow: inset 5px 0 0 var(--accent);
+  transform: translateY(-2px);
+}
+
+td {
+  color: #40506a;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+td strong {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--ink);
+  font-size: 0.98rem;
+}
+
+td span:not(.status-chip) {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.status-chip {
+  display: inline-flex;
+  padding: 7px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.score-meter {
+  position: relative;
+  width: 140px;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+}
+
+.score-meter span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--score);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: meter-fill 920ms 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+td button {
+  min-width: 84px;
+  background: var(--accent);
+}
+
+.row-high {
+  --accent: var(--red);
+  --accent-light: #fb7185;
+  --accent-soft: rgba(220, 38, 38, 0.1);
+  --score: 38%;
+}
+
+.row-medium {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.12);
+  --score: 64%;
+}
+
+.row-good {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.1);
+  --score: 88%;
+}
+
+.row-new {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.1);
+  --score: 72%;
+}
+
+@keyframes row-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes meter-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 760px) {
+  .table-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .metric-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .table-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #47189

**PR Text**

Title: `feat: add data table row focus demo`

```md
## Pull Request Description
Adds a self-contained Data Table Row Focus demo under `submissions/examples/`, featuring animated table rows, visible keyboard focus states, status chips, score meters, and compact row actions.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only table interaction pattern for scanning account or review queues.

**How does a developer use it?**
Use a `table-card` wrapper with regular table rows and row classes like `row-high`, `row-medium`, `row-good`, or `row-new`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion and clear focus styling to make dense table interfaces easier to navigate while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The row naming, score colors, and animation timing can be standardized during framework integration.