### PR TITLE
Add zen garden component

### DIFF
--- a/submissions/examples/zen-garden-as/README.md
+++ b/submissions/examples/zen-garden-as/README.md
@@ -1,0 +1,19 @@
+# Zen Garden
+
+A pure CSS and HTML karesansui: a raked sand garden with standing stones, the rake drawing its lines back and forth as cherry petals drift in.
+
+## What it shows
+
+- Straight rake furrows from a four stop repeating linear gradient that alternates shadow and highlight, so each groove has a lit and a dark face
+- Concentric ripple rings around the stones from repeating radial gradients using the same lit and dark trick
+- A wooden rake whose tined head is cut from a clip-path comb, sweeping across the sand
+- Weathered stones and moss from layered gradients inside a timber frame
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/zen-garden-as/demo.html
+++ b/submissions/examples/zen-garden-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zen Garden</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="frameZ"></span>
+    <span class="sandZ"></span>
+    <span class="ringZ rzA"></span>
+    <span class="ringZ rzB"></span>
+    <span class="ringZ rzC"></span>
+    <span class="rakeLines"></span>
+    <span class="rockZ rkA"></span>
+    <span class="rockZ rkB"></span>
+    <span class="rockZ rkC"></span>
+    <span class="mossZ"></span>
+    <div class="rakeZ">
+      <span class="rakeHead"></span>
+      <span class="rakeHandle"></span>
+    </div>
+    <span class="petalZ pz1"></span>
+    <span class="petalZ pz2"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/zen-garden-as/style.css
+++ b/submissions/examples/zen-garden-as/style.css
@@ -1,0 +1,222 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #6a5a44, #3a2f22);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.frameZ {
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+  background: linear-gradient(160deg, #8a6238, #4a3018);
+  box-shadow:
+    inset 0 0 0 3px rgba(220, 180, 110, 0.24),
+    0 18px 34px rgba(0, 0, 0, 0.45);
+  z-index: 1;
+}
+
+.sandZ {
+  position: absolute;
+  inset: 12px;
+  border-radius: 5px;
+  background:
+    radial-gradient(circle at 22% 30%, rgba(255, 250, 230, 0.24) 0 3px, transparent 4px),
+    radial-gradient(circle at 68% 62%, rgba(140, 120, 84, 0.2) 0 4px, transparent 5px),
+    linear-gradient(170deg, #ece2c6, #cfc2a0);
+  box-shadow: inset 0 4px 12px rgba(90, 74, 44, 0.3);
+  z-index: 2;
+}
+
+.rakeLines {
+  position: absolute;
+  inset: 12px;
+  border-radius: 5px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(150, 132, 92, 0.5) 0 1.5px,
+      transparent 1.5px 4px,
+      rgba(255, 252, 238, 0.5) 4px 5.5px,
+      transparent 5.5px 9px
+    );
+  z-index: 3;
+}
+
+.ringZ {
+  position: absolute;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(
+      circle at 50% 50%,
+      transparent 0 4px,
+      rgba(150, 132, 92, 0.5) 4px 5.5px,
+      transparent 5.5px 7px,
+      rgba(255, 252, 238, 0.55) 7px 8.5px
+    );
+  z-index: 4;
+  animation: settleZ 9s ease-in-out infinite;
+}
+
+.rzA {
+  top: 40px;
+  left: 34px;
+  width: 130px;
+  height: 130px;
+}
+
+.rzB {
+  bottom: 34px;
+  right: 40px;
+  width: 108px;
+  height: 108px;
+  animation-delay: 3s;
+}
+
+.rzC {
+  top: 52px;
+  right: 52px;
+  width: 76px;
+  height: 76px;
+  animation-delay: 6s;
+}
+
+.rockZ {
+  position: absolute;
+  background: linear-gradient(160deg, #7c7a72, #35342e);
+  box-shadow:
+    inset -5px -6px 12px rgba(10, 10, 6, 0.5),
+    0 6px 12px rgba(60, 50, 30, 0.4);
+  z-index: 5;
+}
+
+.rkA {
+  top: 78px;
+  left: 76px;
+  width: 46px;
+  height: 54px;
+  border-radius: 46% 54% 40% 50% / 50% 46% 54% 50%;
+}
+
+.rkB {
+  top: 104px;
+  left: 116px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50% 40% 54% 46% / 46% 54% 40% 50%;
+}
+
+.rkC {
+  bottom: 68px;
+  right: 76px;
+  width: 38px;
+  height: 34px;
+  border-radius: 54% 46% 46% 54% / 50% 50% 44% 50%;
+}
+
+.mossZ {
+  position: absolute;
+  top: 122px;
+  left: 70px;
+  width: 60px;
+  height: 18px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 24% 40%, #6a9a48 0 8px, transparent 9px),
+    radial-gradient(circle at 60% 50%, #557f38 0 9px, transparent 10px),
+    radial-gradient(circle at 84% 44%, #6a9a48 0 6px, transparent 7px);
+  z-index: 6;
+}
+
+.rakeZ {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 76px;
+  height: 150px;
+  margin-left: -14px;
+  transform-origin: 50% 0;
+  z-index: 7;
+  animation: rakeZ 9s ease-in-out infinite;
+}
+
+.rakeHandle {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 9px;
+  height: 120px;
+  margin-left: -4px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #6a4a26, #c69a5a 45%, #5a3e1e);
+  z-index: 2;
+}
+
+.rakeHead {
+  position: absolute;
+  top: 112px;
+  left: 50%;
+  width: 66px;
+  height: 22px;
+  margin-left: -33px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #6a4a26 0 4px,
+      transparent 4px 12px
+    ),
+    linear-gradient(180deg, #8a6238, #4a3018);
+  clip-path: polygon(0 0, 100% 0, 100% 34%, 92% 100%, 80% 34%, 66% 100%, 54% 34%, 40% 100%, 28% 34%, 14% 100%, 0 34%);
+  z-index: 3;
+}
+
+.petalZ {
+  position: absolute;
+  width: 14px;
+  height: 10px;
+  border-radius: 60% 10% 60% 10%;
+  background: radial-gradient(circle at 40% 34%, #ffd8e4, #f2a0bc 74%);
+  z-index: 8;
+  animation: fallPetalZ 11s ease-in infinite;
+}
+
+.pz1 { top: -14px; left: 60px; }
+.pz2 { top: -14px; right: 90px; animation-delay: 5.5s; }
+
+@keyframes rakeZ {
+  0%, 100% { transform: translateX(0) rotate(-6deg); }
+  50% { transform: translateX(-140px) rotate(6deg); }
+}
+
+@keyframes settleZ {
+  0%, 100% { opacity: 0.85; }
+  50% { opacity: 1; }
+}
+
+@keyframes fallPetalZ {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  10% { opacity: 1; }
+  100% { transform: translate(-40px, 320px) rotate(240deg); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rakeZ,
+  .ringZ,
+  .petalZ {
+    animation: none;
+  }
+
+  .petalZ {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML zen sand garden with a sweeping rake.

## Details

- Straight rake furrows from a four stop repeating linear gradient alternating shadow and highlight, so each groove has a lit and a dark face
- Concentric ripple rings around the stones from repeating radial gradients using the same trick
- A wooden rake whose tined head is cut from a clip-path comb, sweeping across the sand
- Weathered stones and moss from layered gradients inside a timber frame, with drifting cherry petals
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/zen-garden-as/demo.html`
- `submissions/examples/zen-garden-as/style.css`
- `submissions/examples/zen-garden-as/README.md`

Closes #47616
