### PR TITLE
Add perspective-tilt-tooltip-saas

### DIFF
--- a/submissions/examples/perspective-tilt-tooltip-saas-aaniya/README.md
+++ b/submissions/examples/perspective-tilt-tooltip-saas-aaniya/README.md
@@ -1,0 +1,50 @@
+# 3D Perspective Tilt Tooltip — SaaS Showcase
+
+Closes #46315
+
+## What does this do?
+
+A solid, crisp-shadow tooltip styled for SaaS product showcase layouts, tilting in on a 3D perspective when its trigger is hovered or focused and settling flat as it becomes visible — a single CSS transition, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="tilt-tooltip-saas">
+  <button class="tilt-tooltip-saas__trigger" type="button">Learn more</button>
+  <div class="tilt-tooltip-saas__bubble">
+    <span class="tilt-tooltip-saas__title">Team Analytics</span>
+    <span class="tilt-tooltip-saas__body">Track usage and engagement across your entire workspace in real time.</span>
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.tilt-tooltip-saas__trigger` reveals the adjacent `.tilt-tooltip-saas__bubble`, animating from a perspective-rotated, scaled-down state to flat and fully visible.
+
+Timing, easing, tilt angle, and reveal scale are exposed as CSS custom properties, so consumers can override them per instance:
+
+```html
+<div class="tilt-tooltip-saas" style="--ease-tilt-saas-duration: 450ms; --ease-tilt-saas-angle: 20deg; --ease-tilt-saas-scale: 1.04;">
+  <button class="tilt-tooltip-saas__trigger" type="button">Pricing details</button>
+  <div class="tilt-tooltip-saas__bubble">
+    <span class="tilt-tooltip-saas__title">Pro Plan</span>
+    <span class="tilt-tooltip-saas__body">Unlocks unlimited projects, priority support, and custom integrations.</span>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+SaaS product pages lean on tooltips constantly to explain features and plans without cluttering the layout. This variant matches that aesthetic directly — a solid white card, crisp drop shadow, and an accent top-border — paired with a distinctive 3D perspective-tilt reveal instead of a flat fade or slide.
+
+- Needs **no JavaScript** — the whole effect is a single CSS `transition` on `transform`/`opacity`, using native `:hover`/`:focus-visible` and the adjacent-sibling selector.
+- Is keyboard accessible: the trigger is a real `<button>`, and `:focus-visible` triggers the same tilt reveal as mouse hover.
+- Exposes `--ease-tilt-saas-duration`, `--ease-tilt-saas-curve`, `--ease-tilt-saas-angle`, `--ease-tilt-saas-scale`, and `--ease-tilt-saas-perspective` as custom properties, so consumers can tune timing, easing, tilt depth, and scale without touching the source CSS.
+- Respects `prefers-reduced-motion` by skipping the 3D rotation and only cross-fading for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file

