### PR TITLE
Add magnetic pull tooltip for e-commerce checkout layouts

### DIFF
--- a/submissions/examples/magnetic-pull-tooltip-ecommerce-aaniya/README.md
+++ b/submissions/examples/magnetic-pull-tooltip-ecommerce-aaniya/README.md
@@ -1,0 +1,57 @@
+# Magnetic Pull Tooltip — E-Commerce Checkout
+
+A pure CSS tooltip styled for e-commerce checkout interfaces. It snaps into
+place with a magnetic pull motion — a small overshoot past its resting
+position — when its trigger is hovered or focused.
+
+## What it does
+
+- Single `@keyframes` animation (`ease-magnet-cart-pull`), no JavaScript
+- Tooltip starts below and slightly scaled down, pulls upward with a subtle
+  overshoot, then settles into place
+- Checkout-specific visual language: a small rounded status tag (e.g. "Free
+  over $50", "10% off", "Only 3 left") above the title, green confirm accent
+  color — distinct from the SaaS card, neumorphic soft-UI, and other
+  magnetic-pull variants in this repo
+
+## How to use it
+
+```html
+<div class="magnet-tooltip-cart">
+  <button class="magnet-tooltip-cart__trigger">Shipping</button>
+  <div class="magnet-tooltip-cart__bubble">
+    <span class="magnet-tooltip-cart__tag">Free over $50</span>
+    <span class="magnet-tooltip-cart__title">Fast delivery</span>
+    <span class="magnet-tooltip-cart__body">
+      Standard shipping arrives in 3–5 business days.
+    </span>
+  </div>
+</div>
+```
+
+Just drop the markup in and hover (or Tab to focus) the trigger button.
+
+## Customization
+
+Tunable via CSS custom properties on `:root` or scoped to a component:
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-magnet-cart-duration` | `480ms` | Animation duration |
+| `--ease-magnet-cart-curve` | `cubic-bezier(0.34, 1.5, 0.6, 1)` | Easing curve (drives the overshoot) |
+| `--ease-magnet-cart-scale` | `1` | Final resting scale of the tooltip |
+| `--ease-magnet-cart-pull-distance` | `22px` | Starting vertical offset before the pull |
+
+## Accessibility
+
+- Triggers via `:hover` **and** `:focus-visible`, so keyboard users see the
+  tooltip too
+- Respects `prefers-reduced-motion`: animation is skipped and the tooltip
+  simply appears in its resting state
+- Responsive down to mobile widths (bubble width adjusts at 480px)
+
+## Why it fits EaseMotion CSS
+
+Readable, single-purpose CSS animation with no dependencies, exposed
+customization points, and accessibility built in — in line with the
+library's animation-first philosophy.

--- a/submissions/examples/magnetic-pull-tooltip-ecommerce-aaniya/demo.html
+++ b/submissions/examples/magnetic-pull-tooltip-ecommerce-aaniya/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Magnetic Pull Tooltip — E-Commerce Checkout</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="page">
+  <h1>Magnetic Pull Tooltip — E-Commerce Checkout</h1>
+  <p>Hover or focus (Tab) any button below. Each tooltip snaps into place with a magnetic pull motion, styled for checkout-flow UI.</p>
+
+  <div class="magnet-tooltip-cart-grid">
+
+    <div class="magnet-tooltip-cart">
+      <button class="magnet-tooltip-cart__trigger">Shipping</button>
+      <div class="magnet-tooltip-cart__bubble">
+        <span class="magnet-tooltip-cart__tag">Free over $50</span>
+        <span class="magnet-tooltip-cart__title">Fast delivery</span>
+        <span class="magnet-tooltip-cart__body">Standard shipping arrives in 3–5 business days.</span>
+      </div>
+    </div>
+
+    <div class="magnet-tooltip-cart">
+      <button class="magnet-tooltip-cart__trigger">Discount Code</button>
+      <div class="magnet-tooltip-cart__bubble">
+        <span class="magnet-tooltip-cart__tag">10% off</span>
+        <span class="magnet-tooltip-cart__title">Apply at checkout</span>
+        <span class="magnet-tooltip-cart__body">Enter code SAVE10 in the promo field before you pay.</span>
+      </div>
+    </div>
+
+    <div class="magnet-tooltip-cart">
+      <button class="magnet-tooltip-cart__trigger">In Stock</button>
+      <div class="magnet-tooltip-cart__bubble">
+        <span class="magnet-tooltip-cart__tag">Only 3 left</span>
+        <span class="magnet-tooltip-cart__title">Order soon</span>
+        <span class="magnet-tooltip-cart__body">This item is in limited stock at your selected warehouse.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-tooltip-ecommerce-aaniya/style.css
+++ b/submissions/examples/magnetic-pull-tooltip-ecommerce-aaniya/style.css
@@ -1,0 +1,156 @@
+/* ==========================================================================
+   Magnetic Pull Tooltip — E-Commerce Checkout
+   A pure CSS tooltip styled for e-commerce checkout interfaces, snapping
+   into place with a magnetic pull motion when its trigger is hovered or
+   focused. Single CSS animation, no JavaScript. Exposes timing, easing,
+   and scale as CSS custom properties.
+
+   Note: distinct from the SaaS card, neumorphic soft-UI, and other
+   magnetic-pull variants — this one uses checkout-specific accents
+   (price/stock tag, green confirm color, cart-style icon).
+   ========================================================================== */
+
+:root {
+  --ease-magnet-cart-bg: #ffffff;
+  --ease-magnet-cart-border: #e2e8e4;
+  --ease-magnet-cart-text: #1e2b23;
+  --ease-magnet-cart-muted: #6b7a70;
+  --ease-magnet-cart-accent: #1a9d5c;
+  --ease-magnet-cart-tag-bg: #eafbf1;
+  --ease-magnet-cart-page-bg: #f6f8f6;
+
+  /* Exposed customization points, per issue requirements */
+  --ease-magnet-cart-duration: 480ms;
+  --ease-magnet-cart-curve: cubic-bezier(0.34, 1.5, 0.6, 1);
+  --ease-magnet-cart-scale: 1;
+  --ease-magnet-cart-pull-distance: 22px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--ease-magnet-cart-page-bg);
+  border-radius: 16px;
+  color: var(--ease-magnet-cart-text);
+}
+
+.page h1 { font-size: 1.4rem; margin-bottom: 8px; }
+.page p { color: var(--ease-magnet-cart-muted); line-height: 1.5; max-width: 460px; margin: 0 auto 40px; }
+
+.magnet-tooltip-cart-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 60px;
+}
+
+/* Trigger + tooltip wrapper ------------------------------------------- */
+
+.magnet-tooltip-cart {
+  position: relative;
+  display: inline-block;
+}
+
+.magnet-tooltip-cart__trigger {
+  padding: 10px 20px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--ease-magnet-cart-accent);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.magnet-tooltip-cart__trigger:focus-visible {
+  outline: 2px solid var(--ease-magnet-cart-accent);
+  outline-offset: 3px;
+}
+
+.magnet-tooltip-cart__bubble {
+  position: absolute;
+  bottom: calc(100% + 18px);
+  left: 50%;
+  width: 230px;
+  padding: 14px 16px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: left;
+  color: var(--ease-magnet-cart-text);
+  background: var(--ease-magnet-cart-bg);
+  border: 1px solid var(--ease-magnet-cart-border);
+  border-radius: 10px;
+  box-shadow: 0 18px 36px rgba(20, 40, 30, 0.14);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+
+  transform: translateX(-50%) translateY(var(--ease-magnet-cart-pull-distance)) scale(0.9);
+}
+
+.magnet-tooltip-cart__tag {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--ease-magnet-cart-accent);
+  background: var(--ease-magnet-cart-tag-bg);
+  padding: 2px 8px;
+  border-radius: 999px;
+  margin-bottom: 6px;
+}
+
+.magnet-tooltip-cart__title {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.magnet-tooltip-cart__body {
+  color: var(--ease-magnet-cart-muted);
+}
+
+/* The single animation this component demonstrates: the tooltip snaps
+   in with a magnetic pull motion toward the trigger. */
+@keyframes ease-magnet-cart-pull {
+  0% {
+    transform: translateX(-50%) translateY(var(--ease-magnet-cart-pull-distance)) scale(0.9);
+    opacity: 0;
+  }
+  62% {
+    transform: translateX(-50%) translateY(-3px) scale(calc(var(--ease-magnet-cart-scale) * 1.02));
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(0) scale(var(--ease-magnet-cart-scale));
+    opacity: 1;
+  }
+}
+
+.magnet-tooltip-cart__trigger:hover + .magnet-tooltip-cart__bubble,
+.magnet-tooltip-cart__trigger:focus-visible + .magnet-tooltip-cart__bubble {
+  visibility: visible;
+  animation: ease-magnet-cart-pull var(--ease-magnet-cart-duration) var(--ease-magnet-cart-curve) forwards;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .magnet-tooltip-cart__trigger:hover + .magnet-tooltip-cart__bubble,
+  .magnet-tooltip-cart__trigger:focus-visible + .magnet-tooltip-cart__bubble {
+    animation: none;
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .page { margin: 24px 12px; padding: 48px 16px; }
+  .magnet-tooltip-cart__bubble { width: 190px; }
+}


### PR DESCRIPTION
Closes #46300
## Pull Request Description
Adds a new e-commerce checkout-styled tooltip submission — `magnetic-pull-tooltip-ecommerce-aaniya` — that snaps into place with a magnetic pull motion, closing #46300.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-tooltip-ecommerce-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS tooltip styled for e-commerce checkout interfaces, snapping into place with a magnetic pull motion when its trigger is hovered or focused.

**How does a developer use it?**
```html
<div class="magnet-tooltip-cart">
  <button class="magnet-tooltip-cart__trigger">Shipping</button>
  <div class="magnet-tooltip-cart__bubble">
    <span class="magnet-tooltip-cart__tag">Free over $50</span>
    <span class="magnet-tooltip-cart__title">Fast delivery</span>
    <span class="magnet-tooltip-cart__body">Standard shipping arrives in 3–5 business days.</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, readable CSS `@keyframes` animation (`ease-magnet-cart-pull`) with no JS dependency, in keeping with the library's human-readable, animation-first philosophy. It's keyboard accessible via `:focus-visible`, exposes `--ease-magnet-cart-duration`, `--ease-magnet-cart-curve`, `--ease-magnet-cart-scale`, and `--ease-magnet-cart-pull-distance` as tunable custom properties, respects `prefers-reduced-motion`, and is responsive down to mobile widths.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This repo has several other "Magnetic Pull Tooltip" issues (SaaS Showcase #46301, Neumorphic Soft #46305, Creative Portfolio #46308, Accessible Web Layouts #46307, Responsive Dashboard #46306), all of which I also submitted. This one uses checkout-specific visual language — a small status/pricing tag ("Free over $50", "10% off", "Only 3 left") and a green confirm accent — distinct from the solid SaaS card, neumorphic soft-UI, and other treatments used elsewhere.
Only check browser boxes you've actually tested. Let me know if the maintainer flags anything.