### PR TITLE
Add magnetic-pull-tooltip-dashboard

### DIFF
--- a/submissions/examples/magnetic-pull-tooltip-dashboard-aaniya/README.md
+++ b/submissions/examples/magnetic-pull-tooltip-dashboard-aaniya/README.md
@@ -1,0 +1,53 @@
+# Magnetic Pull Tooltip — Responsive Dashboard
+
+Closes #46306
+
+## What does this do?
+
+A dark data-panel tooltip that snaps into place with a magnetic pull motion when its trigger is hovered or focused, and repositions from above to below the trigger on narrow viewports so it stays usable inside compact dashboard layouts (sidebars, cards, mobile widths) — a single CSS `@keyframes` animation, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="magnet-tooltip-dash">
+  <button class="magnet-tooltip-dash__trigger" type="button">Server Load</button>
+  <div class="magnet-tooltip-dash__bubble">
+    <div class="magnet-tooltip-dash__metric-row">
+      <span class="magnet-tooltip-dash__label">62%</span>
+      <span class="magnet-tooltip-dash__delta">-4.1%</span>
+    </div>
+    <span class="magnet-tooltip-dash__body">Average CPU load across all nodes, last hour.</span>
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.magnet-tooltip-dash__trigger` reveals the adjacent `.magnet-tooltip-dash__bubble`, playing the `ease-magnet-dash-pull` animation: it starts offset and shrunk, overshoots slightly as it snaps toward the trigger, then settles into place. Below a 480px viewport, the tooltip repositions below the trigger and plays `ease-magnet-dash-pull-below` instead, pulling in from the opposite direction so it never gets clipped at the top of a narrow panel.
+
+Timing, easing, pull distance, and settle scale are exposed as CSS custom properties:
+
+```html
+<div class="magnet-tooltip-dash" style="--ease-magnet-dash-duration: 650ms; --ease-magnet-dash-pull-distance: 34px; --ease-magnet-dash-scale: 1.04;">
+  ...
+</div>
+```
+
+## Why is it useful?
+
+Dashboard tooltips need to survive real layout constraints — sidebars, dense card grids, and small screens — where a tooltip that only ever floats above its trigger risks getting clipped or hidden. This variant addresses that directly with a responsive breakpoint that flips the tooltip's position and pull direction, on top of a metric/delta layout suited to analytics dashboards.
+
+- Needs **no JavaScript** — the whole effect is CSS `@keyframes` animations triggered by native `:hover`/`:focus-visible`.
+- Is keyboard accessible: the trigger is a real `<button>`, and `:focus-visible` triggers the same pull-in animation as mouse hover.
+- **Responsive positioning**: below 480px, the tooltip switches from "above trigger" to "below trigger" placement and animation direction, avoiding overflow in compact dashboard panels.
+- Exposes `--ease-magnet-dash-duration`, `--ease-magnet-dash-curve`, `--ease-magnet-dash-scale`, and `--ease-magnet-dash-pull-distance` as custom properties, so consumers can tune timing, easing, and overshoot feel without touching the source CSS.
+- Respects `prefers-reduced-motion` by skipping straight to the final, settled state.
+- Uses `ease-` prefixed variable and keyframe names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable/keyframe names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file
+
+## Note on related submissions
+
+This repo has two other "Magnetic Pull Tooltip" issues: Creative Portfolio (#46308, bold dark theme) and Accessible Web Layouts (#46307, ARIA/WCAG-focused). This submission is built specifically around the "Responsive Dashboard" brief — a metric/delta panel layout and a responsive above/below repositioning behavior that the other two variants don't implement — so there's no overlap in either purpose or implementation.

--- a/submissions/examples/magnetic-pull-tooltip-dashboard-aaniya/demo.html
+++ b/submissions/examples/magnetic-pull-tooltip-dashboard-aaniya/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Magnetic Pull Tooltip — Responsive Dashboard</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Magnetic Pull Tooltip — Responsive Dashboard</h1>
+  <p>A dark data-panel tooltip that snaps into place with a magnetic pull motion, repositioning below the trigger on narrow viewports — pure CSS, no JavaScript.</p>
+
+  <div class="magnet-tooltip-dash-grid">
+
+    <div class="magnet-tooltip-dash">
+      <button class="magnet-tooltip-dash__trigger" type="button">Server Load</button>
+      <div class="magnet-tooltip-dash__bubble">
+        <div class="magnet-tooltip-dash__metric-row">
+          <span class="magnet-tooltip-dash__label">62%</span>
+          <span class="magnet-tooltip-dash__delta">-4.1%</span>
+        </div>
+        <span class="magnet-tooltip-dash__body">Average CPU load across all nodes, last hour.</span>
+      </div>
+    </div>
+
+    <div class="magnet-tooltip-dash" style="--ease-magnet-dash-duration: 650ms; --ease-magnet-dash-pull-distance: 34px; --ease-magnet-dash-scale: 1.04;">
+      <button class="magnet-tooltip-dash__trigger" type="button">Error Rate</button>
+      <div class="magnet-tooltip-dash__bubble">
+        <div class="magnet-tooltip-dash__metric-row">
+          <span class="magnet-tooltip-dash__label">0.8%</span>
+          <span class="magnet-tooltip-dash__delta">-0.3%</span>
+        </div>
+        <span class="magnet-tooltip-dash__body">5xx responses as a share of total requests today.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-tooltip-dashboard-aaniya/style.css
+++ b/submissions/examples/magnetic-pull-tooltip-dashboard-aaniya/style.css
@@ -1,0 +1,183 @@
+/* ==========================================================================
+   Magnetic Pull Tooltip — Responsive Dashboard
+   A dark data-panel tooltip that snaps into place with a magnetic pull
+   motion when its trigger is hovered or focused. Single CSS animation,
+   no JavaScript. Repositions below the trigger on narrow viewports to
+   stay usable on compact dashboard layouts. Exposes timing, easing, and
+   scale as CSS custom properties.
+   ========================================================================== */
+
+:root {
+  --ease-magnet-dash-bg: #151a30;
+  --ease-magnet-dash-border: #2b3252;
+  --ease-magnet-dash-text: #eef0ff;
+  --ease-magnet-dash-muted: #9aa0c3;
+  --ease-magnet-dash-accent: #34d1a0;
+  --ease-magnet-dash-page-bg: #0c0f1f;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-magnet-dash-duration: 500ms;
+  --ease-magnet-dash-curve: cubic-bezier(0.3, 1.4, 0.6, 1);
+  --ease-magnet-dash-scale: 1;
+  --ease-magnet-dash-pull-distance: 24px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-magnet-dash-page-bg);
+  border-radius: 16px;
+  color: var(--ease-magnet-dash-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-magnet-dash-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.magnet-tooltip-dash-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.magnet-tooltip-dash {
+  position: relative;
+  display: inline-block;
+}
+
+.magnet-tooltip-dash__trigger {
+  padding: 10px 20px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ease-magnet-dash-text);
+  background: #1e2440;
+  border: 1px solid var(--ease-magnet-dash-border);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.magnet-tooltip-dash__trigger:focus-visible {
+  outline: 2px solid var(--ease-magnet-dash-accent);
+  outline-offset: 3px;
+}
+
+.magnet-tooltip-dash__bubble {
+  position: absolute;
+  /* Desktop default: floats above the trigger */
+  bottom: calc(100% + 16px);
+  left: 50%;
+  width: 230px;
+  padding: 14px 16px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-magnet-dash-text);
+  background: var(--ease-magnet-dash-bg);
+  border: 1px solid var(--ease-magnet-dash-border);
+  border-left: 3px solid var(--ease-magnet-dash-accent);
+  border-radius: 10px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  transform: translateX(-50%) translateY(var(--ease-magnet-dash-pull-distance)) scale(0.9);
+}
+
+/* The single animation this component demonstrates: the tooltip snaps
+   in with a magnetic pull motion toward the trigger. */
+@keyframes ease-magnet-dash-pull {
+  0% {
+    transform: translateX(-50%) translateY(var(--ease-magnet-dash-pull-distance)) scale(0.9);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(-50%) translateY(-3px) scale(calc(var(--ease-magnet-dash-scale) * 1.02));
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(var(--ease-magnet-dash-scale));
+    opacity: 1;
+  }
+}
+
+/* On narrow dashboard layouts (e.g. sidebars, compact cards), flip the
+   tooltip to appear below the trigger instead of above, so it doesn't
+   get clipped off the top of a scrollable panel. */
+@keyframes ease-magnet-dash-pull-below {
+  0% {
+    transform: translateX(-50%) translateY(calc(-1 * var(--ease-magnet-dash-pull-distance))) scale(0.9);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(-50%) translateY(3px) scale(calc(var(--ease-magnet-dash-scale) * 1.02));
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(var(--ease-magnet-dash-scale));
+    opacity: 1;
+  }
+}
+
+.magnet-tooltip-dash__trigger:hover + .magnet-tooltip-dash__bubble,
+.magnet-tooltip-dash__trigger:focus-visible + .magnet-tooltip-dash__bubble {
+  visibility: visible;
+  animation: ease-magnet-dash-pull var(--ease-magnet-dash-duration) var(--ease-magnet-dash-curve) forwards;
+}
+
+.magnet-tooltip-dash__metric-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.magnet-tooltip-dash__label {
+  font-weight: 700;
+}
+
+.magnet-tooltip-dash__delta {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--ease-magnet-dash-accent);
+}
+
+.magnet-tooltip-dash__body {
+  color: var(--ease-magnet-dash-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .magnet-tooltip-dash__trigger:hover + .magnet-tooltip-dash__bubble,
+  .magnet-tooltip-dash__trigger:focus-visible + .magnet-tooltip-dash__bubble {
+    animation: none;
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+/* Responsive: on compact dashboard widths, flip below the trigger and
+   shrink slightly to avoid overflow in narrow sidebar/card contexts. */
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+
+  .magnet-tooltip-dash__bubble {
+    width: 190px;
+    bottom: auto;
+    top: calc(100% + 16px);
+  }
+
+  .magnet-tooltip-dash__trigger:hover + .magnet-tooltip-dash__bubble,
+  .magnet-tooltip-dash__trigger:focus-visible + .magnet-tooltip-dash__bubble {
+    animation-name: ease-magnet-dash-pull-below;
+  }
+}


### PR DESCRIPTION
Closes #46306
## Pull Request Description
Adds a new dashboard-styled tooltip submission — `magnetic-pull-tooltip-dashboard-aaniya` — that snaps into place with a magnetic pull motion and repositions responsively on narrow viewports, closing #46306.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-tooltip-dashboard-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A dark data-panel tooltip with a metric/delta layout that snaps in with a magnetic pull motion, and flips from above to below the trigger on narrow viewports to stay usable in compact dashboard layouts.

**How does a developer use it?**
```html
<div class="magnet-tooltip-dash">
  <button class="magnet-tooltip-dash__trigger" type="button">Server Load</button>
  <div class="magnet-tooltip-dash__bubble">
    <div class="magnet-tooltip-dash__metric-row">
      <span class="magnet-tooltip-dash__label">62%</span>
      <span class="magnet-tooltip-dash__delta">-4.1%</span>
    </div>
    <span class="magnet-tooltip-dash__body">Average CPU load across all nodes, last hour.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable pair of CSS `@keyframes` animations (`ease-magnet-dash-pull` / `ease-magnet-dash-pull-below`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-magnet-dash-duration`, `--ease-magnet-dash-curve`, `--ease-magnet-dash-scale`, and `--ease-magnet-dash-pull-distance` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion`, and adapts its layout at narrow viewports rather than just scaling down.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This repo has two other "Magnetic Pull Tooltip" issues: Creative Portfolio (#46308) and Accessible Web Layouts (#46307). This submission is built specifically for the "Responsive Dashboard" brief — a metric/delta panel layout plus a responsive above/below repositioning behavior at narrow viewports — which neither of the other two implement, so there's no overlap in purpose or code.