### PR TITLE
feat: add permission scope ladder demo

### DIFF
--- a/submissions/examples/permission-scope-ladder-sm/README.md
+++ b/submissions/examples/permission-scope-ladder-sm/README.md
@@ -1,0 +1,5 @@
+# Permission Scope Ladder
+
+1. What does this do? Adds responsive permission cards with animated scope ladder levels, risk tone colors, staggered card entry, and hover or focus feedback.
+2. How is it used? Apply `.scope-grid` to the wrapper and use `.scope-card` with tone classes like `.safe-scope`, `.review-scope`, or `.admin-scope` for each permission level.
+3. Why is it useful? It makes access review states easier to compare with purposeful CSS-only motion and keyboard-friendly focus treatment.

--- a/submissions/examples/permission-scope-ladder-sm/demo.html
+++ b/submissions/examples/permission-scope-ladder-sm/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Permission Scope Ladder</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="scope-panel" aria-labelledby="scope-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Access review</p>
+        <h1 id="scope-title">Permission scope ladders with animated levels</h1>
+        <p>
+          Compare access levels with stacked scope ladders, animated level bars, and clear hover or
+          keyboard focus emphasis for review workflows.
+        </p>
+      </div>
+
+      <div class="scope-grid" aria-label="Permission scope cards">
+        <article class="scope-card safe-scope" tabindex="0">
+          <span class="scope-label">Viewer</span>
+          <h2>Read-only workspace</h2>
+          <p>Can inspect dashboards, export snapshots, and comment on motion review notes.</p>
+          <div class="ladder" aria-hidden="true">
+            <span class="step filled"></span>
+            <span class="step"></span>
+            <span class="step"></span>
+            <span class="step"></span>
+          </div>
+          <div class="scope-meta">
+            <span>Low risk</span>
+            <strong>1/4 scope</strong>
+          </div>
+        </article>
+
+        <article class="scope-card review-scope" tabindex="0">
+          <span class="scope-label">Editor</span>
+          <h2>Pattern maintainer</h2>
+          <p>Can update examples, tune animation timings, and prepare submissions for review.</p>
+          <div class="ladder" aria-hidden="true">
+            <span class="step filled"></span>
+            <span class="step filled"></span>
+            <span class="step filled"></span>
+            <span class="step"></span>
+          </div>
+          <div class="scope-meta">
+            <span>Review needed</span>
+            <strong>3/4 scope</strong>
+          </div>
+        </article>
+
+        <article class="scope-card admin-scope" tabindex="0">
+          <span class="scope-label">Admin</span>
+          <h2>Release controller</h2>
+          <p>Can approve publishing, manage tokens, and coordinate release-critical motion changes.</p>
+          <div class="ladder" aria-hidden="true">
+            <span class="step filled"></span>
+            <span class="step filled"></span>
+            <span class="step filled"></span>
+            <span class="step filled"></span>
+          </div>
+          <div class="scope-meta">
+            <span>High trust</span>
+            <strong>4/4 scope</strong>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/permission-scope-ladder-sm/style.css
+++ b/submissions/examples/permission-scope-ladder-sm/style.css
@@ -1,0 +1,287 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --safe: #147b5a;
+  --safe-soft: #e8f7ef;
+  --review: #a95d00;
+  --review-soft: #fff5e5;
+  --admin: #b4237a;
+  --admin-soft: #fdebf5;
+  --empty: #e8edf4;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(20, 123, 90, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 82%, rgba(180, 35, 122, 0.11), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.scope-panel {
+  width: min(100%, 1060px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--safe);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.scope-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.scope-card {
+  --tone: var(--safe);
+  --tone-soft: var(--safe-soft);
+  position: relative;
+  overflow: hidden;
+  min-height: 25rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1.2rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  animation: scope-enter 580ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.scope-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--tone-soft), transparent 62%);
+  opacity: 0.78;
+}
+
+.scope-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.scope-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.scope-card:hover,
+.scope-card:focus-visible {
+  border-color: color-mix(in srgb, var(--tone) 42%, var(--line));
+  box-shadow: var(--shadow);
+  transform: translateY(-5px);
+}
+
+.scope-card:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  outline-offset: 5px;
+}
+
+.safe-scope {
+  --tone: var(--safe);
+  --tone-soft: var(--safe-soft);
+}
+
+.review-scope {
+  --tone: var(--review);
+  --tone-soft: var(--review-soft);
+}
+
+.admin-scope {
+  --tone: var(--admin);
+  --tone-soft: var(--admin-soft);
+}
+
+.scope-label,
+.scope-card h2,
+.scope-card p,
+.ladder,
+.scope-meta {
+  position: relative;
+  z-index: 1;
+}
+
+.scope-label {
+  display: inline-flex;
+  margin-bottom: 0.8rem;
+  border-radius: 999px;
+  padding: 0.32rem 0.72rem;
+  color: var(--tone);
+  background: color-mix(in srgb, var(--tone-soft) 78%, #ffffff);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.scope-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.scope-card p {
+  min-height: 5rem;
+  margin: 0.75rem 0 1.1rem;
+  color: var(--muted);
+  line-height: 1.58;
+}
+
+.ladder {
+  display: grid;
+  gap: 0.55rem;
+  margin: 1.1rem 0;
+}
+
+.step {
+  display: block;
+  height: 0.78rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--empty);
+}
+
+.step::before {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--tone);
+  transform: scaleX(0);
+  transform-origin: left center;
+}
+
+.filled::before {
+  animation: ladder-fill 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.step:nth-child(2)::before {
+  animation-delay: 110ms;
+}
+
+.step:nth-child(3)::before {
+  animation-delay: 220ms;
+}
+
+.step:nth-child(4)::before {
+  animation-delay: 330ms;
+}
+
+.scope-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--line);
+  padding-top: 1rem;
+}
+
+.scope-meta span {
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.scope-meta strong {
+  color: var(--tone);
+  font-size: 1.02rem;
+}
+
+@keyframes scope-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ladder-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .scope-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .scope-card {
+    min-height: auto;
+  }
+
+  .scope-card p {
+    min-height: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scope-card,
+  .filled::before {
+    animation: none;
+    transition: none;
+  }
+
+  .filled::before {
+    transform: scaleX(1);
+  }
+
+  .scope-card:hover,
+  .scope-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #47810

## Pull Request Description

Adds a self-contained Permission Scope Ladder demo with responsive permission cards, animated scope levels, risk tone colors, staggered card entry, hover/focus feedback, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Responsive permission cards with animated scope ladder levels, access-risk color states, staggered card entry, and hover/focus motion feedback.

**How does a developer use it?**

```html
<div class="scope-grid">
  <article class="scope-card review-scope" tabindex="0">
    <span class="scope-label">Editor</span>
    <h2>Pattern maintainer</h2>
    <p>Can update examples, tune animation timings, and prepare submissions for review.</p>
    <div class="ladder" aria-hidden="true">
      <span class="step filled"></span>
      <span class="step filled"></span>
      <span class="step filled"></span>
      <span class="step"></span>
    </div>
  </article>
</div>