### PR TITLE
Add newton cradle component

### DIFF
--- a/submissions/examples/newton-cradle-as/README.md
+++ b/submissions/examples/newton-cradle-as/README.md
@@ -1,0 +1,19 @@
+# Newton Cradle
+
+A pure CSS and HTML Newton's cradle: the end ball swings in, the middle three stay dead still, and the far ball kicks out and returns.
+
+## What it shows
+
+- Momentum transfer faked honestly with timing alone: the two end swings share a cycle so one arrives exactly as the other departs, and the middle balls never move
+- Each ball hung from a real V of two wires, so the pendulum reads as a cradle rather than a single string
+- Chrome spheres from layered radial gradients with a specular dot and an inset shadow for weight
+- A polished frame and base with metal and timber gradients
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+The swing stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/newton-cradle-as/demo.html
+++ b/submissions/examples/newton-cradle-as/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Newton Cradle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="frameTop"></span>
+    <span class="postN pnL"></span>
+    <span class="postN pnR"></span>
+    <div class="swingN snA">
+      <span class="wireN wnL"></span>
+      <span class="wireN wnR"></span>
+      <span class="ballN"></span>
+    </div>
+    <div class="swingN snB">
+      <span class="wireN wnL"></span>
+      <span class="wireN wnR"></span>
+      <span class="ballN"></span>
+    </div>
+    <div class="swingN snC">
+      <span class="wireN wnL"></span>
+      <span class="wireN wnR"></span>
+      <span class="ballN"></span>
+    </div>
+    <div class="swingN snD">
+      <span class="wireN wnL"></span>
+      <span class="wireN wnR"></span>
+      <span class="ballN"></span>
+    </div>
+    <div class="swingN snE">
+      <span class="wireN wnL"></span>
+      <span class="wireN wnR"></span>
+      <span class="ballN"></span>
+    </div>
+    <span class="baseN"></span>
+    <span class="deskN"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/newton-cradle-as/style.css
+++ b/submissions/examples/newton-cradle-as/style.css
@@ -1,0 +1,138 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #3a4256, #12161f 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+}
+
+.deskN {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 44px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 14, 8, 0.36) 0 2px,
+      transparent 2px 34px
+    ),
+    linear-gradient(180deg, #4a3826, #221a10);
+  z-index: 9;
+}
+
+.baseN {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 240px;
+  height: 20px;
+  margin-left: -120px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #8a6238, #45301a);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.45);
+  z-index: 8;
+}
+
+.postN {
+  position: absolute;
+  bottom: 56px;
+  width: 12px;
+  height: 190px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #5a6270, #b8c2d0 44%, #4a5260);
+  z-index: 7;
+}
+
+.pnL { left: 50%; margin-left: -108px; }
+.pnR { left: 50%; margin-left: 96px; }
+
+.frameTop {
+  position: absolute;
+  bottom: 240px;
+  left: 50%;
+  width: 228px;
+  height: 12px;
+  margin-left: -114px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #c2ccd8, #58606e);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  z-index: 8;
+}
+
+.swingN {
+  position: absolute;
+  bottom: 240px;
+  left: 50%;
+  width: 40px;
+  height: 4px;
+  transform-origin: 50% 0;
+  z-index: 6;
+}
+
+.snA { margin-left: -100px; animation: leftSwingN 2s ease-in-out infinite; }
+.snB { margin-left: -60px; }
+.snC { margin-left: -20px; }
+.snD { margin-left: 20px; }
+.snE { margin-left: 60px; animation: rightSwingN 2s ease-in-out infinite; }
+
+.wireN {
+  position: absolute;
+  top: 0;
+  width: 1.5px;
+  height: 112px;
+  background: linear-gradient(180deg, rgba(220, 230, 240, 0.9), rgba(160, 175, 190, 0.6));
+  transform-origin: 50% 0;
+  z-index: 5;
+}
+
+.wnL { left: 4px; transform: rotate(9deg); }
+.wnR { right: 4px; transform: rotate(-9deg); }
+
+.ballN {
+  position: absolute;
+  top: 106px;
+  left: 50%;
+  width: 38px;
+  height: 38px;
+  margin-left: -19px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 34% 28%, #ffffff 0 3px, transparent 4px),
+    radial-gradient(circle at 38% 32%, #dfe6ee, #6a7482 56%, #2a303a 88%);
+  box-shadow:
+    inset -5px -6px 12px rgba(10, 14, 20, 0.7),
+    0 4px 8px rgba(0, 0, 0, 0.4);
+  z-index: 6;
+}
+
+@keyframes leftSwingN {
+  0% { transform: rotate(-32deg); }
+  22% { transform: rotate(0deg); }
+  50%, 72% { transform: rotate(0deg); }
+  100% { transform: rotate(-32deg); }
+}
+
+@keyframes rightSwingN {
+  0%, 22% { transform: rotate(0deg); }
+  50% { transform: rotate(32deg); }
+  78% { transform: rotate(0deg); }
+  100% { transform: rotate(0deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .snA,
+  .snE {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML Newton's cradle.

## Details

- Momentum transfer is faked honestly with timing alone: the two end swings share a cycle so one arrives exactly as the other departs, and the middle balls never move
- Each ball hangs from a real V of two wires, so the pendulum reads as a cradle rather than a single string
- Chrome spheres from layered radial gradients with a specular dot and an inset shadow for weight
- A polished frame and base from metal and timber gradients
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/newton-cradle-as/demo.html`
- `submissions/examples/newton-cradle-as/style.css`
- `submissions/examples/newton-cradle-as/README.md`

Closes #47655
