### PR TITLE
Add perspective-tilt-tooltip-dashboard

### DIFF
--- a/submissions/examples/perspective-tilt-tooltip-dashboard-aaniya/README.md
+++ b/submissions/examples/perspective-tilt-tooltip-dashboard-aaniya/README.md
@@ -1,0 +1,49 @@
+# 3D Perspective Tilt Tooltip — Dashboard Analytics
+
+Closes #46311
+
+## What does this do?
+
+A dark data-panel tooltip styled for analytics dashboards, tilting in on a 3D perspective when its trigger is hovered or focused and settling flat as it becomes visible — a single CSS transition, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="tilt-tooltip-dash">
+  <button class="tilt-tooltip-dash__trigger" type="button">Active Users</button>
+  <div class="tilt-tooltip-dash__bubble">
+    <div class="tilt-tooltip-dash__metric-row">
+      <span class="tilt-tooltip-dash__label">12,480</span>
+      <span class="tilt-tooltip-dash__delta">+8.2%</span>
+    </div>
+    <span class="tilt-tooltip-dash__body">Daily active users, last 30 days.</span>
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.tilt-tooltip-dash__trigger` reveals the adjacent `.tilt-tooltip-dash__bubble`, animating from a perspective-rotated, scaled-down state to flat and fully visible.
+
+Timing, easing, tilt angle, and reveal scale are exposed as CSS custom properties, so consumers can override them per instance:
+
+```html
+<div class="tilt-tooltip-dash" style="--ease-tilt-dash-duration: 420ms; --ease-tilt-dash-angle: 22deg; --ease-tilt-dash-scale: 1.05;">
+  ...
+</div>
+```
+
+## Why is it useful?
+
+Analytics dashboards constantly need contextual tooltips for metrics — trend deltas, sparklines, and short explainer text — without disrupting the surrounding data density. This variant matches that aesthetic directly: a dark panel, metric/delta row, and an inline sparkline slot, paired with a distinctive 3D perspective-tilt reveal instead of a flat fade or slide.
+
+- Needs **no JavaScript** — the whole effect is a single CSS `transition` on `transform`/`opacity`, using native `:hover`/`:focus-visible` and the adjacent-sibling selector.
+- Is keyboard accessible: the trigger is a real `<button>`, and `:focus-visible` triggers the same tilt reveal as mouse hover.
+- Exposes `--ease-tilt-dash-duration`, `--ease-tilt-dash-curve`, `--ease-tilt-dash-angle`, `--ease-tilt-dash-scale`, and `--ease-tilt-dash-perspective` as custom properties, so consumers can tune timing, easing, tilt depth, and scale without touching the source CSS.
+- Respects `prefers-reduced-motion` by skipping the 3D rotation and only cross-fading for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file

--- a/submissions/examples/perspective-tilt-tooltip-dashboard-aaniya/demo.html
+++ b/submissions/examples/perspective-tilt-tooltip-dashboard-aaniya/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Perspective Tilt Tooltip — Dashboard Analytics</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>3D Perspective Tilt Tooltip — Dashboard Analytics</h1>
+  <p>A dark data-panel tooltip styled for analytics dashboards, tilting in on a 3D perspective when hovered or focused — pure CSS, no JavaScript.</p>
+
+  <div class="tilt-tooltip-dash-grid">
+
+    <div class="tilt-tooltip-dash">
+      <button class="tilt-tooltip-dash__trigger" type="button">Active Users</button>
+      <div class="tilt-tooltip-dash__bubble">
+        <div class="tilt-tooltip-dash__metric-row">
+          <span class="tilt-tooltip-dash__label">12,480</span>
+          <span class="tilt-tooltip-dash__delta">+8.2%</span>
+        </div>
+        <span class="tilt-tooltip-dash__body">Daily active users, last 30 days.</span>
+        <svg class="tilt-tooltip-dash__spark" viewBox="0 0 200 28" preserveAspectRatio="none">
+          <polyline points="0,22 30,18 60,20 90,10 120,14 150,6 180,9 200,4"
+            fill="none" stroke="#22d3ee" stroke-width="2" />
+        </svg>
+      </div>
+    </div>
+
+    <div class="tilt-tooltip-dash" style="--ease-tilt-dash-duration: 420ms; --ease-tilt-dash-angle: 22deg; --ease-tilt-dash-scale: 1.05;">
+      <button class="tilt-tooltip-dash__trigger" type="button">Conversion Rate</button>
+      <div class="tilt-tooltip-dash__bubble">
+        <div class="tilt-tooltip-dash__metric-row">
+          <span class="tilt-tooltip-dash__label">4.6%</span>
+          <span class="tilt-tooltip-dash__delta">+1.1%</span>
+        </div>
+        <span class="tilt-tooltip-dash__body">Visitors converted to signups this week.</span>
+        <svg class="tilt-tooltip-dash__spark" viewBox="0 0 200 28" preserveAspectRatio="none">
+          <polyline points="0,20 30,22 60,16 90,18 120,10 150,12 180,6 200,8"
+            fill="none" stroke="#6a5cff" stroke-width="2" />
+        </svg>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/perspective-tilt-tooltip-dashboard-aaniya/style.css
+++ b/submissions/examples/perspective-tilt-tooltip-dashboard-aaniya/style.css
@@ -1,0 +1,148 @@
+/* ==========================================================================
+   3D Perspective Tilt Tooltip — Dashboard Analytics
+   A dark data-panel tooltip styled for analytics dashboards, tilting in
+   on a 3D perspective when its trigger is hovered or focused. Single CSS
+   animation, no JavaScript. Exposes timing, easing, and scale as CSS
+   custom properties.
+   ========================================================================== */
+
+:root {
+  --ease-tilt-dash-bg: #1a1f36;
+  --ease-tilt-dash-border: #2e3550;
+  --ease-tilt-dash-text: #eef0ff;
+  --ease-tilt-dash-muted: #9aa0c3;
+  --ease-tilt-dash-accent: #22d3ee;
+  --ease-tilt-dash-accent-2: #6a5cff;
+  --ease-tilt-dash-page-bg: #0d1021;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-tilt-dash-duration: 300ms;
+  --ease-tilt-dash-curve: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-tilt-dash-scale: 1;
+  --ease-tilt-dash-angle: 16deg;
+  --ease-tilt-dash-perspective: 750px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-tilt-dash-page-bg);
+  border-radius: 16px;
+  color: var(--ease-tilt-dash-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-tilt-dash-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.tilt-tooltip-dash-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.tilt-tooltip-dash {
+  position: relative;
+  display: inline-block;
+  perspective: var(--ease-tilt-dash-perspective);
+}
+
+.tilt-tooltip-dash__trigger {
+  padding: 10px 20px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ease-tilt-dash-text);
+  background: #232946;
+  border: 1px solid var(--ease-tilt-dash-border);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.tilt-tooltip-dash__trigger:focus-visible {
+  outline: 2px solid var(--ease-tilt-dash-accent);
+  outline-offset: 3px;
+}
+
+.tilt-tooltip-dash__bubble {
+  position: absolute;
+  bottom: calc(100% + 14px);
+  left: 50%;
+  width: 240px;
+  padding: 16px 18px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-tilt-dash-text);
+  background: var(--ease-tilt-dash-bg);
+  border: 1px solid var(--ease-tilt-dash-border);
+  border-radius: 12px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+
+  transform-style: preserve-3d;
+  transform-origin: bottom center;
+  transform: translateX(-50%) rotateX(var(--ease-tilt-dash-angle)) scale(0.92);
+  opacity: 0;
+
+  /* The single animation this component demonstrates: the tooltip
+     tilts in on a 3D perspective and settles flat when revealed. */
+  transition:
+    transform var(--ease-tilt-dash-duration) var(--ease-tilt-dash-curve),
+    opacity var(--ease-tilt-dash-duration) var(--ease-tilt-dash-curve);
+}
+
+.tilt-tooltip-dash__trigger:hover + .tilt-tooltip-dash__bubble,
+.tilt-tooltip-dash__trigger:focus-visible + .tilt-tooltip-dash__bubble {
+  transform: translateX(-50%) rotateX(0deg) scale(var(--ease-tilt-dash-scale));
+  opacity: 1;
+}
+
+.tilt-tooltip-dash__metric-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.tilt-tooltip-dash__label {
+  font-weight: 700;
+  color: var(--ease-tilt-dash-text);
+}
+
+.tilt-tooltip-dash__delta {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--ease-tilt-dash-accent);
+}
+
+.tilt-tooltip-dash__body {
+  color: var(--ease-tilt-dash-muted);
+}
+
+.tilt-tooltip-dash__spark {
+  display: block;
+  width: 100%;
+  height: 28px;
+  margin-top: 10px;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-tooltip-dash__bubble {
+    transition: opacity var(--ease-tilt-dash-duration) linear;
+    transform: translateX(-50%) rotateX(0deg) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .tilt-tooltip-dash__bubble { width: 200px; }
+}


### PR DESCRIPTION
Closes #46311
## Pull Request Description
Adds a new dashboard-analytics-styled tooltip submission — `perspective-tilt-tooltip-dashboard-aaniya` — that tilts in on a 3D perspective when its trigger is hovered or focused, closing #46311.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/perspective-tilt-tooltip-dashboard-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A dark data-panel tooltip styled for analytics dashboards, with a metric/delta row and sparkline slot, revealing with a 3D perspective tilt on hover or focus.

**How does a developer use it?**
```html
<div class="tilt-tooltip-dash">
  <button class="tilt-tooltip-dash__trigger" type="button">Active Users</button>
  <div class="tilt-tooltip-dash__bubble">
    <div class="tilt-tooltip-dash__metric-row">
      <span class="tilt-tooltip-dash__label">12,480</span>
      <span class="tilt-tooltip-dash__delta">+8.2%</span>
    </div>
    <span class="tilt-tooltip-dash__body">Daily active users, last 30 days.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS transition (`transform`/`opacity`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-tilt-dash-duration`, `--ease-tilt-dash-curve`, `--ease-tilt-dash-angle`, `--ease-tilt-dash-scale`, and `--ease-tilt-dash-perspective` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Styled with a dark panel, metric/delta row, and an inline SVG sparkline to match analytics dashboard conventions — distinct from the separate glassmorphism (#46316) and SaaS showcase (#46315) tilt-tooltip submissions. Timing, easing, tilt angle, and scale are exposed as `--ease-tilt-dash-*` custom properties for per-instance customization.