### PR TITLE
feat: add scroll-to-top button example

### DIFF
--- a/submissions/examples/ease-scroll-top-btn-adrika4/README.md
+++ b/submissions/examples/ease-scroll-top-btn-adrika4/README.md
@@ -1,0 +1,21 @@
+# Scroll To Top Button
+
+A small, self-contained scroll-to-top button. Appears after scrolling
+300px down the page, and smooth-scrolls back to the top on click.
+
+## Usage
+
+Add the button markup:
+
+```html
+<button id="scrollTopBtn" aria-label="Scroll to top" title="Back to top">
+  ↑
+</button>
+```
+
+Link the stylesheet and include the small script shown in `demo.html`.
+
+## Why it fits EaseMotion CSS
+
+A tiny, reusable, human-readable UI utility with zero dependencies —
+drop it into any page for instant navigation convenience.

--- a/submissions/examples/ease-scroll-top-btn-adrika4/demo.html
+++ b/submissions/examples/ease-scroll-top-btn-adrika4/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Scroll To Top Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <h1>Scroll To Top Button Demo</h1>
+    <p>Scroll down to see the button appear in the bottom-right corner.</p>
+    <div style="height: 1500px;"></div>
+  </main>
+
+  <button id="scrollTopBtn" aria-label="Scroll to top" title="Back to top">
+    ↑
+  </button>
+
+  <script>
+    const scrollBtn = document.getElementById('scrollTopBtn');
+
+    window.addEventListener('scroll', () => {
+      scrollBtn.style.display = window.scrollY > 300 ? 'block' : 'none';
+    });
+
+    scrollBtn.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-top-btn-adrika4/style.css
+++ b/submissions/examples/ease-scroll-top-btn-adrika4/style.css
@@ -1,0 +1,21 @@
+#scrollTopBtn {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  z-index: 999;
+  display: none;
+  width: 48px;
+  height: 48px;
+  border: none;
+  border-radius: 50%;
+  background: #4f46e5;
+  color: #fff;
+  font-size: 20px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  transition: transform 0.2s ease;
+}
+
+#scrollTopBtn:hover {
+  transform: translateY(-4px);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a standalone, reusable scroll-to-top button as a new example
component (`submissions/examples/ease-scroll-top-btn-adrika4/`). Appears
after scrolling 300px down the page and smooth-scrolls back to top on click.

Closes #47642

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-scroll-top-btn-adrika4/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fixed-position scroll-to-top button that appears after scrolling past 300px and smooth-scrolls the page back to the top when clicked.

**How does a developer use it?**

```html
<button id="scrollTopBtn" aria-label="Scroll to top" title="Back to top">
  ↑
</button>
```

**Why does it fit EaseMotion CSS?**

A tiny, reusable, human-readable UI utility with zero dependencies — drop it into any page for instant navigation convenience.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Standalone new component, added as its own folder under `submissions/examples/`. No existing files modified — addresses issue #47642.