### PR TITLE
Add nixie tube component

### DIFF
--- a/submissions/examples/nixie-tube-as/README.md
+++ b/submissions/examples/nixie-tube-as/README.md
@@ -1,0 +1,19 @@
+# Nixie Tube
+
+A pure CSS and HTML pair of nixie tubes glowing orange behind their wire mesh, the colon between them ticking on and off.
+
+## What it shows
+
+- Each numeral built from stacked hard stop linear gradient bars, with a second unlit copy behind it in dull grey so the dark cathodes read the way a real nixie does
+- The neon glow from layered drop-shadow filters rather than a flat colour, plus a soft halo behind the glass
+- The anode mesh from two crossed repeating linear gradients seen through the envelope
+- Glass with a rim highlight, bakelite base, pins, and a colon blinking on steps() so it snaps rather than fades
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+The flicker and blink stop under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/nixie-tube-as/demo.html
+++ b/submissions/examples/nixie-tube-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nixie Tube</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="tubeN tnA">
+      <span class="glassN"></span>
+      <span class="meshN"></span>
+      <span class="digitN dnBack"></span>
+      <span class="digitN dnGlow"></span>
+      <span class="haloN"></span>
+      <span class="shineN"></span>
+      <span class="baseTube"></span>
+      <span class="pinN pnA"></span>
+      <span class="pinN pnB"></span>
+    </div>
+    <div class="tubeN tnB">
+      <span class="glassN"></span>
+      <span class="meshN"></span>
+      <span class="digitN dnBack"></span>
+      <span class="digitN dnGlow"></span>
+      <span class="haloN"></span>
+      <span class="shineN"></span>
+      <span class="baseTube"></span>
+      <span class="pinN pnA"></span>
+      <span class="pinN pnB"></span>
+    </div>
+    <span class="colonN"></span>
+    <span class="boardN"></span>
+    <span class="deskN"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/nixie-tube-as/style.css
+++ b/submissions/examples/nixie-tube-as/style.css
@@ -1,0 +1,226 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 34%, #241a1e, #0a0708 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 300px;
+}
+
+.deskN {
+  position: absolute;
+  bottom: -100vh;
+  left: -50vw;
+  right: -50vw;
+  height: calc(100vh + 40px);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 10, 6, 0.4) 0 2px,
+      transparent 2px 34px
+    ),
+    linear-gradient(180deg, #3a2418, #180e08);
+  z-index: 9;
+}
+
+.boardN {
+  position: absolute;
+  bottom: 34px;
+  left: 50%;
+  width: 230px;
+  height: 26px;
+  margin-left: -115px;
+  border-radius: 4px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 200, 120, 0.08) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(180deg, #2a3a2c, #14201a);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.5);
+  z-index: 8;
+}
+
+.tubeN {
+  position: absolute;
+  bottom: 54px;
+  width: 96px;
+  height: 176px;
+  z-index: 6;
+}
+
+.tnA { left: 50%; margin-left: -104px; }
+.tnB { left: 50%; margin-left: 8px; --dg: 1.3s; }
+
+.glassN {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 92px;
+  height: 140px;
+  margin-left: -46px;
+  border-radius: 46px 46px 12px 12px / 56px 56px 10px 10px;
+  background:
+    linear-gradient(150deg, rgba(210, 230, 240, 0.14), rgba(120, 150, 170, 0.06) 52%, rgba(180, 210, 230, 0.12));
+  border: 1.5px solid rgba(200, 226, 240, 0.24);
+  box-shadow:
+    inset 0 0 26px rgba(150, 190, 220, 0.12),
+    inset -10px 0 20px rgba(30, 50, 70, 0.24);
+  z-index: 4;
+}
+
+.meshN {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  width: 74px;
+  height: 112px;
+  margin-left: -37px;
+  border-radius: 34px 34px 6px 6px;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(190, 200, 190, 0.16) 0 1px,
+      transparent 1px 6px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(190, 200, 190, 0.16) 0 1px,
+      transparent 1px 6px
+    );
+  z-index: 5;
+}
+
+.digitN {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  width: 44px;
+  height: 76px;
+  margin-left: -22px;
+  z-index: 6;
+}
+
+.dnBack {
+  background:
+    linear-gradient(0deg, transparent 0 44%, rgba(150, 160, 160, 0.16) 44% 52%, transparent 52%),
+    linear-gradient(90deg, transparent 0 8%, rgba(150, 160, 160, 0.16) 8% 18%, transparent 18%),
+    linear-gradient(90deg, transparent 0 82%, rgba(150, 160, 160, 0.16) 82% 92%, transparent 92%),
+    linear-gradient(0deg, transparent 0 88%, rgba(150, 160, 160, 0.16) 88% 96%, transparent 96%),
+    linear-gradient(0deg, transparent 0 4%, rgba(150, 160, 160, 0.16) 4% 12%, transparent 12%);
+  z-index: 5;
+}
+
+.dnGlow {
+  background:
+    linear-gradient(0deg, transparent 0 44%, #ff8a2a 44% 52%, transparent 52%),
+    linear-gradient(90deg, transparent 0 8%, #ff8a2a 8% 18%, transparent 18%),
+    linear-gradient(90deg, transparent 0 82%, #ff8a2a 82% 92%, transparent 92%),
+    linear-gradient(0deg, transparent 0 88%, #ff8a2a 88% 96%, transparent 96%),
+    linear-gradient(0deg, transparent 0 4%, #ff8a2a 4% 12%, transparent 12%);
+  filter: drop-shadow(0 0 5px rgba(255, 140, 50, 0.9)) drop-shadow(0 0 14px rgba(255, 110, 30, 0.6));
+  z-index: 7;
+  animation: flickerN 4s ease-in-out infinite var(--dg, 0s);
+}
+
+.haloN {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 84px;
+  height: 92px;
+  margin-left: -42px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 130, 40, 0.28), transparent 66%);
+  z-index: 5;
+  animation: flickerN 4s ease-in-out infinite var(--dg, 0s);
+}
+
+.shineN {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 18px;
+  height: 100px;
+  margin-left: -34px;
+  border-radius: 40%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.24), transparent 70%);
+  z-index: 8;
+}
+
+.baseTube {
+  position: absolute;
+  top: 134px;
+  left: 50%;
+  width: 76px;
+  height: 26px;
+  margin-left: -38px;
+  border-radius: 5px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 14, 8, 0.4) 0 2px,
+      transparent 2px 9px
+    ),
+    linear-gradient(180deg, #d8b06a, #6a4a1e);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.5);
+  z-index: 7;
+}
+
+.pinN {
+  position: absolute;
+  top: 158px;
+  width: 5px;
+  height: 16px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #c8ccd4, #5a6068);
+  z-index: 6;
+}
+
+.pnA { left: 50%; margin-left: -20px; }
+.pnB { left: 50%; margin-left: 14px; }
+
+.colonN {
+  position: absolute;
+  bottom: 128px;
+  left: 50%;
+  width: 10px;
+  height: 46px;
+  margin-left: -5px;
+  background:
+    radial-gradient(circle at 50% 18%, #ff8a2a 0 4px, transparent 5px),
+    radial-gradient(circle at 50% 82%, #ff8a2a 0 4px, transparent 5px);
+  filter: drop-shadow(0 0 5px rgba(255, 140, 50, 0.9));
+  z-index: 8;
+  animation: blinkColonN 2s steps(1, end) infinite;
+}
+
+@keyframes flickerN {
+  0%, 100% { opacity: 1; }
+  6% { opacity: 0.72; }
+  9% { opacity: 1; }
+  47% { opacity: 0.86; }
+  50% { opacity: 1; }
+}
+
+@keyframes blinkColonN {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0.12; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dnGlow,
+  .haloN,
+  .colonN {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML pair of glowing nixie tubes.

## Details

- Each numeral is stacked hard stop linear gradient bars, with a second unlit copy behind it in dull grey so the dark cathodes read the way a real nixie does
- The neon glow comes from layered drop-shadow filters rather than a flat colour, plus a soft halo behind the glass
- The anode mesh is two crossed repeating linear gradients seen through the envelope
- Glass with a rim highlight, bakelite base and pins, and a colon blinking on steps() so it snaps rather than fades
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/nixie-tube-as/demo.html`
- `submissions/examples/nixie-tube-as/style.css`
- `submissions/examples/nixie-tube-as/README.md`

Closes #47659
