### PR TITLE
Add magnetic-pull-tooltip-a11y

### DIFF
--- a/submissions/examples/magnetic-pull-tooltip-a11y-aaniya/README.md
+++ b/submissions/examples/magnetic-pull-tooltip-a11y-aaniya/README.md
@@ -1,0 +1,58 @@
+# Magnetic Pull Tooltip — Accessible Web Layouts
+
+Closes #46307
+
+## What does this do?
+
+A high-contrast tooltip that snaps into place with a magnetic pull motion when its trigger is hovered or focused — built with accessibility as the primary design driver, using a single CSS `@keyframes` animation and no JavaScript.
+
+## How is it used?
+
+```html
+<div class="magnet-tooltip-a11y">
+  <button
+    class="magnet-tooltip-a11y__trigger"
+    type="button"
+    aria-describedby="tip-newsletter"
+  >
+    Subscribe
+  </button>
+  <div class="magnet-tooltip-a11y__bubble" role="tooltip" id="tip-newsletter">
+    <span class="magnet-tooltip-a11y__title">Weekly newsletter</span>
+    <span class="magnet-tooltip-a11y__body">One email a week, no spam. Unsubscribe anytime.</span>
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.magnet-tooltip-a11y__trigger` reveals the adjacent `.magnet-tooltip-a11y__bubble`, playing the `ease-magnet-a11y-pull` animation: it starts offset and shrunk, overshoots slightly as it snaps toward the trigger, then settles into place.
+
+Timing, easing, pull distance, and settle scale are exposed as CSS custom properties:
+
+```html
+<div class="magnet-tooltip-a11y" style="--ease-magnet-a11y-duration: 650ms; --ease-magnet-a11y-pull-distance: 34px; --ease-magnet-a11y-scale: 1.03;">
+  ...
+</div>
+```
+
+## Why is it useful?
+
+Tooltips are frequently one of the least accessible UI patterns — low contrast, no keyboard path, no screen-reader announcement. This variant addresses that directly:
+
+- **`aria-describedby` + `role="tooltip"`** wiring so screen readers announce the tooltip content when the trigger receives focus, not just on mouse hover.
+- **44px minimum touch target** on the trigger per WCAG 2.5.5.
+- **Thick, high-contrast focus ring** (not color-reliant alone) via `:focus-visible`, so keyboard users always know where they are.
+- **`prefers-contrast: more`** support, thickening borders for users who need it.
+- Needs **no JavaScript** — the whole effect is a single CSS `@keyframes` animation triggered by native `:hover`/`:focus-visible`.
+- Respects `prefers-reduced-motion` by skipping straight to the final, settled state.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable and keyframe names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable/keyframe names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file
+
+## Note on related submissions
+
+This repo has a separate "Magnetic Pull Tooltip for Creative Portfolio Layouts" issue (#46308). That variant uses a bold, high-energy dark theme suited to portfolio sites. This submission is deliberately styled and structured around the "Accessible Web Layouts" brief instead — high-contrast light theme, explicit ARIA wiring, and WCAG-driven focus/touch-target sizing — so the two don't overlap in either visuals or purpose.

--- a/submissions/examples/magnetic-pull-tooltip-a11y-aaniya/demo.html
+++ b/submissions/examples/magnetic-pull-tooltip-a11y-aaniya/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Magnetic Pull Tooltip — Accessible Web Layouts</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Magnetic Pull Tooltip — Accessible</h1>
+  <p>A high-contrast tooltip that snaps into place with a magnetic pull motion, built with strong focus indication and ARIA wiring — pure CSS, no JavaScript.</p>
+
+  <div class="magnet-tooltip-a11y-grid">
+
+    <div class="magnet-tooltip-a11y">
+      <button
+        class="magnet-tooltip-a11y__trigger"
+        type="button"
+        aria-describedby="tip-newsletter"
+      >
+        Subscribe
+      </button>
+      <div class="magnet-tooltip-a11y__bubble" role="tooltip" id="tip-newsletter">
+        <span class="magnet-tooltip-a11y__title">Weekly newsletter</span>
+        <span class="magnet-tooltip-a11y__body">One email a week, no spam. Unsubscribe anytime.</span>
+      </div>
+    </div>
+
+    <div
+      class="magnet-tooltip-a11y"
+      style="--ease-magnet-a11y-duration: 650ms; --ease-magnet-a11y-pull-distance: 34px; --ease-magnet-a11y-scale: 1.03;"
+    >
+      <button
+        class="magnet-tooltip-a11y__trigger"
+        type="button"
+        aria-describedby="tip-privacy"
+      >
+        Privacy Settings
+      </button>
+      <div class="magnet-tooltip-a11y__bubble" role="tooltip" id="tip-privacy">
+        <span class="magnet-tooltip-a11y__title">Your data, your control</span>
+        <span class="magnet-tooltip-a11y__body">Adjust what's shared and with whom at any time.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-tooltip-a11y-aaniya/style.css
+++ b/submissions/examples/magnetic-pull-tooltip-a11y-aaniya/style.css
@@ -1,0 +1,149 @@
+/* ==========================================================================
+   Magnetic Pull Tooltip — Accessible Web Layouts
+   A high-contrast tooltip that pulls into place with a magnetic snap
+   motion when its trigger is hovered or focused. Single CSS animation,
+   no JavaScript. Built with accessibility as the primary design driver:
+   strong focus indication, ARIA wiring, and generous touch targets.
+   Exposes timing, easing, and scale as CSS custom properties.
+   ========================================================================== */
+
+:root {
+  --ease-magnet-a11y-bg: #ffffff;
+  --ease-magnet-a11y-text: #0b0b0f;
+  --ease-magnet-a11y-muted: #3d3d46;
+  --ease-magnet-a11y-accent: #005fcc;
+  --ease-magnet-a11y-focus-ring: #ffb400;
+  --ease-magnet-a11y-page-bg: #f2f3f7;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-magnet-a11y-duration: 500ms;
+  --ease-magnet-a11y-curve: cubic-bezier(0.3, 1.4, 0.6, 1);
+  --ease-magnet-a11y-scale: 1;
+  --ease-magnet-a11y-pull-distance: 22px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-magnet-a11y-page-bg);
+  border-radius: 16px;
+  color: var(--ease-magnet-a11y-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-magnet-a11y-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.magnet-tooltip-a11y-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.magnet-tooltip-a11y {
+  position: relative;
+  display: inline-block;
+}
+
+/* Generous touch target (min 44x44px per WCAG 2.5.5) */
+.magnet-tooltip-a11y__trigger {
+  min-height: 44px;
+  padding: 12px 22px;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--ease-magnet-a11y-accent);
+  border: 2px solid var(--ease-magnet-a11y-accent);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+/* Strong, unmissable focus indicator, not reliant on color alone */
+.magnet-tooltip-a11y__trigger:focus-visible {
+  outline: 3px solid var(--ease-magnet-a11y-focus-ring);
+  outline-offset: 3px;
+}
+
+.magnet-tooltip-a11y__bubble {
+  position: absolute;
+  bottom: calc(100% + 16px);
+  left: 50%;
+  width: 240px;
+  padding: 14px 16px;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  text-align: left;
+  color: var(--ease-magnet-a11y-text);
+  background: var(--ease-magnet-a11y-bg);
+  border: 2px solid var(--ease-magnet-a11y-accent);
+  border-radius: 10px;
+  box-shadow: 0 16px 32px rgba(11, 11, 15, 0.18);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  transform: translateX(-50%) translateY(var(--ease-magnet-a11y-pull-distance)) scale(0.9);
+}
+
+/* The single animation this component demonstrates: the tooltip snaps
+   in with a magnetic pull motion toward the trigger. */
+@keyframes ease-magnet-a11y-pull {
+  0% {
+    transform: translateX(-50%) translateY(var(--ease-magnet-a11y-pull-distance)) scale(0.9);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(-50%) translateY(-3px) scale(calc(var(--ease-magnet-a11y-scale) * 1.02));
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(var(--ease-magnet-a11y-scale));
+    opacity: 1;
+  }
+}
+
+.magnet-tooltip-a11y__trigger:hover + .magnet-tooltip-a11y__bubble,
+.magnet-tooltip-a11y__trigger:focus-visible + .magnet-tooltip-a11y__bubble {
+  visibility: visible;
+  animation: ease-magnet-a11y-pull var(--ease-magnet-a11y-duration) var(--ease-magnet-a11y-curve) forwards;
+}
+
+.magnet-tooltip-a11y__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.magnet-tooltip-a11y__body {
+  color: var(--ease-magnet-a11y-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .magnet-tooltip-a11y__trigger:hover + .magnet-tooltip-a11y__bubble,
+  .magnet-tooltip-a11y__trigger:focus-visible + .magnet-tooltip-a11y__bubble {
+    animation: none;
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+/* Respect users who prefer more contrast */
+@media (prefers-contrast: more) {
+  .magnet-tooltip-a11y__bubble { border-width: 3px; }
+  .magnet-tooltip-a11y__trigger { border-width: 3px; }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .magnet-tooltip-a11y__bubble { width: 200px; }
+}


### PR DESCRIPTION
Closes #46307
## Pull Request Description
Adds a new accessibility-focused tooltip submission — `magnetic-pull-tooltip-a11y-aaniya` — that snaps into place with a magnetic pull motion, built around WCAG-driven focus/contrast/touch-target design, closing #46307.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-tooltip-a11y-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A high-contrast tooltip that snaps into place with a magnetic pull motion on hover or focus, built with `aria-describedby`/`role="tooltip"` wiring, a thick visible focus ring, and 44px minimum touch targets.

**How does a developer use it?**
```html
<div class="magnet-tooltip-a11y">
  <button class="magnet-tooltip-a11y__trigger" type="button" aria-describedby="tip-newsletter">
    Subscribe
  </button>
  <div class="magnet-tooltip-a11y__bubble" role="tooltip" id="tip-newsletter">
    <span class="magnet-tooltip-a11y__title">Weekly newsletter</span>
    <span class="magnet-tooltip-a11y__body">One email a week, no spam. Unsubscribe anytime.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS `@keyframes` animation (`ease-magnet-a11y-pull`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It exposes `--ease-magnet-a11y-duration`, `--ease-magnet-a11y-curve`, `--ease-magnet-a11y-scale`, and `--ease-magnet-a11y-pull-distance` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion` and `prefers-contrast: more`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
There's a separate "Magnetic Pull Tooltip for Creative Portfolio Layouts" issue (#46308), which I also submitted — that one uses a bold dark theme suited to portfolio sites. This submission is deliberately built around the "Accessible Web Layouts" brief instead: high-contrast light theme, explicit ARIA wiring, and WCAG-driven focus/touch-target sizing, so there's no overlap in visuals or purpose. Happy to adjust the ARIA pattern if the maintainer prefers a different accessible-tooltip convention.