### PR TITLE
Add magnetic-pull-tooltip-neumorphic

### DIFF
--- a/submissions/examples/magnetic-pull-tooltip-neumorphic-aaniya/README.md
+++ b/submissions/examples/magnetic-pull-tooltip-neumorphic-aaniya/README.md
@@ -1,0 +1,50 @@
+# Magnetic Pull Tooltip — Neumorphic Soft
+
+Closes #46305
+
+## What does this do?
+
+A soft-UI (neumorphic) tooltip that snaps into place with a magnetic pull motion when its trigger is hovered or focused, settling with a slight overshoot — a single CSS `@keyframes` animation, no JavaScript.
+
+## How is it used?
+
+```html
+<div class="magnet-tooltip-neu">
+  <button class="magnet-tooltip-neu__trigger" type="button">Notifications</button>
+  <div class="magnet-tooltip-neu__bubble">
+    <span class="magnet-tooltip-neu__title">Stay in the loop</span>
+    <span class="magnet-tooltip-neu__body">Get alerts when a teammate mentions you or shares a file.</span>
+  </div>
+</div>
+```
+
+Hovering or tab-focusing `.magnet-tooltip-neu__trigger` reveals the adjacent `.magnet-tooltip-neu__bubble`, playing the `ease-magnet-neu-pull` animation: it starts offset and shrunk, overshoots slightly as it snaps toward the trigger, then settles into place.
+
+Timing, easing, pull distance, and settle scale are exposed as CSS custom properties:
+
+```html
+<div class="magnet-tooltip-neu" style="--ease-magnet-neu-duration: 650ms; --ease-magnet-neu-pull-distance: 34px; --ease-magnet-neu-scale: 1.04;">
+  ...
+</div>
+```
+
+## Why is it useful?
+
+Neumorphic soft-UI relies on dual-toned, carved-in or raised shadows rather than borders or flat color blocks to establish hierarchy. This variant matches that directly — both trigger and bubble use soft, layered box-shadows — paired with a distinctive magnetic-snap motion rather than a flat fade or slide.
+
+- Needs **no JavaScript** — the whole effect is a single CSS `@keyframes` animation triggered by native `:hover`/`:focus-visible`.
+- Is keyboard accessible: the trigger is a real `<button>`, and `:focus-visible` triggers the same pull-in animation as mouse hover.
+- Exposes `--ease-magnet-neu-duration`, `--ease-magnet-neu-curve`, `--ease-magnet-neu-scale`, and `--ease-magnet-neu-pull-distance` as custom properties, so consumers can tune timing, easing, and overshoot feel without touching the source CSS.
+- Respects `prefers-reduced-motion` by skipping straight to the final, settled state.
+- Is responsive down to narrow viewports.
+- Uses `ease-` prefixed variable and keyframe names per the library's convention.
+
+## Files
+
+- `demo.html` — self-contained demo with a default and a customized example, opens directly in a browser
+- `style.css` — raw CSS (uses `ease-` prefixed variable/keyframe names; exposes custom properties for timing/easing/scale per the issue's requirement)
+- `README.md` — this file
+
+## Note on related submissions
+
+This repo has other "Magnetic Pull Tooltip" issues styled for Creative Portfolio (#46308), Accessible Web Layouts (#46307), and Responsive Dashboard (#46306). This submission is built specifically for the "Neumorphic Soft" brief — dual-toned soft-shadow styling on both trigger and bubble, distinct from the flat/bordered/glass treatments used in the other variants.

--- a/submissions/examples/magnetic-pull-tooltip-neumorphic-aaniya/demo.html
+++ b/submissions/examples/magnetic-pull-tooltip-neumorphic-aaniya/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Magnetic Pull Tooltip — Neumorphic Soft</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Magnetic Pull Tooltip — Neumorphic Soft</h1>
+  <p>A soft-UI tooltip that snaps into place with a magnetic pull motion when hovered or focused — pure CSS, no JavaScript.</p>
+
+  <div class="magnet-tooltip-neu-grid">
+
+    <div class="magnet-tooltip-neu">
+      <button class="magnet-tooltip-neu__trigger" type="button">Notifications</button>
+      <div class="magnet-tooltip-neu__bubble">
+        <span class="magnet-tooltip-neu__title">Stay in the loop</span>
+        <span class="magnet-tooltip-neu__body">Get alerts when a teammate mentions you or shares a file.</span>
+      </div>
+    </div>
+
+    <div class="magnet-tooltip-neu" style="--ease-magnet-neu-duration: 650ms; --ease-magnet-neu-pull-distance: 34px; --ease-magnet-neu-scale: 1.04;">
+      <button class="magnet-tooltip-neu__trigger" type="button">Storage</button>
+      <div class="magnet-tooltip-neu__bubble">
+        <span class="magnet-tooltip-neu__title">3.2 GB of 10 GB used</span>
+        <span class="magnet-tooltip-neu__body">Upgrade your plan anytime for more space.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-tooltip-neumorphic-aaniya/style.css
+++ b/submissions/examples/magnetic-pull-tooltip-neumorphic-aaniya/style.css
@@ -1,0 +1,146 @@
+/* ==========================================================================
+   Magnetic Pull Tooltip — Neumorphic Soft
+   A soft-UI (neumorphic) tooltip that snaps into place with a magnetic
+   pull motion when its trigger is hovered or focused. Single CSS
+   animation, no JavaScript. Exposes timing, easing, and scale as CSS
+   custom properties.
+   ========================================================================== */
+
+:root {
+  --ease-magnet-neu-bg: #e6e9ef;
+  --ease-magnet-neu-text: #33384a;
+  --ease-magnet-neu-muted: #7d84a0;
+  --ease-magnet-neu-accent: #6a5cff;
+  --ease-magnet-neu-shadow-light: #ffffff;
+  --ease-magnet-neu-shadow-dark: #b9bec9;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-magnet-neu-duration: 500ms;
+  --ease-magnet-neu-curve: cubic-bezier(0.3, 1.4, 0.6, 1);
+  --ease-magnet-neu-scale: 1;
+  --ease-magnet-neu-pull-distance: 24px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-magnet-neu-bg);
+  border-radius: 16px;
+  color: var(--ease-magnet-neu-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-magnet-neu-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.magnet-tooltip-neu-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.magnet-tooltip-neu {
+  position: relative;
+  display: inline-block;
+}
+
+.magnet-tooltip-neu__trigger {
+  padding: 12px 22px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ease-magnet-neu-text);
+  background: var(--ease-magnet-neu-bg);
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+
+  box-shadow:
+    6px 6px 12px var(--ease-magnet-neu-shadow-dark),
+    -6px -6px 12px var(--ease-magnet-neu-shadow-light);
+}
+
+.magnet-tooltip-neu__trigger:focus-visible {
+  outline: 2px solid var(--ease-magnet-neu-accent);
+  outline-offset: 3px;
+}
+
+.magnet-tooltip-neu__bubble {
+  position: absolute;
+  bottom: calc(100% + 18px);
+  left: 50%;
+  width: 230px;
+  padding: 16px 18px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-magnet-neu-text);
+  background: var(--ease-magnet-neu-bg);
+  border-radius: 16px;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  box-shadow:
+    8px 8px 18px var(--ease-magnet-neu-shadow-dark),
+    -8px -8px 18px var(--ease-magnet-neu-shadow-light);
+
+  transform: translateX(-50%) translateY(var(--ease-magnet-neu-pull-distance)) scale(0.9);
+}
+
+/* The single animation this component demonstrates: the tooltip snaps
+   in with a magnetic pull motion toward the trigger. */
+@keyframes ease-magnet-neu-pull {
+  0% {
+    transform: translateX(-50%) translateY(var(--ease-magnet-neu-pull-distance)) scale(0.9);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(-50%) translateY(-3px) scale(calc(var(--ease-magnet-neu-scale) * 1.02));
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(var(--ease-magnet-neu-scale));
+    opacity: 1;
+  }
+}
+
+.magnet-tooltip-neu__trigger:hover + .magnet-tooltip-neu__bubble,
+.magnet-tooltip-neu__trigger:focus-visible + .magnet-tooltip-neu__bubble {
+  visibility: visible;
+  animation: ease-magnet-neu-pull var(--ease-magnet-neu-duration) var(--ease-magnet-neu-curve) forwards;
+}
+
+.magnet-tooltip-neu__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+  color: var(--ease-magnet-neu-accent);
+}
+
+.magnet-tooltip-neu__body {
+  color: var(--ease-magnet-neu-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .magnet-tooltip-neu__trigger:hover + .magnet-tooltip-neu__bubble,
+  .magnet-tooltip-neu__trigger:focus-visible + .magnet-tooltip-neu__bubble {
+    animation: none;
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .magnet-tooltip-neu__bubble { width: 190px; }
+}


### PR DESCRIPTION
Closes #46305
## Pull Request Description
Adds a new neumorphic soft-UI tooltip submission — `magnetic-pull-tooltip-neumorphic-aaniya` — that snaps into place with a magnetic pull motion, closing #46305.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-tooltip-neumorphic-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A neumorphic (soft-UI) tooltip that snaps into place with a magnetic pull motion and a slight overshoot when its trigger is hovered or focused.

**How does a developer use it?**
```html
<div class="magnet-tooltip-neu">
  <button class="magnet-tooltip-neu__trigger" type="button">Notifications</button>
  <div class="magnet-tooltip-neu__bubble">
    <span class="magnet-tooltip-neu__title">Stay in the loop</span>
    <span class="magnet-tooltip-neu__body">Get alerts when a teammate mentions you or shares a file.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS `@keyframes` animation (`ease-magnet-neu-pull`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-magnet-neu-duration`, `--ease-magnet-neu-curve`, `--ease-magnet-neu-scale`, and `--ease-magnet-neu-pull-distance` as tunable custom properties per the issue's requirement, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This repo has other "Magnetic Pull Tooltip" issues for Creative Portfolio (#46308), Accessible Web Layouts (#46307), and Responsive Dashboard (#46306), all of which I also submitted. This one is built specifically around dual-toned soft-shadow styling for the "Neumorphic Soft" brief, distinct from the flat/bordered/glass treatments used elsewhere, so there's no overlap.