### PR TITLE
feat: add file card stack example

### DIFF
--- a/submissions/examples/file-card-stack/README.md
+++ b/submissions/examples/file-card-stack/README.md
@@ -1,0 +1,14 @@
+# File Card Stack
+
+A stacked file preview where cards fan out on hover or keyboard focus.
+
+## Files
+
+- `demo.html` - stacked file preview markup.
+- `style.css` - stacked transforms, hover/focus spread motion, and reduced-motion support.
+
+## Highlights
+
+- Keeps the card stack inside a stable fixed area.
+- Mirrors hover behavior on keyboard focus.
+- Uses separate transforms for each file card.

--- a/submissions/examples/file-card-stack/demo.html
+++ b/submissions/examples/file-card-stack/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>File Card Stack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion files</p>
+    <h1 id="demo-title">File card stack</h1>
+    <p class="intro">A stacked file preview where cards fan out on hover or keyboard focus.</p>
+
+    <div class="stack" tabindex="0" aria-label="Three project files">
+      <span class="file one">CSS</span>
+      <span class="file two">HTML</span>
+      <span class="file three">MD</span>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/file-card-stack/style.css
+++ b/submissions/examples/file-card-stack/style.css
@@ -1,0 +1,102 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 50%, #eef2ff 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(234, 88, 12, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.stack {
+  position: relative;
+  width: 12rem;
+  height: 8rem;
+  outline: 0;
+}
+
+.file {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 1rem;
+  color: #ffffff;
+  background: #ea580c;
+  font-weight: 900;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.18);
+  transition: transform 240ms ease, box-shadow 240ms ease;
+}
+
+.two {
+  background: #4f46e5;
+  transform: translate(0.7rem, 0.55rem) rotate(4deg);
+}
+
+.three {
+  background: #0f766e;
+  transform: translate(1.4rem, 1.1rem) rotate(8deg);
+}
+
+.stack:hover .one,
+.stack:focus-visible .one {
+  transform: translate(-0.8rem, -0.45rem) rotate(-8deg);
+}
+
+.stack:hover .two,
+.stack:focus-visible .two {
+  transform: translate(0.85rem, 0.25rem) rotate(0deg);
+}
+
+.stack:hover .three,
+.stack:focus-visible .three {
+  transform: translate(2.25rem, 0.95rem) rotate(10deg);
+}
+
+.stack:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.35rem;
+  border-radius: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a file card stack motion example
- include hover and focus-visible spread states
- document the stack and reduced-motion fallback

## Verification
- git diff --cached --check