### PR TITLE
feat: add modal action stack example

### DIFF
--- a/submissions/examples/modal-action-stack/README.md
+++ b/submissions/examples/modal-action-stack/README.md
@@ -1,0 +1,14 @@
+# Modal Action Stack
+
+A modal action footer where buttons rise into place with a short stagger.
+
+## Files
+
+- `demo.html` - modal action button markup.
+- `style.css` - staggered button entrance, hover/focus states, and reduced-motion fallback.
+
+## Highlights
+
+- Keeps button widths stable while the entrance runs.
+- Mirrors hover styling on keyboard focus.
+- Falls back to static buttons for reduced-motion users.

--- a/submissions/examples/modal-action-stack/demo.html
+++ b/submissions/examples/modal-action-stack/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal Action Stack</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion modal</p>
+    <h1 id="demo-title">Modal action stack</h1>
+    <p class="intro">A modal footer where action buttons rise in with a compact stagger.</p>
+
+    <section class="actions" aria-label="Modal actions">
+      <button type="button">Cancel</button>
+      <button class="primary" type="button">Publish</button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/modal-action-stack/style.css
+++ b/submissions/examples/modal-action-stack/style.css
@@ -1,0 +1,101 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 50%, #fff7ed 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(79, 70, 229, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(79, 70, 229, 0.12);
+}
+
+.actions button {
+  flex: 1 1 8rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.85rem 1rem;
+  color: #475569;
+  background: #f1f5f9;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(0.65rem);
+  animation: action-rise 520ms ease forwards;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+.actions .primary {
+  color: #ffffff;
+  background: #4f46e5;
+  animation-delay: 110ms;
+}
+
+.actions button:hover,
+.actions button:focus-visible {
+  transform: translateY(-0.18rem);
+  box-shadow: 0 0.9rem 1.6rem rgba(79, 70, 229, 0.2);
+}
+
+.actions button:focus-visible {
+  outline: 0.18rem solid #818cf8;
+  outline-offset: 0.22rem;
+}
+
+@keyframes action-rise {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .actions button {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a modal action stack motion example
- include staggered action button entrance
- document hover, focus, and reduced-motion support

## Verification
- git diff --cached --check