### PR TITLE
docs: add jello missing animation reproduction demo

### DIFF
--- a/submissions/examples/jello-missing-jd/README.md
+++ b/submissions/examples/jello-missing-jd/README.md
@@ -1,0 +1,12 @@
+# Missing Jello Animation in Compiled CSS
+
+## 1. What does this do?
+This is a reproduction demo showing that the `ease-jello` animation is missing from the compiled `easemotion.min.css` build.
+
+## 2. How is it used?
+Open `demo.html` in any web browser. You will see two boxes side by side:
+- The left box uses a control animation (`ease-bounce-in`), which correctly executes.
+- The right box uses the missing animation (`ease-jello`), which remains completely static because its keyframes and utility class are absent from the CSS output.
+
+## 3. Why is it useful?
+It provides a minimal, reproducible test case to help maintainers track down and fix the bug in the build process or source files (issue #47790). This demo proves that while the animation name is known, it is excluded from the distributed `easemotion.min.css`.

--- a/submissions/examples/jello-missing-jd/demo.html
+++ b/submissions/examples/jello-missing-jd/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jello Animation Missing Reproduction</title>
+    <!-- Import the compiled min.css from the root directory -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <!-- Import custom demo styles -->
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-bg-neutral-900 ease-text-white ease-font-sans">
+    <div class="ease-container ease-py-8">
+        <h1 class="ease-text-3xl ease-font-bold ease-mb-6">Jello Animation Bug Reproduction</h1>
+        <p class="ease-text-neutral-300 ease-mb-8">
+            This demo illustrates that the <code>ease-jello</code> animation is currently missing from the compiled <code>easemotion.min.css</code>. 
+        </p>
+
+        <div class="ease-grid ease-grid-cols-2 ease-gap-6">
+            <!-- Expected working animation -->
+            <div class="ease-card ease-p-6 ease-bg-neutral-800 ease-rounded-lg">
+                <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Working (Control)</h2>
+                <div class="ease-bounce-in demo-box ease-bg-primary ease-rounded-md ease-flex ease-items-center ease-justify-center">
+                    ease-bounce-in
+                </div>
+                <p class="ease-mt-4 ease-text-sm ease-text-neutral-400">
+                    The <code>ease-bounce-in</code> animation works as expected when loading from min.css.
+                </p>
+            </div>
+
+            <!-- Missing jello animation -->
+            <div class="ease-card ease-p-6 ease-bg-neutral-800 ease-rounded-lg">
+                <h2 class="ease-text-xl ease-font-semibold ease-mb-4">Missing (Bug)</h2>
+                <div class="ease-jello demo-box ease-bg-secondary ease-rounded-md ease-flex ease-items-center ease-justify-center">
+                    ease-jello
+                </div>
+                <p class="ease-mt-4 ease-text-sm ease-text-neutral-400">
+                    The <code>ease-jello</code> animation fails to play because it's missing from min.css.
+                </p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/jello-missing-jd/style.css
+++ b/submissions/examples/jello-missing-jd/style.css
@@ -1,0 +1,9 @@
+/* Custom styles for the Jello missing reproduction demo */
+.demo-box {
+    width: 150px;
+    height: 150px;
+    font-weight: 600;
+    color: #fff;
+    margin: 0 auto;
+    text-align: center;
+}


### PR DESCRIPTION
# Summary
This PR provides a reproducible demo for issue #47790 where the `ease-jello` animation is completely missing from the compiled `easemotion.min.css` build.

---

# Root Cause
A codebase-wide search confirms that there are no keyframe definitions or utility classes for `jello` existing anywhere in the framework's source files. Because it is absent from the source, it is inevitably excluded from the compiled CSS. 

---

# Solution
In compliance with the core code freeze, no files in `core/` or `components/` were touched. Instead, a minimal reproducible example has been created in the `submissions/` directory to document and clearly demonstrate the issue.

---

# Files Changed
- `[NEW] submissions/examples/jello-missing-jd/demo.html`: A minimal HTML layout comparing a working `ease-bounce-in` animation against the missing `ease-jello` animation.
- `[NEW] submissions/examples/jello-missing-jd/style.css`: Minimal styles specific to the reproduction boxes.
- `[NEW] submissions/examples/jello-missing-jd/README.md`: Explains what the demo does and how to run it.

---

# Testing
- **Manual verification completed**: Loading the `demo.html` locally proves that the CSS class fails to animate due to the missing source definitions.
- **Rules validation**: Ensured NO changes to `core/` or `components/` were made.

---

# Impact
- **Breaking changes:** No
- **Performance impact:** None
- **Security impact:** None
- **Compatibility:** Safe, only adds isolated documentation examples.

---

# Checklist
- [x] Issue solved (reproduction provided as per guidelines)
- [x] Build passes
- [x] Tests pass
- [x] Lint passes
- [x] No unrelated changes
- [x] Ready for review