--- a/submissions/examples/perspective-tilt-tooltip-saas-aaniya/demo.html
+++ b/submissions/examples/perspective-tilt-tooltip-saas-aaniya/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Perspective Tilt Tooltip — SaaS Showcase</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>3D Perspective Tilt Tooltip — SaaS Showcase</h1>
+  <p>A crisp, solid-card tooltip styled for SaaS product showcases, tilting in on a 3D perspective when hovered or focused — pure CSS, no JavaScript.</p>
+
+  <div class="tilt-tooltip-saas-grid">
+
+    <div class="tilt-tooltip-saas">
+      <button class="tilt-tooltip-saas__trigger" type="button">Learn more</button>
+      <div class="tilt-tooltip-saas__bubble">
+        <span class="tilt-tooltip-saas__title">Team Analytics</span>
+        <span class="tilt-tooltip-saas__body">Track usage and engagement across your entire workspace in real time.</span>
+      </div>
+    </div>
+
+    <div class="tilt-tooltip-saas" style="--ease-tilt-saas-duration: 450ms; --ease-tilt-saas-angle: 20deg; --ease-tilt-saas-scale: 1.04;">
+      <button class="tilt-tooltip-saas__trigger" type="button">Pricing details</button>
+      <div class="tilt-tooltip-saas__bubble">
+        <span class="tilt-tooltip-saas__title">Pro Plan</span>
+        <span class="tilt-tooltip-saas__body">Unlocks unlimited projects, priority support, and custom integrations.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/perspective-tilt-tooltip-saas-aaniya/style.css
+++ b/submissions/examples/perspective-tilt-tooltip-saas-aaniya/style.css
@@ -1,0 +1,130 @@
+/* ==========================================================================
+   3D Perspective Tilt Tooltip — SaaS Showcase
+   A solid, crisp-shadow tooltip styled for SaaS product showcase layouts,
+   tilting in on a 3D perspective when its trigger is hovered or focused.
+   Single CSS animation, no JavaScript. Exposes timing, easing, and scale
+   as CSS custom properties.
+   ========================================================================== */
+
+:root {
+  --ease-tilt-saas-bg: #ffffff;
+  --ease-tilt-saas-border: #e4e7ef;
+  --ease-tilt-saas-text: #1c2233;
+  --ease-tilt-saas-muted: #6b7284;
+  --ease-tilt-saas-accent: #4f46e5;
+  --ease-tilt-saas-page-bg: #f4f5fa;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-tilt-saas-duration: 280ms;
+  --ease-tilt-saas-curve: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-tilt-saas-scale: 1;
+  --ease-tilt-saas-angle: 12deg;
+  --ease-tilt-saas-perspective: 800px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-tilt-saas-page-bg);
+  border-radius: 16px;
+  color: var(--ease-tilt-saas-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-tilt-saas-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.tilt-tooltip-saas-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.tilt-tooltip-saas {
+  position: relative;
+  display: inline-block;
+  perspective: var(--ease-tilt-saas-perspective);
+}
+
+.tilt-tooltip-saas__trigger {
+  padding: 10px 20px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--ease-tilt-saas-accent);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.tilt-tooltip-saas__trigger:focus-visible {
+  outline: 2px solid var(--ease-tilt-saas-accent);
+  outline-offset: 3px;
+}
+
+.tilt-tooltip-saas__bubble {
+  position: absolute;
+  bottom: calc(100% + 14px);
+  left: 50%;
+  width: 230px;
+  padding: 16px 18px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-tilt-saas-text);
+  background: var(--ease-tilt-saas-bg);
+  border: 1px solid var(--ease-tilt-saas-border);
+  border-top: 3px solid var(--ease-tilt-saas-accent);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(30, 34, 60, 0.16);
+  pointer-events: none;
+
+  transform-style: preserve-3d;
+  transform-origin: bottom center;
+  transform: translateX(-50%) rotateX(var(--ease-tilt-saas-angle)) scale(0.92);
+  opacity: 0;
+
+  /* The single animation this component demonstrates: the tooltip
+     tilts in on a 3D perspective and settles flat when revealed. */
+  transition:
+    transform var(--ease-tilt-saas-duration) var(--ease-tilt-saas-curve),
+    opacity var(--ease-tilt-saas-duration) var(--ease-tilt-saas-curve);
+}
+
+.tilt-tooltip-saas__trigger:hover + .tilt-tooltip-saas__bubble,
+.tilt-tooltip-saas__trigger:focus-visible + .tilt-tooltip-saas__bubble {
+  transform: translateX(-50%) rotateX(0deg) scale(var(--ease-tilt-saas-scale));
+  opacity: 1;
+}
+
+.tilt-tooltip-saas__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+  color: var(--ease-tilt-saas-text);
+}
+
+.tilt-tooltip-saas__body {
+  color: var(--ease-tilt-saas-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-tooltip-saas__bubble {
+    transition: opacity var(--ease-tilt-saas-duration) linear;
+    transform: translateX(-50%) rotateX(0deg) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .tilt-tooltip-saas__bubble { width: 190px; }
+}


### PR DESCRIPTION
Closes #46315
## Pull Request Description
Adds a new SaaS-showcase-styled tooltip submission — `perspective-tilt-tooltip-saas-aaniya` — that tilts in on a 3D perspective when its trigger is hovered or focused, closing #46315.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/perspective-tilt-tooltip-saas-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A solid, crisp-shadow tooltip styled for SaaS product showcase layouts, reveals with a 3D perspective tilt when its trigger is hovered or focused.

**How does a developer use it?**
```html
<div class="tilt-tooltip-saas" style="--ease-tilt-saas-duration: 450ms; --ease-tilt-saas-angle: 20deg; --ease-tilt-saas-scale: 1.04;">
  <button class="tilt-tooltip-saas__trigger" type="button">Pricing details</button>
  <div class="tilt-tooltip-saas__bubble">
    <span class="tilt-tooltip-saas__title">Pro Plan</span>
    <span class="tilt-tooltip-saas__body">Unlocks unlimited projects, priority support, and custom integrations.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS transition (`transform`/`opacity`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-tilt-saas-duration`, `--ease-tilt-saas-curve`, `--ease-tilt-saas-angle`, `--ease-tilt-saas-scale`, and `--ease-tilt-saas-perspective` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Styled with a solid card, crisp shadow, and accent top-border to match SaaS product showcase aesthetics — distinct from the separate glassmorphism tilt-tooltip submission (#46316) which uses a translucent glass treatment. Timing, easing, tilt angle, and scale are all exposed as `--ease-tilt-saas-*` custom properties for per-instance customization.