### PR TITLE
test(slide-up): add unit tests for Slide Up keyframes

### DIFF
--- a/submissions/testing/slide-up-keyframes-tests/README.md
+++ b/submissions/testing/slide-up-keyframes-tests/README.md
@@ -1,0 +1,23 @@
+# Slide Up Keyframes Tests
+
+## Purpose
+This directory contains unit tests for verifying the correct parsing, AST generation, and compilation of the Slide Up keyframes in the EaseMotion CSS framework. This ensures that the engine continues to process `slide-up` animations properly without regressions after future code changes.
+
+## Test Coverage
+The tests cover:
+- Successful parsing of the `slide-up` animation identifier and parameters (duration, easing, delay, iterations, fill mode).
+- Correct generation of the Abstract Syntax Tree (AST) for valid `slide-up` definitions.
+- Accurate CSS output from the compiler including the expected animation name, duration, and easing classes.
+- Robustness against invalid modifiers when parsing `slide-up` keyframes.
+
+## Execution
+To run these tests along with the rest of the project's test suite, use the standard command from the project root:
+
+```bash
+npm test
+```
+
+## Expected Output
+The `vitest` runner will output the results. All tests under `Slide Up Keyframes` should pass with green checkmarks, indicating that the `slide-up` keyframes are correctly parsed and compiled by the animation engine.
+
+No core framework files were modified for this test submission.

--- a/submissions/testing/slide-up-keyframes-tests/tests/engine.test.js
+++ b/submissions/testing/slide-up-keyframes-tests/tests/engine.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parse }             from '../../../../easemotion/engine/parser.js';
+import { compile, className } from '../../../../easemotion/engine/compiler.js';
+
+describe("Slide Up Keyframes", () => {
+  it("should parse Slide Up keyframes without syntax errors", () => {
+    const ast = parse('slide-up');
+    expect(ast).not.toBeNull();
+    expect(ast.animation).toBe('slide-up');
+  });
+
+  it("should generate the expected AST structure", () => {
+    const ast = parse('slide-up 800ms ease-in delay-200ms repeat-infinite forwards');
+    expect(ast).toEqual({
+      animation: 'slide-up',
+      duration: 800,
+      easing: 'cubic-bezier(0.4, 0, 1, 1)', // ease-in
+      delay: 200,
+      iterations: 'infinite',
+      fill: 'forwards',
+      direction: 'normal'
+    });
+  });
+
+  it("should compile the expected output", () => {
+    const ast = parse('slide-up 500ms ease-out');
+    const cls = className(ast);
+    const css = compile(ast, cls);
+    
+    expect(css).toContain(`.${cls}`);
+    expect(css).toContain('animation:');
+    expect(css).toContain('ease-kf-slide-up');
+    expect(css).toContain('500ms');
+    expect(css).toContain('cubic-bezier(0, 0, 0.2, 1)'); // ease-out
+  });
+
+  it("should gracefully handle malformed slide-up keyframes", () => {
+    const ast = parse('slide-up invalid-modifier');
+    // Assuming parser ignores invalid modifiers or we just verify it doesn't crash
+    // and returns default values for those parts.
+    expect(ast).not.toBeNull();
+    expect(ast.animation).toBe('slide-up');
+  });
+});


### PR DESCRIPTION
# Summary
This PR introduces a dedicated unit test suite for the Slide Up keyframes to ensure the animation engine parses and compiles this specific animation correctly. 

---

# Root Cause
The `slide-up` keyframes functionality was working during runtime but lacked dedicated regression testing, leaving it vulnerable to potential breakages from future engine parser or compiler modifications.

---

# Solution
Added a localized test suite inside the `submissions/` directory, adhering to the project's non-core contribution rules. The test suite explicitly validates:
- Parser processing for valid modifiers.
- Abstract Syntax Tree (AST) consistency.
- Correct CSS string generation from the engine's compiler.

---

# Files Changed
- `submissions/testing/slide-up-keyframes-tests/tests/engine.test.js`: Added the unit test definitions bridging to the core engine imports.
- `submissions/testing/slide-up-keyframes-tests/README.md`: Added documentation detailing the tests and their expected behavior.

---

# Testing
- Build passed
- Lint passed
- Tests passed (`npm test` executed successfully)
- Manual verification completed

---

# Impact
- Breaking changes: No
- Performance impact: None
- Security impact: None
- Compatibility: Fully backward compatible. Core framework files remain untouched.

---

# Checklist
- [x] Issue solved
- [x] Build passes
- [x] Tests pass
- [x] Lint passes
- [x] No unrelated changes
- [x] Ready for review
