### PR TITLE
feat: add tada-click popover for dashboard layouts

### DIFF
--- a/submissions/examples/tada-click-popover/README.md
+++ b/submissions/examples/tada-click-popover/README.md
@@ -1,0 +1,46 @@
+# Tada-Click Popover
+
+A pure CSS popover with a snappy "tada" bounce on open — zero JavaScript,
+built on native `<details>`/`<summary>` for real keyboard accessibility.
+
+## Why `<details>`/`<summary>`?
+
+Instead of a checkbox hack or `:target`, this uses the browser's native
+disclosure widget. That means `Tab`, `Enter`/`Space`, and screen-reader
+semantics work out of the box — no `aria-*` attributes or JS needed to
+wire up accessibility.
+
+## Usage
+
+```html
+<details class="tada-pop">
+  <summary class="tada-pop__trigger">Open</summary>
+  <div class="tada-pop__panel">
+    <p class="tada-pop__title">Title</p>
+    <p class="tada-pop__body">Content goes here.</p>
+  </div>
+</details>
+```
+
+## Custom properties
+
+| Property             | Default                             | Description                          |
+|-----------------------|--------------------------------------|---------------------------------------|
+| `--tada-duration`      | `480ms`                              | Length of the open animation          |
+| `--tada-easing`        | `cubic-bezier(.34, 1.56, .64, 1)`    | Overshoot/bounce curve                |
+| `--tada-scale`         | `1.06`                               | Peak scale during the bounce          |
+| `--tada-rotate`        | `2deg`                               | Wobble rotation during the bounce     |
+| `--popover-gap`        | `12px`                               | Space between trigger and panel       |
+| `--popover-width`      | `280px`                              | Panel width                           |
+| `--popover-accent`     | `var(--gauge-amber)`                 | Accent color for trigger/actions      |
+
+## Accessibility
+
+- Fully keyboard operable via native `<details>` semantics.
+- Respects `prefers-reduced-motion` (animation is disabled, panel appears instantly).
+- Visible focus ring on the trigger via `:focus-visible`.
+
+## Browser support
+
+Works in all evergreen browsers. `<details>` animation support in older
+Safari versions may vary — test on your minimum supported version.

