### PR TITLE
Add star nosed mole component

### DIFF
--- a/submissions/examples/star-nosed-mole-as/README.md
+++ b/submissions/examples/star-nosed-mole-as/README.md
@@ -1,0 +1,19 @@
+# Star Nosed Mole
+
+A pure CSS and HTML star nosed mole shuffling down its tunnel, the twenty two fleshy rays of its star flicking over the soil to find a worm.
+
+## What it shows
+
+- The famous star built with the radial rotate pattern: eleven rays each park their own angle in a custom property so one twitch keyframe fires them all, staggered so the star ripples
+- The rays twitching at 0.6s, the speed that makes the star read as a touch organ rather than a decoration
+- Velvet fur from a fine repeating conic gradient, spade paws with clawed tips from a clip-path sawtooth
+- A dark burrow with an inset shadow, roots overhead and a worm wriggling ahead
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/star-nosed-mole-as/demo.html
+++ b/submissions/examples/star-nosed-mole-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Star Nosed Mole</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="tunnelS"></span>
+    <div class="moleS">
+      <span class="tailS"></span>
+      <span class="bodyS"></span>
+      <span class="furS"></span>
+      <span class="pawS psb"></span>
+      <span class="pawS psf"></span>
+      <span class="headS"></span>
+      <div class="starS">
+        <span class="rayS r1"></span>
+        <span class="rayS r2"></span>
+        <span class="rayS r3"></span>
+        <span class="rayS r4"></span>
+        <span class="rayS r5"></span>
+        <span class="rayS r6"></span>
+        <span class="rayS r7"></span>
+        <span class="rayS r8"></span>
+        <span class="rayS r9"></span>
+        <span class="rayS r10"></span>
+        <span class="rayS r11"></span>
+        <span class="hubS"></span>
+      </div>
+      <span class="eyeS"></span>
+    </div>
+    <span class="wormS"></span>
+    <span class="rootS roA"></span>
+    <span class="rootS roB"></span>
+    <span class="soilS"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/star-nosed-mole-as/style.css
+++ b/submissions/examples/star-nosed-mole-as/style.css
@@ -1,0 +1,271 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #4a3524, #170f08 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #5a4028, #2a1c10);
+}
+
+.soilS {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(255, 230, 190, 0.06) 0 22px, transparent 30px),
+    radial-gradient(circle at 74% 74%, rgba(0, 0, 0, 0.34) 0 30px, transparent 42px),
+    radial-gradient(circle at 40% 84%, rgba(255, 230, 190, 0.05) 0 18px, transparent 26px);
+  z-index: 1;
+}
+
+.tunnelS {
+  position: absolute;
+  top: 50%;
+  left: -30px;
+  right: -30px;
+  height: 150px;
+  margin-top: -75px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, #6a4c2e, #3a2716 74%);
+  box-shadow: inset 0 0 40px rgba(20, 12, 4, 0.7);
+  z-index: 2;
+}
+
+.rootS {
+  position: absolute;
+  width: 8px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #8a6a40, #45301a);
+  z-index: 3;
+  animation: quiverRootS 7s ease-in-out infinite;
+}
+
+.roA { top: 0; left: 60px; height: 76px; transform: rotate(12deg); }
+.roB { bottom: 0; right: 80px; height: 66px; transform: rotate(-16deg); }
+
+.wormS {
+  position: absolute;
+  top: 50%;
+  left: 34px;
+  width: 46px;
+  height: 10px;
+  margin-top: -18px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(140, 60, 70, 0.5) 0 3px,
+      transparent 3px 9px
+    ),
+    linear-gradient(180deg, #e0909a, #a4545e);
+  transform-origin: 100% 50%;
+  z-index: 6;
+  animation: wriggleS 3.2s ease-in-out infinite;
+}
+
+.moleS {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 220px;
+  height: 110px;
+  margin: -46px 0 0 -74px;
+  z-index: 5;
+  animation: shuffleS 3.2s ease-in-out infinite;
+}
+
+.bodyS {
+  position: absolute;
+  top: 26px;
+  left: 42px;
+  width: 130px;
+  height: 62px;
+  border-radius: 44% 40% 40% 44% / 50%;
+  background: radial-gradient(circle at 38% 30%, #6a5a58, #22201f 78%);
+  box-shadow: inset -8px -6px 20px rgba(0, 0, 0, 0.6);
+  z-index: 4;
+}
+
+.furS {
+  position: absolute;
+  top: 26px;
+  left: 42px;
+  width: 130px;
+  height: 62px;
+  border-radius: 44% 40% 40% 44% / 50%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 30% 20%,
+      rgba(150, 140, 138, 0.22) 0 1deg,
+      transparent 1deg 5deg
+    );
+  z-index: 5;
+}
+
+.headS {
+  position: absolute;
+  top: 34px;
+  left: 12px;
+  width: 54px;
+  height: 46px;
+  border-radius: 46% 40% 40% 46% / 50%;
+  background: radial-gradient(circle at 44% 34%, #6a5a58, #2a2726 78%);
+  z-index: 5;
+}
+
+.eyeS {
+  position: absolute;
+  top: 46px;
+  left: 44px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #100c0a;
+  z-index: 7;
+}
+
+.starS {
+  position: absolute;
+  top: 36px;
+  left: 2px;
+  width: 42px;
+  height: 42px;
+  z-index: 8;
+  animation: feelStarS 0.6s ease-in-out infinite;
+}
+
+.rayS {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 7px;
+  height: 21px;
+  margin: -21px 0 0 -3.5px;
+  border-radius: 4px 4px 2px 2px;
+  background: linear-gradient(180deg, #f2a8b4, #b8606e);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--rs, 0deg));
+  z-index: 2;
+  animation: twitchRayS 0.6s ease-in-out infinite;
+}
+
+.r1 { --rs: -150deg; }
+.r2 { --rs: -120deg; animation-delay: 0.04s; }
+.r3 { --rs: -90deg; animation-delay: 0.08s; }
+.r4 { --rs: -60deg; animation-delay: 0.12s; }
+.r5 { --rs: -30deg; animation-delay: 0.16s; }
+.r6 { --rs: 0deg; animation-delay: 0.2s; }
+.r7 { --rs: 30deg; animation-delay: 0.24s; }
+.r8 { --rs: 60deg; animation-delay: 0.28s; }
+.r9 { --rs: 90deg; animation-delay: 0.32s; }
+.r10 { --rs: 120deg; animation-delay: 0.36s; }
+.r11 { --rs: 150deg; animation-delay: 0.4s; }
+
+.hubS {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #f2b0bc, #a4505e 76%);
+  z-index: 3;
+}
+
+.pawS {
+  position: absolute;
+  top: 74px;
+  width: 30px;
+  height: 20px;
+  border-radius: 40% 50% 50% 40%;
+  background: linear-gradient(180deg, #e8c8b0, #a4806a);
+  transform-origin: 60% 0;
+  z-index: 6;
+  animation: digS 0.6s ease-in-out infinite;
+}
+
+.pawS::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: -4px;
+  width: 22px;
+  height: 8px;
+  background: #d8b49a;
+  clip-path: polygon(0 0, 18% 100%, 36% 0, 54% 100%, 72% 0, 90% 100%, 100% 0);
+}
+
+.psf { left: 52px; }
+.psb { left: 92px; filter: brightness(0.82); z-index: 3; animation-delay: 0.3s; }
+
+.tailS {
+  position: absolute;
+  top: 48px;
+  left: 158px;
+  width: 54px;
+  height: 9px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #4a4240, #8a7a72);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: waveTailS 2.4s ease-in-out infinite;
+}
+
+@keyframes feelStarS {
+  0%, 100% { transform: translate(0, 0) rotate(-4deg); }
+  50% { transform: translate(-3px, 2px) rotate(4deg); }
+}
+
+@keyframes twitchRayS {
+  0%, 100% { transform: rotate(var(--rs, 0deg)) scaleY(1); }
+  50% { transform: rotate(calc(var(--rs, 0deg) + 8deg)) scaleY(1.12); }
+}
+
+@keyframes shuffleS {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-8px, 0); }
+}
+
+@keyframes digS {
+  0%, 100% { transform: rotate(-14deg); }
+  50% { transform: rotate(16deg); }
+}
+
+@keyframes waveTailS {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes wriggleS {
+  0%, 100% { transform: rotate(0deg) scaleX(1); }
+  30% { transform: rotate(-10deg) scaleX(0.94); }
+  60% { transform: rotate(8deg) scaleX(1.04); }
+}
+
+@keyframes quiverRootS {
+  0%, 100% { transform: rotate(12deg); }
+  50% { transform: rotate(9deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .moleS,
+  .starS,
+  .rayS,
+  .pawS,
+  .tailS,
+  .wormS,
+  .rootS {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML star nosed mole hunting in its tunnel.

## Details

- The star is built with the radial rotate pattern: each ray parks its own angle in a custom property so one twitch keyframe fires them all, staggered so the star ripples
- The rays twitch fast, so the star reads as a touch organ rather than a decoration
- Velvet fur from a fine repeating conic gradient, spade paws with clawed tips from a clip-path sawtooth
- A dark burrow with an inset shadow, roots overhead and a worm wriggling ahead
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/star-nosed-mole-as/demo.html`
- `submissions/examples/star-nosed-mole-as/style.css`
- `submissions/examples/star-nosed-mole-as/README.md`

Closes #47653
