### PR TITLE
Add shadow-pop-profile-card

### DIFF
--- a/submissions/examples/shadow-pop-profile-card-aaniya/README.md
+++ b/submissions/examples/shadow-pop-profile-card-aaniya/README.md
@@ -1,0 +1,39 @@
+# Shadow Pop Profile Card
+
+Closes #41528
+
+## What does this do?
+
+A glassmorphic profile card whose shadow "pops" outward and intensifies on hover/focus, along with a subtle lift, giving the card a floating feel — all with a single CSS transition, no JavaScript.
+
+## How is it used?
+
+```html
+<article class="shadow-pop-card" tabindex="0">
+  <img class="shadow-pop-card__avatar" src="avatar.jpg" alt="Portrait of Maya Chen">
+  <h2 class="shadow-pop-card__name">Maya Chen</h2>
+  <p class="shadow-pop-card__role">Product Designer</p>
+  <p class="shadow-pop-card__bio">Crafts clean, accessible interfaces.</p>
+  <div class="shadow-pop-card__tags">
+    <span class="shadow-pop-card__tag">UI/UX</span>
+  </div>
+</article>
+```
+
+Hovering or tab-focusing the `.shadow-pop-card` triggers the transition: the card lifts slightly and its box-shadow grows and intensifies, then eases back on mouse-out/blur.
+
+## Why is it useful?
+
+Profile cards are one of the most common UI building blocks, and this variant leans into the Glassmorphism trend the issue called for — translucent, blurred background with a soft border — while adding a distinct, tactile shadow-pop interaction rather than a plain hover-lighten.
+
+- Needs **no JavaScript** — the entire effect is one CSS `transition` on `box-shadow`/`transform`.
+- Is keyboard accessible: the card is a real `tabindex="0"` element with a visible `:focus-visible` state, so the same pop effect works for keyboard users, not just mouse hover.
+- Respects `prefers-reduced-motion` by disabling the transition for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Follows the requested `shadow-pop-profile-card-<suffix>` submission naming.
+
+## Files
+
+- `demo.html` — self-contained demo, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable names per the issue's explicit requirement; the maintainer standardizes the rest)
+- `README.md` — this file

