### PR TITLE
feat: add draw border product catalog popover

### DIFF
--- a/submissions/examples/Draw-Border-Line-Product-Catalog-Popover/README.md
+++ b/submissions/examples/Draw-Border-Line-Product-Catalog-Popover/README.md
@@ -1,0 +1,28 @@
+# Draw Border Line Product Catalog Popover
+
+A responsive **Draw Border Line Popover** designed for product catalog interfaces using only HTML and CSS.
+
+## Features
+
+- Pure HTML & CSS
+- Responsive layout
+- Product preview card
+- Draw-border animation
+- Keyboard accessible
+- CSS custom properties
+- Supports `prefers-reduced-motion`
+- No JavaScript
+
+## Files
+
+- demo.html
+- style.css
+- README.md
+
+## Usage
+
+Open `demo.html` directly in any modern browser.
+
+## Customization
+
+Modify the CSS variables in `:root` to customize colors, spacing, border radius, and animation speed.

--- a/submissions/examples/Draw-Border-Line-Product-Catalog-Popover/demo.html
+++ b/submissions/examples/Draw-Border-Line-Product-Catalog-Popover/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Product Catalog Popover</title>
+<link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<div class="catalog">
+
+    <button class="product-btn">
+        View Product
+    </button>
+
+    <div class="popover" role="dialog" aria-label="Product Information">
+
+        <img
+            src="https://via.placeholder.com/260x150"
+            alt="Product preview">
+
+        <h3>Wireless Headphones</h3>
+
+        <p>
+            Noise cancellation with 30-hour battery life and premium audio.
+        </p>
+
+        <span class="price">$149.99</span>
+
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/Draw-Border-Line-Product-Catalog-Popover/style.css
+++ b/submissions/examples/Draw-Border-Line-Product-Catalog-Popover/style.css
@@ -1,0 +1,124 @@
+:root{
+    --primary:#2563eb;
+    --accent:#f97316;
+    --bg:#f6f7fb;
+    --card:#ffffff;
+    --text:#1f2937;
+    --radius:18px;
+    --speed:.45s;
+}
+
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    min-height:100vh;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    background:var(--bg);
+    font-family:Arial,Helvetica,sans-serif;
+}
+
+.catalog{
+    position:relative;
+}
+
+.product-btn{
+    padding:15px 34px;
+    border:none;
+    border-radius:999px;
+    cursor:pointer;
+    background:var(--primary);
+    color:#fff;
+    font-size:1rem;
+    transition:.3s;
+}
+
+.product-btn:hover,
+.product-btn:focus-visible{
+    background:#1d4ed8;
+    outline:none;
+}
+
+.popover{
+    position:absolute;
+    left:50%;
+    bottom:calc(100% + 18px);
+    transform:translateX(-50%) translateY(12px);
+    opacity:0;
+    pointer-events:none;
+
+    width:280px;
+    background:var(--card);
+    border-radius:var(--radius);
+    overflow:hidden;
+    box-shadow:0 18px 35px rgba(0,0,0,.15);
+
+    transition:
+        opacity var(--speed),
+        transform var(--speed);
+}
+
+.catalog:hover .popover,
+.catalog:focus-within .popover{
+    opacity:1;
+    pointer-events:auto;
+    transform:translateX(-50%) translateY(0);
+}
+
+.popover::before{
+    content:"";
+    position:absolute;
+    inset:0;
+    border:2px solid var(--accent);
+    border-radius:inherit;
+    clip-path:polygon(0 0,0 0,0 100%,0 100%);
+    transition:clip-path .7s ease;
+}
+
+.catalog:hover .popover::before,
+.catalog:focus-within .popover::before{
+    clip-path:polygon(0 0,100% 0,100% 100%,0 100%);
+}
+
+.popover img{
+    width:100%;
+    display:block;
+}
+
+.popover h3{
+    padding:16px 18px 8px;
+    color:var(--primary);
+}
+
+.popover p{
+    padding:0 18px;
+    color:var(--text);
+    line-height:1.5;
+    font-size:.92rem;
+}
+
+.price{
+    display:block;
+    padding:16px 18px 20px;
+    color:var(--accent);
+    font-weight:bold;
+    font-size:1.1rem;
+}
+
+@media(max-width:600px){
+    .popover{
+        width:230px;
+    }
+}
+
+@media(prefers-reduced-motion:reduce){
+    *{
+        animation:none!important;
+        transition:none!important;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

### Type of Change

- [x] 🧩 New component
- [x] ✨ Animation
- [x] 📝 Documentation

---

## Submission Checklist

- [x] Added files only inside `submissions/examples/Draw-Border-Line-Product-Catalog-Popover/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to existing project files
- [x] Pure HTML & CSS
- [x] Responsive
- [x] Keyboard accessible
- [x] No JavaScript

---

## Feature Description

This PR introduces a reusable **Draw Border Line Popover** inspired by product catalog interfaces. It displays a product preview with a smooth border-drawing animation using only HTML and CSS. The component is responsive, accessible, and customizable through CSS variables.

### Features

- Draw-border animation
- Product preview popover
- Pure HTML & CSS
- Responsive layout
- Keyboard accessible
- CSS custom properties
- Supports `prefers-reduced-motion`
- No external dependencies

---

## Demo

Open `demo.html` directly in any modern browser.

---

## Notes for Maintainer

- Built entirely with HTML & CSS
- No JavaScript required
- No modifications to existing project files
- Lightweight and reusable component

Closes #46743