### PR TITLE
Add fern fiddlehead component

### DIFF
--- a/submissions/examples/fern-fiddlehead-as/README.md
+++ b/submissions/examples/fern-fiddlehead-as/README.md
@@ -1,0 +1,19 @@
+# Fern Fiddlehead
+
+A pure CSS and HTML fern croziers uncurling on the forest floor, the tight spiral heads opening into pinnae as light filters through.
+
+## What it shows
+
+- The coiled crozier from a repeating radial gradient banded into a spiral, crossed with a conic gradient for the segment lines and masked into a ring
+- The unfurl driven by rotating and shrinking that ring while the pinnae scale out from zero, so the coil visibly becomes leaf
+- Silvery down on the young coil from a fine conic gradient masked to a thin band at the spiral's edge
+- Pinnae cut from a deep clip-path comb, dew dripping off, over a mossy floor
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/fern-fiddlehead-as/demo.html
+++ b/submissions/examples/fern-fiddlehead-as/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fern Fiddlehead</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="shaftF"></span>
+    <div class="frondF ffA">
+      <span class="stipeF"></span>
+      <span class="crozierF"></span>
+      <span class="downF"></span>
+      <span class="pinnaF pfA"></span>
+      <span class="pinnaF pfB"></span>
+      <span class="pinnaF pfC"></span>
+    </div>
+    <div class="frondF ffB">
+      <span class="stipeF"></span>
+      <span class="crozierF"></span>
+      <span class="downF"></span>
+      <span class="pinnaF pfA"></span>
+      <span class="pinnaF pfB"></span>
+      <span class="pinnaF pfC"></span>
+    </div>
+    <div class="frondF ffC">
+      <span class="stipeF"></span>
+      <span class="crozierF"></span>
+      <span class="downF"></span>
+    </div>
+    <span class="dropF dfA"></span>
+    <span class="dropF dfB"></span>
+    <span class="mossF"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fern-fiddlehead-as/style.css
+++ b/submissions/examples/fern-fiddlehead-as/style.css
@@ -1,0 +1,242 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 46% 26%, #4a6a3a, #101c10 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(circle at 44% 24%, #527640, #162614 78%);
+}
+
+.shaftF {
+  position: absolute;
+  top: -40px;
+  left: 40px;
+  width: 90px;
+  height: 340px;
+  background: linear-gradient(180deg, rgba(220, 245, 190, 0.16), transparent 76%);
+  filter: blur(10px);
+  transform: rotate(9deg);
+  z-index: 1;
+  animation: shimF 10s ease-in-out infinite;
+}
+
+.mossF {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 76px;
+  background:
+    radial-gradient(circle at 16% 24%, #5f9a48 0 20px, transparent 24px),
+    radial-gradient(circle at 48% 12%, #4a7f38 0 26px, transparent 30px),
+    radial-gradient(circle at 82% 26%, #5f9a48 0 22px, transparent 26px),
+    linear-gradient(180deg, #3f6a30, #16240f);
+  z-index: 8;
+}
+
+.frondF {
+  position: absolute;
+  bottom: 52px;
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: swayF 8s ease-in-out infinite;
+}
+
+.ffA { left: 48px; width: 90px; height: 190px; }
+
+.ffB {
+  left: 146px;
+  width: 78px;
+  height: 156px;
+  animation-delay: 2.4s;
+
+  --fs: 0.9;
+}
+
+.ffC {
+  right: 42px;
+  width: 62px;
+  height: 118px;
+  animation-delay: 4.6s;
+  filter: brightness(0.86);
+
+  --fs: 0.76;
+}
+
+.stipeF {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 11px;
+  height: 76%;
+  margin-left: -5px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #3a5f24, #83b34e 42%, #33561e);
+  z-index: 4;
+}
+
+.crozierF {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 76px;
+  height: 76px;
+  margin-left: -32px;
+  border-radius: 50%;
+  border: 9px solid #6faa3c;
+  border-right-color: transparent;
+  border-top-color: #83c04a;
+  box-sizing: border-box;
+  z-index: 5;
+  animation: unfurlF 9s ease-in-out infinite;
+}
+
+.crozierF::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 50%;
+  border: 7px solid #5f9a34;
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  box-sizing: border-box;
+  transform: rotate(56deg);
+}
+
+.downF {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 76px;
+  height: 76px;
+  margin-left: -32px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(230, 214, 150, 0.75) 0 0.6deg,
+      transparent 0.6deg 5deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 44%, #000 48% 56%, transparent 64%);
+  z-index: 6;
+  animation: unfurlF 9s ease-in-out infinite;
+}
+
+.pinnaF {
+  position: absolute;
+  width: 40px;
+  height: 14px;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(20, 50, 12, 0.3) 0 1px,
+      transparent 1px 5px
+    ),
+    linear-gradient(110deg, #7fb44e, #35601e);
+  clip-path: polygon(0 50%, 14% 8%, 30% 46%, 46% 4%, 62% 44%, 78% 6%, 100% 40%, 100% 62%, 78% 96%, 62% 58%, 46% 98%, 30% 56%, 14% 94%);
+  transform-origin: 100% 50%;
+  z-index: 4;
+  animation: openPinnaF 9s ease-in-out infinite;
+}
+
+.pfA {
+  bottom: 48%;
+  left: 50%;
+  margin-left: -40px;
+
+  --pf: 14deg;
+}
+
+.pfB {
+  bottom: 36%;
+  left: 50%;
+  transform: scaleX(-1) rotate(-14deg);
+  transform-origin: 0 50%;
+  animation-name: openPinnaFlipF;
+}
+
+.pfC {
+  bottom: 24%;
+  left: 50%;
+  margin-left: -40px;
+
+  --pf: 20deg;
+
+  animation-delay: 0.4s;
+}
+
+.dropF {
+  position: absolute;
+  width: 8px;
+  height: 11px;
+  border-radius: 50% 50% 60% 60%;
+  background: radial-gradient(circle at 34% 30%, rgba(255, 255, 255, 0.9), rgba(190, 235, 210, 0.4) 70%);
+  opacity: 0;
+  z-index: 9;
+  animation: dripF 6s ease-in infinite;
+}
+
+.dfA { top: 96px; left: 96px; }
+.dfB { top: 130px; left: 188px; animation-delay: 3s; }
+
+@keyframes unfurlF {
+  0%, 26% { transform: rotate(0deg) scale(1); }
+  62%, 86% { transform: rotate(-160deg) scale(0.72); }
+  100% { transform: rotate(0deg) scale(1); }
+}
+
+@keyframes openPinnaF {
+  0%, 30% { transform: rotate(var(--pf, 0deg)) scaleX(0.1); opacity: 0; }
+  56% { transform: rotate(var(--pf, 0deg)) scaleX(1); opacity: 1; }
+  86% { transform: rotate(var(--pf, 0deg)) scaleX(1); opacity: 1; }
+  100% { transform: rotate(var(--pf, 0deg)) scaleX(0.1); opacity: 0; }
+}
+
+@keyframes openPinnaFlipF {
+  0%, 30% { transform: scaleX(-0.1) rotate(-14deg); opacity: 0; }
+  56% { transform: scaleX(-1) rotate(-14deg); opacity: 1; }
+  86% { transform: scaleX(-1) rotate(-14deg); opacity: 1; }
+  100% { transform: scaleX(-0.1) rotate(-14deg); opacity: 0; }
+}
+
+@keyframes swayF {
+  0%, 100% { transform: scale(var(--fs, 1)) rotate(-2deg); }
+  50% { transform: scale(var(--fs, 1)) rotate(2deg); }
+}
+
+@keyframes dripF {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  20% { opacity: 0.9; }
+  100% { transform: translateY(60px) scale(1); opacity: 0; }
+}
+
+@keyframes shimF {
+  0%, 100% { opacity: 0.55; transform: rotate(9deg) scaleX(1); }
+  50% { opacity: 0.95; transform: rotate(12deg) scaleX(1.2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frondF,
+  .crozierF,
+  .downF,
+  .pinnaF,
+  .dropF,
+  .shaftF {
+    animation: none;
+  }
+
+  .dropF {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML stand of fern fiddleheads uncurling.

## Details

- The coil is nested C arcs: a circle with one border side removed plus a second smaller arc rotated inside it, so the head reads as a spiral rather than a ring
- The unfurl rotates and shrinks the coil while the pinnae scale out from zero, so the spiral visibly becomes leaf
- Silvery down on the young coil from a fine conic gradient masked to a thin band at the spiral's edge
- Pinnae cut from a deep clip-path comb and hinged to the stipe, dew dripping off over a mossy floor
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/fern-fiddlehead-as/demo.html`
- `submissions/examples/fern-fiddlehead-as/style.css`
- `submissions/examples/fern-fiddlehead-as/README.md`

Closes #47661
