### PR TITLE
ease-sr-only-motion-bug

### DIFF
--- a/submissions/docs/ease-sr-only-motion-bug-sp/README.md
+++ b/submissions/docs/ease-sr-only-motion-bug-sp/README.md
@@ -1,0 +1,52 @@
+# ease-sr-only + Animated Parent Becomes Announced Twice
+
+A documentation guide explaining why visually hidden text (`ease-sr-only`) inside EaseMotion-animated parents can be announced twice by screen readers, and which markup patterns keep announcements stable.
+
+> Submission track: `submissions/docs/ease-sr-only-motion-bug-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #47711
+
+---
+
+## What does this do?
+
+When `ease-sr-only` content lives inside a parent that animates (fade, bounce, pulse, transform loops), assistive tech may re-read the same label — once for the control and again when motion updates the accessibility tree or when `aria-label` duplicates the hidden text. This guide shows the buggy pattern, the safe alternatives, and copy-ready snippets.
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Compare the **Unsafe** vs **Safe** live demo regions.
+3. Replay the animation and watch the simulated screen-reader log.
+4. Read the “why it happens” section and the pattern checklist.
+5. Copy recommended HTML snippets into your project.
+
+## Features
+
+- Side-by-side unsafe vs safe examples for `ease-sr-only` inside animated regions
+- Simulated screen-reader announcement log (double-read vs single-read)
+- Clear explanation of motion + accessibility-tree interaction
+- Accessibility-focused notes and do/don’t checklist
+- Copy-ready HTML snippets for safe usage
+- Responsive and beginner-friendly documentation UI
+
+## Why is it useful?
+
+- **Prevents a11y bugs** — duplicate announcements confuse SR users.
+- **Teaches layering** — keep motion on decorative siblings, labels on stable controls.
+- **Framework-aware** — uses real `ease-sr-only` from EaseMotion utilities.
+- **Self-contained** — no edits to `core/`, `components/`, or engine files.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Unsafe/safe demos, SR log simulator, snippets |
+| `style.css` | Layout, demo stages, responsive design |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-sr-only-motion-bug-sp/`.
+- No modifications to `core/`, `components/`, `easemotion/engine/`, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/docs/ease-sr-only-motion-bug-sp/demo.html
+++ b/submissions/docs/ease-sr-only-motion-bug-sp/demo.html
@@ -1,0 +1,470 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-sr-only + Animated Parent Double Announcement — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Why ease-sr-only text inside animated parents can be announced twice by screen readers, and safe patterns to avoid it."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="srm-header ease-fade-in">
+    <p class="srm-kicker">EaseMotion CSS · Accessibility Bug Showcase</p>
+    <h1>ease-sr-only + Animated Parent Becomes Announced Twice</h1>
+    <p class="srm-subtitle">
+      Visually hidden labels inside motion-animated regions can be read twice by
+      screen readers. Learn the unsafe pattern, why it happens, and copy-ready fixes.
+    </p>
+  </header>
+
+  <main class="srm-main">
+    <aside class="srm-callout" role="note">
+      <strong>Short answer:</strong> Do not put <code>ease-sr-only</code> text inside
+      a looping / transform-animated parent, and do not duplicate the same string with
+      both <code>aria-label</code> and an SR-only child. Keep motion on a decorative
+      sibling (<code>aria-hidden="true"</code>) and keep the accessible name on a
+      stable control.
+    </aside>
+
+    <!-- What ease-sr-only does -->
+    <section class="srm-card" aria-labelledby="sronly-title">
+      <h2 id="sronly-title">What <code>ease-sr-only</code> does</h2>
+      <p class="srm-lede">
+        From <code>core/utilities.css</code>: the class clips the element out of the
+        visual layout but leaves it in the accessibility tree so assistive tech can
+        still read it.
+      </p>
+      <pre class="srm-definition" tabindex="0"><code>.ease-sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  /* …plus margin / padding / border resets */
+}</code></pre>
+    </section>
+
+    <!-- Live unsafe vs safe -->
+    <section class="srm-card" aria-labelledby="demo-title">
+      <h2 id="demo-title">Live demo — unsafe vs safe</h2>
+      <p>
+        Replay the animation, then click each control. The simulated SR log shows what
+        many screen readers effectively announce.
+      </p>
+
+      <div class="srm-toolbar">
+        <button type="button" class="srm-btn srm-btn--primary" id="replay-btn">
+          Replay animations
+        </button>
+        <button type="button" class="srm-btn" id="clear-log-btn">Clear SR log</button>
+      </div>
+
+      <div class="srm-grid-2">
+        <article class="srm-panel srm-panel--unsafe" aria-labelledby="unsafe-title">
+          <span class="srm-panel-label">Unsafe</span>
+          <h3 id="unsafe-title">SR-only inside animated parent</h3>
+          <p>
+            The whole button pulses. Visible icon + <code>aria-label</code> + nested
+            <code>ease-sr-only</code> with the same name → double announcement risk.
+          </p>
+          <div class="srm-stage" id="unsafe-stage">
+            <button
+              type="button"
+              class="srm-icon-btn ease-pulse"
+              id="unsafe-btn"
+              aria-label="Notifications"
+              data-pattern="unsafe"
+            >
+              🔔
+              <span class="ease-sr-only">Notifications</span>
+            </button>
+          </div>
+          <p>
+            Also common with status chips: animated parent wraps both visible text and
+            an SR-only “status update” string.
+          </p>
+          <div class="srm-stage">
+            <div class="srm-status-chip ease-bounce" id="unsafe-chip" data-pattern="unsafe-chip">
+              <span class="srm-status-dot" aria-hidden="true"></span>
+              Online
+              <span class="ease-sr-only">Status: online, connection active</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="srm-panel srm-panel--safe" aria-labelledby="safe-title">
+          <span class="srm-panel-label">Safe</span>
+          <h3 id="safe-title">Motion on decorative sibling</h3>
+          <p>
+            Accessible name comes from one source (<code>aria-label</code>). Pulse ring
+            is decorative and marked <code>aria-hidden="true"</code>.
+          </p>
+          <div class="srm-stage" id="safe-stage">
+            <button
+              type="button"
+              class="srm-icon-btn"
+              id="safe-btn"
+              aria-label="Notifications"
+              data-pattern="safe"
+            >
+              <span class="srm-pulse-ring ease-pulse" aria-hidden="true"></span>
+              <span aria-hidden="true">🔔</span>
+            </button>
+          </div>
+          <p>
+            Status chip: animate only the decorative dot; keep a single, stable text
+            node for the name.
+          </p>
+          <div class="srm-stage">
+            <div
+              class="srm-status-chip"
+              id="safe-chip"
+              role="status"
+              data-pattern="safe-chip"
+            >
+              <span class="srm-status-dot ease-pulse" aria-hidden="true"></span>
+              Online
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <!-- Simulated SR log -->
+    <section class="srm-card" aria-labelledby="log-title">
+      <h2 id="log-title">Simulated screen-reader log</h2>
+      <p>
+        This is a teaching approximation (not a real AT). It shows the
+        <em>double-name</em> problem when both <code>aria-label</code> and
+        <code>ease-sr-only</code> carry the same string on a moving control.
+      </p>
+      <div
+        id="sr-log"
+        class="srm-sr-log"
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+      ><span class="srm-log-meta">// Click a demo control or press Replay…</span></div>
+    </section>
+
+    <!-- Why it happens -->
+    <section class="srm-card" aria-labelledby="why-title">
+      <h2 id="why-title">Why animated parents cause double announcement</h2>
+      <ol class="srm-why-list">
+        <li>
+          <strong>Duplicate accessible names.</strong>
+          <code>aria-label="Notifications"</code> plus a child
+          <code>&lt;span class="ease-sr-only"&gt;Notifications&lt;/span&gt;</code>
+          can cause some SR / browser combinations to expose the name twice when
+          focus or activation updates.
+        </li>
+        <li>
+          <strong>Motion on the naming container.</strong>
+          Transforms / opacity animations on the ancestor that owns the name can
+          trigger reflow or tree updates; live regions and some SR modes re-speak
+          content that “changed.”
+        </li>
+        <li>
+          <strong>Visible text + SR-only synonym.</strong>
+          A chip that shows “Online” and also hides “Status: online, connection
+          active” inside the same animated node often announces both strings.
+        </li>
+        <li>
+          <strong>Looping classes amplify the bug.</strong>
+          Infinite pulses (<code>ease-pulse</code>, <code>ease-ping</code>) make
+          accidental re-announcements more noticeable during testing.
+        </li>
+      </ol>
+    </section>
+
+    <!-- Comparison table -->
+    <section class="srm-card" aria-labelledby="compare-title">
+      <h2 id="compare-title">Pattern comparison</h2>
+      <div style="overflow-x: auto">
+        <table class="srm-compare-table">
+          <thead>
+            <tr>
+              <th>Pattern</th>
+              <th>What SR hears</th>
+              <th>Verdict</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                Animated button + <code>aria-label</code> + nested
+                <code>ease-sr-only</code> (same string)
+              </td>
+              <td>“Notifications… Notifications”</td>
+              <td style="color: var(--srm-danger); font-weight: 700">Unsafe</td>
+            </tr>
+            <tr>
+              <td>
+                Animated wrapper around visible text + extra SR-only status phrase
+              </td>
+              <td>“Online… Status: online, connection active”</td>
+              <td style="color: var(--srm-danger); font-weight: 700">Unsafe</td>
+            </tr>
+            <tr>
+              <td>
+                Stable button with one <code>aria-label</code>; motion on
+                <code>aria-hidden</code> sibling
+              </td>
+              <td>“Notifications, button”</td>
+              <td style="color: var(--srm-safe); font-weight: 700">Safe</td>
+            </tr>
+            <tr>
+              <td>
+                Stable text node; animate decorative indicator only
+              </td>
+              <td>“Online” (once)</td>
+              <td style="color: var(--srm-safe); font-weight: 700">Safe</td>
+            </tr>
+            <tr>
+              <td>
+                Icon-only button with <em>only</em> <code>ease-sr-only</code> (no
+                duplicate <code>aria-label</code>), no parent animation
+              </td>
+              <td>Single label from SR-only child</td>
+              <td style="color: var(--srm-safe); font-weight: 700">Safe</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Checklist -->
+    <section class="srm-card" aria-labelledby="check-title">
+      <h2 id="check-title">Accessibility checklist</h2>
+      <ul class="srm-checklist">
+        <li>
+          <span class="srm-check" aria-hidden="true"></span>
+          Use one naming strategy: either <code>aria-label</code> <em>or</em>
+          <code>ease-sr-only</code> — not both with the same text.
+        </li>
+        <li>
+          <span class="srm-check" aria-hidden="true"></span>
+          Keep EaseMotion classes on decorative children marked
+          <code>aria-hidden="true"</code>, not on the labeled control when possible.
+        </li>
+        <li>
+          <span class="srm-check" aria-hidden="true"></span>
+          Avoid nesting SR-only “extra context” inside looping animated parents;
+          put context in visible text or a separate static note.
+        </li>
+        <li>
+          <span class="srm-check" aria-hidden="true"></span>
+          Test with a real screen reader (NVDA / VoiceOver / Narrator) after adding
+          motion — simulators only teach the concept.
+        </li>
+        <li>
+          <span class="srm-check" aria-hidden="true"></span>
+          Respect <code>prefers-reduced-motion</code> for loops; less motion means
+          fewer accidental re-announcements during focus.
+        </li>
+      </ul>
+    </section>
+
+    <!-- Copy snippets -->
+    <section class="srm-card" aria-labelledby="snip-title">
+      <h2 id="snip-title">Copy-ready snippets</h2>
+      <p>Paste these into your markup. Prefer the safe pattern for production UI.</p>
+
+      <div class="srm-snippet">
+        <div class="srm-snippet-head">
+          <span>❌ Unsafe — duplicate name + animated parent</span>
+          <button type="button" class="srm-btn" data-copy="unsafe-snip">Copy</button>
+        </div>
+        <span class="srm-copy-feedback" data-feedback="unsafe-snip" hidden>Copied</span>
+        <pre id="unsafe-snip" tabindex="0"><code>&lt;button class="ease-pulse" aria-label="Notifications"&gt;
+  🔔
+  &lt;span class="ease-sr-only"&gt;Notifications&lt;/span&gt;
+&lt;/button&gt;</code></pre>
+      </div>
+
+      <div class="srm-snippet">
+        <div class="srm-snippet-head">
+          <span>✅ Safe — one name, motion on decorative sibling</span>
+          <button type="button" class="srm-btn" data-copy="safe-snip">Copy</button>
+        </div>
+        <span class="srm-copy-feedback" data-feedback="safe-snip" hidden>Copied</span>
+        <pre id="safe-snip" tabindex="0"><code>&lt;button aria-label="Notifications"&gt;
+  &lt;span class="ease-pulse" aria-hidden="true"&gt;&lt;/span&gt;
+  &lt;span aria-hidden="true"&gt;🔔&lt;/span&gt;
+&lt;/button&gt;</code></pre>
+      </div>
+
+      <div class="srm-snippet">
+        <div class="srm-snippet-head">
+          <span>✅ Safe — SR-only only (no aria-label), no parent motion</span>
+          <button type="button" class="srm-btn" data-copy="sronly-snip">Copy</button>
+        </div>
+        <span class="srm-copy-feedback" data-feedback="sronly-snip" hidden>Copied</span>
+        <pre id="sronly-snip" tabindex="0"><code>&lt;button type="button"&gt;
+  &lt;span aria-hidden="true"&gt;🔍&lt;/span&gt;
+  &lt;span class="ease-sr-only"&gt;Search&lt;/span&gt;
+&lt;/button&gt;</code></pre>
+      </div>
+
+      <div class="srm-snippet">
+        <div class="srm-snippet-head">
+          <span>✅ Safe — status chip with decorative pulse</span>
+          <button type="button" class="srm-btn" data-copy="status-snip">Copy</button>
+        </div>
+        <span class="srm-copy-feedback" data-feedback="status-snip" hidden>Copied</span>
+        <pre id="status-snip" tabindex="0"><code>&lt;div role="status"&gt;
+  &lt;span class="ease-pulse" aria-hidden="true"&gt;&lt;/span&gt;
+  Online
+&lt;/div&gt;</code></pre>
+      </div>
+    </section>
+  </main>
+
+  <footer class="srm-footer">
+    Submission:
+    <code>submissions/docs/ease-sr-only-motion-bug-sp/</code>
+    · Resolves Issue #47711 · EaseMotion CSS
+  </footer>
+
+  <script>
+    (function () {
+      var logEl = document.getElementById("sr-log");
+      var lines = [];
+
+      function paintLog() {
+        if (!lines.length) {
+          logEl.innerHTML =
+            '<span class="srm-log-meta">// Click a demo control or press Replay…</span>';
+          return;
+        }
+        logEl.innerHTML = lines.join("\n");
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+
+      function pushLine(html) {
+        var stamp = new Date().toLocaleTimeString();
+        lines.push(
+          '<span class="srm-log-meta">[' + stamp + "]</span> " + html
+        );
+        if (lines.length > 12) lines.shift();
+        paintLog();
+      }
+
+      function clearLog() {
+        lines = [];
+        paintLog();
+      }
+
+      function replayNode(node) {
+        if (!node) return;
+        node.getAnimations().forEach(function (a) {
+          a.cancel();
+        });
+        var cls = node.className;
+        node.className = cls;
+        void node.offsetWidth;
+        node.classList.remove("ease-pulse", "ease-bounce");
+        void node.offsetWidth;
+        if (node.id === "unsafe-btn" || node.classList.contains("srm-pulse-ring") ||
+            node.classList.contains("srm-status-dot")) {
+          node.classList.add("ease-pulse");
+        }
+        if (node.id === "unsafe-chip") {
+          node.classList.add("ease-bounce");
+        }
+      }
+
+      document.getElementById("clear-log-btn").addEventListener("click", clearLog);
+
+      document.getElementById("replay-btn").addEventListener("click", function () {
+        [
+          document.getElementById("unsafe-btn"),
+          document.getElementById("unsafe-chip"),
+          document.querySelector("#safe-btn .srm-pulse-ring"),
+          document.querySelector("#safe-chip .srm-status-dot"),
+        ].forEach(replayNode);
+
+        pushLine(
+          '<span class="srm-log-meta">Animation replayed on demo stages</span>'
+        );
+        pushLine(
+          '<span class="srm-log-dup">⚠ Unsafe region may re-expose nested SR-only during motion update…</span>'
+        );
+        pushLine(
+          '<span class="srm-log-dup">“Notifications” (aria-label)</span>'
+        );
+        pushLine(
+          '<span class="srm-log-dup">“Notifications” (ease-sr-only child) ← double</span>'
+        );
+        pushLine(
+          '<span class="srm-log-ok">✓ Safe region: decorative pulse is aria-hidden — name stays once</span>'
+        );
+      });
+
+      function onActivate(pattern) {
+        if (pattern === "unsafe") {
+          pushLine('<span class="srm-log-dup">button, “Notifications”</span>');
+          pushLine(
+            '<span class="srm-log-dup">“Notifications” ← duplicate from ease-sr-only</span>'
+          );
+        } else if (pattern === "unsafe-chip") {
+          pushLine('<span class="srm-log-dup">“Online”</span>');
+          pushLine(
+            '<span class="srm-log-dup">“Status: online, connection active” ← extra SR-only</span>'
+          );
+        } else if (pattern === "safe") {
+          pushLine(
+            '<span class="srm-log-ok">button, “Notifications” ← single name</span>'
+          );
+        } else if (pattern === "safe-chip") {
+          pushLine('<span class="srm-log-ok">status, “Online” ← single name</span>');
+        }
+      }
+
+      document.querySelectorAll("[data-pattern]").forEach(function (el) {
+        el.addEventListener("click", function () {
+          onActivate(el.getAttribute("data-pattern"));
+        });
+      });
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", async function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          var text = pre ? pre.innerText : "";
+          try {
+            await navigator.clipboard.writeText(text);
+          } catch (err) {
+            var range = document.createRange();
+            range.selectNodeContents(pre);
+            var sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
+          var fb = document.querySelector('[data-feedback="' + id + '"]');
+          if (fb) {
+            fb.hidden = false;
+            setTimeout(function () {
+              fb.hidden = true;
+            }, 1400);
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-sr-only-motion-bug-sp/style.css
+++ b/submissions/docs/ease-sr-only-motion-bug-sp/style.css
@@ -1,0 +1,417 @@
+/* ease-sr-only + Animated Parent Announcement Bug
+   submissions/docs/ease-sr-only-motion-bug-sp */
+
+:root {
+  --srm-ink: #0f172a;
+  --srm-muted: #475569;
+  --srm-surface: #ffffff;
+  --srm-border: #e2e8f0;
+  --srm-primary: #0d9488;
+  --srm-primary-dark: #0f766e;
+  --srm-danger: #b91c1c;
+  --srm-danger-bg: rgb(185 28 28 / 8%);
+  --srm-safe: #15803d;
+  --srm-safe-bg: rgb(21 128 61 / 8%);
+  --srm-radius: 1rem;
+  --srm-mono: "JetBrains Mono", ui-monospace, Consolas, monospace;
+}
+
+body {
+  min-height: 100vh;
+  color: var(--srm-ink);
+  background:
+    radial-gradient(900px 420px at 6% -10%, rgb(13 148 136 / 10%), transparent),
+    radial-gradient(780px 380px at 94% 0%, rgb(14 165 233 / 7%), transparent),
+    var(--ease-color-bg, #f8fafc);
+}
+
+.srm-header,
+.srm-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding-inline: var(--ease-space-6, 1.5rem);
+}
+
+.srm-header {
+  text-align: center;
+  padding-top: var(--ease-space-12, 3rem);
+  padding-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.srm-kicker {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--srm-primary-dark);
+}
+
+.srm-subtitle {
+  max-width: 52rem;
+  margin: 0.75rem auto 0;
+  color: var(--srm-muted);
+  line-height: 1.6;
+}
+
+.srm-main {
+  padding-bottom: var(--ease-space-12, 3rem);
+}
+
+.srm-callout {
+  background: rgb(13 148 136 / 8%);
+  border: 1px solid rgb(13 148 136 / 25%);
+  border-radius: var(--srm-radius);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.srm-card {
+  background: var(--srm-surface);
+  border: 1px solid var(--srm-border);
+  border-radius: var(--srm-radius);
+  padding: var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm, 0 1px 2px rgb(15 23 42 / 6%));
+}
+
+.srm-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: var(--ease-text-lg, 1.125rem);
+}
+
+.srm-card > p,
+.srm-lede {
+  margin: 0 0 var(--ease-space-4, 1rem);
+  color: var(--srm-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.srm-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.srm-btn {
+  appearance: none;
+  border: 1px solid var(--srm-border);
+  background: #f1f5f9;
+  color: var(--srm-ink);
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.9rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.srm-btn:hover {
+  background: #e2e8f0;
+}
+
+.srm-btn:focus-visible {
+  outline: 2px solid var(--srm-primary);
+  outline-offset: 2px;
+}
+
+.srm-btn--primary {
+  background: var(--srm-primary);
+  border-color: var(--srm-primary-dark);
+  color: #fff;
+}
+
+.srm-btn--primary:hover {
+  background: var(--srm-primary-dark);
+}
+
+.srm-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+}
+
+.srm-panel {
+  border: 1px solid var(--srm-border);
+  border-radius: 0.85rem;
+  padding: var(--ease-space-4, 1rem);
+  background: #f8fafc;
+}
+
+.srm-panel--unsafe {
+  border-color: rgb(185 28 28 / 35%);
+  background: var(--srm-danger-bg);
+}
+
+.srm-panel--safe {
+  border-color: rgb(21 128 61 / 35%);
+  background: var(--srm-safe-bg);
+}
+
+.srm-panel-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.65rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
+
+.srm-panel--unsafe .srm-panel-label {
+  color: #fff;
+  background: var(--srm-danger);
+}
+
+.srm-panel--safe .srm-panel-label {
+  color: #fff;
+  background: var(--srm-safe);
+}
+
+.srm-panel h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+
+.srm-panel p {
+  margin: 0 0 0.85rem;
+  font-size: 0.8rem;
+  color: var(--srm-muted);
+  line-height: 1.5;
+}
+
+.srm-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 7.5rem;
+  border-radius: 0.75rem;
+  background: #fff;
+  border: 1px dashed var(--srm-border);
+  margin-bottom: 0.85rem;
+}
+
+.srm-icon-btn {
+  position: relative;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--srm-border);
+  background: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.srm-icon-btn:focus-visible {
+  outline: 2px solid var(--srm-primary);
+  outline-offset: 3px;
+}
+
+.srm-pulse-ring {
+  position: absolute;
+  inset: -4px;
+  border-radius: 999px;
+  border: 2px solid var(--srm-primary);
+  pointer-events: none;
+}
+
+.srm-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid var(--srm-border);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.srm-status-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--srm-primary);
+}
+
+.srm-sr-log {
+  font-family: var(--srm-mono);
+  font-size: 0.75rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  min-height: 7.5rem;
+  white-space: pre-wrap;
+  overflow: auto;
+}
+
+.srm-sr-log .srm-log-dup {
+  color: #fca5a5;
+}
+
+.srm-sr-log .srm-log-ok {
+  color: #86efac;
+}
+
+.srm-sr-log .srm-log-meta {
+  color: #94a3b8;
+}
+
+.srm-why-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--srm-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.65;
+}
+
+.srm-why-list li + li {
+  margin-top: 0.45rem;
+}
+
+.srm-compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.srm-compare-table th,
+.srm-compare-table td {
+  text-align: left;
+  padding: 0.7rem 0.75rem;
+  border-bottom: 1px solid var(--srm-border);
+  vertical-align: top;
+}
+
+.srm-compare-table th {
+  background: #f1f5f9;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.srm-compare-table code {
+  font-family: var(--srm-mono);
+  font-size: 0.72rem;
+}
+
+.srm-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.srm-checklist li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--srm-muted);
+}
+
+.srm-check {
+  flex: 0 0 auto;
+  width: 1.15rem;
+  height: 1.15rem;
+  margin-top: 0.1rem;
+  border-radius: 0.3rem;
+  border: 1px solid var(--srm-border);
+  background: #fff;
+}
+
+.srm-snippet {
+  position: relative;
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.srm-snippet:last-child {
+  margin-bottom: 0;
+}
+
+.srm-snippet-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.srm-snippet-head span {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.srm-snippet pre {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--srm-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+}
+
+.srm-copy-feedback {
+  font-size: 0.7rem;
+  color: var(--srm-safe);
+  font-weight: 600;
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+.srm-definition {
+  font-family: var(--srm-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.srm-footer {
+  text-align: center;
+  padding: 0 1.5rem 2.5rem;
+  color: var(--srm-muted);
+  font-size: 0.8rem;
+}
+
+.srm-footer code {
+  font-family: var(--srm-mono);
+  font-size: 0.72rem;
+}
+
+@media (max-width: 760px) {
+  .srm-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .srm-header h1 {
+    font-size: 1.55rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .srm-pulse-ring,
+  .srm-status-dot,
+  .srm-icon-btn {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an accessibility docs guide for `ease-sr-only` inside animated parents that get announced twice by screen readers
- Includes unsafe vs safe live demos, simulated SR log, comparison table, and copy-ready snippets
- Teaches keeping motion on decorative `aria-hidden` siblings and using a single accessible name

## Test plan
-  Open `submissions/docs/ease-sr-only-motion-bug-sp/demo.html`
-  Replay animations and click unsafe/safe controls; verify SR log differences
-  Copy snippets and confirm clipboard works
-  Check mobile layout
- Confirm only new files under `submissions/docs/ease-sr-only-motion-bug-sp/`

Resolves #47711