### PR TITLE
feat: add audit log event stack demo

### DIFF
--- a/submissions/examples/audit-log-event-stack-sm/README.md
+++ b/submissions/examples/audit-log-event-stack-sm/README.md
@@ -1,0 +1,34 @@
+# Audit Log Event Stack
+
+## What does this do?
+
+Audit Log Event Stack is a self-contained HTML and CSS activity stream that shows system events with animated cards, a status rail, pulsing markers, risk badges, and compact metadata.
+
+## How is it used?
+
+Create an `audit-panel` with an `event-stack`, then add `event-card` items with event modifier classes such as `event-critical`, `event-warning`, `event-info`, or `event-success`.
+
+```html
+<article class="event-card event-critical">
+  <div class="event-marker" aria-hidden="true"></div>
+  <div class="event-body">
+    <div class="event-topline">
+      <p>Access control</p>
+      <span>Critical</span>
+    </div>
+    <h3>Admin role changed outside approval window</h3>
+    <p>A privileged account was assigned elevated permissions.</p>
+  </div>
+</article>
+```
+
+Available event classes:
+
+- `event-critical`
+- `event-warning`
+- `event-info`
+- `event-success`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to clarify activity sequence and severity: events enter gently, the rail reveals the timeline, markers pulse for attention, and hover states make each event easier to inspect. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/audit-log-event-stack-sm/demo.html
+++ b/submissions/examples/audit-log-event-stack-sm/demo.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Audit Log Event Stack Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="audit-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Audit Log Event Stack</h1>
+        <p>
+          A self-contained audit trail pattern with animated event cards, status
+          rails, risk badges, and compact metadata for reviewing system
+          activity.
+        </p>
+      </section>
+
+      <section class="summary-grid" aria-label="Audit summary">
+        <article>
+          <span class="summary-value">142</span>
+          <span class="summary-label">Events today</span>
+        </article>
+        <article>
+          <span class="summary-value">09</span>
+          <span class="summary-label">Require review</span>
+        </article>
+        <article>
+          <span class="summary-value">99.8%</span>
+          <span class="summary-label">Policy coverage</span>
+        </article>
+      </section>
+
+      <section class="audit-panel" aria-label="Audit log event examples">
+        <header class="audit-header">
+          <div>
+            <p class="header-kicker">Activity Stream</p>
+            <h2>Latest security events</h2>
+          </div>
+          <span class="live-chip">Live</span>
+        </header>
+
+        <div class="event-stack">
+          <article class="event-card event-critical">
+            <div class="event-marker" aria-hidden="true"></div>
+            <div class="event-body">
+              <div class="event-topline">
+                <p>Access control</p>
+                <span>Critical</span>
+              </div>
+              <h3>Admin role changed outside approval window</h3>
+              <p>
+                A privileged account was assigned elevated permissions while the
+                scheduled change request was inactive.
+              </p>
+              <footer>
+                <span>2 min ago</span>
+                <span>Policy: RBAC-04</span>
+              </footer>
+            </div>
+          </article>
+
+          <article class="event-card event-warning">
+            <div class="event-marker" aria-hidden="true"></div>
+            <div class="event-body">
+              <div class="event-topline">
+                <p>Authentication</p>
+                <span>Warning</span>
+              </div>
+              <h3>Repeated failed sign-in attempts detected</h3>
+              <p>
+                Five failed attempts were recorded for a known user from a new
+                device fingerprint and untrusted network.
+              </p>
+              <footer>
+                <span>12 min ago</span>
+                <span>Policy: AUTH-11</span>
+              </footer>
+            </div>
+          </article>
+
+          <article class="event-card event-info">
+            <div class="event-marker" aria-hidden="true"></div>
+            <div class="event-body">
+              <div class="event-topline">
+                <p>Configuration</p>
+                <span>Info</span>
+              </div>
+              <h3>Retention settings updated for workspace logs</h3>
+              <p>
+                A workspace owner adjusted audit retention from 90 days to 180
+                days and enabled weekly export reminders.
+              </p>
+              <footer>
+                <span>31 min ago</span>
+                <span>Policy: LOG-02</span>
+              </footer>
+            </div>
+          </article>
+
+          <article class="event-card event-success">
+            <div class="event-marker" aria-hidden="true"></div>
+            <div class="event-body">
+              <div class="event-topline">
+                <p>Compliance</p>
+                <span>Resolved</span>
+              </div>
+              <h3>Quarterly access review completed</h3>
+              <p>
+                Department owners verified user roles, removed stale access, and
+                confirmed exception notes for the current quarter.
+              </p>
+              <footer>
+                <span>1 hr ago</span>
+                <span>Policy: COMP-08</span>
+              </footer>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/audit-log-event-stack-sm/style.css
+++ b/submissions/examples/audit-log-event-stack-sm/style.css
@@ -1,0 +1,382 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.audit-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.header-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.summary-grid article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.audit-panel {
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.audit-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+  padding: 22px;
+}
+
+.audit-header h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.live-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 11px;
+  border-radius: 999px;
+  color: var(--green);
+  background: rgba(22, 163, 74, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.live-chip::before {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  content: "";
+  background: currentColor;
+  box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.2);
+  animation: live-pulse 1.6s ease-out infinite;
+}
+
+.event-stack {
+  position: relative;
+  display: grid;
+  gap: 14px;
+  padding: 22px;
+}
+
+.event-stack::before {
+  position: absolute;
+  top: 34px;
+  bottom: 34px;
+  left: 38px;
+  width: 3px;
+  border-radius: 999px;
+  content: "";
+  background: linear-gradient(
+    180deg,
+    var(--red),
+    var(--amber),
+    var(--blue),
+    var(--green)
+  );
+  transform-origin: top;
+  animation: rail-drop 1s 180ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.event-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 14px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: event-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.event-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.event-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.event-card:nth-child(4) {
+  animation-delay: 270ms;
+}
+
+.event-marker {
+  position: relative;
+  z-index: 1;
+  width: 34px;
+  height: 34px;
+  border: 5px solid #ffffff;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 12px 24px var(--accent-soft);
+  animation: marker-pulse 2.2s ease-out infinite;
+}
+
+.event-body {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 18px;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.event-body:hover {
+  border-color: var(--accent);
+  box-shadow: 0 16px 34px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.event-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.event-topline p {
+  margin-bottom: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.event-topline span,
+.event-body footer span {
+  display: inline-flex;
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 850;
+}
+
+.event-body h3 {
+  margin-bottom: 8px;
+  font-size: 1.08rem;
+  line-height: 1.25;
+}
+
+.event-body > p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.event-body footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.event-critical {
+  --accent: var(--red);
+  --accent-soft: rgba(220, 38, 38, 0.13);
+}
+
+.event-warning {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.14);
+}
+
+.event-info {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.13);
+}
+
+.event-success {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.13);
+}
+
+@keyframes event-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes rail-drop {
+  from {
+    transform: scaleY(0);
+  }
+
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes marker-pulse {
+  0% {
+    box-shadow:
+      0 0 0 0 var(--accent-soft),
+      0 12px 24px var(--accent-soft);
+  }
+
+  70% {
+    box-shadow:
+      0 0 0 12px rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+}
+
+@keyframes live-pulse {
+  70% {
+    box-shadow: 0 0 0 10px rgba(22, 163, 74, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(22, 163, 74, 0);
+  }
+}
+
+@media (max-width: 720px) {
+  .audit-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .audit-header {
+    flex-direction: column;
+  }
+
+  .event-stack {
+    padding: 18px;
+  }
+
+  .event-stack::before {
+    left: 34px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #47194


**PR Text**

Title: `feat: add audit log event stack demo`

```md
## Pull Request Description
Adds a self-contained Audit Log Event Stack demo under `submissions/examples/`, featuring animated event cards, a status rail, pulsing markers, risk badges, and compact metadata.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only audit log activity stream for reviewing system events.

**How does a developer use it?**
Use an `audit-panel` with `event-card` items and classes like `event-critical`, `event-warning`, `event-info`, or `event-success`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate sequence, severity, and live activity while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The event naming, severity colors, and animation timing can be standardized during framework integration.