--- a/submissions/examples/tada-click-popover/demo.html
+++ b/submissions/examples/tada-click-popover/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tada-Click Popover</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="board">
+  <p class="board__eyebrow">EaseMotion / examples</p>
+  <h1 class="board__title">Responsive Dashboard <span>— Tada-Click Popover</span></h1>
+
+  <div class="grid">
+
+    <div class="card">
+      <p class="card__label">API latency</p>
+      <p class="card__value ok">118ms</p>
+      <details class="tada-pop">
+        <summary class="tada-pop__trigger">details</summary>
+        <div class="tada-pop__panel">
+          <p class="tada-pop__title">p95 breakdown</p>
+          <p class="tada-pop__body">Edge routing accounts for 40ms of this figure; the remainder is origin compute.</p>
+          <div class="tada-pop__actions">
+            <button class="primary">View trace</button>
+            <button class="ghost">Dismiss</button>
+          </div>
+        </div>
+      </details>
+    </div>
+
+    <div class="card">
+      <p class="card__label">Error rate</p>
+      <p class="card__value warn">2.3%</p>
+      <details class="tada-pop">
+        <summary class="tada-pop__trigger">details</summary>
+        <div class="tada-pop__panel">
+          <p class="tada-pop__title">Above threshold</p>
+          <p class="tada-pop__body">Rate has been climbing for 12 minutes. Most failures originate from the checkout service.</p>
+          <div class="tada-pop__actions">
+            <button class="primary">Open alert</button>
+            <button class="ghost">Snooze</button>
+          </div>
+        </div>
+      </details>
+    </div>
+
+    <div class="card">
+      <p class="card__label">Active sessions</p>
+      <p class="card__value ok">4,812</p>
+      <details class="tada-pop">
+        <summary class="tada-pop__trigger">details</summary>
+        <div class="tada-pop__panel">
+          <p class="tada-pop__title">Session mix</p>
+          <p class="tada-pop__body">62% mobile, 38% desktop. Distribution is stable against yesterday's baseline.</p>
+          <div class="tada-pop__actions">
+            <button class="primary">Segment</button>
+            <button class="ghost">Dismiss</button>
+          </div>
+        </div>
+      </details>
+    </div>
+
+  </div>
+
+  <p class="footnote">
+    Click, tap, or focus + <code>Enter</code>/<code>Space</code> a "details" trigger to open its popover.
+    Tune the motion globally or per-instance via <code>--tada-duration</code>, <code>--tada-easing</code>,
+    <code>--tada-scale</code>, <code>--tada-rotate</code>, and layout via <code>--popover-gap</code> /
+    <code>--popover-width</code>.
+  </p>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/tada-click-popover/style.css
+++ b/submissions/examples/tada-click-popover/style.css
@@ -1,0 +1,206 @@
+:root{
+  --panel-bg: #14171c;
+  --panel-grid: #1d2129;
+  --card-bg: #1a1e25;
+  --card-border: #2a2f3a;
+  --ink: #e8ebf0;
+  --ink-dim: #8992a3;
+  --gauge-amber: #ffb454;
+  --ok-green: #5fd4a0;
+
+  /* ---- public API: consumers override these ---- */
+  --tada-duration: 480ms;
+  --tada-easing: cubic-bezier(.34, 1.56, .64, 1);
+  --tada-scale: 1.06;
+  --tada-rotate: 2deg;
+  --popover-gap: 12px;
+  --popover-width: 280px;
+  --popover-accent: var(--gauge-amber);
+}
+
+*{ box-sizing:border-box; }
+html,body{ height:100%; }
+body{
+  margin:0;
+  min-height:100vh;
+  background:
+    radial-gradient(circle at 1px 1px, var(--panel-grid) 1px, transparent 0) 0 0/22px 22px,
+    var(--panel-bg);
+  color:var(--ink);
+  font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:48px 20px;
+}
+
+.board{ width:min(920px, 100%); }
+.board__eyebrow{
+  color:var(--gauge-amber);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+  margin:0 0 6px;
+}
+.board__title{
+  font-size:22px;
+  margin:0 0 28px;
+  color:var(--ink);
+  font-weight:600;
+}
+.board__title span{ color:var(--ink-dim); font-weight:400; }
+
+.grid{
+  display:grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap:16px;
+}
+@media (max-width: 720px){
+  .grid{ grid-template-columns: 1fr; }
+}
+
+.card{
+  background:var(--card-bg);
+  border:1px solid var(--card-border);
+  border-radius:10px;
+  padding:18px;
+  position:relative;
+}
+.card__label{
+  font-size:11px;
+  letter-spacing:.1em;
+  text-transform:uppercase;
+  color:var(--ink-dim);
+  margin:0 0 10px;
+}
+.card__value{
+  font-size:28px;
+  font-weight:600;
+  margin:0 0 14px;
+}
+.card__value.ok{ color:var(--ok-green); }
+.card__value.warn{ color:var(--gauge-amber); }
+
+/* ============ TADA-CLICK POPOVER ============ */
+
+.tada-pop{
+  position:relative;
+  display:inline-block;
+}
+
+.tada-pop__trigger{
+  all:unset;
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font: inherit;
+  font-size:12px;
+  color:var(--popover-accent);
+  border:1px solid color-mix(in srgb, var(--popover-accent) 40%, transparent);
+  background:color-mix(in srgb, var(--popover-accent) 8%, transparent);
+  padding:6px 10px;
+  border-radius:6px;
+  transition: background 150ms ease, border-color 150ms ease;
+  list-style:none;
+}
+.tada-pop__trigger::-webkit-details-marker{ display:none; }
+.tada-pop__trigger:hover{
+  background:color-mix(in srgb, var(--popover-accent) 16%, transparent);
+}
+.tada-pop__trigger:focus-visible{
+  outline: 2px solid var(--popover-accent);
+  outline-offset: 2px;
+}
+.tada-pop__trigger::before{
+  content:"";
+  width:6px; height:6px; border-radius:50%;
+  background:var(--popover-accent);
+  box-shadow:0 0 0 3px color-mix(in srgb, var(--popover-accent) 25%, transparent);
+}
+
+.tada-pop__panel{
+  position:absolute;
+  top:calc(100% + var(--popover-gap));
+  left:0;
+  width:var(--popover-width);
+  background:var(--card-bg);
+  border:1px solid var(--card-border);
+  border-radius:10px;
+  padding:14px;
+  box-shadow: 0 12px 28px rgba(0,0,0,.45);
+  z-index:20;
+  transform-origin: 12px -6px;
+}
+
+@keyframes tada-click{
+  0%   { transform: scale(.85) rotate(0deg); opacity:0; }
+  45%  { transform: scale(var(--tada-scale)) rotate(calc(var(--tada-rotate) * -1)); opacity:1; }
+  70%  { transform: scale(.98) rotate(var(--tada-rotate)); }
+  100% { transform: scale(1) rotate(0deg); }
+}
+
+.tada-pop[open] .tada-pop__panel{
+  animation: tada-click var(--tada-duration) var(--tada-easing) both;
+}
+
+@media (prefers-reduced-motion: reduce){
+  .tada-pop[open] .tada-pop__panel{ animation: none; }
+}
+
+.tada-pop__panel::before{
+  content:"";
+  position:absolute;
+  top:-6px; left:14px;
+  width:11px; height:11px;
+  background:var(--card-bg);
+  border-left:1px solid var(--card-border);
+  border-top:1px solid var(--card-border);
+  transform:rotate(45deg);
+}
+
+.tada-pop__title{
+  font-size:12px;
+  font-weight:600;
+  margin:0 0 6px;
+  color:var(--ink);
+}
+.tada-pop__body{
+  font-size:12px;
+  line-height:1.5;
+  color:var(--ink-dim);
+  margin:0 0 12px;
+}
+.tada-pop__actions{
+  display:flex;
+  gap:8px;
+}
+.tada-pop__actions button{
+  all:unset;
+  cursor:pointer;
+  font-size:11px;
+  padding:6px 10px;
+  border-radius:6px;
+}
+.tada-pop__actions .primary{
+  background:var(--popover-accent);
+  color:#1a1400;
+  font-weight:600;
+}
+.tada-pop__actions .ghost{
+  color:var(--ink-dim);
+  border:1px solid var(--card-border);
+}
+
+.footnote{
+  margin-top:28px;
+  font-size:11px;
+  color:var(--ink-dim);
+  line-height:1.6;
+}
+.footnote code{
+  color:var(--gauge-amber);
+  background:color-mix(in srgb, var(--gauge-amber) 10%, transparent);
+  padding:1px 5px;
+  border-radius:4px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS "Tada-Click" popover styled for responsive dashboard layouts. Built on native `<details>`/`<summary>` instead of a checkbox hack, so it's keyboard accessible with zero JavaScript. On open, the panel plays a quick "tada" bounce (scale + slight rotate wobble) driven entirely by CSS custom properties, so consumers can retune the motion without touching the animation code.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/tada-click-popover/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A responsive, pure-CSS popover component with a "tada" bounce-in animation on open, designed for dashboard-style UIs.

**How does a developer use it?**

```html
<details class="tada-pop">
  <summary class="tada-pop__trigger">Open</summary>
  <div class="tada-pop__panel">
    <p class="tada-pop__title">Title</p>
    <p class="tada-pop__body">Content goes here.</p>
  </div>
</details>
```

**Why does it fit EaseMotion CSS?**

It's animation-first and human-readable: the entire interaction (open/close state, bounce timing, easing, scale) is expressed in plain CSS with no JS dependency, and every motion parameter is exposed as a documented custom property (`--tada-duration`, `--tada-easing`, `--tada-scale`, `--tada-rotate`, `--popover-gap`, `--popover-width`) so consumers can retheme it without editing the component's internals.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari

---

## Notes for Maintainer

Uses native `<details>`/`<summary>` rather than a checkbox/`:target` hack for built-in keyboard accessibility and screen-reader semantics without extra ARIA. Respects `prefers-reduced-motion`. Open to adjusting the default timing/easing values if they don't match the rest of the library's motion language.