### PR TITLE
ease-grid-auto-cls-sp

### DIFF
--- a/submissions/docs/ease-grid-auto-cls-sp/README.md
+++ b/submissions/docs/ease-grid-auto-cls-sp/README.md
@@ -1,0 +1,69 @@
+# Grid Auto-Fit + Entrance Animations CLS Mini-Lab
+
+A documentation showcase that reproduces **Cumulative Layout Shift (CLS)** when `ease-grid-auto` cards use `ease-zoom-in`, and documents before/after containment patterns that keep the grid stable.
+
+> Submission track: `submissions/docs/ease-grid-auto-cls-sp/`  
+> Contributor suffix: `sp`  
+> Related issue: [#47545](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47545)
+
+---
+
+## What does this do?
+
+EaseMotion’s responsive auto-fit grid (`ease-grid-auto`) pairs poorly with bounce zoom entrances (`ease-zoom-in`) when the animation runs on the **grid item itself**. Overshoot can spill into neighbors and disturb auto-fit tracks — a layout + motion CLS issue distinct from reveal-CLS or loop-CPU demos.
+
+This mini-lab:
+
+- Reproduces the broken pattern (zoom on grid children)
+- Shows a contained fix (stable shell + inner zoom)
+- Documents copy-friendly containment patterns
+- Optionally reports CLS via `PerformanceObserver` when the browser supports it
+
+## How is it used?
+
+1. Open `demo.html` in a browser (EaseMotion CSS loads from the jsDelivr CDN).
+2. Watch the **Before** panel — cards zoom on the grid items with stagger delays.
+3. Compare the **After** panel — same motion, but shells reserve space and clip overshoot.
+4. Click **Replay entrance animations** to re-run both sides.
+5. Copy a containment snippet from the patterns section.
+
+### Preferred fix pattern
+
+```html
+<div class="ease-grid ease-grid-auto ease-gap">
+  <article class="card-shell">
+    <div class="card-inner ease-zoom-in">…</div>
+  </article>
+</div>
+```
+
+```css
+.card-shell {
+  min-height: 8rem;
+  overflow: hidden;
+  contain: layout;
+}
+```
+
+## Why is it useful?
+
+- Teaches a real Core Web Vitals risk when combining auto-fit grids and zoom entrances
+- Separates **layout shell** from **motion node** — the key mental model
+- Keeps the fix project-local (no core edits)
+- Complements (does not duplicate) reveal-CLS and loop-CPU showcases
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Before/after grids, CLS readout, pattern snippets |
+| `style.css` | Lab layout + shell/containment helpers only |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-grid-auto-cls-sp/`
+- No changes to `core/`, `components/`, workflows, or existing files
+- Uses the official CDN bundle; no framework source copied
+- Folder name includes unique contributor suffix `-sp`
+- Respects `prefers-reduced-motion` in local demo styles

--- a/submissions/docs/ease-grid-auto-cls-sp/demo.html
+++ b/submissions/docs/ease-grid-auto-cls-sp/demo.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Grid Auto-Fit + Entrance Animations CLS Mini-Lab</title>
+  <meta
+    name="description"
+    content="Reproduce CLS when ease-grid-auto cards use ease-zoom-in, and learn before/after containment patterns."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="lab-header ease-fade-in">
+    <p class="lab-eyebrow">EaseMotion CSS · Documentation Showcase · Issue #47545</p>
+    <h1>Grid Auto-Fit + Entrance Animations CLS Mini-Lab</h1>
+    <p class="lab-subtitle">
+      <code>ease-grid-auto</code> cards with <code>ease-zoom-in</code> can cause
+      visible reflow and Cumulative Layout Shift. This lab reproduces the combo
+      and documents containment patterns that keep the grid stable —
+      distinct from reveal-CLS or loop-CPU issues.
+    </p>
+    <button type="button" class="ease-btn ease-btn-primary" id="replay-btn">
+      Replay entrance animations
+    </button>
+  </header>
+
+  <main class="lab-main">
+    <!-- ── Why it happens ──────────────────────────────────── -->
+    <section class="lab-section lab-panel" aria-labelledby="why-title">
+      <h2 id="why-title">Why this combo shifts layout</h2>
+      <ol class="why-list">
+        <li>
+          <strong><code>ease-zoom-in</code></strong> starts at
+          <code>scale(0.85)</code> and uses bounce easing that can overshoot past
+          <code>scale(1)</code>.
+        </li>
+        <li>
+          <strong><code>ease-grid-auto</code></strong> uses
+          <code>repeat(auto-fit, minmax(...))</code> — track sizes react to
+          content and overflow.
+        </li>
+        <li>
+          When zoom is applied <em>on the grid item itself</em>, overshoot +
+          overflow can expand rows, nudge neighbors, or flash scrollbars —
+          registered as layout shift.
+        </li>
+      </ol>
+      <div class="cls-metrics" role="status" aria-live="polite">
+        <div class="cls-metric">
+          <span class="cls-metric-label">Broken panel CLS</span>
+          <span class="cls-metric-value cls-bad" id="cls-broken">0.000</span>
+        </div>
+        <div class="cls-metric">
+          <span class="cls-metric-label">Fixed panel CLS</span>
+          <span class="cls-metric-value cls-good" id="cls-fixed">0.000</span>
+        </div>
+        <p class="cls-hint">
+          Scores use <code>PerformanceObserver</code> layout-shift entries when
+          available. Aim for CLS &lt; 0.1.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Before / After ──────────────────────────────────── -->
+    <div class="compare-row">
+      <section class="lab-panel panel-broken" aria-labelledby="broken-title" id="broken-panel">
+        <div class="panel-head">
+          <h2 id="broken-title">Before — zoom on grid items</h2>
+          <span class="badge badge-bad">High CLS risk</span>
+        </div>
+        <p class="lab-lead">
+          Each card is both the grid item <em>and</em> the animated node.
+          Bounce overshoot can spill into neighbors and reflow the auto-fit grid.
+        </p>
+
+        <div class="ease-grid ease-grid-auto ease-gap demo-grid" id="broken-grid">
+          <article class="demo-card broken-card ease-zoom-in ease-delay-75">
+            <h3>Alpha</h3>
+            <p>Zoom applied on the grid child.</p>
+          </article>
+          <article class="demo-card broken-card ease-zoom-in ease-delay-150">
+            <h3>Beta</h3>
+            <p>Overshoot can collide with neighbors.</p>
+          </article>
+          <article class="demo-card broken-card ease-zoom-in ease-delay-200">
+            <h3>Gamma</h3>
+            <p>Auto-fit tracks feel unstable.</p>
+          </article>
+          <article class="demo-card broken-card ease-zoom-in ease-delay-300">
+            <h3>Delta</h3>
+            <p>Stagger makes reflow more obvious.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="lab-panel panel-fixed" aria-labelledby="fixed-title" id="fixed-panel">
+        <div class="panel-head">
+          <h2 id="fixed-title">After — contained shells</h2>
+          <span class="badge badge-good">CLS-safer</span>
+        </div>
+        <p class="lab-lead">
+          Grid items are stable layout shells. <code>ease-zoom-in</code> runs on
+          an <em>inner</em> wrapper with overflow contained.
+        </p>
+
+        <div class="ease-grid ease-grid-auto ease-gap demo-grid" id="fixed-grid">
+          <article class="demo-shell">
+            <div class="demo-card fixed-inner ease-zoom-in ease-delay-75">
+              <h3>Alpha</h3>
+              <p>Layout box reserved by the shell.</p>
+            </div>
+          </article>
+          <article class="demo-shell">
+            <div class="demo-card fixed-inner ease-zoom-in ease-delay-150">
+              <h3>Beta</h3>
+              <p>Overshoot stays inside the card.</p>
+            </div>
+          </article>
+          <article class="demo-shell">
+            <div class="demo-card fixed-inner ease-zoom-in ease-delay-200">
+              <h3>Gamma</h3>
+              <p>Auto-fit tracks stay put.</p>
+            </div>
+          </article>
+          <article class="demo-shell">
+            <div class="demo-card fixed-inner ease-zoom-in ease-delay-300">
+              <h3>Delta</h3>
+              <p>Motion without grid reflow.</p>
+            </div>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <!-- ── Patterns ────────────────────────────────────────── -->
+    <section class="lab-section lab-panel" aria-labelledby="patterns-title">
+      <h2 id="patterns-title">Containment patterns (copy-friendly)</h2>
+      <p class="lab-lead">
+        Keep motion. Isolate it from the auto-fit grid item. No core edits required.
+      </p>
+
+      <div class="pattern-grid">
+        <article class="pattern-card">
+          <h3>1. Broken (avoid)</h3>
+          <pre class="lab-code" tabindex="0"><code>&lt;div class="ease-grid ease-grid-auto ease-gap"&gt;
+  &lt;article class="card ease-zoom-in"&gt;…&lt;/article&gt;
+  &lt;article class="card ease-zoom-in ease-delay-200"&gt;…&lt;/article&gt;
+&lt;/div&gt;</code></pre>
+          <p>Animation target = grid child. Overshoot can disturb tracks.</p>
+        </article>
+
+        <article class="pattern-card">
+          <h3>2. Shell + inner zoom (preferred)</h3>
+          <pre class="lab-code" tabindex="0"><code>&lt;div class="ease-grid ease-grid-auto ease-gap"&gt;
+  &lt;article class="card-shell"&gt;
+    &lt;div class="card-inner ease-zoom-in"&gt;…&lt;/div&gt;
+  &lt;/article&gt;
+&lt;/div&gt;</code></pre>
+          <pre class="lab-code" tabindex="0"><code>.card-shell {
+  min-height: 8rem;      /* reserve space */
+  overflow: hidden;      /* clip overshoot */
+  contain: layout;       /* isolate reflow */
+}
+.card-inner { height: 100%; }</code></pre>
+        </article>
+
+        <article class="pattern-card">
+          <h3>3. Prefer fade/slide on grid items</h3>
+          <pre class="lab-code" tabindex="0"><code>&lt;!-- Safer on the grid child itself --&gt;
+&lt;article class="card ease-fade-in ease-delay-200"&gt;…&lt;/article&gt;</code></pre>
+          <p>
+            Opacity-only entrances do not scale the box. Save zoom for inner
+            media or hero elements.
+          </p>
+        </article>
+
+        <article class="pattern-card">
+          <h3>4. When to use which</h3>
+          <ul class="pattern-list">
+            <li><strong>Shell + inner</strong> — you want zoom on auto-fit cards</li>
+            <li><strong>Fade / slide</strong> — simplest CLS-safe entrance</li>
+            <li><strong>Avoid</strong> — <code>ease-zoom-in</code> directly on <code>ease-grid-auto</code> children</li>
+            <li><strong>Do not</strong> — change core utilities for a page-level fix</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>
+      Self-contained submission ·
+      <code>submissions/docs/ease-grid-auto-cls-sp/</code> ·
+      no core edits
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      var brokenScore = 0;
+      var fixedScore = 0;
+      var brokenEl = document.getElementById("cls-broken");
+      var fixedEl = document.getElementById("cls-fixed");
+      var brokenPanel = document.getElementById("broken-panel");
+      var fixedPanel = document.getElementById("fixed-panel");
+
+      function format(n) {
+        return n.toFixed(3);
+      }
+
+      function inPanel(node, panel) {
+        return panel && panel.contains(node);
+      }
+
+      if ("PerformanceObserver" in window) {
+        try {
+          var observer = new PerformanceObserver(function (list) {
+            list.getEntries().forEach(function (entry) {
+              if (entry.hadRecentInput) return;
+              var sources = entry.sources || [];
+              var attributed = false;
+              sources.forEach(function (src) {
+                if (!src.node) return;
+                if (inPanel(src.node, brokenPanel)) {
+                  brokenScore += entry.value;
+                  attributed = true;
+                } else if (inPanel(src.node, fixedPanel)) {
+                  fixedScore += entry.value;
+                  attributed = true;
+                }
+              });
+              if (!attributed && sources.length === 0) {
+                /* Fallback: accumulate to broken during early paint if unattributed */
+              }
+              brokenEl.textContent = format(brokenScore);
+              fixedEl.textContent = format(fixedScore);
+            });
+          });
+          observer.observe({ type: "layout-shift", buffered: true });
+        } catch (e) {
+          brokenEl.textContent = "n/a";
+          fixedEl.textContent = "n/a";
+        }
+      } else {
+        brokenEl.textContent = "n/a";
+        fixedEl.textContent = "n/a";
+      }
+
+      function replay(el) {
+        el.style.animation = "none";
+        void el.offsetWidth;
+        el.style.animation = "";
+      }
+
+      document.getElementById("replay-btn").addEventListener("click", function () {
+        brokenScore = 0;
+        fixedScore = 0;
+        brokenEl.textContent = format(0);
+        fixedEl.textContent = format(0);
+        document
+          .querySelectorAll(".broken-card, .fixed-inner")
+          .forEach(replay);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-grid-auto-cls-sp/style.css
+++ b/submissions/docs/ease-grid-auto-cls-sp/style.css
@@ -1,0 +1,354 @@
+/* ============================================================
+   Grid Auto-Fit + Entrance Animations CLS Mini-Lab
+   Local demo styles only — does not modify core.
+   ============================================================ */
+
+:root {
+  --lab-surface: var(--ease-color-surface, #ffffff);
+  --lab-border: var(--ease-color-neutral-200, #e2e8f0);
+  --lab-muted: var(--ease-color-muted, #64748b);
+  --lab-text: var(--ease-color-text, #1e293b);
+  --lab-accent: var(--ease-color-primary, #6c63ff);
+  --lab-danger: var(--ease-color-danger, #b91c1c);
+  --lab-success: var(--ease-color-success, #15803d);
+  --lab-radius: var(--ease-radius-md, 0.5rem);
+  --lab-shadow: var(--ease-shadow-md, 0 4px 16px rgba(15, 23, 42, 0.08));
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--ease-font-sans, "Inter", system-ui, sans-serif);
+  color: var(--lab-text);
+  background:
+    radial-gradient(1100px 480px at 0% -10%, rgba(185, 28, 28, 0.08), transparent 55%),
+    radial-gradient(900px 420px at 100% 0%, rgba(21, 128, 61, 0.08), transparent 50%),
+    var(--ease-color-bg, #f8fafc);
+  line-height: 1.55;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.lab-header {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 1.25rem;
+  text-align: center;
+}
+
+.lab-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--lab-accent);
+}
+
+.lab-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.6rem, 3.5vw, 2.15rem);
+  line-height: 1.2;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.lab-subtitle {
+  margin: 0 auto 1.25rem;
+  max-width: 44rem;
+  color: var(--lab-muted);
+  font-size: 1.02rem;
+}
+
+/* ── Main ────────────────────────────────────────────────── */
+
+.lab-main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.25rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.lab-panel {
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-border);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--lab-shadow);
+  padding: 1.25rem 1.35rem;
+}
+
+.lab-section h2,
+.lab-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.lab-lead {
+  margin: 0 0 1rem;
+  color: var(--lab-muted);
+  font-size: 0.95rem;
+}
+
+.why-list {
+  margin: 0 0 1.25rem;
+  padding-left: 1.2rem;
+  color: var(--lab-muted);
+}
+
+.why-list li + li {
+  margin-top: 0.45rem;
+}
+
+/* ── CLS metrics ─────────────────────────────────────────── */
+
+.cls-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: flex-end;
+  padding: 0.9rem 1rem;
+  border-radius: var(--lab-radius);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px solid var(--lab-border);
+}
+
+.cls-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 8rem;
+}
+
+.cls-metric-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--lab-muted);
+}
+
+.cls-metric-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.cls-bad {
+  color: var(--lab-danger);
+}
+
+.cls-good {
+  color: var(--lab-success);
+}
+
+.cls-hint {
+  flex: 1 1 100%;
+  margin: 0.25rem 0 0;
+  font-size: 0.82rem;
+  color: var(--lab-muted);
+}
+
+/* ── Compare panels ──────────────────────────────────────── */
+
+.compare-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+.panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.badge-bad {
+  color: var(--lab-danger);
+  background: color-mix(in srgb, var(--lab-danger) 12%, white);
+  border: 1px solid color-mix(in srgb, var(--lab-danger) 30%, transparent);
+}
+
+.badge-good {
+  color: var(--lab-success);
+  background: color-mix(in srgb, var(--lab-success) 12%, white);
+  border: 1px solid color-mix(in srgb, var(--lab-success) 30%, transparent);
+}
+
+.panel-broken {
+  border-color: color-mix(in srgb, var(--lab-danger) 35%, var(--lab-border));
+}
+
+.panel-fixed {
+  border-color: color-mix(in srgb, var(--lab-success) 35%, var(--lab-border));
+}
+
+/* ── Demo grids / cards ──────────────────────────────────── */
+
+.demo-grid {
+  /* Give overshoot room to be visible in the broken panel */
+  padding: 0.35rem;
+}
+
+.demo-card {
+  padding: 1rem 1.1rem;
+  border-radius: var(--lab-radius);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--lab-accent) 12%, white),
+    var(--lab-surface)
+  );
+  border: 1px solid var(--lab-border);
+  min-height: 7.5rem;
+}
+
+.demo-card h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.demo-card p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--lab-muted);
+}
+
+/* Broken: animate the grid item itself — overflow can spill */
+.broken-card {
+  overflow: visible;
+}
+
+/* Fixed: stable shell reserves space; clip overshoot */
+.demo-shell {
+  min-height: 7.5rem;
+  overflow: hidden;
+  contain: layout;
+  border-radius: var(--lab-radius);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.fixed-inner {
+  height: 100%;
+  min-height: 7.5rem;
+}
+
+/* ── Patterns ────────────────────────────────────────────── */
+
+.pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.pattern-card {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.pattern-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.98rem;
+}
+
+.pattern-card p {
+  margin: 0.75rem 0 0;
+  font-size: 0.88rem;
+  color: var(--lab-muted);
+}
+
+.pattern-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--lab-muted);
+  font-size: 0.9rem;
+}
+
+.pattern-list li + li {
+  margin-top: 0.4rem;
+}
+
+.lab-code {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  border-radius: 0.4rem;
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.lab-code code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+.lab-code + .lab-code {
+  margin-top: 0.55rem;
+}
+
+/* ── Footer ──────────────────────────────────────────────── */
+
+.lab-footer {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.25rem 2.5rem;
+  text-align: center;
+  color: var(--lab-muted);
+  font-size: 0.85rem;
+}
+
+.lab-footer p {
+  margin: 0;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .compare-row,
+  .pattern-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .broken-card,
+  .fixed-inner {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
# #47545 issue resolved

## Description

This PR adds a Grid Auto-Fit + Entrance Animations CLS Mini-Lab under `submissions/docs/ease-grid-auto-cls-sp/`.

## Features

- Before/after demos of `ease-grid-auto` cards with `ease-zoom-in`
- Shows reflow risk vs contained stable shells
- Documents overflow / reserved-space / inner-animation patterns
- Optional CLS readout via PerformanceObserver
- Self-contained docs submission (`demo.html`, `style.css`, `README.md`)