### PR TITLE
Add roadrunner component

### DIFF
--- a/submissions/examples/roadrunner-as/README.md
+++ b/submissions/examples/roadrunner-as/README.md
@@ -1,0 +1,19 @@
+# Roadrunner
+
+A pure CSS and HTML greater roadrunner sprinting flat out across the desert, legs blurring, crest up and tail steering behind it.
+
+## What it shows
+
+- A running gait from one linear keyframe run twice with a half cycle offset, so the two legs alternate exactly rather than drifting apart
+- The ground stripe scrolled with background-position to give speed without moving the bird, plus dust puffs kicking backwards
+- A spiky crest from a masked conic gradient, streaked plumage from a diagonal repeating linear gradient
+- The whole head group riding the same fast cycle as the legs so the bird bobs as it runs
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/roadrunner-as/demo.html
+++ b/submissions/examples/roadrunner-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Roadrunner</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunR"></span>
+    <span class="mesaR"></span>
+    <span class="cactusR"></span>
+    <div class="runnerR">
+      <span class="tailR"></span>
+      <span class="bodyR"></span>
+      <span class="streakR"></span>
+      <span class="wingR"></span>
+      <span class="legR lrB"></span>
+      <span class="legR lrF"></span>
+      <span class="neckR"></span>
+      <span class="headR"></span>
+      <span class="crestR"></span>
+      <span class="beakR"></span>
+      <span class="eyeR"></span>
+      <span class="patchR"></span>
+    </div>
+    <span class="dustR drA"></span>
+    <span class="dustR drB"></span>
+    <span class="dustR drC"></span>
+    <span class="lineR"></span>
+    <span class="groundR"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/roadrunner-as/style.css
+++ b/submissions/examples/roadrunner-as/style.css
@@ -1,0 +1,362 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #f0c884, #e0954e 54%, #b06a34);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f7d493, #e89a54 52%, #bf7238);
+}
+
+.sunR {
+  position: absolute;
+  top: 24px;
+  right: 40px;
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff6d8, #fbdc8e 60%, #f2b258);
+  box-shadow: 0 0 48px 18px rgba(251, 220, 142, 0.4);
+  z-index: 1;
+  animation: glowR 6s ease-in-out infinite;
+}
+
+.mesaR {
+  position: absolute;
+  bottom: 92px;
+  left: -30px;
+  width: 190px;
+  height: 54px;
+  background: linear-gradient(180deg, #c2703c, #8a4526);
+  clip-path: polygon(0 100%, 8% 26%, 26% 12%, 76% 8%, 92% 28%, 100% 100%);
+  opacity: 0.5;
+  z-index: 2;
+}
+
+.cactusR {
+  position: absolute;
+  bottom: 84px;
+  right: 46px;
+  width: 22px;
+  height: 76px;
+  border-radius: 11px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 60, 20, 0.28) 0 2px,
+      transparent 2px 7px
+    ),
+    linear-gradient(90deg, #3f7a34, #6faa48 44%, #2f6028);
+  z-index: 3;
+}
+
+.cactusR::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  left: -16px;
+  width: 16px;
+  height: 8px;
+  border-radius: 8px 0 0 8px;
+  background: #3f7a34;
+  box-shadow: 0 -14px 0 -1px #3f7a34;
+}
+
+.groundR {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 92px;
+  background:
+    radial-gradient(circle at 14% 24%, rgba(255, 245, 210, 0.22) 0 6px, transparent 7px),
+    radial-gradient(circle at 52% 40%, rgba(110, 56, 20, 0.24) 0 8px, transparent 9px),
+    linear-gradient(180deg, #d9954e, #96592a);
+  z-index: 7;
+}
+
+.lineR {
+  position: absolute;
+  bottom: 62px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(120, 70, 20, 0.5) 0 16px,
+      transparent 16px 34px
+    );
+  z-index: 8;
+  animation: rushLineR 0.4s linear infinite;
+}
+
+.runnerR {
+  position: absolute;
+  bottom: 68px;
+  left: 50%;
+  width: 220px;
+  height: 150px;
+  margin-left: -104px;
+  z-index: 6;
+  animation: sprintR 0.42s ease-in-out infinite;
+}
+
+.bodyR {
+  position: absolute;
+  bottom: 30px;
+  left: 46px;
+  width: 108px;
+  height: 46px;
+  border-radius: 44% 40% 40% 48% / 54% 50% 50% 54%;
+  background: linear-gradient(180deg, #8a7a5c, #423826 72%, #e2d8b8);
+  box-shadow: inset 0 -4px 12px rgba(30, 24, 10, 0.4);
+  z-index: 5;
+}
+
+.streakR {
+  position: absolute;
+  bottom: 30px;
+  left: 46px;
+  width: 108px;
+  height: 46px;
+  border-radius: 44% 40% 40% 48% / 54% 50% 50% 54%;
+  background:
+    repeating-linear-gradient(
+      66deg,
+      rgba(20, 16, 6, 0.4) 0 3px,
+      transparent 3px 10px
+    );
+  z-index: 6;
+}
+
+.wingR {
+  position: absolute;
+  bottom: 34px;
+  left: 74px;
+  width: 56px;
+  height: 32px;
+  border-radius: 40% 50% 50% 40% / 50% 40% 60% 60%;
+  background:
+    repeating-linear-gradient(
+      70deg,
+      rgba(20, 16, 6, 0.34) 0 2px,
+      transparent 2px 9px
+    ),
+    linear-gradient(160deg, #6a5c40, #2a2416);
+  transform-origin: 20% 20%;
+  z-index: 6;
+  animation: flickWingR 0.42s ease-in-out infinite;
+}
+
+.tailR {
+  position: absolute;
+  bottom: 40px;
+  left: -18px;
+  width: 78px;
+  height: 26px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 16, 6, 0.4) 0 5px,
+      transparent 5px 15px
+    ),
+    linear-gradient(90deg, #3a3020, #7a6a4c);
+  clip-path: polygon(0 34%, 100% 6%, 100% 94%, 0 66%);
+  transform-origin: 100% 50%;
+  z-index: 4;
+  animation: steerTailR 0.84s ease-in-out infinite;
+}
+
+.neckR {
+  position: absolute;
+  bottom: 60px;
+  left: 136px;
+  width: 30px;
+  height: 34px;
+  border-radius: 40% 50% 30% 40%;
+  background: linear-gradient(180deg, #7a6a4c, #3a3020);
+  transform-origin: 40% 100%;
+  transform: rotate(18deg);
+  z-index: 5;
+}
+
+.headR {
+  position: absolute;
+  bottom: 84px;
+  left: 152px;
+  width: 38px;
+  height: 30px;
+  border-radius: 46% 54% 40% 40% / 52% 54% 46% 46%;
+  background: radial-gradient(circle at 40% 34%, #8a7a5c, #3a3020 78%);
+  z-index: 6;
+  animation: bobHeadR 0.42s ease-in-out infinite;
+}
+
+.crestR {
+  position: absolute;
+  bottom: 104px;
+  left: 150px;
+  width: 30px;
+  height: 20px;
+  background:
+    repeating-conic-gradient(
+      from 250deg at 40% 100%,
+      #2a2416 0 4deg,
+      transparent 4deg 11deg
+    );
+  mask-image: radial-gradient(ellipse 70% 100% at 40% 100%, #000 0 74%, transparent 86%);
+  transform-origin: 40% 100%;
+  z-index: 5;
+  animation: bobHeadR 0.42s ease-in-out infinite;
+}
+
+.beakR {
+  position: absolute;
+  bottom: 90px;
+  left: 184px;
+  width: 30px;
+  height: 8px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #3a3020, #7a6a4c);
+  clip-path: polygon(0 0, 100% 34%, 100% 66%, 0 100%);
+  z-index: 7;
+  animation: bobHeadR 0.42s ease-in-out infinite;
+}
+
+.eyeR {
+  position: absolute;
+  bottom: 96px;
+  left: 168px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #f0e8c8 0 2px, #100c06 3px);
+  z-index: 8;
+  animation: bobHeadR 0.42s ease-in-out infinite;
+}
+
+.patchR {
+  position: absolute;
+  bottom: 88px;
+  left: 158px;
+  width: 12px;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #d84a3a, #6a8ad8);
+  transform: rotate(-14deg);
+  z-index: 7;
+  animation: bobHeadR 0.42s ease-in-out infinite;
+}
+
+.legR {
+  position: absolute;
+  bottom: -6px;
+  width: 8px;
+  height: 40px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6a5a3a, #2f2718);
+  transform-origin: 50% 0;
+  z-index: 4;
+  animation: strideR 0.42s linear infinite;
+}
+
+.legR::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -8px;
+  width: 26px;
+  height: 8px;
+  background: #2f2718;
+  clip-path: polygon(0 0, 24% 100%, 44% 0, 64% 100%, 84% 0, 100% 100%, 100% 0);
+}
+
+.lrF { left: 88px; }
+.lrB { left: 112px; filter: brightness(0.8); z-index: 3; animation-delay: -0.21s; }
+
+.dustR {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(230, 200, 150, 0.75), transparent 70%);
+  opacity: 0;
+  z-index: 5;
+  animation: puffR 0.7s ease-out infinite;
+}
+
+.drA { bottom: 66px; left: 96px; width: 40px; height: 24px; }
+.drB { bottom: 70px; left: 66px; width: 32px; height: 20px; animation-delay: 0.22s; }
+.drC { bottom: 64px; left: 40px; width: 26px; height: 16px; animation-delay: 0.44s; }
+
+@keyframes sprintR {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+@keyframes bobHeadR {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(3px); }
+}
+
+@keyframes strideR {
+  0% { transform: rotate(-34deg); }
+  50% { transform: rotate(34deg); }
+  100% { transform: rotate(-34deg); }
+}
+
+@keyframes flickWingR {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes steerTailR {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes rushLineR {
+  from { background-position: 0 0; }
+  to { background-position: -34px 0; }
+}
+
+@keyframes puffR {
+  0% { transform: translate(0, 0) scale(0.3); opacity: 0; }
+  20% { opacity: 0.75; }
+  100% { transform: translate(-34px, -12px) scale(1.4); opacity: 0; }
+}
+
+@keyframes glowR {
+  0%, 100% { opacity: 0.92; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .runnerR,
+  .legR,
+  .wingR,
+  .tailR,
+  .headR,
+  .crestR,
+  .beakR,
+  .eyeR,
+  .patchR,
+  .dustR,
+  .lineR,
+  .sunR {
+    animation: none;
+  }
+
+  .dustR {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML roadrunner sprinting across the desert.

## Details

- A running gait from one linear keyframe run twice with a half cycle offset, so the two legs alternate exactly rather than drifting apart
- The road stripe is scrolled with background-position to give speed without moving the bird, plus dust puffs kicking backwards
- A spiky crest from a masked conic gradient, streaked plumage from a diagonal repeating linear gradient
- The whole head group rides the same fast cycle as the legs so the bird bobs as it runs
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/roadrunner-as/demo.html`
- `submissions/examples/roadrunner-as/style.css`
- `submissions/examples/roadrunner-as/README.md`

Closes #47679
