### PR TITLE
Flip or 3D backface-visibility Safari Glitch Doc

### DIFF
--- a/submissions/docs/ease-flip-backface-safari-sp/README.md
+++ b/submissions/docs/ease-flip-backface-safari-sp/README.md
@@ -1,0 +1,75 @@
+# Flip / 3D backface-visibility Safari Glitch Doc
+
+A documentation showcase that reproduces **Safari flicker / reverse-face flash** during EaseMotion flip animations (`ease-flip`, flip-x / flip-y patterns) and documents a **Safari-safe 3D CSS stack**.
+
+> Submission track: `submissions/docs/ease-flip-backface-safari-sp/`  
+> Contributor suffix: `sp`  
+> Related issue: [#47560](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47560)
+
+---
+
+## What does this do?
+
+3D flips look fine in Chrome with an incomplete stack, then flicker in Safari when:
+
+- `-webkit-backface-visibility: hidden` is missing
+- `perspective` sits on the wrong node
+- `transform-style: preserve-3d` is incomplete
+- faces z-fight mid-rotation without a tiny `translateZ`
+
+This is a **3D compositor quirk**, not an iOS `100vh` / navbar issue.
+
+This lab:
+
+- Replays `ease-flip` plus local flip-x / flip-y entrance patterns
+- Shows before (incomplete stack) vs after (Safari-safe) hover flip cards
+- Lists a property checklist in the correct order
+- Provides copy-friendly harden snippets — without editing core
+
+## How is it used?
+
+1. Open `demo.html` in a browser (ideally also check **Safari / iOS Safari**).
+2. Click **Replay entrance flips** for `ease-flip` / flip-x / flip-y entrances.
+3. Hover or focus the **Before** cards — incomplete stack (glitch risk).
+4. Hover or focus the **After** cards — hardened Safari-safe stack.
+5. Copy the checklist / project CSS harden snippet.
+
+### Safari-safe harden snippet
+
+```css
+.ease-flip-3d-inner {
+  -webkit-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+}
+.ease-flip-3d-face {
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  transform: translateZ(0.1px);
+}
+.ease-flip-3d-back {
+  transform: rotateY(180deg) translateZ(0.1px);
+}
+```
+
+## Why is it useful?
+
+- Documents a real Safari-only class of bugs for EaseMotion flip utilities
+- Separates entrance flips (`ease-flip`) from double-sided cards (`ease-flip-3d`)
+- Keeps the fix in project CSS during the core freeze
+- Distinct from iOS viewport / navbar showcases
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Entrance demos, broken vs safe flip cards, checklist |
+| `style.css` | Broken incomplete stack + Safari-safe hardened stack |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-flip-backface-safari-sp/`
+- No changes to `core/`, `components/`, workflows, or existing files
+- Uses the official CDN bundle; no framework source copied
+- Folder name includes unique contributor suffix `-sp`
+- Respects `prefers-reduced-motion` (flips disabled / static)

--- a/submissions/docs/ease-flip-backface-safari-sp/demo.html
+++ b/submissions/docs/ease-flip-backface-safari-sp/demo.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flip / 3D backface-visibility Safari Glitch Doc</title>
+  <meta
+    name="description"
+    content="Reproduce Safari flicker on EaseMotion flip animations and document a Safari-safe 3D CSS stack."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="doc-header ease-fade-in">
+    <p class="doc-eyebrow">EaseMotion CSS · Documentation Showcase · Issue #47560</p>
+    <h1>Flip / 3D backface-visibility Safari Glitch Doc</h1>
+    <p class="doc-subtitle">
+      Safari can flicker, flash the reverse face, or briefly show both sides during
+      <code>ease-flip</code> / flip-x / flip-y motion when
+      <code>backface-visibility</code>, <code>preserve-3d</code>, and perspective
+      are stacked incorrectly. This lab reproduces the glitch and documents a
+      Safari-safe stack — 3D-specific, not iOS <code>100vh</code> / navbar.
+    </p>
+    <button type="button" class="ease-btn ease-btn-primary" id="replay-btn">
+      Replay entrance flips
+    </button>
+  </header>
+
+  <main class="doc-main">
+    <!-- ── Why Safari ──────────────────────────────────────── -->
+    <section class="doc-panel" aria-labelledby="why-title">
+      <h2 id="why-title">Why Safari flickers</h2>
+      <ul class="why-list">
+        <li>
+          Safari is stricter about <strong>compositor layers</strong> for 3D
+          transforms. Missing <code>-webkit-backface-visibility: hidden</code>
+          often leaves the reverse face briefly visible.
+        </li>
+        <li>
+          <code>perspective</code> on the wrong node (animated child instead of
+          parent) fights <code>transform-style: preserve-3d</code>.
+        </li>
+        <li>
+          Without a tiny <code>translateZ(0.1px)</code> (or similar), faces can
+          z-fight at the midpoint of a flip.
+        </li>
+      </ul>
+      <div class="callout" role="note">
+        <strong>Tip:</strong> Test flip cards in Safari / iOS Safari. Chrome may
+        look fine with an incomplete stack — that is the trap.
+      </div>
+    </section>
+
+    <!-- ── Entrance: ease-flip ─────────────────────────────── -->
+    <section class="doc-section" aria-labelledby="entrance-title">
+      <h2 id="entrance-title">Entrance: <code>ease-flip</code></h2>
+      <p class="section-lead">
+        Core utility rotates in on the Y axis with perspective. Replay to watch
+        the entrance; pair it with a Safari-safe parent when nesting flip faces.
+      </p>
+      <div class="entrance-row" id="entrance-stage">
+        <div class="entrance-card ease-flip replay-target">
+          <strong>ease-flip</strong>
+          <span>Y-axis entrance</span>
+        </div>
+        <div class="entrance-card flip-x-demo replay-target">
+          <strong>flip-x pattern</strong>
+          <span>rotateX entrance</span>
+        </div>
+        <div class="entrance-card flip-y-demo replay-target">
+          <strong>flip-y pattern</strong>
+          <span>rotateY entrance</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Broken vs safe card flips ───────────────────────── -->
+    <div class="compare-row">
+      <section class="doc-panel panel-broken" aria-labelledby="broken-title">
+        <div class="panel-head">
+          <h2 id="broken-title">Before — incomplete 3D stack</h2>
+          <span class="badge badge-bad">Safari flicker risk</span>
+        </div>
+        <p class="section-lead">
+          Hover / focus to flip. Missing webkit backface + no <code>translateZ</code>
+          + perspective on the wrong element — classic Safari glitch setup.
+        </p>
+
+        <div class="flip-demo-grid">
+          <div class="broken-scene" tabindex="0" aria-label="Broken flip-y card">
+            <div class="broken-inner broken-inner--y">
+              <div class="face face-front">Front · flip-y</div>
+              <div class="face face-back">Back · visible mid-flip?</div>
+            </div>
+            <p class="flip-hint">Hover or focus</p>
+          </div>
+
+          <div class="broken-scene" tabindex="0" aria-label="Broken flip-x card">
+            <div class="broken-inner broken-inner--x">
+              <div class="face face-front">Front · flip-x</div>
+              <div class="face face-back">Back · z-fight risk</div>
+            </div>
+            <p class="flip-hint">Hover or focus</p>
+          </div>
+        </div>
+
+        <pre class="doc-code" tabindex="0"><code>/* Incomplete — flickers in Safari */
+.scene { /* no perspective here */ }
+.inner { transition: transform .6s; /* no preserve-3d */ }
+.face  { /* no backface-visibility */ }
+.back  { transform: rotateY(180deg); }</code></pre>
+      </section>
+
+      <section class="doc-panel panel-safe" aria-labelledby="safe-title">
+        <div class="panel-head">
+          <h2 id="safe-title">After — Safari-safe stack</h2>
+          <span class="badge badge-good">Stable 3D</span>
+        </div>
+        <p class="section-lead">
+          Same flip-x / flip-y interaction with the full property checklist.
+          Uses EaseMotion <code>ease-flip-3d</code> patterns + hardening.
+        </p>
+
+        <div class="flip-demo-grid">
+          <div class="ease-flip-3d safe-scene" tabindex="0" aria-label="Safe flip-y card">
+            <div class="ease-flip-3d-inner safe-inner safe-inner--y">
+              <div class="ease-flip-3d-face safe-face safe-front">Front · flip-y</div>
+              <div class="ease-flip-3d-face ease-flip-3d-back safe-face safe-back">Back · hidden mid-flip</div>
+            </div>
+            <p class="flip-hint">Hover or focus</p>
+          </div>
+
+          <div class="safe-scene safe-scene--x" tabindex="0" aria-label="Safe flip-x card">
+            <div class="safe-inner safe-inner--x">
+              <div class="safe-face safe-front">Front · flip-x</div>
+              <div class="safe-face safe-back safe-back--x">Back · clipped</div>
+            </div>
+            <p class="flip-hint">Hover or focus</p>
+          </div>
+        </div>
+
+        <pre class="doc-code" tabindex="0"><code>/* Safari-safe stack */
+.scene {
+  perspective: 1000px;
+}
+.inner {
+  position: relative;
+  transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
+  transition: transform 0.6s ease;
+}
+.face {
+  position: absolute; inset: 0;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  transform: translateZ(0.1px);
+}
+.back { transform: rotateY(180deg) translateZ(0.1px); }</code></pre>
+      </section>
+    </div>
+
+    <!-- ── Checklist ───────────────────────────────────────── -->
+    <section class="doc-panel" aria-labelledby="check-title">
+      <h2 id="check-title">Safari-safe property checklist</h2>
+      <ol class="check-list">
+        <li>
+          Put <code>perspective</code> on the <strong>scene / parent</strong>,
+          not only on the rotating face.
+        </li>
+        <li>
+          Set <code>transform-style: preserve-3d</code> (+
+          <code>-webkit-transform-style</code>) on the <strong>inner</strong>.
+        </li>
+        <li>
+          Set <code>backface-visibility: hidden</code> (+
+          <code>-webkit-backface-visibility</code>) on <strong>both faces</strong>.
+        </li>
+        <li>
+          Offset faces with a tiny <code>translateZ(0.1px)</code> to avoid
+          mid-flip z-fighting.
+        </li>
+        <li>
+          Prefer EaseMotion <code>ease-flip-3d</code> / <code>ease-flip-3d-face</code>
+          as the base, then harden with webkit prefixes in project CSS.
+        </li>
+      </ol>
+    </section>
+
+    <!-- ── Patterns ────────────────────────────────────────── -->
+    <section class="doc-panel" aria-labelledby="patterns-title">
+      <h2 id="patterns-title">Copy-friendly patterns</h2>
+      <div class="pattern-grid">
+        <article class="pattern-card">
+          <h3>1. Core entrance (fine alone)</h3>
+          <pre class="doc-code" tabindex="0"><code>&lt;div class="ease-flip"&gt;Hello&lt;/div&gt;</code></pre>
+          <p>
+            <code>ease-flip</code> already sets perspective +
+            <code>backface-visibility</code>. Glitches show up when you nest
+            custom double-sided faces without the full stack.
+          </p>
+        </article>
+
+        <article class="pattern-card">
+          <h3>2. Card flip (use ease-flip-3d)</h3>
+          <pre class="doc-code" tabindex="0"><code>&lt;div class="ease-flip-3d"&gt;
+  &lt;div class="ease-flip-3d-inner"&gt;
+    &lt;div class="ease-flip-3d-face"&gt;Front&lt;/div&gt;
+    &lt;div class="ease-flip-3d-face ease-flip-3d-back"&gt;Back&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+        </article>
+
+        <article class="pattern-card">
+          <h3>3. Harden for Safari (project CSS)</h3>
+          <pre class="doc-code" tabindex="0"><code>.ease-flip-3d-inner {
+  -webkit-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+}
+.ease-flip-3d-face {
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  transform: translateZ(0.1px);
+}
+.ease-flip-3d-back {
+  transform: rotateY(180deg) translateZ(0.1px);
+}</code></pre>
+        </article>
+
+        <article class="pattern-card">
+          <h3>4. When to use which</h3>
+          <ul class="pattern-list">
+            <li><strong>ease-flip</strong> — single-face entrance</li>
+            <li><strong>ease-flip-3d</strong> — double-sided hover cards</li>
+            <li><strong>Project harden</strong> — always add webkit + translateZ</li>
+            <li><strong>Do not</strong> — put perspective only on the face</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="doc-footer">
+    <p>
+      Self-contained submission ·
+      <code>submissions/docs/ease-flip-backface-safari-sp/</code> ·
+      no core edits
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      function replay(el) {
+        el.style.animation = "none";
+        void el.offsetWidth;
+        el.style.animation = "";
+      }
+
+      document.getElementById("replay-btn").addEventListener("click", function () {
+        document.querySelectorAll(".replay-target").forEach(replay);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-flip-backface-safari-sp/style.css
+++ b/submissions/docs/ease-flip-backface-safari-sp/style.css
@@ -1,0 +1,494 @@
+/* ============================================================
+   Flip / 3D backface-visibility Safari Glitch Doc
+   Local demo styles only — does not modify core.
+   ============================================================ */
+
+:root {
+  --doc-surface: var(--ease-color-surface, #ffffff);
+  --doc-border: var(--ease-color-neutral-200, #e2e8f0);
+  --doc-muted: var(--ease-color-muted, #64748b);
+  --doc-text: var(--ease-color-text, #1e293b);
+  --doc-accent: var(--ease-color-primary, #6c63ff);
+  --doc-danger: var(--ease-color-danger, #b91c1c);
+  --doc-success: var(--ease-color-success, #15803d);
+  --doc-radius: var(--ease-radius-md, 0.5rem);
+  --doc-shadow: var(--ease-shadow-md, 0 4px 16px rgba(15, 23, 42, 0.08));
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--ease-font-sans, "Inter", system-ui, sans-serif);
+  color: var(--doc-text);
+  background:
+    radial-gradient(1000px 440px at 5% -8%, rgba(108, 99, 255, 0.12), transparent 55%),
+    radial-gradient(800px 360px at 100% 0%, rgba(14, 165, 233, 0.08), transparent 50%),
+    var(--ease-color-bg, #f8fafc);
+  line-height: 1.55;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.doc-header {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 1.25rem;
+  text-align: center;
+}
+
+.doc-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--doc-accent);
+}
+
+.doc-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.5rem, 3.4vw, 2.1rem);
+  line-height: 1.2;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.doc-subtitle {
+  margin: 0 auto 1.25rem;
+  max-width: 46rem;
+  color: var(--doc-muted);
+  font-size: 1.02rem;
+}
+
+/* ── Main ────────────────────────────────────────────────── */
+
+.doc-main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1.25rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.doc-panel,
+.doc-section {
+  background: var(--doc-surface);
+  border: 1px solid var(--doc-border);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--doc-shadow);
+  padding: 1.25rem 1.35rem;
+}
+
+.doc-panel h2,
+.doc-section h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.section-lead {
+  margin: 0 0 1rem;
+  color: var(--doc-muted);
+  font-size: 0.95rem;
+}
+
+.why-list {
+  margin: 0 0 1rem;
+  padding-left: 1.2rem;
+  color: var(--doc-muted);
+}
+
+.why-list li + li {
+  margin-top: 0.45rem;
+}
+
+.callout {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--doc-radius);
+  border-left: 4px solid var(--doc-accent);
+  background: color-mix(in srgb, var(--doc-accent) 8%, white);
+  font-size: 0.92rem;
+}
+
+.panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.badge-bad {
+  color: var(--doc-danger);
+  background: color-mix(in srgb, var(--doc-danger) 12%, white);
+  border: 1px solid color-mix(in srgb, var(--doc-danger) 30%, transparent);
+}
+
+.badge-good {
+  color: var(--doc-success);
+  background: color-mix(in srgb, var(--doc-success) 12%, white);
+  border: 1px solid color-mix(in srgb, var(--doc-success) 30%, transparent);
+}
+
+.panel-broken {
+  border-color: color-mix(in srgb, var(--doc-danger) 35%, var(--doc-border));
+}
+
+.panel-safe {
+  border-color: color-mix(in srgb, var(--doc-success) 35%, var(--doc-border));
+}
+
+.compare-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+/* ── Entrance demos ──────────────────────────────────────── */
+
+.entrance-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.entrance-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-height: 6.5rem;
+  padding: 1.1rem;
+  border-radius: var(--doc-radius);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--doc-accent) 16%, white),
+    var(--doc-surface)
+  );
+  border: 1px solid var(--doc-border);
+  justify-content: center;
+}
+
+.entrance-card span {
+  font-size: 0.85rem;
+  color: var(--doc-muted);
+}
+
+/* Local flip-x / flip-y entrance patterns (docs only) */
+@keyframes doc-flip-x {
+  from {
+    opacity: 0;
+    transform: perspective(600px) rotateX(90deg);
+  }
+  to {
+    opacity: 1;
+    transform: perspective(600px) rotateX(0deg);
+  }
+}
+
+@keyframes doc-flip-y {
+  from {
+    opacity: 0;
+    transform: perspective(600px) rotateY(90deg);
+  }
+  to {
+    opacity: 1;
+    transform: perspective(600px) rotateY(0deg);
+  }
+}
+
+.flip-x-demo {
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  animation: doc-flip-x var(--ease-speed-medium, 300ms) var(--ease-ease, ease) both;
+}
+
+.flip-y-demo {
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  animation: doc-flip-y var(--ease-speed-medium, 300ms) var(--ease-ease, ease) both;
+}
+
+/* ── Flip card demos ─────────────────────────────────────── */
+
+.flip-demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.flip-hint {
+  margin: 0.55rem 0 0;
+  text-align: center;
+  font-size: 0.78rem;
+  color: var(--doc-muted);
+}
+
+/* Broken stack — intentionally incomplete for Safari glitch repro */
+.broken-scene {
+  height: 9.5rem;
+  /* perspective missing on purpose */
+  outline: none;
+  cursor: pointer;
+}
+
+.broken-inner {
+  width: 100%;
+  height: 8.5rem;
+  position: relative;
+  transition: transform 0.65s ease;
+  /* preserve-3d missing on purpose */
+}
+
+.broken-scene:hover .broken-inner--y,
+.broken-scene:focus .broken-inner--y,
+.broken-scene:focus-within .broken-inner--y {
+  transform: rotateY(180deg);
+}
+
+.broken-scene:hover .broken-inner--x,
+.broken-scene:focus .broken-inner--x,
+.broken-scene:focus-within .broken-inner--x {
+  transform: rotateX(180deg);
+}
+
+.face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--doc-radius);
+  font-weight: 600;
+  font-size: 0.92rem;
+  /* backface-visibility missing on purpose */
+}
+
+.face-front {
+  background: linear-gradient(135deg, #c7d2fe, #e0e7ff);
+  color: #312e81;
+  border: 1px solid #a5b4fc;
+}
+
+.face-back {
+  background: linear-gradient(135deg, #fda4af, #ffe4e6);
+  color: #9f1239;
+  border: 1px solid #fb7185;
+  transform: rotateY(180deg);
+}
+
+.broken-inner--x .face-back {
+  transform: rotateX(180deg);
+}
+
+/* Safe stack — hardened for Safari */
+.safe-scene {
+  height: 9.5rem;
+  perspective: 1000px;
+  -webkit-perspective: 1000px;
+  outline: none;
+  cursor: pointer;
+  position: relative;
+}
+
+.safe-inner {
+  width: 100%;
+  height: 8.5rem;
+  position: relative;
+  transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
+  transition: transform 0.65s var(--ease-ease, ease);
+}
+
+.safe-scene:hover .safe-inner--y,
+.safe-scene:focus .safe-inner--y,
+.safe-scene:focus-within .safe-inner--y,
+.ease-flip-3d:hover .safe-inner--y,
+.ease-flip-3d:focus-within .safe-inner--y {
+  transform: rotateY(180deg);
+}
+
+.safe-scene:hover .safe-inner--x,
+.safe-scene:focus .safe-inner--x,
+.safe-scene:focus-within .safe-inner--x {
+  transform: rotateX(180deg);
+}
+
+.safe-face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--doc-radius);
+  font-weight: 600;
+  font-size: 0.92rem;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  transform: translateZ(0.1px);
+  -webkit-transform: translateZ(0.1px);
+}
+
+.safe-front {
+  background: linear-gradient(135deg, #bbf7d0, #ecfdf5);
+  color: #14532d;
+  border: 1px solid #86efac;
+}
+
+.safe-back {
+  background: linear-gradient(135deg, #bae6fd, #f0f9ff);
+  color: #0c4a6e;
+  border: 1px solid #7dd3fc;
+  transform: rotateY(180deg) translateZ(0.1px);
+  -webkit-transform: rotateY(180deg) translateZ(0.1px);
+}
+
+.safe-back--x {
+  transform: rotateX(180deg) translateZ(0.1px);
+  -webkit-transform: rotateX(180deg) translateZ(0.1px);
+}
+
+/* Ensure ease-flip-3d faces fill the demo height */
+.safe-scene .ease-flip-3d-inner {
+  height: 8.5rem;
+}
+
+.safe-scene .ease-flip-3d-face {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--doc-radius);
+  font-weight: 600;
+}
+
+/* ── Checklist / patterns ────────────────────────────────── */
+
+.check-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--doc-muted);
+}
+
+.check-list li + li {
+  margin-top: 0.55rem;
+}
+
+.pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.pattern-card {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--doc-border);
+  border-radius: var(--doc-radius);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.pattern-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.98rem;
+}
+
+.pattern-card p {
+  margin: 0.75rem 0 0;
+  font-size: 0.88rem;
+  color: var(--doc-muted);
+}
+
+.pattern-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--doc-muted);
+  font-size: 0.9rem;
+}
+
+.pattern-list li + li {
+  margin-top: 0.4rem;
+}
+
+.doc-code {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  border-radius: 0.4rem;
+  background: var(--ease-color-neutral-900, #0f172a);
+  color: #e2e8f0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.doc-code code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+/* ── Footer ──────────────────────────────────────────────── */
+
+.doc-footer {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1.25rem 2.5rem;
+  text-align: center;
+  color: var(--doc-muted);
+  font-size: 0.85rem;
+}
+
+.doc-footer p {
+  margin: 0;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .compare-row,
+  .pattern-grid,
+  .entrance-row,
+  .flip-demo-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-flip,
+  .flip-x-demo,
+  .flip-y-demo,
+  .broken-inner,
+  .safe-inner,
+  .ease-flip-3d-inner {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
# #47560 issue resolved

## Description
I complete a Flip / 3D backface-visibility Safari Glitch Doc under submissions/docs/ease-flip-backface-safari-sp/.

## Features

- Repro demos for flip-x / flip-y flicker
- Before (glitchy) vs after (Safari-safe) flip stacks
- Documented CSS property checklist for stable 3D flips
- Short notes on why Safari paints backfaces differently
- Copy-friendly Safari-safe snippets
- Responsive, clean demo UI suitable for docs review