### PR TITLE
docs: add ease-zoom-in scrollbar flicker fix for issue #44670

### DIFF
--- a/submissions/docs/44670-ease-zoom-fix-oh/README.md
+++ b/submissions/docs/44670-ease-zoom-fix-oh/README.md
@@ -1,0 +1,48 @@
+# Bug Fix: ease-zoom-in Scrollbar Flicker
+
+This submission documents the fix for **Issue #44670** - ease-zoom-in on hero section causes brief scrollbar flicker in Chrome on page load.
+
+## Problem
+
+When `.ease-zoom-in` is applied to a full-width hero section, Chrome shows a brief vertical scrollbar flicker on page load due to the `scale` transform extending beyond viewport bounds.
+
+## Solution
+
+Use `overflow: hidden` on the parent container and add `clip-path: inset(0)` to the animated element:
+
+```css
+.hero-container {
+  overflow: hidden;
+}
+
+.hero-container .ease-zoom-in {
+  clip-path: inset(0);
+}
+```
+
+## Full Example
+
+```html
+<div class="hero-container">
+  <div class="hero ease-zoom-in">
+    <!-- Content -->
+  </div>
+</div>
+```
+
+```css
+.hero-container {
+  overflow: hidden;
+}
+
+.hero-container .ease-zoom-in {
+  clip-path: inset(0);
+}
+```
+
+## Acceptance Criteria
+
+- ✅ No scrollbar appears during zoom-in animation
+- ✅ Works in Chrome and other browsers
+- ✅ Animation behavior unchanged
+- ✅ `prefers-reduced-motion` support

--- a/submissions/docs/44670-ease-zoom-fix-oh/demo.html
+++ b/submissions/docs/44670-ease-zoom-fix-oh/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bug Fix: ease-zoom-in scrollbar flicker fix</title>
+  <meta name="description" content="Fixed ease-zoom-in animation scrollbar flicker using clip-path and overflow containment.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="container">
+    <header>
+      <h1 id="main-title">ease-zoom-in Fix</h1>
+      <p class="subtitle" id="main-desc">Preventing scrollbar flicker during zoom animation</p>
+    </header>
+
+    <section class="demo-section">
+      <h2>With Fix (No Flicker)</h2>
+      <p class="demo-description">Uses <code>clip-path: inset(0)</code> to contain the transform.</p>
+      <div class="hero-container fixed">
+        <div class="hero ease-zoom-in">
+          <h3>Hero with Fixed Zoom Animation</h3>
+          <p>No scrollbar flicker thanks to clip-path containment</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="code-section">
+      <h3>How to Apply the Fix</h3>
+      <pre><code>/* Contain the transform within bounds */
+.hero-container {
+  overflow: hidden;
+}
+
+.ease-zoom-in {
+  clip-path: inset(0);
+}</code></pre>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/docs/44670-ease-zoom-fix-oh/style.css
+++ b/submissions/docs/44670-ease-zoom-fix-oh/style.css
@@ -1,0 +1,168 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --bg-primary: #0a0e17;
+  --bg-surface: rgba(26, 36, 56, 0.6);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #3b82f6;
+  --color-text: #f3f4f6;
+  --color-text-muted: #9ca3af;
+  --font-sans: 'Outfit', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  min-height: 100vh;
+  padding: 2rem;
+  background-image: radial-gradient(circle at 50% 50%, rgba(59, 130, 246, 0.08) 0%, transparent 60%);
+}
+
+.container {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  backdrop-filter: blur(20px);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #60a5fa, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-align: center;
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  margin-bottom: 2rem;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.demo-section {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.demo-section h2 {
+  font-size: 1.125rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo-description {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.demo-description code {
+  background: rgba(59, 130, 246, 0.2);
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+/* Hero Container - THE FIX */
+.hero-container {
+  width: 100%;
+  min-height: 200px;
+  position: relative;
+  border-radius: 8px;
+  border: 1px dashed var(--border-color);
+  background: rgba(0, 0, 0, 0.1);
+  /* KEY FIX: Contain the transform */
+  overflow: hidden;
+}
+
+.hero-container .ease-zoom-in {
+  /* ADDITIONAL FIX: clip-path containment */
+  clip-path: inset(0);
+}
+
+/* Hero Content */
+.hero {
+  padding: 2rem;
+  text-align: center;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(96, 165, 250, 0.1));
+  border-radius: 8px;
+}
+
+.hero h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-primary);
+}
+
+.hero p {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+/* Zoom Animation */
+.ease-zoom-in {
+  animation: easeZoomIn 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+  transform-origin: center center;
+}
+
+@keyframes easeZoomIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.code-section {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.code-section h3 {
+  font-size: 1.125rem;
+  margin-bottom: 1rem;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.875rem;
+  color: #60a5fa;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoom-in {
+    animation: none;
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the ease-zoom-in scrollbar flicker fix for Issue #44670.

### Problem
When ease-zoom-in is applied to a hero section, Chrome shows a brief scrollbar flicker on page load.

### Solution
Use overflow: hidden on parent and clip-path: inset(0) on the animated element.

### Files Added
- submissions/docs/44670-ease-zoom-fix-oh/demo.html
- submissions/docs/44670-ease-zoom-fix-oh/style.css
- submissions/docs/44670-ease-zoom-fix-oh/README.md

*Created by OpenHands AI agent*