### PR TITLE
Add kea component

### DIFF
--- a/submissions/examples/kea-as/README.md
+++ b/submissions/examples/kea-as/README.md
@@ -1,0 +1,29 @@
+# Kea
+
+A pure CSS/HTML scene of a kea, the New Zealand alpine parrot, working a hiker's boot lace apart on a snowy scree slope.
+
+## What it shows
+
+The kea is the only true alpine parrot, and it is notorious for taking apart anything a human leaves outside: boot laces, window seals, rubber trim. Two features drive the scene.
+
+The bill is not a generic parrot hook. It is a long, slender, strongly decurved upper mandible built for levering, and it is the reason the bird can get under a lace at all. The plumage is drab olive from above and brilliant scarlet-orange underneath, a colour the bird only reveals when the wing lifts.
+
+## How it is built
+
+- **Plumage texture** - a `repeating-conic-gradient` scale layer over the body's `radial-gradient` base, so the olive back reads as feathered rather than flat.
+- **Decurved bill** - the upper mandible is one element with an asymmetric `border-radius` (`60% 10% 6% 40% / 90% 10% 10% 70%`), giving the long levering hook. The lower mandible is separate and hinges on its own `transform-origin`.
+- **The reach** - the head is a nested box on its own keyframe, so the neck bends down and the bill tip lands on the lace instead of hovering above it.
+- **The pull** - the lace stretches with `scaleX` and swings from a `0 50%` origin while the boot rocks back on a matching keyframe, so the tug reads as one linked action.
+- **The flash** - the scarlet underwing sits behind the body at rest and rotates out mid-pull on a delayed keyframe, which is when the real bird shows it.
+- **Setting** - snowy peaks are `clip-path` triangles with a snowline stop in the gradient, over a scree rock and snowfield.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the head in its pried-down pose, so the scene still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/kea-as/demo.html
+++ b/submissions/examples/kea-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kea</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="peakK pkA"></span>
+    <span class="peakK pkB"></span>
+    <span class="snowK"></span>
+    <div class="keaK">
+      <span class="tailK"></span>
+      <span class="underWing"></span>
+      <span class="bodyK"></span>
+      <span class="scaleK"></span>
+      <span class="wingK"></span>
+      <span class="legK lkB"></span>
+      <span class="legK lkF"></span>
+      <div class="headK">
+        <span class="skullK"></span>
+        <span class="lowerK"></span>
+        <span class="upperK"></span>
+        <span class="cereK"></span>
+        <span class="eyeK"></span>
+      </div>
+    </div>
+    <span class="bootK"></span>
+    <span class="laceK"></span>
+    <span class="rockK"></span>
+    <span class="scree"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/kea-as/style.css
+++ b/submissions/examples/kea-as/style.css
@@ -1,0 +1,333 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #9fc4dc, #6f9ab8 58%, #4a6f88);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #b6d8ec, #7fa8c4 56%, #55788e);
+}
+
+.peakK {
+  position: absolute;
+  bottom: 88px;
+  background: linear-gradient(180deg, #f4f8fa 0 26%, #8ba3b4 28%, #5f7686);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  z-index: 1;
+}
+
+.pkA { left: -24px; width: 210px; height: 130px; }
+.pkB { right: -30px; width: 240px; height: 160px; filter: brightness(0.92); }
+
+.snowK {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 96px;
+  background:
+    radial-gradient(circle at 16% 24%, rgba(255, 255, 255, 0.5) 0 14px, transparent 18px),
+    radial-gradient(circle at 62% 12%, rgba(255, 255, 255, 0.4) 0 18px, transparent 22px),
+    linear-gradient(180deg, #8a9aa6, #4a5a66);
+  z-index: 7;
+}
+
+.rockK {
+  position: absolute;
+  bottom: 80px;
+  left: 50%;
+  width: 200px;
+  height: 46px;
+  margin-left: -100px;
+  border-radius: 50% 50% 18% 18% / 80% 80% 20% 20%;
+  background: linear-gradient(180deg, #8a8a82, #3f3f3a);
+  box-shadow: inset -6px -8px 16px rgba(20, 20, 16, 0.5);
+  z-index: 6;
+}
+
+.bootK {
+  position: absolute;
+  bottom: 126px;
+  left: 52px;
+  width: 66px;
+  height: 34px;
+  border-radius: 6px 14px 5px 5px / 6px 20px 5px 5px;
+  background: linear-gradient(180deg, #8a3a2a, #4a1a12);
+  box-shadow: inset -4px -4px 10px rgba(30, 8, 4, 0.5);
+  z-index: 7;
+  animation: tugBootK 3.4s ease-in-out infinite;
+}
+
+.laceK {
+  position: absolute;
+  bottom: 150px;
+  left: 96px;
+  width: 44px;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #e8e0c8, #a09880);
+  transform-origin: 0 50%;
+  z-index: 8;
+  animation: pullLaceK 3.4s ease-in-out infinite;
+}
+
+.keaK {
+  position: absolute;
+  bottom: 108px;
+  left: 50%;
+  width: 200px;
+  height: 160px;
+  margin-left: -48px;
+  z-index: 8;
+  animation: leanK 3.4s ease-in-out infinite;
+}
+
+.bodyK {
+  position: absolute;
+  bottom: 16px;
+  left: 26px;
+  width: 104px;
+  height: 76px;
+  border-radius: 54% 44% 44% 54% / 62% 58% 42% 42%;
+  background: radial-gradient(circle at 40% 32%, #6a7a3a, #2f3a18 78%);
+  box-shadow: inset -8px -6px 18px rgba(20, 26, 8, 0.5);
+  z-index: 4;
+}
+
+.scaleK {
+  position: absolute;
+  bottom: 16px;
+  left: 26px;
+  width: 104px;
+  height: 76px;
+  border-radius: 54% 44% 44% 54% / 62% 58% 42% 42%;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 34% 20%,
+      rgba(20, 30, 8, 0.34) 0 2deg,
+      transparent 2deg 8deg
+    );
+  z-index: 5;
+}
+
+.underWing {
+  position: absolute;
+  bottom: 24px;
+  left: 8px;
+  width: 74px;
+  height: 46px;
+  border-radius: 50% 40% 40% 50%;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(120, 30, 10, 0.4) 0 3px,
+      transparent 3px 10px
+    ),
+    linear-gradient(120deg, #e0682a, #a83a12);
+  transform-origin: 90% 40%;
+  z-index: 3;
+  animation: flashUnderK 3.4s ease-in-out infinite;
+}
+
+.wingK {
+  position: absolute;
+  bottom: 26px;
+  left: 56px;
+  width: 66px;
+  height: 54px;
+  border-radius: 40% 50% 50% 40% / 50% 40% 60% 60%;
+  background:
+    repeating-linear-gradient(
+      70deg,
+      rgba(20, 30, 8, 0.3) 0 3px,
+      transparent 3px 11px
+    ),
+    linear-gradient(160deg, #5f6f30, #26300f);
+  transform-origin: 20% 20%;
+  z-index: 6;
+  animation: flickWingK 3.4s ease-in-out infinite;
+}
+
+.tailK {
+  position: absolute;
+  bottom: 20px;
+  left: 112px;
+  width: 60px;
+  height: 30px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 30, 8, 0.4) 0 5px,
+      transparent 5px 15px
+    ),
+    linear-gradient(90deg, #4f5f28, #7a8a44);
+  clip-path: polygon(0 10%, 100% 30%, 100% 70%, 0 90%);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: steerTailK 3.4s ease-in-out infinite;
+}
+
+.legK {
+  position: absolute;
+  bottom: -8px;
+  width: 9px;
+  height: 30px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #4a4a3a, #1c1c14);
+  transform-origin: 50% 0;
+  z-index: 5;
+}
+
+.legK::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -8px;
+  width: 26px;
+  height: 8px;
+  background: #23231a;
+  clip-path: polygon(0 0, 24% 100%, 44% 0, 64% 100%, 84% 0, 100% 100%, 100% 0);
+}
+
+.lkF { left: 52px; }
+.lkB { left: 76px; filter: brightness(0.8); z-index: 4; }
+
+.headK {
+  position: absolute;
+  bottom: 46px;
+  left: -12px;
+  width: 78px;
+  height: 60px;
+  transform-origin: 76% 100%;
+  z-index: 7;
+  animation: prybeakK 3.4s ease-in-out infinite;
+}
+
+.skullK {
+  position: absolute;
+  bottom: 0;
+  left: 26px;
+  width: 48px;
+  height: 44px;
+  border-radius: 50% 50% 42% 42% / 54% 54% 46% 46%;
+  background: radial-gradient(circle at 42% 34%, #7a8a46, #2f3a18 78%);
+  z-index: 5;
+}
+
+.cereK {
+  position: absolute;
+  bottom: 24px;
+  left: 22px;
+  width: 18px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #4a4a3a, #1c1c12 76%);
+  z-index: 7;
+}
+
+.upperK {
+  position: absolute;
+  bottom: 6px;
+  left: -8px;
+  width: 44px;
+  height: 30px;
+  border-radius: 60% 10% 6% 40% / 90% 10% 10% 70%;
+  background: linear-gradient(180deg, #4a4436, #17150e);
+  z-index: 6;
+}
+
+.lowerK {
+  position: absolute;
+  bottom: 2px;
+  left: 8px;
+  width: 26px;
+  height: 12px;
+  border-radius: 30% 10% 8% 40%;
+  background: linear-gradient(180deg, #3a3628, #14120c);
+  transform-origin: 100% 20%;
+  z-index: 5;
+  animation: chompK 3.4s ease-in-out infinite;
+}
+
+.eyeK {
+  position: absolute;
+  bottom: 28px;
+  left: 44px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #5a5a3a, #0e0e06 66%);
+  box-shadow: 0 0 0 1.5px rgba(230, 240, 200, 0.3);
+  z-index: 8;
+}
+
+@keyframes leanK {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  44% { transform: translate(-7px, 2px) rotate(-3deg); }
+  70% { transform: translate(-3px, 0) rotate(1deg); }
+}
+
+@keyframes prybeakK {
+  0%, 100% { transform: rotate(-22deg); }
+  44% { transform: rotate(-38deg); }
+  66% { transform: rotate(-16deg); }
+}
+
+@keyframes chompK {
+  0%, 30%, 100% { transform: rotate(0deg); }
+  46%, 62% { transform: rotate(20deg); }
+}
+
+@keyframes pullLaceK {
+  0%, 100% { transform: rotate(0deg) scaleX(1); }
+  46% { transform: rotate(-14deg) scaleX(1.2); }
+  70% { transform: rotate(4deg) scaleX(1.05); }
+}
+
+@keyframes tugBootK {
+  0%, 100% { transform: rotate(0deg) translateX(0); }
+  46% { transform: rotate(-4deg) translateX(-4px); }
+  70% { transform: rotate(1deg) translateX(-1px); }
+}
+
+@keyframes flashUnderK {
+  0%, 30%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-24deg); }
+}
+
+@keyframes flickWingK {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(5deg); }
+}
+
+@keyframes steerTailK {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .keaK,
+  .headK,
+  .lowerK,
+  .underWing,
+  .wingK,
+  .tailK,
+  .laceK,
+  .bootK {
+    animation: none;
+  }
+
+  .headK {
+    transform: rotate(-22deg);
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/kea-as/`, a self-contained pure CSS/HTML scene of a kea prying open a hiker's boot lace on an alpine scree slope.

Closes #47686

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **Plumage texture**: a `repeating-conic-gradient` scale layer sits over the body's `radial-gradient` base, so the olive back reads as feathered rather than as a flat blob.
- **Decurved bill**: the upper mandible is a single element with an asymmetric `border-radius` (`60% 10% 6% 40% / 90% 10% 10% 70%`) which gives the long levering hook the kea is known for. The lower mandible is separate and hinges on its own `transform-origin`.
- **The reach**: the head is a nested box with its own keyframe, so the neck bends down and the bill tip lands on the lace instead of hovering above it.
- **The pull**: the lace stretches with `scaleX` and swings on a `0 50%` origin while the boot rocks back on a matching keyframe, so the tug reads as one linked action.
- **The flash**: the scarlet underwing is behind the body at rest and rotates out mid-pull on a delayed keyframe, which is exactly when the real bird shows it.
- **Setting**: snowy peaks are `clip-path` triangles with a snowline stop in the gradient, over a scree rock and snowfield.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the head in its pried-down pose, so the scene still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the animation runs, the bill reaches the lace, the underwing flashes on the pull, and the reduced-motion path renders a static pose. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
