### PR TITLE
docs: add dual stylesheet cascade surprise lab (#46185)

### DIFF
--- a/submissions/examples/ease-dual-css-load-pp/README.md
+++ b/submissions/examples/ease-dual-css-load-pp/README.md
@@ -1,0 +1,38 @@
+# Dual Stylesheet Cascade Surprise Lab
+
+An interactive documentation lab highlighting the visual cascade overrides and HTTP download weight duplicates when loading both `easemotion.css` and `easemotion.min.css` on the same page.
+
+---
+
+## 1. What does this do?
+This showcase dynamically injects main stylesheet assets into the DOM head to illustrate browser devtools rule crossings, source order priority defeats, and page load telemetry sizes.
+
+---
+
+## 2. How is it used?
+Open `demo.html` directly in a browser to switch stylesheet states, inspect the devtools simulated rule strikes, test style-tag positioning overrides, and copy correct link tags:
+
+```html
+<!-- Correct production usage: link only the minified stylesheet -->
+<link rel="stylesheet" 
+      href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+```
+
+---
+
+## 3. Why is it useful?
+It prevents beginner mistakes related to loading redundant library formats, clarifies how source declaration order overrides custom user variables, and promotes clean dependency configurations in EaseMotion projects.
+
+---
+
+## Technical Features & Suffix
+
+- **Folder Path:** `submissions/examples/ease-dual-css-load-pp/`
+- **Contributor Suffix:** `pp` (Pratyush Panda)
+- **Resolved Ticket:** [Issue #46185](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46185)
+
+### Features Included:
+1. **Interactive Style Mounter:** Mounts raw source, minified, both, or no CSS assets onto the page dynamically.
+2. **DevTools Rule Inspector:** Renders a simulated web inspector displaying strikethroughs on overridden declarations.
+3. **Mount Position Tester:** Demonstrates why custom style blocks mounted before framework dependencies fail to execute.
+4. **Specificity Quiz:** In-app quiz to verify cascade logic and file sizes.

--- a/submissions/examples/ease-dual-css-load-pp/demo.html
+++ b/submissions/examples/ease-dual-css-load-pp/demo.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dual Stylesheet Cascade Surprise Lab</title>
+  
+  <!-- SEO & Accessibility Metadata -->
+  <meta name="description" content="An interactive lab detailing the dangers of dual-loading source and minified stylesheets, demonstrating cascade overrides, HTTP bloat, and source specificity." />
+  <meta name="author" content="Pratyush Panda (pp)" />
+  
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  
+  <!-- Local Styles (Loaded statically) -->
+  <link rel="stylesheet" href="./style.css" />
+  
+  <!-- Dynamic Stylesheet Mount Anchor (Where we dynamically inject EaseMotion stylesheets) -->
+  <style id="dynamicOverrideStyle"></style>
+  <div id="dynamicLinkContainer"></div>
+</head>
+<body>
+
+  <!-- Theme Toggle Button -->
+  <button class="pp-theme-toggle" id="themeToggleBtn" aria-label="Toggle Dark/Light Mode">
+    <!-- Sun Icon (shown in dark mode) -->
+    <svg id="sunIcon" style="display:none;" viewBox="0 0 24 24">
+      <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41l-1.06-1.06zm1.06-12.37c-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.38.39-1.02 0-1.41zM5.99 18.01l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.39.39-1.03 0-1.41z"/>
+    </svg>
+    <!-- Moon Icon (shown in light mode) -->
+    <svg id="moonIcon" viewBox="0 0 24 24">
+      <path d="M9.37 5.51c-.18-.64-.86-1.02-1.5-.84-2.32.63-4.13 2.5-4.7 4.88-.66 2.76.62 5.57 3.03 6.77.34.17.65.41.9.7l1.06 1.18c1.3 1.45 3.39 1.83 5.09 1 .73-.36 1.34-.9 1.81-1.57.4-.57.19-1.35-.47-1.63-3.64-1.55-5.91-5.32-5.46-9.45.08-.75-.5-1.4-1.26-1.07z"/>
+    </svg>
+  </button>
+
+  <header class="pp-header">
+    <div class="pp-container">
+      <span class="pp-eyebrow">Cascade Literacy Lab</span>
+      <h1>Dual Stylesheet Cascade Surprise</h1>
+      <p class="pp-subtitle">
+        Loading both <code>easemotion.css</code> and <code>easemotion.min.css</code> simultaneously duplicates rules, increases HTTP weight, and causes unexpected specificity overrides. 
+        Toggle the sandbox states below to see how the browser devtools and style assets behave.
+      </p>
+      <div class="pp-meta-badge">
+        <span>Resolves</span> Issue #46185
+      </div>
+    </div>
+  </header>
+
+  <main class="pp-container pp-main-grid">
+
+    <!-- Section: The Interactive Sandbox -->
+    <section class="pp-card pp-card-primary" aria-labelledby="sandbox-heading">
+      <h2 class="pp-card-title" id="sandbox-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line><line x1="15" y1="3" x2="15" y2="21"></line><line x1="3" y1="9" x2="21" y2="9"></line><line x1="3" y1="15" x2="21" y2="15"></line></svg>
+        Interactive Load Sandbox
+      </h2>
+      <p class="pp-card-desc">
+        Select a loading state below. The lab will inject the real stylesheets into the document head dynamically, updating both the element rendering and the DevTools inspector simulation.
+      </p>
+
+      <!-- Selector state buttons -->
+      <div class="pp-selector-group" id="stateSelector">
+        <button class="pp-state-btn active" data-state="none">No Stylesheets</button>
+        <button class="pp-state-btn" data-state="src">easemotion.css (Source only)</button>
+        <button class="pp-state-btn" data-state="min">easemotion.min.css (Minified only)</button>
+        <button class="pp-state-btn" data-state="both">Both Stylesheets loaded</button>
+      </div>
+
+      <!-- Telemetry reporting stats -->
+      <div class="pp-tel-grid">
+        <div class="pp-tel-card">
+          <span class="pp-tel-lbl">HTTP Requests</span>
+          <span class="pp-tel-val" id="telemetryReq">0</span>
+        </div>
+        <div class="pp-tel-card">
+          <span class="pp-tel-lbl">Payload Size</span>
+          <span class="pp-tel-val" id="telemetryWeight">0 KB</span>
+        </div>
+        <div class="pp-tel-card">
+          <span class="pp-tel-lbl">Duplicate Rules</span>
+          <span class="pp-tel-val" id="telemetryDupe">0%</span>
+        </div>
+        <div class="pp-tel-card">
+          <span class="pp-tel-lbl">Cascade Status</span>
+          <span class="pp-tel-val status-safe" id="telemetryStatus">Safe</span>
+        </div>
+      </div>
+
+      <!-- DevTools Inspector Simulation Grid -->
+      <div class="pp-inspector-split">
+        <!-- Render preview block -->
+        <div class="pp-preview-box">
+          <span class="pp-preview-tag">Render View</span>
+          <!-- When styles load, the ease-btn ease-btn-primary classes will style this button -->
+          <button type="button" class="ease-btn ease-btn-primary ease-btn-hover pp-sim-button" id="sandboxBtn">
+            EaseMotion CTA
+          </button>
+        </div>
+
+        <!-- DevTools Rules block -->
+        <div class="pp-devtools-card">
+          <div class="pp-dev-header">
+            <span class="pp-dev-title">Styles Inspector</span>
+            <span style="color:#676e95; font-size:0.7rem;">:hov :cls</span>
+          </div>
+          <div class="pp-dev-body" id="devtoolsRules">
+            <!-- Dynamic css rules injected depending on selection -->
+            <span class="pp-css-comment">/* Select a stylesheet state above to inspect devtools properties */</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Custom Specifity Sandbox -->
+    <section class="pp-card pp-card-accent" aria-labelledby="override-heading">
+      <h2 class="pp-card-title" id="override-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent);"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+        Local Custom Override Simulator
+      </h2>
+      <p class="pp-card-desc">
+        How does stylesheet ordering impact custom rules? Let's write a custom class override <code>.override-color { background: red; }</code>. Adjust its mount position relative to the main files.
+      </p>
+
+      <div class="pp-sandbox-row">
+        <!-- Benchmark controls -->
+        <div class="pp-override-bench">
+          <button type="button" class="ease-btn ease-btn-primary pp-custom-button" id="overrideBtn">
+            Action Button
+          </button>
+          
+          <div class="pp-control-group" style="width:100%;">
+            <label for="overridePosition">Style Tag Mount Location</label>
+            <select id="overridePosition" class="pp-state-btn" style="width:100%; border-radius: var(--radius-sm);">
+              <option value="before">Linked BEFORE EaseMotion (Source Order Loss)</option>
+              <option value="after">Linked AFTER EaseMotion (Source Order Win)</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Diagnostic Panel -->
+        <div class="pp-override-diagnostics">
+          <div class="pp-diag-item" id="diagBefore">
+            <div class="pp-diag-bullet err">!</div>
+            <div class="pp-diag-text">
+              <strong>Source Order Defeat:</strong>
+              When your custom overrides are declared before the framework links in the HTML header, the framework's declaration loads last and overrides your custom values. The button remains default indigo.
+            </div>
+          </div>
+          <div class="pp-diag-item" id="diagAfter" style="display:none;">
+            <div class="pp-diag-bullet ok">&checkmark;</div>
+            <div class="pp-diag-text">
+              <strong>Source Order Victory:</strong>
+              Declarations made after the framework links are read last. The browser overrides the primary indigo background with your custom red property. The button changes color.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Performance Quiz -->
+    <section class="pp-card pp-card-secondary" aria-labelledby="quiz-heading">
+      <h2 class="pp-card-title" id="quiz-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--secondary);"><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line><circle cx="12" cy="12" r="10"></circle></svg>
+        Specificity &amp; Cascade Quiz
+      </h2>
+      <p class="pp-card-desc">
+        Take this short interactive quiz to master CSS specificity guidelines.
+      </p>
+
+      <div class="pp-quiz-card">
+        <div class="pp-quiz-question" id="quizQuestion">Loading question...</div>
+        <div class="pp-quiz-options" id="quizOptions"></div>
+        <div class="pp-quiz-feedback" id="quizFeedback"></div>
+        <button type="button" class="pp-quiz-next" id="quizNextBtn">Next Question</button>
+      </div>
+    </section>
+
+    <!-- Section: Code Snippets -->
+    <section class="pp-card pp-card-primary" id="snippets" aria-labelledby="snippets-heading">
+      <h2 class="pp-card-title" id="snippets-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Correct link tag snippets
+      </h2>
+      <p class="pp-card-desc">
+        Link only one file at a time! Copy these recommended snippets.
+      </p>
+
+      <div class="pp-snippets">
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">Production CDN Link (Recommended)</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetProd">Copy Link</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetProd">&lt;!-- Link only minified bundle in production --&gt;
+&lt;link rel="stylesheet" 
+      href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" /&gt;</pre>
+        </div>
+
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">Development Local Link</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetDev">Copy Link</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetDev">&lt;!-- Link only source css for debugging local changes --&gt;
+&lt;link rel="stylesheet" href="./easemotion.css" /&gt;</pre>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Toast Notification -->
+  <div class="pp-toast" id="copyToast" role="status" aria-live="polite">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--success);"><polyline points="20 6 9 17 4 12"></polyline></svg>
+    Link copied to clipboard!
+  </div>
+
+  <footer class="pp-footer">
+    <div class="pp-container">
+      <div class="pp-footer-links">
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+        <span>&bull;</span>
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46185" target="_blank" rel="noopener noreferrer">Issue Ticket</a>
+      </div>
+      <p>&copy; 2026 EaseMotion CSS. Cascade optimization guidelines.</p>
+    </div>
+  </footer>
+
+  <!-- Interactivity Scripts -->
+  <script>
+    (function() {
+      "use strict";
+
+      // --- Dark Theme Toggle ---
+      const themeToggleBtn = document.getElementById('themeToggleBtn');
+      const sunIcon = document.getElementById('sunIcon');
+      const moonIcon = document.getElementById('moonIcon');
+      const rootHtml = document.documentElement;
+
+      const savedTheme = localStorage.getItem('pp-theme') || 'light';
+      rootHtml.setAttribute('data-theme', savedTheme);
+      updateThemeIcons(savedTheme);
+
+      themeToggleBtn.addEventListener('click', () => {
+        const currentTheme = rootHtml.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        rootHtml.setAttribute('data-theme', newTheme);
+        localStorage.setItem('pp-theme', newTheme);
+        updateThemeIcons(newTheme);
+      });
+
+      function updateThemeIcons(theme) {
+        if (theme === 'dark') {
+          sunIcon.style.display = 'block';
+          moonIcon.style.display = 'none';
+        } else {
+          sunIcon.style.display = 'none';
+          moonIcon.style.display = 'block';
+        }
+      }
+
+      // --- Dynamic Stylesheet Mount System ---
+      const stateSelector = document.getElementById('stateSelector');
+      const dynamicLinkContainer = document.getElementById('dynamicLinkContainer');
+      const sandboxBtn = document.getElementById('sandboxBtn');
+      
+      const reqVal = document.getElementById('telemetryReq');
+      const weightVal = document.getElementById('telemetryWeight');
+      const dupeVal = document.getElementById('telemetryDupe');
+      const statusVal = document.getElementById('telemetryStatus');
+      
+      const devtoolsRules = document.getElementById('devtoolsRules');
+
+      const srcCdn = "https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.css";
+      const minCdn = "https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css";
+
+      function updateLoadState(state) {
+        // Clear previous links
+        dynamicLinkContainer.innerHTML = '';
+        
+        let req = 0;
+        let weight = "0 KB";
+        let dupe = "0%";
+        let status = "Safe";
+        let statusClass = "status-safe";
+        
+        let mockRulesHtml = '';
+        
+        if (state === 'none') {
+          req = 0;
+          weight = "0 KB";
+          dupe = "0%";
+          status = "Safe";
+          sandboxBtn.className = "pp-sim-button"; // unstyled button
+          
+          mockRulesHtml = '<span class="pp-css-comment">/* No stylesheets loaded. Button renders with browser defaults. */</span>';
+        }
+        else if (state === 'src') {
+          req = 1;
+          weight = "28.5 KB";
+          dupe = "0%";
+          status = "Safe";
+          sandboxBtn.className = "ease-btn ease-btn-primary ease-btn-hover pp-sim-button styled animated";
+          
+          // Inject stylesheet link
+          injectLink(srcCdn);
+          
+          mockRulesHtml = `
+            <div class="pp-css-rule">
+              <span class="pp-rule-source">easemotion.css</span>
+              <span class="pp-css-selector">.ease-btn-primary</span> {<br>
+              <span class="pp-css-prop">background: <span class="pp-css-val">#6366f1</span>;</span>
+              <span class="pp-css-prop">color: <span class="pp-css-val">white</span>;</span>
+              }
+            </div>
+            <div class="pp-css-rule">
+              <span class="pp-rule-source">easemotion.css</span>
+              <span class="pp-css-selector">.ease-btn-hover:hover</span> {<br>
+              <span class="pp-css-prop">transform: <span class="pp-css-val">translate3d(0, -3px, 0)</span>;</span>
+              }
+            </div>
+          `;
+        }
+        else if (state === 'min') {
+          req = 1;
+          weight = "17.8 KB (gzipped)";
+          dupe = "0%";
+          status = "Safe";
+          sandboxBtn.className = "ease-btn ease-btn-primary ease-btn-hover pp-sim-button styled animated";
+          
+          injectLink(minCdn);
+          
+          mockRulesHtml = `
+            <div class="pp-css-rule">
+              <span class="pp-rule-source">easemotion.min.css</span>
+              <span class="pp-css-selector">.ease-btn-primary</span> {<br>
+              <span class="pp-css-prop">background: <span class="pp-css-val">#6366f1</span>;</span>
+              <span class="pp-css-prop">color: <span class="pp-css-val">white</span>;</span>
+              }
+            </div>
+            <div class="pp-css-rule">
+              <span class="pp-rule-source">easemotion.min.css</span>
+              <span class="pp-css-selector">.ease-btn-hover:hover</span> {<br>
+              <span class="pp-css-prop">transform: <span class="pp-css-val">translate3d(0, -3px, 0)</span>;</span>
+              }
+            </div>
+          `;
+        }
+        else if (state === 'both') {
+          req = 2;
+          weight = "46.3 KB (gzipped)";
+          dupe = "100%";
+          status = "Jank / Bloat";
+          statusClass = "status-danger";
+          sandboxBtn.className = "ease-btn ease-btn-primary ease-btn-hover pp-sim-button styled animated";
+          
+          // Inject both
+          injectLink(srcCdn);
+          injectLink(minCdn);
+          
+          mockRulesHtml = `
+            <div class="pp-css-rule">
+              <span class="pp-rule-source">easemotion.min.css (declared last)</span>
+              <span class="pp-css-selector">.ease-btn-primary</span> {<br>
+              <span class="pp-css-prop">background: <span class="pp-css-val">#6366f1</span>;</span>
+              <span class="pp-css-prop">color: <span class="pp-css-val">white</span>;</span>
+              }
+            </div>
+            <div class="pp-css-rule">
+              <span class="pp-rule-source">easemotion.css (overridden)</span>
+              <span class="pp-css-selector">.ease-btn-primary</span> {<br>
+              <span class="pp-css-prop pp-overridden">background: <span class="pp-css-val">#6366f1</span>;</span>
+              <span class="pp-css-prop pp-overridden">color: <span class="pp-css-val">white</span>;</span>
+              }
+            </div>
+          `;
+        }
+        
+        reqVal.textContent = req;
+        weightVal.textContent = weight;
+        dupeVal.textContent = dupe;
+        statusVal.textContent = status;
+        statusVal.className = `pp-tel-val ${statusClass}`;
+        
+        devtoolsRules.innerHTML = mockRulesHtml;
+      }
+
+      function injectLink(url) {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = url;
+        dynamicLinkContainer.appendChild(link);
+      }
+
+      stateSelector.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-state]');
+        if (!btn) return;
+
+        stateSelector.querySelectorAll('.pp-state-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        updateLoadState(btn.dataset.state);
+        updateOverrideSystem();
+      });
+
+      // Initialize
+      updateLoadState('none');
+
+      // --- Custom Specificity Sandbox ---
+      const overridePosition = document.getElementById('overridePosition');
+      const dynamicOverrideStyle = document.getElementById('dynamicOverrideStyle');
+      const overrideBtn = document.getElementById('overrideBtn');
+      const diagBefore = document.getElementById('diagBefore');
+      const diagAfter = document.getElementById('diagAfter');
+
+      function updateOverrideSystem() {
+        const pos = overridePosition.value;
+        const stateBtnActive = stateSelector.querySelector('.pp-state-btn.active');
+        const state = stateBtnActive ? stateBtnActive.dataset.state : 'none';
+
+        // Clear stylesheet tag
+        dynamicOverrideStyle.textContent = '';
+
+        if (state === 'none') {
+          // If no EaseMotion is loaded, custom color red always wins
+          dynamicOverrideStyle.textContent = '.pp-custom-button { background: #f43f5e !important; }';
+          overrideBtn.className = 'pp-custom-button override-active';
+          diagBefore.style.display = 'block';
+          diagAfter.style.display = 'none';
+          return;
+        }
+
+        // Apply styled framework class simulation
+        overrideBtn.className = 'ease-btn ease-btn-primary pp-custom-button';
+
+        if (pos === 'before') {
+          // Declare style tag. Because the link tags are appended to #dynamicLinkContainer 
+          // (which is located after #dynamicOverrideStyle in HTML head), the links load last 
+          // and override the style tag bg.
+          dynamicOverrideStyle.textContent = '.pp-custom-button { background: #f43f5e; }';
+          overrideBtn.classList.remove('override-active');
+          diagBefore.style.display = 'block';
+          diagAfter.style.display = 'none';
+        } else {
+          // Declare style tag but we append a custom override style at the very end of header.
+          // For sandbox simulation we apply the override active class locally to verify.
+          overrideBtn.classList.add('override-active');
+          diagBefore.style.display = 'none';
+          diagAfter.style.display = 'block';
+        }
+      }
+
+      overridePosition.addEventListener('change', updateOverrideSystem);
+
+      // --- Specificity Quiz System ---
+      const quizQuestions = [
+        {
+          question: "If two styles have the exact same specificity (e.g. .ease-btn-primary), which one is applied by the browser?",
+          options: [
+            "The one loaded first in the HTML document",
+            "The one loaded last in the HTML document (Source Order Rule)",
+            "The one with the smallest file size",
+            "The browser ignores both rules and applies default colors"
+          ],
+          correct: 1,
+          explanation: "Under the CSS Cascade rules, if specificity is equal, the rule declared last in the document wins."
+        },
+        {
+          question: "What is the primary danger of linking both easemotion.css and easemotion.min.css on the same page?",
+          options: [
+            "Unexpected override outcomes and redundant download payloads",
+            "The browser flags a security violation",
+            "Visual elements flicker and animate twice as fast",
+            "Fonts render with incorrect size metrics"
+          ],
+          correct: 0,
+          explanation: "Dual loading duplicates layout rules, causing high payload weights and hard-to-debug source order wins."
+        }
+      ];
+
+      let quizIdx = 0;
+      const quizQuestion = document.getElementById('quizQuestion');
+      const quizOptions = document.getElementById('quizOptions');
+      const quizFeedback = document.getElementById('quizFeedback');
+      const quizNextBtn = document.getElementById('quizNextBtn');
+
+      function loadQuiz() {
+        const data = quizQuestions[quizIdx];
+        quizQuestion.textContent = `Question ${quizIdx + 1}: ${data.question}`;
+        quizOptions.innerHTML = '';
+        quizFeedback.style.display = 'none';
+        quizFeedback.className = 'pp-quiz-feedback';
+        quizNextBtn.style.display = 'none';
+
+        data.options.forEach((opt, idx) => {
+          const optBtn = document.createElement('button');
+          optBtn.type = 'button';
+          optBtn.className = 'pp-quiz-option';
+          optBtn.innerHTML = `<span class="pp-option-index">${String.fromCharCode(65 + idx)}</span> <span>${opt}</span>`;
+          optBtn.addEventListener('click', () => selectQuiz(idx));
+          quizOptions.appendChild(optBtn);
+        });
+      }
+
+      function selectQuiz(selIdx) {
+        const data = quizQuestions[quizIdx];
+        const buttons = quizOptions.querySelectorAll('.pp-quiz-option');
+        buttons.forEach(btn => btn.disabled = true);
+
+        if (selIdx === data.correct) {
+          buttons[selIdx].classList.add('correct');
+          quizFeedback.textContent = `Correct! ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback success';
+        } else {
+          buttons[selIdx].classList.add('incorrect');
+          buttons[data.correct].classList.add('correct');
+          quizFeedback.textContent = `Incorrect. ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback error';
+        }
+        quizNextBtn.style.display = 'inline-block';
+      }
+
+      quizNextBtn.addEventListener('click', () => {
+        quizIdx++;
+        if (quizIdx < quizQuestions.length) {
+          loadQuiz();
+        } else {
+          quizQuestion.textContent = 'Diagnostic Complete!';
+          quizOptions.innerHTML = '<p class="pp-text-center pp-mt-4">Excellent! You are now fully literate in stylesheet loading best practices.</p>';
+          quizFeedback.style.display = 'none';
+          quizNextBtn.style.display = 'none';
+        }
+      });
+
+      loadQuiz();
+
+      // --- Snippet Copy System ---
+      const copyBtns = document.querySelectorAll('.pp-copy-btn');
+      const toastEl = document.getElementById('copyToast');
+
+      copyBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const preId = btn.dataset.codeId;
+          const preEl = document.getElementById(preId);
+          if (!preEl) return;
+
+          const text = preEl.textContent.trim();
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(() => showToast(btn));
+          } else {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            showToast(btn);
+          }
+        });
+      });
+
+      function showToast(btn) {
+        btn.classList.add('copied');
+        btn.textContent = 'Copied!';
+        toastEl.classList.add('show');
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.textContent = 'Copy Link';
+          toastEl.classList.remove('show');
+        }, 2000);
+      }
+
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-dual-css-load-pp/style.css
+++ b/submissions/examples/ease-dual-css-load-pp/style.css
@@ -1,0 +1,813 @@
+/* ==========================================================================
+   EaseMotion CSS - Cascade Diagnostics Lab
+   Lab: Dual Stylesheet Cascade Surprise
+   File: style.css
+   Author: Pratyush Panda (pp)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design System & CSS Variables
+   -------------------------------------------------------------------------- */
+:root {
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+
+  /* Theme colors - Light default */
+  --bg-app: #f8fafc;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f1f5f9;
+  --border-color: #e2e8f0;
+  
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #64748b;
+  
+  --primary: #6366f1;
+  --primary-hover: #4f46e5;
+  --primary-glow: rgba(99, 102, 241, 0.12);
+  
+  --secondary: #0ea5e9;
+  --secondary-glow: rgba(14, 165, 233, 0.12);
+  
+  --accent: #f43f5e;
+  
+  --success: #10b981;
+  --success-bg: #d1fae5;
+  --error: #ef4444;
+  --error-bg: #fee2e2;
+  --warning: #f59e0b;
+  --warning-bg: #fef3c7;
+  
+  /* Shadow Elevation System */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+  /* Border Radii */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 24px;
+  --radius-full: 9999px;
+  
+  /* Motion & Animations */
+  --transition-fast: 0.15s ease;
+  --transition-normal: 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-slow: 0.45s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-bounce: 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Dark Theme Variables Override */
+[data-theme="dark"] {
+  --bg-app: #080c14;
+  --bg-card: #0f172a;
+  --bg-card-hover: #1e293b;
+  --border-color: #1e293b;
+  
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  
+  --primary: #818cf8;
+  --primary-hover: #6366f1;
+  --primary-glow: rgba(129, 140, 248, 0.25);
+  
+  --secondary: #38bdf8;
+  --secondary-glow: rgba(56, 189, 248, 0.25);
+  
+  --accent: #fb7185;
+  
+  --success: #34d399;
+  --success-bg: rgba(52, 211, 153, 0.1);
+  --error: #f87171;
+  --error-bg: rgba(248, 113, 113, 0.1);
+  --warning: #fbbf24;
+  --warning-bg: rgba(251, 191, 36, 0.1);
+}
+
+/* --------------------------------------------------------------------------
+   2. Reset & Core Base Styles
+   -------------------------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background-color: var(--bg-app);
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Custom Scrollbar */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg-app);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+code, pre {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  border-radius: 4px;
+}
+
+code {
+  background-color: var(--bg-app);
+  padding: 0.2em 0.4em;
+  color: var(--accent);
+  border: 1px solid var(--border-color);
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+a:hover {
+  color: var(--primary-hover);
+}
+
+/* Layout container */
+.pp-container {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Header & Hero Section
+   -------------------------------------------------------------------------- */
+.pp-header {
+  padding: 3rem 0 2rem;
+  text-align: center;
+}
+
+.pp-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+  display: inline-block;
+  background: var(--primary-glow);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.pp-header h1 {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, var(--text-primary) 30%, var(--primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.pp-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.15rem);
+  max-width: 68ch;
+  margin: 0 auto 1.5rem;
+}
+
+.pp-meta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.pp-meta-badge span {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* Theme Toggle Widget */
+.pp-theme-toggle {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.75rem;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xl);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition-bounce), background-color var(--transition-fast);
+}
+.pp-theme-toggle:hover {
+  transform: scale(1.1);
+  background-color: var(--bg-card-hover);
+}
+.pp-theme-toggle svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: var(--text-secondary);
+}
+
+/* Grid Layout */
+.pp-main-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* --------------------------------------------------------------------------
+   4. Cards & Component Panels
+   -------------------------------------------------------------------------- */
+.pp-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+.pp-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: var(--border-color);
+}
+.pp-card.pp-card-primary::before { background: var(--primary); }
+.pp-card.pp-card-secondary::before { background: var(--secondary); }
+.pp-card.pp-card-accent::before { background: var(--accent); }
+
+.pp-card-title {
+  font-size: 1.35rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pp-card-desc {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   5. Interactive State Selectors
+   -------------------------------------------------------------------------- */
+.pp-selector-group {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.pp-state-btn {
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  padding: 0.6rem 1.25rem;
+  border-radius: var(--radius-md);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.pp-state-btn:hover {
+  background-color: var(--bg-card-hover);
+}
+.pp-state-btn.active {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+  box-shadow: var(--shadow-md);
+}
+
+/* Load State Stats telemetry */
+.pp-tel-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+@media (max-width: 768px) {
+  .pp-tel-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.pp-tel-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  background: var(--bg-app);
+  text-align: center;
+}
+
+.pp-tel-lbl {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+  display: block;
+}
+
+.pp-tel-val {
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.pp-tel-val.status-safe { color: var(--success); }
+.pp-tel-val.status-danger { color: var(--error); }
+.pp-tel-val.status-warn { color: var(--warning); }
+
+/* --------------------------------------------------------------------------
+   6. DevTools Inspector Simulation
+   -------------------------------------------------------------------------- */
+.pp-inspector-split {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-inspector-split {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-preview-box {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 2.5rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-app);
+  position: relative;
+}
+
+.pp-preview-tag {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.pp-sim-button {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-sm);
+  border: none;
+  font-size: 0.95rem;
+  /* Transitions and animations will toggle depending on stylesheets */
+  background: #cbd5e1;
+  color: #64748b;
+  cursor: default;
+  transition: all 0.3s ease;
+}
+
+/* Classes simulated depending on mock load state */
+.pp-sim-button.styled {
+  background: #6366f1;
+  color: white;
+  box-shadow: 0 4px 6px -1px rgba(99, 102, 241, 0.2);
+}
+
+.pp-sim-button.animated:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 15px -3px rgba(99, 102, 241, 0.4);
+}
+
+.pp-devtools-card {
+  background: #1e1e24;
+  border: 1px solid #2d2d34;
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  box-shadow: var(--shadow-xl);
+}
+
+.pp-dev-header {
+  padding: 0.6rem 1rem;
+  background: #2d2d34;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #3c3c44;
+}
+
+.pp-dev-title {
+  color: #a6accd;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.pp-dev-body {
+  padding: 1.25rem 1rem;
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  min-height: 220px;
+}
+
+.pp-css-rule {
+  margin-bottom: 1.25rem;
+}
+.pp-css-rule:last-child {
+  margin-bottom: 0;
+}
+
+.pp-css-selector {
+  color: #ffcb6b;
+}
+
+.pp-css-prop {
+  padding-left: 1.5rem;
+  color: #89ddff;
+  display: block;
+}
+
+.pp-css-val {
+  color: #c3e88d;
+}
+
+.pp-css-comment {
+  color: #676e95;
+  font-style: italic;
+  display: block;
+  padding-left: 1.5rem;
+}
+
+.pp-overridden {
+  text-decoration: line-through;
+  opacity: 0.5;
+}
+
+.pp-rule-source {
+  float: right;
+  color: #676e95;
+  font-size: 0.72rem;
+}
+
+/* --------------------------------------------------------------------------
+   7. Override specificity sandbox
+   -------------------------------------------------------------------------- */
+.pp-sandbox-row {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 2rem;
+  align-items: center;
+}
+
+@media (max-width: 768px) {
+  .pp-sandbox-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-override-bench {
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.pp-override-diagnostics {
+  background: var(--bg-card-hover);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+}
+
+.pp-diag-item {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.pp-diag-item:last-child {
+  margin-bottom: 0;
+}
+
+.pp-diag-bullet {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+.pp-diag-bullet.ok { background: var(--success); }
+.pp-diag-bullet.err { background: var(--error); }
+
+.pp-diag-text {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+.pp-diag-text strong {
+  color: var(--text-primary);
+  display: block;
+  margin-bottom: 0.15rem;
+}
+
+/* Custom override target button */
+.pp-custom-button {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-sm);
+  border: none;
+  font-size: 0.95rem;
+  background: #6366f1; /* base standard */
+  color: white;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+/* Custom override applied class */
+.pp-custom-button.override-active {
+  background: #f43f5e; /* Custom override rule wins color */
+}
+
+/* --------------------------------------------------------------------------
+   8. Interactive Quiz System
+   -------------------------------------------------------------------------- */
+.pp-quiz-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  background: var(--bg-app);
+  margin-top: 1rem;
+}
+
+.pp-quiz-question {
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+  color: var(--text-primary);
+}
+
+.pp-quiz-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.pp-quiz-option {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: left;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.pp-quiz-option:hover {
+  background-color: var(--bg-card-hover);
+  border-color: var(--primary);
+}
+.pp-quiz-option.correct {
+  border-color: var(--success);
+  background-color: var(--success-bg);
+  color: var(--success);
+}
+.pp-quiz-option.incorrect {
+  border-color: var(--error);
+  background-color: var(--error-bg);
+  color: var(--error);
+}
+
+.pp-option-index {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+.pp-quiz-option.correct .pp-option-index {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+.pp-quiz-option.incorrect .pp-option-index {
+  background: var(--error);
+  color: white;
+  border-color: var(--error);
+}
+
+.pp-quiz-feedback {
+  font-size: 0.88rem;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  margin-top: 1rem;
+  display: none;
+}
+.pp-quiz-feedback.success {
+  background: var(--success-bg);
+  color: var(--success);
+  border: 1px solid var(--success);
+  display: block;
+}
+.pp-quiz-feedback.error {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error);
+  display: block;
+}
+
+.pp-quiz-next {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+}
+.pp-quiz-next:hover {
+  background: var(--primary-hover);
+}
+
+/* --------------------------------------------------------------------------
+   9. Code Snippets & Copy System
+   -------------------------------------------------------------------------- */
+.pp-snippets {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-snippets {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-snippet-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-app);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.pp-snippet-header {
+  padding: 0.75rem 1rem;
+  background: rgba(0,0,0,0.03);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pp-snippet-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.pp-snippet-pre {
+  margin: 0;
+  padding: 1.25rem 1rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.pp-copy-btn {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.pp-copy-btn:hover {
+  background-color: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+.pp-copy-btn.copied {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+
+.pp-toast {
+  position: fixed;
+  bottom: 2.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(100px);
+  background: var(--text-primary);
+  color: var(--bg-card);
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-xl);
+  opacity: 0;
+  transition: transform var(--transition-bounce), opacity var(--transition-fast);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.pp-toast.show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+/* --------------------------------------------------------------------------
+   10. Footer Section
+   -------------------------------------------------------------------------- */
+.pp-footer {
+  margin-top: 4rem;
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.pp-footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
- Closes #46185
- Adds an interactive cascade diagnostic lab inside `submissions/examples/ease-dual-css-load-pp/` detailing conflicts when loading both human-readable and minified css formats.
- Includes interactive dynamic stylesheet mounts, simulated devtools rule inspectors, override order testers, and a specificity quiz.
- Fully self-contained and responsive, with support for local light/dark mode toggling.