### PR TITLE
Add manta ray component

### DIFF
--- a/submissions/examples/manta-ray-as/README.md
+++ b/submissions/examples/manta-ray-as/README.md
@@ -1,0 +1,19 @@
+# Manta Ray
+
+A pure CSS and HTML manta ray flying through open blue water, its great wings beating in slow mirrored strokes.
+
+## What it shows
+
+- Wings cut from clip-path with a combined rotate and skewY, so each stroke twists like a real wingbeat rather than just tilting
+- Cephalic head fins that curl and unfurl, each parking its own angle in a custom property
+- Gill slits from a repeating linear gradient masked to the belly plate, plus pale dorsal spotting
+- A second manta scaled and dimmed with filter, gliding on its own slower path for depth
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/manta-ray-as/demo.html
+++ b/submissions/examples/manta-ray-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manta Ray</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="rayShaft rs1"></span>
+    <span class="rayShaft rs2"></span>
+    <div class="mantaM">
+      <span class="wingM wmL"></span>
+      <span class="wingM wmR"></span>
+      <span class="discM"></span>
+      <span class="spotM"></span>
+      <span class="cephM cml"></span>
+      <span class="cephM cmr"></span>
+      <span class="gillM"></span>
+      <span class="tailM"></span>
+    </div>
+    <div class="mantaM mmFar">
+      <span class="wingM wmL"></span>
+      <span class="wingM wmR"></span>
+      <span class="discM"></span>
+      <span class="spotM"></span>
+      <span class="cephM cml"></span>
+      <span class="cephM cmr"></span>
+      <span class="gillM"></span>
+      <span class="tailM"></span>
+    </div>
+    <span class="planktonM pm1"></span>
+    <span class="planktonM pm2"></span>
+    <span class="planktonM pm3"></span>
+    <span class="deepM"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/manta-ray-as/style.css
+++ b/submissions/examples/manta-ray-as/style.css
@@ -1,0 +1,229 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #3aa0c0, #10516e 58%, #05243a);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #46b0cc, #12587a 56%, #061e32);
+}
+
+.deepM {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 90px;
+  background: linear-gradient(180deg, transparent, rgba(2, 12, 24, 0.7));
+  z-index: 8;
+}
+
+.rayShaft {
+  position: absolute;
+  top: -40px;
+  width: 70px;
+  height: 330px;
+  background: linear-gradient(180deg, rgba(220, 250, 255, 0.22), transparent 78%);
+  filter: blur(9px);
+  transform-origin: 50% 0;
+  z-index: 1;
+  animation: shimM 10s ease-in-out infinite;
+}
+
+.rs1 { left: 44px; transform: rotate(8deg); }
+.rs2 { right: 54px; width: 50px; animation-delay: 3.4s; }
+
+.planktonM {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(220, 250, 255, 0.6);
+  z-index: 2;
+  animation: driftM 16s linear infinite;
+}
+
+.pm1 { top: 60px; left: 40px; width: 4px; height: 4px; }
+.pm2 { top: 150px; left: 100px; width: 3px; height: 3px; animation-delay: 5s; }
+.pm3 { top: 220px; left: 60px; width: 5px; height: 5px; animation-delay: 10s; }
+
+.mantaM {
+  position: absolute;
+  top: 92px;
+  left: 50%;
+  width: 240px;
+  height: 130px;
+  margin-left: -120px;
+  z-index: 6;
+  animation: glideM 7s ease-in-out infinite;
+}
+
+.mmFar {
+  top: 44px;
+  left: 50%;
+  margin-left: -180px;
+  transform: scale(0.5);
+  filter: brightness(0.72) blur(0.6px);
+  z-index: 4;
+  animation: glideFarM 9s ease-in-out infinite;
+}
+
+.discM {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 96px;
+  height: 76px;
+  margin-left: -48px;
+  border-radius: 50% 50% 44% 44% / 40% 40% 60% 60%;
+  background: linear-gradient(180deg, #2c3f52, #101c2a 76%);
+  box-shadow: inset 0 -6px 14px rgba(2, 10, 20, 0.6);
+  z-index: 5;
+}
+
+.spotM {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 96px;
+  height: 76px;
+  margin-left: -48px;
+  border-radius: 50% 50% 44% 44% / 40% 40% 60% 60%;
+  background:
+    radial-gradient(circle at 32% 40%, rgba(220, 240, 250, 0.5) 0 6px, transparent 8px),
+    radial-gradient(circle at 66% 36%, rgba(220, 240, 250, 0.4) 0 5px, transparent 7px),
+    radial-gradient(circle at 48% 60%, rgba(220, 240, 250, 0.35) 0 7px, transparent 9px);
+  z-index: 6;
+}
+
+.wingM {
+  position: absolute;
+  top: 20px;
+  width: 118px;
+  height: 92px;
+  background: linear-gradient(200deg, #354a60, #0c1620 82%);
+  z-index: 4;
+}
+
+.wmL {
+  left: 50%;
+  margin-left: -150px;
+  clip-path: polygon(100% 2%, 100% 82%, 0 52%, 22% 34%);
+  transform-origin: 100% 26%;
+  animation: flapLM 3.4s ease-in-out infinite;
+}
+
+.wmR {
+  left: 50%;
+  margin-left: 32px;
+  clip-path: polygon(0 2%, 0 82%, 100% 52%, 78% 34%);
+  transform-origin: 0 26%;
+  animation: flapRM 3.4s ease-in-out infinite;
+}
+
+.cephM {
+  position: absolute;
+  top: 24px;
+  width: 16px;
+  height: 34px;
+  border-radius: 8px 8px 4px 4px;
+  background: linear-gradient(180deg, #37506a, #16222e);
+  transform-origin: 50% 100%;
+  z-index: 7;
+  animation: curlCephM 3.4s ease-in-out infinite;
+}
+
+.cml { left: 50%; margin-left: -40px; --cf: -18deg; transform: rotate(-18deg); }
+.cmr { left: 50%; margin-left: 24px; --cf: 18deg; transform: rotate(18deg); }
+
+.gillM {
+  position: absolute;
+  top: 74px;
+  left: 50%;
+  width: 70px;
+  height: 26px;
+  margin-left: -35px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(190, 215, 235, 0.22) 0 2px,
+      transparent 2px 12px
+    );
+  mask-image: radial-gradient(ellipse 60% 100% at 50% 40%, #000 0 60%, transparent 82%);
+  z-index: 7;
+}
+
+.tailM {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 5px;
+  height: 92px;
+  margin-left: -2px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #22323f, transparent);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: tailWaveM 3.4s ease-in-out infinite;
+}
+
+@keyframes glideM {
+  0%, 100% { transform: translate(0, 0) rotate(-2deg); }
+  50% { transform: translate(-10px, -16px) rotate(2deg); }
+}
+
+@keyframes glideFarM {
+  0%, 100% { transform: translate(0, 0) scale(0.5) rotate(2deg); }
+  50% { transform: translate(30px, 12px) scale(0.5) rotate(-2deg); }
+}
+
+@keyframes flapLM {
+  0%, 100% { transform: rotate(-7deg) skewY(5deg); }
+  50% { transform: rotate(8deg) skewY(-5deg); }
+}
+
+@keyframes flapRM {
+  0%, 100% { transform: rotate(7deg) skewY(-5deg); }
+  50% { transform: rotate(-8deg) skewY(5deg); }
+}
+
+@keyframes curlCephM {
+  0%, 100% { transform: rotate(var(--cf, 0deg)); }
+  50% { transform: rotate(calc(var(--cf, 0deg) * 0.4)); }
+}
+
+@keyframes tailWaveM {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes shimM {
+  0%, 100% { opacity: 0.5; transform: rotate(6deg) scaleX(1); }
+  50% { opacity: 0.9; transform: rotate(10deg) scaleX(1.2); }
+}
+
+@keyframes driftM {
+  0% { transform: translate(0, 0); opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { transform: translate(280px, -60px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mantaM,
+  .wingM,
+  .cephM,
+  .tailM,
+  .rayShaft,
+  .planktonM {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML manta ray gliding through open water.

## Details

- Wings cut from clip-path with a combined rotate and skewY, so each stroke twists like a real wingbeat rather than just tilting
- Cephalic head fins curl and unfurl, each parking its own angle in a custom property
- Gill slits from a repeating linear gradient masked to the belly plate, plus pale dorsal spotting
- A second manta scaled and dimmed with filter glides on its own slower path for depth, under drifting light shafts
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/manta-ray-as/demo.html`
- `submissions/examples/manta-ray-as/style.css`
- `submissions/examples/manta-ray-as/README.md`

Closes #47608
