### PR TITLE
ease-suffix-collision-cases

### DIFF
--- a/submissions/docs/ease-suffix-collision-cases-sp/README.md
+++ b/submissions/docs/ease-suffix-collision-cases-sp/README.md
@@ -1,0 +1,53 @@
+# Contribution Suffix Collision When Two People Use Same Initials
+
+A documentation guide focused on **suffix collision cases and naming policy** — what happens when two contributors both use short initials like `ak`, why `ease-card-ak` clashes, and safer patterns (longer suffix, date, GitHub username).
+
+> Submission track: `submissions/docs/ease-suffix-collision-cases-sp/`  
+> Contributor suffix: `sp`  
+> Resolves: Issue #47725  
+> Note: Different from `ease-suffix-generator-sp` — this guide is about **collision cases / policy**, not generating a suffix.
+
+---
+
+## What does this do?
+
+`CONTRIBUTING.md` asks contributors to append a unique identifier (e.g. `ease-tabs-ak`, `ease-card-pr`). Short 2-letter initials feel convenient but collide often when many people share `ak`, `as`, `js`, etc. This page walks through concrete clash scenarios, risk levels, and recommended unique folder names across docs / examples / react / scss tracks.
+
+## How is it used?
+
+1. Open `demo.html` in a browser.
+2. Read the `ease-card-ak` collision case study.
+3. Use the risk checker to score a proposed suffix.
+4. Compare unsafe vs safe naming examples.
+5. Copy recommended folder names for your track.
+
+## Features
+
+- Side-by-side collision vs safe name examples
+- Case study of same-initial clashes (`ease-card-ak`)
+- Policy recommendations (longer token, date, GitHub username)
+- Interactive collision-risk checker
+- Copy-ready safe folder names per submission track
+- Responsive and beginner-friendly documentation UI
+
+## Why is it useful?
+
+- **Prevents rejected / conflicting PRs** from duplicate folder paths.
+- **Policy clarity** — goes beyond “add a suffix” to “make it unique enough.”
+- **Complements the generator** — teach *why* collisions happen.
+- **Self-contained** — no edits to `core/` or `components/`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Case studies, risk checker, safe-name gallery |
+| `style.css` | Layout, panels, responsive design |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only **new files** inside `submissions/docs/ease-suffix-collision-cases-sp/`.
+- No modifications to `core/`, `components/`, or existing files.
+- All three required submission files included (`demo.html`, `style.css`, `README.md`).
+- Folder name carries the unique contributor suffix `-sp`.

