### PR TITLE
Add elastic-input-field

### DIFF
--- a/submissions/examples/elastic-input-field-aaniya/README.md
+++ b/submissions/examples/elastic-input-field-aaniya/README.md
@@ -1,0 +1,39 @@
+# Elastic Input Field — Neumorphism
+
+Closes #41547
+
+## What does this do?
+
+A neumorphic (soft-UI) input field that "pops" with an elastic bounce when it gains focus, transitioning from a raised shadow to a gently pressed-in shadow — all with a single CSS animation, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="elastic-field">
+  <label class="elastic-field__label" for="name">Full Name</label>
+  <input
+    class="elastic-field__input"
+    type="text"
+    id="name"
+    placeholder="e.g. Maya Chen"
+  />
+</div>
+```
+
+Clicking or tab-focusing the `.elastic-field__input` triggers a one-shot elastic bounce (`ease-elastic-pop`) and the shadow shifts from raised to inset, giving the pressed-in neumorphic look while focused.
+
+## Why is it useful?
+
+Input fields are one of the most reused primitives in any UI kit, and this variant delivers the requested Neumorphism style — soft, dual-toned shadows that make the field look carved out of the background — while adding a distinct elastic "pop" on focus rather than a flat border-color change.
+
+- Needs **no JavaScript** — the whole effect is a single CSS `@keyframes` animation triggered by `:focus`.
+- Is keyboard accessible: uses a real `<input>` element with `:focus-visible` support, so keyboard users get the same pop as mouse users.
+- Respects `prefers-reduced-motion` by disabling the animation for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable and keyframe names per the issue's requirement.
+
+## Files
+
+- `demo.html` — self-contained demo, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable/keyframe names per the issue's explicit requirement)
+- `README.md` — this file

--- a/submissions/examples/elastic-input-field-aaniya/demo.html
+++ b/submissions/examples/elastic-input-field-aaniya/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Elastic Input Field — Neumorphism</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Elastic Input Field</h1>
+  <p>A soft-UI input that pops with an elastic bounce on focus — pure CSS, no JavaScript.</p>
+
+  <div class="elastic-field">
+    <label class="elastic-field__label" for="name">Full Name</label>
+    <input
+      class="elastic-field__input"
+      type="text"
+      id="name"
+      placeholder="e.g. Maya Chen"
+    />
+  </div>
+
+  <div class="elastic-field">
+    <label class="elastic-field__label" for="email">Email Address</label>
+    <input
+      class="elastic-field__input"
+      type="email"
+      id="email"
+      placeholder="you@example.com"
+    />
+    <div class="elastic-field__hint">Click or tab into a field to see the elastic pop.</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/elastic-input-field-aaniya/style.css
+++ b/submissions/examples/elastic-input-field-aaniya/style.css
@@ -1,0 +1,111 @@
+/* ==========================================================================
+   Elastic Input Field — Neumorphism
+   A soft-UI (neumorphic) input that "pops" with an elastic bounce on
+   focus, shifting from a raised to a gently pressed shadow state.
+   Single CSS animation, no JavaScript.
+   ========================================================================== */
+
+:root {
+  --ease-elastic-bg: #e6e9ef;
+  --ease-elastic-text: #33384a;
+  --ease-elastic-muted: #8a90a3;
+  --ease-elastic-accent: #6a5cff;
+  --ease-elastic-shadow-light: #ffffff;
+  --ease-elastic-shadow-dark: #b9bec9;
+  --ease-kf-elastic-duration: 480ms;
+  --ease-kf-elastic-curve: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 48px 24px;
+  text-align: center;
+  background: var(--ease-elastic-bg);
+  border-radius: 16px;
+  color: var(--ease-elastic-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-elastic-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 32px; }
+
+/* Field wrapper ---------------------------------------------------------- */
+
+.elastic-field {
+  position: relative;
+  max-width: 320px;
+  margin: 0 auto 20px;
+  text-align: left;
+}
+
+.elastic-field__label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--ease-elastic-muted);
+}
+
+.elastic-field__input {
+  width: 100%;
+  padding: 14px 16px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  color: var(--ease-elastic-text);
+  background: var(--ease-elastic-bg);
+  border: none;
+  border-radius: 12px;
+  outline: none;
+
+  /* Resting state: raised neumorphic shadow */
+  box-shadow:
+    6px 6px 12px var(--ease-elastic-shadow-dark),
+    -6px -6px 12px var(--ease-elastic-shadow-light);
+
+  transition: box-shadow 200ms ease;
+}
+
+.elastic-field__input::placeholder {
+  color: var(--ease-elastic-muted);
+}
+
+/* The single animation this component demonstrates: an elastic bounce
+   that plays once when the field gains focus. */
+@keyframes ease-elastic-pop {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.035); }
+  70%  { transform: scale(0.985); }
+  100% { transform: scale(1); }
+}
+
+.elastic-field__input:focus-visible,
+.elastic-field__input:focus {
+  animation: ease-elastic-pop var(--ease-kf-elastic-duration) var(--ease-kf-elastic-curve);
+
+  /* Pressed-in neumorphic shadow, softened by the accent color */
+  box-shadow:
+    inset 4px 4px 8px var(--ease-elastic-shadow-dark),
+    inset -4px -4px 8px var(--ease-elastic-shadow-light),
+    0 0 0 2px var(--ease-elastic-accent);
+}
+
+.elastic-field__hint {
+  margin-top: 8px;
+  font-size: 0.75rem;
+  color: var(--ease-elastic-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .elastic-field__input {
+    animation: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 32px 16px; }
+  .elastic-field { max-width: 100%; }
+}


### PR DESCRIPTION
Closes #41547
## Pull Request Description
Adds a new neumorphic (soft-UI) input field submission — `elastic-input-field-aaniya` — that pops with an elastic bounce on focus, closing #41547.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/elastic-input-field-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A neumorphic input field that pops with a one-shot elastic bounce and shifts from a raised to a pressed-in shadow when focused.

**How does a developer use it?**
```html
<div class="elastic-field">
  <label class="elastic-field__label" for="name">Full Name</label>
  <input
    class="elastic-field__input"
    type="text"
    id="name"
    placeholder="e.g. Maya Chen"
  />
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS `@keyframes` animation (`ease-elastic-pop`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It uses `ease-` prefixed variable and keyframe names as required, works via native `:focus`/`:focus-visible` so it's keyboard accessible, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Used the `ease-` prefixed CSS variable/keyframe naming as required by the issue. Shadow values are tuned for a light neumorphic background — happy to adjust for dark mode support if the maintainer wants a `data-theme` variant.