### PR TITLE
feat: add card badge slide example

### DIFF
--- a/submissions/examples/card-badge-slide/README.md
+++ b/submissions/examples/card-badge-slide/README.md
@@ -1,0 +1,14 @@
+# Card Badge Slide
+
+A feature card where the status badge slides into focus when the card is hovered or focused.
+
+## Files
+
+- `demo.html` - focusable feature card markup.
+- `style.css` - card lift, badge slide, focus-visible state, and reduced-motion support.
+
+## Highlights
+
+- Keeps the badge inside a stable card layout.
+- Mirrors hover behavior on keyboard focus.
+- Uses a reduced-motion fallback for transitions.

--- a/submissions/examples/card-badge-slide/demo.html
+++ b/submissions/examples/card-badge-slide/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Badge Slide</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion card</p>
+    <h1 id="demo-title">Card badge slide</h1>
+    <p class="intro">A compact feature card where the status badge slides into focus on interaction.</p>
+
+    <article class="feature-card" tabindex="0">
+      <span class="badge">Featured</span>
+      <strong>Motion presets</strong>
+      <span>Reusable timing and easing examples.</span>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/card-badge-slide/style.css
+++ b/submissions/examples/card-badge-slide/style.css
@@ -1,0 +1,97 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 50%, #ecfeff 100%);
+}
+
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(234, 88, 12, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #ea580c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  line-height: 1;
+}
+
+.intro {
+  margin: 1rem 0 2rem;
+  color: #526173;
+  line-height: 1.65;
+}
+
+.feature-card {
+  position: relative;
+  display: grid;
+  gap: 0.65rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.12);
+  overflow: hidden;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.badge {
+  width: max-content;
+  padding: 0.28rem 0.68rem;
+  border-radius: 999px;
+  color: #ffffff;
+  background: #ea580c;
+  font-size: 0.8rem;
+  font-weight: 900;
+  transform: translateX(-0.7rem);
+  opacity: 0.74;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+.feature-card span:last-child {
+  color: #64748b;
+}
+
+.feature-card:hover,
+.feature-card:focus-visible {
+  transform: translateY(-0.28rem);
+  box-shadow: 0 1.3rem 2.5rem rgba(234, 88, 12, 0.18);
+}
+
+.feature-card:hover .badge,
+.feature-card:focus-visible .badge {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.feature-card:focus-visible {
+  outline: 0.18rem solid #fdba74;
+  outline-offset: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a card badge slide motion example
- include hover and focus-visible badge states
- document the feature card and reduced-motion fallback

## Verification
- git diff --cached --check