### PR TITLE
Add spiral-gauge

### DIFF
--- a/submissions/examples/spiral-gauge-aaniya/README.md
+++ b/submissions/examples/spiral-gauge-aaniya/README.md
@@ -1,0 +1,40 @@
+# Spiral Gauge — Analytics Dashboard Design
+
+Closes #41801
+
+## What does this do?
+
+A circular gauge whose ring spirals open from empty to a target percentage on load — like a progress ring for analytics dashboards — using a single CSS animation and no JavaScript.
+
+## How is it used?
+
+```html
+<div class="spiral-gauge spiral-gauge--62">
+  <div class="spiral-gauge__inner">
+    <span class="spiral-gauge__value">62%</span>
+    <span class="spiral-gauge__label">Revenue</span>
+  </div>
+</div>
+```
+
+Each gauge sweeps from 0° to its target angle (set via the `--ease-spiral-value` custom property) once on page load, animating a `conic-gradient` ring using CSS `@property` for a smooth angle transition.
+
+## Why is it useful?
+
+Gauges are a core building block for analytics/metrics dashboards, and this variant leans into that use case directly — a radial progress indicator that reveals its value with a spiral fill rather than a flat instant render.
+
+- Needs **no JavaScript** — the animation is driven entirely by an animated CSS custom property (`@property --ease-spiral-angle`) feeding a `conic-gradient`.
+- Is easily reusable: any gauge just needs a target angle set via `--ease-spiral-value` (percent/100 × 360deg) and its own modifier class.
+- Respects `prefers-reduced-motion` by skipping straight to the final value for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable, custom-property, and keyframe names per the issue's requirement.
+
+## Files
+
+- `demo.html` — self-contained demo with three example gauges, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable/keyframe names per the issue's explicit requirement)
+- `README.md` — this file
+
+## Browser note
+
+The spiral fill uses `@property` for animatable `conic-gradient` angles, supported in current Chrome, Edge, and Firefox. In unsupported browsers the ring will render at its final value without the sweep animation (graceful degradation, no broken layout).

--- a/submissions/examples/spiral-gauge-aaniya/demo.html
+++ b/submissions/examples/spiral-gauge-aaniya/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Spiral Gauge — Analytics Dashboard Design</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Spiral Gauge</h1>
+  <p>A circular gauge that spirals open to its target value on load — pure CSS, no JavaScript.</p>
+
+  <div class="spiral-gauge-grid">
+
+    <div class="spiral-gauge spiral-gauge--62">
+      <div class="spiral-gauge__inner">
+        <span class="spiral-gauge__value">62%</span>
+        <span class="spiral-gauge__label">Revenue</span>
+      </div>
+    </div>
+
+    <div class="spiral-gauge spiral-gauge--88">
+      <div class="spiral-gauge__inner">
+        <span class="spiral-gauge__value">88%</span>
+        <span class="spiral-gauge__label">Retention</span>
+      </div>
+    </div>
+
+    <div class="spiral-gauge spiral-gauge--45">
+      <div class="spiral-gauge__inner">
+        <span class="spiral-gauge__value">45%</span>
+        <span class="spiral-gauge__label">Conversion</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/spiral-gauge-aaniya/style.css
+++ b/submissions/examples/spiral-gauge-aaniya/style.css
@@ -1,0 +1,121 @@
+/* ==========================================================================
+   Spiral Gauge — Analytics Dashboard Design
+   A circular gauge whose ring sweeps open like a spiral, filling toward
+   a target value. Single CSS animation, no JavaScript.
+   ========================================================================== */
+
+@property --ease-spiral-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+:root {
+  --ease-spiral-bg: #12162b;
+  --ease-spiral-track: #232946;
+  --ease-spiral-fill-start: #6a5cff;
+  --ease-spiral-fill-end: #38c6ff;
+  --ease-spiral-text: #eef0ff;
+  --ease-spiral-muted: #9aa0c3;
+  --ease-kf-spiral-duration: 1600ms;
+  --ease-kf-spiral-curve: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spiral-value: 320deg; /* target sweep angle: (percent/100)*360deg */
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 48px 24px;
+  text-align: center;
+  background: var(--ease-spiral-bg);
+  border-radius: 16px;
+  color: var(--ease-spiral-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-spiral-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 32px; }
+
+.spiral-gauge-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 40px;
+}
+
+/* Gauge -------------------------------------------------------------- */
+
+.spiral-gauge {
+  --ease-spiral-angle: 0deg;
+  position: relative;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background:
+    conic-gradient(
+      from -90deg,
+      var(--ease-spiral-fill-start) 0deg,
+      var(--ease-spiral-fill-end) var(--ease-spiral-angle),
+      var(--ease-spiral-track) var(--ease-spiral-angle) 360deg
+    );
+
+  /* The single animation this component demonstrates: the gauge ring
+     spirals open from 0 to its target value on load. */
+  animation: ease-spiral-fill var(--ease-kf-spiral-duration) var(--ease-kf-spiral-curve) forwards;
+}
+
+@keyframes ease-spiral-fill {
+  from { --ease-spiral-angle: 0deg; }
+  to   { --ease-spiral-angle: var(--ease-spiral-value); }
+}
+
+.spiral-gauge__inner {
+  position: relative;
+  width: 138px;
+  height: 138px;
+  border-radius: 50%;
+  background: var(--ease-spiral-bg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.spiral-gauge__value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.spiral-gauge__label {
+  margin-top: 6px;
+  font-size: 0.72rem;
+  color: var(--ease-spiral-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Individual gauges can override the target sweep angle inline via
+   the --ease-spiral-value custom property (percent/100 * 360deg). */
+.spiral-gauge--62  { --ease-spiral-value: 223deg; }
+.spiral-gauge--88  { --ease-spiral-value: 317deg; }
+.spiral-gauge--45  { --ease-spiral-value: 162deg; }
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .spiral-gauge {
+    animation: none;
+    --ease-spiral-angle: var(--ease-spiral-value);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 32px 16px; }
+  .spiral-gauge-grid { gap: 24px; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new analytics-dashboard-style component — `spiral-gauge-aaniya` — a circular gauge whose ring spirals open to a target value on load, closing #41801.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/spiral-gauge-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A circular gauge that animates its ring from empty to a target percentage on load, driven by an animated CSS custom property feeding a `conic-gradient`.

**How does a developer use it?**
```html
<div class="spiral-gauge spiral-gauge--62">
  <div class="spiral-gauge__inner">
    <span class="spiral-gauge__value">62%</span>
    <span class="spiral-gauge__label">Revenue</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS animation (`ease-spiral-fill`) with no JS dependency, keeping with the library's human-readable, animation-first philosophy. It uses `ease-` prefixed variable, custom-property, and keyframe names as required, degrades gracefully in browsers without `@property` support, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Uses `@property` for the animatable `conic-gradient` angle (supported in current Chrome, Edge, Firefox). In older/unsupported browsers the ring renders at its final value without the sweep animation, so there's no broken layout — happy to add a JS-free fallback if the maintainer wants broader support.