### PR TITLE
Add echidna component

### DIFF
--- a/submissions/examples/echidna-as/README.md
+++ b/submissions/examples/echidna-as/README.md
@@ -1,0 +1,19 @@
+# Echidna
+
+A pure CSS and HTML short beaked echidna probing an ant mound, its sticky tongue flicking out as the ants scatter.
+
+## What it shows
+
+- The whole coat of spines from one repeating conic gradient, each quill given a lit and a shaded face by a three stop sweep, masked to the animal's back
+- A long tongue driven by scaleX from a hinge at the beak, timed to the ants breaking ranks
+- Coarse fur under the quills from a second finer conic gradient
+- Ants each carrying their own escape vector in custom properties, clawed feet from a clip-path sawtooth
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/echidna-as/demo.html
+++ b/submissions/examples/echidna-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Echidna</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="echidnaE">
+      <span class="spineFan"></span>
+      <span class="bodyE"></span>
+      <span class="furE"></span>
+      <span class="legE leB"></span>
+      <span class="legE leF"></span>
+      <span class="headE"></span>
+      <span class="beakE"></span>
+      <span class="eyeE"></span>
+      <span class="tongueE"></span>
+    </div>
+    <span class="moundE"></span>
+    <span class="antE aeA"></span>
+    <span class="antE aeB"></span>
+    <span class="antE aeC"></span>
+    <span class="logE"></span>
+    <span class="soilE"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/echidna-as/style.css
+++ b/submissions/examples/echidna-as/style.css
@@ -1,0 +1,249 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #d8c49a, #a5814e 60%, #6f5430);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #e4d2a8, #b08c56 58%, #78582e);
+}
+
+.soilE {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 84px;
+  background:
+    radial-gradient(circle at 16% 24%, rgba(255, 245, 215, 0.18) 0 6px, transparent 7px),
+    radial-gradient(circle at 58% 40%, rgba(70, 44, 18, 0.24) 0 8px, transparent 9px),
+    linear-gradient(180deg, #9a7440, #4f3820);
+  z-index: 8;
+}
+
+.logE {
+  position: absolute;
+  bottom: 84px;
+  right: -20px;
+  width: 130px;
+  height: 30px;
+  border-radius: 15px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(40, 24, 10, 0.3) 0 3px,
+      transparent 3px 20px
+    ),
+    linear-gradient(180deg, #7a5a38, #3c2a16);
+  z-index: 7;
+}
+
+.moundE {
+  position: absolute;
+  bottom: 84px;
+  left: 26px;
+  width: 76px;
+  height: 34px;
+  border-radius: 50% 50% 14% 14% / 90% 90% 10% 10%;
+  background: radial-gradient(circle at 40% 30%, #8a6a40, #46301a 78%);
+  z-index: 7;
+}
+
+.antE {
+  position: absolute;
+  width: 6px;
+  height: 4px;
+  border-radius: 50%;
+  background: #2a1c10;
+  z-index: 9;
+  animation: scatterE 3.6s ease-in-out infinite;
+}
+
+.aeA { bottom: 116px; left: 60px; --ax: -28px; --ay: -14px; }
+.aeB { bottom: 112px; left: 76px; --ax: 22px; --ay: -20px; animation-delay: 0.3s; }
+.aeC { bottom: 120px; left: 48px; --ax: -34px; --ay: 6px; animation-delay: 0.6s; }
+
+.echidnaE {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 210px;
+  height: 130px;
+  margin-left: -86px;
+  z-index: 6;
+  animation: ambleE 3.6s ease-in-out infinite;
+}
+
+.bodyE {
+  position: absolute;
+  bottom: 4px;
+  left: 42px;
+  width: 132px;
+  height: 74px;
+  border-radius: 48% 44% 40% 46% / 62% 58% 42% 42%;
+  background: radial-gradient(circle at 40% 32%, #6a5238, #2c2013 78%);
+  box-shadow: inset -8px -6px 18px rgba(16, 10, 4, 0.5);
+  z-index: 4;
+}
+
+.furE {
+  position: absolute;
+  bottom: 4px;
+  left: 42px;
+  width: 132px;
+  height: 74px;
+  border-radius: 48% 44% 40% 46% / 62% 58% 42% 42%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 40% 22%,
+      rgba(120, 96, 60, 0.24) 0 1deg,
+      transparent 1deg 5deg
+    );
+  z-index: 5;
+}
+
+.spineFan {
+  position: absolute;
+  bottom: 4px;
+  left: 34px;
+  width: 148px;
+  height: 106px;
+  background:
+    repeating-conic-gradient(
+      from 196deg at 50% 100%,
+      #f2dca4 0 1.2deg,
+      rgba(90, 60, 20, 0.9) 1.2deg 2.6deg,
+      transparent 2.6deg 8deg
+    );
+  mask-image: radial-gradient(ellipse 60% 100% at 50% 100%, transparent 0 40%, #000 46% 96%, transparent 100%);
+  z-index: 6;
+  animation: bristleE 3.6s ease-in-out infinite;
+}
+
+.headE {
+  position: absolute;
+  bottom: 6px;
+  left: 20px;
+  width: 46px;
+  height: 40px;
+  border-radius: 40% 54% 46% 40% / 46% 52% 50% 46%;
+  background: radial-gradient(circle at 42% 34%, #6a5238, #34261a 78%);
+  z-index: 5;
+}
+
+.beakE {
+  position: absolute;
+  bottom: 12px;
+  left: -14px;
+  width: 46px;
+  height: 11px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #2a2016, #6a5440);
+  transform-origin: 100% 50%;
+  transform: rotate(-8deg);
+  z-index: 6;
+  animation: probeE 3.6s ease-in-out infinite;
+}
+
+.eyeE {
+  position: absolute;
+  bottom: 30px;
+  left: 34px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #4a3a24, #100c06 66%);
+  z-index: 7;
+}
+
+.tongueE {
+  position: absolute;
+  bottom: 14px;
+  left: -46px;
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #e0708a, #b8405a);
+  transform-origin: 100% 50%;
+  transform: scaleX(0.05) rotate(-8deg);
+  z-index: 5;
+  animation: lickE 3.6s ease-in-out infinite;
+}
+
+.legE {
+  position: absolute;
+  bottom: -12px;
+  width: 18px;
+  height: 26px;
+  border-radius: 7px 7px 4px 4px;
+  background: linear-gradient(180deg, #5a4530, #2a1e12);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: stepE 1.2s ease-in-out infinite;
+}
+
+.legE::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -5px;
+  width: 26px;
+  height: 8px;
+  background: #241a10;
+  clip-path: polygon(0 0, 22% 100%, 42% 0, 62% 100%, 82% 0, 100% 100%, 100% 0);
+}
+
+.leF { left: 58px; }
+.leB { left: 132px; filter: brightness(0.82); z-index: 2; animation-delay: 0.6s; }
+
+@keyframes ambleE {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-7px, 0); }
+}
+
+@keyframes bristleE {
+  0%, 62%, 100% { transform: scaleY(1); }
+  76% { transform: scaleY(1.1); }
+}
+
+@keyframes probeE {
+  0%, 100% { transform: rotate(-8deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@keyframes lickE {
+  0%, 40%, 100% { transform: scaleX(0.05) rotate(-8deg); }
+  56%, 68% { transform: scaleX(1) rotate(-4deg); }
+}
+
+@keyframes stepE {
+  0%, 100% { transform: rotate(9deg); }
+  50% { transform: rotate(-9deg); }
+}
+
+@keyframes scatterE {
+  0%, 44% { transform: translate(0, 0); opacity: 1; }
+  70% { transform: translate(var(--ax, 0), var(--ay, 0)); opacity: 1; }
+  84%, 100% { transform: translate(var(--ax, 0), var(--ay, 0)); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .echidnaE,
+  .spineFan,
+  .beakE,
+  .tongueE,
+  .legE,
+  .antE {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML echidna raiding an ant mound.

## Details

- The whole coat of spines is one repeating conic gradient, each quill given a lit and a shaded face by a three stop sweep, masked to the animal's back
- A long tongue driven by scaleX from a hinge at the beak, timed to the ants breaking ranks
- Coarse fur under the quills from a second finer conic gradient
- Ants each carry their own escape vector in custom properties, clawed feet from a clip-path sawtooth
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/echidna-as/demo.html`
- `submissions/examples/echidna-as/style.css`
- `submissions/examples/echidna-as/README.md`

Closes #47665
