### PR TITLE
Add leafcutter ant component

### DIFF
--- a/submissions/examples/leafcutter-ant-as/README.md
+++ b/submissions/examples/leafcutter-ant-as/README.md
@@ -1,0 +1,19 @@
+# Leafcutter Ant
+
+A pure CSS and HTML column of leafcutter ants marching a cut leaf fragment each back to the nest hole.
+
+## What it shows
+
+- A trail of ants crossing the scene on one shared march keyframe, each parking its scale in a custom property so the march cannot wipe it, and staggered by delay so they file past in a line
+- Six segmented body parts per ant plus legs and antennae, each leg parking its own angle so a shared step keyframe can drive the gait
+- Leaf fragments held overhead, veined with a repeating linear gradient and bobbing with each step
+- A nest mound with a dark entrance hole, and the cut plant they came from
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/leafcutter-ant-as/demo.html
+++ b/submissions/examples/leafcutter-ant-as/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Leafcutter Ant</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="plantL"></span>
+    <span class="stemL"></span>
+    <div class="antL alA">
+      <span class="leafL"></span>
+      <span class="gasterL"></span>
+      <span class="thoraxL"></span>
+      <span class="headL"></span>
+      <span class="antennaL anl"></span>
+      <span class="antennaL anr"></span>
+      <span class="legL llg1"></span>
+      <span class="legL llg2"></span>
+      <span class="legL llg3"></span>
+    </div>
+    <div class="antL alB">
+      <span class="leafL"></span>
+      <span class="gasterL"></span>
+      <span class="thoraxL"></span>
+      <span class="headL"></span>
+      <span class="antennaL anl"></span>
+      <span class="antennaL anr"></span>
+      <span class="legL llg1"></span>
+      <span class="legL llg2"></span>
+      <span class="legL llg3"></span>
+    </div>
+    <div class="antL alC">
+      <span class="leafL"></span>
+      <span class="gasterL"></span>
+      <span class="thoraxL"></span>
+      <span class="headL"></span>
+      <span class="antennaL anl"></span>
+      <span class="antennaL anr"></span>
+      <span class="legL llg1"></span>
+      <span class="legL llg2"></span>
+      <span class="legL llg3"></span>
+    </div>
+    <span class="moundL"></span>
+    <span class="holeL"></span>
+    <span class="groundL"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/leafcutter-ant-as/style.css
+++ b/submissions/examples/leafcutter-ant-as/style.css
@@ -1,0 +1,241 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #cfe0b0, #9cc07a 60%, #6f9450);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #dcebc4, #a8c884 58%, #7a9c58);
+}
+
+.groundL {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 74px;
+  background:
+    radial-gradient(circle at 18% 24%, rgba(255, 245, 215, 0.16) 0 6px, transparent 7px),
+    radial-gradient(circle at 62% 40%, rgba(70, 44, 18, 0.24) 0 8px, transparent 9px),
+    linear-gradient(180deg, #8a6a40, #4f3620);
+  z-index: 7;
+}
+
+.moundL {
+  position: absolute;
+  bottom: 56px;
+  right: 6px;
+  width: 130px;
+  height: 54px;
+  border-radius: 50% 50% 10% 10% / 90% 90% 10% 10%;
+  background: radial-gradient(circle at 40% 30%, #a5804e, #5a3f22 78%);
+  box-shadow: inset -6px -6px 14px rgba(40, 24, 10, 0.4);
+  z-index: 8;
+}
+
+.holeL {
+  position: absolute;
+  bottom: 56px;
+  right: 56px;
+  width: 34px;
+  height: 24px;
+  border-radius: 50% 50% 20% 20%;
+  background: radial-gradient(ellipse at 50% 30%, #2a1a0a, #100a04 76%);
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.7);
+  z-index: 9;
+}
+
+.stemL {
+  position: absolute;
+  bottom: 60px;
+  left: 26px;
+  width: 12px;
+  height: 150px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #3f6a24, #7aa845 45%, #35591e);
+  z-index: 4;
+}
+
+.plantL {
+  position: absolute;
+  bottom: 170px;
+  left: -22px;
+  width: 130px;
+  height: 90px;
+  border-radius: 60% 20% 60% 20%;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(20, 50, 10, 0.28) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(120deg, #6faa3c, #2f5a1c);
+  clip-path: polygon(0 40%, 30% 6%, 62% 0, 100% 30%, 88% 60%, 100% 96%, 52% 78%, 16% 92%);
+  z-index: 3;
+  animation: swayPlantL 7s ease-in-out infinite;
+}
+
+.antL {
+  position: absolute;
+  bottom: 70px;
+  width: 54px;
+  height: 60px;
+  transform-origin: 0 100%;
+  z-index: 6;
+}
+
+.alA {
+  left: 30px;
+  transform: scale(1.7);
+  animation: marchL 9s linear infinite;
+
+  --as: 1.7;
+}
+
+.alB {
+  left: 30px;
+  transform: scale(1.42);
+  animation: marchL 9s linear infinite 3s;
+
+  --as: 1.42;
+}
+
+.alC {
+  left: 30px;
+  transform: scale(1.2);
+  animation: marchL 9s linear infinite 6s;
+
+  --as: 1.2;
+}
+
+.gasterL {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  width: 22px;
+  height: 16px;
+  border-radius: 50% 40% 40% 50%;
+  background: radial-gradient(circle at 40% 34%, #a5502a, #5a2410 78%);
+  z-index: 4;
+}
+
+.thoraxL {
+  position: absolute;
+  bottom: 10px;
+  left: 18px;
+  width: 16px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #94441e, #4a1e0c 78%);
+  z-index: 5;
+}
+
+.headL {
+  position: absolute;
+  bottom: 10px;
+  left: 32px;
+  width: 14px;
+  height: 13px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #a5502a, #4a1e0c 78%);
+  z-index: 5;
+}
+
+.antennaL {
+  position: absolute;
+  bottom: 20px;
+  left: 38px;
+  width: 2px;
+  height: 12px;
+  border-radius: 1px;
+  background: #4a1e0c;
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: feelL 1.2s ease-in-out infinite;
+}
+
+.anl { transform: rotate(-24deg); --fa: -24deg; }
+.anr { left: 42px; transform: rotate(-6deg); --fa: -6deg; animation-delay: 0.3s; }
+
+.legL {
+  position: absolute;
+  bottom: 0;
+  width: 2px;
+  height: 13px;
+  border-radius: 1px;
+  background: #4a1e0c;
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: stepAntL 0.5s ease-in-out infinite;
+}
+
+.llg1 { left: 8px; --la: 16deg; transform: rotate(16deg); }
+.llg2 { left: 20px; --la: -8deg; transform: rotate(-8deg); animation-delay: 0.16s; }
+.llg3 { left: 32px; --la: -20deg; transform: rotate(-20deg); animation-delay: 0.32s; }
+
+.leafL {
+  position: absolute;
+  bottom: 20px;
+  left: 14px;
+  width: 40px;
+  height: 34px;
+  border-radius: 60% 8% 60% 8%;
+  background:
+    repeating-linear-gradient(
+      66deg,
+      rgba(20, 50, 10, 0.3) 0 1px,
+      transparent 1px 8px
+    ),
+    linear-gradient(120deg, #7fbc46, #3f6a24);
+  box-shadow: 0 2px 4px rgba(20, 40, 10, 0.3);
+  transform-origin: 30% 100%;
+  z-index: 7;
+  animation: bobLeafL 0.5s ease-in-out infinite;
+}
+
+@keyframes marchL {
+  0% { transform: translateX(0) scale(var(--as, 1)); opacity: 0; }
+  6% { opacity: 1; }
+  88% { opacity: 1; }
+  100% { transform: translateX(150px) scale(var(--as, 1)); opacity: 0; }
+}
+
+@keyframes stepAntL {
+  0%, 100% { transform: rotate(var(--la, 0deg)); }
+  50% { transform: rotate(calc(var(--la, 0deg) + 20deg)); }
+}
+
+@keyframes feelL {
+  0%, 100% { transform: rotate(var(--fa, 0deg)); }
+  50% { transform: rotate(calc(var(--fa, 0deg) - 14deg)); }
+}
+
+@keyframes bobLeafL {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(-2deg); }
+}
+
+@keyframes swayPlantL {
+  0%, 100% { transform: rotate(-2deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .antL,
+  .legL,
+  .antennaL,
+  .leafL,
+  .plantL {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML column of leafcutter ants carrying leaf fragments to the nest.

## Details

- A trail of ants on one shared march keyframe, each parking its scale in a custom property so the march cannot wipe it, staggered by delay so they file past in a line
- Segmented bodies with legs and antennae, each leg parking its own angle so a shared step keyframe drives the gait
- Leaf fragments held overhead, veined with a repeating linear gradient and bobbing with each step
- A nest mound with a dark entrance hole and the cut plant they came from
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/leafcutter-ant-as/demo.html`
- `submissions/examples/leafcutter-ant-as/style.css`
- `submissions/examples/leafcutter-ant-as/README.md`

Closes #47600