--- a/submissions/docs/ease-suffix-collision-cases-sp/demo.html
+++ b/submissions/docs/ease-suffix-collision-cases-sp/demo.html
@@ -1,0 +1,530 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contribution Suffix Collision Cases — EaseMotion CSS</title>
+  <meta
+    name="description"
+    content="Document suffix collisions like ease-card-ak when two contributors share initials, and recommend safer unique naming policies."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css"
+  />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <header class="scc-header ease-fade-in">
+    <p class="scc-kicker">EaseMotion CSS · Contribution Policy Guide</p>
+    <h1>Contribution Suffix Collision When Two People Use Same Initials</h1>
+    <p class="scc-subtitle">
+      Focus: <strong>collision cases &amp; policy</strong> — not a suffix generator.
+      Short initials like <code>ak</code> look fine until two people both invent
+      <code>ease-card-ak</code>. Learn why clashes happen and which longer /
+      dated / username suffixes stay unique.
+    </p>
+  </header>
+
+  <main class="scc-main">
+    <aside class="scc-callout" role="note">
+      <strong>Policy takeaway:</strong> A suffix must be unique in
+      <code>submissions/</code>, not merely “your initials.” Prefer GitHub
+      username, a date stamp, or a longer personal token over 2-letter initials
+      alone. See also <code>CONTRIBUTING.md</code> examples:
+      <code>ease-hover-sap</code>, <code>ease-tabs-ak</code>, <code>ease-card-pr</code>.
+    </aside>
+
+    <!-- Case study -->
+    <section class="scc-card" aria-labelledby="case-title">
+      <h2 id="case-title">Case study: <code>ease-card-ak</code> clash</h2>
+      <p>
+        Two contributors — Ananya Kapoor and Amir Khan — both choose initials
+        <code>ak</code> and both want a card demo. Same feature slug + same
+        short suffix = identical folder path.
+      </p>
+
+      <div class="scc-grid-2">
+        <article class="scc-panel scc-panel--bug" aria-labelledby="clash-title">
+          <span class="scc-panel-label">Collision</span>
+          <h3 id="clash-title">Same initials → same folder</h3>
+          <p>Git cannot store two directories with one name. The second PR conflicts or overwrites intent.</p>
+          <pre class="scc-tree" tabindex="0"><code><span class="meta">submissions/examples/</span>
+├── <span class="clash">ease-card-ak/</span>   <span class="meta">← Ananya (PR #1)</span>
+└── <span class="clash">ease-card-ak/</span>   <span class="meta">← Amir (PR #2) CLASH</span></code></pre>
+        </article>
+
+        <article class="scc-panel scc-panel--fix" aria-labelledby="safe-title">
+          <span class="scc-panel-label">Safe</span>
+          <h3 id="safe-title">Longer / unique suffixes</h3>
+          <p>Same idea, different unique tokens — both PRs can merge cleanly.</p>
+          <pre class="scc-tree" tabindex="0"><code><span class="meta">submissions/examples/</span>
+├── <span class="ok">ease-card-ananyak/</span>
+├── <span class="ok">ease-card-amirkhan/</span>
+└── <span class="ok">ease-card-ak-20260315/</span></code></pre>
+        </article>
+      </div>
+    </section>
+
+    <!-- Why risky -->
+    <section class="scc-card" aria-labelledby="why-title">
+      <h2 id="why-title">Why short initials are risky at scale</h2>
+      <ul class="scc-list">
+        <li>
+          <strong>Common initials cluster.</strong>
+          Many people share <code>ak</code>, <code>as</code>, <code>js</code>,
+          <code>sk</code>, <code>ap</code> — especially in large programs like GSSoC.
+        </li>
+        <li>
+          <strong>Feature names also collide.</strong>
+          Popular ideas reuse the same slug (<code>card</code>, <code>navbar</code>,
+          <code>modal</code>). Suffix is often the only differentiator.
+        </li>
+        <li>
+          <strong>CONTRIBUTING examples use short forms as illustration</strong>
+          (<code>ease-tabs-ak</code> is an example format — not a guarantee that
+          <code>ak</code> is free in the tree.
+        </li>
+        <li>
+          <strong>Reviewers lose signal.</strong>
+          Duplicate paths force renames mid-review and slow merges.
+        </li>
+      </ul>
+      <aside class="scc-callout scc-callout--warn" role="note" style="margin: 1rem 0 0">
+        This page documents <em>collision policy</em>. For interactive name generation,
+        see <code>submissions/docs/ease-suffix-generator-sp/</code> — a different tool.
+      </aside>
+    </section>
+
+    <!-- Risk checker -->
+    <section class="scc-card" aria-labelledby="check-title">
+      <h2 id="check-title">Collision risk checker</h2>
+      <p>
+        Heuristic only (no live repo scan). Scores how collision-prone a proposed
+        suffix looks before you open a PR.
+      </p>
+
+      <form class="scc-form" id="risk-form">
+        <div class="scc-field">
+          <label for="feature-input">Feature slug (kebab-case)</label>
+          <input id="feature-input" type="text" value="card" autocomplete="off" />
+        </div>
+        <div class="scc-field">
+          <label for="suffix-input">Your proposed suffix</label>
+          <input id="suffix-input" type="text" value="ak" autocomplete="off" />
+        </div>
+        <div class="scc-field">
+          <label for="track-select">Submission track</label>
+          <select id="track-select">
+            <option value="docs">docs</option>
+            <option value="examples" selected>examples</option>
+            <option value="react">react</option>
+            <option value="scss">scss</option>
+          </select>
+        </div>
+        <div class="scc-toolbar">
+          <button type="submit" class="scc-btn scc-btn--primary">Score risk</button>
+          <button type="button" class="scc-btn" id="suggest-btn">Suggest safer names</button>
+        </div>
+      </form>
+
+      <div class="scc-result" id="risk-result" aria-live="polite"></div>
+    </section>
+
+    <!-- Policy recommendations -->
+    <section class="scc-card" aria-labelledby="policy-title">
+      <h2 id="policy-title">Recommended suffix policies</h2>
+      <div class="scc-policy-grid">
+        <article class="scc-policy">
+          <h3>1. GitHub username</h3>
+          <p>Best default. Already unique on GitHub and easy for reviewers to map to a person.</p>
+          <code>ease-card-suman20041</code>
+        </article>
+        <article class="scc-policy">
+          <h3>2. Longer personal token</h3>
+          <p>First name + last initial, or 4–8 letter handle — much rarer than 2 letters.</p>
+          <code>ease-card-ananyak</code>
+        </article>
+        <article class="scc-policy">
+          <h3>3. Initials + date</h3>
+          <p>Keep short initials only if you append a date or issue number for uniqueness.</p>
+          <code>ease-card-ak-20260315</code>
+        </article>
+      </div>
+    </section>
+
+    <!-- Comparison table -->
+    <section class="scc-card" aria-labelledby="table-title">
+      <h2 id="table-title">Unsafe vs safe naming</h2>
+      <div style="overflow-x: auto">
+        <table class="scc-table">
+          <thead>
+            <tr>
+              <th>Proposed folder</th>
+              <th>Risk</th>
+              <th>Safer alternative</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ease-card-ak</code></td>
+              <td style="color: var(--scc-danger); font-weight: 700">High</td>
+              <td><code>ease-card-ananyak</code> / <code>ease-card-ak-20260315</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-navbar-as</code></td>
+              <td style="color: var(--scc-danger); font-weight: 700">High</td>
+              <td><code>ease-navbar-amitsharma</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-modal-js</code></td>
+              <td style="color: var(--scc-warn); font-weight: 700">Medium</td>
+              <td><code>ease-modal-janesmith</code> / <code>ease-modal-js42</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-tabs-pr</code></td>
+              <td style="color: var(--scc-warn); font-weight: 700">Medium</td>
+              <td><code>ease-tabs-priyareddy</code></td>
+            </tr>
+            <tr>
+              <td><code>ease-hover-sap</code></td>
+              <td style="color: var(--scc-safe); font-weight: 700">Lower*</td>
+              <td>Still verify the path is free; username is safer</td>
+            </tr>
+            <tr>
+              <td><code>ease-suffix-collision-cases-sp</code></td>
+              <td style="color: var(--scc-safe); font-weight: 700">Low</td>
+              <td>Descriptive feature + distinct token (this submission)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="scc-lede" style="margin-top: 0.75rem; margin-bottom: 0">
+        *Lower relative to 2-letter initials — always search the repo for the
+        exact folder before opening a PR.
+      </p>
+    </section>
+
+    <!-- Gallery per track -->
+    <section class="scc-card" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Safe name examples by track</h2>
+      <p>Copy a pattern, then swap in your username / date / feature.</p>
+      <div class="scc-gallery" id="name-gallery"></div>
+    </section>
+
+    <!-- Checklist -->
+    <section class="scc-card" aria-labelledby="checklist-title">
+      <h2 id="checklist-title">Before you open a PR</h2>
+      <ul class="scc-list">
+        <li>Search GitHub for your exact folder name under <code>submissions/</code>.</li>
+        <li>Avoid lone 2-letter initials when the feature slug is a common word.</li>
+        <li>Prefer <code>ease-{feature}-{github-username}</code> for uniqueness.</li>
+        <li>If you keep initials, append <code>-YYYYMMDD</code> or an issue number.</li>
+        <li>Match the track folder: <code>docs/</code>, <code>examples/</code>, <code>react/</code>, or <code>scss/</code>.</li>
+        <li>Do not rename or delete someone else’s existing submission folder.</li>
+      </ul>
+    </section>
+
+    <!-- Snippets -->
+    <section class="scc-card" aria-labelledby="snip-title">
+      <h2 id="snip-title">Copy-ready policy snippets</h2>
+
+      <div class="scc-snippet">
+        <div class="scc-snippet-head">
+          <span>CONTRIBUTING-style format reminder</span>
+          <button type="button" class="scc-btn" data-copy="policy-snip">Copy</button>
+        </div>
+        <span class="scc-copy-feedback" data-feedback="policy-snip" hidden>Copied</span>
+        <pre id="policy-snip" tabindex="0"><code>// Required idea from CONTRIBUTING.md:
+// append a short unique identifier to your feature name.
+// Examples of format (not reserved names):
+ease-hover-sap
+ease-tabs-ak
+ease-card-pr
+
+// Collision-safe upgrade when initials are shared:
+ease-card-suman20041
+ease-card-ak-20260315
+ease-tabs-ananyakapoor</code></pre>
+      </div>
+
+      <div class="scc-snippet">
+        <div class="scc-snippet-head">
+          <span>Folder naming checklist (markdown)</span>
+          <button type="button" class="scc-btn" data-copy="check-snip">Copy</button>
+        </div>
+        <span class="scc-copy-feedback" data-feedback="check-snip" hidden>Copied</span>
+        <pre id="check-snip" tabindex="0"><code>- [ ] Feature slug is kebab-case
+- [ ] Suffix is unique (username / long token / initials+date)
+- [ ] Searched repo for exact path
+- [ ] Track folder is correct (docs|examples|react|scss)
+- [ ] No deletion of another contributor’s folder</code></pre>
+      </div>
+
+      <div class="scc-snippet">
+        <div class="scc-snippet-head">
+          <span>Shell: quick local uniqueness check</span>
+          <button type="button" class="scc-btn" data-copy="shell-snip">Copy</button>
+        </div>
+        <span class="scc-copy-feedback" data-feedback="shell-snip" hidden>Copied</span>
+        <pre id="shell-snip" tabindex="0"><code># From repo root — replace with your folder name
+ls submissions/*/ease-card-ak 2>/dev/null
+# If anything prints, pick a different suffix</code></pre>
+      </div>
+    </section>
+
+    <section class="scc-card" aria-labelledby="source-title">
+      <h2 id="source-title">Source policy excerpt</h2>
+      <pre class="scc-definition" tabindex="0"><code>// CONTRIBUTING.md — Contribution Policy Update
+To avoid naming conflicts and overlapping components, contributors must
+append a short unique identifier or abbreviation to their
+feature/component/mixin name.
+
+Example:
+  ease-hover-sap
+  ease-tabs-ak
+  ease-card-pr</code></pre>
+    </section>
+  </main>
+
+  <footer class="scc-footer">
+    Submission:
+    <code>submissions/docs/ease-suffix-collision-cases-sp/</code>
+    · Resolves Issue #47725 · EaseMotion CSS
+  </footer>
+
+  <script>
+    (function () {
+      var COMMON_SUFFIXES = {
+        ak: true, as: true, ap: true, ar: true, js: true, sk: true, sp: true,
+        pr: true, pk: true, rk: true, rs: true, ss: true, aa: true, ab: true,
+        am: true, an: true, ay: true, dk: true, mk: true, nk: true, vk: true,
+        sm: true, sa: true, sj: true, jr: true, jd: true, mj: true, ms: true,
+      };
+
+      var COMMON_FEATURES = {
+        card: true, navbar: true, modal: true, button: true, footer: true,
+        hero: true, tabs: true, toast: true, tooltip: true, form: true,
+        loader: true, sidebar: true, accordion: true, carousel: true,
+      };
+
+      var GALLERY = [
+        { track: "docs", path: "submissions/docs/ease-a11y-checklist-suman20041/" },
+        { track: "docs", path: "submissions/docs/ease-suffix-collision-cases-sp/" },
+        { track: "examples", path: "submissions/examples/ease-card-ananyak/" },
+        { track: "examples", path: "submissions/examples/ease-card-ak-20260315/" },
+        { track: "react", path: "submissions/react/ease-remount-key-pitfalls-janedoe/" },
+        { track: "scss", path: "submissions/scss/_ease-theme-tokens-priyareddy.scss" },
+        { track: "examples", path: "submissions/examples/ease-navbar-amitsharma/" },
+        { track: "docs", path: "submissions/docs/ease-hash-collision-modal-sp/" },
+      ];
+
+      var resultEl = document.getElementById("risk-result");
+      var galleryEl = document.getElementById("name-gallery");
+
+      function normalize(value) {
+        return String(value || "")
+          .trim()
+          .toLowerCase()
+          .replace(/^-+|-+$/g, "")
+          .replace(/\s+/g, "-");
+      }
+
+      function scoreSuffix(feature, suffix) {
+        var reasons = [];
+        var score = 0;
+        var f = normalize(feature);
+        var s = normalize(suffix).replace(/^-+/, "");
+
+        if (!f || !s) {
+          return {
+            level: "high",
+            label: "Incomplete",
+            reasons: ["Enter both a feature slug and a suffix."],
+            folder: "—",
+          };
+        }
+
+        if (s.length <= 2) {
+          score += 45;
+          reasons.push("Suffix is only " + s.length + " character(s) — very collision-prone.");
+        } else if (s.length === 3) {
+          score += 25;
+          reasons.push("3-letter suffixes still collide often; prefer 5+ characters or a username.");
+        } else if (s.length < 6) {
+          score += 10;
+          reasons.push("Short token — better than initials, but username/date is safer.");
+        } else {
+          reasons.push("Length looks healthier (≥ 6). Still verify the path is free.");
+        }
+
+        if (COMMON_SUFFIXES[s]) {
+          score += 30;
+          reasons.push("`" + s + "` is a commonly chosen initial/token in large contributor pools.");
+        }
+
+        if (/^[a-z]{2}$/.test(s) && COMMON_FEATURES[f]) {
+          score += 15;
+          reasons.push("Common feature (`" + f + "`) + 2-letter initials is a classic clash pattern (e.g. ease-card-ak).");
+        }
+
+        if (/^\d{6,8}$/.test(s) || /-\d{6,8}$/.test(s) || /\d{4}-\d{2}-\d{2}/.test(s)) {
+          score = Math.max(0, score - 25);
+          reasons.push("Date-like token detected — good uniqueness boost.");
+        }
+
+        if (s.length >= 6 && /[a-z].*[0-9]|[0-9].*[a-z]/.test(s)) {
+          score = Math.max(0, score - 15);
+          reasons.push("Alphanumeric handle resembles a username — usually unique enough.");
+        }
+
+        if (s.indexOf("-") !== -1 && s.length >= 5) {
+          score = Math.max(0, score - 10);
+          reasons.push("Compound suffix (e.g. initials+date) reduces collision risk.");
+        }
+
+        var level = "low";
+        var label = "Low risk";
+        if (score >= 55) {
+          level = "high";
+          label = "High collision risk";
+        } else if (score >= 25) {
+          level = "medium";
+          label = "Medium collision risk";
+        }
+
+        return {
+          level: level,
+          label: label,
+          reasons: reasons,
+          folder: "ease-" + f + "-" + s,
+          score: score,
+        };
+      }
+
+      function suggestNames(feature, suffix) {
+        var f = normalize(feature) || "card";
+        var s = normalize(suffix).replace(/^-+/, "") || "ak";
+        var today = new Date();
+        var y = today.getFullYear();
+        var m = String(today.getMonth() + 1).padStart(2, "0");
+        var d = String(today.getDate()).padStart(2, "0");
+        var stamp = "" + y + m + d;
+        return [
+          "ease-" + f + "-yourgithubusername",
+          "ease-" + f + "-" + s + "-" + stamp,
+          "ease-" + f + "-" + s + "dev",
+          "ease-" + f + "-issue47725",
+        ];
+      }
+
+      function renderResult(track) {
+        var feature = document.getElementById("feature-input").value;
+        var suffix = document.getElementById("suffix-input").value;
+        var scored = scoreSuffix(feature, suffix);
+        var path =
+          scored.folder === "—"
+            ? "—"
+            : "submissions/" + track + "/" + scored.folder + "/";
+        var suggestions = suggestNames(feature, suffix);
+
+        resultEl.innerHTML =
+          '<span class="scc-risk scc-risk--' +
+          scored.level +
+          '">' +
+          scored.label +
+          "</span>" +
+          '<p style="margin:0 0 0.35rem;font-size:0.85rem;color:var(--scc-muted)">Proposed path</p>' +
+          '<div class="scc-path">' +
+          path +
+          "</div>" +
+          "<ul class=\"scc-reasons\">" +
+          scored.reasons
+            .map(function (r) {
+              return "<li>" + r + "</li>";
+            })
+            .join("") +
+          "</ul>" +
+          '<p style="margin:0.85rem 0 0.35rem;font-size:0.85rem;font-weight:700">Safer alternatives</p>' +
+          "<ul class=\"scc-reasons\">" +
+          suggestions
+            .map(function (n) {
+              return "<li><code>submissions/" + track + "/" + n + "/</code></li>";
+            })
+            .join("") +
+          "</ul>";
+      }
+
+      function renderGallery() {
+        galleryEl.innerHTML = GALLERY.map(function (item) {
+          return (
+            '<div class="scc-name-row">' +
+            '<div><span class="scc-chip scc-chip--' +
+            item.track +
+            '">' +
+            item.track +
+            "</span> <code>" +
+            item.path +
+            "</code></div>" +
+            '<button type="button" class="scc-btn" data-copy-text="' +
+            item.path +
+            '">Copy</button>' +
+            "</div>"
+          );
+        }).join("");
+      }
+
+      document.getElementById("risk-form").addEventListener("submit", function (e) {
+        e.preventDefault();
+        renderResult(document.getElementById("track-select").value);
+      });
+
+      document.getElementById("suggest-btn").addEventListener("click", function () {
+        renderResult(document.getElementById("track-select").value);
+      });
+
+      async function copyText(text, feedbackEl) {
+        try {
+          await navigator.clipboard.writeText(text);
+        } catch (err) {
+          // fallback ignored
+        }
+        if (feedbackEl) {
+          feedbackEl.hidden = false;
+          setTimeout(function () {
+            feedbackEl.hidden = true;
+          }, 1400);
+        }
+      }
+
+      document.querySelectorAll("[data-copy]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var id = btn.getAttribute("data-copy");
+          var pre = document.getElementById(id);
+          var fb = document.querySelector('[data-feedback="' + id + '"]');
+          copyText(pre ? pre.innerText : "", fb);
+        });
+      });
+
+      galleryEl.addEventListener("click", function (e) {
+        var btn = e.target.closest("[data-copy-text]");
+        if (!btn) return;
+        copyText(btn.getAttribute("data-copy-text"));
+        btn.textContent = "Copied";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+        }, 1200);
+      });
+
+      renderGallery();
+      renderResult("examples");
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-suffix-collision-cases-sp/style.css
+++ b/submissions/docs/ease-suffix-collision-cases-sp/style.css
@@ -1,0 +1,496 @@
+/* Suffix Collision Cases / Policy Guide
+   submissions/docs/ease-suffix-collision-cases-sp */
+
+:root {
+  --scc-ink: #0f172a;
+  --scc-muted: #475569;
+  --scc-surface: #ffffff;
+  --scc-border: #e2e8f0;
+  --scc-primary: #0f766e;
+  --scc-primary-dark: #115e59;
+  --scc-danger: #b91c1c;
+  --scc-danger-bg: rgb(185 28 28 / 7%);
+  --scc-safe: #15803d;
+  --scc-safe-bg: rgb(21 128 61 / 7%);
+  --scc-warn: #b45309;
+  --scc-warn-bg: rgb(180 83 9 / 8%);
+  --scc-radius: 1rem;
+  --scc-mono: "JetBrains Mono", ui-monospace, Consolas, monospace;
+}
+
+body {
+  min-height: 100vh;
+  color: var(--scc-ink);
+  background:
+    radial-gradient(900px 420px at 8% -8%, rgb(15 118 110 / 10%), transparent),
+    radial-gradient(780px 380px at 92% 0%, rgb(14 165 233 / 6%), transparent),
+    var(--ease-color-bg, #f8fafc);
+}
+
+.scc-header,
+.scc-main {
+  max-width: 76rem;
+  margin: 0 auto;
+  padding-inline: var(--ease-space-6, 1.5rem);
+}
+
+.scc-header {
+  text-align: center;
+  padding-top: var(--ease-space-12, 3rem);
+  padding-bottom: var(--ease-space-6, 1.5rem);
+}
+
+.scc-kicker {
+  margin-bottom: var(--ease-space-2, 0.5rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--scc-primary-dark);
+}
+
+.scc-subtitle {
+  max-width: 54rem;
+  margin: 0.75rem auto 0;
+  color: var(--scc-muted);
+  line-height: 1.6;
+}
+
+.scc-main {
+  padding-bottom: var(--ease-space-12, 3rem);
+}
+
+.scc-callout {
+  background: rgb(15 118 110 / 8%);
+  border: 1px solid rgb(15 118 110 / 25%);
+  border-radius: var(--scc-radius);
+  padding: var(--ease-space-4, 1rem) var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.scc-callout--warn {
+  background: var(--scc-warn-bg);
+  border-color: rgb(180 83 9 / 30%);
+}
+
+.scc-card {
+  background: var(--scc-surface);
+  border: 1px solid var(--scc-border);
+  border-radius: var(--scc-radius);
+  padding: var(--ease-space-5, 1.25rem);
+  margin-bottom: var(--ease-space-5, 1.25rem);
+  box-shadow: var(--ease-shadow-sm, 0 1px 2px rgb(15 23 42 / 6%));
+}
+
+.scc-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: var(--ease-text-lg, 1.125rem);
+}
+
+.scc-card > p,
+.scc-lede {
+  margin: 0 0 var(--ease-space-4, 1rem);
+  color: var(--scc-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.6;
+}
+
+.scc-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ease-space-4, 1rem);
+}
+
+.scc-panel {
+  border: 1px solid var(--scc-border);
+  border-radius: 0.85rem;
+  padding: var(--ease-space-4, 1rem);
+  background: #f8fafc;
+}
+
+.scc-panel--bug {
+  border-color: rgb(185 28 28 / 35%);
+  background: var(--scc-danger-bg);
+}
+
+.scc-panel--fix {
+  border-color: rgb(21 128 61 / 35%);
+  background: var(--scc-safe-bg);
+}
+
+.scc-panel-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.65rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+}
+
+.scc-panel--bug .scc-panel-label {
+  background: var(--scc-danger);
+}
+
+.scc-panel--fix .scc-panel-label {
+  background: var(--scc-safe);
+}
+
+.scc-panel h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+
+.scc-panel p {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  color: var(--scc-muted);
+  line-height: 1.5;
+}
+
+.scc-tree {
+  font-family: var(--scc-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  margin: 0;
+  overflow-x: auto;
+}
+
+.scc-tree .clash {
+  color: #fca5a5;
+  font-weight: 700;
+}
+
+.scc-tree .ok {
+  color: #86efac;
+}
+
+.scc-tree .meta {
+  color: #94a3b8;
+}
+
+.scc-form {
+  display: grid;
+  gap: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+.scc-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.scc-field label {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.scc-field input,
+.scc-field select {
+  border: 1px solid var(--scc-border);
+  border-radius: 0.55rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  background: #fff;
+}
+
+.scc-field input:focus-visible,
+.scc-field select:focus-visible {
+  outline: 2px solid var(--scc-primary);
+  outline-offset: 2px;
+}
+
+.scc-btn {
+  appearance: none;
+  border: 1px solid var(--scc-border);
+  background: #f1f5f9;
+  color: var(--scc-ink);
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.9rem;
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.scc-btn:hover {
+  background: #e2e8f0;
+}
+
+.scc-btn:focus-visible {
+  outline: 2px solid var(--scc-primary);
+  outline-offset: 2px;
+}
+
+.scc-btn--primary {
+  background: var(--scc-primary);
+  border-color: var(--scc-primary-dark);
+  color: #fff;
+}
+
+.scc-btn--primary:hover {
+  background: var(--scc-primary-dark);
+}
+
+.scc-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.scc-result {
+  border: 1px solid var(--scc-border);
+  border-radius: 0.85rem;
+  padding: 1rem;
+  background: #fff;
+}
+
+.scc-risk {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  margin-bottom: 0.65rem;
+}
+
+.scc-risk--high {
+  background: var(--scc-danger-bg);
+  color: var(--scc-danger);
+  border: 1px solid rgb(185 28 28 / 30%);
+}
+
+.scc-risk--medium {
+  background: var(--scc-warn-bg);
+  color: var(--scc-warn);
+  border: 1px solid rgb(180 83 9 / 30%);
+}
+
+.scc-risk--low {
+  background: var(--scc-safe-bg);
+  color: var(--scc-safe);
+  border: 1px solid rgb(21 128 61 / 30%);
+}
+
+.scc-path {
+  font-family: var(--scc-mono);
+  font-size: 0.8rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.55rem;
+  padding: 0.65rem 0.8rem;
+  word-break: break-all;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.scc-reasons {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--scc-muted);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.scc-policy-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.scc-policy {
+  border: 1px solid var(--scc-border);
+  border-radius: 0.75rem;
+  padding: 0.9rem;
+  background: #fff;
+}
+
+.scc-policy h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.scc-policy p {
+  margin: 0 0 0.55rem;
+  font-size: 0.8rem;
+  color: var(--scc-muted);
+  line-height: 1.5;
+}
+
+.scc-policy code {
+  font-family: var(--scc-mono);
+  font-size: 0.72rem;
+  background: #f1f5f9;
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.3rem;
+}
+
+.scc-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.scc-table th,
+.scc-table td {
+  text-align: left;
+  padding: 0.7rem 0.75rem;
+  border-bottom: 1px solid var(--scc-border);
+  vertical-align: top;
+}
+
+.scc-table th {
+  background: #f1f5f9;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.scc-table code {
+  font-family: var(--scc-mono);
+  font-size: 0.72rem;
+}
+
+.scc-gallery {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.scc-name-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border: 1px solid var(--scc-border);
+  border-radius: 0.65rem;
+  padding: 0.65rem 0.75rem;
+  background: #fff;
+}
+
+.scc-name-row code {
+  font-family: var(--scc-mono);
+  font-size: 0.75rem;
+  word-break: break-all;
+}
+
+.scc-chip {
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: var(--scc-muted);
+}
+
+.scc-chip--docs { background: rgb(37 99 235 / 12%); color: #1d4ed8; }
+.scc-chip--examples { background: rgb(124 58 237 / 12%); color: #6d28d9; }
+.scc-chip--react { background: rgb(14 165 233 / 14%); color: #0369a1; }
+.scc-chip--scss { background: rgb(236 72 153 / 12%); color: #be185d; }
+
+.scc-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--scc-muted);
+  font-size: var(--ease-text-sm, 0.875rem);
+  line-height: 1.65;
+}
+
+.scc-list li + li {
+  margin-top: 0.4rem;
+}
+
+.scc-snippet {
+  margin-bottom: 1rem;
+}
+
+.scc-snippet:last-child {
+  margin-bottom: 0;
+}
+
+.scc-snippet-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.scc-snippet-head span {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.scc-snippet pre {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--scc-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+}
+
+.scc-copy-feedback {
+  font-size: 0.7rem;
+  color: var(--scc-safe);
+  font-weight: 600;
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+.scc-definition {
+  font-family: var(--scc-mono);
+  font-size: 0.72rem;
+  line-height: 1.55;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.scc-footer {
+  text-align: center;
+  padding: 0 1.5rem 2.5rem;
+  color: var(--scc-muted);
+  font-size: 0.8rem;
+}
+
+.scc-footer code {
+  font-family: var(--scc-mono);
+  font-size: 0.72rem;
+}
+
+@media (max-width: 900px) {
+  .scc-policy-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .scc-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .scc-header h1 {
+    font-size: 1.45rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a docs guide on contribution suffix collisions when two people share the same initials (e.g. `ease-card-ak`)
- Focuses on collision cases and naming policy (distinct from the suffix generator)
- Includes risk checker, safer naming patterns (username / date / longer token), and per-track examples

## Test plan
-  Open `submissions/docs/ease-suffix-collision-cases-sp/demo.html`
- Score `card` + `ak` and confirm high collision risk
-  Try a longer/username-style suffix and confirm lower risk
-  Copy gallery paths and policy snippets
- Confirm only new files under `submissions/docs/ease-suffix-collision-cases-sp/`

Resolves #47725