### PR TITLE
fix: standardize CDN path to npm convention for easemotion.min.css (#47282)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ EaseMotion CSS lets you build polished interfaces with readable class names such
 />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css"
 />
 ```
 
@@ -138,7 +138,7 @@ Most people simply forget. This is your reminder. 😊
 | Metric               | Value                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------- |
 | 📦 **npm Package**   | [`easemotion-css`](https://www.npmjs.com/package/easemotion-css)                                              |
-| 🌐 **CDN**           | [cdn.jsdelivr.net/gh/...](https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css) |
+| 🌐 **CDN**           | [cdn.jsdelivr.net/npm/...](https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css) |
 | ⚡ **Classes**       | 80+ utility classes, 20+ animation classes                                                                    |
 | 🎨 **Components**    | Buttons (6 variants), Cards (13 variants)                                                                     |
 | 🔑 **Design Tokens** | 60+ CSS custom properties                                                                                     |
@@ -226,7 +226,7 @@ EaseMotion CSS is a curated, animation-first CSS framework where class names rea
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+      href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css"
     />
   </head>
   <body>
@@ -248,7 +248,7 @@ EaseMotion CSS can also be loaded using alternative CDN providers.
 ```html
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css"
 />
 ```
 
@@ -1235,7 +1235,7 @@ The project encourages creative variations and parallel implementations rather t
 | 🔀 **Pull Requests**    | [Submit a contribution](https://github.com/SAPTARSHI-coder/EaseMotion-css/pulls)                              |
 | 📖 **Documentation**    | [Full docs site](https://saptarshi-coder.github.io/EaseMotion-css/)                                           |
 | 📦 **npm Package**      | [easemotion-css on npm](https://www.npmjs.com/package/easemotion-css)                                         |
-| 🌐 **CDN**              | [jsDelivr (GitHub CDN)](https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css)   |
+| 🌐 **CDN**              | [jsDelivr (npm CDN)](https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css)   |
 | 🏆 **GSSoC 2026**       | [GirlScript Summer of Code](https://gssoc.girlscript.tech/)                                                   |
 | 💬 **Discord Server (Optional)**   | [Join Discord (Optional)](https://discord.gg/hWSdGrccBU)                                                                 |
 


### PR DESCRIPTION
## Pull Request Description

Fixes issue #47282 — the README referenced `easemotion.min.css` via two inconsistent jsDelivr CDN conventions:

- GitHub-path style: `cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css` (used in Quick Setup, Quick Start, Alternative CDN section, and the Community table)
- npm-path style: `cdn.jsdelivr.net/npm/easemotion-css/...` (used everywhere else for modular core/component files)

This PR standardizes all `easemotion.min.css` references to the npm-path convention, matching the rest of the file and the published npm package. Link labels were also updated to match (e.g. "jsDelivr (GitHub CDN)" → "jsDelivr (npm CDN)").

## Type of Change

- [x] 📝 Documentation improvement

## Notes for Maintainer

This is a documentation-only fix to `README.md` — no `submissions/` folder, `demo.html`, or `style.css` involved, since it doesn't add a new feature/component. Happy to adjust the format if you'd prefer this routed differently.