### PR TITLE
feat: add sidebar tooltip rise example

### DIFF
--- a/submissions/examples/sidebar-tooltip-rise/README.md
+++ b/submissions/examples/sidebar-tooltip-rise/README.md
@@ -1,0 +1,14 @@
+# Sidebar Tooltip Rise
+
+An icon-only sidebar action with a tooltip that rises into place on hover or keyboard focus.
+
+## Files
+
+- `demo.html` - button and tooltip markup.
+- `style.css` - button lift, tooltip rise, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Uses `aria-describedby` to connect the button and tooltip.
+- Mirrors hover behavior on keyboard focus.
+- Keeps the tooltip non-interactive and layout stable.

--- a/submissions/examples/sidebar-tooltip-rise/demo.html
+++ b/submissions/examples/sidebar-tooltip-rise/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sidebar Tooltip Rise</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion sidebar</p>
+    <h1 id="demo-title">Sidebar tooltip rise</h1>
+    <p class="intro">An icon-only sidebar button with a tooltip that rises in on hover or keyboard focus.</p>
+
+    <div class="sidebar-action">
+      <button type="button" aria-describedby="tip-dashboard">D</button>
+      <span class="tooltip" id="tip-dashboard" role="tooltip">Dashboard</span>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sidebar-tooltip-rise/style.css
+++ b/submissions/examples/sidebar-tooltip-rise/style.css
@@ -1,0 +1,107 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 50%, #f0fdfa 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(79, 70, 229, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.sidebar-action {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+button {
+  display: grid;
+  place-items: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border: 0;
+  border-radius: 1rem;
+  color: #ffffff;
+  background: #4f46e5;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  box-shadow: 0 1rem 2rem rgba(79, 70, 229, 0.2);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.tooltip {
+  position: absolute;
+  left: calc(100% + 0.75rem);
+  top: 50%;
+  width: max-content;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.65rem;
+  color: #ffffff;
+  background: #172033;
+  font-weight: 850;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(calc(-50% + 0.35rem)) scale(0.96);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.sidebar-action:hover button,
+.sidebar-action:focus-within button {
+  transform: translateY(-0.18rem);
+  box-shadow: 0 1.25rem 2.4rem rgba(79, 70, 229, 0.28);
+}
+
+.sidebar-action:hover .tooltip,
+.sidebar-action:focus-within .tooltip {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}
+
+button:focus-visible {
+  outline: 0.18rem solid #818cf8;
+  outline-offset: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a sidebar tooltip rise motion example
- include hover and focus-within states
- document tooltip accessibility and reduced-motion support

## Verification
- git diff --cached --check