### PR TITLE
Add frogmouth component

### DIFF
--- a/submissions/examples/frogmouth-as/README.md
+++ b/submissions/examples/frogmouth-as/README.md
@@ -1,0 +1,19 @@
+# Frogmouth
+
+A pure CSS and HTML tawny frogmouth pretending to be a broken bough, squinting into a slit until a moth strays close and the huge mouth gapes.
+
+## What it shows
+
+- Camouflage as behaviour: the bird holds a bark coloured freeze with its eyes squinted to slits, and only breaks it when the moth arrives
+- The enormous frogmouth gape from two clip-path mandibles hinged apart on one shared timeline with the head tilt
+- Bark plumage from a repeating linear gradient plus mottling, with a moonlit rim so the silhouette still separates from the branch
+- Bristly rictal tufts over the bill from masked conic gradients
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/frogmouth-as/demo.html
+++ b/submissions/examples/frogmouth-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Frogmouth</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moonR"></span>
+    <span class="boughR"></span>
+    <div class="birdR">
+      <span class="tailR"></span>
+      <span class="bodyR"></span>
+      <span class="barkR"></span>
+      <span class="wingR"></span>
+      <div class="headR">
+        <span class="skullR"></span>
+        <span class="upperR"></span>
+        <span class="lowerR"></span>
+        <span class="tuftR trL"></span>
+        <span class="tuftR trR"></span>
+        <span class="eyeR erL"></span>
+        <span class="eyeR erR"></span>
+        <span class="lidR llL"></span>
+        <span class="lidR llR"></span>
+      </div>
+      <span class="footR"></span>
+    </div>
+    <span class="mothR"></span>
+    <span class="leafR lrA"></span>
+    <span class="nightR"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/frogmouth-as/style.css
+++ b/submissions/examples/frogmouth-as/style.css
@@ -1,0 +1,351 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #1e2a3e, #0a0f1a 74%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #26344a, #090e18 76%);
+}
+
+.moonR {
+  position: absolute;
+  top: 30px;
+  right: 40px;
+  width: 66px;
+  height: 66px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 62% 40%, rgba(120, 130, 120, 0.36) 0 7px, transparent 9px),
+    radial-gradient(circle, #eef0dc, #cfd2b4 72%);
+  box-shadow: 0 0 46px 14px rgba(230, 235, 200, 0.26);
+  z-index: 1;
+  animation: glowR 8s ease-in-out infinite;
+}
+
+.nightR {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 76% 22%, rgba(240, 245, 220, 0.1), transparent 52%);
+  z-index: 1;
+}
+
+.boughR {
+  position: absolute;
+  bottom: 76px;
+  left: -30px;
+  right: -30px;
+  height: 42px;
+  border-radius: 21px;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(16, 10, 5, 0.44) 0 3px,
+      transparent 3px 18px
+    ),
+    linear-gradient(180deg, #5a4530, #221a10);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);
+  z-index: 7;
+}
+
+.leafR {
+  position: absolute;
+  width: 48px;
+  height: 18px;
+  border-radius: 60% 8% 60% 8%;
+  background: linear-gradient(100deg, #2f4a2c, #16260f);
+  transform-origin: 0 50%;
+  z-index: 8;
+  animation: nodLeafR 7s ease-in-out infinite;
+}
+
+.lrA { bottom: 104px; right: 26px; }
+
+.birdR {
+  position: absolute;
+  bottom: 110px;
+  left: 50%;
+  width: 150px;
+  height: 170px;
+  margin-left: -70px;
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: freezeR 9s ease-in-out infinite;
+}
+
+.bodyR {
+  position: absolute;
+  bottom: 0;
+  left: 26px;
+  width: 92px;
+  height: 128px;
+  border-radius: 46% 46% 40% 40% / 34% 34% 66% 66%;
+  background: linear-gradient(180deg, #6a5a44, #33291d 74%, #4a3d2c);
+  box-shadow:
+    inset -8px 0 20px rgba(10, 6, 2, 0.5),
+    5px 0 12px -4px rgba(230, 235, 200, 0.24);
+  z-index: 4;
+}
+
+.barkR {
+  position: absolute;
+  bottom: 0;
+  left: 26px;
+  width: 92px;
+  height: 128px;
+  border-radius: 46% 46% 40% 40% / 34% 34% 66% 66%;
+  background:
+    repeating-linear-gradient(
+      86deg,
+      rgba(16, 10, 5, 0.38) 0 2px,
+      transparent 2px 12px
+    ),
+    radial-gradient(circle at 32% 40%, rgba(210, 195, 155, 0.22) 0 5px, transparent 7px),
+    radial-gradient(circle at 64% 66%, rgba(16, 10, 5, 0.32) 0 6px, transparent 8px);
+  z-index: 5;
+}
+
+.wingR {
+  position: absolute;
+  bottom: 16px;
+  left: 66px;
+  width: 46px;
+  height: 100px;
+  border-radius: 40% 50% 46% 50% / 30% 40% 60% 70%;
+  background:
+    repeating-linear-gradient(
+      82deg,
+      rgba(16, 10, 5, 0.32) 0 3px,
+      transparent 3px 14px
+    ),
+    linear-gradient(180deg, #5a4a36, #2a2116);
+  z-index: 5;
+}
+
+.tailR {
+  position: absolute;
+  bottom: -30px;
+  left: 44px;
+  width: 54px;
+  height: 62px;
+  border-radius: 0 0 36% 36%;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(16, 10, 5, 0.4) 0 5px,
+      transparent 5px 15px
+    ),
+    linear-gradient(180deg, #4a3b2a, #221a10);
+  z-index: 3;
+}
+
+.footR {
+  position: absolute;
+  bottom: -8px;
+  left: 56px;
+  width: 34px;
+  height: 12px;
+  background: #2a2116;
+  clip-path: polygon(0 0, 22% 100%, 42% 0, 62% 100%, 82% 0, 100% 100%, 100% 0);
+  z-index: 6;
+}
+
+.headR {
+  position: absolute;
+  bottom: 106px;
+  left: 12px;
+  width: 122px;
+  height: 74px;
+  transform-origin: 60% 100%;
+  z-index: 7;
+  animation: tiltR 9s ease-in-out infinite;
+}
+
+.skullR {
+  position: absolute;
+  bottom: 0;
+  left: 22px;
+  width: 78px;
+  height: 56px;
+  border-radius: 48% 48% 40% 40% / 56% 56% 44% 44%;
+  background: radial-gradient(circle at 42% 34%, #7a6a50, #3a2f20 78%);
+  z-index: 4;
+}
+
+.upperR {
+  position: absolute;
+  bottom: 12px;
+  left: 6px;
+  width: 112px;
+  height: 20px;
+  background: linear-gradient(180deg, #6a5a42, #3a3022);
+  clip-path: polygon(0 46%, 22% 12%, 78% 12%, 100% 46%, 96% 70%, 4% 70%);
+  z-index: 6;
+  animation: gapeUpR 9s ease-in-out infinite;
+  transform-origin: 50% 100%;
+}
+
+.lowerR {
+  position: absolute;
+  bottom: 2px;
+  left: 12px;
+  width: 100px;
+  height: 16px;
+  background: linear-gradient(180deg, #3a3022, #1c160e);
+  clip-path: polygon(2% 0, 98% 0, 88% 84%, 12% 84%);
+  transform-origin: 50% 0;
+  z-index: 5;
+  animation: gapeLowR 9s ease-in-out infinite;
+}
+
+.tuftR {
+  position: absolute;
+  bottom: 40px;
+  width: 30px;
+  height: 22px;
+  background:
+    repeating-conic-gradient(
+      from 250deg at 50% 100%,
+      #8a7a5c 0 3deg,
+      transparent 3deg 9deg
+    );
+  mask-image: radial-gradient(ellipse 70% 100% at 50% 100%, #000 0 72%, transparent 84%);
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: bristleR 9s ease-in-out infinite;
+}
+
+.trL { left: 22px; --tr: -14deg; transform: rotate(-14deg); }
+.trR { right: 22px; --tr: 14deg; transform: rotate(14deg); animation-delay: 0.4s; }
+
+.eyeR {
+  position: absolute;
+  bottom: 26px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 40% 36%, #fff2b0 0 3px, transparent 4px),
+    radial-gradient(circle at 50% 50%, #17120a 0 6px, #d8a63a 7px 10px, #4a3416 11px);
+  box-shadow: 0 0 8px rgba(216, 166, 58, 0.4);
+  z-index: 7;
+}
+
+.erL { left: 30px; }
+.erR { right: 30px; }
+
+.lidR {
+  position: absolute;
+  bottom: 34px;
+  width: 26px;
+  height: 15px;
+  border-radius: 50% 50% 0 0;
+  background: linear-gradient(180deg, #6a5a42, #3a3022);
+  transform-origin: 50% 100%;
+  z-index: 8;
+  animation: squintR 9s ease-in-out infinite;
+}
+
+.llL { left: 28px; }
+.llR { right: 28px; }
+
+.mothR {
+  position: absolute;
+  bottom: 190px;
+  left: 34px;
+  width: 15px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(220, 210, 180, 0.85);
+  z-index: 9;
+  animation: flyMothR 9s ease-in-out infinite;
+}
+
+.mothR::before,
+.mothR::after {
+  content: "";
+  position: absolute;
+  top: -1px;
+  width: 9px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgba(230, 224, 200, 0.7);
+}
+
+.mothR::before { left: -5px; transform: rotate(-18deg); }
+.mothR::after { right: -5px; transform: rotate(18deg); }
+
+@keyframes freezeR {
+  0%, 56%, 100% { transform: rotate(0deg) scaleY(1); }
+  68% { transform: rotate(0deg) scaleY(1.03); }
+}
+
+@keyframes tiltR {
+  0%, 52%, 100% { transform: rotate(0deg); }
+  64% { transform: rotate(-9deg); }
+  78% { transform: rotate(3deg); }
+}
+
+@keyframes gapeUpR {
+  0%, 58%, 100% { transform: rotate(0deg); }
+  68%, 76% { transform: rotate(-16deg); }
+}
+
+@keyframes gapeLowR {
+  0%, 58%, 100% { transform: rotate(0deg); }
+  68%, 76% { transform: rotate(26deg); }
+}
+
+@keyframes squintR {
+  0%, 50% { transform: scaleY(1); }
+  60%, 84% { transform: scaleY(0.1); }
+  94%, 100% { transform: scaleY(1); }
+}
+
+@keyframes bristleR {
+  0%, 100% { transform: rotate(var(--tr, 0deg)); }
+  62% { transform: rotate(calc(var(--tr, 0deg) * 1.5)); }
+}
+
+@keyframes flyMothR {
+  0% { transform: translate(0, 0); opacity: 1; }
+  30% { transform: translate(40px, 24px); opacity: 1; }
+  58% { transform: translate(58px, 52px); opacity: 1; }
+  70% { transform: translate(62px, 62px); opacity: 1; }
+  78% { transform: translate(62px, 62px); opacity: 0; }
+  100% { transform: translate(0, 0); opacity: 0; }
+}
+
+@keyframes nodLeafR {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes glowR {
+  0%, 100% { opacity: 0.9; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .birdR,
+  .headR,
+  .upperR,
+  .lowerR,
+  .lidR,
+  .tuftR,
+  .mothR,
+  .leafR,
+  .moonR {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML tawny frogmouth camouflaged on a bough.

## Details

- Camouflage as behaviour: the bird holds a bark coloured freeze with its eyes squinted to slits, and only breaks it when the moth arrives
- The enormous gape is two clip-path mandibles hinged apart on one shared timeline with the head tilt
- Bark plumage from a repeating linear gradient plus mottling, with a moonlit rim so the silhouette still separates from the branch
- Bristly rictal tufts over the bill from masked conic gradients
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/frogmouth-as/demo.html`
- `submissions/examples/frogmouth-as/style.css`
- `submissions/examples/frogmouth-as/README.md`

Closes #47671
