### PR TITLE
Add quill inkwell component

### DIFF
--- a/submissions/examples/quill-inkwell-as/README.md
+++ b/submissions/examples/quill-inkwell-as/README.md
@@ -1,0 +1,19 @@
+# Quill and Inkwell
+
+A pure CSS and HTML quill pen dipping into its inkwell and writing a line of script across the page by candlelight.
+
+## What it shows
+
+- One timeline for the whole ritual: the quill travels to the well, dips, lifts with a drop falling back, returns to the page and draws its line
+- The ink line drawn by scaling an element from its left edge in step with the nib arriving, so the writing appears under the pen rather than beside it
+- A feather vane cut from a clip-path with barb lines from a repeating linear gradient, ruffling as the pen moves
+- A glass inkwell from translucent gradients with ink sloshing inside and a candle glow flickering over the desk
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`, leaving the line written.

--- a/submissions/examples/quill-inkwell-as/demo.html
+++ b/submissions/examples/quill-inkwell-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quill and Inkwell</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="candleGlow"></span>
+    <span class="paperQ"></span>
+    <span class="lineQ lqA"></span>
+    <span class="lineQ lqB"></span>
+    <span class="lineQ lqC"></span>
+    <span class="inkTrail"></span>
+    <div class="quillQ">
+      <span class="vaneQ"></span>
+      <span class="rachisQ"></span>
+      <span class="nibQ"></span>
+    </div>
+    <span class="dropQ"></span>
+    <div class="wellQ">
+      <span class="wellBody"></span>
+      <span class="wellNeck"></span>
+      <span class="inkPool"></span>
+      <span class="wellShine"></span>
+    </div>
+    <span class="deskQ"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/quill-inkwell-as/style.css
+++ b/submissions/examples/quill-inkwell-as/style.css
@@ -1,0 +1,273 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 44% 28%, #4a3a26, #150f08 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 42% 26%, #54402a, #17110a 78%);
+}
+
+.candleGlow {
+  position: absolute;
+  top: -40px;
+  left: 20px;
+  width: 220px;
+  height: 200px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 200, 110, 0.22), transparent 66%);
+  z-index: 1;
+  animation: flickerGlowQ 4s ease-in-out infinite;
+}
+
+.deskQ {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 96px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 12, 6, 0.36) 0 2px,
+      transparent 2px 32px
+    ),
+    linear-gradient(180deg, #6a4a2c, #2a1c10);
+  z-index: 2;
+}
+
+.paperQ {
+  position: absolute;
+  bottom: 52px;
+  left: 32px;
+  width: 200px;
+  height: 92px;
+  border-radius: 3px;
+  background: linear-gradient(170deg, #f4ecd8, #d8cbaa);
+  box-shadow: 0 8px 18px rgba(10, 6, 2, 0.5);
+  transform: rotate(-3deg);
+  z-index: 5;
+}
+
+.lineQ {
+  position: absolute;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, #2a2418, rgba(42, 36, 24, 0.4));
+  transform: rotate(-3deg);
+  z-index: 6;
+}
+
+.lqA { bottom: 118px; left: 46px; width: 150px; }
+.lqB { bottom: 100px; left: 46px; width: 168px; }
+.lqC { bottom: 82px; left: 46px; width: 96px; }
+
+.inkTrail {
+  position: absolute;
+  bottom: 66px;
+  left: 46px;
+  width: 132px;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, #2a2418, #4a4230);
+  transform: rotate(-3deg);
+  transform-origin: 0 50%;
+  z-index: 6;
+  animation: writeQ 6s ease-in-out infinite;
+}
+
+.quillQ {
+  position: absolute;
+  bottom: 60px;
+  left: 40px;
+  width: 40px;
+  height: 190px;
+  transform-origin: 50% 100%;
+  z-index: 8;
+  animation: scribeQ 6s ease-in-out infinite;
+}
+
+.rachisQ {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 6px;
+  height: 170px;
+  margin-left: -3px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #b8a882, #f4ecd0 44%, #a89872);
+  z-index: 5;
+}
+
+.vaneQ {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 46px;
+  height: 140px;
+  margin-left: -23px;
+  background:
+    repeating-linear-gradient(
+      100deg,
+      rgba(150, 130, 90, 0.4) 0 1px,
+      transparent 1px 6px
+    ),
+    linear-gradient(90deg, rgba(245, 240, 220, 0.95), rgba(210, 200, 170, 0.85));
+  clip-path: polygon(46% 100%, 8% 74%, 2% 34%, 30% 6%, 50% 0, 70% 6%, 98% 34%, 92% 74%, 54% 100%);
+  z-index: 4;
+  animation: ruffleQ 6s ease-in-out infinite;
+}
+
+.nibQ {
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  width: 8px;
+  height: 18px;
+  margin-left: -4px;
+  background: linear-gradient(180deg, #d8c8a0, #4a3f28);
+  clip-path: polygon(0 0, 100% 0, 62% 82%, 50% 100%, 38% 82%);
+  z-index: 6;
+}
+
+.dropQ {
+  position: absolute;
+  width: 6px;
+  height: 9px;
+  border-radius: 50% 50% 60% 60%;
+  background: radial-gradient(circle at 34% 30%, #4a4a5a, #14141c 74%);
+  opacity: 0;
+  z-index: 9;
+  animation: dripQ 6s ease-in infinite;
+}
+
+.wellQ {
+  position: absolute;
+  bottom: 62px;
+  right: 34px;
+  width: 84px;
+  height: 74px;
+  z-index: 7;
+}
+
+.wellBody {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 84px;
+  height: 56px;
+  border-radius: 14px 14px 20px 20px / 8px 8px 26px 26px;
+  background: linear-gradient(150deg, rgba(120, 170, 190, 0.5), rgba(50, 90, 110, 0.42) 60%, rgba(30, 60, 80, 0.5));
+  border: 1.5px solid rgba(180, 220, 235, 0.3);
+  box-shadow:
+    inset 0 0 18px rgba(140, 200, 220, 0.16),
+    0 8px 16px rgba(0, 0, 0, 0.5);
+  z-index: 4;
+}
+
+.inkPool {
+  position: absolute;
+  bottom: 4px;
+  left: 6px;
+  width: 72px;
+  height: 30px;
+  border-radius: 0 0 18px 18px / 0 0 22px 22px;
+  background: linear-gradient(180deg, #23233a, #0a0a12);
+  z-index: 5;
+  animation: sloshQ 6s ease-in-out infinite;
+}
+
+.wellNeck {
+  position: absolute;
+  bottom: 50px;
+  left: 50%;
+  width: 40px;
+  height: 22px;
+  margin-left: -20px;
+  border-radius: 6px 6px 2px 2px;
+  background: linear-gradient(150deg, rgba(140, 190, 205, 0.5), rgba(60, 100, 120, 0.44));
+  border: 1.5px solid rgba(180, 220, 235, 0.3);
+  border-bottom: none;
+  z-index: 6;
+}
+
+.wellShine {
+  position: absolute;
+  bottom: 8px;
+  left: 12px;
+  width: 12px;
+  height: 46px;
+  border-radius: 40%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.4), transparent 74%);
+  z-index: 7;
+}
+
+@keyframes scribeQ {
+  0% { transform: translate(0, 0) rotate(-16deg); }
+  14% { transform: translate(196px, -6px) rotate(-12deg); }
+  22% { transform: translate(196px, 6px) rotate(-12deg); }
+  30% { transform: translate(196px, -6px) rotate(-12deg); }
+  44% { transform: translate(10px, 0) rotate(-16deg); }
+  64% { transform: translate(60px, 2px) rotate(-14deg); }
+  84% { transform: translate(122px, 4px) rotate(-13deg); }
+  100% { transform: translate(0, 0) rotate(-16deg); }
+}
+
+@keyframes writeQ {
+  0%, 44% { transform: rotate(-3deg) scaleX(0); }
+  64% { transform: rotate(-3deg) scaleX(0.42); }
+  84% { transform: rotate(-3deg) scaleX(0.95); }
+  96%, 100% { transform: rotate(-3deg) scaleX(0); }
+}
+
+@keyframes ruffleQ {
+  0%, 100% { transform: rotate(-1.5deg); }
+  50% { transform: rotate(1.5deg); }
+}
+
+@keyframes dripQ {
+  0%, 30% { transform: translate(240px, 96px) scale(0.4); opacity: 0; }
+  36% { transform: translate(240px, 108px) scale(1); opacity: 1; }
+  44% { transform: translate(232px, 150px) scale(1); opacity: 0; }
+  100% { opacity: 0; }
+}
+
+@keyframes sloshQ {
+  0%, 100% { transform: scaleY(1) translateX(0); }
+  32% { transform: scaleY(1.12) translateX(-3px); }
+}
+
+@keyframes flickerGlowQ {
+  0%, 100% { opacity: 0.82; }
+  30% { opacity: 1; }
+  62% { opacity: 0.9; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quillQ,
+  .vaneQ,
+  .inkTrail,
+  .dropQ,
+  .inkPool,
+  .candleGlow {
+    animation: none;
+  }
+
+  .dropQ {
+    opacity: 0;
+  }
+
+  .inkTrail {
+    transform: rotate(-3deg) scaleX(0.95);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML quill and inkwell writing by candlelight.

## Details

- One timeline for the whole ritual: the quill travels to the well, dips, lifts with a drop falling back, returns to the page and draws its line
- The ink line is drawn by scaling an element from its left edge in step with the nib arriving, so the writing appears under the pen rather than beside it
- A feather vane cut from a clip-path with barb lines from a repeating linear gradient, ruffling as the pen moves
- A glass inkwell from translucent gradients with ink sloshing inside and a candle glow flickering over the desk
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/quill-inkwell-as/demo.html`
- `submissions/examples/quill-inkwell-as/style.css`
- `submissions/examples/quill-inkwell-as/README.md`

Closes #47669
