### PR TITLE
feat: add calendar event pop example

### DIFF
--- a/submissions/examples/calendar-event-pop/README.md
+++ b/submissions/examples/calendar-event-pop/README.md
@@ -1,0 +1,14 @@
+# Calendar Event Pop
+
+A calendar date tile where the event marker pops into view on hover or keyboard focus.
+
+## Files
+
+- `demo.html` - accessible date tile button markup.
+- `style.css` - tile lift, event marker pop, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Uses a native button for interaction.
+- Keeps the event marker readable before and after motion.
+- Preserves keyboard focus styling.

--- a/submissions/examples/calendar-event-pop/demo.html
+++ b/submissions/examples/calendar-event-pop/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calendar Event Pop</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion calendar</p>
+    <h1 id="demo-title">Calendar event pop</h1>
+    <p class="intro">A calendar date tile where an event marker pops into view on interaction.</p>
+
+    <button class="date-tile" type="button" aria-label="July 15 has 3 events">
+      <span class="month">Jul</span>
+      <strong>15</strong>
+      <span class="events">3 events</span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/calendar-event-pop/style.css
+++ b/submissions/examples/calendar-event-pop/style.css
@@ -1,0 +1,109 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 50%, #f0fdfa 100%);
+}
+
+.panel {
+  width: min(92vw, 30rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(234, 88, 12, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.date-tile {
+  display: grid;
+  justify-items: center;
+  gap: 0.35rem;
+  width: 8.5rem;
+  min-height: 9rem;
+  border: 0;
+  border-radius: 1.1rem;
+  padding: 1rem;
+  color: #172033;
+  background: #ffffff;
+  font: inherit;
+  cursor: pointer;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.12);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.month {
+  color: #ea580c;
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.date-tile strong {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.events {
+  border-radius: 999px;
+  padding: 0.32rem 0.68rem;
+  color: #ffffff;
+  background: #0f766e;
+  font-size: 0.8rem;
+  font-weight: 900;
+  transform: scale(0.86);
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+.date-tile:hover,
+.date-tile:focus-visible {
+  transform: translateY(-0.25rem);
+  box-shadow: 0 1.3rem 2.5rem rgba(234, 88, 12, 0.18);
+}
+
+.date-tile:hover .events,
+.date-tile:focus-visible .events {
+  background: #ea580c;
+  transform: scale(1.08);
+}
+
+.date-tile:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a calendar event pop motion example
- include hover and focus-visible event marker states
- document the tile and reduced-motion fallback

## Verification
- git diff --cached --check