### PR TITLE
feat: add navbar focus transition example

### DIFF
--- a/submissions/examples/ease-navbar-focus-transitions-adrika4/README.md
+++ b/submissions/examples/ease-navbar-focus-transitions-adrika4/README.md
@@ -1,0 +1,21 @@
+# Navbar Focus Transitions
+
+Adds smooth CSS transitions to navbar focus states for keyboard/assistive
+navigation, instead of abrupt instant changes.
+
+## Usage
+
+```html
+<nav class="ease-navbar">
+  <a href="#" class="navbar-item">Home</a>
+</nav>
+```
+
+Link the stylesheet — focus-visible states will transition smoothly
+over ~200ms while preserving accessible contrast and visible outlines.
+
+## Why it fits EaseMotion CSS
+
+Keeps accessibility (visible focus, WCAG contrast) while making
+interactions feel more polished and consistent with animation-first
+design.

--- a/submissions/examples/ease-navbar-focus-transitions-adrika4/demo.html
+++ b/submissions/examples/ease-navbar-focus-transitions-adrika4/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Navbar Focus Transitions</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="ease-navbar">
+    <a href="#" class="navbar-item">Home</a>
+    <a href="#" class="navbar-item">About</a>
+    <a href="#" class="navbar-item">Services</a>
+    <a href="#" class="navbar-item">Contact</a>
+  </nav>
+  <p style="margin-top:2rem; font-family:sans-serif;">
+    Use Tab to navigate the links above and see the smooth focus transition.
+  </p>
+</body>
+</html>

--- a/submissions/examples/ease-navbar-focus-transitions-adrika4/style.css
+++ b/submissions/examples/ease-navbar-focus-transitions-adrika4/style.css
@@ -1,0 +1,31 @@
+.ease-navbar {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  background: #111827;
+}
+
+.navbar-item {
+  color: #e5e7eb;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.navbar-item:hover {
+  background-color: #1f2937;
+}
+
+.navbar-item:focus-visible {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+  background-color: #1f2937;
+  color: #ffffff;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a standalone example demonstrating smooth CSS transitions for
navbar focus states, addressing abrupt/instant focus changes during
keyboard navigation. Implemented as a new example component under
`submissions/examples/ease-navbar-focus-transitions-adrika4/`.

Closes #47726

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-navbar-focus-transitions-adrika4/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Smooth (~200ms) CSS transitions on navbar link focus states — background color, text color, border color, and box-shadow — instead of instant/abrupt focus changes.

**How does a developer use it?**

```html
<nav class="ease-navbar">
  <a href="#" class="navbar-item">Home</a>
</nav>
```

**Why does it fit EaseMotion CSS?**

Keeps accessible, WCAG-compliant focus indicators visible while making the transition feel polished and consistent with the framework's animation-first philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

New standalone example — doesn't modify the actual project navbar/core files. Note: issue #47726 already has a linked PR (#47728) in progress; happy to close this one if that PR already covers it, or use this as an alternative implementation if useful.