### PR TITLE
docs: add color-scheme auto token behavior lab (#46189)

### DIFF
--- a/submissions/examples/ease-color-scheme-auto-pp/README.md
+++ b/submissions/examples/ease-color-scheme-auto-pp/README.md
@@ -1,0 +1,39 @@
+# color-scheme: light dark Auto Token Behavior Lab
+
+An interactive theming diagnostic lab demonstrating how the root `color-scheme: light dark` automatically darkens browser native input controls and scrollbars, and why custom containers still require explicit color tokens.
+
+---
+
+## 1. What does this do?
+This showcase presents a side-by-side theme sandbox comparing automatic user-agent dark styles with explicit design token remapping, together with an in-app selector and quiz.
+
+---
+
+## 2. How is it used?
+Open `demo.html` in a web browser to test form controls and scrollareas under different scheme settings, and copy variables configurations:
+
+```html
+<!-- Native inputs and scrollbars darken automatically under this element context -->
+<div style="color-scheme: dark;">
+  <input type="text" value="Auto Dark Input" />
+</div>
+```
+
+---
+
+## 3. Why is it useful?
+It prevents developers from assuming that setting a color-scheme auto-darkens all custom elements, details what changes automatically vs manually, and guides users in writing clean prefers-color-scheme overrides.
+
+---
+
+## Features & Implementation Suffix
+
+- **Folder Path:** `submissions/examples/ease-color-scheme-auto-pp/`
+- **Contributor Suffix:** `pp` (Pratyush Panda)
+- **Resolved Ticket:** [Issue #46189](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46189)
+
+### Included Theming Diagnostics:
+1. **Side-by-Side Sandbox:** Compares browser-level auto dark (UA chrome only) with fully remapped design token sets.
+2. **Diagnostic Toggles:** Lock light mode, toggle auto-dark color-scheme, or switch to explicit variables remapping.
+3. **Theming Checklist:** Outlines what changes automatically (scrollbars, input borders, options dropdowns) vs manually (card surfaces, app divides, gradient typography).
+4. **Theming Quiz:** In-app quiz focusing on user-agent style rules and color inheritance properties.

--- a/submissions/examples/ease-color-scheme-auto-pp/demo.html
+++ b/submissions/examples/ease-color-scheme-auto-pp/demo.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>color-scheme Auto Token Behavior Demo</title>
+  
+  <!-- SEO & Accessibility Metadata -->
+  <meta name="description" content="An interactive showcase proving how color-scheme: light dark automatically handles native inputs and scrollbars, but requires manual token remapping for custom backgrounds." />
+  <meta name="author" content="Pratyush Panda (pp)" />
+  
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  
+  <!-- EaseMotion CSS from CDN -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  
+  <!-- Local Styles -->
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <!-- Theme Toggle Button -->
+  <button class="pp-theme-toggle" id="themeToggleBtn" aria-label="Toggle Dark/Light Mode">
+    <!-- Sun Icon (shown in dark mode) -->
+    <svg id="sunIcon" style="display:none;" viewBox="0 0 24 24">
+      <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41l-1.06-1.06zm1.06-12.37c-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.38.39-1.02 0-1.41zM5.99 18.01l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.39.39-1.03 0-1.41z"/>
+    </svg>
+    <!-- Moon Icon (shown in light mode) -->
+    <svg id="moonIcon" viewBox="0 0 24 24">
+      <path d="M9.37 5.51c-.18-.64-.86-1.02-1.5-.84-2.32.63-4.13 2.5-4.7 4.88-.66 2.76.62 5.57 3.03 6.77.34.17.65.41.9.7l1.06 1.18c1.3 1.45 3.39 1.83 5.09 1 .73-.36 1.34-.9 1.81-1.57.4-.57.19-1.35-.47-1.63-3.64-1.55-5.91-5.32-5.46-9.45.08-.75-.5-1.4-1.26-1.07z"/>
+    </svg>
+  </button>
+
+  <header class="pp-header">
+    <div class="pp-container">
+      <span class="pp-eyebrow">Theming Diagnostic Lab</span>
+      <h1>color-scheme Auto Token Behavior</h1>
+      <p class="pp-subtitle">
+        Understand how setting <code>color-scheme: light dark</code> on `:root` updates browser UI elements automatically, 
+        and when you still need to write explicit token variables.
+      </p>
+      <div class="pp-meta-badge">
+        <span>Resolves</span> Issue #46189
+      </div>
+    </div>
+  </header>
+
+  <main class="pp-container pp-main-grid">
+
+    <!-- Section: Toggles & Compare Grid -->
+    <section class="pp-card pp-card-primary" aria-labelledby="sandbox-heading">
+      <h2 class="pp-card-title" id="sandbox-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line><line x1="15" y1="3" x2="15" y2="21"></line><line x1="3" y1="9" x2="21" y2="9"></line><line x1="3" y1="15" x2="21" y2="15"></line></svg>
+        Theming Sandbox &amp; Contrast Bench
+      </h2>
+      <p class="pp-card-desc">
+        Interact with the selector below to toggle between standard auto-schemes and full custom token remapping. Observe how each panel handles colors.
+      </p>
+
+      <div class="pp-selector-group" id="themeSelector">
+        <button class="pp-state-btn active" data-mode="light">Lock Light Theme</button>
+        <button class="pp-state-btn" data-mode="auto-dark">color-scheme: dark (Scheme-Only)</button>
+        <button class="pp-state-btn" data-mode="remap-dark">Full Color Token Remap</button>
+      </div>
+
+      <div class="pp-compare-grid">
+        <!-- Panel A: Scheme Only -->
+        <div class="pp-compare-card" id="cardSchemeOnly">
+          <h3>Scheme-Only Auto Dark</h3>
+          <p class="pp-card-desc" style="margin-bottom:0.5rem; font-size:0.8rem;">
+            Only UA styling changes. Native components adapt, but custom containers remain white.
+          </p>
+
+          <div class="pp-sandbox-stage">
+            <div class="pp-scroll-preview">
+              Scroll me! Note how the scrollbar color tracks the color-scheme value dynamically. This is handled by the browser's User Agent sheet.
+              <br><br>
+              More lines of text...<br>
+              Scrollbar indicator testing...<br>
+              Testing...
+            </div>
+            
+            <input type="text" placeholder="Native Input Box" value="Browser Autofilled Text" />
+            <select aria-label="Simulated Options dropdown">
+              <option>Native Select Option A</option>
+              <option>Native Select Option B</option>
+            </select>
+            
+            <div class="pp-custom-surface">
+              <strong>Custom Card Surface</strong>
+              <p style="font-size:0.8rem; margin-top:0.25rem;">Custom variables still resolve to default light theme colors!</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Panel B: Full Remap -->
+        <div class="pp-compare-card" id="cardFullRemap">
+          <h3>Themed Variables Remap</h3>
+          <p class="pp-card-desc" style="margin-bottom:0.5rem; font-size:0.8rem;">
+            Both UA styling and custom variables adapt, providing a fully themed dark interface.
+          </p>
+
+          <div class="pp-sandbox-stage">
+            <div class="pp-scroll-preview">
+              Scroll me! Custom variables map correctly to slate/dark shades, keeping borders and layout styling in harmony.
+              <br><br>
+              More lines of text...<br>
+              Scrollbar indicator testing...<br>
+              Testing...
+            </div>
+            
+            <input type="text" placeholder="Native Input Box" value="Browser Autofilled Text" />
+            <select aria-label="Simulated Options dropdown">
+              <option>Native Select Option A</option>
+              <option>Native Select Option B</option>
+            </select>
+            
+            <div class="pp-custom-surface">
+              <strong>Custom Card Surface</strong>
+              <p style="font-size:0.8rem; margin-top:0.25rem;">Custom variables remapped to Slate 800/900 shades!</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Diagnostics Checklist -->
+    <section class="pp-card pp-card-secondary" aria-labelledby="checklist-heading">
+      <h2 class="pp-card-title" id="checklist-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--secondary);"><polyline points="9 11 12 14 22 4"></polyline><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg>
+        Theme Diagnostic Checklist
+      </h2>
+      <p class="pp-card-desc">
+        Know what to expect from native browser schemes vs explicit token rules.
+      </p>
+
+      <div class="pp-compare-grid">
+        <div>
+          <h4 style="margin-bottom:0.75rem; color:var(--success);">What Changes Automatically:</h4>
+          <ul class="pp-check-list">
+            <li class="pp-check-item">
+              <div class="pp-check-bullet ok">&checkmark;</div>
+              <span>Browser scrollbars (track and thumb color)</span>
+            </li>
+            <li class="pp-check-item">
+              <div class="pp-check-bullet ok">&checkmark;</div>
+              <span>Native text input field backgrounds &amp; borders</span>
+            </li>
+            <li class="pp-check-item">
+              <div class="pp-check-bullet ok">&checkmark;</div>
+              <span>Select dropdown lists and option menu containers</span>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4 style="margin-bottom:0.75rem; color:var(--error);">What Requires Manual Variables:</h4>
+          <ul class="pp-check-list">
+            <li class="pp-check-item">
+              <div class="pp-check-bullet danger">!</div>
+              <span>Custom card background classes (e.g. <code>.pp-card</code>)</span>
+            </li>
+            <li class="pp-check-item">
+              <div class="pp-check-bullet danger">!</div>
+              <span>App-level layout borders and custom divide colors</span>
+            </li>
+            <li class="pp-check-item">
+              <div class="pp-check-bullet danger">!</div>
+              <span>Linear gradient texts and logo graphic assets</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Theming Literacy Quiz -->
+    <section class="pp-card pp-card-accent" aria-labelledby="quiz-heading">
+      <h2 class="pp-card-title" id="quiz-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent);"><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line><circle cx="12" cy="12" r="10"></circle></svg>
+        Theming Literacy Quiz
+      </h2>
+      <p class="pp-card-desc">
+        Verify your understanding of user-agent stylesheets and color variable overrides.
+      </p>
+
+      <div class="pp-quiz-card">
+        <div class="pp-quiz-question" id="quizQuestion">Loading question...</div>
+        <div class="pp-quiz-options" id="quizOptions"></div>
+        <div class="pp-quiz-feedback" id="quizFeedback"></div>
+        <button type="button" class="pp-quiz-next" id="quizNextBtn">Next Question</button>
+      </div>
+    </section>
+
+    <!-- Section: Code Snippets -->
+    <section class="pp-card pp-card-primary" id="snippets" aria-labelledby="snippets-heading">
+      <h2 class="pp-card-title" id="snippets-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Implementation Snippets
+      </h2>
+      <p class="pp-card-desc">
+        Use these boilerplate templates to configure theme logic in your stylesheets.
+      </p>
+
+      <div class="pp-snippets">
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">Step 1: Declare color-scheme</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetScheme">Copy CSS</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetScheme">/* Declare on root so scrollbars and inputs darken automatically */
+:root {
+  color-scheme: light dark;
+}</pre>
+        </div>
+
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">Step 2: Remap custom variables</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetTokens">Copy CSS</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetTokens">/* Explicitly override variables on prefers-color-scheme */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-card: #0f172a;
+    --border-color: #1e293b;
+    --text-primary: #f8fafc;
+  }
+}</pre>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Toast Notification -->
+  <div class="pp-toast" id="copyToast" role="status" aria-live="polite">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--success);"><polyline points="20 6 9 17 4 12"></polyline></svg>
+    Snippet copied to clipboard!
+  </div>
+
+  <footer class="pp-footer">
+    <div class="pp-container">
+      <div class="pp-footer-links">
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+        <span>&bull;</span>
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46189" target="_blank" rel="noopener noreferrer">Issue Ticket</a>
+      </div>
+      <p>&copy; 2026 EaseMotion CSS. Theme mapping guidelines.</p>
+    </div>
+  </footer>
+
+  <!-- Interactivity Scripts -->
+  <script>
+    (function() {
+      "use strict";
+
+      // --- Dark Theme Toggle ---
+      const themeToggleBtn = document.getElementById('themeToggleBtn');
+      const sunIcon = document.getElementById('sunIcon');
+      const moonIcon = document.getElementById('moonIcon');
+      const rootHtml = document.documentElement;
+
+      const savedTheme = localStorage.getItem('pp-theme') || 'light';
+      rootHtml.setAttribute('data-theme', savedTheme);
+      updateThemeIcons(savedTheme);
+
+      themeToggleBtn.addEventListener('click', () => {
+        const currentTheme = rootHtml.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        rootHtml.setAttribute('data-theme', newTheme);
+        localStorage.setItem('pp-theme', newTheme);
+        updateThemeIcons(newTheme);
+      });
+
+      function updateThemeIcons(theme) {
+        if (theme === 'dark') {
+          sunIcon.style.display = 'block';
+          moonIcon.style.display = 'none';
+        } else {
+          sunIcon.style.display = 'none';
+          moonIcon.style.display = 'block';
+        }
+      }
+
+      // --- Sandbox Mode Switcher ---
+      const themeSelector = document.getElementById('themeSelector');
+      const cardSchemeOnly = document.getElementById('cardSchemeOnly');
+      const cardFullRemap = document.getElementById('cardFullRemap');
+
+      function switchSandboxMode(mode) {
+        // Clear classes
+        cardSchemeOnly.className = "pp-compare-card";
+        cardFullRemap.className = "pp-compare-card";
+
+        if (mode === 'light') {
+          // Lock light mode
+          cardSchemeOnly.style.colorScheme = 'light';
+          cardFullRemap.style.colorScheme = 'light';
+        } 
+        else if (mode === 'auto-dark') {
+          // Apply scheme dark only (left card is dark scheme, right is remapped dark)
+          cardSchemeOnly.style.colorScheme = 'dark';
+          cardFullRemap.style.colorScheme = 'dark';
+          
+          cardSchemeOnly.classList.add('pp-theme-auto-dark');
+        } 
+        else if (mode === 'remap-dark') {
+          // Apply full remapped dark mode to both
+          cardSchemeOnly.style.colorScheme = 'dark';
+          cardFullRemap.style.colorScheme = 'dark';
+
+          cardSchemeOnly.classList.add('pp-theme-auto-dark');
+          cardFullRemap.classList.add('pp-theme-remap-dark');
+        }
+      }
+
+      themeSelector.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-mode]');
+        if (!btn) return;
+
+        themeSelector.querySelectorAll('.pp-state-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        switchSandboxMode(btn.dataset.mode);
+      });
+
+      // Default init
+      switchSandboxMode('light');
+
+      // --- Quiz System ---
+      const quizQuestions = [
+        {
+          question: "Which native elements update automatically when you specify color-scheme: dark on :root?",
+          options: [
+            "Card background variables and custom grids",
+            "Scrollbars, input fields, select option dropdowns, and button focus rings",
+            "Linear text gradients and site logo graphics",
+            "SVG icons and will-change animations"
+          ],
+          correct: 1,
+          explanation: "The browser's User Agent stylesheet automatically darkens native input components, options dropdowns, and scrollbars matching color-scheme values."
+        },
+        {
+          question: "Why do custom layout classes like .ease-card fail to automatically flip to dark colors under scheme-only dark mode?",
+          options: [
+            "The browser disables variable reading",
+            "Custom elements do not check user-agent stylesheets and must declare custom color variables manually",
+            "Custom elements fail compatibility compilation checks",
+            "Transition duration hooks lock color variables in light state"
+          ],
+          correct: 1,
+          explanation: "Custom components use design system variables which do not change unless explicit remapping values are declared (such as inside a prefers-color-scheme query)."
+        }
+      ];
+
+      let quizIdx = 0;
+      const quizQuestion = document.getElementById('quizQuestion');
+      const quizOptions = document.getElementById('quizOptions');
+      const quizFeedback = document.getElementById('quizFeedback');
+      const quizNextBtn = document.getElementById('quizNextBtn');
+
+      function loadQuiz() {
+        const data = quizQuestions[quizIdx];
+        quizQuestion.textContent = `Question ${quizIdx + 1}: ${data.question}`;
+        quizOptions.innerHTML = '';
+        quizFeedback.style.display = 'none';
+        quizFeedback.className = 'pp-quiz-feedback';
+        quizNextBtn.style.display = 'none';
+
+        data.options.forEach((opt, idx) => {
+          const optBtn = document.createElement('button');
+          optBtn.type = 'button';
+          optBtn.className = 'pp-quiz-option';
+          optBtn.innerHTML = `<span class="pp-option-index">${String.fromCharCode(65 + idx)}</span> <span>${opt}</span>`;
+          optBtn.addEventListener('click', () => selectQuiz(idx));
+          quizOptions.appendChild(optBtn);
+        });
+      }
+
+      function selectQuiz(selIdx) {
+        const data = quizQuestions[quizIdx];
+        const buttons = quizOptions.querySelectorAll('.pp-quiz-option');
+        buttons.forEach(btn => btn.disabled = true);
+
+        if (selIdx === data.correct) {
+          buttons[selIdx].classList.add('correct');
+          quizFeedback.textContent = `Correct! ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback success';
+        } else {
+          buttons[selIdx].classList.add('incorrect');
+          buttons[data.correct].classList.add('correct');
+          quizFeedback.textContent = `Incorrect. ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback error';
+        }
+        quizNextBtn.style.display = 'inline-block';
+      }
+
+      quizNextBtn.addEventListener('click', () => {
+        quizIdx++;
+        if (quizIdx < quizQuestions.length) {
+          loadQuiz();
+        } else {
+          quizQuestion.textContent = 'Diagnostic Complete!';
+          quizOptions.innerHTML = '<p class="pp-text-center pp-mt-4">Excellent! You understand auto color-schemes and remapping rules.</p>';
+          quizFeedback.style.display = 'none';
+          quizNextBtn.style.display = 'none';
+        }
+      });
+
+      loadQuiz();
+
+      // --- Snippet Copy System ---
+      const copyBtns = document.querySelectorAll('.pp-copy-btn');
+      const toastEl = document.getElementById('copyToast');
+
+      copyBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const preId = btn.dataset.codeId;
+          const preEl = document.getElementById(preId);
+          if (!preEl) return;
+
+          const text = preEl.textContent.trim();
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(() => showToast(btn));
+          } else {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            showToast(btn);
+          }
+        });
+      });
+
+      function showToast(btn) {
+        btn.classList.add('copied');
+        btn.textContent = 'Copied!';
+        toastEl.classList.add('show');
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.textContent = 'Copy CSS';
+          toastEl.classList.remove('show');
+        }, 2000);
+      }
+
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-color-scheme-auto-pp/style.css
+++ b/submissions/examples/ease-color-scheme-auto-pp/style.css
@@ -1,0 +1,691 @@
+/* ==========================================================================
+   EaseMotion CSS - User-Agent Theme Diagnostics
+   Lab: Auto color-scheme vs Manual Token Switcher
+   File: style.css
+   Author: Pratyush Panda (pp)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design System & CSS Variables
+   -------------------------------------------------------------------------- */
+:root {
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+
+  /* Theme colors - Light default */
+  --bg-app: #f8fafc;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f1f5f9;
+  --border-color: #e2e8f0;
+  
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #64748b;
+  
+  --primary: #6366f1;
+  --primary-hover: #4f46e5;
+  --primary-glow: rgba(99, 102, 241, 0.12);
+  
+  --secondary: #0ea5e9;
+  --secondary-glow: rgba(14, 165, 233, 0.12);
+  
+  --accent: #f59e0b;
+  --accent-soft: rgba(245, 158, 11, 0.08);
+  
+  --success: #10b981;
+  --success-bg: #d1fae5;
+  --error: #ef4444;
+  --error-bg: #fee2e2;
+  --warning: #f59e0b;
+  --warning-bg: #fef3c7;
+  
+  /* Shadow Elevation System */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+  /* Border Radii */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 24px;
+  --radius-full: 9999px;
+  
+  /* Motion & Animations */
+  --transition-fast: 0.15s ease;
+  --transition-normal: 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-slow: 0.45s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-bounce: 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Dark Theme Variables Override */
+[data-theme="dark"] {
+  --bg-app: #080c14;
+  --bg-card: #0f172a;
+  --bg-card-hover: #1e293b;
+  --border-color: #1e293b;
+  
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  
+  --primary: #818cf8;
+  --primary-hover: #6366f1;
+  --primary-glow: rgba(129, 140, 248, 0.25);
+  
+  --secondary: #38bdf8;
+  --secondary-glow: rgba(56, 189, 248, 0.25);
+  
+  --accent: #fbbf24;
+  --accent-soft: rgba(251, 191, 36, 0.15);
+  
+  --success: #34d399;
+  --success-bg: rgba(52, 211, 153, 0.1);
+  --error: #f87171;
+  --error-bg: rgba(248, 113, 113, 0.1);
+  --warning: #fbbf24;
+  --warning-bg: rgba(251, 191, 36, 0.1);
+}
+
+/* --------------------------------------------------------------------------
+   2. Reset & Core Base Styles
+   -------------------------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background-color: var(--bg-app);
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Custom Scrollbar */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg-app);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+code, pre {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  border-radius: 4px;
+}
+
+code {
+  background-color: var(--bg-app);
+  padding: 0.2em 0.4em;
+  color: var(--accent);
+  border: 1px solid var(--border-color);
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+a:hover {
+  color: var(--primary-hover);
+}
+
+/* Layout container */
+.pp-container {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Header & Hero Section
+   -------------------------------------------------------------------------- */
+.pp-header {
+  padding: 3rem 0 2rem;
+  text-align: center;
+}
+
+.pp-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+  display: inline-block;
+  background: var(--primary-glow);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.pp-header h1 {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, var(--text-primary) 30%, var(--primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.pp-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.15rem);
+  max-width: 68ch;
+  margin: 0 auto 1.5rem;
+}
+
+.pp-meta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.pp-meta-badge span {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* Theme Toggle Widget */
+.pp-theme-toggle {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.75rem;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xl);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition-bounce), background-color var(--transition-fast);
+}
+.pp-theme-toggle:hover {
+  transform: scale(1.1);
+  background-color: var(--bg-card-hover);
+}
+.pp-theme-toggle svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: var(--text-secondary);
+}
+
+/* Grid Layout */
+.pp-main-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* --------------------------------------------------------------------------
+   4. Cards & Component Panels
+   -------------------------------------------------------------------------- */
+.pp-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+.pp-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: var(--border-color);
+}
+.pp-card.pp-card-primary::before { background: var(--primary); }
+.pp-card.pp-card-secondary::before { background: var(--secondary); }
+.pp-card.pp-card-accent::before { background: var(--accent); }
+
+.pp-card-title {
+  font-size: 1.35rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pp-card-desc {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   5. Interactive State Selectors
+   -------------------------------------------------------------------------- */
+.pp-selector-group {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.pp-state-btn {
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  padding: 0.6rem 1.25rem;
+  border-radius: var(--radius-md);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.pp-state-btn:hover {
+  background-color: var(--bg-card-hover);
+}
+.pp-state-btn.active {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+  box-shadow: var(--shadow-md);
+}
+
+/* --------------------------------------------------------------------------
+   6. Side-by-Side Comparison Blocks
+   -------------------------------------------------------------------------- */
+.pp-compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .pp-compare-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-compare-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-app);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.pp-compare-card h3 {
+  font-size: 1.1rem;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5rem;
+}
+
+.pp-sandbox-stage {
+  padding: 1.5rem;
+  border-radius: var(--radius-sm);
+  background: white;
+  border: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 250px;
+}
+
+/* Scrollbar Preview Node inside sandbox */
+.pp-scroll-preview {
+  height: 80px;
+  overflow-y: scroll;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: #475569;
+}
+
+/* Inputs styling inside sandbox */
+.pp-sandbox-stage input,
+.pp-sandbox-stage select,
+.pp-sandbox-stage textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+}
+
+/* Simulated Custom Cards in stage */
+.pp-custom-surface {
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: var(--shadow-sm);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Simulated Dark CSS variables loaded on target container */
+.pp-theme-auto-dark {
+  /* color-scheme only is active */
+  color-scheme: dark;
+}
+
+/* Under color-scheme dark, custom surfaces still need variables override */
+.pp-theme-remap-dark {
+  color-scheme: dark;
+}
+.pp-theme-remap-dark .pp-sandbox-stage {
+  background: #0f172a;
+  border-color: #1e293b;
+}
+.pp-theme-remap-dark .pp-custom-surface {
+  background: #1e293b;
+  color: #f8fafc;
+  border-color: #334155;
+}
+.pp-theme-remap-dark input,
+.pp-theme-remap-dark select,
+.pp-theme-remap-dark textarea {
+  border-color: #334155;
+}
+.pp-theme-remap-dark .pp-scroll-preview {
+  border-color: #334155;
+  color: #cbd5e1;
+}
+
+/* --------------------------------------------------------------------------
+   7. Checklist items
+   -------------------------------------------------------------------------- */
+.pp-check-list {
+  list-style: none;
+}
+
+.pp-check-item {
+  display: flex;
+  gap: 0.85rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.92rem;
+}
+.pp-check-item:last-child {
+  margin-bottom: 0;
+}
+
+.pp-check-bullet {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+.pp-check-bullet.ok { background: var(--success); }
+.pp-check-bullet.danger { background: var(--error); }
+
+/* --------------------------------------------------------------------------
+   8. Interactive Quiz System
+   -------------------------------------------------------------------------- */
+.pp-quiz-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  background: var(--bg-app);
+  margin-top: 1rem;
+}
+
+.pp-quiz-question {
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+  color: var(--text-primary);
+}
+
+.pp-quiz-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.pp-quiz-option {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: left;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.pp-quiz-option:hover {
+  background-color: var(--bg-card-hover);
+  border-color: var(--primary);
+}
+.pp-quiz-option.correct {
+  border-color: var(--success);
+  background-color: var(--success-bg);
+  color: var(--success);
+}
+.pp-quiz-option.incorrect {
+  border-color: var(--error);
+  background-color: var(--error-bg);
+  color: var(--error);
+}
+
+.pp-option-index {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+.pp-quiz-option.correct .pp-option-index {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+.pp-quiz-option.incorrect .pp-option-index {
+  background: var(--error);
+  color: white;
+  border-color: var(--error);
+}
+
+.pp-quiz-feedback {
+  font-size: 0.88rem;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  margin-top: 1rem;
+  display: none;
+}
+.pp-quiz-feedback.success {
+  background: var(--success-bg);
+  color: var(--success);
+  border: 1px solid var(--success);
+  display: block;
+}
+.pp-quiz-feedback.error {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error);
+  display: block;
+}
+
+.pp-quiz-next {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+}
+.pp-quiz-next:hover {
+  background: var(--primary-hover);
+}
+
+/* --------------------------------------------------------------------------
+   9. Code Snippets & Copy System
+   -------------------------------------------------------------------------- */
+.pp-snippets {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-snippets {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-snippet-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-app);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.pp-snippet-header {
+  padding: 0.75rem 1rem;
+  background: rgba(0,0,0,0.03);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pp-snippet-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.pp-snippet-pre {
+  margin: 0;
+  padding: 1.25rem 1rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.pp-copy-btn {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.pp-copy-btn:hover {
+  background-color: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+.pp-copy-btn.copied {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+
+.pp-toast {
+  position: fixed;
+  bottom: 2.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(100px);
+  background: var(--text-primary);
+  color: var(--bg-card);
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-xl);
+  opacity: 0;
+  transition: transform var(--transition-bounce), opacity var(--transition-fast);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.pp-toast.show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+/* --------------------------------------------------------------------------
+   10. Footer Section
+   -------------------------------------------------------------------------- */
+.pp-footer {
+  margin-top: 4rem;
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.pp-footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
- Closes #46189
- Adds an interactive theming diagnostic lab inside `submissions/examples/ease-color-scheme-auto-pp/` detailing auto-theming interactions under `color-scheme: light dark`.
- Includes a side-by-side sandbox comparison, diagnostic selectors, checklist tables, and an interactive quiz.
- Fully self-contained and responsive, with support for local light/dark mode toggling.