### PR TITLE
ease-cdn-main-vs-npm-drift-sp

### DIFF
--- a/submissions/docs/ease-cdn-main-vs-npm-drift-sp/README.md
+++ b/submissions/docs/ease-cdn-main-vs-npm-drift-sp/README.md
@@ -1,0 +1,34 @@
+# jsDelivr `@main` vs npm Version Drift Visualizer
+
+An interactive documentation demo that compares EaseMotion CSS class availability between the moving jsDelivr GitHub `@main` build and the latest published npm version.
+
+## What does this do?
+
+This tool fetches both CSS sources, extracts all `ease-*` class selectors, and computes:
+
+- classes present on jsDelivr `@main` but missing from npm
+- classes present on npm but missing from jsDelivr `@main`
+- classes shared by both sources
+
+It also provides a clear "pin for production" policy panel so contributors and users can understand freshness risk.
+
+## How is it used?
+
+1. Open `demo.html` in a browser with internet access.
+2. Click **Run Drift Check** (or use auto-run on page load).
+3. Review summary counters and drift risk.
+4. Use search to filter class names quickly.
+5. Copy a recommended pinned npm CDN link for production usage.
+
+## Why is it useful?
+
+- Makes source drift visible before it causes production issues.
+- Helps contributors explain "freshest vs stable" tradeoffs.
+- Encourages pinned production URLs instead of unpinned `@main`.
+- Works as a self-contained docs showcase without changing core files.
+
+## Files
+
+- `demo.html` - drift visualizer UI + JavaScript comparison logic
+- `style.css` - layout, cards, risk states, and responsive styling
+- `README.md` - feature overview and usage guidance

