### PR TITLE
Add stereoscope component

### DIFF
--- a/submissions/examples/stereoscope-as/README.md
+++ b/submissions/examples/stereoscope-as/README.md
@@ -1,0 +1,29 @@
+# Stereoscope
+
+A pure CSS/HTML Holmes stereoscope holding an alpine viaduct stereograph, sliding the card along the rail to focus.
+
+## What it shows
+
+Oliver Wendell Holmes designed this pattern in 1861 and refused to patent it, which is why it became the shape everyone recognises. A hooded pair of prismatic lenses, a wooden septum splitting the two lines of sight, and a wire card holder that slides along a rail until the pair fuses.
+
+A stereograph is not two copies of the same photo. It is two photos taken about as far apart as a person's eyes, so anything close to the camera sits at a different horizontal position in each half while anything far away does not move at all. That difference is the entire illusion.
+
+## How it is built
+
+- **Real disparity**: the two halves are the same markup, but the near subjects (rail posts, foreground trees) are offset horizontally between `.hlL` and `.hlR` while the distant peaks are identical in both. That is the actual geometry of a stereo pair, not a decorative duplicate.
+- **The septum**: a raised centre divider running the full depth of the hood, which is what stops each eye seeing the wrong half.
+- **The hood**: an asymmetric `border-radius` (`8px 8px 26px 26px / 6px 6px 40px 40px`) gives the flared face-cup, with a `repeating-linear-gradient` wood grain over the base.
+- **Lenses**: an off-centre `radial-gradient` puts the highlight up and left on both, with a `box-shadow` ring for the bezel; they brighten on the same keyframe as the focus pull.
+- **Focus**: the card and its wire slide share one keyframe and travel down the rail together, which is how you actually focus one of these.
+- **Card stock**: warm mount board with a sepia print inset, an ink caption underneath.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and parks the card partway down the rail, so the instrument still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/stereoscope-as/demo.html
+++ b/submissions/examples/stereoscope-as/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stereoscope</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="deskT">
+    <div class="rigT">
+      <div class="cardT">
+        <div class="halfT hlL">
+          <span class="skyT"></span>
+          <span class="peakT pkFar"></span>
+          <span class="peakT pkNear"></span>
+          <span class="treeT trA"></span>
+          <span class="treeT trB"></span>
+          <span class="railT"></span>
+          <span class="postT poA"></span>
+          <span class="postT poB"></span>
+          <span class="postT poC"></span>
+        </div>
+        <div class="halfT hlR">
+          <span class="skyT"></span>
+          <span class="peakT pkFar"></span>
+          <span class="peakT pkNear"></span>
+          <span class="treeT trA"></span>
+          <span class="treeT trB"></span>
+          <span class="railT"></span>
+          <span class="postT poA"></span>
+          <span class="postT poB"></span>
+          <span class="postT poC"></span>
+        </div>
+      </div>
+      <span class="slideT"></span>
+      <span class="armT"></span>
+      <div class="hoodT">
+        <span class="septumT"></span>
+        <span class="lensT lnL"></span>
+        <span class="lensT lnR"></span>
+        <span class="browT"></span>
+      </div>
+      <span class="handleT"></span>
+    </div>
+    <span class="capT">stereograph no. 412 : alpine viaduct</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/stereoscope-as/style.css
+++ b/submissions/examples/stereoscope-as/style.css
@@ -1,0 +1,286 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #4a4038, #171310 78%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.deskT {
+  position: relative;
+  width: 340px;
+  height: 360px;
+  overflow: hidden;
+  border-radius: 16px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(70, 46, 26, 0.24) 0 2px,
+      transparent 2px 22px
+    ),
+    radial-gradient(ellipse at 50% 30%, #5f4a34, #1d1610 82%);
+}
+
+.rigT {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 300px;
+  height: 300px;
+  margin-left: -150px;
+}
+
+.cardT {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 244px;
+  height: 104px;
+  margin-left: -122px;
+  display: flex;
+  gap: 4px;
+  padding: 5px;
+  box-sizing: border-box;
+  border-radius: 4px 4px 2px 2px;
+  background: linear-gradient(180deg, #d8c49a, #a88a62);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.55);
+  z-index: 7;
+  animation: focusT 9s ease-in-out infinite;
+}
+
+.halfT {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  border-radius: 2px;
+  background: #6f6a5c;
+}
+
+.skyT {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, #cfc7ad, #8d8874 62%, #6a6656);
+  z-index: 1;
+}
+
+.peakT {
+  position: absolute;
+  background: linear-gradient(180deg, #e6dfc6 0 22%, #7e7a66 24%, #56523f);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  z-index: 2;
+}
+
+/* far subject: no disparity between the two halves */
+.pkFar { bottom: 34px; left: 6px; width: 74px; height: 44px; }
+.pkNear { bottom: 34px; left: 54px; width: 62px; height: 34px; filter: brightness(0.9); }
+
+.treeT {
+  position: absolute;
+  bottom: 30px;
+  width: 9px;
+  height: 26px;
+  background: #33301f;
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  z-index: 4;
+}
+
+.railT {
+  position: absolute;
+  bottom: 24px;
+  left: -4px;
+  right: -4px;
+  height: 7px;
+  background: linear-gradient(180deg, #4a4534, #24210f);
+  z-index: 5;
+}
+
+.postT {
+  position: absolute;
+  bottom: 0;
+  width: 6px;
+  height: 26px;
+  background: linear-gradient(180deg, #454031, #191608);
+  z-index: 5;
+}
+
+.postT::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: -4px;
+  width: 14px;
+  height: 4px;
+  background: #2f2b1c;
+  clip-path: polygon(0 0, 100% 100%, 50% 100%, 0 40%);
+}
+
+/* near subject: shifted between halves, which is the whole point of a stereograph */
+.hlL .trA { left: 20px; }
+.hlL .trB { left: 90px; }
+.hlL .poA { left: 16px; }
+.hlL .poB { left: 52px; }
+.hlL .poC { left: 88px; }
+.hlR .trA { left: 17px; }
+.hlR .trB { left: 87px; }
+.hlR .poA { left: 8px; }
+.hlR .poB { left: 44px; }
+.hlR .poC { left: 80px; }
+
+.slideT {
+  position: absolute;
+  top: 96px;
+  left: 50%;
+  width: 258px;
+  height: 12px;
+  margin-left: -129px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #7a5f3c, #38280f);
+  box-shadow: inset 0 -3px 5px rgba(0, 0, 0, 0.5);
+  z-index: 8;
+  animation: focusT 9s ease-in-out infinite;
+}
+
+.armT {
+  position: absolute;
+  top: 104px;
+  left: 50%;
+  width: 22px;
+  height: 112px;
+  margin-left: -11px;
+  border-radius: 3px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 12, 4, 0.4) 0 1px,
+      transparent 1px 7px
+    ),
+    linear-gradient(90deg, #8a6c44, #4f3a1e 50%, #2a1c0c);
+  z-index: 5;
+}
+
+.armT::after {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 6px;
+  bottom: 8px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, rgba(230, 200, 150, 0.34), rgba(230, 200, 150, 0.06));
+}
+
+.hoodT {
+  position: absolute;
+  bottom: 44px;
+  left: 50%;
+  width: 214px;
+  height: 96px;
+  margin-left: -107px;
+  border-radius: 8px 8px 26px 26px / 6px 6px 40px 40px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(40, 22, 8, 0.26) 0 2px,
+      transparent 2px 16px
+    ),
+    linear-gradient(180deg, #a07c4e, #4e3618 62%, #241708);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.6);
+  z-index: 9;
+}
+
+.browT {
+  position: absolute;
+  top: -9px;
+  left: 50%;
+  width: 190px;
+  height: 16px;
+  margin-left: -95px;
+  border-radius: 50% 50% 0 0 / 100% 100% 0 0;
+  background: linear-gradient(180deg, #241a10, #4a3620);
+  z-index: 10;
+}
+
+.septumT {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 9px;
+  height: 90px;
+  margin-left: -4.5px;
+  border-radius: 2px 2px 0 0;
+  background: linear-gradient(90deg, #2a1c0c, #6a4e2c 50%, #2a1c0c);
+  z-index: 11;
+}
+
+.lensT {
+  position: absolute;
+  top: 22px;
+  width: 76px;
+  height: 52px;
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      ellipse at 34% 28%,
+      rgba(226, 240, 246, 0.5),
+      rgba(90, 130, 150, 0.34) 42%,
+      rgba(16, 26, 32, 0.9) 86%
+    );
+  box-shadow:
+    0 0 0 4px #2c1d0d,
+    inset 0 0 12px rgba(0, 0, 0, 0.7);
+  z-index: 10;
+  animation: glintT 9s ease-in-out infinite;
+}
+
+.lnL { left: 20px; }
+.lnR { right: 20px; animation-delay: -0.35s; }
+
+.handleT {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 26px;
+  height: 48px;
+  margin-left: -13px;
+  border-radius: 4px 4px 10px 10px;
+  background: linear-gradient(90deg, #7a5c34, #3a2810 54%, #1f1408);
+  z-index: 8;
+}
+
+.capT {
+  position: absolute;
+  bottom: 14px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  color: rgba(230, 208, 168, 0.62);
+  z-index: 12;
+}
+
+@keyframes focusT {
+  0%, 100% { transform: translateY(0); }
+  46%, 62% { transform: translateY(30px); }
+}
+
+@keyframes glintT {
+  0%, 100% { filter: brightness(1); }
+  46%, 62% { filter: brightness(1.3); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cardT,
+  .slideT,
+  .lensT {
+    animation: none;
+  }
+
+  .cardT,
+  .slideT {
+    transform: translateY(18px);
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/stereoscope-as/`, a self-contained pure CSS/HTML Holmes stereoscope holding an alpine viaduct stereograph.

Closes #47692

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **Real disparity**: the two halves of the card are the same markup, but the near subjects (rail posts, foreground trees) are offset horizontally between `.hlL` and `.hlR` while the distant peaks are identical in both. That is the actual geometry of a stereo pair. A component that duplicates one image would miss the entire point of the instrument.
- **The septum**: a raised centre divider running the full depth of the hood, which is what stops each eye from seeing the wrong half.
- **The hood**: an asymmetric `border-radius` (`8px 8px 26px 26px / 6px 6px 40px 40px`) gives the flared face-cup, with a `repeating-linear-gradient` wood grain over the base.
- **Lenses**: an off-centre `radial-gradient` puts the highlight up and left on both, with a `box-shadow` ring for the bezel. They brighten on the same keyframe as the focus pull.
- **Focus**: the card and its wire slide share one keyframe and travel down the rail together, which is how you actually focus one of these.
- **Card stock**: warm mount board with a sepia print inset and an ink caption underneath.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and parks the card partway down the rail, so the instrument still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the card slides the rail, the lenses catch light on the pull, and the reduced-motion path renders a static instrument. Measured the two halves in the browser: the near post carries an 8px horizontal disparity between left and right while the far peak measures 0, so the stereo geometry is actually there rather than implied. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