--- a/submissions/examples/shadow-pop-profile-card-aaniya/demo.html
+++ b/submissions/examples/shadow-pop-profile-card-aaniya/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Shadow Pop Profile Card Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <h1>Shadow Pop Profile Card</h1>
+    <p>A glassmorphic profile card whose shadow "pops" outward and intensifies on hover/focus, giving the card a lift-off feel. Pure CSS, no JavaScript.</p>
+
+    <div class="pop-card-grid">
+      <article class="shadow-pop-card" tabindex="0">
+        <img class="shadow-pop-card__avatar" src="https://i.pravatar.cc/120?img=47" alt="Portrait of Maya Chen">
+        <h2 class="shadow-pop-card__name">Maya Chen</h2>
+        <p class="shadow-pop-card__role">Product Designer</p>
+        <p class="shadow-pop-card__bio">Crafts clean, accessible interfaces and obsesses over micro-interactions.</p>
+        <div class="shadow-pop-card__tags">
+          <span class="shadow-pop-card__tag">UI/UX</span>
+          <span class="shadow-pop-card__tag">Design Systems</span>
+        </div>
+      </article>
+
+      <article class="shadow-pop-card" tabindex="0">
+        <img class="shadow-pop-card__avatar" src="https://i.pravatar.cc/120?img=12" alt="Portrait of Daniel Osei">
+        <h2 class="shadow-pop-card__name">Daniel Osei</h2>
+        <p class="shadow-pop-card__role">Frontend Engineer</p>
+        <p class="shadow-pop-card__bio">Builds performant, animation-rich web experiences with modern CSS.</p>
+        <div class="shadow-pop-card__tags">
+          <span class="shadow-pop-card__tag">CSS</span>
+          <span class="shadow-pop-card__tag">Accessibility</span>
+        </div>
+      </article>
+    </div>
+
+    <p class="hint">Hover or tab-focus a card to see the shadow pop.</p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/shadow-pop-profile-card-aaniya/style.css
+++ b/submissions/examples/shadow-pop-profile-card-aaniya/style.css
@@ -1,0 +1,128 @@
+/* ==========================================================================
+   Shadow Pop Profile Card
+   A glassmorphic card whose shadow "pops" outward and intensifies on
+   hover/focus. Single animation, pure CSS, no JavaScript.
+   ========================================================================== */
+
+:root {
+  --ease-shadow-pop-bg-start: #6a5cff;
+  --ease-shadow-pop-bg-end: #38c6ff;
+  --ease-shadow-pop-glass-bg: rgba(255, 255, 255, 0.14);
+  --ease-shadow-pop-glass-border: rgba(255, 255, 255, 0.35);
+  --ease-shadow-pop-text: #ffffff;
+  --ease-shadow-pop-muted: rgba(255, 255, 255, 0.75);
+  --ease-kf-pop-duration: 320ms;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 760px;
+  margin: 48px auto;
+  padding: 40px 24px;
+  text-align: center;
+  background: linear-gradient(135deg, var(--ease-shadow-pop-bg-start), var(--ease-shadow-pop-bg-end));
+  border-radius: 16px;
+  color: var(--ease-shadow-pop-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-shadow-pop-muted); line-height: 1.5; max-width: 480px; margin: 0 auto; }
+.page .hint { margin-top: 32px; font-size: 0.85rem; }
+
+.pop-card-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 28px;
+  margin-top: 36px;
+}
+
+/* Glassmorphic card ---------------------------------------------------- */
+
+.shadow-pop-card {
+  width: 240px;
+  padding: 28px 20px;
+  border-radius: 18px;
+  background: var(--ease-shadow-pop-glass-bg);
+  border: 1px solid var(--ease-shadow-pop-glass-border);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: 0 8px 20px rgba(15, 15, 40, 0.25);
+  cursor: pointer;
+  outline: none;
+
+  /* The single animation this component demonstrates: a shadow + lift
+     "pop" that eases outward on hover/focus and settles back on exit. */
+  transition:
+    box-shadow var(--ease-kf-pop-duration) cubic-bezier(0.22, 1, 0.36, 1),
+    transform var(--ease-kf-pop-duration) cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.shadow-pop-card:hover,
+.shadow-pop-card:focus-visible {
+  transform: translateY(-10px) scale(1.03);
+  box-shadow:
+    0 24px 40px rgba(15, 15, 40, 0.35),
+    0 0 0 1px var(--ease-shadow-pop-glass-border);
+}
+
+.shadow-pop-card:focus-visible {
+  outline: 2px solid var(--ease-shadow-pop-text);
+  outline-offset: 4px;
+}
+
+.shadow-pop-card__avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--ease-shadow-pop-glass-border);
+  margin-bottom: 14px;
+}
+
+.shadow-pop-card__name {
+  font-size: 1.05rem;
+  margin: 0 0 2px;
+}
+
+.shadow-pop-card__role {
+  font-size: 0.82rem;
+  color: var(--ease-shadow-pop-muted);
+  margin: 0 0 12px;
+}
+
+.shadow-pop-card__bio {
+  font-size: 0.82rem;
+  color: var(--ease-shadow-pop-muted);
+  line-height: 1.5;
+  margin: 0 0 16px;
+}
+
+.shadow-pop-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+.shadow-pop-card__tag {
+  font-size: 0.7rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid var(--ease-shadow-pop-glass-border);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .shadow-pop-card {
+    transition: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 28px 16px; }
+  .shadow-pop-card { width: 100%; max-width: 280px; }
+}


### PR DESCRIPTION
Closes #41528
## Pull Request Description
Adds a new glassmorphic profile card submission — `shadow-pop-profile-card-aaniya` — whose shadow "pops" outward and intensifies on hover/focus, closing #41528.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/shadow-pop-profile-card-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A glassmorphic profile card whose shadow lifts and intensifies on hover/focus, using a single CSS transition and no JavaScript.

**How does a developer use it?**
```html
<div class="shadow-pop-card" tabindex="0">
  <img class="shadow-pop-card__avatar" src="avatar.jpg" alt="Maya Chen" />
  <h3 class="shadow-pop-card__name">Maya Chen</h3>
  <p class="shadow-pop-card__role">Product Designer</p>
  <p class="shadow-pop-card__bio">Crafts clean, accessible interfaces.</p>
  <div class="shadow-pop-card__tags">
    <span class="shadow-pop-card__tag">UI/UX</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS transition (`box-shadow` + `transform`) with no JS dependency, keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Used the `ease-` prefixed CSS variable naming as requested in the issue; happy to adjust naming conventions or timing values if the maintainer prefers something different.