### PR TITLE
Add corpse flower component

### DIFF
--- a/submissions/examples/corpse-flower-as/README.md
+++ b/submissions/examples/corpse-flower-as/README.md
@@ -1,0 +1,19 @@
+# Corpse Flower
+
+A pure CSS and HTML titan arum opening its enormous maroon spathe around a pale spadix, wafting its famous stench up to circling flies.
+
+## What it shows
+
+- The spathe unfurling by scaling from a furled sliver to full spread, its three parts sharing one timeline so the whole bloom opens as a piece
+- A frilled crimped rim from a repeating conic gradient masked into an arc, the trick that makes the spathe read as ruffled rather than smooth
+- The spadix warming and dimming on its own cycle, the way the real flower thermogenerates to push scent
+- Scent plumes each carrying their own drift vector in a custom property, with flies drawn in on wandering paths
+- No images, no JavaScript, no external dependencies
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Accessibility
+
+All motion stops under `prefers-reduced-motion: reduce`, leaving the bloom open.

--- a/submissions/examples/corpse-flower-as/demo.html
+++ b/submissions/examples/corpse-flower-as/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Corpse Flower</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="bloomC">
+      <span class="spatheBack"></span>
+      <span class="spadixC"></span>
+      <span class="spatheFront"></span>
+      <span class="frillC"></span>
+      <span class="collarC"></span>
+    </div>
+    <span class="stinkC skA"></span>
+    <span class="stinkC skB"></span>
+    <span class="stinkC skC"></span>
+    <span class="flyC fcA"></span>
+    <span class="flyC fcB"></span>
+    <span class="potC"></span>
+    <span class="soilC"></span>
+    <span class="floorC"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/corpse-flower-as/style.css
+++ b/submissions/examples/corpse-flower-as/style.css
@@ -1,0 +1,275 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #3a4436, #101408 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 22%, #46543e, #0d1108 78%);
+}
+
+.floorC {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 44px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 14, 6, 0.4) 0 2px,
+      transparent 2px 30px
+    ),
+    linear-gradient(180deg, #3a2f20, #150f08);
+  z-index: 9;
+}
+
+.potC {
+  position: absolute;
+  bottom: 36px;
+  left: 50%;
+  width: 130px;
+  height: 56px;
+  margin-left: -65px;
+  border-radius: 6px 6px 14px 14px / 4px 4px 20px 20px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 30, 14, 0.24) 0 2px,
+      transparent 2px 16px
+    ),
+    linear-gradient(180deg, #a8603a, #5a2f18);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);
+  z-index: 8;
+}
+
+.potC::before {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: -8px;
+  right: -8px;
+  height: 12px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #c07a4a, #6a3a20);
+}
+
+.soilC {
+  position: absolute;
+  bottom: 82px;
+  left: 50%;
+  width: 118px;
+  height: 12px;
+  margin-left: -59px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 40%, #4a3a24, #1c1408 76%);
+  z-index: 7;
+}
+
+.bloomC {
+  position: absolute;
+  bottom: 84px;
+  left: 50%;
+  width: 200px;
+  height: 240px;
+  margin-left: -100px;
+  z-index: 6;
+  animation: breatheC 8s ease-in-out infinite;
+}
+
+.spadixC {
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  width: 34px;
+  height: 210px;
+  margin-left: -17px;
+  border-radius: 17px 17px 6px 6px / 40px 40px 6px 6px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(150, 120, 60, 0.24) 0 2px,
+      transparent 2px 12px
+    ),
+    linear-gradient(180deg, #f0e0a8, #c8a862 62%, #8a6a34);
+  box-shadow: inset -6px 0 14px rgba(90, 60, 16, 0.4);
+  z-index: 5;
+  animation: heatC 8s ease-in-out infinite;
+}
+
+.spatheBack {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  width: 176px;
+  height: 150px;
+  margin-left: -88px;
+  border-radius: 50% 50% 30% 30% / 62% 62% 38% 38%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 50% 96%,
+      rgba(90, 20, 40, 0.4) 0 1.2deg,
+      transparent 1.2deg 7deg
+    ),
+    radial-gradient(circle at 50% 84%, #8a2440 0 30%, #5f1730 62%, #3a0e1e 88%);
+  z-index: 4;
+  animation: openC 8s ease-in-out infinite;
+}
+
+.spatheFront {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  width: 176px;
+  height: 116px;
+  margin-left: -88px;
+  border-radius: 50% 50% 34% 34% / 70% 70% 30% 30%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 50% 100%,
+      rgba(50, 10, 22, 0.34) 0 1deg,
+      transparent 1deg 6deg
+    ),
+    radial-gradient(circle at 50% 96%, #b8506a 0 22%, #7a2244 60%, #4a1026 90%);
+  mask-image: radial-gradient(ellipse 74% 100% at 50% 100%, #000 0 72%, transparent 96%);
+  z-index: 6;
+  animation: openC 8s ease-in-out infinite;
+}
+
+.frillC {
+  position: absolute;
+  bottom: 118px;
+  left: 50%;
+  width: 190px;
+  height: 48px;
+  margin-left: -95px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 186deg at 50% 100%,
+      #a83a58 0 2.4deg,
+      #6f1c38 2.4deg 5deg
+    );
+  mask-image: radial-gradient(ellipse 60% 100% at 50% 100%, transparent 0 52%, #000 60% 94%, transparent 100%);
+  z-index: 7;
+  animation: openC 8s ease-in-out infinite;
+}
+
+.collarC {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  width: 96px;
+  height: 26px;
+  margin-left: -48px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 30%, #6a8a3c, #2f4a18 78%);
+  z-index: 7;
+}
+
+.stinkC {
+  position: absolute;
+  bottom: 220px;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  margin-left: -15px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(170, 200, 120, 0.3), transparent 68%);
+  opacity: 0;
+  z-index: 5;
+  animation: wafC 6s ease-in infinite;
+}
+
+.skA { --sx: -46px; }
+.skB { --sx: 38px; animation-delay: 2s; }
+.skC { --sx: -14px; animation-delay: 4s; }
+
+.flyC {
+  position: absolute;
+  width: 8px;
+  height: 5px;
+  border-radius: 50%;
+  background: #23201a;
+  z-index: 9;
+  animation: buzzC 7s ease-in-out infinite;
+}
+
+.flyC::before,
+.flyC::after {
+  content: "";
+  position: absolute;
+  top: -1px;
+  width: 6px;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(220, 235, 240, 0.55);
+}
+
+.flyC::before { left: -4px; transform: rotate(-20deg); }
+.flyC::after { right: -4px; transform: rotate(20deg); }
+
+.fcA { bottom: 250px; left: 60px; }
+.fcB { bottom: 210px; left: 240px; animation-delay: 3.5s; }
+
+@keyframes openC {
+  0%, 14% { transform: scaleX(0.28) scaleY(0.9); }
+  40%, 84% { transform: scaleX(1) scaleY(1); }
+  100% { transform: scaleX(0.28) scaleY(0.9); }
+}
+
+@keyframes heatC {
+  0%, 100% { filter: brightness(0.9); }
+  50% { filter: brightness(1.14); }
+}
+
+@keyframes breatheC {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.02); }
+}
+
+@keyframes wafC {
+  0% { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  25% { opacity: 0.85; }
+  100% { transform: translate(var(--sx, 0), -110px) scale(2.2); opacity: 0; }
+}
+
+@keyframes buzzC {
+  0% { transform: translate(0, 0); }
+  30% { transform: translate(60px, 34px); }
+  55% { transform: translate(94px, 6px); }
+  80% { transform: translate(30px, 44px); }
+  100% { transform: translate(0, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bloomC,
+  .spatheBack,
+  .spatheFront,
+  .frillC,
+  .spadixC,
+  .stinkC,
+  .flyC {
+    animation: none;
+  }
+
+  .spatheBack,
+  .spatheFront,
+  .frillC {
+    transform: scaleX(1) scaleY(1);
+  }
+
+  .stinkC {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS and HTML titan arum opening its spathe.

## Details

- The spathe unfurls by scaling from a furled sliver to full spread, its three parts sharing one timeline so the whole bloom opens as a piece
- A frilled crimped rim from a repeating conic gradient masked into an arc, so the spathe reads as ruffled rather than smooth
- The spadix warms and dims on its own cycle, the way the real flower thermogenerates to push scent
- Scent plumes each carry their own drift vector in a custom property, with flies drawn in on wandering paths
- No images, no JavaScript, no external dependencies
- Fully guarded by prefers-reduced-motion

## Files

- `submissions/examples/corpse-flower-as/demo.html`
- `submissions/examples/corpse-flower-as/style.css`
- `submissions/examples/corpse-flower-as/README.md`

Closes #47684
