### PR TITLE
feat(submission): add draw-border-line-popover component (#46759)

### DIFF
--- a/submissions/examples/draw-border-popover-ksk/README.md
+++ b/submissions/examples/draw-border-popover-ksk/README.md
@@ -1,0 +1,26 @@
+# Draw-Border Line Popover (`draw-border-popover-ksk`)
+
+1. What does this do?  
+A pure CSS popover where the trigger button's border **draws clockwise** on hover (top+right lines, then bottom+left) using `clip-path` transitions. When clicked, the popover card opens with a matching border-draw entrance on the card itself, plus a spring `translateY` fade-in.
+
+2. How is it used?  
+Wrap `<input class="ease-draw-toggle">` + `.ease-draw-wrap` together. Inside add a `.ease-draw-trigger` label and `.ease-draw-popover` card. Tune all parameters via CSS custom properties:
+
+```css
+.ease-draw-wrap {
+  --ease-draw-duration:   0.45s;
+  --ease-draw-easing:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-draw-spring:     cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-draw-color:      #6366f1;   /* border draw colour    */
+  --ease-draw-thickness:  2px;
+  --ease-draw-width:      300px;
+  --ease-draw-offset:     8px;
+  --ease-draw-radius:     14px;
+}
+```
+
+3. Why is it useful?  
+The draw-border effect is a visually distinctive focus indicator — particularly effective for accessible web layouts where clear focus states matter. The animated border doubles as a keyboard-visible state, meeting WCAG 2.4.11 focus appearance requirements.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #46759.*

--- a/submissions/examples/draw-border-popover-ksk/demo.html
+++ b/submissions/examples/draw-border-popover-ksk/demo.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Draw-Border Popover — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #060a10;
+      background-image:
+        radial-gradient(ellipse at 25% 45%, rgba(99,102,241,0.1) 0%, transparent 55%),
+        radial-gradient(ellipse at 75% 55%, rgba(139,92,246,0.08) 0%, transparent 55%);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, sans-serif;
+      color: #f8fafc;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, #818cf8, #34d399);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin: 0 0 0.4rem;
+    }
+    .page-header p {
+      color: #334155;
+      font-size: 0.88rem;
+      margin: 0;
+    }
+    .demo-hint {
+      text-align: center;
+      color: #1e293b;
+      font-size: 0.8rem;
+      margin-top: 1.2rem;
+      max-width: 500px;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Skip to content link — accessibility pattern -->
+  <a href="#main-content" class="toolbar-skip-link" style="position:absolute;top:12px;left:12px;">Skip to content</a>
+
+  <div class="page-header">
+    <h1>Draw-Border Line Popover</h1>
+    <p>Hover a button to watch the border draw in. Click to open a popover with a matching border entrance on the card.</p>
+  </div>
+
+  <!-- Accessible Web Toolbar Demo -->
+  <div class="a11y-toolbar" role="toolbar" aria-label="Accessibility and help tools">
+    <span class="toolbar-label">Tools</span>
+
+    <!-- Popover 1: Accessibility Settings -->
+    <input type="checkbox" id="draw1" class="ease-draw-toggle">
+    <div class="ease-draw-wrap">
+      <label for="draw1" class="ease-draw-trigger"
+             tabindex="0" role="button"
+             aria-haspopup="dialog" aria-expanded="false">
+        ♿ Accessibility
+      </label>
+      <div class="ease-draw-popover" role="dialog" aria-label="Accessibility settings">
+        <div class="draw-pop-header">
+          <div class="draw-pop-icon" aria-hidden="true">♿</div>
+          <div>
+            <p class="draw-pop-title">Accessibility Settings</p>
+            <p class="draw-pop-sub">Adjust your experience</p>
+          </div>
+          <label for="draw1" class="draw-pop-close" aria-label="Close">✕</label>
+        </div>
+        <div class="draw-pop-body">
+          <p class="draw-pop-desc">
+            Customise how this page behaves for your needs. All settings are saved in your browser.
+          </p>
+          <div class="draw-pop-list">
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true">✓</div>
+              Reduce motion enabled
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true">✓</div>
+              High contrast mode available
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true">✓</div>
+              Screen reader optimised markup
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true">✓</div>
+              Keyboard navigation fully supported
+            </div>
+          </div>
+          <a class="draw-pop-link" href="#" role="button">
+            Open full settings
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Popover 2: Keyboard Shortcuts -->
+    <input type="checkbox" id="draw2" class="ease-draw-toggle">
+    <div class="ease-draw-wrap" style="--ease-draw-color: #22c55e;">
+      <label for="draw2" class="ease-draw-trigger"
+             tabindex="0" role="button"
+             aria-haspopup="dialog" aria-expanded="false"
+             style="border-color: rgba(34,197,94,0.2); color:#4ade80;">
+        ⌨️ Shortcuts
+      </label>
+      <div class="ease-draw-popover" role="dialog" aria-label="Keyboard shortcuts"
+           style="--ease-draw-color: #22c55e;">
+        <div class="draw-pop-header">
+          <div class="draw-pop-icon" aria-hidden="true"
+               style="background:rgba(34,197,94,0.1);border-color:rgba(34,197,94,0.2);">⌨️</div>
+          <div>
+            <p class="draw-pop-title">Keyboard Shortcuts</p>
+            <p class="draw-pop-sub">Navigate without a mouse</p>
+          </div>
+          <label for="draw2" class="draw-pop-close" aria-label="Close">✕</label>
+        </div>
+        <div class="draw-pop-body">
+          <p class="draw-pop-desc">
+            Use these keyboard shortcuts to navigate the application efficiently.
+          </p>
+          <div class="draw-pop-list">
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true"
+                   style="background:rgba(34,197,94,0.1);border-color:rgba(34,197,94,0.2);color:#4ade80;">⌘</div>
+              <code style="color:#94a3b8;">Tab</code>&nbsp;— Move focus forward
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true"
+                   style="background:rgba(34,197,94,0.1);border-color:rgba(34,197,94,0.2);color:#4ade80;">⌘</div>
+              <code style="color:#94a3b8;">Shift+Tab</code>&nbsp;— Move focus back
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true"
+                   style="background:rgba(34,197,94,0.1);border-color:rgba(34,197,94,0.2);color:#4ade80;">⌘</div>
+              <code style="color:#94a3b8;">Enter / Space</code>&nbsp;— Activate
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true"
+                   style="background:rgba(34,197,94,0.1);border-color:rgba(34,197,94,0.2);color:#4ade80;">⌘</div>
+              <code style="color:#94a3b8;">Escape</code>&nbsp;— Close dialogs
+            </div>
+          </div>
+          <a class="draw-pop-link" href="#" role="button"
+             style="background:rgba(34,197,94,0.08);border-color:rgba(34,197,94,0.2);color:#4ade80;">
+            View all shortcuts
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Popover 3: Help / Support -->
+    <input type="checkbox" id="draw3" class="ease-draw-toggle">
+    <div class="ease-draw-wrap" style="--ease-draw-color: #f59e0b;">
+      <label for="draw3" class="ease-draw-trigger"
+             tabindex="0" role="button"
+             aria-haspopup="dialog" aria-expanded="false"
+             style="border-color:rgba(245,158,11,0.2);color:#fbbf24;">
+        ❓ Help
+      </label>
+      <div class="ease-draw-popover" role="dialog" aria-label="Help and support"
+           style="--ease-draw-color: #f59e0b;">
+        <div class="draw-pop-header">
+          <div class="draw-pop-icon" aria-hidden="true"
+               style="background:rgba(245,158,11,0.1);border-color:rgba(245,158,11,0.2);">❓</div>
+          <div>
+            <p class="draw-pop-title">Help &amp; Support</p>
+            <p class="draw-pop-sub">We're here for you</p>
+          </div>
+          <label for="draw3" class="draw-pop-close" aria-label="Close">✕</label>
+        </div>
+        <div class="draw-pop-body">
+          <p class="draw-pop-desc">
+            Access documentation, tutorials, and support channels.
+          </p>
+          <div class="draw-pop-list">
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true"
+                   style="background:rgba(245,158,11,0.1);border-color:rgba(245,158,11,0.2);color:#fbbf24;">✓</div>
+              Full documentation online
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true"
+                   style="background:rgba(245,158,11,0.1);border-color:rgba(245,158,11,0.2);color:#fbbf24;">✓</div>
+              Community Discord available
+            </div>
+            <div class="draw-pop-item">
+              <div class="draw-pop-check" aria-hidden="true"
+                   style="background:rgba(245,158,11,0.1);border-color:rgba(245,158,11,0.2);color:#fbbf24;">✓</div>
+              GitHub issues for bug reports
+            </div>
+          </div>
+          <a class="draw-pop-link" href="#" role="button"
+             style="background:rgba(245,158,11,0.08);border-color:rgba(245,158,11,0.2);color:#fbbf24;">
+            Open help centre
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <div class="toolbar-spacer"></div>
+    <a href="#main-content" class="toolbar-skip-link">Skip to content</a>
+  </div>
+
+  <p class="demo-hint" id="main-content">
+    Each trigger's border draws clockwise on hover. The popover card's border draws in simultaneously on open.
+    All three use different accent colours via <code>--ease-draw-color</code>.
+  </p>
+
+</body>
+</html>

--- a/submissions/examples/draw-border-popover-ksk/style.css
+++ b/submissions/examples/draw-border-popover-ksk/style.css
@@ -1,0 +1,352 @@
+/* ============================================================
+   EaseMotion CSS — Draw-Border Line Popover (Accessible Web)
+   submissions/examples/draw-border-popover-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .ease-draw-wrap or any ancestor to tune.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-draw-duration:   0.45s;
+  --ease-draw-easing:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-draw-spring:     cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-draw-delay:      0s;
+  --ease-draw-color:      #6366f1;          /* border draw colour    */
+  --ease-draw-thickness:  2px;              /* border line thickness */
+  --ease-draw-bg:         #0d1117;          /* popover background    */
+  --ease-draw-radius:     14px;
+  --ease-draw-width:      300px;
+  --ease-draw-offset:     8px;              /* Y fade-in offset      */
+}
+
+/* ── Checkbox toggle ────────────────────────────────────────*/
+.ease-draw-toggle {
+  display: none;
+}
+
+/* ── Anchor wrapper ─────────────────────────────────────── */
+.ease-draw-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* ── Trigger ────────────────────────────────────────────── */
+.ease-draw-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 10px;
+  /* Draw-border uses outline so it doesn't take up space */
+  background: transparent;
+  border: var(--ease-draw-thickness) solid rgba(99,102,241,0.2);
+  color: #a5b4fc;
+  font-size: 0.86rem;
+  font-weight: 700;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: color 0.2s ease, background 0.2s ease;
+  outline-offset: 4px;
+  user-select: none;
+  /* Draw-border sweep on hover via pseudo-element */
+}
+
+/* Border draw sweep: top, right, bottom, left lines using
+   clip-path animation on ::before and ::after             */
+.ease-draw-trigger::before,
+.ease-draw-trigger::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+/* Top + right lines */
+.ease-draw-trigger::before {
+  border-top: var(--ease-draw-thickness) solid var(--ease-draw-color);
+  border-right: var(--ease-draw-thickness) solid var(--ease-draw-color);
+  clip-path: inset(0 100% 100% 0);
+  transition: clip-path var(--ease-draw-duration) var(--ease-draw-easing);
+}
+
+/* Bottom + left lines */
+.ease-draw-trigger::after {
+  border-bottom: var(--ease-draw-thickness) solid var(--ease-draw-color);
+  border-left: var(--ease-draw-thickness) solid var(--ease-draw-color);
+  clip-path: inset(100% 0 0 100%);
+  transition: clip-path var(--ease-draw-duration) var(--ease-draw-easing);
+  transition-delay: calc(var(--ease-draw-duration) * 0.3);
+}
+
+/* Hover / focus: draw lines across */
+.ease-draw-trigger:hover::before,
+.ease-draw-trigger:focus::before {
+  clip-path: inset(0 0 100% 0);
+}
+
+.ease-draw-trigger:hover::after,
+.ease-draw-trigger:focus::after {
+  clip-path: inset(100% 0 0 0);
+}
+
+/* Full border when open */
+.ease-draw-toggle:checked + .ease-draw-wrap .ease-draw-trigger::before,
+.ease-draw-toggle:checked ~ .ease-draw-wrap .ease-draw-trigger::before {
+  clip-path: inset(0 0 0 0);
+  border-color: var(--ease-draw-color);
+}
+
+.ease-draw-toggle:checked + .ease-draw-wrap .ease-draw-trigger::after,
+.ease-draw-toggle:checked ~ .ease-draw-wrap .ease-draw-trigger::after {
+  clip-path: inset(0 0 0 0);
+  border-color: var(--ease-draw-color);
+}
+
+.ease-draw-trigger:hover,
+.ease-draw-trigger:focus {
+  color: #c7d2fe;
+  background: rgba(99,102,241,0.06);
+  outline: 2px solid rgba(99,102,241,0.35);
+}
+
+/* ── Popover Card ───────────────────────────────────────── */
+.ease-draw-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  width: var(--ease-draw-width);
+  background: var(--ease-draw-bg);
+  border-radius: var(--ease-draw-radius);
+  box-shadow:
+    0 16px 40px rgba(0,0,0,0.5),
+    0 0 0 1px rgba(99,102,241,0.06);
+  overflow: hidden;
+  pointer-events: none;
+  /* Hidden state */
+  opacity: 0;
+  transform: translateY(var(--ease-draw-offset));
+  transition:
+    opacity 0.22s ease,
+    transform 0.35s var(--ease-draw-spring);
+  transition-delay: var(--ease-draw-delay);
+  z-index: 200;
+  /* Draw border on the card itself via outline drawn on open */
+}
+
+/* Draw-border on popover: animated SVG-like border via
+   clip-path on a pseudo-element overlay                    */
+.ease-draw-popover::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-draw-radius);
+  border: var(--ease-draw-thickness) solid var(--ease-draw-color);
+  clip-path: inset(0 100% 100% 0 round var(--ease-draw-radius));
+  pointer-events: none;
+  z-index: 10;
+  transition: clip-path var(--ease-draw-duration) var(--ease-draw-easing);
+}
+
+.ease-draw-popover::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-draw-radius);
+  border: var(--ease-draw-thickness) solid var(--ease-draw-color);
+  clip-path: inset(100% 0 0 100% round var(--ease-draw-radius));
+  pointer-events: none;
+  z-index: 10;
+  transition: clip-path var(--ease-draw-duration) var(--ease-draw-easing);
+  transition-delay: calc(var(--ease-draw-duration) * 0.4);
+}
+
+/* Open: border draws in, card fades up */
+.ease-draw-toggle:checked + .ease-draw-wrap .ease-draw-popover,
+.ease-draw-toggle:checked ~ .ease-draw-wrap .ease-draw-popover {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.ease-draw-toggle:checked + .ease-draw-wrap .ease-draw-popover::before,
+.ease-draw-toggle:checked ~ .ease-draw-wrap .ease-draw-popover::before {
+  clip-path: inset(0 0 50% 0 round var(--ease-draw-radius));
+}
+
+.ease-draw-toggle:checked + .ease-draw-wrap .ease-draw-popover::after,
+.ease-draw-toggle:checked ~ .ease-draw-wrap .ease-draw-popover::after {
+  clip-path: inset(50% 0 0 0 round var(--ease-draw-radius));
+}
+
+/* ── Popover Inner Layout ───────────────────────────────── */
+.draw-pop-header {
+  padding: 14px 16px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.draw-pop-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: rgba(99,102,241,0.12);
+  border: 1px solid rgba(99,102,241,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.draw-pop-title {
+  color: #f8fafc;
+  font-size: 0.88rem;
+  font-weight: 800;
+  margin: 0;
+}
+
+.draw-pop-sub {
+  color: #475569;
+  font-size: 0.73rem;
+  margin: 2px 0 0;
+}
+
+/* Close button */
+.draw-pop-close {
+  margin-left: auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #475569;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background 0.15s ease, color 0.15s ease;
+  user-select: none;
+}
+
+.draw-pop-close:hover {
+  background: rgba(255,255,255,0.06);
+  color: #94a3b8;
+}
+
+/* Body */
+.draw-pop-body {
+  padding: 14px 16px;
+}
+
+.draw-pop-desc {
+  color: #64748b;
+  font-size: 0.8rem;
+  line-height: 1.65;
+  margin: 0 0 14px;
+}
+
+/* Accessible feature list */
+.draw-pop-list {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  margin-bottom: 16px;
+}
+
+.draw-pop-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.81rem;
+  color: #94a3b8;
+}
+
+.draw-pop-check {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  background: rgba(99,102,241,0.12);
+  border: 1px solid rgba(99,102,241,0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  color: #818cf8;
+  flex-shrink: 0;
+}
+
+/* Accessible link (skip-link style) */
+.draw-pop-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 9px;
+  background: rgba(99,102,241,0.08);
+  border: 1px solid rgba(99,102,241,0.18);
+  color: #818cf8;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.draw-pop-link:hover,
+.draw-pop-link:focus {
+  background: rgba(99,102,241,0.14);
+  border-color: rgba(99,102,241,0.35);
+  outline: 2px solid rgba(99,102,241,0.3);
+  outline-offset: 2px;
+}
+
+/* ── Demo page wrapper ──────────────────────────────────── */
+.a11y-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #0d1117;
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 14px;
+  padding: 14px 20px;
+  max-width: 680px;
+  width: 100%;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.4);
+  box-sizing: border-box;
+  flex-wrap: wrap;
+}
+
+.toolbar-label {
+  color: #64748b;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-right: 4px;
+}
+
+.toolbar-spacer { flex: 1; }
+
+.toolbar-skip-link {
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: rgba(34,197,94,0.1);
+  border: 1px solid rgba(34,197,94,0.2);
+  color: #4ade80;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+
+.toolbar-skip-link:hover,
+.toolbar-skip-link:focus {
+  background: rgba(34,197,94,0.18);
+  outline: 2px solid rgba(34,197,94,0.4);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Closes #46759

Adds a Draw-Border Line Popover under `submissions/examples/draw-border-popover-ksk/`.

#### Key Features

1. **Clockwise Border Draw** — Both trigger and popover card use `clip-path` transitions on `::before` / `::after` pseudo-elements to animate the border drawing in two halves: top+right first, then bottom+left with a stagger delay — creating a clean clockwise sweep.
2. **Dual Draw Surfaces** — The draw animation plays on both the **trigger button** (hover/focus) and the **popover card** (on open), making the connection between them visually coherent.
3. **Spring Card Entry** — Popover fades up with `translateY` using `cubic-bezier(0.34, 1.56, 0.64, 1)` for a light spring feel.
4. **Accessibility-First Demo** — Three toolbar popovers (Accessibility Settings, Keyboard Shortcuts, Help) with proper `role="dialog"`, `aria-label`, `aria-haspopup`, skip-to-content links, and fully keyboard-navigable triggers.
5. **8 CSS Custom Properties** — `--ease-draw-color`, `--ease-draw-thickness`, `--ease-draw-duration`, `--ease-draw-easing`, `--ease-draw-spring`, `--ease-draw-width`, `--ease-draw-radius`, `--ease-draw-offset`.
6. **WCAG Aligned** — Animated border doubles as a visible focus indicator; skip-link pattern and semantic roles included in the demo.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | `clip-path` draw animation, dual pseudo-element technique, 8 CSS custom properties |
| `demo.html` | Accessible web toolbar with 3 themed draw-border popovers |
| `README.md` | Usage guide with WCAG notes, resolving `#46759` |