### PR TITLE
Add magnetic-pull-tooltip

### DIFF
--- a/submissions/examples/magnetic-pull-tooltip-aaniya/README.md
+++ b/submissions/examples/magnetic-pull-tooltip-aaniya/README.md
@@ -1,0 +1,46 @@
+# Magnetic Pull Tooltip — Creative Portfolio
+
+Closes #46308
+
+## What does this do?
+
+A bold tooltip that appears to get pulled in like a magnet toward its trigger, snapping into place with a bouncy overshoot — a single CSS `@keyframes` animation, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="magnet-tooltip">
+  <button class="magnet-tooltip__trigger" type="button">View Project</button>
+  <div class="magnet-tooltip__bubble">
+    <span class="magnet-tooltip__title">Neon Horizons</span>
+    <span class="magnet-tooltip__body">A generative art series exploring light and motion, 2025.</span>
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.magnet-tooltip__trigger` reveals the adjacent `.magnet-tooltip__bubble`, which plays the `ease-magnet-pull` animation: it starts offset and shrunk, overshoots slightly as it "snaps" toward the trigger, then settles into place.
+
+Timing, easing, pull distance, and settle scale are exposed as CSS custom properties, so consumers can override them per instance:
+
+```html
+<div class="magnet-tooltip" style="--ease-magnet-duration: 750ms; --ease-magnet-pull-distance: 40px; --ease-magnet-scale: 1.05;">
+  ...
+</div>
+```
+
+## Why is it useful?
+
+Creative portfolio sites lean into bold, playful interactions rather than subtle corporate UI patterns. This tooltip matches that energy with a distinctive "magnetic snap" motion — a bright accent-bordered card that visibly gets pulled toward its trigger rather than fading or sliding in flatly.
+
+- Needs **no JavaScript** — the whole effect is a single CSS `@keyframes` animation triggered by native `:hover`/`:focus-visible` and the adjacent-sibling selector.
+- Is keyboard accessible: the trigger is a real `<button>`, and `:focus-visible` triggers the same pull-in animation as mouse hover.
+- Exposes `--ease-magnet-duration`, `--ease-magnet-curve`, `--ease-magnet-scale`, and `--ease-magnet-pull-distance` as custom properties, so consumers can tune timing, easing, overshoot feel, and pull distance without touching the source CSS.
+- Respects `prefers-reduced-motion` by skipping straight to the final, settled state for users who've opted out of motion.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable and keyframe names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable/keyframe names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file

--- a/submissions/examples/magnetic-pull-tooltip-aaniya/demo.html
+++ b/submissions/examples/magnetic-pull-tooltip-aaniya/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Magnetic Pull Tooltip — Creative Portfolio</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Magnetic Pull Tooltip</h1>
+  <p>A bold tooltip that snaps into place like it's being magnetically pulled toward its trigger — pure CSS, no JavaScript.</p>
+
+  <div class="magnet-tooltip-grid">
+
+    <div class="magnet-tooltip">
+      <button class="magnet-tooltip__trigger" type="button">View Project</button>
+      <div class="magnet-tooltip__bubble">
+        <span class="magnet-tooltip__title">Neon Horizons</span>
+        <span class="magnet-tooltip__body">A generative art series exploring light and motion, 2025.</span>
+      </div>
+    </div>
+
+    <div class="magnet-tooltip" style="--ease-magnet-duration: 750ms; --ease-magnet-pull-distance: 40px; --ease-magnet-scale: 1.05;">
+      <button class="magnet-tooltip__trigger" type="button">About Me</button>
+      <div class="magnet-tooltip__bubble">
+        <span class="magnet-tooltip__title">Maya Chen</span>
+        <span class="magnet-tooltip__body">Visual artist and motion designer based in Brooklyn, NY.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-tooltip-aaniya/style.css
+++ b/submissions/examples/magnetic-pull-tooltip-aaniya/style.css
@@ -1,0 +1,144 @@
+/* ==========================================================================
+   Magnetic Pull Tooltip — Creative Portfolio
+   A bold tooltip that appears to get pulled in like a magnet toward its
+   trigger, snapping into place with a slight overshoot. Single CSS
+   animation, no JavaScript. Exposes timing, easing, and scale as CSS
+   custom properties.
+   ========================================================================== */
+
+:root {
+  --ease-magnet-bg: #0e0e12;
+  --ease-magnet-text: #f5f4ff;
+  --ease-magnet-muted: #b3aecf;
+  --ease-magnet-accent: #ff4d8d;
+  --ease-magnet-accent-2: #ffd23f;
+  --ease-magnet-page-bg: #1a1720;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-magnet-duration: 550ms;
+  --ease-magnet-curve: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-magnet-scale: 1;
+  --ease-magnet-pull-distance: 26px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-magnet-page-bg);
+  border-radius: 16px;
+  color: var(--ease-magnet-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-magnet-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.magnet-tooltip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.magnet-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.magnet-tooltip__trigger {
+  padding: 12px 24px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--ease-magnet-text);
+  background: transparent;
+  border: 2px solid var(--ease-magnet-accent);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.magnet-tooltip__trigger:focus-visible {
+  outline: 2px solid var(--ease-magnet-accent-2);
+  outline-offset: 3px;
+}
+
+.magnet-tooltip__bubble {
+  position: absolute;
+  bottom: calc(100% + 18px);
+  left: 50%;
+  width: 230px;
+  padding: 16px 18px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-magnet-text);
+  background: var(--ease-magnet-bg);
+  border: 2px solid var(--ease-magnet-accent);
+  border-radius: 14px;
+  box-shadow: 0 0 0 4px rgba(255, 77, 141, 0.12), 0 20px 40px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  /* Starts pulled away (below/offset), gets "pulled in" magnetically
+     toward the trigger with a bouncy overshoot. */
+  transform: translateX(-50%) translateY(var(--ease-magnet-pull-distance)) scale(0.85);
+}
+
+/* The single animation this component demonstrates: the tooltip snaps
+   in from a distance like it's being magnetically pulled toward the
+   trigger, with a bouncy overshoot on arrival. */
+@keyframes ease-magnet-pull {
+  0% {
+    transform: translateX(-50%) translateY(var(--ease-magnet-pull-distance)) scale(0.85);
+    opacity: 0;
+  }
+  60% {
+    transform: translateX(-50%) translateY(-4px) scale(calc(var(--ease-magnet-scale) * 1.03));
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(var(--ease-magnet-scale));
+    opacity: 1;
+  }
+}
+
+.magnet-tooltip__trigger:hover + .magnet-tooltip__bubble,
+.magnet-tooltip__trigger:focus-visible + .magnet-tooltip__bubble {
+  visibility: visible;
+  animation: ease-magnet-pull var(--ease-magnet-duration) var(--ease-magnet-curve) forwards;
+}
+
+.magnet-tooltip__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+  color: var(--ease-magnet-accent-2);
+}
+
+.magnet-tooltip__body {
+  color: var(--ease-magnet-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .magnet-tooltip__trigger:hover + .magnet-tooltip__bubble,
+  .magnet-tooltip__trigger:focus-visible + .magnet-tooltip__bubble {
+    animation: none;
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .magnet-tooltip__bubble { width: 190px; }
+}


### PR DESCRIPTION
Closes #46308
## Pull Request Description
Adds a new creative-portfolio-styled tooltip submission — `magnetic-pull-tooltip-aaniya` — that snaps into place like it's being magnetically pulled toward its trigger, closing #46308.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-tooltip-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A bold tooltip that appears to get pulled in like a magnet toward its trigger, snapping into place with a bouncy overshoot on hover or focus.

**How does a developer use it?**
```html
<div class="magnet-tooltip">
  <button class="magnet-tooltip__trigger" type="button">View Project</button>
  <div class="magnet-tooltip__bubble">
    <span class="magnet-tooltip__title">Neon Horizons</span>
    <span class="magnet-tooltip__body">A generative art series exploring light and motion, 2025.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS `@keyframes` animation (`ease-magnet-pull`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-magnet-duration`, `--ease-magnet-curve`, `--ease-magnet-scale`, and `--ease-magnet-pull-distance` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Styled with a bold accent-bordered dark card to match creative portfolio aesthetics — this is a distinct interaction pattern (snap/overshoot) from the separate 3D perspective-tilt tooltip submissions, so no overlap there. Happy to tune the overshoot intensity or pull distance if the maintainer prefers something subtler.