### PR TITLE
Add welwitschia component

### DIFF
--- a/submissions/examples/welwitschia-as/README.md
+++ b/submissions/examples/welwitschia-as/README.md
@@ -1,0 +1,29 @@
+# Welwitschia
+
+A pure CSS/HTML scene of *Welwitschia mirabilis* on the Namib gravel plains, its two leaves sprawling in the coastal fog.
+
+## What it shows
+
+Welwitschia is a plant that grows exactly two leaves in its entire life and never sheds them. They emerge from a woody crown and keep extending from the base for a thousand years or more, so the far ends are ancient, sun-bleached, and torn. What looks like a dozen straps is those same two leaves, split lengthwise by wind into ribbons.
+
+It lives in a desert that gets almost no rain, and drinks the fog that rolls in off the Atlantic instead.
+
+## How it is built
+
+- **The straps** - each ribbon carries a `repeating-linear-gradient` running *along* its length, because welwitschia veins are lengthwise. Vein lines running across the strap would read as a caterpillar, not a leaf.
+- **Torn tips** - a `clip-path` polygon notches the far end of every strap, mirrored for the left and right fans, so the ends look wind-shredded rather than cut.
+- **The fan** - straps anchor at the crown via `transform-origin` on the inner edge and splay by a per-strap `--a` angle. The ripple keyframe rebuilds that angle with `rotate(calc(var(--a) + 2.4deg))`, so the shared animation cannot wipe each strap's own rotation.
+- **The crown** - a `repeating-conic-gradient` bark texture over a `radial-gradient` base, with the central growth groove the two leaves emerge from.
+- **Cones** - the ribbed salmon strobili nod on the crown on offset delays.
+- **The fog** - translucent ellipses drift across on a long linear keyframe, fading in and out at the scene edges. This is the plant's actual water source.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and parks the fog mid-scene, so the plant still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/welwitschia-as/demo.html
+++ b/submissions/examples/welwitschia-as/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Welwitschia</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunW"></span>
+    <span class="duneW dnA"></span>
+    <span class="duneW dnB"></span>
+    <span class="hazeW"></span>
+    <div class="plantW">
+      <span class="strapW spL sw1"></span>
+      <span class="strapW spL sw2"></span>
+      <span class="strapW spL sw3"></span>
+      <span class="strapW spL sw4"></span>
+      <span class="strapW spR sw5"></span>
+      <span class="strapW spR sw6"></span>
+      <span class="strapW spR sw7"></span>
+      <span class="strapW spR sw8"></span>
+      <span class="crownW"></span>
+      <span class="grooveW"></span>
+      <span class="coneW cnA"></span>
+      <span class="coneW cnB"></span>
+    </div>
+    <span class="fogW fgA"></span>
+    <span class="fogW fgB"></span>
+    <span class="gravelW"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/welwitschia-as/style.css
+++ b/submissions/examples/welwitschia-as/style.css
@@ -1,0 +1,208 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #d8c096, #a88a68 58%, #6a5642);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #e8d4a8, #cbb086 46%, #9a7f60 64%, #6f5a44);
+}
+
+.sunW {
+  position: absolute;
+  top: 34px;
+  left: 62px;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff8dc, #f0d68a 58%, rgba(230, 200, 130, 0) 78%);
+  z-index: 1;
+}
+
+.duneW {
+  position: absolute;
+  border-radius: 50% 50% 0 0 / 100% 100% 0 0;
+  background: linear-gradient(180deg, #c2a67e, #8a7154);
+  z-index: 2;
+}
+
+.dnA { bottom: 96px; left: -40px; width: 240px; height: 54px; }
+.dnB { bottom: 96px; right: -50px; width: 260px; height: 40px; filter: brightness(0.9); }
+
+.hazeW {
+  position: absolute;
+  bottom: 96px;
+  left: 0;
+  right: 0;
+  height: 26px;
+  background: linear-gradient(180deg, rgba(250, 240, 214, 0.6), transparent);
+  z-index: 3;
+}
+
+.gravelW {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 100px;
+  background:
+    radial-gradient(circle at 14% 30%, rgba(90, 72, 52, 0.5) 0 3px, transparent 4px),
+    radial-gradient(circle at 46% 62%, rgba(90, 72, 52, 0.45) 0 4px, transparent 5px),
+    radial-gradient(circle at 78% 24%, rgba(90, 72, 52, 0.5) 0 3px, transparent 4px),
+    radial-gradient(circle at 92% 70%, rgba(90, 72, 52, 0.4) 0 4px, transparent 5px),
+    radial-gradient(circle at 28% 84%, rgba(90, 72, 52, 0.4) 0 3px, transparent 4px),
+    linear-gradient(180deg, #a88a66, #5f4c38);
+  z-index: 2;
+}
+
+.plantW {
+  position: absolute;
+  bottom: 50px;
+  left: 50%;
+  width: 300px;
+  height: 110px;
+  margin-left: -150px;
+  z-index: 6;
+}
+
+.strapW {
+  position: absolute;
+  height: 17px;
+  border-radius: 3px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(24, 34, 12, 0.62) 0 1.5px,
+      transparent 1.5px 4px
+    ),
+    linear-gradient(180deg, #93a355, #35411a);
+  transform: rotate(var(--a, 0deg));
+  z-index: 4;
+  animation: rippleW 7s ease-in-out infinite;
+  animation-delay: var(--d, 0s);
+}
+
+.spL {
+  right: 150px;
+  transform-origin: 100% 50%;
+  clip-path: polygon(4% 0, 100% 0, 100% 100%, 10% 100%, 0 62%, 8% 44%, 0 26%);
+}
+
+.spR {
+  left: 150px;
+  transform-origin: 0 50%;
+  clip-path: polygon(0 0, 96% 0, 100% 26%, 92% 44%, 100% 62%, 90% 100%, 0 100%);
+}
+
+.sw1 { --a: -14deg; --d: 0s; bottom: 40px; width: 158px; }
+.sw2 { --a: -3deg; --d: -1.4s; bottom: 29px; width: 172px; filter: brightness(0.92); }
+.sw3 { --a: 7deg; --d: -2.8s; bottom: 18px; width: 142px; }
+.sw4 { --a: 17deg; --d: -4.2s; bottom: 9px; width: 120px; filter: brightness(0.82); }
+.sw5 { --a: 13deg; --d: -0.7s; bottom: 40px; width: 150px; }
+.sw6 { --a: 2deg; --d: -2.1s; bottom: 29px; width: 168px; filter: brightness(0.92); }
+.sw7 { --a: -8deg; --d: -3.5s; bottom: 18px; width: 138px; }
+.sw8 { --a: -18deg; --d: -4.9s; bottom: 9px; width: 114px; filter: brightness(0.82); }
+
+.crownW {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 96px;
+  height: 44px;
+  margin-left: -48px;
+  border-radius: 46% 46% 30% 30% / 62% 62% 38% 38%;
+  background:
+    repeating-conic-gradient(
+      from 180deg at 50% 100%,
+      rgba(40, 26, 12, 0.34) 0 1.6deg,
+      transparent 1.6deg 6deg
+    ),
+    radial-gradient(circle at 50% 30%, #8a6a44, #3a2a16 78%);
+  box-shadow: inset 0 -6px 12px rgba(24, 14, 6, 0.6);
+  z-index: 6;
+}
+
+.grooveW {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  width: 5px;
+  height: 28px;
+  margin-left: -2.5px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #24180c, #4a3620);
+  z-index: 7;
+}
+
+.coneW {
+  position: absolute;
+  bottom: 34px;
+  width: 13px;
+  height: 32px;
+  border-radius: 5px 5px 4px 4px / 9px 9px 4px 4px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(60, 20, 10, 0.4) 0 2px,
+      transparent 2px 6px
+    ),
+    linear-gradient(180deg, #c8603a, #7a2f18);
+  transform-origin: 50% 100%;
+  z-index: 7;
+  animation: noddW 7s ease-in-out infinite;
+}
+
+.cnA { left: 50%; margin-left: -24px; }
+.cnB { left: 50%; margin-left: 12px; animation-delay: -3.5s; }
+
+.fogW {
+  position: absolute;
+  height: 30px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(240, 244, 246, 0.42), transparent 70%);
+  z-index: 8;
+  animation: driftW 14s linear infinite;
+}
+
+.fgA { bottom: 72px; left: -160px; width: 200px; }
+.fgB { bottom: 40px; left: -220px; width: 260px; animation-delay: -7s; }
+
+@keyframes rippleW {
+  0%, 100% { transform: rotate(var(--a, 0deg)); }
+  50% { transform: rotate(calc(var(--a, 0deg) + 2.4deg)); }
+}
+
+@keyframes noddW {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes driftW {
+  0% { transform: translateX(0); opacity: 0; }
+  16% { opacity: 1; }
+  84% { opacity: 1; }
+  100% { transform: translateX(560px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .strapW,
+  .coneW,
+  .fogW {
+    animation: none;
+  }
+
+  .fogW {
+    opacity: 0.5;
+    transform: translateX(300px);
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/welwitschia-as/`, a self-contained pure CSS/HTML scene of *Welwitschia mirabilis* on the Namib gravel plains.

Closes #47690

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The straps**: each ribbon carries a `repeating-linear-gradient` running *along* its length, because welwitschia veins are lengthwise. Vein lines running across the strap read as a caterpillar instead of a leaf, so the direction matters.
- **Torn tips**: a `clip-path` polygon notches the far end of every strap, mirrored between the left and right fans, so the ends look wind-shredded rather than cut. In the real plant those tips are centuries old.
- **The fan**: straps anchor at the crown via `transform-origin` on the inner edge and splay by a per-strap `--a` angle. The ripple keyframe rebuilds that angle with `rotate(calc(var(--a) + 2.4deg))`, so one shared animation cannot wipe each strap's own rotation.
- **The crown**: a `repeating-conic-gradient` bark texture over a `radial-gradient` base, with the central growth groove the two leaves actually emerge from.
- **Cones**: ribbed salmon strobili nodding on the crown on offset delays.
- **The fog**: translucent ellipses drift across on a long linear keyframe, fading in and out at the scene edges. This is the plant's real water source, not set dressing.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and parks the fog mid-scene, so the plant still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the straps ripple without losing their splay angles, the veins run lengthwise, the cones nod, the fog drifts, and the reduced-motion path renders a static scene. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
