### PR TITLE
feat: add incident response timeline demo

### DIFF
--- a/submissions/examples/incident-response-timeline-sm/README.md
+++ b/submissions/examples/incident-response-timeline-sm/README.md
@@ -1,0 +1,34 @@
+# Incident Response Timeline
+
+## What does this do?
+
+Incident Response Timeline is a self-contained HTML and CSS operations timeline that shows response phases with animated severity markers, ownership chips, progress rails, and review-friendly incident cards.
+
+## How is it used?
+
+Create a `response-panel` with a `timeline`, then add `timeline-item` entries with phase modifier classes such as `phase-detect`, `phase-triage`, `phase-contain`, or `phase-review`.
+
+```html
+<article class="timeline-item phase-contain">
+  <div class="timeline-marker" aria-hidden="true"></div>
+  <div class="timeline-card">
+    <div class="card-topline">
+      <p>Contain</p>
+      <span>08:38</span>
+    </div>
+    <h3>Import traffic throttled</h3>
+    <p>Background workers were rate-limited while checkout recovered.</p>
+  </div>
+</article>
+```
+
+Available phase classes:
+
+- `phase-detect`
+- `phase-triage`
+- `phase-contain`
+- `phase-review`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to clarify incident sequence and urgency: response items enter gently, the progress rail fills in order, severity markers pulse for attention, and hover states make each phase easier to inspect. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/incident-response-timeline-sm/demo.html
+++ b/submissions/examples/incident-response-timeline-sm/demo.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Incident Response Timeline Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="incident-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Incident Response Timeline</h1>
+        <p>
+          A self-contained operations timeline with animated severity markers,
+          response phases, ownership chips, and visible progress for incident
+          review workflows.
+        </p>
+      </section>
+
+      <section class="incident-summary" aria-label="Incident summary">
+        <article>
+          <span class="summary-value">24m</span>
+          <span class="summary-label">Time to contain</span>
+        </article>
+        <article>
+          <span class="summary-value">04</span>
+          <span class="summary-label">Teams involved</span>
+        </article>
+        <article>
+          <span class="summary-value">S2</span>
+          <span class="summary-label">Current severity</span>
+        </article>
+      </section>
+
+      <section class="response-panel" aria-label="Incident response timeline">
+        <header class="panel-header">
+          <div>
+            <p class="panel-kicker">Live Response</p>
+            <h2>Payment latency incident</h2>
+          </div>
+          <span class="status-pill">Contained</span>
+        </header>
+
+        <div class="timeline">
+          <article class="timeline-item phase-detect">
+            <div class="timeline-marker" aria-hidden="true"></div>
+            <div class="timeline-card">
+              <div class="card-topline">
+                <p>Detect</p>
+                <span>08:14</span>
+              </div>
+              <h3>Latency threshold breached</h3>
+              <p>
+                Checkout latency crossed the alert threshold across two regions
+                and triggered the incident response workflow.
+              </p>
+              <footer>
+                <span>Owner: Observability</span>
+                <span>Signal confirmed</span>
+              </footer>
+            </div>
+          </article>
+
+          <article class="timeline-item phase-triage">
+            <div class="timeline-marker" aria-hidden="true"></div>
+            <div class="timeline-card">
+              <div class="card-topline">
+                <p>Triage</p>
+                <span>08:22</span>
+              </div>
+              <h3>Database queue saturation isolated</h3>
+              <p>
+                The response team traced the slowdown to a queue spike after a
+                scheduled import job expanded beyond normal volume.
+              </p>
+              <footer>
+                <span>Owner: Platform</span>
+                <span>Root cause likely</span>
+              </footer>
+            </div>
+          </article>
+
+          <article class="timeline-item phase-contain">
+            <div class="timeline-marker" aria-hidden="true"></div>
+            <div class="timeline-card">
+              <div class="card-topline">
+                <p>Contain</p>
+                <span>08:38</span>
+              </div>
+              <h3>Import traffic throttled</h3>
+              <p>
+                Background import workers were rate-limited while checkout
+                requests received priority routing until latency recovered.
+              </p>
+              <footer>
+                <span>Owner: Reliability</span>
+                <span>Customer impact reduced</span>
+              </footer>
+            </div>
+          </article>
+
+          <article class="timeline-item phase-review">
+            <div class="timeline-marker" aria-hidden="true"></div>
+            <div class="timeline-card">
+              <div class="card-topline">
+                <p>Review</p>
+                <span>Next</span>
+              </div>
+              <h3>Post-incident notes queued</h3>
+              <p>
+                Action items include import guardrails, earlier saturation
+                alerts, and a rollback checklist for high-volume batch jobs.
+              </p>
+              <footer>
+                <span>Owner: Incident lead</span>
+                <span>Follow-up open</span>
+              </footer>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/incident-response-timeline-sm/style.css
+++ b/submissions/examples/incident-response-timeline-sm/style.css
@@ -1,0 +1,393 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.incident-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.panel-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.incident-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.incident-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.response-panel {
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+  padding: 22px;
+}
+
+.panel-header h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 11px;
+  border-radius: 999px;
+  color: var(--green);
+  background: rgba(22, 163, 74, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.status-pill::before {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  content: "";
+  background: currentColor;
+  box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.2);
+  animation: status-pulse 1.6s ease-out infinite;
+}
+
+.timeline {
+  position: relative;
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+}
+
+.timeline::before {
+  position: absolute;
+  top: 38px;
+  bottom: 38px;
+  left: 39px;
+  width: 4px;
+  border-radius: 999px;
+  content: "";
+  background: #e7eef8;
+}
+
+.timeline::after {
+  position: absolute;
+  top: 38px;
+  left: 39px;
+  width: 4px;
+  height: calc(100% - 76px);
+  border-radius: 999px;
+  content: "";
+  background: linear-gradient(
+    180deg,
+    var(--red),
+    var(--amber),
+    var(--blue),
+    var(--green)
+  );
+  transform-origin: top;
+  animation: rail-fill 1.05s 180ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.timeline-item {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 16px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: item-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.timeline-item:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.timeline-item:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.timeline-item:nth-child(4) {
+  animation-delay: 270ms;
+}
+
+.timeline-marker {
+  width: 36px;
+  height: 36px;
+  border: 5px solid #ffffff;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 12px 24px var(--accent-soft);
+  animation: marker-pulse 2.2s ease-out infinite;
+}
+
+.timeline-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 18px;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.timeline-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 16px 34px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.card-topline p {
+  margin-bottom: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.card-topline span,
+.timeline-card footer span {
+  display: inline-flex;
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 850;
+}
+
+.timeline-card h3 {
+  margin-bottom: 8px;
+  font-size: 1.08rem;
+  line-height: 1.25;
+}
+
+.timeline-card > p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.timeline-card footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.phase-detect {
+  --accent: var(--red);
+  --accent-soft: rgba(220, 38, 38, 0.13);
+}
+
+.phase-triage {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.14);
+}
+
+.phase-contain {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.13);
+}
+
+.phase-review {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.13);
+}
+
+@keyframes item-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes rail-fill {
+  from {
+    transform: scaleY(0);
+  }
+
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes marker-pulse {
+  0% {
+    box-shadow:
+      0 0 0 0 var(--accent-soft),
+      0 12px 24px var(--accent-soft);
+  }
+
+  70% {
+    box-shadow:
+      0 0 0 12px rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+}
+
+@keyframes status-pulse {
+  70% {
+    box-shadow: 0 0 0 10px rgba(22, 163, 74, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(22, 163, 74, 0);
+  }
+}
+
+@media (max-width: 720px) {
+  .incident-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .incident-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-header {
+    flex-direction: column;
+  }
+
+  .timeline {
+    padding: 18px;
+  }
+
+  .timeline::before,
+  .timeline::after {
+    left: 34px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #47806


**PR Text**

Title: `feat: add incident response timeline demo`

```md
## Pull Request Description
Adds a self-contained Incident Response Timeline demo under `submissions/examples/`, featuring animated response phases, severity markers, ownership chips, and a progress rail.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only incident response timeline pattern for operations and reliability dashboards.

**How does a developer use it?**
Use a `response-panel` with `timeline-item` entries and phase classes like `phase-detect`, `phase-triage`, `phase-contain`, or `phase-review`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate sequence, severity, and active response state while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The phase naming, severity colors, and timing can be standardized during framework integration.