### PR TITLE
Add dandelion clock component

### DIFF
--- a/submissions/examples/dandelion-clock-as/README.md
+++ b/submissions/examples/dandelion-clock-as/README.md
@@ -1,0 +1,19 @@
+# Dandelion Clock
+
+A pure CSS and HTML dandelion seed head, its pappus trembling in the breeze as seeds break loose and sail away.
+
+## What it shows
+
+- The seed head from two gradients: a fine repeating conic gradient for the radiating stalks crossed with a repeating radial gradient for the ring of parachutes, masked hollow at the centre
+- Each escaping seed carrying its own drift vector in a pair of custom properties, so they scatter on different paths from one shared keyframe
+- Every seed drawn as a stalk with its own parachute of conic gradient filaments on ::before
+- The whole plant bending and the head thinning as gusts cross the meadow
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/dandelion-clock-as/demo.html
+++ b/submissions/examples/dandelion-clock-as/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dandelion Clock</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunD"></span>
+    <span class="gustD gd1"></span>
+    <span class="gustD gd2"></span>
+    <div class="stalkD">
+      <span class="stemD"></span>
+      <span class="leafD ldA"></span>
+      <span class="leafD ldB"></span>
+      <div class="headD">
+        <span class="pappusD"></span>
+        <span class="recepD"></span>
+      </div>
+    </div>
+    <span class="seedD sdA"></span>
+    <span class="seedD sdB"></span>
+    <span class="seedD sdC"></span>
+    <span class="seedD sdD"></span>
+    <span class="seedD sdE"></span>
+    <span class="grassD grA"></span>
+    <span class="grassD grB"></span>
+    <span class="meadowD"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dandelion-clock-as/style.css
+++ b/submissions/examples/dandelion-clock-as/style.css
@@ -1,0 +1,281 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #cfe6f4, #9fc8dc 58%, #8fb87e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #dcf0fa, #a8d0e2 56%, #7fae6a 58%, #4f7a3e);
+}
+
+.sunD {
+  position: absolute;
+  top: 24px;
+  right: 40px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe0, #f8e49a 62%, #f0c464);
+  box-shadow: 0 0 44px 16px rgba(248, 228, 154, 0.4);
+  z-index: 1;
+  animation: glowD 6s ease-in-out infinite;
+}
+
+.meadowD {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 136px;
+  background:
+    radial-gradient(circle at 18% 20%, rgba(255, 255, 220, 0.14) 0 16px, transparent 22px),
+    radial-gradient(circle at 66% 40%, rgba(30, 60, 20, 0.2) 0 20px, transparent 28px),
+    linear-gradient(180deg, #7fae6a, #3a6030);
+  z-index: 7;
+}
+
+.grassD {
+  position: absolute;
+  bottom: 96px;
+  width: 34px;
+  height: 60px;
+  background:
+    repeating-linear-gradient(
+      80deg,
+      #4f8a3c 0 3px,
+      transparent 3px 10px
+    );
+  mask-image: linear-gradient(180deg, transparent 0 8%, #000 44%);
+  transform-origin: 50% 100%;
+  z-index: 8;
+  animation: swayGrassD 5s ease-in-out infinite;
+}
+
+.grA { left: 26px; }
+.grB { right: 32px; height: 46px; animation-delay: 2s; }
+
+.gustD {
+  position: absolute;
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.65), transparent);
+  opacity: 0;
+  z-index: 9;
+  animation: blowD 5s ease-in infinite;
+}
+
+.gd1 { top: 96px; left: -70px; width: 90px; }
+.gd2 { top: 132px; left: -70px; width: 64px; animation-delay: 2.2s; }
+
+.stalkD {
+  position: absolute;
+  bottom: 108px;
+  left: 50%;
+  width: 130px;
+  height: 190px;
+  margin-left: -65px;
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: bendD 5s ease-in-out infinite;
+}
+
+.stemD {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 8px;
+  height: 128px;
+  margin-left: -4px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #3f6a2c, #7fb44e 44%, #35591e);
+  z-index: 4;
+}
+
+.leafD {
+  position: absolute;
+  bottom: 0;
+  width: 50px;
+  height: 20px;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(20, 50, 12, 0.24) 0 1px,
+      transparent 1px 8px
+    ),
+    linear-gradient(120deg, #5f9a3c, #2f5a1c);
+  clip-path: polygon(0 50%, 18% 12%, 40% 44%, 62% 8%, 82% 46%, 100% 20%, 100% 80%, 62% 96%, 40% 62%, 18% 92%);
+  transform-origin: 100% 50%;
+  z-index: 3;
+  animation: nodLeafD 7s ease-in-out infinite;
+}
+
+.ldA { left: 6px; transform: rotate(6deg); }
+
+.ldB {
+  right: 6px;
+  transform: scaleX(-1) rotate(6deg);
+  animation-name: nodLeafFlipD;
+  animation-delay: 2.6s;
+}
+
+.headD {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 110px;
+  height: 110px;
+  margin-left: -55px;
+  z-index: 5;
+  animation: shiverD 5s ease-in-out infinite;
+}
+
+.pappusD {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(255, 255, 255, 0.9) 0 0.6deg,
+      transparent 0.6deg 4deg
+    ),
+    repeating-radial-gradient(
+      circle at 50% 50%,
+      transparent 0 38px,
+      rgba(255, 255, 255, 0.55) 38px 40px,
+      transparent 40px 44px,
+      rgba(255, 255, 255, 0.4) 44px 46px
+    );
+  mask-image: radial-gradient(circle, transparent 0 8%, #000 12% 88%, transparent 100%);
+  z-index: 4;
+  animation: puffD 5s ease-in-out infinite;
+}
+
+.recepD {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 34%, #d8e0a0, #7a8a3a 76%);
+  z-index: 5;
+}
+
+.seedD {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 3px;
+  height: 16px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), #c8b88a);
+  opacity: 0;
+  z-index: 9;
+  animation: flyD 5s ease-in infinite;
+}
+
+.seedD::before {
+  content: "";
+  position: absolute;
+  top: -9px;
+  left: 50%;
+  width: 18px;
+  height: 18px;
+  margin-left: -9px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(255, 255, 255, 0.9) 0 1deg,
+      transparent 1deg 12deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 10%, #000 16% 90%, transparent 100%);
+}
+
+.sdA { --sx: 130px; --sy: -50px; animation-delay: 0.2s; }
+.sdB { --sx: 176px; --sy: -14px; animation-delay: 0.7s; }
+.sdC { --sx: 150px; --sy: -84px; animation-delay: 1.3s; }
+.sdD { --sx: 200px; --sy: -46px; animation-delay: 2.1s; }
+.sdE { --sx: 116px; --sy: 12px; animation-delay: 2.9s; }
+
+@keyframes bendD {
+  0%, 100% { transform: rotate(-1deg); }
+  40% { transform: rotate(5deg); }
+  60% { transform: rotate(3deg); }
+}
+
+@keyframes shiverD {
+  0%, 100% { transform: translate(0, 0); }
+  42% { transform: translate(3px, 1px); }
+}
+
+@keyframes puffD {
+  0%, 30% { opacity: 1; transform: scale(1); }
+  46% { opacity: 0.85; transform: scale(0.97); }
+  74% { opacity: 0.5; transform: scale(0.9); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes flyD {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 0; }
+  30% { opacity: 0; }
+  38% { transform: translate(14px, -8px) rotate(20deg); opacity: 1; }
+  86% { opacity: 1; }
+  100% { transform: translate(var(--sx, 120px), var(--sy, -40px)) rotate(200deg); opacity: 0; }
+}
+
+@keyframes blowD {
+  0% { transform: translateX(0); opacity: 0; }
+  20% { opacity: 0.8; }
+  100% { transform: translateX(440px); opacity: 0; }
+}
+
+@keyframes swayGrassD {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes nodLeafD {
+  0%, 100% { transform: rotate(4deg); }
+  50% { transform: rotate(-4deg); }
+}
+
+@keyframes nodLeafFlipD {
+  0%, 100% { transform: scaleX(-1) rotate(4deg); }
+  50% { transform: scaleX(-1) rotate(-4deg); }
+}
+
+@keyframes glowD {
+  0%, 100% { opacity: 0.92; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stalkD,
+  .headD,
+  .pappusD,
+  .seedD,
+  .gustD,
+  .grassD,
+  .leafD,
+  .sunD {
+    animation: none;
+  }
+
+  .seedD,
+  .gustD {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML dandelion clock shedding seeds on the breeze.

## Details

- The seed head is two gradients: a fine repeating conic gradient for the radiating stalks crossed with a repeating radial gradient for the ring of parachutes, masked hollow at the centre
- Each escaping seed carries its own drift vector in a pair of custom properties, so they scatter on different paths from one shared keyframe
- Every seed is a stalk with its own parachute of conic gradient filaments on ::before
- The whole plant bends and the head thins as gusts cross the meadow
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/dandelion-clock-as/demo.html`
- `submissions/examples/dandelion-clock-as/style.css`
- `submissions/examples/dandelion-clock-as/README.md`

Closes #47657
