### PR TITLE
Add split flap component

### DIFF
--- a/submissions/examples/split-flap-as/README.md
+++ b/submissions/examples/split-flap-as/README.md
@@ -1,0 +1,19 @@
+# Split Flap
+
+A pure CSS and HTML split flap display, the leaves toppling over their axles in sequence the way an old departure board reshuffles.
+
+## What it shows
+
+- Real 3D flaps: each leaf rotates on rotateX inside a perspective cell, hinged at its bottom edge, so it topples forward rather than just sliding
+- backface-visibility hiding the leaf as it passes the halfway point, which is what sells the swap
+- The card split into a lit top half and a shadowed bottom half either side of a hard hinge line
+- Cells firing on staggered delays so the board ripples left to right, with axles and a rail
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+The flapping stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/split-flap-as/demo.html
+++ b/submissions/examples/split-flap-as/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Split Flap</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="boardS">
+      <div class="cellS csA">
+        <span class="halfTop"></span>
+        <span class="halfBot"></span>
+        <span class="flipLeaf"></span>
+        <span class="hingeS"></span>
+        <span class="axleS axL"></span>
+        <span class="axleS axR"></span>
+      </div>
+      <div class="cellS csB">
+        <span class="halfTop"></span>
+        <span class="halfBot"></span>
+        <span class="flipLeaf"></span>
+        <span class="hingeS"></span>
+        <span class="axleS axL"></span>
+        <span class="axleS axR"></span>
+      </div>
+      <div class="cellS csC">
+        <span class="halfTop"></span>
+        <span class="halfBot"></span>
+        <span class="flipLeaf"></span>
+        <span class="hingeS"></span>
+        <span class="axleS axL"></span>
+        <span class="axleS axR"></span>
+      </div>
+      <div class="cellS csD">
+        <span class="halfTop"></span>
+        <span class="halfBot"></span>
+        <span class="flipLeaf"></span>
+        <span class="hingeS"></span>
+        <span class="axleS axL"></span>
+        <span class="axleS axR"></span>
+      </div>
+      <span class="railS"></span>
+    </div>
+    <span class="wallS"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/split-flap-as/style.css
+++ b/submissions/examples/split-flap-as/style.css
@@ -1,0 +1,182 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #2c3038, #0e1013 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 240px;
+}
+
+.wallS {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.02) 0 1px,
+      transparent 1px 26px
+    );
+  z-index: 1;
+}
+
+.boardS {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 280px;
+  height: 128px;
+  margin: -64px 0 0 -140px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #2a2e34, #15181c);
+  box-shadow:
+    inset 0 0 0 3px rgba(140, 150, 160, 0.18),
+    0 18px 34px rgba(0, 0, 0, 0.5);
+  z-index: 4;
+}
+
+.railS {
+  position: absolute;
+  bottom: 6px;
+  left: 10px;
+  right: 10px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #6a727e, #2f343a);
+  z-index: 8;
+}
+
+.cellS {
+  position: absolute;
+  top: 14px;
+  width: 58px;
+  height: 92px;
+  perspective: 320px;
+  z-index: 5;
+}
+
+.csA { left: 14px; --ch: "R"; }
+.csB { left: 80px; --fd: 0.35s; --ch: "O"; }
+.csC { left: 146px; --fd: 0.7s; --ch: "M"; }
+.csD { left: 212px; --fd: 1.05s; --ch: "A"; }
+
+.halfTop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 45px;
+  border-radius: 5px 5px 0 0;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, #3f454e, #262b31);
+  box-shadow: inset 0 1px 0 rgba(200, 210, 220, 0.16);
+  z-index: 4;
+}
+
+.halfTop::after {
+  content: var(--ch, "A");
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 90px;
+  color: #f2f6fa;
+  font: 700 52px/90px system-ui, sans-serif;
+  text-align: center;
+}
+
+.halfBot {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 45px;
+  border-radius: 0 0 5px 5px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #21262c, #171b20);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.5);
+  z-index: 4;
+}
+
+.halfBot::after {
+  content: var(--ch, "A");
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 90px;
+  color: #c2ccd6;
+  font: 700 52px/90px system-ui, sans-serif;
+  text-align: center;
+}
+
+.hingeS {
+  position: absolute;
+  top: 45px;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: rgba(8, 10, 12, 0.9);
+  z-index: 7;
+}
+
+.flipLeaf {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 45px;
+  border-radius: 5px 5px 0 0;
+  overflow: hidden;
+  background: linear-gradient(180deg, #3f454e, #262b31);
+  box-shadow: inset 0 1px 0 rgba(200, 210, 220, 0.16);
+  transform-origin: 50% 100%;
+  backface-visibility: hidden;
+  z-index: 6;
+  animation: flipS 1.4s cubic-bezier(0.5, 0, 0.7, 1) infinite var(--fd, 0s);
+}
+
+.flipLeaf::after {
+  content: var(--ch, "A");
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 90px;
+  color: #f2f6fa;
+  font: 700 52px/90px system-ui, sans-serif;
+  text-align: center;
+}
+
+.axleS {
+  position: absolute;
+  top: 41px;
+  width: 7px;
+  height: 10px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #9aa4b0, #454c54);
+  z-index: 8;
+}
+
+.axL { left: -4px; }
+.axR { right: -4px; }
+
+@keyframes flipS {
+  0%, 34% { transform: rotateX(0deg); opacity: 1; }
+  62% { transform: rotateX(-90deg); opacity: 1; }
+  63%, 100% { transform: rotateX(-90deg); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flipLeaf {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML split flap departure board.

## Details

- Real 3D flaps: each leaf rotates on rotateX inside a perspective cell, hinged at its bottom edge, so it topples forward rather than sliding
- backface-visibility hides the leaf as it passes the halfway point, which is what sells the swap
- Each character is passed in as a custom property and drawn with content: var(--ch), then split by the hinge into a lit top half and a shadowed bottom half
- Cells fire on staggered delays so the board ripples left to right, with axles and a rail
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/split-flap-as/demo.html`
- `submissions/examples/split-flap-as/style.css`
- `submissions/examples/split-flap-as/README.md`

Closes #47663
