### PR TITLE
ease-delay-gap-lab-sp

### DIFF
--- a/submissions/docs/ease-delay-gap-lab-sp/README.md
+++ b/submissions/docs/ease-delay-gap-lab-sp/README.md
@@ -1,0 +1,80 @@
+# Delay Class Gap Finder
+
+An educational documentation showcase that maps EaseMotion’s official `ease-delay-*` ladder, highlights gaps (especially **200ms → 300ms** with no 250ms class), and teaches safe `--custom-delay` / inline patterns — **without editing core**.
+
+> Submission track: `submissions/docs/ease-delay-gap-lab-sp/`  
+> Contributor suffix: `sp`  
+> Related issue: [#47543](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47543)
+
+---
+
+## What does this do?
+
+EaseMotion ships a fixed set of animation-delay utilities in `core/animations.css`:
+
+| Class | Delay |
+|-------|-------|
+| `ease-delay-75` | 75ms |
+| `ease-delay-100` | 100ms |
+| `ease-delay-150` | 150ms |
+| `ease-delay-200` | 200ms |
+| `ease-delay-300` | 300ms |
+| `ease-delay-400` | 400ms |
+| `ease-delay-500` | 500ms |
+| `ease-delay-600` | 600ms |
+| `ease-delay-700` | 700ms |
+| `ease-delay-800` | 800ms |
+| `ease-delay-1000` | 1000ms |
+
+There is **no** `ease-delay-250` (or `ease-delay-900`). This lab is not a stagger builder — it is a gap finder and workaround guide.
+
+## How is it used?
+
+1. Open `demo.html` in a browser (EaseMotion CSS loads from the jsDelivr CDN).
+2. Read the **official ladder** and note highlighted gaps.
+3. Replay the **200 vs 250 vs 300** comparison to feel the mid-value difference.
+4. Copy a workaround pattern:
+   - Prefer an official class when it fits
+   - Use `--custom-delay` for mid-gap values
+   - Use inline `animation-delay` only for quick prototypes
+5. Drag the **Try a custom delay** slider to generate a ready-to-paste snippet.
+
+### Recommended custom-delay pattern
+
+```html
+<div
+  class="ease-fade-in custom-delay"
+  style="--custom-delay: 250ms"
+>
+  …
+</div>
+```
+
+```css
+/* In your project stylesheet — not in core/ */
+.custom-delay {
+  animation-delay: var(--custom-delay, 0ms);
+}
+```
+
+## Why is it useful?
+
+- Documents real ladder limits so contributors do not invent missing utility names by mistake
+- Shows that mid-values are a **project-level** CSS variable concern, not a core PR
+- Gives copy-friendly snippets for 250ms (and any other gap fill)
+- Keeps the submission self-contained under `submissions/docs/`
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive lab UI + replay / slider logic |
+| `style.css` | Lab layout styles (uses `--ease-*` tokens; local `.custom-delay` helper only) |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-delay-gap-lab-sp/` — no core, components, or workflow changes
+- Uses the official CDN bundle (`easemotion.min.css`); no framework source copied
+- Folder name includes unique contributor suffix `-sp`
+- Respects `prefers-reduced-motion` in local demo styles (EaseMotion also reduces motion globally)

--- a/submissions/docs/ease-delay-gap-lab-sp/demo.html
+++ b/submissions/docs/ease-delay-gap-lab-sp/demo.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Delay Class Gap Finder — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Map EaseMotion ease-delay-* class limits and learn custom-delay patterns for in-between values like 250ms — without editing core."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="lab-header ease-fade-in">
+    <p class="lab-eyebrow">EaseMotion CSS · Documentation Showcase · Issue #47543</p>
+    <h1>Delay Class Gap Finder</h1>
+    <p class="lab-subtitle">
+      Need a <strong>250ms</strong> stagger? Official utilities jump from
+      <code>ease-delay-200</code> to <code>ease-delay-300</code>. This lab maps
+      the ladder, highlights the gaps, and shows safe
+      <code>--custom-delay</code> / inline patterns — without editing core.
+    </p>
+    <button type="button" class="lab-replay ease-btn ease-btn-primary" id="replay-all">
+      Replay animations
+    </button>
+  </header>
+
+  <main class="lab-main">
+    <!-- ── Official ladder ─────────────────────────────────── -->
+    <section class="lab-section" aria-labelledby="ladder-title">
+      <h2 id="ladder-title">Official <code>ease-delay-*</code> ladder</h2>
+      <p class="lab-lead">
+        These are the only animation-delay utilities shipped in
+        <code>core/animations.css</code>. Steps are uneven — early gaps are
+        25–50ms, then 100ms, then a 200ms jump at the end.
+      </p>
+
+      <ol class="delay-ladder" aria-label="Official delay classes">
+        <li class="delay-step" data-ms="75">
+          <code>ease-delay-75</code>
+          <span class="delay-ms">75ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+25ms</span></li>
+        <li class="delay-step" data-ms="100">
+          <code>ease-delay-100</code>
+          <span class="delay-ms">100ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+50ms</span></li>
+        <li class="delay-step" data-ms="150">
+          <code>ease-delay-150</code>
+          <span class="delay-ms">150ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+50ms</span></li>
+        <li class="delay-step" data-ms="200">
+          <code>ease-delay-200</code>
+          <span class="delay-ms">200ms</span>
+        </li>
+        <li class="delay-gap delay-gap--highlight" title="No official class for 250ms">
+          <span>gap · no 250ms</span>
+        </li>
+        <li class="delay-step delay-step--focus" data-ms="300">
+          <code>ease-delay-300</code>
+          <span class="delay-ms">300ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+100ms</span></li>
+        <li class="delay-step" data-ms="400">
+          <code>ease-delay-400</code>
+          <span class="delay-ms">400ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+100ms</span></li>
+        <li class="delay-step" data-ms="500">
+          <code>ease-delay-500</code>
+          <span class="delay-ms">500ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+100ms</span></li>
+        <li class="delay-step" data-ms="600">
+          <code>ease-delay-600</code>
+          <span class="delay-ms">600ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+100ms</span></li>
+        <li class="delay-step" data-ms="700">
+          <code>ease-delay-700</code>
+          <span class="delay-ms">700ms</span>
+        </li>
+        <li class="delay-gap" aria-hidden="true"><span>+100ms</span></li>
+        <li class="delay-step" data-ms="800">
+          <code>ease-delay-800</code>
+          <span class="delay-ms">800ms</span>
+        </li>
+        <li class="delay-gap delay-gap--highlight" title="No official class for 900ms">
+          <span>gap · no 900ms</span>
+        </li>
+        <li class="delay-step" data-ms="1000">
+          <code>ease-delay-1000</code>
+          <span class="delay-ms">1000ms</span>
+        </li>
+      </ol>
+
+      <div class="lab-callout" role="note">
+        <strong>Key gap:</strong> If you need <em>250ms</em>, there is no
+        <code>ease-delay-250</code>. Pick 200, pick 300, or use a custom delay
+        (below) — do not patch core for a one-off stagger.
+      </div>
+    </section>
+
+    <!-- ── Side-by-side comparison ──────────────────────────── -->
+    <section class="lab-section" aria-labelledby="compare-title">
+      <h2 id="compare-title">200 vs 250 vs 300 — see the difference</h2>
+      <p class="lab-lead">
+        Same entrance animation (<code>ease-slide-up</code>). Only the delay
+        changes. Watch the middle bar land between the two official classes.
+      </p>
+
+      <div class="compare-grid" id="compare-stage">
+        <article class="compare-card">
+          <p class="compare-label">Official</p>
+          <h3><code>ease-delay-200</code></h3>
+          <div class="compare-track" aria-hidden="true">
+            <div class="compare-bar ease-slide-up ease-delay-200 replay-target"></div>
+          </div>
+          <p class="compare-meta">animation-delay: 200ms</p>
+        </article>
+
+        <article class="compare-card compare-card--custom">
+          <p class="compare-label">Custom (gap fill)</p>
+          <h3>250ms via <code>--custom-delay</code></h3>
+          <div class="compare-track" aria-hidden="true">
+            <div
+              class="compare-bar ease-slide-up custom-delay replay-target"
+              style="--custom-delay: 250ms"
+            ></div>
+          </div>
+          <p class="compare-meta">animation-delay: var(--custom-delay)</p>
+        </article>
+
+        <article class="compare-card">
+          <p class="compare-label">Official</p>
+          <h3><code>ease-delay-300</code></h3>
+          <div class="compare-track" aria-hidden="true">
+            <div class="compare-bar ease-slide-up ease-delay-300 replay-target"></div>
+          </div>
+          <p class="compare-meta">animation-delay: 300ms</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- ── Patterns ────────────────────────────────────────── -->
+    <section class="lab-section" aria-labelledby="patterns-title">
+      <h2 id="patterns-title">Workaround patterns (no core edits)</h2>
+      <p class="lab-lead">
+        Use a utility when it matches. For mid-values, set a local CSS variable
+        or an inline delay. Both keep your project self-contained.
+      </p>
+
+      <div class="pattern-grid">
+        <article class="pattern-card">
+          <h3>1. Utility class (preferred when it fits)</h3>
+          <pre class="lab-code" tabindex="0"><code>&lt;div class="ease-fade-in ease-delay-200"&gt;…&lt;/div&gt;
+&lt;div class="ease-fade-in ease-delay-300"&gt;…&lt;/div&gt;</code></pre>
+          <p>Use when 200ms or 300ms is close enough. Zero custom CSS.</p>
+        </article>
+
+        <article class="pattern-card">
+          <h3>2. Inline <code>--custom-delay</code></h3>
+          <pre class="lab-code" tabindex="0"><code>&lt;div
+  class="ease-fade-in custom-delay"
+  style="--custom-delay: 250ms"
+&gt;…&lt;/div&gt;</code></pre>
+          <pre class="lab-code" tabindex="0"><code>/* in your project stylesheet — not core */
+.custom-delay {
+  animation-delay: var(--custom-delay, 0ms);
+}</code></pre>
+          <p>Best for one-off mid-values like 250ms, 350ms, or 900ms.</p>
+        </article>
+
+        <article class="pattern-card">
+          <h3>3. Inline <code>style</code> delay</h3>
+          <pre class="lab-code" tabindex="0"><code>&lt;div
+  class="ease-fade-in"
+  style="animation-delay: 250ms"
+&gt;…&lt;/div&gt;</code></pre>
+          <p>
+            Fastest for demos. Prefer the variable pattern in real apps so you
+            can theme delays from one place.
+          </p>
+        </article>
+
+        <article class="pattern-card">
+          <h3>4. When to use which</h3>
+          <ul class="pattern-list">
+            <li><strong>Official class</strong> — value exists on the ladder</li>
+            <li><strong><code>--custom-delay</code></strong> — mid-gap values, reusable</li>
+            <li><strong>Inline style</strong> — quick prototypes only</li>
+            <li><strong>Do not</strong> — add <code>ease-delay-250</code> to core for a single page</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <!-- ── Live custom delay tryout ─────────────────────────── -->
+    <section class="lab-section" aria-labelledby="tryout-title">
+      <h2 id="tryout-title">Try a custom delay</h2>
+      <p class="lab-lead">
+        Drag the slider to any mid-value. The bar uses
+        <code>--custom-delay</code> only — no new framework class.
+      </p>
+
+      <div class="tryout">
+        <label for="delay-slider" class="tryout-label">
+          Custom delay
+          <span id="delay-value" class="tryout-value">250ms</span>
+        </label>
+        <input
+          type="range"
+          id="delay-slider"
+          min="0"
+          max="1000"
+          step="10"
+          value="250"
+          aria-valuetext="250 milliseconds"
+        />
+        <div class="tryout-hints" aria-hidden="true">
+          <span>0</span>
+          <span class="tryout-hint-gap">200 — gap — 300</span>
+          <span>1000</span>
+        </div>
+        <div class="compare-track tryout-track" aria-hidden="true">
+          <div
+            id="tryout-bar"
+            class="compare-bar ease-slide-up custom-delay replay-target"
+            style="--custom-delay: 250ms"
+          ></div>
+        </div>
+        <pre class="lab-code" tabindex="0"><code id="tryout-snippet">&lt;div class="ease-slide-up custom-delay" style="--custom-delay: 250ms"&gt;</code></pre>
+      </div>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>
+      Self-contained submission ·
+      <code>submissions/docs/ease-delay-gap-lab-sp/</code> ·
+      no core edits
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      function replay(el) {
+        el.style.animation = "none";
+        void el.offsetWidth;
+        el.style.animation = "";
+      }
+
+      function replayAll() {
+        document.querySelectorAll(".replay-target").forEach(replay);
+      }
+
+      document.getElementById("replay-all").addEventListener("click", replayAll);
+
+      var slider = document.getElementById("delay-slider");
+      var valueEl = document.getElementById("delay-value");
+      var bar = document.getElementById("tryout-bar");
+      var snippet = document.getElementById("tryout-snippet");
+
+      slider.addEventListener("input", function () {
+        var ms = slider.value + "ms";
+        valueEl.textContent = ms;
+        slider.setAttribute("aria-valuetext", slider.value + " milliseconds");
+        bar.style.setProperty("--custom-delay", ms);
+        snippet.textContent =
+          '<div class="ease-slide-up custom-delay" style="--custom-delay: ' +
+          ms +
+          '">';
+        replay(bar);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-delay-gap-lab-sp/style.css
+++ b/submissions/docs/ease-delay-gap-lab-sp/style.css
@@ -1,0 +1,397 @@
+/* ============================================================
+   Delay Class Gap Finder — local demo styles only
+   Uses EaseMotion --ease-* tokens. Does not modify core.
+   ============================================================ */
+
+:root {
+  --lab-surface: var(--ease-color-surface, #ffffff);
+  --lab-border: var(--ease-color-neutral-200, #e2e8f0);
+  --lab-muted: var(--ease-color-muted, #64748b);
+  --lab-text: var(--ease-color-text, #1e293b);
+  --lab-accent: var(--ease-color-primary, #6c63ff);
+  --lab-warn: var(--ease-color-warning, #b45309);
+  --lab-warn-bg: color-mix(in srgb, var(--lab-warn) 12%, white);
+  --lab-radius: var(--ease-radius-md, 0.5rem);
+  --lab-shadow: var(--ease-shadow-md, 0 4px 16px rgba(15, 23, 42, 0.08));
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--ease-font-sans, "Inter", system-ui, sans-serif);
+  color: var(--lab-text);
+  background:
+    radial-gradient(1200px 500px at 10% -10%, rgba(108, 99, 255, 0.12), transparent 60%),
+    radial-gradient(900px 400px at 100% 0%, rgba(245, 158, 11, 0.1), transparent 55%),
+    var(--ease-color-bg, #f8fafc);
+  line-height: 1.55;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.lab-header {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 1.5rem;
+  text-align: center;
+}
+
+.lab-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--lab-accent);
+}
+
+.lab-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.75rem, 4vw, 2.35rem);
+  line-height: 1.2;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.lab-subtitle {
+  margin: 0 auto 1.25rem;
+  max-width: 42rem;
+  color: var(--lab-muted);
+  font-size: 1.05rem;
+}
+
+.lab-replay {
+  margin-top: 0.25rem;
+}
+
+/* ── Main sections ───────────────────────────────────────── */
+
+.lab-main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.25rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.lab-section h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.lab-lead {
+  margin: 0 0 1.25rem;
+  color: var(--lab-muted);
+  max-width: 40rem;
+}
+
+.lab-callout {
+  margin-top: 1.25rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--lab-warn) 35%, var(--lab-border));
+  border-left: 4px solid var(--lab-warn);
+  border-radius: var(--lab-radius);
+  background: var(--lab-warn-bg);
+  color: var(--ease-color-neutral-800, #1e293b);
+  font-size: 0.95rem;
+}
+
+/* ── Delay ladder ────────────────────────────────────────── */
+
+.delay-ladder {
+  list-style: none;
+  margin: 0;
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.35rem;
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  box-shadow: var(--lab-shadow);
+}
+
+.delay-step {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.4rem;
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px solid var(--lab-border);
+  min-width: 7.5rem;
+}
+
+.delay-step--focus {
+  border-color: var(--lab-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--lab-accent) 25%, transparent);
+}
+
+.delay-step code {
+  background: transparent;
+  padding: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--lab-accent);
+}
+
+.delay-ms {
+  font-size: 0.75rem;
+  color: var(--lab-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.delay-gap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--lab-muted);
+  opacity: 0.85;
+}
+
+.delay-gap--highlight {
+  min-width: 5.5rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  background: var(--lab-warn-bg);
+  color: var(--lab-warn);
+  border: 1px dashed color-mix(in srgb, var(--lab-warn) 45%, transparent);
+  opacity: 1;
+}
+
+/* ── Comparison cards ────────────────────────────────────── */
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.compare-card {
+  padding: 1rem;
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  box-shadow: var(--lab-shadow);
+}
+
+.compare-card--custom {
+  border-color: color-mix(in srgb, var(--lab-warn) 50%, var(--lab-border));
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--lab-warn) 8%, white),
+      var(--lab-surface) 40%
+    );
+}
+
+.compare-label {
+  margin: 0 0 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--lab-muted);
+}
+
+.compare-card h3 {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.compare-meta {
+  margin: 0.85rem 0 0;
+  font-size: 0.8rem;
+  color: var(--lab-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.compare-track {
+  height: 3.25rem;
+  padding: 0.5rem;
+  border-radius: 0.4rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  overflow: hidden;
+}
+
+.compare-bar {
+  height: 100%;
+  width: 70%;
+  border-radius: 0.35rem;
+  background: linear-gradient(
+    90deg,
+    var(--lab-accent),
+    color-mix(in srgb, var(--lab-accent) 65%, #22d3ee)
+  );
+}
+
+/* Local helper — not a framework class */
+.custom-delay {
+  animation-delay: var(--custom-delay, 0ms);
+}
+
+/* ── Patterns ────────────────────────────────────────────── */
+
+.pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.pattern-card {
+  padding: 1.1rem 1.15rem;
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  box-shadow: var(--lab-shadow);
+}
+
+.pattern-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.pattern-card p {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+  color: var(--lab-muted);
+}
+
+.pattern-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--lab-muted);
+  font-size: 0.92rem;
+}
+
+.pattern-list li + li {
+  margin-top: 0.4rem;
+}
+
+.lab-code {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  border-radius: 0.4rem;
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.lab-code code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+.lab-code + .lab-code {
+  margin-top: 0.6rem;
+}
+
+/* ── Tryout ──────────────────────────────────────────────── */
+
+.tryout {
+  padding: 1.25rem;
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  box-shadow: var(--lab-shadow);
+}
+
+.tryout-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.tryout-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--lab-accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+#delay-slider {
+  width: 100%;
+  accent-color: var(--lab-accent);
+}
+
+.tryout-hints {
+  display: flex;
+  justify-content: space-between;
+  margin: 0.35rem 0 1rem;
+  font-size: 0.72rem;
+  color: var(--lab-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.tryout-hint-gap {
+  color: var(--lab-warn);
+  font-weight: 600;
+}
+
+.tryout-track {
+  margin-bottom: 1rem;
+}
+
+/* ── Footer ──────────────────────────────────────────────── */
+
+.lab-footer {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.25rem 2.5rem;
+  text-align: center;
+  color: var(--lab-muted);
+  font-size: 0.85rem;
+}
+
+.lab-footer p {
+  margin: 0;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 800px) {
+  .compare-grid,
+  .pattern-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .delay-step {
+    min-width: 6.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compare-bar,
+  .replay-target {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
# #47543 issue resolved

## Description
This PR adds a Delay Class Gap Finder docs showcase under submissions/docs/ease-delay-gap-lab-sp/.

## Features

- Maps the official ease-delay-* ladder and highlights gaps (e.g. 200ms → 300ms, no 250ms)
- Side-by-side demos: ease-delay-200 vs custom 250ms vs ease-delay-300
- Shows --custom-delay / inline style workarounds without editing core
- Explains when to use a utility vs a custom delay token
- Responsive, self-contained demo (demo.html, style.css, README.md)