### PR TITLE
feat(engine): Implement prefers-reduced-motion AST interception (Issue #47697)

### DIFF
--- a/submissions/docs/engine-a11y-viidhii19/README.md
+++ b/submissions/docs/engine-a11y-viidhii19/README.md
@@ -1,0 +1,48 @@
+## Engine Showcase: Native A11y AST Interception (engine-a11y-viidhii19)
+
+### Architecture Motivation
+Heavy translational animations (slides, zooms, bounces, flips) can trigger nausea and dizziness in users with vestibular disorders. Developers often neglect to manually configure `@media (prefers-reduced-motion: reduce)` wrappers, leading to severe WCAG compliance failures. 
+
+This component demonstrates an enhancement to the v1.2 EaseMotion Engine compiler. By intercepting parsing tokens during the AST compilation phase, the framework checks the operating system's `prefers-reduced-motion` environment natively. If reduced motion is requested, the engine strips heavy transforms and maps them into a graceful opacity fallback (`ease-kf-fade-in`), ensuring strict accessibility compliance without requiring developer intervention.
+
+### Engine Integration Plan (For the Maintainer)
+
+To implement this fallback natively into the core framework, inject the following AST mapping block into `easemotion/engine/compiler.js`, directly inside the token resolution loop before keyframe injection.
+
+```javascript
+/**
+ * AST Interception Phase: Native WCAG Compliance
+ * Strips aggressive transform keyframes and degrades to opacity fades when reduced motion is requested.
+ */
+const isReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+function applyA11yDegradation(astNodes) {
+    if (!isReducedMotion) return astNodes;
+
+    const translationalPattern = /slide|zoom|bounce|flip/i;
+    const fallbackUtilityToken = { type: 'token', value: 'ease-kf-fade-in' };
+    
+    let isFallbackRequired = false;
+    
+    const accessibleNodes = astNodes.filter(node => {
+        if (node.type === 'token' && translationalPattern.test(node.value)) {
+            isFallbackRequired = true;
+            return false; // Intercept and discard heavy transform token
+        }
+        return true;
+    });
+
+    if (isFallbackRequired) {
+        const hasExistingFade = accessibleNodes.some(n => n.value === 'ease-kf-fade-in');
+        if (!hasExistingFade) {
+            accessibleNodes.push(fallbackUtilityToken); // Inject the safe fallback
+        }
+    }
+
+    return accessibleNodes;
+}
+
+// Implementation context:
+// const compiledNodes = applyA11yDegradation(parsedNodes);
+// processKeyframes(compiledNodes);
+```

--- a/submissions/docs/engine-a11y-viidhii19/demo.html
+++ b/submissions/docs/engine-a11y-viidhii19/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion a11y AST Interception Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ease-a11y-demo-wrapper">
+    <div class="controls">
+      <label class="toggle">
+        <input type="checkbox" id="reduced-motion-toggle">
+        <span class="slider"></span>
+      </label>
+      <span>Simulate OS Reduced Motion</span>
+    </div>
+    
+    <div class="animation-container">
+      <div id="test-element" class="demo-box" em="slide-up bounce zoom-in">Watch Me Animate</div>
+    </div>
+    
+    <div class="controls">
+      <button id="trigger-animation">Replay Animation</button>
+    </div>
+  </div>
+
+  <script>
+    class MockASTCompiler {
+      constructor() {
+        this.fallbackUtility = 'ease-kf-fade-in'; 
+        this.heavyMotionPattern = /slide|zoom|bounce|flip/i;
+      }
+
+      compileAndApply(element, forceReducedMotion = false) {
+        const emTokenString = element.getAttribute('em');
+        if (!emTokenString) return;
+
+        const osPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const isReducedMotion = forceReducedMotion || osPrefersReducedMotion;
+
+        let astTokens = emTokenString.split(/\s+/).filter(Boolean);
+
+        if (isReducedMotion) {
+          let intercepted = false;
+          
+          astTokens = astTokens.filter(token => {
+            if (this.heavyMotionPattern.test(token)) {
+              intercepted = true;
+              return false; 
+            }
+            return true;
+          });
+
+          if (intercepted && !astTokens.includes(this.fallbackUtility)) {
+            astTokens.push(this.fallbackUtility);
+          }
+        }
+
+        element.style.animation = 'none';
+        element.className = 'demo-box';
+        
+        void element.offsetWidth;
+        
+        element.style.animation = '';
+        astTokens.forEach(token => element.classList.add(token));
+        
+        console.log(`[AST Compiler Output] Final mapped tokens:`, astTokens);
+      }
+    }
+
+    const compiler = new MockASTCompiler();
+    const targetElement = document.getElementById('test-element');
+    const simToggle = document.getElementById('reduced-motion-toggle');
+    const replayBtn = document.getElementById('trigger-animation');
+
+    function executeEngine() {
+      compiler.compileAndApply(targetElement, simToggle.checked);
+    }
+
+    simToggle.addEventListener('change', executeEngine);
+    replayBtn.addEventListener('click', executeEngine);
+    
+    executeEngine();
+  </script>
+</body>
+</html>

--- a/submissions/docs/engine-a11y-viidhii19/style.css
+++ b/submissions/docs/engine-a11y-viidhii19/style.css
@@ -1,0 +1,130 @@
+:root {
+  --background: #0f172a;
+  --surface: #1e293b;
+  --text: #f8fafc;
+  --primary: #38bdf8;
+  --box-gradient: linear-gradient(135deg, #3b82f6, #8b5cf6);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--background);
+  color: var(--text);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.ease-a11y-demo-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+  padding: 3rem;
+  background: var(--surface);
+  border-radius: 1.5rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  width: 90%;
+  max-width: 500px;
+}
+
+.animation-container {
+  width: 100%;
+  height: 250px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.demo-box {
+  width: 160px;
+  height: 160px;
+  background: var(--box-gradient);
+  border-radius: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.25rem;
+  box-shadow: 0 10px 25px rgba(59, 130, 246, 0.3);
+  animation-duration: 1.2s !important;
+  animation-fill-mode: both !important;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+button {
+  background: transparent;
+  color: var(--primary);
+  border: 2px solid var(--primary);
+  padding: 0.75rem 2rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+button:hover {
+  background: var(--primary);
+  color: var(--background);
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 52px;
+  height: 28px;
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #334155;
+  transition: .3s;
+  border-radius: 34px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  transition: .3s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: var(--primary);
+}
+
+input:checked + .slider:before {
+  transform: translateX(24px);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves #47697 by implementing a Proof-of-Concept for native accessibility handling within the v1.2 Motion Engine. It intercepts heavy translational motion tokens (such as slides, bounces, and zooms) during AST compilation and automatically degrades them into simple opacity fades (`ease-kf-fade-in`) if the user's OS has `prefers-reduced-motion` enabled.

Because of the current contribution freeze on core files, the logic has been implemented as a self-contained showcase inside `submissions/docs/engine-a11y-viidhii19/` for maintainer review.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: **Core Architecture Showcase / Engine Accessibility PoC**

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It provides a compiler-level safeguard that gracefully strips aggressive translational keyframes from the DOM and falls back to a simple opacity fade if the user's operating system requests reduced motion.

**How does a developer use it?**

```html
<!-- Developers continue writing standard EaseMotion attributes natively: -->
<div class="card" em="slide-up bounce zoom-in">Watch Me Animate</div>

<!-- The engine automatically handles the @media fallback behind the scenes. -->
```
**Why does it fit EaseMotion CSS?**

Heavy translational animations violate WCAG accessibility guidelines for users with vestibular disorders. Developers often forget to manually add @media (prefers-reduced-motion: reduce) wrappers. By moving this check into the AST Compiler, EaseMotion becomes highly accessible by default, perfectly aligning with the framework's human-readable, developer-friendly philosophy.

---

## Demo

- [X] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
