### PR TITLE
Add axolotl gills component

### DIFF
--- a/submissions/examples/axolotl-gills-as/README.md
+++ b/submissions/examples/axolotl-gills-as/README.md
@@ -1,0 +1,19 @@
+# Axolotl Gills
+
+A pure CSS and HTML axolotl hovering over the gravel, its six feathery external gills fanning in slow sequence.
+
+## What it shows
+
+- Six gill stalks, each parking its own splay angle in a custom property so a shared fan keyframe waves them, staggered so the frill ripples front to back
+- Every gill wearing its own crown of filaments from a masked repeating conic gradient on ::after
+- A translucent tail and dorsal fin that undulate independently of the body
+- Webbed feet from a clip-path sawtooth, plants swaying with a rotate and skew
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/axolotl-gills-as/demo.html
+++ b/submissions/examples/axolotl-gills-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Axolotl Gills</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="axoX">
+      <span class="tailX"></span>
+      <span class="finTopX"></span>
+      <span class="bodyX"></span>
+      <span class="legX lxB"></span>
+      <span class="legX lxF"></span>
+      <span class="headX"></span>
+      <span class="gillX gxA"></span>
+      <span class="gillX gxB"></span>
+      <span class="gillX gxC"></span>
+      <span class="gillX gxD"></span>
+      <span class="gillX gxE"></span>
+      <span class="gillX gxF"></span>
+      <span class="eyeX exL"></span>
+      <span class="eyeX exR"></span>
+      <span class="smileX"></span>
+    </div>
+    <span class="bubX bxA"></span>
+    <span class="bubX bxB"></span>
+    <span class="plantX pxA"></span>
+    <span class="plantX pxB"></span>
+    <span class="gravelX"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/axolotl-gills-as/style.css
+++ b/submissions/examples/axolotl-gills-as/style.css
@@ -1,0 +1,271 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #2f8a9c, #0e4a5e 62%, #06252f);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #35a0b2, #0f5468 60%, #072a36);
+}
+
+.gravelX {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 62px;
+  background:
+    radial-gradient(circle at 14% 30%, #7a8a92 0 9px, transparent 10px),
+    radial-gradient(circle at 38% 16%, #5f6f78 0 11px, transparent 12px),
+    radial-gradient(circle at 64% 34%, #7a8a92 0 8px, transparent 9px),
+    radial-gradient(circle at 88% 18%, #556570 0 10px, transparent 11px),
+    linear-gradient(180deg, #4f5f68, #232f36);
+  z-index: 8;
+}
+
+.plantX {
+  position: absolute;
+  bottom: 46px;
+  width: 30px;
+  height: 130px;
+  background:
+    repeating-linear-gradient(
+      86deg,
+      #2f7a48 0 4px,
+      transparent 4px 12px
+    );
+  mask-image: linear-gradient(180deg, transparent 0 6%, #000 32%);
+  transform-origin: 50% 100%;
+  z-index: 7;
+  animation: swayPlantX 8s ease-in-out infinite;
+}
+
+.pxA { left: 22px; }
+.pxB { right: 26px; height: 96px; animation-delay: 3s; }
+
+.bubX {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.85), rgba(180, 240, 250, 0.3) 70%);
+  border: 1px solid rgba(210, 245, 250, 0.5);
+  opacity: 0;
+  z-index: 9;
+  animation: riseX 6s ease-in infinite;
+}
+
+.bxA { bottom: 130px; left: 236px; width: 8px; height: 8px; }
+.bxB { bottom: 140px; left: 258px; width: 5px; height: 5px; animation-delay: 3s; }
+
+.axoX {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  width: 240px;
+  height: 120px;
+  margin-left: -108px;
+  z-index: 6;
+  animation: hoverX 6s ease-in-out infinite;
+}
+
+.bodyX {
+  position: absolute;
+  bottom: 6px;
+  left: 22px;
+  width: 150px;
+  height: 52px;
+  border-radius: 40% 46% 46% 40% / 50%;
+  background: linear-gradient(180deg, #ffd6e2, #f2a8bc 72%, #ffe8ee);
+  box-shadow: inset 0 -5px 12px rgba(190, 110, 140, 0.4);
+  z-index: 4;
+}
+
+.finTopX {
+  position: absolute;
+  bottom: 50px;
+  left: 40px;
+  width: 116px;
+  height: 20px;
+  border-radius: 50% 50% 0 0;
+  background: linear-gradient(180deg, rgba(255, 220, 232, 0.8), rgba(240, 170, 195, 0.45));
+  z-index: 3;
+  animation: waveFinX 2.4s ease-in-out infinite;
+}
+
+.headX {
+  position: absolute;
+  bottom: 8px;
+  left: 148px;
+  width: 62px;
+  height: 48px;
+  border-radius: 36% 52% 46% 40% / 44% 52% 50% 46%;
+  background: radial-gradient(circle at 42% 34%, #ffe2ea, #f2a8bc 80%);
+  z-index: 5;
+}
+
+.eyeX {
+  position: absolute;
+  bottom: 36px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #1a1014;
+  z-index: 7;
+  animation: blinkX 5s ease-in-out infinite;
+}
+
+.exL { left: 168px; }
+.exR { left: 194px; }
+
+.smileX {
+  position: absolute;
+  bottom: 18px;
+  left: 178px;
+  width: 28px;
+  height: 12px;
+  border-radius: 0 0 60% 60%;
+  border-bottom: 2px solid rgba(190, 110, 140, 0.7);
+  z-index: 6;
+}
+
+.gillX {
+  position: absolute;
+  bottom: 40px;
+  left: 146px;
+  width: 12px;
+  height: 54px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #ff5f8a, #d02a56);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--gx, 0deg));
+  z-index: 3;
+  animation: fanGillX 2.2s ease-in-out infinite;
+}
+
+.gillX::after {
+  content: "";
+  position: absolute;
+  inset: -4px -7px 4px -7px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 50% 100%,
+      rgba(255, 130, 165, 0.95) 0 2deg,
+      transparent 2deg 8deg
+    );
+  mask-image: radial-gradient(ellipse 60% 100% at 50% 100%, #000 0 76%, transparent 88%);
+}
+
+.gxA { --gx: -54deg; height: 44px; }
+.gxB { --gx: -30deg; height: 52px; animation-delay: 0.18s; }
+.gxC { --gx: -8deg; height: 56px; animation-delay: 0.36s; }
+.gxD { left: 196px; --gx: 8deg; height: 56px; animation-delay: 0.54s; }
+.gxE { left: 196px; --gx: 30deg; height: 52px; animation-delay: 0.72s; }
+.gxF { left: 196px; --gx: 54deg; height: 44px; animation-delay: 0.9s; }
+
+.legX {
+  position: absolute;
+  bottom: -10px;
+  width: 10px;
+  height: 26px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #ffd0de, #e894ac);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: paddleX 2.4s ease-in-out infinite;
+}
+
+.legX::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -5px;
+  width: 20px;
+  height: 8px;
+  background: #f0a0b8;
+  clip-path: polygon(0 0, 26% 100%, 50% 0, 74% 100%, 100% 0);
+}
+
+.lxF { left: 130px; }
+.lxB { left: 48px; filter: brightness(0.92); animation-delay: 1.2s; }
+
+.tailX {
+  position: absolute;
+  bottom: 2px;
+  left: -18px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50% 0 0 50%;
+  background: linear-gradient(90deg, rgba(240, 170, 195, 0.6), #f2a8bc);
+  clip-path: polygon(0 26%, 100% 8%, 100% 92%, 0 74%);
+  transform-origin: 100% 50%;
+  z-index: 3;
+  animation: swishX 2.4s ease-in-out infinite;
+}
+
+@keyframes hoverX {
+  0%, 100% { transform: translate(0, 0) rotate(-1deg); }
+  50% { transform: translate(-8px, -6px) rotate(1deg); }
+}
+
+@keyframes fanGillX {
+  0%, 100% { transform: rotate(var(--gx, 0deg)); }
+  50% { transform: rotate(calc(var(--gx, 0deg) * 1.22)); }
+}
+
+@keyframes swishX {
+  0%, 100% { transform: rotate(-7deg); }
+  50% { transform: rotate(7deg); }
+}
+
+@keyframes waveFinX {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.14); }
+}
+
+@keyframes paddleX {
+  0%, 100% { transform: rotate(-10deg); }
+  50% { transform: rotate(10deg); }
+}
+
+@keyframes blinkX {
+  0%, 93%, 100% { transform: scaleY(1); }
+  96% { transform: scaleY(0.1); }
+}
+
+@keyframes swayPlantX {
+  0%, 100% { transform: rotate(-4deg) skewX(3deg); }
+  50% { transform: rotate(4deg) skewX(-3deg); }
+}
+
+@keyframes riseX {
+  0% { transform: translateY(0) scale(0.6); opacity: 0; }
+  20% { opacity: 0.9; }
+  100% { transform: translateY(-140px) scale(1.1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .axoX,
+  .gillX,
+  .tailX,
+  .finTopX,
+  .legX,
+  .eyeX,
+  .plantX,
+  .bubX {
+    animation: none;
+  }
+
+  .bubX {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML axolotl with fanning feathery gills.

## Details

- Six gill stalks each park their own splay angle in a custom property so a shared fan keyframe waves them, staggered so the frill ripples front to back
- Every gill wears its own crown of filaments from a masked repeating conic gradient on ::after
- A translucent tail and dorsal fin undulate independently of the body
- Webbed feet from a clip-path sawtooth, plants swaying with a rotate and skew
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/axolotl-gills-as/demo.html`
- `submissions/examples/axolotl-gills-as/style.css`
- `submissions/examples/axolotl-gills-as/README.md`

Closes #47675
