### PR TITLE
ease-scss-load-paths-sp

### DIFF
--- a/submissions/scss/ease-scss-load-paths-sp/README.md
+++ b/submissions/scss/ease-scss-load-paths-sp/README.md
@@ -1,0 +1,179 @@
+# SCSS `@use 'easemotion-css/scss'` Path Failures in Vite
+
+A setup-focused SCSS submission documenting why `@use 'easemotion-css/scss'` fails in some Vite/Next.js projects, and how to fix it with reliable load-path patterns.
+
+> Submission track: `submissions/scss/ease-scss-load-paths-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #47644
+
+---
+
+## What does this do?
+
+This guide closes a common setup gap: SCSS path resolution failures when importing the official EaseMotion SCSS layer.
+
+It provides:
+
+- failure pattern explanations (`includePaths`, alias confusion, workspace paths)
+- copy-ready Vite and Next.js snippets
+- mini troubleshooting recipes (`error -> cause -> fix`)
+- a tiny SCSS helper partial for safer fallback imports
+
+---
+
+## Common error symptoms
+
+Typical failures beginners see:
+
+```text
+Can't find stylesheet to import.
+  @use 'easemotion-css/scss';
+```
+
+```text
+[sass] Can't find stylesheet to import.
+```
+
+```text
+This module was already loaded, so it can't be configured using "with".
+```
+
+---
+
+## Why path failures happen
+
+1. **Missing package install**
+   - `easemotion-css` is not in `node_modules`.
+
+2. **Wrong resolver context**
+   - Sass is executed from a different working directory (monorepo/workspace).
+
+3. **Custom `includePaths` hides defaults**
+   - Loader config points only to `src/styles`, not `node_modules`.
+
+4. **Alias mismatch**
+   - Trying `@use '@/scss/easemotion-css'` without a valid alias mapping.
+
+5. **Mixing `@import` and `@use` incorrectly**
+   - Legacy import patterns can produce duplicate-load or config errors.
+
+---
+
+## Working Vite snippet
+
+Use plain package import first:
+
+```scss
+/* src/styles/main.scss */
+@use 'easemotion-css/scss' as ease;
+
+.hero {
+  @include ease.fade-in();
+}
+```
+
+Optional Vite config (only if your setup has custom load paths):
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+import path from 'node:path';
+
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        includePaths: [
+          path.resolve(process.cwd(), 'node_modules'),
+          path.resolve(process.cwd(), 'src/styles')
+        ]
+      }
+    }
+  }
+});
+```
+
+---
+
+## Working Next.js snippet
+
+```scss
+/* app/globals.scss (or styles/globals.scss) */
+@use 'easemotion-css/scss' as ease;
+
+.card {
+  @include ease.slide-up();
+}
+```
+
+```jsx
+// app/layout.js (App Router)
+import './globals.scss';
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+---
+
+## Mini recipes (`error -> cause -> fix`)
+
+### Recipe 1
+
+- **Error:** `Can't find stylesheet to import` on `@use 'easemotion-css/scss'`
+- **Cause:** Package missing
+- **Fix:** `npm install easemotion-css` (or `pnpm add easemotion-css`, `yarn add easemotion-css`)
+
+### Recipe 2
+
+- **Error:** Works locally, fails in CI
+- **Cause:** CI runs from a different working directory in monorepo
+- **Fix:** Ensure install in the app package and set consistent workspace root for Sass build
+
+### Recipe 3
+
+- **Error:** Sass resolves local files but not package paths
+- **Cause:** Narrow `includePaths` excludes `node_modules`
+- **Fix:** Add absolute `node_modules` path (see Vite snippet)
+
+### Recipe 4
+
+- **Error:** Duplicate load/config warning around `@use ... with (...)`
+- **Cause:** Module already loaded elsewhere
+- **Fix:** Load once at the top-level stylesheet and avoid multiple configured `@use` calls
+
+---
+
+## Included SCSS helper partial
+
+This submission includes:
+
+- `_ease-scss-load-paths-sp.scss`
+
+It demonstrates:
+
+- preferred package import with `@use 'easemotion-css/scss' as ease;`
+- optional local fallback for unusual workspace setups
+- tiny diagnostic helpers that keep output readable
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `_ease-scss-load-paths-sp.scss` | SCSS helper + safe import recipe examples |
+| `README.md` | Path-failure troubleshooting guide |
+
+---
+
+## Compliance notes
+
+- Only new files inside `submissions/scss/ease-scss-load-paths-sp/`
+- No edits to `core/`, `components/`, workflows, or root configs
+- Focused on setup/docs gap (not a mixin cookbook replacement)

--- a/submissions/scss/ease-scss-load-paths-sp/_ease-scss-load-paths-sp.scss
+++ b/submissions/scss/ease-scss-load-paths-sp/_ease-scss-load-paths-sp.scss
@@ -1,0 +1,55 @@
+// EaseMotion SCSS load-path helper
+// submissions/scss/ease-scss-load-paths-sp
+//
+// Purpose:
+// - Demonstrate stable @use patterns for "easemotion-css/scss"
+// - Provide tiny utility mixins for smoke-testing path resolution
+
+// Preferred path (works when node_modules resolution is healthy)
+@use 'easemotion-css/scss' as ease;
+
+// Optional fallback for unusual workspaces:
+// Uncomment only if your toolchain cannot resolve package paths.
+// @use '../../../scss/index' as ease;
+
+/// Emits a visible fallback style to verify SCSS compiled at all.
+/// This does NOT verify package path success by itself.
+@mixin em-path-smoke-style() {
+  outline: 2px dashed rgba(108, 99, 255, 0.45);
+  outline-offset: 3px;
+}
+
+/// Uses official EaseMotion mixins.
+/// If this compiles, your @use path to easemotion-css/scss is working.
+@mixin em-path-smoke-motion() {
+  @include ease.fade-in();
+}
+
+/// Mini recipe: safe hero entry animation with explicit namespace usage.
+@mixin em-hero-entry() {
+  @include ease.slide-up();
+}
+
+/// Mini recipe: subtle interactive card movement.
+@mixin em-card-interaction() {
+  @include ease.transition(transform, var(--ease-speed-fast), var(--ease-ease));
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-4px);
+  }
+}
+
+// Example classes (optional usage in your project)
+.em-path-check {
+  @include em-path-smoke-style();
+  @include em-path-smoke-motion();
+}
+
+.em-hero-entry {
+  @include em-hero-entry();
+}
+
+.em-card-interaction {
+  @include em-card-interaction();
+}


### PR DESCRIPTION
# #47644 issue resolved
## Description
This PR adds a SCSS setup troubleshooting guide for @use 'easemotion-css/scss' path failures under submissions/scss/ease-scss-load-paths-sp/.

## Features

- Explains common SCSS load-path failures in Vite/Next.js
- Covers includePaths and node_modules resolution pitfalls
- Provides working Vite and Next.js configuration snippets
- Includes mini troubleshooting recipes (error → cause → fix)
- Adds a reusable SCSS helper partial for import smoke-testing