### PR TITLE
Add lyrebird component

### DIFF
--- a/submissions/examples/lyrebird-as/README.md
+++ b/submissions/examples/lyrebird-as/README.md
@@ -1,0 +1,19 @@
+# Lyrebird
+
+A pure CSS and HTML superb lyrebird throwing its tail forward into the famous lyre shaped display while it sings.
+
+## What it shows
+
+- The whole tail fan opening from a folded sliver to full spread on one scale keyframe, so every filament unfurls together
+- Seven gauzy filamentary plumes, each parking its own angle in a custom property and textured with a fine repeating linear gradient
+- The two banded lyre arms curving out to frame the fan, barred with a repeating linear gradient
+- Head and beak singing on their own timing, with musical notes drifting off
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`, leaving the tail fanned.

--- a/submissions/examples/lyrebird-as/demo.html
+++ b/submissions/examples/lyrebird-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lyrebird</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="fernY fy1"></span>
+    <span class="fernY fy2"></span>
+    <div class="lyreY">
+      <div class="tailFan">
+        <span class="filY fl1"></span>
+        <span class="filY fl2"></span>
+        <span class="filY fl3"></span>
+        <span class="filY fl4"></span>
+        <span class="filY fl5"></span>
+        <span class="filY fl6"></span>
+        <span class="filY fl7"></span>
+        <span class="lyreArm laL"></span>
+        <span class="lyreArm laR"></span>
+      </div>
+      <span class="legY lyb"></span>
+      <span class="legY lyf"></span>
+      <span class="bodyY"></span>
+      <span class="wingY"></span>
+      <span class="neckY"></span>
+      <span class="headY"></span>
+      <span class="beakY"></span>
+      <span class="eyeY"></span>
+    </div>
+    <span class="noteY ny1"></span>
+    <span class="noteY ny2"></span>
+    <span class="noteY ny3"></span>
+    <span class="moundY"></span>
+    <span class="floorY"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/lyrebird-as/style.css
+++ b/submissions/examples/lyrebird-as/style.css
@@ -1,0 +1,306 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #4a6a4a, #16281a 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.floorY {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 44px);
+  background:
+    radial-gradient(circle at 20% 10%, #4a5a34 0 20px, transparent 20px),
+    radial-gradient(circle at 62% 4%, #3c4a2c 0 24px, transparent 24px),
+    linear-gradient(180deg, #40522e, #1c2614);
+  z-index: 8;
+}
+
+.moundY {
+  position: absolute;
+  bottom: 36px;
+  left: 50%;
+  width: 170px;
+  height: 34px;
+  margin-left: -85px;
+  border-radius: 50% 50% 20% 20% / 80% 80% 20% 20%;
+  background: radial-gradient(circle at 40% 30%, #6a5a3a, #33291a 78%);
+  z-index: 7;
+}
+
+.fernY {
+  position: absolute;
+  bottom: 40px;
+  width: 26px;
+  height: 130px;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(10, 30, 12, 0.4) 0 3px,
+      transparent 3px 13px
+    ),
+    linear-gradient(180deg, #4f8a45, #23522a);
+  border-radius: 13px 13px 0 0;
+  transform-origin: 50% 100%;
+  z-index: 2;
+  animation: swayFernY 7s ease-in-out infinite;
+}
+
+.fy1 { left: 14px; transform: rotate(-8deg); }
+.fy2 { right: 20px; height: 100px; animation-delay: 2.6s; }
+
+.noteY {
+  position: absolute;
+  color: rgba(240, 250, 220, 0.75);
+  font-size: 20px;
+  z-index: 3;
+  animation: floatNoteY 5s ease-in infinite;
+}
+
+.noteY::before { content: "\266B"; }
+.ny1 { top: 92px; left: 44px; }
+.ny2 { top: 60px; left: 84px; font-size: 16px; animation-delay: 1.7s; }
+.ny3 { top: 110px; left: 20px; font-size: 24px; animation-delay: 3.4s; }
+
+.lyreY {
+  position: absolute;
+  bottom: 52px;
+  left: 50%;
+  width: 220px;
+  height: 240px;
+  margin-left: -84px;
+  z-index: 6;
+  animation: strutY 5s ease-in-out infinite;
+}
+
+.tailFan {
+  position: absolute;
+  bottom: 24px;
+  left: 44px;
+  width: 10px;
+  height: 10px;
+  transform-origin: 50% 100%;
+  z-index: 3;
+  animation: fanOpenY 8s ease-in-out infinite;
+}
+
+.filY {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 9px;
+  height: 190px;
+  margin-left: -4px;
+  border-radius: 5px 5px 0 0;
+  background:
+    repeating-linear-gradient(
+      86deg,
+      rgba(255, 255, 255, 0.5) 0 1px,
+      transparent 1px 5px
+    ),
+    linear-gradient(180deg, rgba(240, 240, 225, 0.9), rgba(190, 190, 170, 0.5));
+  transform-origin: 50% 100%;
+  transform: rotate(var(--fy, 0deg));
+  z-index: 3;
+}
+
+.fl1 { --fy: -54deg; height: 150px; }
+.fl2 { --fy: -36deg; height: 168px; }
+.fl3 { --fy: -18deg; height: 182px; }
+.fl4 { --fy: 0deg; height: 190px; }
+.fl5 { --fy: 18deg; height: 182px; }
+.fl6 { --fy: 36deg; height: 168px; }
+.fl7 { --fy: 54deg; height: 150px; }
+
+.lyreArm {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 15px;
+  height: 176px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #2a2418 0 10px,
+      #d8cba0 10px 20px
+    );
+  transform-origin: 50% 100%;
+  z-index: 4;
+}
+
+.laL {
+  margin-left: -30px;
+  border-radius: 70% 14% 8px 8px / 46% 12% 8px 8px;
+  transform: rotate(-52deg);
+}
+
+.laR {
+  margin-left: 16px;
+  border-radius: 14% 70% 8px 8px / 12% 46% 8px 8px;
+  transform: rotate(52deg);
+}
+
+.bodyY {
+  position: absolute;
+  bottom: 24px;
+  left: 22px;
+  width: 96px;
+  height: 66px;
+  border-radius: 54% 44% 44% 54% / 62% 58% 42% 42%;
+  background: radial-gradient(circle at 40% 32%, #7a6a52, #362c1e 78%);
+  box-shadow: inset -8px -6px 16px rgba(20, 16, 8, 0.5);
+  z-index: 5;
+}
+
+.wingY {
+  position: absolute;
+  bottom: 28px;
+  left: 44px;
+  width: 62px;
+  height: 52px;
+  border-radius: 40% 50% 50% 40% / 50% 40% 60% 60%;
+  background:
+    repeating-linear-gradient(
+      70deg,
+      rgba(20, 16, 8, 0.3) 0 3px,
+      transparent 3px 12px
+    ),
+    linear-gradient(160deg, #6a5c46, #2a2216);
+  z-index: 6;
+}
+
+.neckY {
+  position: absolute;
+  bottom: 70px;
+  left: 20px;
+  width: 26px;
+  height: 44px;
+  border-radius: 40% 50% 30% 40%;
+  background: linear-gradient(180deg, #6a5c46, #38301f);
+  transform-origin: 50% 100%;
+  transform: rotate(-14deg);
+  z-index: 5;
+}
+
+.headY {
+  position: absolute;
+  bottom: 104px;
+  left: 8px;
+  width: 34px;
+  height: 30px;
+  border-radius: 50% 54% 44% 40% / 54% 54% 46% 46%;
+  background: radial-gradient(circle at 40% 34%, #7a6a52, #362c1e 78%);
+  transform-origin: 80% 100%;
+  z-index: 6;
+  animation: singY 2.4s ease-in-out infinite;
+}
+
+.beakY {
+  position: absolute;
+  bottom: 110px;
+  left: -8px;
+  width: 22px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #1c1810, #4a4030);
+  clip-path: polygon(0 30%, 100% 0, 100% 100%, 0 70%);
+  transform-origin: 100% 50%;
+  z-index: 7;
+  animation: singY 2.4s ease-in-out infinite;
+}
+
+.eyeY {
+  position: absolute;
+  bottom: 120px;
+  left: 22px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #5a4a30, #100c06 66%);
+  box-shadow: 0 0 0 1.5px rgba(240, 240, 220, 0.4);
+  z-index: 8;
+}
+
+.legY {
+  position: absolute;
+  bottom: -14px;
+  width: 8px;
+  height: 40px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6a5c3a, #33281a);
+  z-index: 4;
+}
+
+.legY::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -6px;
+  width: 22px;
+  height: 8px;
+  background: #33281a;
+  clip-path: polygon(0 0, 24% 100%, 44% 0, 64% 100%, 84% 0, 100% 100%, 100% 0);
+}
+
+.lyf { left: 46px; }
+.lyb { left: 66px; filter: brightness(0.8); z-index: 3; }
+
+@keyframes fanOpenY {
+  0%, 14% { transform: scale(0.2, 0.24); }
+  32%, 82% { transform: scale(1, 1); }
+  100% { transform: scale(0.2, 0.24); }
+}
+
+@keyframes strutY {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-4px) rotate(1deg); }
+}
+
+@keyframes singY {
+  0%, 60%, 100% { transform: rotate(0deg); }
+  72% { transform: rotate(-10deg); }
+  84% { transform: rotate(-2deg); }
+}
+
+@keyframes floatNoteY {
+  0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+  30% { opacity: 1; }
+  100% { transform: translate(-24px, -50px) scale(1.1); opacity: 0; }
+}
+
+@keyframes swayFernY {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lyreY,
+  .tailFan,
+  .headY,
+  .beakY,
+  .noteY,
+  .fernY {
+    animation: none;
+  }
+
+  .tailFan {
+    transform: scale(1, 1);
+  }
+
+  .noteY {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML lyrebird performing its lyre shaped tail display.

## Details

- The whole tail fan opens from a folded sliver to full spread on one scale keyframe, so every filament unfurls together
- Seven gauzy plumes, each parking its own angle in a custom property and textured with a fine repeating linear gradient
- Two banded lyre arms curve out to frame the fan, barred with a repeating linear gradient
- Head and beak sing on their own timing, with musical notes drifting off through the ferns
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/lyrebird-as/demo.html`
- `submissions/examples/lyrebird-as/style.css`
- `submissions/examples/lyrebird-as/README.md`

Closes #47602
