### PR TITLE
Add perspective-tilt-tooltip-aaniya submission

### DIFF
--- a/submissions/examples/perspective-tilt-tooltip-aaniya/README.md
+++ b/submissions/examples/perspective-tilt-tooltip-aaniya/README.md
@@ -1,0 +1,46 @@
+# 3D Perspective Tilt Tooltip — Glassmorphism
+
+Closes #46316
+
+## What does this do?
+
+A glassmorphic tooltip that tilts in on a 3D perspective when its trigger is hovered or focused, settling flat as it becomes visible — a single CSS transition, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="tilt-tooltip">
+  <button class="tilt-tooltip__trigger" type="button">Hover me</button>
+  <div class="tilt-tooltip__bubble">
+    Your tooltip content here.
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.tilt-tooltip__trigger` reveals the adjacent `.tilt-tooltip__bubble`, which animates from a perspective-rotated, scaled-down state to flat and fully visible.
+
+Timing, easing, tilt angle, and reveal scale are all exposed as CSS custom properties, so consumers can override them per instance:
+
+```html
+<div class="tilt-tooltip" style="--ease-tilt-duration: 500ms; --ease-tilt-angle: 24deg; --ease-tilt-scale: 1.05;">
+  <button class="tilt-tooltip__trigger" type="button">Custom tilt</button>
+  <div class="tilt-tooltip__bubble">Slower, deeper tilt, slightly larger reveal.</div>
+</div>
+```
+
+## Why is it useful?
+
+Tooltips are a near-universal UI primitive, and this variant delivers the requested glassmorphism aeshetic — translucent, blurred background with a soft border — combined with a distinctive 3D perspective-tilt reveal rather than a flat fade or slide.
+
+- Needs **no JavaScript** — the whole effect is a single CSS `transition` on `transform`/`opacity`, using native `:hover`/`:focus-visible` and the adjacent-sibling selector.
+- Is keyboard accessible: the trigger is a real `<button>`, and `:focus-visible` triggers the same tilt reveal as mouse hover.
+- Exposes `--ease-tilt-duration`, `--ease-tilt-curve`, `--ease-tilt-angle`, `--ease-tilt-scale`, and `--ease-tilt-perspective` as custom properties, so consumers can tune timing, easing, tilt depth, and scale without touching the source CSS.
+- Respects `prefers-reduced-motion` by skipping the 3D rotation and only cross-fading for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file

--- a/submissions/examples/perspective-tilt-tooltip-aaniya/demo.html
+++ b/submissions/examples/perspective-tilt-tooltip-aaniya/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Perspective Tilt Tooltip — Glassmorphism</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>3D Perspective Tilt Tooltip</h1>
+  <p>A glassmorphic tooltip that tilts in on a 3D perspective when hovered or focused — pure CSS, no JavaScript.</p>
+
+  <div class="tilt-tooltip-grid">
+
+    <div class="tilt-tooltip">
+      <button class="tilt-tooltip__trigger" type="button">Hover me</button>
+      <div class="tilt-tooltip__bubble">
+        Default tilt: 320ms duration, 14° angle, 1x scale.
+      </div>
+    </div>
+
+    <div class="tilt-tooltip" style="--ease-tilt-duration: 500ms; --ease-tilt-angle: 24deg; --ease-tilt-scale: 1.05;">
+      <button class="tilt-tooltip__trigger" type="button">Slower + deeper tilt</button>
+      <div class="tilt-tooltip__bubble">
+        Customized via inline CSS variables: 500ms, 24° angle, 1.05x scale.
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/perspective-tilt-tooltip-aaniya/style.css
+++ b/submissions/examples/perspective-tilt-tooltip-aaniya/style.css
@@ -1,0 +1,130 @@
+/* ==========================================================================
+   3D Perspective Tilt Tooltip — Glassmorphism
+   A glassmorphic tooltip that tilts in on a 3D perspective when its
+   trigger is hovered or focused. Single CSS animation, no JavaScript.
+   Exposes timing, easing, and scale as CSS custom properties.
+   ========================================================================== */
+
+:root {
+  --ease-tilt-glass-bg: rgba(255, 255, 255, 0.14);
+  --ease-tilt-glass-border: rgba(255, 255, 255, 0.35);
+  --ease-tilt-text: #ffffff;
+  --ease-tilt-muted: rgba(255, 255, 255, 0.75);
+  --ease-tilt-page-bg-start: #232946;
+  --ease-tilt-page-bg-end: #121629;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-tilt-duration: 320ms;
+  --ease-tilt-curve: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-tilt-scale: 1;
+  --ease-tilt-angle: 14deg;
+  --ease-tilt-perspective: 700px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: linear-gradient(135deg, var(--ease-tilt-page-bg-start), var(--ease-tilt-page-bg-end));
+  border-radius: 16px;
+  color: var(--ease-tilt-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-tilt-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.tilt-tooltip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.tilt-tooltip {
+  position: relative;
+  display: inline-block;
+  perspective: var(--ease-tilt-perspective);
+}
+
+.tilt-tooltip__trigger {
+  padding: 10px 20px;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--ease-tilt-text);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--ease-tilt-glass-border);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.tilt-tooltip__trigger:focus-visible {
+  outline: 2px solid var(--ease-tilt-text);
+  outline-offset: 3px;
+}
+
+.tilt-tooltip__bubble {
+  position: absolute;
+  bottom: calc(100% + 14px);
+  left: 50%;
+  width: 220px;
+  padding: 14px 16px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--ease-tilt-text);
+  background: var(--ease-tilt-glass-bg);
+  border: 1px solid var(--ease-tilt-glass-border);
+  border-radius: 14px;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: 0 16px 32px rgba(10, 10, 30, 0.35);
+  pointer-events: none;
+
+  transform-style: preserve-3d;
+  transform-origin: bottom center;
+  transform: translateX(-50%) rotateX(var(--ease-tilt-angle)) scale(0.92);
+  opacity: 0;
+
+  /* The single animation this component demonstrates: the tooltip
+     tilts in on a 3D perspective and settles flat when revealed. */
+  transition:
+    transform var(--ease-tilt-duration) var(--ease-tilt-curve),
+    opacity var(--ease-tilt-duration) var(--ease-tilt-curve);
+}
+
+.tilt-tooltip__trigger:hover + .tilt-tooltip__bubble,
+.tilt-tooltip__trigger:focus-visible + .tilt-tooltip__bubble {
+  transform: translateX(-50%) rotateX(0deg) scale(var(--ease-tilt-scale));
+  opacity: 1;
+}
+
+.tilt-tooltip__bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  background: var(--ease-tilt-glass-bg);
+  border-right: 1px solid var(--ease-tilt-glass-border);
+  border-bottom: 1px solid var(--ease-tilt-glass-border);
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-tooltip__bubble {
+    transition: opacity var(--ease-tilt-duration) linear;
+    transform: translateX(-50%) rotateX(0deg) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .tilt-tooltip__bubble { width: 180px; }
+}


### PR DESCRIPTION
Closes #46316
## Pull Request Description
Adds a new glassmorphic tooltip submission — `perspective-tilt-tooltip-aaniya` — that tilts in on a 3D perspective when its trigger is hovered or focused, closing #46316.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/perspective-tilt-tooltip-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A glassmorphic tooltip that reveals with a 3D perspective tilt when its trigger is hovered or focused, settling flat as it becomes visible.

**How does a developer use it?**
```html
<div class="tilt-tooltip" style="--ease-tilt-duration: 500ms; --ease-tilt-angle: 24deg; --ease-tilt-scale: 1.05;">
  <button class="tilt-tooltip__trigger" type="button">Hover me</button>
  <div class="tilt-tooltip__bubble">Your tooltip content here.</div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS transition (`transform`/`opacity`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-tilt-duration`, `--ease-tilt-curve`, `--ease-tilt-angle`, `--ease-tilt-scale`, and `--ease-tilt-perspective` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Exposed timing, easing, tilt angle, and scale as `--ease-tilt-*` custom properties so consumers can override per instance without editing the source CSS — the demo shows a default and a customized example side by side. Happy to adjust default values if the maintainer prefers a subtler/stronger tilt.