### PR TITLE
feat: add release health radar demo

### DIFF
--- a/submissions/examples/release-health-radar-sm/README.md
+++ b/submissions/examples/release-health-radar-sm/README.md
@@ -1,0 +1,30 @@
+# Release Health Radar
+
+## What does this do?
+
+Release Health Radar is a self-contained HTML and CSS release dashboard pattern with animated health rings, radar scan motion, signal cards, and compact deployment readiness metrics.
+
+## How is it used?
+
+Create a `radar-layout` with a `radar-card` for the scan visualization and `signal-card` items with modifier classes such as `signal-good`, `signal-watch`, or `signal-info`.
+
+```html
+<article class="signal-card signal-good">
+  <div class="signal-icon" aria-hidden="true">01</div>
+  <div>
+    <p>Build Pipeline</p>
+    <h3>All required jobs passed</h3>
+    <span>18 checks complete</span>
+  </div>
+</article>
+```
+
+Available signal classes:
+
+- `signal-good`
+- `signal-watch`
+- `signal-info`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to clarify release readiness: the radar scan suggests live monitoring, pulsing dots highlight healthy systems, and signal cards enter gently for quick review. The demo is standalone and works by opening `demo.html` directly in a browser.

--- a/submissions/examples/release-health-radar-sm/demo.html
+++ b/submissions/examples/release-health-radar-sm/demo.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release Health Radar Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="release-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Release Health Radar</h1>
+        <p>
+          A self-contained release dashboard pattern with animated health rings,
+          signal cards, scan motion, and compact deployment readiness
+          indicators.
+        </p>
+      </section>
+
+      <section class="release-summary" aria-label="Release summary">
+        <article>
+          <span class="summary-value">96%</span>
+          <span class="summary-label">Checks passing</span>
+        </article>
+        <article>
+          <span class="summary-value">14</span>
+          <span class="summary-label">Services ready</span>
+        </article>
+        <article>
+          <span class="summary-value">03</span>
+          <span class="summary-label">Signals watched</span>
+        </article>
+      </section>
+
+      <section class="radar-layout" aria-label="Release health radar preview">
+        <article class="radar-card">
+          <div class="radar-screen" aria-hidden="true">
+            <span class="radar-ring ring-one"></span>
+            <span class="radar-ring ring-two"></span>
+            <span class="radar-ring ring-three"></span>
+            <span class="radar-sweep"></span>
+            <span class="radar-dot dot-build"></span>
+            <span class="radar-dot dot-api"></span>
+            <span class="radar-dot dot-cache"></span>
+            <strong>Ready</strong>
+          </div>
+          <div class="radar-copy">
+            <p class="radar-kicker">Deployment Gate</p>
+            <h2>Production release is stable</h2>
+            <p>
+              Build checks, incident signals, and service dependencies are
+              inside the expected release threshold.
+            </p>
+          </div>
+        </article>
+
+        <section class="signal-stack" aria-label="Release signal cards">
+          <article class="signal-card signal-good">
+            <div class="signal-icon" aria-hidden="true">01</div>
+            <div>
+              <p>Build Pipeline</p>
+              <h3>All required jobs passed</h3>
+              <span>18 checks complete</span>
+            </div>
+          </article>
+
+          <article class="signal-card signal-watch">
+            <div class="signal-icon" aria-hidden="true">02</div>
+            <div>
+              <p>Error Budget</p>
+              <h3>Minor increase under watch</h3>
+              <span>0.7% burn rate</span>
+            </div>
+          </article>
+
+          <article class="signal-card signal-info">
+            <div class="signal-icon" aria-hidden="true">03</div>
+            <div>
+              <p>Service Mesh</p>
+              <h3>Dependency routes healthy</h3>
+              <span>14 services synced</span>
+            </div>
+          </article>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/release-health-radar-sm/style.css
+++ b/submissions/examples/release-health-radar-sm/style.css
@@ -1,0 +1,374 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.release-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.radar-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.release-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.release-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.radar-layout {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.95fr) minmax(0, 1.05fr);
+  gap: 20px;
+  align-items: stretch;
+}
+
+.radar-card,
+.signal-card {
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.radar-card {
+  overflow: hidden;
+  padding: 24px;
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  animation: panel-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.radar-screen {
+  position: relative;
+  display: grid;
+  aspect-ratio: 1;
+  width: min(100%, 390px);
+  margin: 0 auto 24px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(22, 163, 74, 0.12), transparent 58%),
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(255, 255, 255, 0.86));
+}
+
+.radar-screen::before,
+.radar-screen::after {
+  position: absolute;
+  inset: 50% auto auto 0;
+  width: 100%;
+  height: 1px;
+  content: "";
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.radar-screen::after {
+  transform: rotate(90deg);
+}
+
+.radar-ring {
+  position: absolute;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 50%;
+}
+
+.ring-one {
+  inset: 18%;
+}
+
+.ring-two {
+  inset: 32%;
+}
+
+.ring-three {
+  inset: 46%;
+}
+
+.radar-sweep {
+  position: absolute;
+  inset: 50% 50% 0 auto;
+  width: 44%;
+  height: 44%;
+  background: linear-gradient(45deg, rgba(22, 163, 74, 0.34), transparent 68%);
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+  transform-origin: 100% 0;
+  animation: radar-scan 3.8s linear infinite;
+}
+
+.radar-dot {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 3px solid #ffffff;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.18);
+  animation: dot-pulse 1.8s ease-out infinite;
+}
+
+.dot-build {
+  top: 28%;
+  left: 58%;
+}
+
+.dot-api {
+  top: 62%;
+  left: 34%;
+  animation-delay: 320ms;
+}
+
+.dot-cache {
+  top: 48%;
+  left: 72%;
+  animation-delay: 640ms;
+}
+
+.radar-screen strong {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 94px;
+  height: 94px;
+  place-items: center;
+  border: 8px solid #ffffff;
+  border-radius: 50%;
+  color: var(--green);
+  background: var(--surface);
+  box-shadow: 0 18px 38px rgba(22, 163, 74, 0.16);
+  font-size: 0.95rem;
+  font-weight: 950;
+}
+
+.radar-copy h2 {
+  margin-bottom: 10px;
+  font-size: 1.35rem;
+}
+
+.radar-copy p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.signal-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.signal-card {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+  padding: 20px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: panel-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.signal-card:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.signal-card:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+.signal-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 18px 42px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.signal-icon {
+  display: grid;
+  width: 52px;
+  height: 52px;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 950;
+}
+
+.signal-card p {
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.signal-card h3 {
+  margin-bottom: 8px;
+  font-size: 1.08rem;
+}
+
+.signal-card span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 750;
+}
+
+.signal-good {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.13);
+}
+
+.signal-watch {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.14);
+}
+
+.signal-info {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.13);
+}
+
+@keyframes panel-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes radar-scan {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dot-pulse {
+  70% {
+    box-shadow: 0 0 0 12px rgba(22, 163, 74, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(22, 163, 74, 0);
+  }
+}
+
+@media (max-width: 820px) {
+  .release-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .release-summary,
+  .radar-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #47199


**PR Text**

Title: `feat: add release health radar demo`

```md
## Pull Request Description
Adds a self-contained Release Health Radar demo under `submissions/examples/`, featuring animated health rings, radar scan motion, signal cards, and deployment readiness metrics.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only release health dashboard pattern for deployment readiness reviews.

**How does a developer use it?**
Use a `radar-layout` with a `radar-card` and `signal-card` items using classes like `signal-good`, `signal-watch`, or `signal-info`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate live monitoring, service health, and readiness while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The signal names, readiness colors, and radar animation timing can be standardized during framework integration.