### PR TITLE
ease-ping-overflow-scroll-sp

### DIFF
--- a/submissions/docs/ease-ping-overflow-scroll-sp/README.md
+++ b/submissions/docs/ease-ping-overflow-scroll-sp/README.md
@@ -1,0 +1,52 @@
+# Ping/Pulse Scale Overflow Creating Horizontal Scrollbar
+
+A documentation guide explaining how edge-of-viewport `.ease-ping` / pulse scale animations can create unwanted body `overflow-x`, and which containment fixes stop the horizontal scrollbar.
+
+> Submission track: `submissions/docs/ease-ping-overflow-scroll-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #47717
+
+---
+
+## What does this do?
+
+`.ease-ping` scales to `scale(2)` while fading out. When a ping indicator sits near the left or right viewport edge, that expanded paint box extends past the layout width and the page grows a horizontal scrollbar — even though your content columns are not wider than the screen. This guide shows the bug live, compares containment fixes, and provides copy-ready snippets.
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Watch the **Buggy** edge demo create horizontal overflow (or toggle the overflow highlighter).
+3. Compare the **Fixed** panels that clip ping paint with a containment wrapper.
+4. Read why `transform: scale()` overflows and which recipes to use.
+5. Copy recommended HTML/CSS into your project.
+
+## Features
+
+- Side-by-side bug vs fix demos for `.ease-ping` near viewport edges
+- Overflow highlighter / scrollbar callouts
+- Clear explanation of scale overflow vs layout width
+- Containment recipes (`overflow: hidden`, wrapper clip, isolation)
+- Copy-ready HTML/CSS snippets
+- Responsive and beginner-friendly documentation UI
+
+## Why is it useful?
+
+- **Stops a common layout bug** — mysterious horizontal scroll from decorative motion.
+- **Framework-aware** — documents real `.ease-ping` / `ease-kf-ping` behavior.
+- **Practical fixes** — containment wrappers without removing the animation.
+- **Self-contained** — no edits to `core/`, `components/`, or engine files.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Bug/fix stages, overflow meter, snippets |
+| `style.css` | Containment demos, layout, responsive design |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-ping-overflow-scroll-sp/`.
+- No modifications to `core/`, `components/`, `easemotion/engine/`, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/docs/ease-ping-overflow-scroll-sp/demo.html
+++ b/submissions/docs/ease-ping-overflow-scroll-sp/demo.html
@@ -1,0 +1,509 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ping/Pulse Scale Overflow → Horizontal Scroll — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="How edge-of-viewport .ease-ping scale animations create body overflow-x, and containment fixes that stop the horizontal scrollbar."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body class="pos-page-contained">
+  <header class="pos-header ease-fade-in">
+    <p class="pos-kicker">EaseMotion CSS · Layout Bug Showcase</p>
+    <h1>Ping/Pulse Scale Overflow Creating Horizontal Scrollbar</h1>
+    <p class="pos-subtitle">
+      Edge-of-viewport <code>.ease-ping</code> scales to <code>scale(2)</code>.
+      That paint box can escape the layout width and force unwanted
+      <code>overflow-x</code> — even when your content is not wider than the screen.
+    </p>
+  </header>
+
+  <main class="pos-main">
+    <aside class="pos-callout" role="note">
+      <strong>Short answer:</strong> Clip the ping with a small containment wrapper
+      (<code>overflow: hidden</code>) or hide overflow on the edge section. Do not
+      remove the animation — contain its paint so it cannot widen
+      <code>scrollWidth</code>.
+    </aside>
+
+    <!-- What ease-ping does -->
+    <section class="pos-card" aria-labelledby="ping-title">
+      <h2 id="ping-title">What <code>.ease-ping</code> does</h2>
+      <p class="pos-lede">
+        From <code>core/animations.css</code>: the ping keyframe scales the element
+        up while fading out. Transforms expand the <em>visual</em> box; without a
+        clipping ancestor, that expansion can increase scrollable overflow.
+      </p>
+      <pre class="pos-definition" tabindex="0"><code>@keyframes ease-kf-ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+.ease-ping {
+  animation: ease-kf-ping 1s … infinite;
+}</code></pre>
+    </section>
+
+    <!-- Overflow meter -->
+    <section class="pos-card" aria-labelledby="meter-title">
+      <h2 id="meter-title">Live overflow meter</h2>
+      <p>
+        Compares each sandbox’s <code>clientWidth</code> vs <code>scrollWidth</code>.
+        When scrollWidth is larger, a horizontal scrollbar (or overflow) is present.
+      </p>
+
+      <div class="pos-toolbar">
+        <button type="button" class="pos-btn pos-btn--primary" id="measure-btn">
+          Re-measure overflow
+        </button>
+        <button type="button" class="pos-btn" id="replay-btn">Replay ping</button>
+        <label class="pos-btn" style="cursor: pointer">
+          <input type="checkbox" id="bleed-toggle" style="margin-right: 0.4rem" />
+          Show full-bleed edge strip
+        </label>
+      </div>
+
+      <div class="pos-meter" id="overflow-meter" aria-live="polite"></div>
+    </section>
+
+    <!-- Bug vs fix sandboxes -->
+    <section class="pos-card" aria-labelledby="demo-title">
+      <h2 id="demo-title">Bug vs fix — edge ping sandboxes</h2>
+      <p>
+        Both demos place a ping indicator on the far right edge of a fixed-width
+        frame (the classic “badge at the corner of the viewport” case).
+      </p>
+
+      <div class="pos-grid-2">
+        <article class="pos-panel pos-panel--bug" aria-labelledby="bug-title">
+          <span class="pos-panel-label">Bug</span>
+          <h3 id="bug-title">No containment</h3>
+          <p>
+            Ping sits at the right edge with <code>overflow: visible</code>. Scale
+            paint escapes → sandbox <code>scrollWidth</code> grows.
+          </p>
+          <div class="pos-sandbox pos-sandbox--bug" id="sandbox-bug">
+            <div class="pos-sandbox-inner">
+              <div class="pos-edge-row">
+                <span class="pos-edge-tag">← content</span>
+                <div class="pos-dot-wrap" title="Uncontained ping">
+                  <span class="pos-dot-ping ease-ping" aria-hidden="true"></span>
+                  <span class="pos-dot" aria-hidden="true"></span>
+                </div>
+              </div>
+              <span class="pos-overflow-hint" id="bug-hint">overflow-x risk</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="pos-panel pos-panel--fix" aria-labelledby="fix-title">
+          <span class="pos-panel-label">Fix</span>
+          <h3 id="fix-title">Containment wrapper</h3>
+          <p>
+            Same ping, wrapped in <code>.pos-contain { overflow: hidden }</code>.
+            Motion stays; scroll width does not grow.
+          </p>
+          <div class="pos-sandbox pos-sandbox--fix" id="sandbox-fix">
+            <div class="pos-sandbox-inner">
+              <div class="pos-edge-row">
+                <span class="pos-edge-tag">← content</span>
+                <div class="pos-contain">
+                  <div class="pos-dot-wrap">
+                    <span class="pos-dot-ping ease-ping" aria-hidden="true"></span>
+                    <span class="pos-dot" aria-hidden="true"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <!-- Full-bleed strip (optional) -->
+    <section class="pos-card" id="bleed-section" hidden aria-labelledby="bleed-title">
+      <h2 id="bleed-title">Full-bleed edge strip</h2>
+      <p>
+        Toggle between open overflow (page-level risk) and section-level
+        <code>overflow-x: hidden</code>.
+      </p>
+      <div class="pos-toolbar">
+        <button type="button" class="pos-btn" id="bleed-open-btn" aria-pressed="true">
+          Open (buggy)
+        </button>
+        <button type="button" class="pos-btn" id="bleed-clip-btn" aria-pressed="false">
+          Clip section (fixed)
+        </button>
+      </div>
+    </section>
+  </main>
+
+  <div
+    class="pos-bleed pos-bleed--open"
+    id="bleed-strip"
+    hidden
+    aria-label="Full-bleed ping edge demo"
+  >
+    <div class="pos-bleed-row">
+      <span style="font-size: 0.85rem; color: var(--pos-muted)">
+        Viewport-edge ping strip
+      </span>
+      <div class="pos-dot-wrap" id="bleed-dot">
+        <span class="pos-dot-ping ease-ping" aria-hidden="true"></span>
+        <span class="pos-dot" aria-hidden="true"></span>
+      </div>
+    </div>
+  </div>
+
+  <main class="pos-main" style="padding-top: 0">
+    <!-- Why -->
+    <section class="pos-card" aria-labelledby="why-title">
+      <h2 id="why-title">Why scale creates horizontal scroll</h2>
+      <ol class="pos-why-list">
+        <li>
+          <strong>Transforms expand paint, not layout flow — but overflow still
+          counts.</strong>
+          <code>scale(2)</code> does not change the element’s layout size in the
+          flex/grid sense, yet browsers still include the transformed ink in
+          overflow calculations for ancestors with visible overflow.
+        </li>
+        <li>
+          <strong>Edge placement removes the safety margin.</strong>
+          Centered pings usually bloom inside the content box. Right/left-edge
+          badges bloom past the viewport.
+        </li>
+        <li>
+          <strong>Body / main rarely clips by default.</strong>
+          Without <code>overflow-x: hidden</code> (or a local clip wrapper), the
+          document grows a horizontal scrollbar.
+        </li>
+        <li>
+          <strong>Pulse can contribute too.</strong>
+          Soft scale pulses near edges are milder than ping’s
+          <code>scale(2)</code>, but stacked effects + shadows can still tip
+          overflow.
+        </li>
+      </ol>
+    </section>
+
+    <!-- Comparison -->
+    <section class="pos-card" aria-labelledby="compare-title">
+      <h2 id="compare-title">Pattern comparison</h2>
+      <div style="overflow-x: auto">
+        <table class="pos-compare-table">
+          <thead>
+            <tr>
+              <th>Pattern</th>
+              <th>Result</th>
+              <th>Verdict</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                Edge <code>.ease-ping</code> on a visible-overflow ancestor
+              </td>
+              <td>
+                <code>scrollWidth &gt; clientWidth</code> → horizontal scrollbar
+              </td>
+              <td style="color: var(--pos-danger); font-weight: 700">Bug</td>
+            </tr>
+            <tr>
+              <td>
+                Local wrapper <code>overflow: hidden</code> around the ping stack
+              </td>
+              <td>Ping animates; overflow stays local</td>
+              <td style="color: var(--pos-safe); font-weight: 700">Fix</td>
+            </tr>
+            <tr>
+              <td>
+                Section / card <code>overflow-x: hidden</code>
+              </td>
+              <td>Clips all edge effects in that region</td>
+              <td style="color: var(--pos-safe); font-weight: 700">Fix</td>
+            </tr>
+            <tr>
+              <td>
+                Global <code>body { overflow-x: hidden }</code> only
+              </td>
+              <td>Hides symptom site-wide; can mask real layout bugs</td>
+              <td style="color: var(--pos-warn); font-weight: 700">Last resort</td>
+            </tr>
+            <tr>
+              <td>
+                Move indicator inward (≥ half of max scale radius)
+              </td>
+              <td>Bloom stays inside the content box</td>
+              <td style="color: var(--pos-safe); font-weight: 700">Fix</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Recipes -->
+    <section class="pos-card" aria-labelledby="recipe-title">
+      <h2 id="recipe-title">Containment recipes</h2>
+      <div class="pos-recipe-grid">
+        <article class="pos-recipe">
+          <h3>1. Ping clip wrapper</h3>
+          <p>
+            Best default. Size the wrapper to the max bloom
+            (~2× the dot) and set <code>overflow: hidden</code>.
+          </p>
+        </article>
+        <article class="pos-recipe">
+          <h3>2. Card / section clip</h3>
+          <p>
+            Use when many badges share an edge. Prefer
+            <code>overflow-x: hidden</code> on the section, not the whole page.
+          </p>
+        </article>
+        <article class="pos-recipe">
+          <h3>3. Inset the indicator</h3>
+          <p>
+            Add padding/margin so <code>scale(2)</code> never reaches the
+            viewport edge. Combine with a clip wrapper for safety.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <!-- Checklist -->
+    <section class="pos-card" aria-labelledby="check-title">
+      <h2 id="check-title">Debug checklist</h2>
+      <ul class="pos-checklist">
+        <li>
+          <span class="pos-check" aria-hidden="true"></span>
+          Measure <code>document.documentElement.scrollWidth</code> vs
+          <code>clientWidth</code> while ping is running.
+        </li>
+        <li>
+          <span class="pos-check" aria-hidden="true"></span>
+          Temporarily remove <code>ease-ping</code> / <code>ease-pulse</code> —
+          if the scrollbar vanishes, motion overflow is the cause.
+        </li>
+        <li>
+          <span class="pos-check" aria-hidden="true"></span>
+          Prefer a local clip wrapper over global body overflow hacks.
+        </li>
+        <li>
+          <span class="pos-check" aria-hidden="true"></span>
+          Keep decorative pings <code>aria-hidden="true"</code>; they are visual
+          only.
+        </li>
+        <li>
+          <span class="pos-check" aria-hidden="true"></span>
+          Respect <code>prefers-reduced-motion</code> for infinite pings.
+        </li>
+      </ul>
+    </section>
+
+    <!-- Snippets -->
+    <section class="pos-card" aria-labelledby="snip-title">
+      <h2 id="snip-title">Copy-ready snippets</h2>
+      <p>Prefer the containment wrapper for production UI.</p>
+
+      <div class="pos-snippet">
+        <div class="pos-snippet-head">
+          <span>❌ Bug — edge ping, no clip</span>
+          <button type="button" class="pos-btn" data-copy="bug-snip">Copy</button>
+        </div>
+        <span class="pos-copy-feedback" data-feedback="bug-snip" hidden>Copied</span>
+        <pre id="bug-snip" tabindex="0"><code>&lt;!-- Near the right edge of the viewport / card --&gt;
+&lt;div class="badge"&gt;
+  &lt;span class="ease-ping"&gt;&lt;/span&gt;
+  &lt;span class="dot"&gt;&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+      </div>
+
+      <div class="pos-snippet">
+        <div class="pos-snippet-head">
+          <span>✅ Fix — local containment wrapper</span>
+          <button type="button" class="pos-btn" data-copy="fix-snip">Copy</button>
+        </div>
+        <span class="pos-copy-feedback" data-feedback="fix-snip" hidden>Copied</span>
+        <pre id="fix-snip" tabindex="0"><code>&lt;style&gt;
+  .ping-contain {
+    overflow: hidden;
+    width: 2.75rem;
+    height: 2.75rem;
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+  }
+&lt;/style&gt;
+
+&lt;div class="ping-contain"&gt;
+  &lt;span class="ease-ping" aria-hidden="true"&gt;&lt;/span&gt;
+  &lt;span class="dot" aria-hidden="true"&gt;&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+      </div>
+
+      <div class="pos-snippet">
+        <div class="pos-snippet-head">
+          <span>✅ Fix — section overflow-x clip</span>
+          <button type="button" class="pos-btn" data-copy="section-snip">Copy</button>
+        </div>
+        <span class="pos-copy-feedback" data-feedback="section-snip" hidden>Copied</span>
+        <pre id="section-snip" tabindex="0"><code>.hero,
+.navbar,
+.status-bar {
+  overflow-x: hidden; /* clip edge pings without hiding the whole page */
+}</code></pre>
+      </div>
+
+      <div class="pos-snippet">
+        <div class="pos-snippet-head">
+          <span>🔍 Debug — detect overflow-x in DevTools console</span>
+          <button type="button" class="pos-btn" data-copy="debug-snip">Copy</button>
+        </div>
+        <span class="pos-copy-feedback" data-feedback="debug-snip" hidden>Copied</span>
+        <pre id="debug-snip" tabindex="0"><code>const root = document.documentElement;
+console.log({
+  clientWidth: root.clientWidth,
+  scrollWidth: root.scrollWidth,
+  overflowing: root.scrollWidth > root.clientWidth
+});</code></pre>
+      </div>
+    </section>
+  </main>
+
+  <footer class="pos-footer">
+    Submission:
+    <code>submissions/docs/ease-ping-overflow-scroll-sp/</code>
+    · Resolves Issue #47717 · EaseMotion CSS
+  </footer>
+
+  <script>
+    (function () {
+      var bugBox = document.getElementById("sandbox-bug");
+      var fixBox = document.getElementById("sandbox-fix");
+      var meter = document.getElementById("overflow-meter");
+      var bugHint = document.getElementById("bug-hint");
+      var bleedStrip = document.getElementById("bleed-strip");
+      var bleedSection = document.getElementById("bleed-section");
+
+      function measure(el) {
+        return {
+          client: el.clientWidth,
+          scroll: el.scrollWidth,
+          overflow: el.scrollWidth > el.clientWidth + 1,
+        };
+      }
+
+      function pill(label, data) {
+        var cls = data.overflow ? "pos-pill pos-pill--bad" : "pos-pill pos-pill--ok";
+        var status = data.overflow ? "OVERFLOW" : "OK";
+        return (
+          '<span class="' +
+          cls +
+          '">' +
+          label +
+          ": " +
+          status +
+          " · client " +
+          data.client +
+          " / scroll " +
+          data.scroll +
+          "</span>"
+        );
+      }
+
+      function updateMeter() {
+        var bug = measure(bugBox);
+        var fix = measure(fixBox);
+        meter.innerHTML =
+          pill("Bug sandbox", bug) + pill("Fix sandbox", fix);
+        if (bugHint) bugHint.hidden = !bug.overflow;
+      }
+
+      function replayPings() {
+        document.querySelectorAll(".pos-dot-ping").forEach(function (node) {
+          node.classList.remove("ease-ping");
+          void node.offsetWidth;
+          node.classList.add("ease-ping");
+        });
+        setTimeout(updateMeter, 50);
+        setTimeout(updateMeter, 400);
+        setTimeout(updateMeter, 900);
+      }
+
+      document.getElementById("measure-btn").addEventListener("click", updateMeter);
+      document.getElementById("replay-btn").addEventListener("click", replayPings);
+
+      document.getElementById("bleed-toggle").addEventListener("change", function (e) {
+        var on = e.target.checked;
+        bleedStrip.hidden = !on;
+        bleedSection.hidden = !on;
+        if (on) {
+          document.body.classList.remove("pos-page-contained");
+        } else {
+          document.body.classList.add("pos-page-contained");
+          bleedStrip.classList.add("pos-bleed--open");
+          bleedStrip.classList.remove("pos-bleed--clipped");
+        }
+        updateMeter();
+      });
+
+      document.getElementById("bleed-open-btn").addEventListener("click", function () {
+        bleedStrip.classList.add("pos-bleed--open");
+        bleedStrip.classList.remove("pos-bleed--clipped");
+        this.setAttribute("aria-pressed", "true");
+        document.getElementById("bleed-clip-btn").setAttribute("aria-pressed", "false");
+        document.body.classList.remove("pos-page-contained");
+      });
+
+      document.getElementById("bleed-clip-btn").addEventListener("click", function () {
+        bleedStrip.classList.remove("pos-bleed--open");
+        bleedStrip.classList.add("pos-bleed--clipped");
+        this.setAttribute("aria-pressed", "true");
+        document.getElementById("bleed-open-btn").setAttribute("aria-pressed", "false");
+      });
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", async function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          var text = pre ? pre.innerText : "";
+          try {
+            await navigator.clipboard.writeText(text);
+          } catch (err) {
+            var range = document.createRange();
+            range.selectNodeContents(pre);
+            var sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
+          var fb = document.querySelector('[data-feedback="' + id + '"]');
+          if (fb) {
+            fb.hidden = false;
+            setTimeout(function () {
+              fb.hidden = true;
+            }, 1400);
+          }
+        });
+      });
+
+      window.addEventListener("resize", updateMeter);
+      updateMeter();
+      setInterval(updateMeter, 1000);
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-ping-overflow-scroll-sp/style.css
+++ b/submissions/docs/ease-ping-overflow-scroll-sp/style.css
@@ -1,0 +1,537 @@
+/* Ping/Pulse Scale Overflow → Horizontal Scroll
+   submissions/docs/ease-ping-overflow-scroll-sp */
+
+:root {
+  --pos-ink: #0f172a;
+  --pos-muted: #475569;
+  --pos-surface: #ffffff;
+  --pos-border: #e2e8f0;
+  --pos-primary: #2563eb;
+  --pos-primary-dark: #1d4ed8;
+  --pos-danger: #b91c1c;
+  --pos-danger-bg: rgb(185 28 28 / 7%);
+  --pos-safe: #15803d;
+  --pos-safe-bg: rgb(21 128 61 / 7%);
+  --pos-warn: #b45309;
+  --pos-radius: 1rem;
+  --pos-mono: "JetBrains Mono", ui-monospace, Consolas, monospace;
+}
+
+body {
+  min-height: 100vh;
+  color: var(--pos-ink);
+  background:
+    radial-gradient(900px 420px at 8% -8%, rgb(37 99 235 / 9%), transparent),
+    radial-gradient(780px 380px at 92% 0%, rgb(14 165 233 / 6%), transparent),
+    var(--ease-color-bg, #f8fafc);
+}
+
+/* Default page is contained so docs UI stays usable.
+   The buggy iframe / sandbox demos intentionally allow overflow. */
+body.pos-page-contained {
+  overflow-x: hidden;
+}
+
+.pos-header,
+.pos-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding-inline: var(--ease-space-6, 1.5rem);
+}
+
+.pos-header {
+  text-align: center;
+  padding-top: var(--ease-space-12, 3rem);
+  padding-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.pos-kicker {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--pos-primary-dark);
+}
+
+.pos-subtitle {
+  max-width: 52rem;
+  margin: 0.75rem auto 0;
+  color: var(--pos-muted);
+  line-height: 1.6;
+}
+
+.pos-main {
+  padding-bottom: var(--ease-space-12, 3rem);
+}
+
+.pos-callout {
+  background: rgb(37 99 235 / 8%);
+  border: 1px solid rgb(37 99 235 / 22%);
+  border-radius: var(--pos-radius);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.pos-card {
+  background: var(--pos-surface);
+  border: 1px solid var(--pos-border);
+  border-radius: var(--pos-radius);
+  padding: var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm, 0 1px 2px rgb(15 23 42 / 6%));
+}
+
+.pos-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: var(--ease-text-lg, 1.125rem);
+}
+
+.pos-card > p,
+.pos-lede {
+  margin: 0 0 var(--ease-space-4, 1rem);
+  color: var(--pos-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.pos-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ease-space-3, 0.75rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.pos-btn {
+  appearance: none;
+  border: 1px solid var(--pos-border);
+  background: #f1f5f9;
+  color: var(--pos-ink);
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.9rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pos-btn:hover {
+  background: #e2e8f0;
+}
+
+.pos-btn:focus-visible {
+  outline: 2px solid var(--pos-primary);
+  outline-offset: 2px;
+}
+
+.pos-btn--primary {
+  background: var(--pos-primary);
+  border-color: var(--pos-primary-dark);
+  color: #fff;
+}
+
+.pos-btn--primary:hover {
+  background: var(--pos-primary-dark);
+}
+
+.pos-meter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.pos-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid var(--pos-border);
+  background: #fff;
+  font-family: var(--pos-mono);
+  font-size: 0.72rem;
+}
+
+.pos-pill--ok {
+  border-color: rgb(21 128 61 / 35%);
+  color: var(--pos-safe);
+  background: var(--pos-safe-bg);
+}
+
+.pos-pill--bad {
+  border-color: rgb(185 28 28 / 35%);
+  color: var(--pos-danger);
+  background: var(--pos-danger-bg);
+}
+
+.pos-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+}
+
+.pos-panel {
+  border: 1px solid var(--pos-border);
+  border-radius: 0.85rem;
+  padding: var(--ease-space-4, 1rem);
+  background: #f8fafc;
+}
+
+.pos-panel--bug {
+  border-color: rgb(185 28 28 / 35%);
+  background: var(--pos-danger-bg);
+}
+
+.pos-panel--fix {
+  border-color: rgb(21 128 61 / 35%);
+  background: var(--pos-safe-bg);
+}
+
+.pos-panel-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.65rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+}
+
+.pos-panel--bug .pos-panel-label {
+  background: var(--pos-danger);
+}
+
+.pos-panel--fix .pos-panel-label {
+  background: var(--pos-safe);
+}
+
+.pos-panel h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+
+.pos-panel p {
+  margin: 0 0 0.85rem;
+  font-size: 0.8rem;
+  color: var(--pos-muted);
+  line-height: 1.5;
+}
+
+/* Viewport-edge sandbox: fixed width frame that can show its own scrollbar */
+.pos-sandbox {
+  position: relative;
+  width: 100%;
+  height: 11rem;
+  border-radius: 0.75rem;
+  border: 1px dashed var(--pos-border);
+  background:
+    linear-gradient(90deg, rgb(37 99 235 / 4%) 0 40%, transparent 40%),
+    #fff;
+  overflow: auto;
+}
+
+.pos-sandbox-inner {
+  position: relative;
+  width: 100%;
+  min-height: 100%;
+  padding: 1.25rem;
+}
+
+.pos-sandbox--bug .pos-sandbox-inner {
+  /* Intentionally no overflow clip — ping can widen scrollWidth */
+  overflow: visible;
+}
+
+.pos-sandbox--fix {
+  overflow: hidden;
+}
+
+.pos-sandbox--fix .pos-sandbox-inner {
+  overflow: hidden;
+  height: 100%;
+}
+
+.pos-edge-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  min-height: 5rem;
+}
+
+.pos-dot-wrap {
+  position: relative;
+  width: 1.15rem;
+  height: 1.15rem;
+  flex: 0 0 auto;
+}
+
+.pos-dot {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--pos-primary);
+}
+
+.pos-dot-ping {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--pos-primary);
+}
+
+/* Containment wrapper recipe */
+.pos-contain {
+  overflow: hidden;
+  border-radius: 999px;
+  /* Give the scaled ping room inside the clip without escaping the sandbox */
+  width: 2.75rem;
+  height: 2.75rem;
+  display: grid;
+  place-items: center;
+}
+
+.pos-contain .pos-dot-wrap {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.pos-edge-tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pos-warn);
+}
+
+.pos-overflow-hint {
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.4rem;
+  font-family: var(--pos-mono);
+  font-size: 0.65rem;
+  color: var(--pos-danger);
+  background: rgb(255 255 255 / 92%);
+  border: 1px solid rgb(185 28 28 / 30%);
+  border-radius: 0.4rem;
+  padding: 0.2rem 0.4rem;
+  pointer-events: none;
+}
+
+.pos-overflow-hint[hidden] {
+  display: none;
+}
+
+.pos-definition {
+  font-family: var(--pos-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.pos-why-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--pos-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.65;
+}
+
+.pos-why-list li + li {
+  margin-top: 0.45rem;
+}
+
+.pos-compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.pos-compare-table th,
+.pos-compare-table td {
+  text-align: left;
+  padding: 0.7rem 0.75rem;
+  border-bottom: 1px solid var(--pos-border);
+  vertical-align: top;
+}
+
+.pos-compare-table th {
+  background: #f1f5f9;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.pos-compare-table code {
+  font-family: var(--pos-mono);
+  font-size: 0.72rem;
+}
+
+.pos-recipe-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--ease-space-3, 0.75rem);
+}
+
+.pos-recipe {
+  border: 1px solid var(--pos-border);
+  border-radius: 0.75rem;
+  padding: 0.85rem;
+  background: #fff;
+}
+
+.pos-recipe h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
+}
+
+.pos-recipe p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--pos-muted);
+  line-height: 1.5;
+}
+
+.pos-snippet {
+  position: relative;
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.pos-snippet:last-child {
+  margin-bottom: 0;
+}
+
+.pos-snippet-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.pos-snippet-head span {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.pos-snippet pre {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--pos-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+}
+
+.pos-copy-feedback {
+  font-size: 0.7rem;
+  color: var(--pos-safe);
+  font-weight: 600;
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+.pos-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.pos-checklist li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--pos-muted);
+}
+
+.pos-check {
+  flex: 0 0 auto;
+  width: 1.15rem;
+  height: 1.15rem;
+  margin-top: 0.1rem;
+  border-radius: 0.3rem;
+  border: 1px solid var(--pos-border);
+  background: #fff;
+}
+
+.pos-footer {
+  text-align: center;
+  padding: 0 1.5rem 2.5rem;
+  color: var(--pos-muted);
+  font-size: 0.8rem;
+}
+
+.pos-footer code {
+  font-family: var(--pos-mono);
+  font-size: 0.72rem;
+}
+
+/* Full-bleed edge demo strip (optional highlighter mode) */
+.pos-bleed {
+  position: relative;
+  margin-inline: calc(50% - 50vw);
+  width: 100vw;
+  max-width: 100vw;
+  padding: 1.25rem 1.5rem;
+  border-block: 1px solid var(--pos-border);
+  background: #fff;
+}
+
+.pos-bleed--open {
+  overflow: visible;
+}
+
+.pos-bleed--clipped {
+  overflow-x: hidden;
+}
+
+.pos-bleed-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 76rem;
+  margin: 0 auto;
+}
+
+@media (max-width: 900px) {
+  .pos-recipe-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .pos-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .pos-header h1 {
+    font-size: 1.55rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pos-dot-ping,
+  .ease-ping,
+  .ease-pulse {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a docs guide for `.ease-ping` / pulse scale overflow creating horizontal scrollbars at viewport edges
- Includes bug vs fix sandboxes, live overflow meter, containment recipes, and copy-ready snippets
- Teaches local `overflow: hidden` wrappers instead of global body overflow hacks

## Test plan
- Open `submissions/docs/ease-ping-overflow-scroll-sp/demo.html`
- Confirm bug sandbox reports OVERFLOW and fix sandbox reports OK
- Replay ping and toggle full-bleed strip
- Copy snippets and check mobile layout
- Confirm only new files under `submissions/docs/ease-ping-overflow-scroll-sp/`

Resolves #47717