### PR TITLE
ease-global-rm-engine-overlap

### DIFF
--- a/submissions/docs/ease-global-rm-engine-overlap-sp/README.md
+++ b/submissions/docs/ease-global-rm-engine-overlap-sp/README.md
@@ -1,0 +1,53 @@
+# Global Reduced-Motion Rule vs Engine Class Double-Apply
+
+A documentation guide explaining why DevTools shows two `@media (prefers-reduced-motion: reduce)` blocks for the same element — the global rule in `easemotion.css` and the Motion Engine compiler's per-class guard — and which one effectively wins.
+
+> Submission track: `submissions/docs/ease-global-rm-engine-overlap-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #47706
+
+---
+
+## What does this do?
+
+When users enable "Reduce motion" and inspect an element with both a framework class (`ease-fade-in`) and an engine-injected class (`_em_*`), DevTools lists multiple reduced-motion rules. This looks like a bug but is intentional redundancy. The guide clarifies cascade behavior and expected outcomes.
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Toggle **Reduce motion** on/off to compare animation behavior.
+3. Read the DevTools-style cascade panels for global vs engine rules.
+4. See the "winner" callout explaining why both rules produce the same result.
+5. Copy snippets for local reduced-motion testing.
+
+## Features
+
+- Side-by-side explanation of global RM media query vs engine per-class RM guard
+- Fake DevTools-style cascade panels showing rule overlap
+- Clear "winner" callouts for animation duration/iteration behavior
+- Live toggle to simulate `prefers-reduced-motion: reduce`
+- Accessibility-focused notes
+- Copy-ready snippets for testing reduced motion locally
+- Responsive and beginner-friendly documentation UI
+
+## Why is it useful?
+
+- **Prevents false bug reports** — "double RM rules" is by design, not a cascade bug.
+- **Explains engine standalone mode** — per-class guards work when `easemotion.css` is not loaded.
+- **DevTools literacy** — teaches how to read strikethrough and `!important` in RM context.
+- **Self-contained** — no edits to `core/`, `components/`, or engine files.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Cascade explorer, RM toggle, live animation demo |
+| `style.css` | DevTools panel styling, layout, responsive design |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-global-rm-engine-overlap-sp/`.
+- No modifications to `core/`, `components/`, `easemotion/engine/`, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/docs/ease-global-rm-engine-overlap-sp/demo.html
+++ b/submissions/docs/ease-global-rm-engine-overlap-sp/demo.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Global RM vs Engine Double-Apply — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Understand why DevTools shows two prefers-reduced-motion rules on EaseMotion elements and which one wins."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="rmo-header ease-fade-in">
+    <p class="rmo-kicker">EaseMotion CSS · Accessibility Deep-Dive</p>
+    <h1>Global Reduced-Motion vs Engine Class Double-Apply</h1>
+    <p class="rmo-subtitle">
+      Why DevTools shows two <code>@media (prefers-reduced-motion: reduce)</code> blocks
+      on the same element — and why that is intentional, not a bug.
+    </p>
+  </header>
+
+  <main class="rmo-main">
+    <aside class="rmo-callout" role="note">
+      <strong>Short answer:</strong> Both rules apply the same outcome
+      (<code>animation-duration: 0.01ms !important</code>). The global rule in
+      <code>easemotion.css</code> covers everything; the engine's per-class guard exists
+      so <code>em=""</code> animations still respect reduced motion when the full CSS
+      bundle is not loaded. Neither "wins" over the other — they reinforce the same result.
+    </aside>
+
+    <!-- Live demo -->
+    <section class="rmo-card" aria-labelledby="demo-title">
+      <h2 id="demo-title">Live animation demo</h2>
+      <p>Toggle reduced motion and replay the animation to see the effect instantly.</p>
+
+      <div class="rmo-toggle-row">
+        <label class="rmo-toggle">
+          <input type="checkbox" id="rm-toggle" />
+          Simulate <code>prefers-reduced-motion: reduce</code>
+        </label>
+        <span id="rm-pill" class="rmo-status-pill rmo-status-pill--off">Motion: normal</span>
+        <button type="button" class="rmo-replay-btn" id="replay-btn">Replay animation</button>
+      </div>
+
+      <div class="rmo-grid-2">
+        <div class="rmo-demo-stage">
+          <p style="margin:0;font-size:0.8rem;color:var(--ease-color-muted);">
+            Framework class only
+          </p>
+          <div id="demo-framework" class="rmo-demo-box ease-bounce">CSS</div>
+          <code style="font-size:0.65rem;">.ease-bounce</code>
+        </div>
+        <div class="rmo-demo-stage">
+          <p style="margin:0;font-size:0.8rem;color:var(--ease-color-muted);">
+            Framework + engine-style class
+          </p>
+          <div id="demo-engine" class="rmo-demo-box ease-bounce rmo-engine-demo">em</div>
+          <code style="font-size:0.65rem;">.ease-bounce + ._em_*</code>
+        </div>
+      </div>
+    </section>
+
+    <!-- DevTools cascade -->
+    <section class="rmo-card" aria-labelledby="cascade-title">
+      <h2 id="cascade-title">Fake DevTools cascade (reduced motion ON)</h2>
+      <p>What you see when inspecting an element with both framework and engine classes.</p>
+
+      <div class="rmo-grid-2">
+        <div class="rmo-devtools">
+          <div class="rmo-devtools-head">Styles — .ease-bounce (framework only)</div>
+          <div class="rmo-devtools-body" id="cascade-framework"></div>
+        </div>
+        <div class="rmo-devtools">
+          <div class="rmo-devtools-head">Styles — .ease-bounce + ._em_a3f2c1 (engine)</div>
+          <div class="rmo-devtools-body" id="cascade-engine"></div>
+        </div>
+      </div>
+
+      <div class="rmo-winner-box">
+        <h3>Who wins?</h3>
+        <p id="winner-text">
+          When reduced motion is active, the global <code>*</code> rule and the engine's
+          <code>._em_*</code> rule both set <code>animation-duration: 0.01ms !important</code>.
+          DevTools may show one as struck through due to equal specificity + !important,
+          but the computed value is identical. There is no conflict — only redundancy.
+        </p>
+      </div>
+    </section>
+
+    <!-- Comparison table -->
+    <section class="rmo-card" aria-labelledby="compare-title">
+      <h2 id="compare-title">Global rule vs engine per-class guard</h2>
+      <table class="rmo-compare-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Global (<code>easemotion.css</code>)</th>
+            <th>Engine (<code>compiler.js</code>)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Selector</td>
+            <td><code>*, *::before, *::after</code></td>
+            <td><code>._em_{hash}</code> (specific class)</td>
+          </tr>
+          <tr>
+            <td>animation-duration</td>
+            <td><code>0.01ms !important</code></td>
+            <td><code>0.01ms !important</code></td>
+          </tr>
+          <tr>
+            <td>animation-iteration-count</td>
+            <td><code>1 !important</code></td>
+            <td><code>1 !important</code></td>
+          </tr>
+          <tr>
+            <td>transition-duration</td>
+            <td><code>0.01ms !important</code></td>
+            <td><em>not set</em></td>
+          </tr>
+          <tr>
+            <td>scroll-behavior</td>
+            <td><code>auto !important</code></td>
+            <td><em>not set</em></td>
+          </tr>
+          <tr>
+            <td>When needed</td>
+            <td>Always (full bundle loaded)</td>
+            <td>Engine standalone / <code>em=""</code> without full CSS</td>
+          </tr>
+          <tr>
+            <td>Source file</td>
+            <td><code>easemotion.css</code> (end of bundle)</td>
+            <td><code>easemotion/engine/compiler.js</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- Why both exist -->
+    <section class="rmo-card" aria-labelledby="why-title">
+      <h2 id="why-title">Why both rules exist</h2>
+      <div class="rmo-notes">
+        <article class="rmo-note">
+          <h3>Global rule purpose</h3>
+          <p>
+            The catch-all <code>*</code> selector at the end of <code>easemotion.css</code>
+            ensures every animation, transition, and scroll behavior respects the user's
+            OS-level reduced-motion setting — framework classes, components, and utilities.
+          </p>
+        </article>
+        <article class="rmo-note">
+          <h3>Engine guard purpose</h3>
+          <p>
+            The Motion Engine can run standalone (importing only <code>easemotion-css/engine</code>
+            without the full CSS bundle). Per-class guards ensure <code>em=""</code> injected
+            animations still respect reduced motion even when the global rule is absent.
+          </p>
+        </article>
+        <article class="rmo-note">
+          <h3>DevTools confusion</h3>
+          <p>
+            When both are loaded, DevTools lists two <code>@media</code> blocks. One may
+            appear struck through. This is normal cascade display — not a bug or override
+            conflict. The computed animation duration is <code>0.01ms</code> either way.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <!-- Source snippets -->
+    <section class="rmo-card" aria-labelledby="source-title">
+      <h2 id="source-title">Actual source snippets</h2>
+      <p>From the real framework files — not simplified.</p>
+
+      <h3 style="font-size:0.9rem;margin:1rem 0 0.5rem;">Global rule — easemotion.css</h3>
+      <pre class="rmo-code-block" id="snip-global">/* easemotion.css — end of bundle */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}</pre>
+
+      <h3 style="font-size:0.9rem;margin:1rem 0 0.5rem;">Engine per-class guard — compiler.js</h3>
+      <pre class="rmo-code-block" id="snip-engine">/* easemotion/engine/compiler.js — compile() output */
+._em_a3f2c1 {
+  animation: ease-kf-fade-in 500ms cubic-bezier(0,0,0.2,1) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  ._em_a3f2c1 {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}</pre>
+
+      <div class="rmo-copy-row">
+        <button type="button" class="rmo-btn" data-copy="snip-global">Copy global rule</button>
+        <button type="button" class="rmo-btn" data-copy="snip-engine">Copy engine guard</button>
+      </div>
+    </section>
+
+    <!-- Testing locally -->
+    <section class="rmo-card" aria-labelledby="test-title">
+      <h2 id="test-title">How to test reduced motion locally</h2>
+      <pre class="rmo-code-block" id="snip-test">/* Option 1 — OS setting */
+Windows: Settings → Accessibility → Visual effects → Animation effects OFF
+macOS: System Settings → Accessibility → Display → Reduce motion ON
+
+/* Option 2 — Chrome DevTools */
+1. Open DevTools (F12)
+2. Cmd/Ctrl + Shift + P → type "Rendering"
+3. Open Rendering tab → Emulate CSS media feature
+4. Select prefers-reduced-motion: reduce
+
+/* Option 3 — Firefox */
+about:config → ui.prefersReducedMotion → 1
+
+/* Verify in DevTools Computed tab */
+animation-duration should show 0.01ms on any .ease-* element</pre>
+      <div class="rmo-copy-row">
+        <button type="button" class="rmo-btn" data-copy="snip-test">Copy test guide</button>
+      </div>
+    </section>
+
+    <p id="copy-status" class="rmo-status" role="status" aria-live="polite"></p>
+  </main>
+
+  <footer class="rmo-footer">
+    <p>
+      Built for EaseMotion CSS ·
+      <code>submissions/docs/ease-global-rm-engine-overlap-sp</code> ·
+      Resolves Issue #47706
+    </p>
+  </footer>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var CASCADE_FRAMEWORK = [
+        { type: 'normal', selector: '.ease-bounce', prop: 'animation', value: 'ease-kf-bounce 300ms ... infinite', source: 'animations.css' },
+        { type: 'media', text: '@media (prefers-reduced-motion: reduce)' },
+        { type: 'winner', selector: '*, *::before, *::after', prop: 'animation-duration', value: '0.01ms !important', source: 'easemotion.css (global)' },
+        { type: 'winner', selector: '*, *::before, *::after', prop: 'animation-iteration-count', value: '1 !important', source: 'easemotion.css (global)' },
+        { type: 'winner', selector: '*, *::before, *::after', prop: 'transition-duration', value: '0.01ms !important', source: 'easemotion.css (global)' },
+        { type: 'struck', selector: '.ease-bounce', prop: 'animation', value: 'ease-kf-bounce 300ms ... infinite', source: 'animations.css (overridden)' }
+      ];
+
+      var CASCADE_ENGINE = [
+        { type: 'normal', selector: '.ease-bounce', prop: 'animation', value: 'ease-kf-bounce 300ms ... infinite', source: 'animations.css' },
+        { type: 'normal', selector: '._em_a3f2c1', prop: 'animation', value: 'ease-kf-fade-in 500ms ease-out both', source: 'engine injected' },
+        { type: 'media', text: '@media (prefers-reduced-motion: reduce)' },
+        { type: 'winner', selector: '*, *::before, *::after', prop: 'animation-duration', value: '0.01ms !important', source: 'easemotion.css (global)' },
+        { type: 'struck', selector: '._em_a3f2c1', prop: 'animation-duration', value: '0.01ms !important', source: 'compiler.js (redundant)' },
+        { type: 'struck', selector: '._em_a3f2c1', prop: 'animation-iteration-count', value: '1 !important', source: 'compiler.js (redundant)' },
+        { type: 'struck', selector: '.ease-bounce', prop: 'animation', value: 'ease-kf-bounce 300ms ...', source: 'animations.css (overridden)' }
+      ];
+
+      var rmToggle = document.getElementById('rm-toggle');
+      var rmPill = document.getElementById('rm-pill');
+      var replayBtn = document.getElementById('replay-btn');
+      var demoFramework = document.getElementById('demo-framework');
+      var demoEngine = document.getElementById('demo-engine');
+      var copyStatus = document.getElementById('copy-status');
+
+      function renderCascade(container, rules, showRm) {
+        container.innerHTML = '';
+        rules.forEach(function (rule) {
+          var div = document.createElement('div');
+          if (rule.type === 'media') {
+            div.className = 'rmo-rule';
+            div.innerHTML = '<span class="rmo-rule-media">' + rule.text + '</span>';
+          } else {
+            var cls = 'rmo-rule';
+            if (!showRm && (rule.type === 'winner' || rule.type === 'struck')) return;
+            if (showRm && rule.type === 'winner') cls += ' rmo-rule--winner';
+            if (showRm && rule.type === 'struck') cls += ' rmo-rule--struck';
+            if (!showRm && rule.type === 'normal') cls += ' rmo-rule--active';
+            div.className = cls;
+            div.innerHTML =
+              '<span class="rmo-rule-selector">' + rule.selector + '</span> {' +
+              '<div class="rmo-rule-prop">' + rule.prop + ': <span class="rmo-rule-value">' + rule.value + '</span>;</div>' +
+              '<div class="rmo-rule-source">/* ' + rule.source + ' */</div>}';
+          }
+          container.appendChild(div);
+        });
+      }
+
+      function updateRmState() {
+        var on = rmToggle.checked;
+        document.body.classList.toggle('rmo-simulate-rm', on);
+        rmPill.textContent = on ? 'Motion: reduced' : 'Motion: normal';
+        rmPill.className = 'rmo-status-pill ' + (on ? 'rmo-status-pill--on' : 'rmo-status-pill--off');
+        renderCascade(document.getElementById('cascade-framework'), CASCADE_FRAMEWORK, on);
+        renderCascade(document.getElementById('cascade-engine'), CASCADE_ENGINE, on);
+        document.getElementById('winner-text').textContent = on
+          ? 'When reduced motion is active, the global * rule and the engine ._em_* rule both set animation-duration: 0.01ms !important. DevTools may show the engine rule as struck through because the global * rule already applied the same value. There is no conflict — only redundancy.'
+          : 'When reduced motion is OFF, only the normal animation rules apply. The @media blocks are inactive and hidden in DevTools until the user enables reduced motion.';
+      }
+
+      function replayAnimation() {
+        [demoFramework, demoEngine].forEach(function (el) {
+          var classes = el.className;
+          el.className = classes.replace(/\bease-\S+/g, '').trim();
+          void el.offsetWidth;
+          el.className = classes;
+        });
+      }
+
+      rmToggle.addEventListener('change', updateRmState);
+      replayBtn.addEventListener('click', replayAnimation);
+
+      document.querySelectorAll('[data-copy]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var el = document.getElementById(btn.dataset.copy);
+          if (!navigator.clipboard) {
+            copyStatus.textContent = 'Clipboard not available.';
+            return;
+          }
+          navigator.clipboard.writeText(el.textContent).then(
+            function () { copyStatus.textContent = 'Copied to clipboard.'; },
+            function () { copyStatus.textContent = 'Copy failed.'; }
+          );
+        });
+      });
+
+      updateRmState();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-global-rm-engine-overlap-sp/style.css
+++ b/submissions/docs/ease-global-rm-engine-overlap-sp/style.css
@@ -1,0 +1,406 @@
+/* Global RM vs Engine Overlap — style.css
+   submissions/docs/ease-global-rm-engine-overlap-sp */
+
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(900px 420px at 8% -8%, rgb(108 99 255 / 9%), transparent),
+    radial-gradient(780px 380px at 92% 0%, rgb(34 197 94 / 6%), transparent),
+    var(--ease-color-bg, #f8fafc);
+}
+
+.rmo-header,
+.rmo-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding-inline: var(--ease-space-6, 1.5rem);
+}
+
+.rmo-header {
+  text-align: center;
+  padding-top: var(--ease-space-12, 3rem);
+  padding-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.rmo-kicker {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--ease-color-primary-dark, #4b44cc);
+}
+
+.rmo-subtitle {
+  max-width: 52rem;
+  margin: 0.75rem auto 0;
+  color: var(--ease-color-muted, #475569);
+}
+
+.rmo-main {
+  padding-bottom: var(--ease-space-12, 3rem);
+}
+
+.rmo-callout {
+  background: rgb(34 197 94 / 8%);
+  border: 1px solid rgb(34 197 94 / 25%);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.rmo-card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm);
+}
+
+.rmo-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: var(--ease-text-lg, 1.125rem);
+}
+
+.rmo-card > p {
+  margin: 0 0 var(--ease-space-4, 1rem);
+  color: var(--ease-color-muted, #475569);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.rmo-toggle-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-4, 1rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.rmo-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.rmo-toggle input {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+.rmo-status-pill {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 700;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--ease-radius-full, 9999px);
+}
+
+.rmo-status-pill--on {
+  background: rgb(34 197 94 / 15%);
+  color: #15803d;
+}
+
+.rmo-status-pill--off {
+  background: rgb(59 130 246 / 12%);
+  color: #1d4ed8;
+}
+
+.rmo-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-space-4, 1rem);
+}
+
+.rmo-demo-stage {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: var(--ease-space-6, 1.5rem);
+  min-height: 10rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-3, 0.75rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+  text-align: center;
+}
+
+.rmo-demo-box {
+  width: 4rem;
+  height: 4rem;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: var(--ease-color-primary, #6c63ff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.rmo-replay-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #fff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.rmo-replay-btn:hover {
+  background: var(--ease-color-primary-alpha, rgb(108 99 255 / 12%));
+}
+
+.rmo-replay-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* DevTools-style cascade panel */
+.rmo-devtools {
+  background: #1e1e1e;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  overflow: hidden;
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+  line-height: 1.6;
+}
+
+.rmo-devtools-head {
+  background: #2d2d2d;
+  padding: 0.5rem 0.75rem;
+  color: #ccc;
+  font-weight: 600;
+  border-bottom: 1px solid #3c3c3c;
+}
+
+.rmo-devtools-body {
+  padding: 0.5rem 0;
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.rmo-rule {
+  padding: 0.35rem 0.75rem;
+  border-left: 3px solid transparent;
+}
+
+.rmo-rule--active {
+  background: rgb(108 99 255 / 12%);
+  border-left-color: #6c63ff;
+}
+
+.rmo-rule--struck {
+  opacity: 0.45;
+  text-decoration: line-through;
+}
+
+.rmo-rule--winner {
+  background: rgb(34 197 94 / 10%);
+  border-left-color: #22c55e;
+}
+
+.rmo-rule-selector {
+  color: #d7ba7d;
+}
+
+.rmo-rule-prop {
+  color: #9cdcfe;
+  padding-left: 1rem;
+}
+
+.rmo-rule-value {
+  color: #ce9178;
+}
+
+.rmo-rule-media {
+  color: #c586c0;
+  font-style: italic;
+}
+
+.rmo-rule-source {
+  color: #6a9955;
+  font-size: 0.6rem;
+  padding-left: 1rem;
+}
+
+.rmo-winner-box {
+  border: 2px solid rgb(34 197 94 / 40%);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: var(--ease-space-4, 1rem);
+  background: rgb(34 197 94 / 5%);
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+.rmo-winner-box h3 {
+  margin: 0 0 0.4rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: #15803d;
+}
+
+.rmo-winner-box p {
+  margin: 0;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.55;
+}
+
+.rmo-compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--ease-text-xs, 0.75rem);
+}
+
+.rmo-compare-table th,
+.rmo-compare-table td {
+  padding: 0.55rem 0.7rem;
+  border-bottom: 1px solid var(--ease-color-neutral-100, #f1f5f9);
+  text-align: left;
+  vertical-align: top;
+}
+
+.rmo-compare-table th {
+  background: var(--ease-color-neutral-50, #f8fafc);
+  font-weight: 700;
+}
+
+.rmo-compare-table code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.62rem;
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.05rem 0.3rem;
+  border-radius: 2px;
+}
+
+.rmo-notes {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.rmo-note {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: var(--ease-space-4, 1rem);
+  background: var(--ease-color-neutral-50, #f8fafc);
+}
+
+.rmo-note h3 {
+  margin: 0 0 0.4rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.rmo-note p {
+  margin: 0;
+  font-size: var(--ease-text-xs, 0.75rem);
+  color: var(--ease-color-muted, #475569);
+  line-height: 1.55;
+}
+
+.rmo-code-block {
+  margin: 0;
+  padding: var(--ease-space-4, 1rem);
+  font-family: var(--ease-font-mono, monospace);
+  font-size: 0.68rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.rmo-copy-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: var(--ease-space-3, 0.75rem);
+}
+
+.rmo-btn {
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #fff);
+  color: var(--ease-color-primary-dark, #4b44cc);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+  cursor: pointer;
+}
+
+.rmo-btn:hover {
+  background: var(--ease-color-primary-alpha, rgb(108 99 255 / 12%));
+}
+
+.rmo-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.rmo-status {
+  text-align: center;
+  min-height: 1.25rem;
+  margin-top: var(--ease-space-3, 0.75rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--ease-color-success-dark, #15803d);
+}
+
+.rmo-footer {
+  text-align: center;
+  padding: var(--ease-space-8, 2rem) var(--ease-space-6, 1.5rem);
+  border-top: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+}
+
+.rmo-footer p {
+  margin: 0;
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--ease-color-muted, #475569);
+}
+
+.rmo-footer code {
+  font-family: var(--ease-font-mono, monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}
+
+/* Simulated reduced motion — mirrors easemotion.css global rule */
+body.rmo-simulate-rm *,
+body.rmo-simulate-rm *::before,
+body.rmo-simulate-rm *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+/* Engine-style per-class guard (demo injected class) */
+@media (prefers-reduced-motion: reduce) {
+  .rmo-engine-demo {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+body.rmo-simulate-rm .rmo-engine-demo {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+}
+
+@media (max-width: 60rem) {
+  .rmo-grid-2,
+  .rmo-notes {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds documentation guide explaining global `prefers-reduced-motion` rule vs Motion Engine per-class reduced-motion guards
- Includes fake DevTools cascade panels, RM toggle simulator, and accessibility-safe usage patterns
- Clarifies that double-apply in DevTools is intentional redundancy, not a cascade bug

## Test plan
- Open `submissions/docs/ease-global-rm-engine-overlap-sp/demo.html` in browser
-  Toggle Reduce motion on/off and verify animation behavior changes
- Review cascade panels for global vs engine rule explanation
- Confirm responsive layout on mobile viewport
- Verify only new files under `submissions/docs/ease-global-rm-engine-overlap-sp/`

Resolves #47706