### PR TITLE
Add dung beetle component

### DIFF
--- a/submissions/examples/dung-beetle-as/README.md
+++ b/submissions/examples/dung-beetle-as/README.md
@@ -1,0 +1,19 @@
+# Dung Beetle
+
+A pure CSS and HTML dung beetle rolling its ball across the hot dirt, head down and back legs driving.
+
+## What it shows
+
+- The ball genuinely rotating on its own axis while its mottled surface texture turns with it, so the roll reads as real
+- The beetle braced at an angle, its hind legs kicking in opposition and its front legs pumping against the ball
+- Ridged elytra from a central seam plus a fine repeating linear gradient over a dark shell
+- A drag track left in the dirt, faded out with a mask
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/dung-beetle-as/demo.html
+++ b/submissions/examples/dung-beetle-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dung Beetle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunD"></span>
+    <div class="ballD">
+      <span class="ballTex"></span>
+    </div>
+    <div class="beetleD">
+      <span class="legD ldb1"></span>
+      <span class="legD ldb2"></span>
+      <span class="elytraD"></span>
+      <span class="seamD"></span>
+      <span class="thoraxD"></span>
+      <span class="headD"></span>
+      <span class="hornD"></span>
+      <span class="legD ldf1"></span>
+      <span class="legD ldf2"></span>
+    </div>
+    <span class="trackD"></span>
+    <span class="grassD gd1"></span>
+    <span class="grassD gd2"></span>
+    <span class="dirtD"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dung-beetle-as/style.css
+++ b/submissions/examples/dung-beetle-as/style.css
@@ -1,0 +1,273 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #e8c078, #d19a52 58%, #a8702e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f0cd8a, #d99a4e 56%, #b5732e);
+}
+
+.sunD {
+  position: absolute;
+  top: 26px;
+  right: 40px;
+  width: 78px;
+  height: 78px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff4d0, #f9d283 60%, #eda94e);
+  box-shadow: 0 0 50px 20px rgba(250, 210, 130, 0.4);
+  z-index: 1;
+  animation: glowD 6s ease-in-out infinite;
+}
+
+.dirtD {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 74px;
+  background:
+    radial-gradient(circle at 14% 20%, rgba(255, 240, 200, 0.2) 0 5px, transparent 6px),
+    radial-gradient(circle at 46% 40%, rgba(90, 50, 20, 0.24) 0 7px, transparent 8px),
+    radial-gradient(circle at 78% 16%, rgba(255, 240, 200, 0.16) 0 6px, transparent 7px),
+    linear-gradient(180deg, #a5702e, #6a4318);
+  z-index: 7;
+}
+
+.trackD {
+  position: absolute;
+  bottom: 62px;
+  left: 0;
+  right: 0;
+  height: 10px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 50, 18, 0.4) 0 6px,
+      transparent 6px 16px
+    );
+  mask-image: linear-gradient(90deg, #000 0 60%, transparent 92%);
+  z-index: 8;
+}
+
+.grassD {
+  position: absolute;
+  bottom: 60px;
+  width: 28px;
+  height: 46px;
+  background:
+    repeating-linear-gradient(
+      80deg,
+      #a8912e 0 3px,
+      transparent 3px 9px
+    );
+  mask-image: linear-gradient(180deg, transparent 0 8%, #000 40%);
+  transform-origin: 50% 100%;
+  z-index: 9;
+  animation: swayGrassD 5s ease-in-out infinite;
+}
+
+.gd1 { left: 16px; }
+.gd2 { right: 24px; height: 36px; animation-delay: 2s; }
+
+.ballD {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 104px;
+  height: 104px;
+  margin-left: -20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 30%, #8a6a44, #3f2c18 78%);
+  box-shadow:
+    inset -10px -10px 26px rgba(20, 12, 4, 0.6),
+    0 8px 16px rgba(60, 34, 10, 0.4);
+  z-index: 6;
+  animation: rollBallD 4s linear infinite;
+}
+
+.ballTex {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 26%, rgba(20, 12, 4, 0.5) 0 8px, transparent 10px),
+    radial-gradient(circle at 62% 40%, rgba(140, 110, 70, 0.4) 0 7px, transparent 9px),
+    radial-gradient(circle at 44% 66%, rgba(20, 12, 4, 0.45) 0 9px, transparent 11px),
+    radial-gradient(circle at 74% 72%, rgba(140, 110, 70, 0.32) 0 6px, transparent 8px),
+    radial-gradient(circle at 20% 60%, rgba(20, 12, 4, 0.4) 0 6px, transparent 8px);
+}
+
+.beetleD {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 130px;
+  height: 96px;
+  margin-left: -120px;
+  z-index: 5;
+  animation: pushD 0.9s ease-in-out infinite;
+}
+
+.elytraD {
+  position: absolute;
+  bottom: 16px;
+  left: 6px;
+  width: 78px;
+  height: 50px;
+  border-radius: 50% 40% 40% 50% / 60% 50% 50% 60%;
+  background: radial-gradient(circle at 40% 30%, #4a4a52, #16161c 78%);
+  box-shadow: inset -6px -4px 14px rgba(0, 0, 0, 0.6);
+  z-index: 4;
+}
+
+.seamD {
+  position: absolute;
+  bottom: 16px;
+  left: 6px;
+  width: 78px;
+  height: 50px;
+  border-radius: 50% 40% 40% 50% / 60% 50% 50% 60%;
+  background:
+    linear-gradient(90deg, transparent 47%, rgba(90, 90, 100, 0.6) 48% 52%, transparent 53%),
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 90, 100, 0.18) 0 1px,
+      transparent 1px 9px
+    );
+  z-index: 5;
+}
+
+.thoraxD {
+  position: absolute;
+  bottom: 26px;
+  left: 70px;
+  width: 34px;
+  height: 38px;
+  border-radius: 40% 50% 40% 40%;
+  background: radial-gradient(circle at 40% 34%, #55555e, #1a1a20 78%);
+  z-index: 5;
+}
+
+.headD {
+  position: absolute;
+  bottom: 28px;
+  left: 96px;
+  width: 26px;
+  height: 26px;
+  border-radius: 40% 50% 50% 40%;
+  background: radial-gradient(circle at 40% 34%, #4a4a52, #14141a 76%);
+  z-index: 4;
+}
+
+.hornD {
+  position: absolute;
+  bottom: 46px;
+  left: 104px;
+  width: 8px;
+  height: 26px;
+  border-radius: 4px 4px 0 0;
+  background: linear-gradient(180deg, #6a6a74, #23232a);
+  transform-origin: 50% 100%;
+  transform: rotate(24deg);
+  z-index: 5;
+}
+
+.legD {
+  position: absolute;
+  width: 10px;
+  height: 40px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #3a3a42, #101014);
+  transform-origin: 50% 0;
+  z-index: 6;
+}
+
+.legD::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: -2px;
+  width: 22px;
+  height: 8px;
+  border-radius: 4px;
+  background: #23232a;
+  transform-origin: 0 50%;
+  transform: rotate(-30deg);
+}
+
+.ldb1 { bottom: 4px; left: 10px; animation: kickD 0.9s ease-in-out infinite; }
+.ldb2 { bottom: 6px; left: 30px; animation: kickD 0.9s ease-in-out infinite reverse; }
+
+.ldf1 {
+  bottom: 56px;
+  left: 92px;
+  height: 44px;
+
+  --lf: -74deg;
+
+  transform: rotate(-74deg);
+  animation: pumpD 0.9s ease-in-out infinite;
+}
+
+.ldf2 {
+  bottom: 40px;
+  left: 96px;
+  height: 42px;
+
+  --lf: -56deg;
+
+  transform: rotate(-56deg);
+  animation: pumpD 0.9s ease-in-out infinite 0.2s;
+}
+
+@keyframes rollBallD {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes pushD {
+  0%, 100% { transform: translate(0, 0) rotate(-12deg); }
+  50% { transform: translate(3px, -2px) rotate(-8deg); }
+}
+
+@keyframes kickD {
+  0%, 100% { transform: rotate(-14deg); }
+  50% { transform: rotate(16deg); }
+}
+
+@keyframes pumpD {
+  0%, 100% { transform: rotate(var(--lf, -70deg)); }
+  50% { transform: rotate(calc(var(--lf, -70deg) + 12deg)); }
+}
+
+@keyframes swayGrassD {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes glowD {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ballD,
+  .beetleD,
+  .legD,
+  .grassD,
+  .sunD {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML dung beetle rolling its ball across the dirt.

## Details

- The ball genuinely rotates on its own axis with its mottled surface texture turning with it, so the roll reads as real
- Legs kick in opposition, the front pair parking its angle in a custom property so a shared pump keyframe braces them against the ball
- Ridged elytra from a central seam plus a fine repeating linear gradient over a dark shell
- A drag track left in the dirt, faded out with a mask
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/dung-beetle-as/demo.html`
- `submissions/examples/dung-beetle-as/style.css`
- `submissions/examples/dung-beetle-as/README.md`

Closes #47598
