### PR TITLE
Add magnetic pull tooltip for SaaS showcase layouts

### DIFF
--- a/submissions/examples/magnetic-pull-tooltip-saas-aaniya/README.md
+++ b/submissions/examples/magnetic-pull-tooltip-saas-aaniya/README.md
@@ -1,0 +1,56 @@
+# Magnetic Pull Tooltip — SaaS Showcase
+
+A clean, solid-card tooltip built for SaaS product showcase layouts. It snaps
+into place with a magnetic pull motion — a slight overshoot past its resting
+position — when its trigger button is hovered or focused.
+
+## What it does
+
+- Single `@keyframes` animation (`ease-magnet-saas-pull`), no JavaScript
+- Tooltip starts below and slightly scaled down, "pulls" upward with a small
+  overshoot, then settles into place
+- Solid white card styling with a colored top accent border and soft drop
+  shadow — designed to read as a SaaS product UI element, distinct from the
+  dark/neumorphic/glass treatments used in other Magnetic Pull submissions
+  in this repo
+
+## How to use it
+
+```html
+<div class="magnet-tooltip-saas">
+  <button class="magnet-tooltip-saas__trigger">Notifications</button>
+  <div class="magnet-tooltip-saas__bubble">
+    <span class="magnet-tooltip-saas__title">Stay in the loop</span>
+    <span class="magnet-tooltip-saas__body">
+      Get alerts when a teammate mentions you or shares a file.
+    </span>
+  </div>
+</div>
+```
+
+Just drop the markup in and hover (or Tab to focus) the trigger button.
+
+## Customization
+
+Tunable via CSS custom properties on `:root` or scoped to a component:
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-magnet-saas-duration` | `500ms` | Animation duration |
+| `--ease-magnet-saas-curve` | `cubic-bezier(0.3, 1.4, 0.6, 1)` | Easing curve (drives the overshoot) |
+| `--ease-magnet-saas-scale` | `1` | Final resting scale of the tooltip |
+| `--ease-magnet-saas-pull-distance` | `24px` | Starting vertical offset before the pull |
+
+## Accessibility
+
+- Triggers via `:hover` **and** `:focus-visible`, so keyboard users see the
+  tooltip too
+- Respects `prefers-reduced-motion`: animation is skipped and the tooltip
+  simply appears in its resting state
+- Responsive down to mobile widths (bubble width adjusts at 480px)
+
+## Why it fits EaseMotion CSS
+
+Readable, single-purpose CSS animation with no dependencies, exposed
+customization points, and accessibility built in — in line with the
+library's animation-first philosophy.

--- a/submissions/examples/magnetic-pull-tooltip-saas-aaniya/demo.html
+++ b/submissions/examples/magnetic-pull-tooltip-saas-aaniya/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Magnetic Pull Tooltip — SaaS Showcase</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Magnetic Pull Tooltip — SaaS Showcase</h1>
+  <p>Hover or focus (Tab) any button below. Each tooltip snaps into place with a magnetic pull motion, styled as a clean solid SaaS card.</p>
+
+  <div class="magnet-tooltip-saas-grid">
+
+    <div class="magnet-tooltip-saas">
+      <button class="magnet-tooltip-saas__trigger">Notifications</button>
+      <div class="magnet-tooltip-saas__bubble">
+        <span class="magnet-tooltip-saas__title">Stay in the loop</span>
+        <span class="magnet-tooltip-saas__body">Get alerts when a teammate mentions you or shares a file.</span>
+      </div>
+    </div>
+
+    <div class="magnet-tooltip-saas">
+      <button class="magnet-tooltip-saas__trigger">Integrations</button>
+      <div class="magnet-tooltip-saas__bubble">
+        <span class="magnet-tooltip-saas__title">Connect your stack</span>
+        <span class="magnet-tooltip-saas__body">Sync with Slack, Notion, and 40+ other tools in one click.</span>
+      </div>
+    </div>
+
+    <div class="magnet-tooltip-saas">
+      <button class="magnet-tooltip-saas__trigger">Analytics</button>
+      <div class="magnet-tooltip-saas__bubble">
+        <span class="magnet-tooltip-saas__title">Track what matters</span>
+        <span class="magnet-tooltip-saas__body">Real-time dashboards for usage, retention, and revenue.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-tooltip-saas-aaniya/style.css
+++ b/submissions/examples/magnetic-pull-tooltip-saas-aaniya/style.css
@@ -1,0 +1,144 @@
+/* ==========================================================================
+   Magnetic Pull Tooltip — SaaS Showcase
+   A clean, solid-card tooltip styled for SaaS product showcase layouts,
+   snapping into place with a magnetic pull motion when its trigger is
+   hovered or focused. Single CSS animation, no JavaScript. Exposes
+   timing, easing, and scale as CSS custom properties.
+
+   Note: distinct from perspective-tilt-tooltip-saas (3D tilt reveal) and
+   from the other magnetic-pull variants (dark/neumorphic/glass) — this
+   one pairs the magnetic snap motion with a clean, solid white SaaS card.
+   ========================================================================== */
+
+:root {
+  --ease-magnet-saas-bg: #ffffff;
+  --ease-magnet-saas-border: #e4e7ef;
+  --ease-magnet-saas-text: #1c2233;
+  --ease-magnet-saas-muted: #6b7284;
+  --ease-magnet-saas-accent: #4f46e5;
+  --ease-magnet-saas-page-bg: #f4f5fa;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-magnet-saas-duration: 500ms;
+  --ease-magnet-saas-curve: cubic-bezier(0.3, 1.4, 0.6, 1);
+  --ease-magnet-saas-scale: 1;
+  --ease-magnet-saas-pull-distance: 24px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-magnet-saas-page-bg);
+  border-radius: 16px;
+  color: var(--ease-magnet-saas-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-magnet-saas-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.magnet-tooltip-saas-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.magnet-tooltip-saas {
+  position: relative;
+  display: inline-block;
+}
+
+.magnet-tooltip-saas__trigger {
+  padding: 10px 20px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--ease-magnet-saas-accent);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.magnet-tooltip-saas__trigger:focus-visible {
+  outline: 2px solid var(--ease-magnet-saas-accent);
+  outline-offset: 3px;
+}
+
+.magnet-tooltip-saas__bubble {
+  position: absolute;
+  bottom: calc(100% + 18px);
+  left: 50%;
+  width: 230px;
+  padding: 16px 18px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-magnet-saas-text);
+  background: var(--ease-magnet-saas-bg);
+  border: 1px solid var(--ease-magnet-saas-border);
+  border-top: 3px solid var(--ease-magnet-saas-accent);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(30, 34, 60, 0.16);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  transform: translateX(-50%) translateY(var(--ease-magnet-saas-pull-distance)) scale(0.9);
+}
+
+/* The single animation this component demonstrates: the tooltip snaps
+   in with a magnetic pull motion toward the trigger. */
+@keyframes ease-magnet-saas-pull {
+  0% {
+    transform: translateX(-50%) translateY(var(--ease-magnet-saas-pull-distance)) scale(0.9);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(-50%) translateY(-3px) scale(calc(var(--ease-magnet-saas-scale) * 1.02));
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(var(--ease-magnet-saas-scale));
+    opacity: 1;
+  }
+}
+
+.magnet-tooltip-saas__trigger:hover + .magnet-tooltip-saas__bubble,
+.magnet-tooltip-saas__trigger:focus-visible + .magnet-tooltip-saas__bubble {
+  visibility: visible;
+  animation: ease-magnet-saas-pull var(--ease-magnet-saas-duration) var(--ease-magnet-saas-curve) forwards;
+}
+
+.magnet-tooltip-saas__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.magnet-tooltip-saas__body {
+  color: var(--ease-magnet-saas-muted);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .magnet-tooltip-saas__trigger:hover + .magnet-tooltip-saas__bubble,
+  .magnet-tooltip-saas__trigger:focus-visible + .magnet-tooltip-saas__bubble {
+    animation: none;
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .magnet-tooltip-saas__bubble { width: 190px; }
+}


### PR DESCRIPTION
Closes #46301
## Pull Request Description
Adds a new solid-card SaaS-styled tooltip submission — `magnetic-pull-tooltip-saas-aaniya` — that snaps into place with a magnetic pull motion, closing #46301.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-tooltip-saas-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A clean, solid-card SaaS-style tooltip that snaps into place with a magnetic pull motion and a slight overshoot when its trigger is hovered or focused.

**How does a developer use it?**
```html
<div class="magnet-tooltip-saas">
  <button class="magnet-tooltip-saas__trigger">Notifications</button>
  <div class="magnet-tooltip-saas__bubble">
    <span class="magnet-tooltip-saas__title">Stay in the loop</span>
    <span class="magnet-tooltip-saas__body">Get alerts when a teammate mentions you or shares a file.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS `@keyframes` animation (`ease-magnet-saas-pull`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-magnet-saas-duration`, `--ease-magnet-saas-curve`, `--ease-magnet-saas-scale`, and `--ease-magnet-saas-pull-distance` as tunable custom properties, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This repo has other "Magnetic Pull Tooltip" issues for Neumorphic Soft (#46305), Creative Portfolio (#46308), Accessible Web Layouts (#46307), and Responsive Dashboard (#46306), all of which I also submitted. This one is styled specifically as a solid white SaaS card (top accent border, soft drop shadow), distinct from the dark/neumorphic/glass treatments used elsewhere, and distinct from perspective-tilt-tooltip-saas (#46315) which uses 3D tilt instead of a magnetic snap.
Only check browser boxes you've actually tested. Let me know if the maintainer flags anything.