### PR TITLE
Add perspective-tilt-tooltip-modern-saas

### DIFF
--- a/submissions/examples/perspective-tilt-tooltip-modern-saas-aaniya/README.md
+++ b/submissions/examples/perspective-tilt-tooltip-modern-saas-aaniya/README.md
@@ -1,0 +1,50 @@
+# 3D Perspective Tilt Tooltip — Modern SaaS
+
+Closes #46310
+
+## What does this do?
+
+A gradient-bordered, pill-shaped tooltip styled for modern SaaS product layouts, tilting in on a 3D perspective when its trigger is hovered or focused and settling flat as it becomes visible — a single CSS transition, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="tilt-tooltip-modern">
+  <button class="tilt-tooltip-modern__trigger" type="button">Get Started</button>
+  <div class="tilt-tooltip-modern__bubble">
+    <span class="tilt-tooltip-modern__title">Onboard in minutes</span>
+    <span class="tilt-tooltip-modern__body">No credit card required. Set up your workspace and invite your team instantly.</span>
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.tilt-tooltip-modern__trigger` reveals the adjacent `.tilt-tooltip-modern__bubble`, animating from a perspective-rotated, scaled-down state to flat and fully visible.
+
+Timing, easing, tilt angle, and reveal scale are exposed as CSS custom properties, so consumers can override them per instance:
+
+```html
+<div class="tilt-tooltip-modern" style="--ease-tilt-modern-duration: 400ms; --ease-tilt-modern-angle: 22deg; --ease-tilt-modern-scale: 1.05;">
+  ...
+</div>
+```
+
+## Why is it useful?
+
+Modern SaaS marketing and onboarding surfaces increasingly lean on soft gradients, pill-shaped buttons, and glowing accents rather than flat cards. This variant matches that aesthetic directly — a gradient-bordered pill trigger, a gradient-clipped title, and a soft colored glow — paired with a distinctive 3D perspective-tilt reveal instead of a flat fade or slide.
+
+- Needs **no JavaScript** — the whole effect is a single CSS `transition` on `transform`/`opacity`, using native `:hover`/`:focus-visible` and the adjacent-sibling selector.
+- Is keyboard accessible: the trigger is a real `<button>`, and `:focus-visible` triggers the same tilt reveal as mouse hover.
+- Exposes `--ease-tilt-modern-duration`, `--ease-tilt-modern-curve`, `--ease-tilt-modern-angle`, `--ease-tilt-modern-scale`, and `--ease-tilt-modern-perspective` as custom properties, so consumers can tune timing, easing, tilt depth, and scale without touching the source CSS.
+- Respects `prefers-reduced-motion` by skipping the 3D rotation and only cross-fading for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file
+
+## Note on related submissions
+
+This repo has several similarly-titled tilt-tooltip issues (glassmorphism, SaaS showcase, dashboard analytics, modern SaaS). This submission is deliberately styled distinctly from `perspective-tilt-tooltip-saas` (#46315) — using a gradient border, pill shape, and gradient-clipped text instead of a solid white card with a flat accent border — to avoid duplicating that variant's visual treatment.

--- a/submissions/examples/perspective-tilt-tooltip-modern-saas-aaniya/demo.html
+++ b/submissions/examples/perspective-tilt-tooltip-modern-saas-aaniya/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Perspective Tilt Tooltip — Modern SaaS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>3D Perspective Tilt Tooltip — Modern SaaS</h1>
+  <p>A gradient-bordered, pill-shaped tooltip styled for modern SaaS product layouts, tilting in on a 3D perspective when hovered or focused — pure CSS, no JavaScript.</p>
+
+  <div class="tilt-tooltip-modern-grid">
+
+    <div class="tilt-tooltip-modern">
+      <button class="tilt-tooltip-modern__trigger" type="button">Get Started</button>
+      <div class="tilt-tooltip-modern__bubble">
+        <span class="tilt-tooltip-modern__title">Onboard in minutes</span>
+        <span class="tilt-tooltip-modern__body">No credit card required. Set up your workspace and invite your team instantly.</span>
+      </div>
+    </div>
+
+    <div class="tilt-tooltip-modern" style="--ease-tilt-modern-duration: 400ms; --ease-tilt-modern-angle: 22deg; --ease-tilt-modern-scale: 1.05;">
+      <button class="tilt-tooltip-modern__trigger" type="button">Explore Features</button>
+      <div class="tilt-tooltip-modern__bubble">
+        <span class="tilt-tooltip-modern__title">Built for scale</span>
+        <span class="tilt-tooltip-modern__body">Automations, integrations, and real-time collaboration in one platform.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/perspective-tilt-tooltip-modern-saas-aaniya/style.css
+++ b/submissions/examples/perspective-tilt-tooltip-modern-saas-aaniya/style.css
@@ -1,0 +1,142 @@
+/* ==========================================================================
+   3D Perspective Tilt Tooltip — Modern SaaS
+   A gradient-bordered, pill-shaped tooltip styled for modern SaaS product
+   layouts, tilting in on a 3D perspective when its trigger is hovered or
+   focused. Single CSS animation, no JavaScript. Exposes timing, easing,
+   and scale as CSS custom properties.
+
+   Note: distinct in treatment from the "SaaS Showcase" variant
+   (perspective-tilt-tooltip-saas) — that one uses a solid white card with
+   a flat accent border; this one uses a gradient border, pill shape, and
+   soft glow to match a more modern, gradient-driven SaaS aesthetic.
+   ========================================================================== */
+
+:root {
+  --ease-tilt-modern-bg: #ffffff;
+  --ease-tilt-modern-text: #201a3d;
+  --ease-tilt-modern-muted: #6f6a94;
+  --ease-tilt-modern-grad-start: #ff6ec7;
+  --ease-tilt-modern-grad-end: #7c5cff;
+  --ease-tilt-modern-page-bg: #f7f5ff;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-tilt-modern-duration: 300ms;
+  --ease-tilt-modern-curve: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-tilt-modern-scale: 1;
+  --ease-tilt-modern-angle: 15deg;
+  --ease-tilt-modern-perspective: 750px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-tilt-modern-page-bg);
+  border-radius: 16px;
+  color: var(--ease-tilt-modern-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-tilt-modern-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.tilt-tooltip-modern-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.tilt-tooltip-modern {
+  position: relative;
+  display: inline-block;
+  perspective: var(--ease-tilt-modern-perspective);
+}
+
+.tilt-tooltip-modern__trigger {
+  padding: 10px 22px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--ease-tilt-modern-grad-start), var(--ease-tilt-modern-grad-end));
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.tilt-tooltip-modern__trigger:focus-visible {
+  outline: 2px solid var(--ease-tilt-modern-grad-end);
+  outline-offset: 3px;
+}
+
+.tilt-tooltip-modern__bubble {
+  position: absolute;
+  bottom: calc(100% + 16px);
+  left: 50%;
+  width: 230px;
+  padding: 16px 18px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-tilt-modern-text);
+
+  /* Gradient border via layered background (padding-box + border-box) */
+  background:
+    linear-gradient(var(--ease-tilt-modern-bg), var(--ease-tilt-modern-bg)) padding-box,
+    linear-gradient(135deg, var(--ease-tilt-modern-grad-start), var(--ease-tilt-modern-grad-end)) border-box;
+  border: 2px solid transparent;
+  border-radius: 20px;
+
+  box-shadow: 0 18px 40px rgba(124, 92, 255, 0.25);
+  pointer-events: none;
+
+  transform-style: preserve-3d;
+  transform-origin: bottom center;
+  transform: translateX(-50%) rotateX(var(--ease-tilt-modern-angle)) scale(0.92);
+  opacity: 0;
+
+  /* The single animation this component demonstrates: the tooltip
+     tilts in on a 3D perspective and settles flat when revealed. */
+  transition:
+    transform var(--ease-tilt-modern-duration) var(--ease-tilt-modern-curve),
+    opacity var(--ease-tilt-modern-duration) var(--ease-tilt-modern-curve);
+}
+
+.tilt-tooltip-modern__trigger:hover + .tilt-tooltip-modern__bubble,
+.tilt-tooltip-modern__trigger:focus-visible + .tilt-tooltip-modern__bubble {
+  transform: translateX(-50%) rotateX(0deg) scale(var(--ease-tilt-modern-scale));
+  opacity: 1;
+}
+
+.tilt-tooltip-modern__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+  background: linear-gradient(135deg, var(--ease-tilt-modern-grad-start), var(--ease-tilt-modern-grad-end));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.tilt-tooltip-modern__body {
+  color: var(--ease-tilt-modern-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-tooltip-modern__bubble {
+    transition: opacity var(--ease-tilt-modern-duration) linear;
+    transform: translateX(-50%) rotateX(0deg) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .tilt-tooltip-modern__bubble { width: 190px; }
+}


### PR DESCRIPTION
Closes #46310
## Pull Request Description
Adds a new modern-SaaS-styled tooltip submission — `perspective-tilt-tooltip-modern-saas-aaniya` — that tilts in on a 3D perspective when its trigger is hovered or focused, closing #46310.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/perspective-tilt-tooltip-modern-saas-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A gradient-bordered, pill-shaped tooltip styled for modern SaaS product layouts, revealing with a 3D perspective tilt on hover or focus.

**How does a developer use it?**
```html
<div class="tilt-tooltip-modern">
  <button class="tilt-tooltip-modern__trigger" type="button">Get Started</button>
  <div class="tilt-tooltip-modern__bubble">
    <span class="tilt-tooltip-modern__title">Onboard in minutes</span>
    <span class="tilt-tooltip-modern__body">No credit card required. Set up your workspace and invite your team instantly.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS transition (`transform`/`opacity`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-tilt-modern-duration`, `--ease-tilt-modern-curve`, `--ease-tilt-modern-angle`, `--ease-tilt-modern-scale`, and `--ease-tilt-modern-perspective` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This repo has several similarly-titled tilt-tooltip issues (glassmorphism #46316, SaaS showcase #46315, dashboard analytics #46311, modern SaaS #46310). I deliberately styled this one distinctly from `perspective-tilt-tooltip-saas` (#46315) — gradient border, pill shape, and gradient-clipped title text, versus that variant's solid white card with a flat accent border — to avoid visual duplication. Happy to adjust further if the maintainer feels there's still too much overlap.