### PR TITLE
Add foucault pendulum component

### DIFF
--- a/submissions/examples/foucault-pendulum-as/README.md
+++ b/submissions/examples/foucault-pendulum-as/README.md
@@ -1,0 +1,19 @@
+# Foucault Pendulum
+
+A pure CSS and HTML Foucault pendulum swinging under a museum dome, its plane of swing slowly precessing until it topples the next pin on the dial.
+
+## What it shows
+
+- Two nested rotations doing the physics: an inner element swings the bob fast while an outer one turns the whole plane slowly, which is exactly how the real demonstration reads
+- A very long swing period against a 24s precession, so the plane visibly creeps round rather than spinning
+- The dial ring of degree ticks from a repeating conic gradient masked to a band, with pins standing on it and one toppling as the plane comes round
+- A ribbed dome overhead and a polished brass bob with a specular highlight
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/foucault-pendulum-as/demo.html
+++ b/submissions/examples/foucault-pendulum-as/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Foucault Pendulum</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="domeF"></span>
+    <span class="anchorF"></span>
+    <div class="precessF">
+      <div class="swingF">
+        <span class="wireF"></span>
+        <span class="bobF"></span>
+        <span class="tipF"></span>
+      </div>
+    </div>
+    <span class="dialF"></span>
+    <span class="ticksF"></span>
+    <span class="pinF pfA"></span>
+    <span class="pinF pfB"></span>
+    <span class="pinF pfC"></span>
+    <span class="pinF pfD"></span>
+    <span class="floorF"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/foucault-pendulum-as/style.css
+++ b/submissions/examples/foucault-pendulum-as/style.css
@@ -1,0 +1,197 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #33384a, #0e1016 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 16%, #3a4055, #0c0e14 76%);
+}
+
+.domeF {
+  position: absolute;
+  top: -70px;
+  left: 50%;
+  width: 300px;
+  height: 150px;
+  margin-left: -150px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 50% 100%,
+      rgba(150, 165, 200, 0.16) 0 0.6deg,
+      transparent 0.6deg 9deg
+    ),
+    radial-gradient(ellipse at 50% 100%, #2a3048, #12151f 76%);
+  z-index: 2;
+}
+
+.anchorF {
+  position: absolute;
+  top: 66px;
+  left: 50%;
+  width: 26px;
+  height: 16px;
+  margin-left: -13px;
+  border-radius: 4px 4px 8px 8px;
+  background: linear-gradient(180deg, #a8b0c0, #40465a);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.5);
+  z-index: 6;
+}
+
+.precessF {
+  position: absolute;
+  top: 76px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 5;
+  animation: precessF 24s linear infinite;
+}
+
+.swingF {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  transform-origin: 0 0;
+  animation: swingF 3.2s ease-in-out infinite;
+}
+
+.wireF {
+  position: absolute;
+  top: 0;
+  left: -0.75px;
+  width: 1.5px;
+  height: 104px;
+  background: linear-gradient(180deg, rgba(210, 220, 240, 0.85), rgba(150, 160, 185, 0.5));
+}
+
+.bobF {
+  position: absolute;
+  top: 98px;
+  left: -21px;
+  width: 42px;
+  height: 52px;
+  border-radius: 50% 50% 42% 42% / 40% 40% 60% 60%;
+  background:
+    radial-gradient(circle at 34% 26%, #ffffff 0 3px, transparent 4px),
+    radial-gradient(circle at 38% 30%, #d8dee8, #6a7280 54%, #262c38 88%);
+  box-shadow:
+    inset -6px -6px 14px rgba(8, 10, 16, 0.7),
+    0 6px 14px rgba(0, 0, 0, 0.5);
+  z-index: 8;
+}
+
+.tipF {
+  position: absolute;
+  top: 146px;
+  left: -3px;
+  width: 6px;
+  height: 14px;
+  border-radius: 0 0 50% 50%;
+  background: linear-gradient(180deg, #9aa2b0, #4a5060);
+  clip-path: polygon(0 0, 100% 0, 60% 100%, 40% 100%);
+  z-index: 8;
+}
+
+.dialF {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 240px;
+  height: 80px;
+  margin-left: -120px;
+  border-radius: 50%;
+  background:
+    radial-gradient(ellipse at 50% 40%, #2a3040, #14181f 78%);
+  box-shadow:
+    inset 0 4px 12px rgba(0, 0, 0, 0.6),
+    0 8px 18px rgba(0, 0, 0, 0.5);
+  z-index: 7;
+}
+
+.ticksF {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 240px;
+  height: 80px;
+  margin-left: -120px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(190, 205, 235, 0.5) 0 0.8deg,
+      transparent 0.8deg 12deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 40%, #000 44% 49%, transparent 52%);
+  z-index: 8;
+}
+
+.pinF {
+  position: absolute;
+  bottom: 62px;
+  width: 5px;
+  height: 20px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #d8dee8, #5a6070);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  z-index: 9;
+}
+
+.pfA { left: 50%; margin-left: -104px; }
+.pfB { left: 50%; margin-left: -58px; }
+.pfC { left: 50%; margin-left: 54px; animation: topplePin 24s linear infinite; transform-origin: 50% 100%; }
+.pfD { left: 50%; margin-left: 100px; }
+
+.floorF {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(160, 175, 210, 0.05) 0 2px,
+      transparent 2px 30px
+    ),
+    linear-gradient(180deg, #1c2029, #0a0c10);
+  z-index: 9;
+}
+
+@keyframes swingF {
+  0%, 100% { transform: rotate(-19deg); }
+  50% { transform: rotate(19deg); }
+}
+
+@keyframes precessF {
+  from { transform: rotateY(0deg); }
+  to { transform: rotateY(360deg); }
+}
+
+@keyframes topplePin {
+  0%, 44% { transform: rotate(0deg); opacity: 1; }
+  50% { transform: rotate(-72deg); opacity: 1; }
+  96%, 100% { transform: rotate(-72deg); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .precessF,
+  .swingF,
+  .pfC {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML Foucault pendulum precessing under a dome.

## Details

- Two nested rotations do the physics: an inner element swings the bob while an outer one turns the whole plane slowly
- A short swing period against a 24s precession, so the plane visibly creeps round rather than spinning
- The dial ring of degree ticks from a repeating conic gradient masked to a band, with pins standing on it and one toppling as the plane comes round
- A ribbed dome overhead and a polished bob with a specular highlight
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/foucault-pendulum-as/demo.html`
- `submissions/examples/foucault-pendulum-as/style.css`
- `submissions/examples/foucault-pendulum-as/README.md`

Closes #47667