--- a/submissions/docs/ease-cdn-main-vs-npm-drift-sp/demo.html
+++ b/submissions/docs/ease-cdn-main-vs-npm-drift-sp/demo.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>jsDelivr @main vs npm Drift Visualizer</title>
+  <meta
+    name="description"
+    content="Compare EaseMotion CSS class drift between jsDelivr @main and latest npm package."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="dv-header ease-fade-in">
+    <p class="dv-kicker">EaseMotion CSS · Docs Utility</p>
+    <h1>jsDelivr <code>@main</code> vs npm Version Drift Visualizer</h1>
+    <p class="dv-subtitle">
+      Detect class API drift between freshest CDN branch builds and stable npm releases.
+      Use this to decide when to prototype with <code>@main</code> and when to pin for production.
+    </p>
+  </header>
+
+  <main class="dv-main">
+    <section class="dv-top">
+      <div class="dv-source-card">
+        <h2>Data sources</h2>
+        <ul>
+          <li><strong>CDN branch:</strong> <code id="main-url-label"></code></li>
+          <li><strong>npm latest tag:</strong> <code id="npm-meta-label"></code></li>
+          <li><strong>npm CSS URL:</strong> <code id="npm-url-label"></code></li>
+        </ul>
+      </div>
+
+      <div class="dv-controls-card">
+        <h2>Run comparison</h2>
+        <div class="dv-controls">
+          <button type="button" id="run-btn" class="ease-btn ease-btn-primary">Run Drift Check</button>
+          <label class="dv-autorun">
+            <input type="checkbox" id="autorun-toggle" checked />
+            Auto-run on load
+          </label>
+        </div>
+        <p id="status" class="dv-status" role="status" aria-live="polite">
+          Waiting to start...
+        </p>
+      </div>
+    </section>
+
+    <section class="dv-metrics" aria-label="drift summary">
+      <article class="dv-metric">
+        <h3>CDN (@main) classes</h3>
+        <p id="cdn-count">-</p>
+      </article>
+      <article class="dv-metric">
+        <h3>npm latest classes</h3>
+        <p id="npm-count">-</p>
+      </article>
+      <article class="dv-metric">
+        <h3>Common classes</h3>
+        <p id="common-count">-</p>
+      </article>
+      <article class="dv-metric dv-metric-warn">
+        <h3>Total drift</h3>
+        <p id="drift-count">-</p>
+      </article>
+    </section>
+
+    <section id="policy" class="dv-policy dv-policy-neutral">
+      <h2>Pin for production policy</h2>
+      <p id="policy-text">
+        Run a comparison first. This panel will explain drift risk and recommended usage.
+      </p>
+      <p id="pin-link" class="dv-pin-link"></p>
+    </section>
+
+    <section class="dv-filter-row">
+      <label for="search-input">Filter class names</label>
+      <input
+        id="search-input"
+        type="search"
+        placeholder="Search class (example: ease-hover, ease-fade)"
+        autocomplete="off"
+      />
+    </section>
+
+    <section class="dv-grids">
+      <article class="dv-list-card">
+        <h3>CDN-only classes (<span id="cdn-only-count">0</span>)</h3>
+        <p class="dv-hint">Exists on jsDelivr <code>@main</code>, missing in npm latest.</p>
+        <ul id="cdn-only-list" class="dv-class-list"></ul>
+      </article>
+      <article class="dv-list-card">
+        <h3>npm-only classes (<span id="npm-only-count">0</span>)</h3>
+        <p class="dv-hint">Exists in npm latest, missing on current CDN <code>@main</code>.</p>
+        <ul id="npm-only-list" class="dv-class-list"></ul>
+      </article>
+      <article class="dv-list-card">
+        <h3>Common classes (<span id="common-list-count">0</span>)</h3>
+        <p class="dv-hint">Present on both sources.</p>
+        <ul id="common-list" class="dv-class-list"></ul>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var URL_MAIN = 'https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css';
+      var URL_NPM_META = 'https://registry.npmjs.org/easemotion-css/latest';
+
+      var state = {
+        npmVersion: '',
+        npmCssUrl: '',
+        cdnClasses: [],
+        npmClasses: [],
+        common: [],
+        cdnOnly: [],
+        npmOnly: []
+      };
+
+      var mainLabel = document.getElementById('main-url-label');
+      var npmMetaLabel = document.getElementById('npm-meta-label');
+      var npmUrlLabel = document.getElementById('npm-url-label');
+      var runBtn = document.getElementById('run-btn');
+      var autoRunToggle = document.getElementById('autorun-toggle');
+      var statusEl = document.getElementById('status');
+      var searchInput = document.getElementById('search-input');
+      var policyBox = document.getElementById('policy');
+      var policyText = document.getElementById('policy-text');
+      var pinLink = document.getElementById('pin-link');
+
+      var counts = {
+        cdn: document.getElementById('cdn-count'),
+        npm: document.getElementById('npm-count'),
+        common: document.getElementById('common-count'),
+        drift: document.getElementById('drift-count'),
+        cdnOnly: document.getElementById('cdn-only-count'),
+        npmOnly: document.getElementById('npm-only-count'),
+        commonList: document.getElementById('common-list-count')
+      };
+
+      var lists = {
+        cdnOnly: document.getElementById('cdn-only-list'),
+        npmOnly: document.getElementById('npm-only-list'),
+        common: document.getElementById('common-list')
+      };
+
+      mainLabel.textContent = URL_MAIN;
+      npmMetaLabel.textContent = URL_NPM_META;
+      npmUrlLabel.textContent = '-';
+
+      function normalizeClassName(raw) {
+        return raw.trim().replace(/^\.?/, '').replace(/[:\s].*$/, '');
+      }
+
+      function extractEaseClasses(cssText) {
+        var classSet = new Set();
+        var rx = /\.ease-[A-Za-z0-9_-]+/g;
+        var match = null;
+        while ((match = rx.exec(cssText)) !== null) {
+          classSet.add(normalizeClassName(match[0]));
+        }
+        return Array.from(classSet).sort();
+      }
+
+      function diffLists(a, b) {
+        var bSet = new Set(b);
+        return a.filter(function (item) { return !bSet.has(item); });
+      }
+
+      function intersectLists(a, b) {
+        var bSet = new Set(b);
+        return a.filter(function (item) { return bSet.has(item); });
+      }
+
+      function setStatus(message, type) {
+        statusEl.textContent = message;
+        statusEl.className = 'dv-status ' + (type ? 'dv-status-' + type : '');
+      }
+
+      function renderList(container, values, query) {
+        container.innerHTML = '';
+        var filtered = values;
+        if (query) {
+          filtered = values.filter(function (value) { return value.indexOf(query) !== -1; });
+        }
+        if (filtered.length === 0) {
+          var empty = document.createElement('li');
+          empty.className = 'dv-empty';
+          empty.textContent = query ? 'No matching classes for current filter.' : 'No classes in this bucket.';
+          container.appendChild(empty);
+          return;
+        }
+        filtered.forEach(function (name) {
+          var li = document.createElement('li');
+          li.textContent = name;
+          container.appendChild(li);
+        });
+      }
+
+      function renderPolicy() {
+        var totalDrift = state.cdnOnly.length + state.npmOnly.length;
+        var overlapPct = state.cdnClasses.length
+          ? Math.round((state.common.length / state.cdnClasses.length) * 100)
+          : 0;
+
+        policyBox.classList.remove('dv-policy-neutral', 'dv-policy-safe', 'dv-policy-warn');
+        if (totalDrift === 0) {
+          policyBox.classList.add('dv-policy-safe');
+          policyText.textContent =
+            'No class drift detected right now. You can prototype on @main, but keep production pinned to a versioned npm URL for reproducibility.';
+        } else {
+          policyBox.classList.add('dv-policy-warn');
+          policyText.textContent =
+            'Drift detected (' + totalDrift + ' classes differ). Prefer a pinned npm version in production to avoid freshness-related breakage.';
+        }
+
+        pinLink.textContent =
+          'Recommended production pin: https://cdn.jsdelivr.net/npm/easemotion-css@' +
+          state.npmVersion + '/easemotion.min.css  (overlap ' + overlapPct + '%)';
+      }
+
+      function renderAll() {
+        counts.cdn.textContent = state.cdnClasses.length;
+        counts.npm.textContent = state.npmClasses.length;
+        counts.common.textContent = state.common.length;
+        counts.cdnOnly.textContent = state.cdnOnly.length;
+        counts.npmOnly.textContent = state.npmOnly.length;
+        counts.commonList.textContent = state.common.length;
+        counts.drift.textContent = state.cdnOnly.length + state.npmOnly.length;
+
+        var query = searchInput.value.trim().toLowerCase();
+        renderList(lists.cdnOnly, state.cdnOnly, query);
+        renderList(lists.npmOnly, state.npmOnly, query);
+        renderList(lists.common, state.common, query);
+        renderPolicy();
+      }
+
+      async function fetchText(url) {
+        var response = await fetch(url, { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error('Failed fetch: ' + url + ' (' + response.status + ')');
+        }
+        return response.text();
+      }
+
+      async function runComparison() {
+        runBtn.disabled = true;
+        setStatus('Fetching npm latest metadata...', 'loading');
+        try {
+          var npmMetaRaw = await fetchText(URL_NPM_META);
+          var npmMeta = JSON.parse(npmMetaRaw);
+          state.npmVersion = npmMeta.version;
+          state.npmCssUrl =
+            'https://cdn.jsdelivr.net/npm/easemotion-css@' + state.npmVersion + '/easemotion.min.css';
+          npmUrlLabel.textContent = state.npmCssUrl;
+
+          setStatus('Fetching CSS from both sources...', 'loading');
+          var results = await Promise.all([fetchText(URL_MAIN), fetchText(state.npmCssUrl)]);
+
+          setStatus('Extracting class API and computing drift...', 'loading');
+          state.cdnClasses = extractEaseClasses(results[0]);
+          state.npmClasses = extractEaseClasses(results[1]);
+          state.common = intersectLists(state.cdnClasses, state.npmClasses);
+          state.cdnOnly = diffLists(state.cdnClasses, state.npmClasses);
+          state.npmOnly = diffLists(state.npmClasses, state.cdnClasses);
+
+          renderAll();
+          setStatus(
+            'Done. Compared @main vs npm@' + state.npmVersion +
+              '. Drift classes: ' + (state.cdnOnly.length + state.npmOnly.length) + '.',
+            'success'
+          );
+        } catch (error) {
+          setStatus(
+            'Comparison failed: ' + error.message + '. Check network access and retry.',
+            'error'
+          );
+        } finally {
+          runBtn.disabled = false;
+        }
+      }
+
+      runBtn.addEventListener('click', runComparison);
+      searchInput.addEventListener('input', renderAll);
+
+      if (autoRunToggle.checked) {
+        runComparison();
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-cdn-main-vs-npm-drift-sp/style.css
+++ b/submissions/docs/ease-cdn-main-vs-npm-drift-sp/style.css
@@ -1,0 +1,275 @@
+/* Drift Visualizer styles
+   submissions/docs/ease-cdn-main-vs-npm-drift-sp */
+
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(900px 420px at 8% -8%, rgb(108 99 255 / 9%), transparent),
+    radial-gradient(780px 380px at 92% 0%, rgb(59 130 246 / 8%), transparent),
+    var(--ease-color-bg, #f8fafc);
+}
+
+.dv-header,
+.dv-main {
+  max-width: 78rem;
+  margin: 0 auto;
+  padding-inline: var(--ease-space-6, 1.5rem);
+}
+
+.dv-header {
+  text-align: center;
+  padding-top: var(--ease-space-12, 3rem);
+  padding-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.dv-kicker {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.dv-subtitle {
+  max-width: 56rem;
+  margin: 0.75rem auto 0;
+  color: var(--ease-color-muted, #475569);
+}
+
+.dv-main {
+  padding-bottom: var(--ease-space-12, 3rem);
+}
+
+.dv-top {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-space-4, 1rem);
+}
+
+.dv-source-card,
+.dv-controls-card,
+.dv-list-card,
+.dv-policy,
+.dv-metric {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.dv-source-card,
+.dv-controls-card {
+  padding: var(--ease-space-5, 1.25rem);
+}
+
+.dv-source-card h2,
+.dv-controls-card h2,
+.dv-policy h2 {
+  margin: 0 0 0.6rem;
+  font-size: var(--ease-text-base, 1rem);
+}
+
+.dv-source-card ul {
+  margin: 0;
+  padding-left: var(--ease-space-5, 1.25rem);
+}
+
+.dv-source-card li {
+  margin-bottom: 0.45rem;
+  font-size: var(--ease-text-xs, 0.75rem);
+  line-height: 1.5;
+}
+
+.dv-source-card code,
+.dv-pin-link {
+  font-family: var(--ease-font-mono, monospace);
+  word-break: break-all;
+}
+
+.dv-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-4, 1rem);
+  flex-wrap: wrap;
+}
+
+.dv-autorun {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.dv-status {
+  margin: 0.85rem 0 0;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+.dv-status-loading {
+  color: #0369a1;
+}
+
+.dv-status-success {
+  color: #166534;
+}
+
+.dv-status-error {
+  color: #b91c1c;
+}
+
+.dv-metrics {
+  margin-top: var(--ease-space-4, 1rem);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.dv-metric {
+  padding: var(--ease-space-4, 1rem);
+}
+
+.dv-metric h3 {
+  margin: 0 0 0.35rem;
+  font-size: var(--ease-text-xs, 0.75rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ease-color-muted, #475569);
+}
+
+.dv-metric p {
+  margin: 0;
+  font-size: 1.7rem;
+  font-weight: 700;
+  color: var(--ease-color-neutral-900, #0f172a);
+}
+
+.dv-metric-warn {
+  border-color: rgb(245 158 11 / 40%);
+}
+
+.dv-metric-warn p {
+  color: #b45309;
+}
+
+.dv-policy {
+  margin-top: var(--ease-space-4, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+}
+
+.dv-policy p {
+  margin: 0.4rem 0 0;
+  color: var(--ease-color-muted, #475569);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.dv-policy-safe {
+  border-color: rgb(34 197 94 / 40%);
+  background: rgb(34 197 94 / 5%);
+}
+
+.dv-policy-warn {
+  border-color: rgb(239 68 68 / 40%);
+  background: rgb(239 68 68 / 4%);
+}
+
+.dv-policy-neutral {
+  background: var(--ease-color-surface, #fff);
+}
+
+.dv-pin-link {
+  font-size: var(--ease-text-xs, 0.75rem);
+}
+
+.dv-filter-row {
+  margin-top: var(--ease-space-4, 1rem);
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.dv-filter-row label {
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+.dv-filter-row input {
+  flex: 1;
+  min-width: 16rem;
+  border: 1px solid var(--ease-color-neutral-300, #cbd5e1);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: 0.55rem 0.75rem;
+  background: var(--ease-color-surface, #fff);
+  color: var(--ease-color-text, #1e293b);
+}
+
+.dv-filter-row input:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.dv-grids {
+  margin-top: var(--ease-space-4, 1rem);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.dv-list-card {
+  padding: var(--ease-space-4, 1rem);
+}
+
+.dv-list-card h3 {
+  margin: 0;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.dv-hint {
+  margin: 0.45rem 0 0.8rem;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+.dv-class-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  max-height: 22rem;
+  overflow: auto;
+}
+
+.dv-class-list li {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.72rem;
+  padding: 0.42rem 0.6rem;
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+}
+
+.dv-class-list li:last-child {
+  border-bottom: 0;
+}
+
+.dv-empty {
+  color: var(--ease-color-muted, #475569);
+  font-style: italic;
+}
+
+@media (max-width: 72rem) {
+  .dv-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dv-grids {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 56rem) {
+  .dv-top {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
# #47596 issue resolved
## Description
This PR adds a jsDelivr @main vs npm Version Drift Visualizer under submissions/docs/ease-cdn-main-vs-npm-drift-sp/.

## Features

- Compares jsDelivr GitHub CDN @main with latest npm published version
- Extracts and lists ease-* class names from both builds
- Shows CDN-only, npm-only, and common class diff buckets
- Displays summary stats (total classes, drift count, overlap %)
- Includes search filter and “pin for production” policy guidance
- Handles loading and error states with responsive UI