### PR TITLE
feat(examples): add sidebar focus state example

### DIFF
--- a/submissions/examples/sidebar-jd/README.md
+++ b/submissions/examples/sidebar-jd/README.md
@@ -1,0 +1,18 @@
+# Sidebar Focus State
+
+This example demonstrates an accessible, animated focus state for sidebar navigation items.
+
+## Usage
+
+```html
+<a href="#" class="sidebar-link">
+    <span class="icon">🏠</span>
+    <span class="text">Dashboard</span>
+</a>
+```
+
+The example uses standard HTML markup and applies custom CSS classes (`.sidebar-link`) that implement focus-visible styles. Use the `Tab` key to navigate through the links. 
+
+## Why is it useful?
+
+It provides clear visual feedback for keyboard users navigating a sidebar, enhancing accessibility (WCAG compliance) while maintaining a modern, animated aesthetic using transitions and transforms.

--- a/submissions/examples/sidebar-jd/demo.html
+++ b/submissions/examples/sidebar-jd/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sidebar Focus State Example - EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="app-container">
+        <aside class="sidebar">
+            <nav class="sidebar-nav">
+                <a href="#" class="sidebar-link">
+                    <span class="icon">🏠</span>
+                    <span class="text">Dashboard</span>
+                </a>
+                <a href="#" class="sidebar-link">
+                    <span class="icon">📊</span>
+                    <span class="text">Analytics</span>
+                </a>
+                <a href="#" class="sidebar-link">
+                    <span class="icon">⚙️</span>
+                    <span class="text">Settings</span>
+                </a>
+                <a href="#" class="sidebar-link">
+                    <span class="icon">👤</span>
+                    <span class="text">Profile</span>
+                </a>
+            </nav>
+        </aside>
+        <main class="main-content">
+            <h1>Sidebar Focus State</h1>
+            <p>Use the <strong>Tab</strong> key to navigate through the sidebar items and see the focus state transitions.</p>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/sidebar-jd/style.css
+++ b/submissions/examples/sidebar-jd/style.css
@@ -1,0 +1,110 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: #f4f4f5;
+    color: #18181b;
+}
+
+.app-container {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 250px;
+    background-color: #ffffff;
+    border-right: 1px solid #e4e4e7;
+    padding: 20px 10px;
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.sidebar-link {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    text-decoration: none;
+    color: #52525b;
+    border-radius: 8px;
+    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    outline: none;
+}
+
+.sidebar-link:hover {
+    background-color: #f4f4f5;
+    color: #18181b;
+}
+
+/* Focus State Implementation */
+.sidebar-link:focus-visible {
+    background-color: #f4f4f5;
+    color: #18181b;
+    transform: translateX(4px);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.5); /* Blue focus ring */
+    outline: 2px solid transparent;
+}
+
+.sidebar-link:active {
+    transform: scale(0.98);
+}
+
+.icon {
+    font-size: 1.25rem;
+}
+
+.text {
+    font-weight: 500;
+    font-size: 0.95rem;
+}
+
+.main-content {
+    flex: 1;
+    padding: 40px;
+}
+
+.main-content h1 {
+    margin-bottom: 16px;
+    font-size: 2rem;
+}
+
+.main-content p {
+    color: #52525b;
+    line-height: 1.5;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .app-container {
+        flex-direction: column;
+    }
+    .sidebar {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #e4e4e7;
+        padding: 10px;
+    }
+    .sidebar-nav {
+        flex-direction: row;
+        justify-content: space-around;
+    }
+    .sidebar-link {
+        flex-direction: column;
+        gap: 4px;
+        padding: 8px;
+    }
+    .sidebar-link:focus-visible {
+        transform: translateY(-4px);
+    }
+}


### PR DESCRIPTION
# Summary
This PR adds a new "Sidebar Focus State" example to the EaseMotion CSS library examples gallery to demonstrate accessible keyboard navigation.

---

# Root Cause
The repository needed a clear, self-contained example showing how to implement responsive, accessible focus states for sidebar navigation without relying on abrupt visual changes.

---

# Solution
Created a new self-contained example in `submissions/examples/sidebar-jd/` that implements a sidebar with focusable items. It uses `:focus-visible` to ensure focus rings are shown exclusively to keyboard users (via the Tab key). It incorporates smooth CSS transitions on `transform`, `background-color`, and `box-shadow` for an enhanced aesthetic.

---

# Files Changed
* `submissions/examples/sidebar-jd/demo.html` - Self-contained HTML demo.
* `submissions/examples/sidebar-jd/style.css` - Custom styling for sidebar layout and focus transitions.
* `submissions/examples/sidebar-jd/README.md` - Documentation explaining usage and accessibility benefits.

---

# Testing
* Manual verification completed in browser.
* Keyboard navigation verified (Tab / Shift + Tab).
* Responsive layout verified across mobile and desktop widths.
* Verified no core framework files were modified.

---

# Impact
* Breaking changes: No
* Performance impact: None (uses standard CSS transforms and transitions)
* Security impact: None
* Compatibility: Fully compatible with modern browsers (Chrome, Firefox, Safari, Edge)

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review

