### PR TITLE
docs: add ease-btn-hover vs ease-hover-grow confusion lab (#46181

### DIFF
--- a/submissions/examples/ease-hover-class-confusion-pp/README.md
+++ b/submissions/examples/ease-hover-class-confusion-pp/README.md
@@ -1,0 +1,46 @@
+# ease-btn-hover vs ease-hover-grow Naming Confusion Lab
+
+A self-contained interactive documentation lab comparing **`ease-btn-hover`** and **`ease-hover-grow`**, showing visual behavior, resolving collision conflicts, and offering a decision table.
+
+---
+
+## 1. What does this do?
+This showcase places identical components (buttons, cards, badges, and avatars) side-by-side to visually compare the translational lift + shadow of `ease-btn-hover` against the generic scale transition of `ease-hover-grow`, clarifying API boundaries.
+
+---
+
+## 2. How is it used?
+Open `demo.html` directly in any web browser and interact with the sandbox, quiz, and stacking collision checkboxes.
+
+Apply the respective classes to your markup as follows:
+
+```html
+<!-- For Action Button Lift (translates -3px and adds deep shadow) -->
+<button class="ease-btn ease-btn-primary ease-btn-hover">
+  Button Lift &rarr;
+</button>
+
+<!-- For Generic Element Scale (scales to 1.06 of size) -->
+<div class="ease-card ease-hover-grow">
+  Scale Element
+</div>
+```
+
+---
+
+## 3. Why is it useful?
+It addresses developer confusion regarding visually-similar naming schemes, demonstrates browser transform shorthand collisions when both utilities are stacked, and promotes API literacy inside the EaseMotion CSS framework without adding codebase bloat.
+
+---
+
+## Technical Details & Specifics
+
+- **Folder Path:** `submissions/examples/ease-hover-class-confusion-pp/`
+- **Contributor Suffix:** `pp` (Pratyush Panda)
+- **Resolved Ticket:** [Issue #46181](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46181)
+
+### Features Included:
+1. **Multi-Component Sandbox:** Real A/B comparison for buttons, cards, badges, and avatars.
+2. **Stacking Collision Zone:** VISUALLY demonstrates why stacking `ease-btn-hover` and `ease-hover-grow` breaks one transition, explaining browser specification details.
+3. **Interactive Mini-Quiz:** A built-in JavaScript quiz to test developers' API knowledge directly on the page.
+4. **Dark/Light Mode:** Full styling support with a floating toggle.

--- a/submissions/examples/ease-hover-class-confusion-pp/demo.html
+++ b/submissions/examples/ease-hover-class-confusion-pp/demo.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-btn-hover vs ease-hover-grow Naming Confusion Lab</title>
+  
+  <!-- SEO & Accessibility Metadata -->
+  <meta name="description" content="A side-by-side interactive lab comparing ease-btn-hover vs ease-hover-grow on different UI components, demonstrating transform overrides, stacking rules, and API best practices in EaseMotion CSS." />
+  <meta name="author" content="Pratyush Panda (pp)" />
+  
+  <!-- Typography & Styling Links -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  
+  <!-- EaseMotion CSS from main repository CDN -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  
+  <!-- Local Styles -->
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <!-- Theme Toggle Button -->
+  <button class="pp-theme-toggle" id="themeToggleBtn" aria-label="Toggle Dark/Light Mode">
+    <!-- Sun Icon (shown in dark mode) -->
+    <svg id="sunIcon" style="display:none;" viewBox="0 0 24 24">
+      <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41l-1.06-1.06zm1.06-12.37c-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.38.39-1.02 0-1.41zM5.99 18.01l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.39.39-1.03 0-1.41z"/>
+    </svg>
+    <!-- Moon Icon (shown in light mode) -->
+    <svg id="moonIcon" viewBox="0 0 24 24">
+      <path d="M9.37 5.51c-.18-.64-.86-1.02-1.5-.84-2.32.63-4.13 2.5-4.7 4.88-.66 2.76.62 5.57 3.03 6.77.34.17.65.41.9.7l1.06 1.18c1.3 1.45 3.39 1.83 5.09 1 .73-.36 1.34-.9 1.81-1.57.4-.57.19-1.35-.47-1.63-3.64-1.55-5.91-5.32-5.46-9.45.08-.75-.5-1.4-1.26-1.07z"/>
+    </svg>
+  </button>
+
+  <header class="pp-header">
+    <div class="pp-container">
+      <span class="pp-eyebrow">Interactive API Literacy Lab</span>
+      <h1>ease-btn-hover vs ease-hover-grow</h1>
+      <p class="pp-subtitle">
+        Both classes react to mouse hover events, but target different elements and design surfaces. 
+        Explore this side-by-side interactive playground to master their differences, resolve layout collisions, and prevent CSS specificity issues.
+      </p>
+      <div class="pp-meta-badge">
+        <span>Resolves</span> Issue #46181
+      </div>
+    </div>
+  </header>
+
+  <main class="pp-container pp-main-grid">
+
+    <!-- Section: Comparison Sandbox -->
+    <section class="pp-card pp-card-primary" aria-labelledby="sandbox-heading">
+      <h2 class="pp-card-title" id="sandbox-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></section>
+      </h2>
+      <p class="pp-card-desc">
+        Change the UI component below using the sandbox selector. Hover each container to visually compare how the classes execute their transitions.
+      </p>
+      
+      <!-- Component Selector -->
+      <div class="pp-sandbox-selector" id="sandboxSelector">
+        <button class="pp-selector-btn active" data-target="button">Button</button>
+        <button class="pp-selector-btn" data-target="card">Card</button>
+        <button class="pp-selector-btn" data-target="badge">Badge / Chip</button>
+        <button class="pp-selector-btn" data-target="avatar">Avatar Icon</button>
+      </div>
+
+      <!-- Sandbox Grid -->
+      <div class="pp-ab-comparator">
+        <!-- Panel 1: Button-specific lift -->
+        <article class="pp-panel">
+          <div class="pp-panel-header">
+            <span class="pp-panel-title">ease-btn-hover</span>
+            <span class="pp-badge pp-badge-primary">Button Modifier</span>
+          </div>
+          <div class="pp-panel-body" id="sandboxPanelA">
+            <!-- Dynamic Content A -->
+            <button type="button" class="pp-sim-btn pp-sim-btn-hover">
+              Get Started &rarr;
+            </button>
+          </div>
+          <div class="pp-panel-footer">
+            <strong>Effect:</strong> Translates element by <code>-3px</code> on the Y-axis and generates a deep indigo box-shadow. Designed for clickable components.
+          </div>
+        </article>
+
+        <!-- Panel 2: Generic Scale -->
+        <article class="pp-panel">
+          <div class="pp-panel-header">
+            <span class="pp-panel-title">ease-hover-grow</span>
+            <span class="pp-badge pp-badge-secondary">Generic Utility</span>
+          </div>
+          <div class="pp-panel-body" id="sandboxPanelB">
+            <!-- Dynamic Content B -->
+            <button type="button" class="pp-sim-btn pp-sim-hover-grow">
+              Get Started &rarr;
+            </button>
+          </div>
+          <div class="pp-panel-footer">
+            <strong>Effect:</strong> Scales element size to <code>1.06</code> of its original footprint. Does not add box shadow or glow effects.
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <!-- Section: The Stacking Collision Simulator -->
+    <section class="pp-card pp-card-accent" aria-labelledby="collision-heading">
+      <h2 class="pp-card-title" id="collision-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent);"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+        Stacking Collision Simulator
+      </h2>
+      <p class="pp-card-desc">
+        What happens when you stack both classes on the same element? Both utilities try to animate the <code>transform</code> property, causing collisions. Try it out below.
+      </p>
+
+      <div class="pp-collision-zone">
+        <div class="pp-collision-demo">
+          <button type="button" class="pp-sim-btn pp-sim-stacked stacked" id="collisionBtn">
+            Hover to Test Stack
+          </button>
+          <label class="pp-checkbox-container">
+            <input type="checkbox" id="stackToggle" checked />
+            Stack active: both classes applied
+          </label>
+        </div>
+
+        <div class="pp-collision-diagnostics">
+          <div class="pp-diag-item">
+            <div class="pp-diag-icon warn">!</div>
+            <div class="pp-diag-text">
+              <strong>Transform Collision</strong>
+              Because both classes write to the <code>transform</code> shorthand property, the browser cannot compose them. The class declared last in the stylesheet will completely override the other.
+            </div>
+          </div>
+          <div class="pp-diag-item">
+            <div class="pp-diag-icon info">i</div>
+            <div class="pp-diag-text">
+              <strong>Shadow Composition</strong>
+              Since <code>ease-btn-hover</code> applies a <code>box-shadow</code> and <code>ease-hover-grow</code> does not, the shadow effect is preserved even if the translation is overridden.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Decision Matrix -->
+    <section class="pp-card pp-card-secondary" aria-labelledby="matrix-heading">
+      <h2 class="pp-card-title" id="matrix-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--secondary);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line><line x1="15" y1="3" x2="15" y2="21"></line><line x1="3" y1="9" x2="21" y2="9"></line><line x1="3" y1="15" x2="21" y2="15"></line></svg>
+        Decision Matrix &mdash; Which One When?
+      </h2>
+      <p class="pp-card-desc">
+        Use this quick reference to pick the right tool for the job. Avoid naming overlap confusion by focusing on the UI component type.
+      </p>
+
+      <div class="pp-table-container">
+        <table class="pp-matrix-table">
+          <thead>
+            <tr>
+              <th>Component Type</th>
+              <th>Primary Utility</th>
+              <th>Visual Interaction</th>
+              <th>Recommendation reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Primary / Action Buttons</strong></td>
+              <td class="pp-matrix-select btn-color"><code>ease-btn-hover</code></td>
+              <td>Translational Lift (3px) + Glowing Glow</td>
+              <td>Highlights primary call-to-actions with real-world elevation mimicking depth.</td>
+            </tr>
+            <tr>
+              <td><strong>Bento Grid / Layout Cards</strong></td>
+              <td class="pp-matrix-select grow-color"><code>ease-hover-grow</code></td>
+              <td>Visual Scale (1.06)</td>
+              <td>Scale makes large blocks feel active and responsive without rendering distracting shadows.</td>
+            </tr>
+            <tr>
+              <td><strong>Interactive Chips / Badges</strong></td>
+              <td class="pp-matrix-select grow-color"><code>ease-hover-grow</code></td>
+              <td>Visual Scale (1.06)</td>
+              <td>Maintains content layout alignment while giving micro-feedback on cursor entry.</td>
+            </tr>
+            <tr>
+              <td><strong>Circular Avatars / Profile Images</strong></td>
+              <td class="pp-matrix-select grow-color"><code>ease-hover-grow</code></td>
+              <td>Visual Scale (1.06)</td>
+              <td>Draws immediate user focus by popping the element forward in 2D space.</td>
+            </tr>
+            <tr>
+              <td><strong>Small Control Icons</strong></td>
+              <td class="pp-matrix-select grow-color"><code>ease-hover-grow</code></td>
+              <td>Visual Scale (1.06)</td>
+              <td>Scale is cleaner than translation and shadow for tight spacing environments.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Section: Interactive Quiz -->
+    <section class="pp-card" aria-labelledby="quiz-heading">
+      <h2 class="pp-card-title" id="quiz-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent);"><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line><circle cx="12" cy="12" r="10"></circle></svg>
+        Test Your API Literacy
+      </h2>
+      <p class="pp-card-desc">
+        Take this short interactive quiz to test your mastery over EaseMotion's hover interactions and utilities.
+      </p>
+
+      <div class="pp-quiz-wrapper">
+        <div class="pp-quiz-card">
+          <div class="pp-quiz-question" id="quizQuestion">
+            Loading question...
+          </div>
+          <div class="pp-quiz-options" id="quizOptions">
+            <!-- Dynamic quiz options -->
+          </div>
+          <div class="pp-quiz-feedback" id="quizFeedback"></div>
+          <button type="button" class="pp-quiz-next" id="quizNextBtn">Next Question</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Usage Code Snippets -->
+    <section class="pp-card pp-card-primary" aria-labelledby="snippets-heading">
+      <h2 class="pp-card-title" id="snippets-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Copy-Paste Code Snippets
+      </h2>
+      <p class="pp-card-desc">
+        Ready-to-use HTML code snippets. Ensure you avoid stacking collisions in your codebases.
+      </p>
+
+      <div class="pp-snippets">
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">CTA Button Lift</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetBtn">Copy Code</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetBtn">&lt;!-- Use ease-btn-hover on buttons only --&gt;
+&lt;button class="ease-btn ease-btn-primary ease-btn-hover"&gt;
+  Primary Action &amp;rarr;
+&lt;/button&gt;</pre>
+        </div>
+
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">Generic Scale Interaction</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetGrow">Copy Code</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetGrow">&lt;!-- Use ease-hover-grow on general items --&gt;
+&lt;div class="ease-card ease-hover-grow"&gt;
+  &lt;h3&gt;Interactive Card&lt;/h3&gt;
+  &lt;p&gt;Scales up slightly on hover.&lt;/p&gt;
+&lt;/div&gt;</pre>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Toast Notification -->
+  <div class="pp-toast" id="copyToast" role="status" aria-live="polite">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--success);"><polyline points="20 6 9 17 4 12"></polyline></svg>
+    Snippet copied to clipboard!
+  </div>
+
+  <footer class="pp-footer">
+    <div class="pp-container">
+      <div class="pp-footer-links">
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+        <span>&bull;</span>
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46181" target="_blank" rel="noopener noreferrer">Issue Ticket</a>
+      </div>
+      <p>&copy; 2026 EaseMotion CSS. Contributed under standard docs track.</p>
+    </div>
+  </footer>
+
+  <!-- Interactivity Logic -->
+  <script>
+    (function() {
+      "use strict";
+
+      // --- Dark Theme Toggle ---
+      const themeToggleBtn = document.getElementById('themeToggleBtn');
+      const sunIcon = document.getElementById('sunIcon');
+      const moonIcon = document.getElementById('moonIcon');
+      const rootHtml = document.documentElement;
+
+      // Read initial theme preference
+      const savedTheme = localStorage.getItem('pp-theme') || 'light';
+      rootHtml.setAttribute('data-theme', savedTheme);
+      updateThemeIcons(savedTheme);
+
+      themeToggleBtn.addEventListener('click', () => {
+        const currentTheme = rootHtml.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        rootHtml.setAttribute('data-theme', newTheme);
+        localStorage.setItem('pp-theme', newTheme);
+        updateThemeIcons(newTheme);
+      });
+
+      function updateThemeIcons(theme) {
+        if (theme === 'dark') {
+          sunIcon.style.display = 'block';
+          moonIcon.style.display = 'none';
+        } else {
+          sunIcon.style.display = 'none';
+          moonIcon.style.display = 'block';
+        }
+      }
+
+      // --- Sandbox Component Selector ---
+      const sandboxSelector = document.getElementById('sandboxSelector');
+      const panelA = document.getElementById('sandboxPanelA');
+      const panelB = document.getElementById('sandboxPanelB');
+
+      const elementsData = {
+        button: {
+          htmlA: '<button type="button" class="pp-sim-btn pp-sim-btn-hover">Get Started &rarr;</button>',
+          htmlB: '<button type="button" class="pp-sim-btn pp-sim-hover-grow">Get Started &rarr;</button>'
+        },
+        card: {
+          htmlA: '<div class="pp-sim-card pp-sim-btn-hover"><h4>Lift Card</h4><p>Hover me to feel the lift &amp; drop shadow.</p></div>',
+          htmlB: '<div class="pp-sim-card pp-sim-hover-grow"><h4>Scale Card</h4><p>Hover me to see scale translation.</p></div>'
+        },
+        badge: {
+          htmlA: '<span class="pp-sim-badge pp-sim-btn-hover">Interactive Lift Badge</span>',
+          htmlB: '<span class="pp-sim-badge pp-sim-hover-grow">Interactive Scale Badge</span>'
+        },
+        avatar: {
+          htmlA: '<div class="pp-sim-avatar pp-sim-btn-hover">PP</div>',
+          htmlB: '<div class="pp-sim-avatar pp-sim-hover-grow">PP</div>'
+        }
+      };
+
+      sandboxSelector.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-target]');
+        if (!btn) return;
+        
+        // Remove active class from all selectors
+        sandboxSelector.querySelectorAll('.pp-selector-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        // Swap inner content
+        const target = btn.dataset.target;
+        if (elementsData[target]) {
+          panelA.innerHTML = elementsData[target].htmlA;
+          panelB.innerHTML = elementsData[target].htmlB;
+        }
+      });
+
+      // --- Stacking Collision Toggle ---
+      const stackToggle = document.getElementById('stackToggle');
+      const collisionBtn = document.getElementById('collisionBtn');
+
+      stackToggle.addEventListener('change', () => {
+        if (stackToggle.checked) {
+          collisionBtn.className = 'pp-sim-btn pp-sim-stacked stacked';
+          collisionBtn.textContent = 'Hover to Test Stack';
+        } else {
+          collisionBtn.className = 'pp-sim-btn pp-sim-btn-hover';
+          collisionBtn.textContent = 'Lift Only Active';
+        }
+      });
+
+      // --- Interactive Quiz Logic ---
+      const quizQuestions = [
+        {
+          question: "Which CSS class should you apply if you want a card to grow visually in size on hover without casting a shadow?",
+          options: [
+            "ease-btn-hover",
+            "ease-hover-grow",
+            "Stacking both classes together",
+            "None of the above"
+          ],
+          correct: 1,
+          explanation: "ease-hover-grow scales an element to 1.06 of its size and does not affect the box-shadow property."
+        },
+        {
+          question: "What is the primary UX hazard of adding both ease-btn-hover and ease-hover-grow to the same button?",
+          options: [
+            "The browser crashes due to infinite layout loop",
+            "The transition duration multiplies, causing lags",
+            "The transform properties collide, and only one transition takes effect",
+            "The element becomes invisible on touch devices"
+          ],
+          correct: 2,
+          explanation: "Since both classes write to the transform shorthand property, CSS specificity rules override one with the other."
+        },
+        {
+          question: "Under which EaseMotion directory does the ease-btn-hover definition reside?",
+          options: [
+            "core/animations.css",
+            "components/buttons.css",
+            "core/variables.css",
+            "react/helpers.jsx"
+          ],
+          correct: 1,
+          explanation: "ease-btn-hover is specifically designed to work as a component modifier and resides in components/buttons.css."
+        }
+      ];
+
+      let currentQuestionIndex = 0;
+      const quizQuestionEl = document.getElementById('quizQuestion');
+      const quizOptionsEl = document.getElementById('quizOptions');
+      const quizFeedbackEl = document.getElementById('quizFeedback');
+      const quizNextBtn = document.getElementById('quizNextBtn');
+
+      function loadQuestion() {
+        const currentData = quizQuestions[currentQuestionIndex];
+        quizQuestionEl.textContent = `Question ${currentQuestionIndex + 1}: ${currentData.question}`;
+        quizOptionsEl.innerHTML = '';
+        quizFeedbackEl.className = 'pp-quiz-feedback';
+        quizFeedbackEl.style.display = 'none';
+        quizNextBtn.style.display = 'none';
+
+        currentData.options.forEach((opt, idx) => {
+          const optBtn = document.createElement('button');
+          optBtn.type = 'button';
+          optBtn.className = 'pp-quiz-option';
+          optBtn.innerHTML = `<span class="pp-option-index">${String.fromCharCode(65 + idx)}</span> <span>${opt}</span>`;
+          optBtn.addEventListener('click', () => selectAnswer(idx));
+          quizOptionsEl.appendChild(optBtn);
+        });
+      }
+
+      function selectAnswer(selectedIndex) {
+        const currentData = quizQuestions[currentQuestionIndex];
+        const allOptionBtns = quizOptionsEl.querySelectorAll('.pp-quiz-option');
+
+        // Disable all options
+        allOptionBtns.forEach(btn => btn.disabled = true);
+
+        if (selectedIndex === currentData.correct) {
+          allOptionBtns[selectedIndex].classList.add('correct');
+          quizFeedbackEl.textContent = `Correct! ${currentData.explanation}`;
+          quizFeedbackEl.className = 'pp-quiz-feedback success';
+        } else {
+          allOptionBtns[selectedIndex].classList.add('incorrect');
+          allOptionBtns[currentData.correct].classList.add('correct');
+          quizFeedbackEl.textContent = `Incorrect. ${currentData.explanation}`;
+          quizFeedbackEl.className = 'pp-quiz-feedback error';
+        }
+        
+        quizNextBtn.style.display = 'inline-block';
+      }
+
+      quizNextBtn.addEventListener('click', () => {
+        currentQuestionIndex++;
+        if (currentQuestionIndex < quizQuestions.length) {
+          loadQuestion();
+        } else {
+          // Quiz completed
+          quizQuestionEl.textContent = "Quiz Completed!";
+          quizOptionsEl.innerHTML = '<p class="pp-text-center pp-mt-4">Excellent! You are now fully literate in the EaseMotion CSS hover API ecosystem.</p>';
+          quizFeedbackEl.style.display = 'none';
+          quizNextBtn.style.display = 'none';
+        }
+      });
+
+      // Load first question
+      loadQuestion();
+
+      // --- Snippet Copy System ---
+      const copyBtns = document.querySelectorAll('.pp-copy-btn');
+      const toastEl = document.getElementById('copyToast');
+
+      copyBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const preId = btn.dataset.codeId;
+          const preEl = document.getElementById(preId);
+          if (!preEl) return;
+
+          // Extract plain text to copy
+          const plainText = preEl.textContent.trim();
+
+          // Clipboard copy
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(plainText).then(() => {
+              showToast(btn);
+            });
+          } else {
+            // Fallback
+            const textArea = document.createElement("textarea");
+            textArea.value = plainText;
+            textArea.style.position = "fixed";
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand("copy");
+            document.body.removeChild(textArea);
+            showToast(btn);
+          }
+        });
+      });
+
+      function showToast(btn) {
+        btn.classList.add('copied');
+        btn.textContent = 'Copied!';
+        
+        toastEl.classList.add('show');
+
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.textContent = 'Copy Code';
+          toastEl.classList.remove('show');
+        }, 2000);
+      }
+
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hover-class-confusion-pp/style.css
+++ b/submissions/examples/ease-hover-class-confusion-pp/style.css
@@ -1,0 +1,888 @@
+/* ==========================================================================
+   EaseMotion CSS - API Literacy Showcase
+   Lab: ease-btn-hover vs ease-hover-grow Naming Confusion
+   File: style.css
+   Author: Pratyush Panda (pp)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design System & CSS Variables
+   -------------------------------------------------------------------------- */
+:root {
+  /* Fonts */
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, monospace;
+
+  /* Colors (Light Theme Default) */
+  --bg-app: #f8fafc;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f1f5f9;
+  --border-color: #e2e8f0;
+  
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #64748b;
+  
+  --primary: #6366f1;
+  --primary-hover: #4f46e5;
+  --primary-glow: rgba(99, 102, 241, 0.12);
+  
+  --secondary: #0ea5e9;
+  --secondary-glow: rgba(14, 165, 233, 0.12);
+  
+  --accent: #ec4899;
+  --accent-soft: rgba(236, 72, 153, 0.08);
+  
+  --success: #10b981;
+  --success-bg: #d1fae5;
+  --error: #ef4444;
+  --error-bg: #fee2e2;
+  --warning: #f59e0b;
+  --warning-bg: #fef3c7;
+  
+  /* Shadow Elevation System */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  
+  /* Custom API-specific shadow glow emulation */
+  --glow-btn: 0 12px 24px -4px rgba(99, 102, 241, 0.4), 0 4px 12px -2px rgba(99, 102, 241, 0.2);
+  --glow-grow: 0 10px 15px -3px rgba(14, 165, 233, 0.2);
+
+  /* Border Radii */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 24px;
+  --radius-full: 9999px;
+  
+  /* Motion & Animations */
+  --transition-fast: 0.15s ease;
+  --transition-normal: 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-slow: 0.45s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-bounce: 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Dark Theme Variables Override */
+[data-theme="dark"] {
+  --bg-app: #080c14;
+  --bg-card: #0f172a;
+  --bg-card-hover: #1e293b;
+  --border-color: #1e293b;
+  
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  
+  --primary: #818cf8;
+  --primary-hover: #6366f1;
+  --primary-glow: rgba(129, 140, 248, 0.25);
+  
+  --secondary: #38bdf8;
+  --secondary-glow: rgba(56, 189, 248, 0.25);
+  
+  --accent: #f472b6;
+  --accent-soft: rgba(244, 114, 182, 0.15);
+  
+  --success: #34d399;
+  --success-bg: rgba(52, 211, 153, 0.1);
+  --error: #f87171;
+  --error-bg: rgba(248, 113, 113, 0.1);
+  --warning: #fbbf24;
+  --warning-bg: rgba(251, 191, 36, 0.1);
+  
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 10px 10px -5px rgba(0, 0, 0, 0.3);
+  
+  --glow-btn: 0 12px 28px -2px rgba(129, 140, 248, 0.5), 0 4px 14px -1px rgba(129, 140, 248, 0.25);
+  --glow-grow: 0 10px 20px -3px rgba(56, 189, 248, 0.35);
+}
+
+/* --------------------------------------------------------------------------
+   2. Reset & Core Base Styles
+   -------------------------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background-color: var(--bg-app);
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-image: 
+    radial-gradient(circle at 10% 20%, rgba(99, 102, 241, 0.04) 0%, transparent 40%),
+    radial-gradient(circle at 90% 80%, rgba(14, 165, 233, 0.04) 0%, transparent 40%);
+  background-attachment: fixed;
+  padding-bottom: 4rem;
+}
+
+/* Scrollbar Customization */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg-app);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* Typography elements */
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--text-primary);
+}
+
+p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+code, pre {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  border-radius: 4px;
+}
+
+code {
+  background-color: var(--bg-app);
+  padding: 0.2em 0.4em;
+  color: var(--accent);
+  border: 1px solid var(--border-color);
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+a:hover {
+  color: var(--primary-hover);
+}
+
+/* --------------------------------------------------------------------------
+   3. Layout & Structure
+   -------------------------------------------------------------------------- */
+.pp-container {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* Header & Banner Styles */
+.pp-header {
+  padding: 3rem 0 2rem;
+  text-align: center;
+  position: relative;
+}
+
+.pp-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+  display: inline-block;
+  background: var(--primary-glow);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.pp-header h1 {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, var(--text-primary) 30%, var(--primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.pp-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.15rem);
+  max-width: 68ch;
+  margin: 0 auto 1.5rem;
+}
+
+.pp-meta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.pp-meta-badge span {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* Floating Controls (Theme Toggle) */
+.pp-theme-toggle {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 100;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.75rem;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xl);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition-bounce), background-color var(--transition-fast);
+}
+.pp-theme-toggle:hover {
+  transform: scale(1.1);
+  background-color: var(--bg-card-hover);
+}
+.pp-theme-toggle svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: var(--text-secondary);
+}
+
+/* Grid Layout */
+.pp-main-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* --------------------------------------------------------------------------
+   4. Core Component Cards & Panels
+   -------------------------------------------------------------------------- */
+.pp-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+.pp-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: var(--border-color);
+}
+.pp-card.pp-card-primary::before { background: var(--primary); }
+.pp-card.pp-card-secondary::before { background: var(--secondary); }
+.pp-card.pp-card-accent::before { background: var(--accent); }
+
+.pp-card-title {
+  font-size: 1.35rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pp-card-desc {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   5. Interactive Lab / A-B Comparator
+   -------------------------------------------------------------------------- */
+.pp-ab-comparator {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-ab-comparator {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-panel {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-app);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.pp-panel-header {
+  padding: 1rem 1.25rem;
+  background: rgba(0, 0, 0, 0.02);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pp-panel-title {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.pp-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--radius-full);
+}
+.pp-badge-primary { background: var(--primary-glow); color: var(--primary); }
+.pp-badge-secondary { background: var(--secondary-glow); color: var(--secondary); }
+
+.pp-panel-body {
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  min-height: 180px;
+  background-image: radial-gradient(circle at center, var(--bg-card) 0%, transparent 80%);
+}
+
+.pp-panel-footer {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  background: rgba(0, 0, 0, 0.01);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+/* Simulated Classes Styles */
+.pp-sim-btn {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  background: var(--primary);
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Simulated ease-btn-hover behavior locally (pure fallback) */
+.pp-sim-btn-hover {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.pp-sim-btn-hover:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--glow-btn);
+}
+
+/* Simulated ease-hover-grow behavior locally (pure fallback) */
+.pp-sim-hover-grow {
+  transition: transform 0.2s ease;
+}
+.pp-sim-hover-grow:hover {
+  transform: scale(1.06);
+}
+
+/* Element selector for Sandbox comparison */
+.pp-sandbox-selector {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.pp-selector-btn {
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+.pp-selector-btn:hover {
+  background-color: var(--bg-card-hover);
+}
+.pp-selector-btn.active {
+  background: var(--primary);
+  color: #ffffff;
+  border-color: var(--primary);
+}
+
+/* Simulated card layout */
+.pp-sim-card {
+  width: 100%;
+  max-width: 240px;
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-sm);
+  text-align: left;
+}
+.pp-sim-card h4 {
+  font-size: 0.95rem;
+  margin-bottom: 0.35rem;
+}
+.pp-sim-card p {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Simulated Badge layout */
+.pp-sim-badge {
+  display: inline-flex;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-full);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 1px solid rgba(236, 72, 153, 0.15);
+}
+
+/* Simulated Icon/Avatar layout */
+.pp-sim-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1.25rem;
+  box-shadow: var(--shadow-md);
+}
+
+/* --------------------------------------------------------------------------
+   6. Stacking Collision visualizer
+   -------------------------------------------------------------------------- */
+.pp-collision-zone {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 2rem;
+  align-items: center;
+}
+
+@media (max-width: 768px) {
+  .pp-collision-zone {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-collision-demo {
+  border: 1px dashed var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: rgba(0, 0, 0, 0.01);
+}
+
+.pp-sim-stacked {
+  /* Both transforms applied simulation */
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.pp-sim-stacked.stacked:hover {
+  /* Under CSS priority rules, if both are set on standard classes they clash.
+     Here we simulate the scale taking precedence over translation, but retaining shadow */
+  transform: scale(1.06); /* ease-hover-grow wins transform */
+  box-shadow: var(--glow-btn); /* ease-btn-hover adds shadow */
+}
+
+.pp-checkbox-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  user-select: none;
+}
+
+.pp-collision-diagnostics {
+  background: var(--bg-app);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+}
+
+.pp-diag-item {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.75rem;
+}
+.pp-diag-item:last-child {
+  margin-bottom: 0;
+}
+
+.pp-diag-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.pp-diag-icon.warn { background: var(--warning-bg); color: var(--warning); }
+.pp-diag-icon.info { background: var(--primary-glow); color: var(--primary); }
+
+.pp-diag-text {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+.pp-diag-text strong {
+  color: var(--text-primary);
+  display: block;
+  margin-bottom: 0.15rem;
+}
+
+/* --------------------------------------------------------------------------
+   7. Interactive Quiz System
+   -------------------------------------------------------------------------- */
+.pp-quiz-wrapper {
+  margin-top: 1rem;
+}
+
+.pp-quiz-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  background: var(--bg-app);
+}
+
+.pp-quiz-question {
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--text-primary);
+}
+
+.pp-quiz-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.pp-quiz-option {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: left;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.pp-quiz-option:hover {
+  background-color: var(--bg-card-hover);
+  border-color: var(--primary);
+}
+.pp-quiz-option.correct {
+  border-color: var(--success);
+  background-color: var(--success-bg);
+  color: var(--success);
+}
+.pp-quiz-option.incorrect {
+  border-color: var(--error);
+  background-color: var(--error-bg);
+  color: var(--error);
+}
+
+.pp-option-index {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+.pp-quiz-option.correct .pp-option-index {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+.pp-quiz-option.incorrect .pp-option-index {
+  background: var(--error);
+  color: white;
+  border-color: var(--error);
+}
+
+.pp-quiz-feedback {
+  font-size: 0.88rem;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  margin-top: 1rem;
+  display: none;
+}
+.pp-quiz-feedback.success {
+  background: var(--success-bg);
+  color: var(--success);
+  border: 1px solid var(--success);
+  display: block;
+}
+.pp-quiz-feedback.error {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error);
+  display: block;
+}
+
+.pp-quiz-next {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+}
+.pp-quiz-next:hover {
+  background: var(--primary-hover);
+}
+
+/* --------------------------------------------------------------------------
+   8. Interactive Decision Matrix / Table
+   -------------------------------------------------------------------------- */
+.pp-table-container {
+  overflow-x: auto;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  margin-top: 1rem;
+}
+
+.pp-matrix-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.pp-matrix-table th, 
+.pp-matrix-table td {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.pp-matrix-table th {
+  background: rgba(0, 0, 0, 0.02);
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.pp-matrix-table tr:last-child td {
+  border-bottom: none;
+}
+
+.pp-matrix-table code {
+  font-size: 0.8rem;
+}
+
+.pp-matrix-select {
+  font-weight: 700;
+  font-family: var(--font-mono);
+}
+.pp-matrix-select.btn-color { color: var(--primary); }
+.pp-matrix-select.grow-color { color: var(--secondary); }
+
+/* --------------------------------------------------------------------------
+   9. Code Snippets & Utility Generator
+   -------------------------------------------------------------------------- */
+.pp-snippets {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-snippets {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-snippet-card {
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.pp-snippet-header {
+  padding: 0.75rem 1rem;
+  background: rgba(0,0,0,0.03);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pp-snippet-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.pp-snippet-pre {
+  margin: 0;
+  padding: 1.25rem 1rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.pp-copy-btn {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.pp-copy-btn:hover {
+  background-color: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+.pp-copy-btn.copied {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+
+.pp-toast {
+  position: fixed;
+  bottom: 2.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(100px);
+  background: var(--text-primary);
+  color: var(--bg-card);
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-xl);
+  opacity: 0;
+  transition: transform var(--transition-bounce), opacity var(--transition-fast);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.pp-toast.show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+/* --------------------------------------------------------------------------
+   10. Footer Section
+   -------------------------------------------------------------------------- */
+.pp-footer {
+  margin-top: 3rem;
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.pp-footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+/* --------------------------------------------------------------------------
+   11. Helper / Utility Classes
+   -------------------------------------------------------------------------- */
+.pp-mt-2 { margin-top: 0.5rem; }
+.pp-mt-4 { margin-top: 1rem; }
+.pp-mt-6 { margin-top: 1.5rem; }
+.pp-mb-4 { margin-bottom: 1rem; }
+.pp-mb-6 { margin-bottom: 1.5rem; }
+
+.pp-text-center { text-align: center; }
+
+/* Micro-animations */
+@keyframes ppPulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.05); opacity: 0.8; }
+}
+
+.pp-animate-pulse {
+  animation: ppPulse 2s infinite ease-in-out;
+}


### PR DESCRIPTION
- Closes #46181
- Adds an interactive naming confusion lab inside `submissions/examples/ease-hover-class-confusion-pp/` comparing `ease-btn-hover` and `ease-hover-grow`.
- Includes a multi-component sandbox, interactive stacking collision zone, API decision matrix, and an interactive quiz to test knowledge.
- Fully self-contained and responsive, with support for local light/dark mode toggling.