### PR TITLE
feat: add pricing tier radar demo

### DIFF
--- a/submissions/examples/pricing-tier-radar-sm/README.md
+++ b/submissions/examples/pricing-tier-radar-sm/README.md
@@ -1,0 +1,5 @@
+# Pricing Tier Radar
+
+1. What does this do? Adds responsive pricing tier cards with animated radar badges, pulsing fit indicators, staggered card entry, and hover or focus feedback.
+2. How is it used? Apply `.pricing-grid` to the wrapper and use `.tier-card` with tone classes like `.starter-tier`, `.studio-tier`, or `.scale-tier` for each plan.
+3. Why is it useful? It helps users compare plan fit quickly with purposeful CSS-only motion and readable pricing details.

--- a/submissions/examples/pricing-tier-radar-sm/demo.html
+++ b/submissions/examples/pricing-tier-radar-sm/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pricing Tier Radar</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="pricing-panel" aria-labelledby="pricing-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Plan fit</p>
+        <h1 id="pricing-title">Pricing tiers with animated fit radar</h1>
+        <p>
+          Each plan card pairs readable pricing details with a pulsing radar badge that highlights
+          who the tier is best suited for.
+        </p>
+      </div>
+
+      <div class="pricing-grid" aria-label="Pricing tier radar cards">
+        <article class="tier-card starter-tier" tabindex="0">
+          <div class="radar-badge" aria-hidden="true">
+            <span class="radar-dot"></span>
+          </div>
+          <span class="tier-label">Starter</span>
+          <h2>Prototype</h2>
+          <p class="price">$12<span>/mo</span></p>
+          <p class="tier-copy">Best for small experiments, landing pages, and one-off motion demos.</p>
+          <ul>
+            <li>12 animation presets</li>
+            <li>Basic hover utilities</li>
+            <li>Reduced-motion helpers</li>
+          </ul>
+        </article>
+
+        <article class="tier-card studio-tier" tabindex="0">
+          <div class="radar-badge" aria-hidden="true">
+            <span class="radar-dot"></span>
+          </div>
+          <span class="tier-label">Studio</span>
+          <h2>Product team</h2>
+          <p class="price">$29<span>/mo</span></p>
+          <p class="tier-copy">Best for teams shipping polished dashboards and reusable UI patterns.</p>
+          <ul>
+            <li>48 animation presets</li>
+            <li>Focus and hover packs</li>
+            <li>Token-ready examples</li>
+          </ul>
+        </article>
+
+        <article class="tier-card scale-tier" tabindex="0">
+          <div class="radar-badge" aria-hidden="true">
+            <span class="radar-dot"></span>
+          </div>
+          <span class="tier-label">Scale</span>
+          <h2>Design system</h2>
+          <p class="price">$79<span>/mo</span></p>
+          <p class="tier-copy">Best for mature systems that need consistent motion across surfaces.</p>
+          <ul>
+            <li>Unlimited pattern exports</li>
+            <li>Audit-ready motion states</li>
+            <li>Advanced rollout templates</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pricing-tier-radar-sm/style.css
+++ b/submissions/examples/pricing-tier-radar-sm/style.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --starter: #a95d00;
+  --starter-soft: #fff5e5;
+  --studio: #3158e8;
+  --studio-soft: #e9eeff;
+  --scale: #147b5a;
+  --scale-soft: #e8f7ef;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(49, 88, 232, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 82%, rgba(20, 123, 90, 0.12), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.pricing-panel {
+  width: min(100%, 1080px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--studio);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.tier-card {
+  --tone: var(--studio);
+  --tone-soft: var(--studio-soft);
+  position: relative;
+  overflow: hidden;
+  min-height: 28rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1.2rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  animation: tier-enter 580ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.tier-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--tone-soft), transparent 62%);
+  opacity: 0.78;
+}
+
+.tier-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.tier-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.tier-card:hover,
+.tier-card:focus-visible {
+  border-color: color-mix(in srgb, var(--tone) 42%, var(--line));
+  box-shadow: var(--shadow);
+  transform: translateY(-5px);
+}
+
+.tier-card:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  outline-offset: 5px;
+}
+
+.starter-tier {
+  --tone: var(--starter);
+  --tone-soft: var(--starter-soft);
+}
+
+.studio-tier {
+  --tone: var(--studio);
+  --tone-soft: var(--studio-soft);
+}
+
+.scale-tier {
+  --tone: var(--scale);
+  --tone-soft: var(--scale-soft);
+}
+
+.radar-badge,
+.tier-label,
+.tier-card h2,
+.price,
+.tier-copy,
+.tier-card ul {
+  position: relative;
+  z-index: 1;
+}
+
+.radar-badge {
+  display: grid;
+  width: 5.2rem;
+  height: 5.2rem;
+  place-items: center;
+  margin-bottom: 1rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 28%, transparent);
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(circle, transparent 0 0.72rem, color-mix(in srgb, var(--tone) 18%, transparent) 0.76rem 0.8rem),
+    var(--tone-soft);
+  box-shadow: inset 0 0 0 0.75rem rgba(255, 255, 255, 0.42);
+}
+
+.radar-badge::before,
+.radar-badge::after {
+  content: "";
+  position: absolute;
+  border-radius: inherit;
+}
+
+.radar-badge::before {
+  inset: 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 28%, transparent);
+}
+
+.radar-badge::after {
+  inset: 1.2rem;
+  background: conic-gradient(from 35deg, transparent 0 72%, color-mix(in srgb, var(--tone) 45%, transparent) 74%, transparent 86% 100%);
+  animation: radar-spin 2.6s linear infinite;
+}
+
+.radar-dot {
+  position: relative;
+  z-index: 1;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: var(--tone);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--tone) 34%, transparent);
+  animation: radar-pulse 1.8s ease-out infinite;
+}
+
+.tier-label {
+  display: inline-flex;
+  margin-bottom: 0.65rem;
+  border-radius: 999px;
+  padding: 0.32rem 0.7rem;
+  color: var(--tone);
+  background: color-mix(in srgb, var(--tone-soft) 78%, #ffffff);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.tier-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.price {
+  margin: 0.75rem 0;
+  color: var(--tone);
+  font-size: clamp(2.4rem, 7vw, 4rem);
+  font-weight: 950;
+  line-height: 0.9;
+}
+
+.price span {
+  color: var(--muted);
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.tier-copy {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  line-height: 1.58;
+}
+
+.tier-card ul {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tier-card li {
+  position: relative;
+  padding-left: 1.2rem;
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.tier-card li::before {
+  content: "";
+  position: absolute;
+  top: 0.48em;
+  left: 0;
+  width: 0.46rem;
+  height: 0.46rem;
+  border-radius: 999px;
+  background: var(--tone);
+}
+
+@keyframes tier-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes radar-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes radar-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--tone) 34%, transparent);
+  }
+
+  72%,
+  100% {
+    box-shadow: 0 0 0 0.9rem transparent;
+  }
+}
+
+@media (max-width: 860px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .pricing-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tier-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tier-card,
+  .radar-badge::after,
+  .radar-dot {
+    animation: none;
+    transition: none;
+  }
+
+  .tier-card:hover,
+  .tier-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #47197

## Pull Request Description

Adds a self-contained Pricing Tier Radar demo with responsive pricing cards, animated radar badges, pulsing fit indicators, staggered card entry, hover/focus feedback, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Responsive pricing tier cards with animated radar badges, pulsing plan-fit indicators, readable pricing details, and hover/focus motion feedback.

**How does a developer use it?**

```html
<div class="pricing-grid">
  <article class="tier-card studio-tier" tabindex="0">
    <div class="radar-badge" aria-hidden="true">
      <span class="radar-dot"></span>
    </div>
    <span class="tier-label">Studio</span>
    <h2>Product team</h2>
    <p class="price">$29<span>/mo</span></p>
  </article>
</div>