### PR TITLE
Enhancement: Add CSS Staggered Entrance Tooltip for Product Catalog Layouts (Fixes #46271)

### DIFF
--- a/submissions/examples/staggered-entrance-tooltip/README.md
+++ b/submissions/examples/staggered-entrance-tooltip/README.md
@@ -1,0 +1,14 @@
+# Staggered Entrance Tooltip
+
+A pure CSS animated **Tooltip** utilizing a smooth **Staggered Entrance** interaction transition, styled to complement **Product Catalog** interface aesthetics.
+
+## Features
+- **Zero JavaScript**: Pure CSS implementation using `:hover`, `:focus-within`, and staggered `transition-delay`.
+- **Keyboard Accessible**: Tabbing into the container triggers the staggered entrance animation naturally.
+- **Customizable**: Exposes CSS custom parameters to tweak timing and easing.
+
+## Custom Properties
+Override these in your stylesheet to customize the animation:
+- `--tooltip-transition-speed`: Base transition speed (default `0.4s`).
+- `--tooltip-stagger-delay`: Delay increment between each item (default `0.05s`).
+- `--tooltip-ease`: Easing function for the animations.

--- a/submissions/examples/staggered-entrance-tooltip/demo.html
+++ b/submissions/examples/staggered-entrance-tooltip/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — Staggered Entrance Tooltip</title>
+  
+  <link rel="stylesheet" href="./style.css">
+  
+  <style>
+    body {
+      background-color: #0f172a;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      padding: 1rem;
+    }
+    .catalog-grid {
+      display: flex;
+      gap: 2rem;
+      width: 100%;
+      max-width: 600px;
+      justify-content: center;
+    }
+    .product-card {
+      background: #1e293b;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      border-radius: 1rem;
+      padding: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+    }
+    .product-img {
+      width: 120px;
+      height: 120px;
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 0.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 3rem;
+    }
+    .action-btn {
+      background: #3b82f6;
+      border: none;
+      color: white;
+      padding: 0.5rem 1rem;
+      border-radius: 0.5rem;
+      font-weight: 600;
+      cursor: pointer;
+      font-family: system-ui, sans-serif;
+      font-size: 0.875rem;
+      transition: background 0.2s ease;
+    }
+    .action-btn:hover {
+      background: #2563eb;
+    }
+    .tooltip-header {
+      font-weight: 700;
+      font-size: 0.95rem;
+      margin-bottom: 0.25rem;
+      color: #fff;
+    }
+    .tooltip-desc {
+      color: #94a3b8;
+      font-size: 0.8rem;
+      margin-bottom: 0.5rem;
+    }
+    .tooltip-price {
+      color: #10b981;
+      font-weight: 600;
+      font-size: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <header style="text-align: center; max-width: 600px; margin-bottom: 3.5rem;">
+    <h1 style="color: white; margin: 0; font-size: 1.75rem; font-weight: 700;">Staggered Entrance Tooltip</h1>
+    <p style="color: #64748b; margin: 8px 0 0 0; font-size: 0.95rem;">Hover over the "Quick View" buttons below. A pure CSS tooltip will appear, animating its internal elements with a staggered sequence tailored for Product Catalog aesthetics.</p>
+  </header>
+
+  <div class="catalog-grid">
+    
+    <div class="product-card">
+      <div class="product-img">🎧</div>
+      <div class="tooltip-container">
+        <button class="action-btn" aria-haspopup="true" aria-expanded="false">
+          Quick View
+        </button>
+
+        <div class="tooltip-content" role="tooltip">
+          <div class="stagger-item tooltip-header">Studio Pro Headphones</div>
+          <div class="stagger-item tooltip-desc">Noise cancelling, 30hr battery life, spatial audio support.</div>
+          <div class="stagger-item tooltip-price">$299.00</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="product-card">
+      <div class="product-img">⌚</div>
+      <div class="tooltip-container">
+        <button class="action-btn" aria-haspopup="true" aria-expanded="false">
+          Quick View
+        </button>
+
+        <div class="tooltip-content" role="tooltip">
+          <div class="stagger-item tooltip-header">Fitness Smartwatch</div>
+          <div class="stagger-item tooltip-desc">Heart rate monitor, GPS, water resistant up to 50m.</div>
+          <div class="stagger-item tooltip-price">$199.00</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/staggered-entrance-tooltip/style.css
+++ b/submissions/examples/staggered-entrance-tooltip/style.css
@@ -1,0 +1,101 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — staggered-entrance-tooltip/style.css
+   ============================================================ */
+
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+/* ── Tooltip Custom Properties ───────────────────────────── */
+:root {
+  --tooltip-transition-speed: 0.4s;
+  --tooltip-stagger-delay: 0.05s;
+  --tooltip-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── Tooltip Container ───────────────────────────────────── */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+}
+
+/* ── The Tooltip Frame ────────────────────────────────────── */
+.tooltip-content {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(10px);
+  background: var(--ease-color-dark, #1e293b);
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.1));
+  color: var(--ease-color-text, #f8fafc);
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  font-size: 0.875rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  width: max-content;
+  max-width: 250px;
+  
+  /* Initial hidden state */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  
+  /* Container transition */
+  transition: 
+    opacity var(--tooltip-transition-speed) var(--tooltip-ease),
+    transform var(--tooltip-transition-speed) var(--tooltip-ease),
+    visibility var(--tooltip-transition-speed) var(--tooltip-ease);
+}
+
+/* ── The Pointer Arrow ────────────────────────────────────── */
+.tooltip-content::after {
+  content: "";
+  position: absolute;
+  top: 100%; 
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px 6px 0 6px;
+  border-style: solid;
+  border-color: var(--ease-color-dark, #1e293b) transparent transparent transparent;
+}
+
+/* ── Staggered Children Setup ─────────────────────────────── */
+.tooltip-content .stagger-item {
+  opacity: 0;
+  transform: translateY(10px);
+  transition: 
+    opacity var(--tooltip-transition-speed) var(--tooltip-ease),
+    transform var(--tooltip-transition-speed) var(--tooltip-ease);
+}
+
+/* ── Stagger Delays (Entrance) ────────────────────────────── */
+.tooltip-container:hover .tooltip-content .stagger-item:nth-child(1),
+.tooltip-container:focus-within .tooltip-content .stagger-item:nth-child(1) {
+  transition-delay: calc(var(--tooltip-stagger-delay) * 1);
+}
+
+.tooltip-container:hover .tooltip-content .stagger-item:nth-child(2),
+.tooltip-container:focus-within .tooltip-content .stagger-item:nth-child(2) {
+  transition-delay: calc(var(--tooltip-stagger-delay) * 2);
+}
+
+.tooltip-container:hover .tooltip-content .stagger-item:nth-child(3),
+.tooltip-container:focus-within .tooltip-content .stagger-item:nth-child(3) {
+  transition-delay: calc(var(--tooltip-stagger-delay) * 3);
+}
+
+/* ── Interactive Active Hover & Focus Lifecycles ─────────── */
+.tooltip-container:hover .tooltip-content,
+.tooltip-container:focus-within .tooltip-content {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+
+.tooltip-container:hover .tooltip-content .stagger-item,
+.tooltip-container:focus-within .tooltip-content .stagger-item {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves #46271 by adding a `staggered-entrance-tooltip` component to the examples library. It introduces a pure CSS tooltip that smoothly staggers the entrance of its internal content using `transition-delay`. It's specifically tailored and styled for dark-mode Product Catalog interface aesthetics.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS animated tooltip that utilizes a smooth Staggered Entrance sequence for its internal children.

**How does a developer use it?**

```html
<div class="tooltip-container">
  <button class="action-btn" aria-haspopup="true" aria-expanded="false">
    Quick View
  </button>

  <div class="tooltip-content" role="tooltip">
    <div class="stagger-item">Item 1</div>
    <div class="stagger-item">Item 2</div>
    <div class="stagger-item">Item 3</div>
  </div>
</div>
