### PR TITLE
ease-neuro-glass-contrast-sp

### DIFF
--- a/submissions/docs/ease-neuro-glass-contrast-sp/README.md
+++ b/submissions/docs/ease-neuro-glass-contrast-sp/README.md
@@ -1,0 +1,76 @@
+# Neumorphic + Glass Combo Contrast Fail Board
+
+An accessibility documentation showcase that measures **WCAG contrast failures** when stacking `ease-card-neumorphic`, `ease-card-glass`, and glow hover on a **light soft-UI** stage — then documents safer combo patterns.
+
+> Submission track: `submissions/docs/ease-neuro-glass-contrast-sp/`  
+> Contributor suffix: `sp`  
+> Related issue: [#47558](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47558)
+
+---
+
+## What does this do?
+
+EaseMotion ships soft-UI card modifiers that look great alone. Stacking them on a light background is a common accident:
+
+| Utility | Soft-UI effect |
+|---------|----------------|
+| `ease-card-neumorphic` | Soft tint + dual shadows |
+| `ease-card-glass` | Translucent white + blur |
+| `ease-card-glow` / `ease-hover-glow` | Primary glow bloom on hover |
+
+Together they wash out muted, lavender, and meta text — a **light soft-UI** contrast problem, distinct from dark glass + glow audits.
+
+This board:
+
+- Reproduces failing neuro + glass + glow stacks
+- Labels approximate contrast ratios (relative luminance)
+- Shows safer combos (one surface, solid ink, glow without glass)
+- Provides copy-friendly pairing rules — without editing core
+
+## How is it used?
+
+1. Open `demo.html` in a browser (EaseMotion CSS loads from the jsDelivr CDN).
+2. Review the **Fail board** on the soft pastel stage (hover cards to see glow).
+3. Compare the **Safer combos** panel.
+4. Read the measured FG/BG table (AA threshold ≥ 4.5:1 for normal text).
+5. Copy a safer pairing snippet from the patterns section.
+
+### Preferred patterns
+
+```html
+<!-- One soft surface + dark text tokens -->
+<article class="ease-card ease-card-neumorphic">
+  <h3 class="ease-card-title">Title</h3>
+  <p>Body copy…</p>
+</article>
+```
+
+```html
+<!-- Glass shell + opaque ink panel (project CSS) -->
+<article class="ease-card ease-card-glass">
+  <div class="ink-panel">Readable body…</div>
+</article>
+```
+
+## Why is it useful?
+
+- Makes light soft-UI contrast fails visible and measurable
+- Teaches “pick one surface utility” instead of stacking all three
+- Keeps remediation project-local during the core freeze
+- Complements (does not duplicate) dark glass / button contrast labs
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Fail/safer boards, ratio table, pairing snippets |
+| `style.css` | Soft stage + intentional fail text colors + ink panel helper |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-neuro-glass-contrast-sp/`
+- No changes to `core/`, `components/`, workflows, or existing files
+- Uses the official CDN bundle; no framework source copied
+- Folder name includes unique contributor suffix `-sp`
+- Respects `prefers-reduced-motion` for local hover transitions

--- a/submissions/docs/ease-neuro-glass-contrast-sp/demo.html
+++ b/submissions/docs/ease-neuro-glass-contrast-sp/demo.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neumorphic + Glass Combo Contrast Fail Board</title>
+  <meta
+    name="description"
+    content="Measure contrast failures when stacking ease-card-neumorphic, ease-card-glass, and glow hover on light soft-UI — plus safer combos."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="board-header ease-fade-in">
+    <p class="board-eyebrow">EaseMotion CSS · Accessibility Showcase · Issue #47558</p>
+    <h1>Neumorphic + Glass Combo Contrast Fail Board</h1>
+    <p class="board-subtitle">
+      Stacking <code>ease-card-neumorphic</code>, <code>ease-card-glass</code>, and
+      glow hover on a <strong>light soft-UI</strong> background can wash out text
+      and controls. This board measures those fails and documents safer combos —
+      different from dark glass + glow issues.
+    </p>
+  </header>
+
+  <main class="board-main">
+    <!-- ── Context ─────────────────────────────────────────── -->
+    <section class="board-panel" aria-labelledby="context-title">
+      <h2 id="context-title">What goes wrong on light soft-UI</h2>
+      <ul class="context-list">
+        <li>
+          <strong>Neumorphic</strong> uses a soft page-tint background
+          (<code>--ease-color-bg</code>) with low-contrast dual shadows.
+        </li>
+        <li>
+          <strong>Glass</strong> adds translucent white
+          (<code>rgba(255,255,255,0.35)</code> + blur — text sits on a washed surface.
+        </li>
+        <li>
+          <strong>Glow hover</strong> (<code>ease-card-glow</code> /
+          <code>ease-hover-glow</code>) blooms primary light over the mix and
+          further softens perceived contrast.
+        </li>
+      </ul>
+      <p class="wcag-note">
+        WCAG AA needs <strong>≥ 4.5:1</strong> for normal text and
+        <strong>≥ 3:1</strong> for large text / UI components.
+      </p>
+    </section>
+
+    <!-- ── Fail board ──────────────────────────────────────── -->
+    <section class="board-section" aria-labelledby="fail-title">
+      <div class="section-head">
+        <h2 id="fail-title">Fail board — stacked soft utilities</h2>
+        <span class="badge badge-fail">Contrast risk</span>
+      </div>
+      <p class="section-lead">
+        Soft pastel stage. Cards combine neumorphic + glass + glow. Hover to see
+        glow wash the surface further.
+      </p>
+
+      <div class="soft-stage soft-stage--fail" id="fail-stage">
+        <article
+          class="ease-card ease-card-neumorphic ease-card-glass ease-card-glow sample-card"
+          tabindex="0"
+          data-fg="#64748b"
+          data-bg="#eef2ff"
+          data-label="Muted body on neuro+glass"
+        >
+          <div class="ease-card-header">
+            <h3 class="ease-card-title sample-title-muted">Soft Dashboard</h3>
+            <p class="ease-card-subtitle sample-muted">Neumorphic + glass + glow</p>
+          </div>
+          <div class="ease-card-body">
+            <p class="sample-muted">
+              Body copy uses muted slate on a translucent soft surface — easy to
+              ship, hard to read.
+            </p>
+          </div>
+          <div class="ease-card-footer">
+            <button type="button" class="ease-btn ease-btn-primary sample-btn-wash">
+              Continue
+            </button>
+            <span class="sample-link-wash">Learn more →</span>
+          </div>
+          <p class="ratio-chip" data-ratio-for="fail-1">Measuring…</p>
+        </article>
+
+        <article
+          class="ease-card ease-card-neumorphic ease-card-glass ease-hover-glow sample-card"
+          tabindex="0"
+          data-fg="#a09af8"
+          data-bg="#f1f5f9"
+          data-label="Primary-light text on soft glass"
+        >
+          <div class="ease-card-header">
+            <h3 class="sample-title-lavender">Glow Accent Title</h3>
+            <p class="sample-lavender">ease-hover-glow on neuro+glass</p>
+          </div>
+          <div class="ease-card-body">
+            <p class="sample-lavender">
+              Lavender title/body on soft glass looks “on brand” but fails AA for
+              normal text.
+            </p>
+          </div>
+          <p class="ratio-chip" data-ratio-for="fail-2">Measuring…</p>
+        </article>
+
+        <article
+          class="ease-card ease-card-neumorphic ease-card-glass ease-card-glow sample-card"
+          tabindex="0"
+          data-fg="#94a3b8"
+          data-bg="#f8fafc"
+          data-label="Placeholder / meta text"
+        >
+          <div class="ease-card-body">
+            <p class="sample-meta">Meta · Updated just now · soft-UI mix</p>
+            <p class="sample-meta">
+              Secondary labels and timestamps are the first things to disappear
+              when glass sits on neumorphic tint.
+            </p>
+          </div>
+          <p class="ratio-chip" data-ratio-for="fail-3">Measuring…</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- ── Safer combos ────────────────────────────────────── -->
+    <section class="board-section" aria-labelledby="safe-title">
+      <div class="section-head">
+        <h2 id="safe-title">Safer combos — keep the soft look</h2>
+        <span class="badge badge-pass">AA-friendlier</span>
+      </div>
+      <p class="section-lead">
+        Pick <em>one</em> soft surface utility, keep text on solid tokens, and
+        use glow sparingly (border/shadow — not washed text color).
+      </p>
+
+      <div class="soft-stage soft-stage--safe" id="safe-stage">
+        <article
+          class="ease-card ease-card-neumorphic sample-card"
+          tabindex="0"
+          data-fg="#0f172a"
+          data-bg="#f8fafc"
+          data-label="Neumorphic only + dark text"
+        >
+          <div class="ease-card-header">
+            <h3 class="ease-card-title">Neumorphic only</h3>
+            <p class="ease-card-subtitle sample-safe-sub">No glass stack</p>
+          </div>
+          <div class="ease-card-body">
+            <p class="sample-safe-body">
+              Soft dual-shadow card with dark text tokens. Readable without
+              translucent wash.
+            </p>
+          </div>
+          <div class="ease-card-footer">
+            <button type="button" class="ease-btn ease-btn-primary">Continue</button>
+          </div>
+          <p class="ratio-chip ratio-chip--pass" data-ratio-for="safe-1">Measuring…</p>
+        </article>
+
+        <article
+          class="ease-card ease-card-glass sample-card sample-glass-safe"
+          tabindex="0"
+          data-fg="#0f172a"
+          data-bg="#e8edf7"
+          data-label="Glass + opaque text panel"
+        >
+          <div class="ease-card-header">
+            <h3 class="ease-card-title">Glass + solid ink</h3>
+            <p class="ease-card-subtitle sample-safe-sub">Opaque text panel inside</p>
+          </div>
+          <div class="ease-card-body sample-ink-panel">
+            <p>
+              Glass stays decorative. Body text sits on a near-opaque panel so
+              contrast is predictable.
+            </p>
+          </div>
+          <p class="ratio-chip ratio-chip--pass" data-ratio-for="safe-2">Measuring…</p>
+        </article>
+
+        <article
+          class="ease-card ease-card-neumorphic ease-card-glow sample-card"
+          tabindex="0"
+          data-fg="#1e293b"
+          data-bg="#f8fafc"
+          data-label="Neuro + glow, no glass"
+        >
+          <div class="ease-card-header">
+            <h3 class="ease-card-title">Glow without glass</h3>
+            <p class="ease-card-subtitle sample-safe-sub">Hover for border glow</p>
+          </div>
+          <div class="ease-card-body">
+            <p class="sample-safe-body">
+              Neumorphic + <code>ease-card-glow</code> is fine when text stays
+              dark and glass is not stacked on top.
+            </p>
+          </div>
+          <p class="ratio-chip ratio-chip--pass" data-ratio-for="safe-3">Measuring…</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- ── Measurement table ───────────────────────────────── -->
+    <section class="board-panel" aria-labelledby="table-title">
+      <h2 id="table-title">Measured pairs (approx. relative luminance)</h2>
+      <div class="table-wrap">
+        <table class="contrast-table">
+          <thead>
+            <tr>
+              <th scope="col">Sample</th>
+              <th scope="col">FG</th>
+              <th scope="col">BG (approx.)</th>
+              <th scope="col">Ratio</th>
+              <th scope="col">WCAG AA</th>
+            </tr>
+          </thead>
+          <tbody id="contrast-tbody">
+            <!-- filled by script -->
+          </tbody>
+        </table>
+      </div>
+      <p class="table-note">
+        Backgrounds for translucent glass are approximated against the soft stage
+        color. Use these as educational estimates — always verify in DevTools /
+        axe for production.
+      </p>
+    </section>
+
+    <!-- ── Patterns ────────────────────────────────────────── -->
+    <section class="board-panel" aria-labelledby="patterns-title">
+      <h2 id="patterns-title">Safer pairing rules</h2>
+      <div class="pattern-grid">
+        <article class="pattern-card">
+          <h3>Avoid (fail stack)</h3>
+          <pre class="board-code" tabindex="0"><code>&lt;article class="ease-card
+  ease-card-neumorphic
+  ease-card-glass
+  ease-card-glow"&gt;
+  &lt;p class="muted"&gt;…&lt;/p&gt;
+&lt;/article&gt;</code></pre>
+          <p>Three soft layers + muted ink ≈ contrast fail on light UI.</p>
+        </article>
+
+        <article class="pattern-card">
+          <h3>Prefer (one surface)</h3>
+          <pre class="board-code" tabindex="0"><code>&lt;!-- Pick ONE soft surface --&gt;
+&lt;article class="ease-card ease-card-neumorphic"&gt;
+  &lt;h3 class="ease-card-title"&gt;Title&lt;/h3&gt;
+  &lt;p&gt;Body uses default dark text tokens.&lt;/p&gt;
+&lt;/article&gt;</code></pre>
+        </article>
+
+        <article class="pattern-card">
+          <h3>Glass with ink panel</h3>
+          <pre class="board-code" tabindex="0"><code>&lt;article class="ease-card ease-card-glass"&gt;
+  &lt;div class="ink-panel"&gt;
+    &lt;p&gt;Readable body…&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/article&gt;
+
+/* project CSS — not core */
+.ink-panel {
+  background: color-mix(in srgb, #fff 92%, transparent);
+  color: #0f172a;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+}</code></pre>
+        </article>
+
+        <article class="pattern-card">
+          <h3>When to use which</h3>
+          <ul class="pattern-list">
+            <li><strong>Neumorphic alone</strong> — soft-UI cards with dark text</li>
+            <li><strong>Glass alone</strong> — decorative shell + opaque ink panel</li>
+            <li><strong>Glow</strong> — border/shadow accent, never light text color</li>
+            <li><strong>Do not</strong> — stack neuro + glass + glow on light stages</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="board-footer">
+    <p>
+      Self-contained submission ·
+      <code>submissions/docs/ease-neuro-glass-contrast-sp/</code> ·
+      no core edits
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      function hexToRgb(hex) {
+        var h = hex.replace("#", "");
+        if (h.length === 3) {
+          h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+        }
+        var n = parseInt(h, 16);
+        return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+      }
+
+      function channel(c) {
+        var s = c / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+      }
+
+      function luminance(hex) {
+        var rgb = hexToRgb(hex);
+        return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+      }
+
+      function contrastRatio(fg, bg) {
+        var L1 = luminance(fg);
+        var L2 = luminance(bg);
+        var lighter = Math.max(L1, L2);
+        var darker = Math.min(L1, L2);
+        return (lighter + 0.05) / (darker + 0.05);
+      }
+
+      var samples = document.querySelectorAll("[data-fg][data-bg]");
+      var tbody = document.getElementById("contrast-tbody");
+
+      samples.forEach(function (el, index) {
+        var fg = el.getAttribute("data-fg");
+        var bg = el.getAttribute("data-bg");
+        var label = el.getAttribute("data-label") || "Sample " + (index + 1);
+        var ratio = contrastRatio(fg, bg);
+        var pass = ratio >= 4.5;
+        var ratioText = ratio.toFixed(2) + ":1";
+
+        var chip = el.querySelector(".ratio-chip");
+        if (chip) {
+          chip.textContent = ratioText + (pass ? " PASS" : " FAIL");
+          chip.classList.toggle("ratio-chip--pass", pass);
+          chip.classList.toggle("ratio-chip--fail", !pass);
+        }
+
+        var tr = document.createElement("tr");
+        tr.innerHTML =
+          "<td>" +
+          label +
+          "</td><td><code>" +
+          fg +
+          '</code></td><td><code>' +
+          bg +
+          "</code></td><td>" +
+          ratioText +
+          '</td><td><span class="' +
+          (pass ? "badge badge-pass" : "badge badge-fail") +
+          '">' +
+          (pass ? "PASS" : "FAIL") +
+          "</span></td>";
+        tbody.appendChild(tr);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-neuro-glass-contrast-sp/style.css
+++ b/submissions/docs/ease-neuro-glass-contrast-sp/style.css
@@ -1,0 +1,391 @@
+/* ============================================================
+   Neumorphic + Glass Combo Contrast Fail Board
+   Local demo styles only — does not modify core.
+   ============================================================ */
+
+:root {
+  --board-surface: var(--ease-color-surface, #ffffff);
+  --board-border: var(--ease-color-neutral-200, #e2e8f0);
+  --board-muted: var(--ease-color-muted, #64748b);
+  --board-text: var(--ease-color-text, #1e293b);
+  --board-accent: var(--ease-color-primary, #6c63ff);
+  --board-danger: var(--ease-color-danger, #b91c1c);
+  --board-success: var(--ease-color-success, #15803d);
+  --board-radius: var(--ease-radius-md, 0.5rem);
+  --board-shadow: var(--ease-shadow-md, 0 4px 16px rgba(15, 23, 42, 0.08));
+  --soft-stage: #e8eef8;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--ease-font-sans, "Inter", system-ui, sans-serif);
+  color: var(--board-text);
+  background:
+    radial-gradient(1000px 420px at 10% -5%, rgba(108, 99, 255, 0.1), transparent 55%),
+    radial-gradient(800px 360px at 100% 0%, rgba(148, 163, 184, 0.18), transparent 50%),
+    var(--ease-color-bg, #f8fafc);
+  line-height: 1.55;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.board-header {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 1.25rem;
+  text-align: center;
+}
+
+.board-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--board-accent);
+}
+
+.board-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.55rem, 3.4vw, 2.1rem);
+  line-height: 1.2;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.board-subtitle {
+  margin: 0 auto;
+  max-width: 44rem;
+  color: var(--board-muted);
+  font-size: 1.02rem;
+}
+
+/* ── Main ────────────────────────────────────────────────── */
+
+.board-main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1.25rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.board-panel,
+.board-section {
+  background: var(--board-surface);
+  border: 1px solid var(--board-border);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--board-shadow);
+  padding: 1.25rem 1.35rem;
+}
+
+.board-panel h2,
+.section-head h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.context-list {
+  margin: 0 0 1rem;
+  padding-left: 1.2rem;
+  color: var(--board-muted);
+}
+
+.context-list li + li {
+  margin-top: 0.45rem;
+}
+
+.wcag-note {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--board-radius);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  border: 1px solid var(--board-border);
+  font-size: 0.92rem;
+  color: var(--board-text);
+}
+
+.section-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.section-lead {
+  margin: 0 0 1rem;
+  color: var(--board-muted);
+  font-size: 0.95rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.badge-fail {
+  color: var(--board-danger);
+  background: color-mix(in srgb, var(--board-danger) 12%, white);
+  border: 1px solid color-mix(in srgb, var(--board-danger) 30%, transparent);
+}
+
+.badge-pass {
+  color: var(--board-success);
+  background: color-mix(in srgb, var(--board-success) 12%, white);
+  border: 1px solid color-mix(in srgb, var(--board-success) 30%, transparent);
+}
+
+/* ── Soft stages ─────────────────────────────────────────── */
+
+.soft-stage {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  gap: 1.1rem;
+  padding: 1.25rem;
+  border-radius: var(--ease-radius-lg, 1rem);
+  background:
+    linear-gradient(145deg, #dfe7f5 0%, var(--soft-stage) 45%, #f4f7fc 100%);
+  border: 1px dashed color-mix(in srgb, var(--board-accent) 25%, var(--board-border));
+}
+
+.soft-stage--fail {
+  border-color: color-mix(in srgb, var(--board-danger) 35%, var(--board-border));
+}
+
+.soft-stage--safe {
+  border-color: color-mix(in srgb, var(--board-success) 35%, var(--board-border));
+}
+
+.sample-card {
+  position: relative;
+  min-height: 12rem;
+}
+
+/* Intentionally washed / failing text colors for the fail board */
+.sample-muted,
+.sample-title-muted {
+  color: #64748b !important;
+}
+
+.sample-lavender,
+.sample-title-lavender {
+  color: #a09af8 !important;
+}
+
+.sample-meta {
+  color: #94a3b8 !important;
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+}
+
+.sample-link-wash {
+  color: #a09af8;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.sample-btn-wash {
+  /* Keep primary button, but show washed companion link nearby */
+  flex-shrink: 0;
+}
+
+/* Safer text */
+.sample-safe-body {
+  color: #1e293b;
+  margin: 0;
+}
+
+.sample-safe-sub {
+  color: #475569 !important;
+}
+
+.sample-ink-panel {
+  background: color-mix(in srgb, #ffffff 92%, transparent);
+  color: #0f172a;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.sample-ink-panel p {
+  margin: 0;
+  color: #0f172a;
+}
+
+.sample-glass-safe {
+  /* Slightly stronger glass base for the safe demo stage */
+  --ease-glass-bg: rgba(255, 255, 255, 0.55);
+}
+
+.ratio-chip {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  margin: 0;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--board-border);
+  color: var(--board-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.ratio-chip--fail {
+  color: var(--board-danger);
+  border-color: color-mix(in srgb, var(--board-danger) 35%, transparent);
+  background: color-mix(in srgb, var(--board-danger) 10%, white);
+}
+
+.ratio-chip--pass {
+  color: var(--board-success);
+  border-color: color-mix(in srgb, var(--board-success) 35%, transparent);
+  background: color-mix(in srgb, var(--board-success) 10%, white);
+}
+
+/* ── Table ───────────────────────────────────────────────── */
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.contrast-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.contrast-table th,
+.contrast-table td {
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--board-border);
+  vertical-align: middle;
+}
+
+.contrast-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--board-muted);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.table-note {
+  margin: 0.85rem 0 0;
+  font-size: 0.85rem;
+  color: var(--board-muted);
+}
+
+/* ── Patterns ────────────────────────────────────────────── */
+
+.pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.pattern-card {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--board-border);
+  border-radius: var(--board-radius);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.pattern-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.98rem;
+}
+
+.pattern-card p {
+  margin: 0.75rem 0 0;
+  font-size: 0.88rem;
+  color: var(--board-muted);
+}
+
+.pattern-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--board-muted);
+  font-size: 0.9rem;
+}
+
+.pattern-list li + li {
+  margin-top: 0.4rem;
+}
+
+.board-code {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  border-radius: 0.4rem;
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.board-code code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+/* ── Footer ──────────────────────────────────────────────── */
+
+.board-footer {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1.25rem 2.5rem;
+  text-align: center;
+  color: var(--board-muted);
+  font-size: 0.85rem;
+}
+
+.board-footer p {
+  margin: 0;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 800px) {
+  .pattern-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-card-neumorphic,
+  .ease-card-glow,
+  .ease-hover-glow {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
# #47558 issue resolved

## Description

This PR adds a Neumorphic + Glass Combo Contrast Fail Board under `submissions/docs/ease-neuro-glass-contrast-sp/`.

## Features

- Fail board for light soft-UI mixes of neumorphic + glass + glow hover
- Safer combo examples with readable text tokens
- Approximate WCAG AA contrast ratio measurements
- Copy-friendly pairing rules (no core edits)
- Self-contained docs submission (`demo.html`, `style.css`, `README.md`)