### PR TITLE
ease-hash-collision-modal

### DIFF
--- a/submissions/docs/ease-hash-collision-modal-sp/README.md
+++ b/submissions/docs/ease-hash-collision-modal-sp/README.md
@@ -1,0 +1,53 @@
+# Hash Modal Open While URL Already Has Unrelated #id
+
+A documentation guide focused on **hash collision**: when an in-page `#section` deep-link already exists in the URL and a hash-driven EaseMotion modal (`#modal-x`) opens or closes — including stray hash clears from `core/modal.js`.
+
+> Submission track: `submissions/docs/ease-hash-collision-modal-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #47721  
+> Note: Different from the deep-link playground (`ease-hash-modal-lab-sp`) — this guide focuses on **collision**, not general modal deep-linking.
+
+---
+
+## What does this do?
+
+EaseMotion modals can open via URL hash (`href="#modal-x"`) and `core/modal.js`. The browser only allows **one** hash at a time. If the user is already on `#features` (or any unrelated section id), opening a modal overwrites that hash. Closing via Escape / backdrop sets `location.hash = ''`, which clears the section deep-link instead of restoring it. This guide reproduces that path and shows safer patterns.
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Jump to a page section (sets an unrelated `#id`).
+3. Open the hash modal and watch the URL / timeline panel.
+4. Close the modal and observe the stray hash clear.
+5. Compare the safer “remember & restore” pattern and copy snippets.
+
+## Features
+
+- Interactive `#section` + `#modal-x` collision demo
+- Live URL / hash state panel (before → during → after)
+- Reproduction steps aligned with `core/modal.js` behavior
+- Callouts for scroll jumps and stray hash clears
+- Side-by-side collision vs safer restore explanations
+- Copy-ready snippets and beginner-friendly UI
+
+## Why is it useful?
+
+- **Explains a real gotcha** — section deep-links disappear after modal close.
+- **Tied to real source** — documents `window.location.hash = ''` close behavior.
+- **Actionable fixes** — restore previous hash or avoid hash for modals.
+- **Self-contained** — no edits to `core/` or `components/`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Collision demo, modal, timeline, snippets |
+| `style.css` | Lab layout, state panel, responsive design |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-hash-collision-modal-sp/`.
+- No modifications to `core/`, `components/`, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/docs/ease-hash-collision-modal-sp/demo.html
+++ b/submissions/docs/ease-hash-collision-modal-sp/demo.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hash Modal × Unrelated #id Collision — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Reproduce page #section vs modal #modal-x hash collision and stray hash clears from core/modal.js."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="hcm-header ease-fade-in">
+    <p class="hcm-kicker">EaseMotion CSS · Hash Collision Showcase</p>
+    <h1>Hash Modal Open While URL Already Has Unrelated #id</h1>
+    <p class="hcm-subtitle">
+      Focus: <strong>collision</strong> between an in-page section hash
+      (<code>#features</code>) and a modal hash (<code>#hcm-modal-x</code>) —
+      including the stray hash clear when <code>modal.js</code> sets
+      <code>location.hash = ''</code> on close. Not a general deep-link playground.
+    </p>
+  </header>
+
+  <main class="hcm-main">
+    <aside class="hcm-callout" role="note">
+      <strong>Short answer:</strong> The URL can only hold one hash. Opening a
+      modal overwrites <code>#section</code>. Closing via Escape / backdrop clears
+      the hash entirely — it does <em>not</em> restore the previous section id.
+      Remember the prior hash (or avoid hash for modals) to keep deep-links intact.
+    </aside>
+
+    <!-- Live URL panel -->
+    <section class="hcm-sticky-panel" aria-labelledby="url-title">
+      <h2 id="url-title">Live URL / hash state</h2>
+      <div class="hcm-url-row">
+        <span class="hcm-url-label">location.href</span>
+        <span class="hcm-url-value" id="url-full">—</span>
+      </div>
+      <div class="hcm-url-row">
+        <span class="hcm-url-label">location.hash</span>
+        <span class="hcm-hash-pill hcm-hash-pill--empty" id="hash-pill">(empty)</span>
+        <span class="hcm-url-label" style="margin-left: 0.5rem">kind</span>
+        <span id="hash-kind" style="font-size: 0.8rem; color: #cbd5e1">none</span>
+      </div>
+      <div class="hcm-timeline" aria-label="Collision timeline">
+        <div class="hcm-tl-step">
+          <strong>1 · Before</strong>
+          Section deep-link<br /><code id="tl-before">—</code>
+        </div>
+        <div class="hcm-tl-step">
+          <strong>2 · During</strong>
+          Modal overwrites<br /><code id="tl-during">—</code>
+        </div>
+        <div class="hcm-tl-step">
+          <strong>3 · After close</strong>
+          Stray clear<br /><code id="tl-after">—</code>
+        </div>
+      </div>
+    </section>
+
+    <!-- Reproduce -->
+    <section class="hcm-card" aria-labelledby="repro-title">
+      <h2 id="repro-title">Reproduce the collision (aligned with modal.js)</h2>
+      <ol class="hcm-steps">
+        <li>Click <strong>Jump to #features</strong> — URL becomes a section hash (unrelated to any modal).</li>
+        <li>Click <strong>Open modal (#hcm-modal-x)</strong> — hash is overwritten; section deep-link is gone.</li>
+        <li>Close with <kbd>Esc</kbd>, backdrop click, or the close control — <code>modal.js</code> sets <code>hash = ''</code>.</li>
+        <li>Observe timeline step 3: the original <code>#features</code> is <em>not</em> restored.</li>
+      </ol>
+
+      <div class="hcm-toolbar">
+        <a class="hcm-btn" href="#features" id="jump-features">Jump to #features</a>
+        <a class="hcm-btn" href="#pricing" id="jump-pricing">Jump to #pricing</a>
+        <a class="hcm-btn hcm-btn--primary" href="#hcm-modal-x" id="open-modal">
+          Open modal (#hcm-modal-x)
+        </a>
+        <button type="button" class="hcm-btn" id="reset-hash-btn">Clear hash now</button>
+        <button type="button" class="hcm-btn" id="clear-log-btn">Clear event log</button>
+      </div>
+
+      <aside class="hcm-callout hcm-callout--warn" role="note" style="margin-bottom: 1rem">
+        <strong>modal.js close path:</strong> backdrop click and Escape both do
+        <code>window.location.hash = ''</code>. That closes the modal, but it also
+        wipes any previous unrelated <code>#id</code>.
+      </aside>
+
+      <div id="features" class="hcm-section">
+        <span class="hcm-section-id">#features</span>
+        <h3>Features section</h3>
+        <p>
+          Pretend this is a long docs page section. When this id is in the URL,
+          <code>:target</code> highlights the box. Opening a modal will steal the hash.
+        </p>
+      </div>
+      <div id="pricing" class="hcm-section">
+        <span class="hcm-section-id">#pricing</span>
+        <h3>Pricing section</h3>
+        <p>
+          Another unrelated section id. Same collision: only one hash can win.
+        </p>
+      </div>
+      <div class="hcm-spacer" aria-hidden="true"></div>
+    </section>
+
+    <!-- Event log -->
+    <section class="hcm-card" aria-labelledby="log-title">
+      <h2 id="log-title">Hash event log</h2>
+      <p>Records <code>hashchange</code> events and collision notes as you click through the repro.</p>
+      <div id="event-log" class="hcm-log" role="log" aria-live="polite">
+        <span class="meta">// Jump to a section, then open the modal…</span>
+      </div>
+    </section>
+
+    <!-- Collision vs safer -->
+    <section class="hcm-card" aria-labelledby="compare-demo-title">
+      <h2 id="compare-demo-title">Collision vs safer pattern</h2>
+      <div class="hcm-grid-2">
+        <article class="hcm-panel hcm-panel--bug" aria-labelledby="bug-title">
+          <span class="hcm-panel-label">Default (collision)</span>
+          <h3 id="bug-title">Open with hash · close clears all</h3>
+          <p>
+            Uses real <code>href="#hcm-modal-x"</code> + <code>modal.js</code>.
+            Close always ends at an empty hash.
+          </p>
+          <div class="hcm-toolbar">
+            <a class="hcm-btn" href="#features">1. Set #features</a>
+            <a class="hcm-btn hcm-btn--danger" href="#hcm-modal-x">2. Open modal</a>
+          </div>
+          <p style="margin: 0; font-size: 0.78rem">
+            After Esc/backdrop → hash is empty. Section deep-link lost.
+          </p>
+        </article>
+
+        <article class="hcm-panel hcm-panel--fix" aria-labelledby="fix-title">
+          <span class="hcm-panel-label">Safer demo</span>
+          <h3 id="fix-title">Remember prior hash · restore on close</h3>
+          <p>
+            Lab-only helper: stores the current hash before opening, restores it
+            when you close with the safe button (does not patch <code>modal.js</code>).
+          </p>
+          <div class="hcm-toolbar">
+            <a class="hcm-btn" href="#pricing">1. Set #pricing</a>
+            <button type="button" class="hcm-btn hcm-btn--safe" id="safe-open-btn">
+              2. Safe open + remember
+            </button>
+            <button type="button" class="hcm-btn hcm-btn--safe" id="safe-close-btn">
+              3. Safe close + restore
+            </button>
+          </div>
+          <p style="margin: 0; font-size: 0.78rem">
+            Stored prior hash: <code id="stored-hash">(none)</code>
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <!-- Why -->
+    <section class="hcm-card" aria-labelledby="why-title">
+      <h2 id="why-title">Why the collision happens</h2>
+      <ol class="hcm-why-list">
+        <li>
+          <strong>One hash slot.</strong>
+          <code>location.hash</code> is a single string. <code>#features</code> and
+          <code>#hcm-modal-x</code> cannot coexist.
+        </li>
+        <li>
+          <strong>Modal open overwrites.</strong>
+          Navigating to <code>#hcm-modal-x</code> replaces the section id. CSS
+          <code>:target</code> and <code>modal.js</code> both key off that one value.
+        </li>
+        <li>
+          <strong>Close clears to empty.</strong>
+          From <code>core/modal.js</code>: Escape and backdrop set
+          <code>window.location.hash = ''</code>. That closes the overlay but
+          also drops the previous unrelated <code>#id</code> (stray clear).
+        </li>
+        <li>
+          <strong>Scroll / :target side effects.</strong>
+          Jumping hashes can scroll the page; losing <code>#features</code> means
+          refresh/share no longer lands on that section.
+        </li>
+      </ol>
+      <pre class="hcm-definition" style="margin-top: 1rem" tabindex="0"><code>// core/modal.js (close paths)
+if (e.target === overlay) {
+  window.location.hash = ''; // Clear hash = close modal
+}
+if (e.key === 'Escape') {
+  window.location.hash = ''; // triggers hashchange → close
+}</code></pre>
+    </section>
+
+    <!-- Table -->
+    <section class="hcm-card" aria-labelledby="table-title">
+      <h2 id="table-title">Behavior matrix</h2>
+      <div style="overflow-x: auto">
+        <table class="hcm-compare-table">
+          <thead>
+            <tr>
+              <th>Starting URL</th>
+              <th>Action</th>
+              <th>Resulting hash</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>#features</code></td>
+              <td>Open <code>#hcm-modal-x</code></td>
+              <td><code>#hcm-modal-x</code></td>
+              <td style="color: var(--hcm-danger); font-weight: 700">Section id overwritten</td>
+            </tr>
+            <tr>
+              <td><code>#hcm-modal-x</code></td>
+              <td>Esc / backdrop</td>
+              <td><code>(empty)</code></td>
+              <td style="color: var(--hcm-danger); font-weight: 700">Stray clear — no restore</td>
+            </tr>
+            <tr>
+              <td><code>#features</code></td>
+              <td>Safe remember → open → restore close</td>
+              <td><code>#features</code></td>
+              <td style="color: var(--hcm-safe); font-weight: 700">Deep-link preserved</td>
+            </tr>
+            <tr>
+              <td><code>#features</code></td>
+              <td>Button opens modal via class JS (no hash)</td>
+              <td><code>#features</code></td>
+              <td style="color: var(--hcm-safe); font-weight: 700">Hash never touches modal</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Snippets -->
+    <section class="hcm-card" aria-labelledby="snip-title">
+      <h2 id="snip-title">Copy-ready snippets</h2>
+      <p>Use these as teaching notes — prefer restore or non-hash open in production apps.</p>
+
+      <div class="hcm-snippet">
+        <div class="hcm-snippet-head">
+          <span>Default hash modal markup (collision-prone with sections)</span>
+          <button type="button" class="hcm-btn" data-copy="default-snip">Copy</button>
+        </div>
+        <span class="hcm-copy-feedback" data-feedback="default-snip" hidden>Copied</span>
+        <pre id="default-snip" tabindex="0"><code>&lt;a href="#features"&gt;Features&lt;/a&gt;
+&lt;a href="#hcm-modal-x"&gt;Open modal&lt;/a&gt;
+
+&lt;div id="hcm-modal-x" class="ease-modal-overlay"&gt;
+  &lt;div class="ease-modal" role="dialog" aria-modal="true"&gt;
+    &lt;a href="#" aria-label="Close"&gt;×&lt;/a&gt;
+    …
+  &lt;/div&gt;
+&lt;/div&gt;
+&lt;!-- Close via Esc/backdrop → hash becomes "" (section lost) --&gt;</code></pre>
+      </div>
+
+      <div class="hcm-snippet">
+        <div class="hcm-snippet-head">
+          <span>Safer — remember previous hash, restore on close</span>
+          <button type="button" class="hcm-btn" data-copy="restore-snip">Copy</button>
+        </div>
+        <span class="hcm-copy-feedback" data-feedback="restore-snip" hidden>Copied</span>
+        <pre id="restore-snip" tabindex="0"><code>let previousHash = '';
+
+function openModalRememberingHash(modalHash) {
+  previousHash = window.location.hash; // e.g. "#features"
+  window.location.hash = modalHash;    // e.g. "#hcm-modal-x"
+}
+
+function closeModalRestoringHash() {
+  window.location.hash = previousHash || '';
+  previousHash = '';
+}</code></pre>
+      </div>
+
+      <div class="hcm-snippet">
+        <div class="hcm-snippet-head">
+          <span>Safer — keep section hash; toggle modal with is-active only</span>
+          <button type="button" class="hcm-btn" data-copy="class-snip">Copy</button>
+        </div>
+        <span class="hcm-copy-feedback" data-feedback="class-snip" hidden>Copied</span>
+        <pre id="class-snip" tabindex="0"><code>// Do not change location.hash for the modal at all
+const overlay = document.querySelector('#hcm-modal-x');
+openBtn.addEventListener('click', () => {
+  overlay.classList.add('is-active');
+  document.body.style.overflow = 'hidden';
+});
+closeBtn.addEventListener('click', () => {
+  overlay.classList.remove('is-active');
+  document.body.style.overflow = '';
+});
+// URL can stay on #features the whole time</code></pre>
+      </div>
+    </section>
+  </main>
+
+  <!-- Real EaseMotion hash modal -->
+  <div id="hcm-modal-x" class="ease-modal-overlay">
+    <div
+      class="ease-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="hcm-modal-title"
+    >
+      <div class="ease-modal-header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid #e2e8f0">
+        <h2 id="hcm-modal-title" style="margin:0;font-size:1.1rem">Modal #hcm-modal-x</h2>
+        <a href="#" class="hcm-btn" aria-label="Close modal" style="padding:0.35rem 0.65rem">×</a>
+      </div>
+      <div class="ease-modal-body" style="padding:1.25rem">
+        <p style="margin:0 0 0.75rem;color:#475569;font-size:0.9rem;line-height:1.55">
+          You opened this via hash. If you arrived from <code>#features</code> or
+          <code>#pricing</code>, that section id was overwritten.
+        </p>
+        <p style="margin:0;color:#475569;font-size:0.9rem;line-height:1.55">
+          Close with <kbd>Esc</kbd>, backdrop, or × — default <code>modal.js</code>
+          clears the hash to empty (stray clear).
+        </p>
+      </div>
+      <div class="ease-modal-footer" style="padding:1rem 1.25rem;border-top:1px solid #e2e8f0;display:flex;gap:0.5rem;justify-content:flex-end">
+        <a href="#" class="hcm-btn">Close (href="#")</a>
+      </div>
+    </div>
+  </div>
+
+  <footer class="hcm-footer">
+    Submission:
+    <code>submissions/docs/ease-hash-collision-modal-sp/</code>
+    · Resolves Issue #47721 · EaseMotion CSS
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/core/modal.js"></script>
+  <script>
+    (function () {
+      var MODAL_HASH = "#hcm-modal-x";
+      var SECTION_HASHES = { "#features": "section", "#pricing": "section" };
+      var previousHashBeforeModal = "";
+      var storedForSafe = "";
+      var timeline = { before: "—", during: "—", after: "—" };
+      var logLines = [];
+      var sawModalOpen = false;
+
+      var urlFull = document.getElementById("url-full");
+      var hashPill = document.getElementById("hash-pill");
+      var hashKind = document.getElementById("hash-kind");
+      var tlBefore = document.getElementById("tl-before");
+      var tlDuring = document.getElementById("tl-during");
+      var tlAfter = document.getElementById("tl-after");
+      var eventLog = document.getElementById("event-log");
+      var storedHashEl = document.getElementById("stored-hash");
+
+      function classify(hash) {
+        if (!hash) return { kind: "none", pill: "empty", label: "(empty)" };
+        if (hash === MODAL_HASH)
+          return { kind: "modal", pill: "modal", label: hash };
+        if (SECTION_HASHES[hash])
+          return { kind: "section", pill: "section", label: hash };
+        return { kind: "other", pill: "section", label: hash };
+      }
+
+      function paintUrl() {
+        var hash = window.location.hash || "";
+        var info = classify(hash);
+        urlFull.textContent = window.location.href;
+        hashPill.textContent = info.label;
+        hashPill.className =
+          "hcm-hash-pill hcm-hash-pill--" + info.pill;
+        hashKind.textContent = info.kind;
+        tlBefore.textContent = timeline.before;
+        tlDuring.textContent = timeline.during;
+        tlAfter.textContent = timeline.after;
+      }
+
+      function pushLog(html) {
+        var stamp = new Date().toLocaleTimeString();
+        logLines.push(
+          '<span class="meta">[' + stamp + "]</span> " + html
+        );
+        if (logLines.length > 16) logLines.shift();
+        eventLog.innerHTML = logLines.join("\n");
+        eventLog.scrollTop = eventLog.scrollHeight;
+      }
+
+      function onHashChange(reason) {
+        var hash = window.location.hash || "";
+        var info = classify(hash);
+
+        if (info.kind === "section") {
+          timeline.before = hash;
+          timeline.during = "—";
+          timeline.after = "—";
+          sawModalOpen = false;
+          previousHashBeforeModal = hash;
+          pushLog(
+            '<span class="ok">Section hash set → ' +
+              hash +
+              "</span> <span class=\"meta\">(" +
+              reason +
+              ")</span>"
+          );
+        } else if (info.kind === "modal") {
+          if (!sawModalOpen) {
+            timeline.before = previousHashBeforeModal || timeline.before || "(empty)";
+          }
+          timeline.during = hash;
+          timeline.after = "—";
+          sawModalOpen = true;
+          pushLog(
+            '<span class="warn">Modal hash overwrote prior → ' +
+              hash +
+              " (lost " +
+              (previousHashBeforeModal || "(empty)") +
+              ")</span>"
+          );
+        } else {
+          if (sawModalOpen) {
+            timeline.after = "(empty)";
+            pushLog(
+              '<span class="warn">Stray hash clear on close → "" — prior section not restored</span>'
+            );
+            sawModalOpen = false;
+          } else {
+            pushLog(
+              '<span class="meta">Hash cleared → (empty)</span>'
+            );
+          }
+        }
+        paintUrl();
+      }
+
+      window.addEventListener("hashchange", function () {
+        onHashChange("hashchange");
+      });
+
+      document.getElementById("reset-hash-btn").addEventListener("click", function () {
+        previousHashBeforeModal = "";
+        timeline = { before: "—", during: "—", after: "—" };
+        sawModalOpen = false;
+        if (window.location.hash) {
+          window.location.hash = "";
+        } else {
+          paintUrl();
+          pushLog('<span class="meta">Hash already empty</span>');
+        }
+      });
+
+      document.getElementById("clear-log-btn").addEventListener("click", function () {
+        logLines = [];
+        eventLog.innerHTML =
+          '<span class="meta">// Jump to a section, then open the modal…</span>';
+      });
+
+      document.getElementById("jump-features").addEventListener("click", function () {
+        previousHashBeforeModal = "#features";
+      });
+      document.getElementById("jump-pricing").addEventListener("click", function () {
+        previousHashBeforeModal = "#pricing";
+      });
+
+      /* Safer remember / restore (lab helper — does not patch modal.js) */
+      document.getElementById("safe-open-btn").addEventListener("click", function () {
+        storedForSafe = window.location.hash || "";
+        storedHashEl.textContent = storedForSafe || "(empty)";
+        previousHashBeforeModal = storedForSafe;
+        window.location.hash = MODAL_HASH;
+        pushLog(
+          '<span class="ok">Safe open remembered ' +
+            (storedForSafe || "(empty)") +
+            "</span>"
+        );
+      });
+
+      document.getElementById("safe-close-btn").addEventListener("click", function () {
+        var restore = storedForSafe || "";
+        window.location.hash = restore;
+        timeline.after = restore || "(empty)";
+        sawModalOpen = false;
+        pushLog(
+          '<span class="ok">Safe close restored → ' +
+            (restore || "(empty)") +
+            "</span>"
+        );
+        storedForSafe = "";
+        storedHashEl.textContent = "(none)";
+        paintUrl();
+      });
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", async function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          var text = pre ? pre.innerText : "";
+          try {
+            await navigator.clipboard.writeText(text);
+          } catch (err) {
+            var range = document.createRange();
+            range.selectNodeContents(pre);
+            var sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
+          var fb = document.querySelector('[data-feedback="' + id + '"]');
+          if (fb) {
+            fb.hidden = false;
+            setTimeout(function () {
+              fb.hidden = true;
+            }, 1400);
+          }
+        });
+      });
+
+      // Seed timeline if page loads with a hash
+      previousHashBeforeModal =
+        classify(window.location.hash).kind === "section"
+          ? window.location.hash
+          : "";
+      if (previousHashBeforeModal) timeline.before = previousHashBeforeModal;
+      if (window.location.hash === MODAL_HASH) {
+        timeline.during = MODAL_HASH;
+        sawModalOpen = true;
+      }
+      paintUrl();
+      pushLog('<span class="meta">Ready — start with Jump to #features</span>');
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-hash-collision-modal-sp/style.css
+++ b/submissions/docs/ease-hash-collision-modal-sp/style.css
@@ -1,0 +1,495 @@
+/* Hash Modal × Unrelated #id Collision
+   submissions/docs/ease-hash-collision-modal-sp */
+
+:root {
+  --hcm-ink: #0f172a;
+  --hcm-muted: #475569;
+  --hcm-surface: #ffffff;
+  --hcm-border: #e2e8f0;
+  --hcm-primary: #7c3aed;
+  --hcm-primary-dark: #6d28d9;
+  --hcm-danger: #b91c1c;
+  --hcm-danger-bg: rgb(185 28 28 / 7%);
+  --hcm-safe: #15803d;
+  --hcm-safe-bg: rgb(21 128 61 / 7%);
+  --hcm-warn: #b45309;
+  --hcm-radius: 1rem;
+  --hcm-mono: "JetBrains Mono", ui-monospace, Consolas, monospace;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  color: var(--hcm-ink);
+  background:
+    radial-gradient(900px 420px at 8% -8%, rgb(124 58 237 / 9%), transparent),
+    radial-gradient(780px 380px at 92% 0%, rgb(14 165 233 / 6%), transparent),
+    var(--ease-color-bg, #f8fafc);
+}
+
+.hcm-header,
+.hcm-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding-inline: var(--ease-space-6, 1.5rem);
+}
+
+.hcm-header {
+  text-align: center;
+  padding-top: var(--ease-space-12, 3rem);
+  padding-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.hcm-kicker {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--hcm-primary-dark);
+}
+
+.hcm-subtitle {
+  max-width: 54rem;
+  margin: 0.75rem auto 0;
+  color: var(--hcm-muted);
+  line-height: 1.6;
+}
+
+.hcm-main {
+  padding-bottom: var(--ease-space-12, 3rem);
+}
+
+.hcm-callout {
+  background: rgb(124 58 237 / 8%);
+  border: 1px solid rgb(124 58 237 / 22%);
+  border-radius: var(--hcm-radius);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.hcm-callout--warn {
+  background: rgb(180 83 9 / 8%);
+  border-color: rgb(180 83 9 / 28%);
+}
+
+.hcm-card {
+  background: var(--hcm-surface);
+  border: 1px solid var(--hcm-border);
+  border-radius: var(--hcm-radius);
+  padding: var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm, 0 1px 2px rgb(15 23 42 / 6%));
+}
+
+.hcm-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: var(--ease-text-lg, 1.125rem);
+}
+
+.hcm-card > p,
+.hcm-lede {
+  margin: 0 0 var(--ease-space-4, 1rem);
+  color: var(--hcm-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.hcm-sticky-panel {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 40;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: var(--hcm-radius);
+  padding: 0.9rem 1rem;
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  box-shadow: 0 10px 30px rgb(15 23 42 / 18%);
+}
+
+.hcm-sticky-panel h2 {
+  margin: 0 0 0.55rem;
+  font-size: 0.95rem;
+  color: #fff;
+}
+
+.hcm-url-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.65rem;
+}
+
+.hcm-url-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  font-weight: 700;
+}
+
+.hcm-url-value {
+  font-family: var(--hcm-mono);
+  font-size: 0.78rem;
+  background: rgb(255 255 255 / 8%);
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.55rem;
+  word-break: break-all;
+}
+
+.hcm-hash-pill {
+  font-family: var(--hcm-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / 15%);
+}
+
+.hcm-hash-pill--empty {
+  color: #fca5a5;
+  background: rgb(185 28 28 / 25%);
+}
+
+.hcm-hash-pill--section {
+  color: #93c5fd;
+  background: rgb(37 99 235 / 25%);
+}
+
+.hcm-hash-pill--modal {
+  color: #c4b5fd;
+  background: rgb(124 58 237 / 30%);
+}
+
+.hcm-timeline {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.hcm-tl-step {
+  background: rgb(255 255 255 / 6%);
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 0.55rem;
+  padding: 0.55rem 0.6rem;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.hcm-tl-step strong {
+  display: block;
+  margin-bottom: 0.2rem;
+  color: #cbd5e1;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hcm-tl-step code {
+  font-family: var(--hcm-mono);
+  color: #fde68a;
+}
+
+.hcm-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.hcm-btn {
+  appearance: none;
+  border: 1px solid var(--hcm-border);
+  background: #f1f5f9;
+  color: var(--hcm-ink);
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.9rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.hcm-btn:hover {
+  background: #e2e8f0;
+}
+
+.hcm-btn:focus-visible {
+  outline: 2px solid var(--hcm-primary);
+  outline-offset: 2px;
+}
+
+.hcm-btn--primary {
+  background: var(--hcm-primary);
+  border-color: var(--hcm-primary-dark);
+  color: #fff;
+}
+
+.hcm-btn--primary:hover {
+  background: var(--hcm-primary-dark);
+}
+
+.hcm-btn--danger {
+  background: var(--hcm-danger);
+  border-color: #991b1b;
+  color: #fff;
+}
+
+.hcm-btn--safe {
+  background: var(--hcm-safe);
+  border-color: #166534;
+  color: #fff;
+}
+
+.hcm-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+}
+
+.hcm-panel {
+  border: 1px solid var(--hcm-border);
+  border-radius: 0.85rem;
+  padding: var(--ease-space-4, 1rem);
+  background: #f8fafc;
+}
+
+.hcm-panel--bug {
+  border-color: rgb(185 28 28 / 35%);
+  background: var(--hcm-danger-bg);
+}
+
+.hcm-panel--fix {
+  border-color: rgb(21 128 61 / 35%);
+  background: var(--hcm-safe-bg);
+}
+
+.hcm-panel-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.65rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+}
+
+.hcm-panel--bug .hcm-panel-label {
+  background: var(--hcm-danger);
+}
+
+.hcm-panel--fix .hcm-panel-label {
+  background: var(--hcm-safe);
+}
+
+.hcm-panel h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+
+.hcm-panel p {
+  margin: 0 0 0.85rem;
+  font-size: 0.8rem;
+  color: var(--hcm-muted);
+  line-height: 1.5;
+}
+
+.hcm-section {
+  scroll-margin-top: 6.5rem;
+  border: 1px solid var(--hcm-border);
+  border-radius: 0.85rem;
+  padding: 1.1rem 1.15rem;
+  margin-bottom: 0.85rem;
+  background: #fff;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.hcm-section:target {
+  border-color: var(--hcm-primary);
+  box-shadow: 0 0 0 3px rgb(124 58 237 / 18%);
+}
+
+.hcm-section h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.hcm-section p {
+  margin: 0;
+  color: var(--hcm-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.hcm-section-id {
+  font-family: var(--hcm-mono);
+  font-size: 0.7rem;
+  color: var(--hcm-primary-dark);
+  font-weight: 700;
+}
+
+.hcm-log {
+  font-family: var(--hcm-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  min-height: 8rem;
+  max-height: 14rem;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
+.hcm-log .meta {
+  color: #94a3b8;
+}
+
+.hcm-log .warn {
+  color: #fca5a5;
+}
+
+.hcm-log .ok {
+  color: #86efac;
+}
+
+.hcm-definition {
+  font-family: var(--hcm-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.hcm-why-list,
+.hcm-steps {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--hcm-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.65;
+}
+
+.hcm-why-list li + li,
+.hcm-steps li + li {
+  margin-top: 0.45rem;
+}
+
+.hcm-compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.hcm-compare-table th,
+.hcm-compare-table td {
+  text-align: left;
+  padding: 0.7rem 0.75rem;
+  border-bottom: 1px solid var(--hcm-border);
+  vertical-align: top;
+}
+
+.hcm-compare-table th {
+  background: #f1f5f9;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hcm-compare-table code {
+  font-family: var(--hcm-mono);
+  font-size: 0.72rem;
+}
+
+.hcm-snippet {
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.hcm-snippet:last-child {
+  margin-bottom: 0;
+}
+
+.hcm-snippet-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.hcm-snippet-head span {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.hcm-snippet pre {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--hcm-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+}
+
+.hcm-copy-feedback {
+  font-size: 0.7rem;
+  color: var(--hcm-safe);
+  font-weight: 600;
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+.hcm-footer {
+  text-align: center;
+  padding: 0 1.5rem 2.5rem;
+  color: var(--hcm-muted);
+  font-size: 0.8rem;
+}
+
+.hcm-footer code {
+  font-family: var(--hcm-mono);
+  font-size: 0.72rem;
+}
+
+/* Extra space so section jumps are visible */
+.hcm-spacer {
+  height: 2rem;
+}
+
+@media (max-width: 760px) {
+  .hcm-grid-2,
+  .hcm-timeline {
+    grid-template-columns: 1fr;
+  }
+
+  .hcm-header h1 {
+    font-size: 1.45rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a hash-collision docs guide for page `#section` vs modal `#modal-x` (distinct from the deep-link playground)
- Reproduces `core/modal.js` overwrite + stray `hash = ''` clear on Esc/backdrop close
- Includes live URL/timeline panel, safer remember/restore demo, and copy-ready snippets

## Test plan
- Open `submissions/docs/ease-hash-collision-modal-sp/demo.html`
- Jump to `#features`, open modal, confirm hash becomes `#hcm-modal-x`
- Close with Esc/backdrop; confirm hash is empty (section not restored)
- Try safe open/remember → safe close/restore; confirm `#pricing` returns
-  Confirm only new files under `submissions/docs/ease-hash-collision-modal-sp/`

Resolves #47721