### PR TITLE
feat: add slide-right popover for Neumorphic Soft layouts (#46603)

### DIFF
--- a/submissions/examples/slide-right-popover-neumorphic-soft/README.md
+++ b/submissions/examples/slide-right-popover-neumorphic-soft/README.md
@@ -1,0 +1,25 @@
+# Slide Right Popover - Neumorphic Soft Layouts
+
+A pure CSS animated Slide-Right Popover component designed for Neumorphic Soft UI interfaces.
+
+## Features
+
+- Smooth slide-right animation
+- Neumorphic soft shadow design
+- Pure CSS implementation
+- Responsive layout support
+- Keyboard focus accessibility
+- Custom CSS animation variables
+- No JavaScript required
+
+
+## Usage
+
+```html
+<button class="neo-button">
+  View Report
+
+  <div class="popover">
+    Dashboard information
+  </div>
+</button>

--- a/submissions/examples/slide-right-popover-neumorphic-soft/demo.html
+++ b/submissions/examples/slide-right-popover-neumorphic-soft/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic Slide Right Popover</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <section class="container">
+
+    <h1>Neumorphic Dashboard</h1>
+
+    <div class="card">
+
+      <h2>Analytics</h2>
+      <p>Track your latest performance data.</p>
+
+      <button class="neo-button">
+        View Report
+
+        <div class="popover">
+          <h3>Monthly Analytics</h3>
+          <p>
+            Your engagement increased by 24% this month.
+          </p>
+        </div>
+
+      </button>
+
+    </div>
+
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/slide-right-popover-neumorphic-soft/style.css
+++ b/submissions/examples/slide-right-popover-neumorphic-soft/style.css
@@ -1,0 +1,180 @@
+:root {
+    --popover-duration: 0.45s;
+    --popover-distance: 35px;
+    --popover-easing: cubic-bezier(.25,.8,.25,1);
+    --popover-width: 260px;
+  }
+  
+  
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  
+  
+  body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  
+    font-family: Arial, sans-serif;
+  
+    background: #e0e5ec;
+  }
+  
+  
+  .container {
+    width: min(90%, 600px);
+  }
+  
+  
+  .container h1 {
+    margin-bottom: 30px;
+    color: #333;
+  }
+  
+  
+  .card {
+    padding: 35px;
+    border-radius: 25px;
+  
+    background: #e0e5ec;
+  
+    box-shadow:
+      10px 10px 20px #b8bec7,
+      -10px -10px 20px #ffffff;
+  }
+  
+  
+  .card h2 {
+    margin-bottom: 12px;
+  }
+  
+  
+  .neo-button {
+  
+    position: relative;
+  
+    margin-top: 25px;
+  
+    padding: 14px 25px;
+  
+    border: none;
+    border-radius: 15px;
+  
+    cursor: pointer;
+  
+    background: #e0e5ec;
+  
+    box-shadow:
+      5px 5px 10px #b8bec7,
+      -5px -5px 10px #ffffff;
+  
+    color: #333;
+  
+    font-size: 16px;
+  }
+  
+  
+  /* Popover */
+  
+  .popover {
+  
+    position: absolute;
+  
+    top: 0;
+    left: 100%;
+  
+    margin-left: 20px;
+  
+    width: var(--popover-width);
+  
+    padding: 20px;
+  
+    border-radius: 18px;
+  
+    background: #e0e5ec;
+  
+    box-shadow:
+      8px 8px 18px #b8bec7,
+      -8px -8px 18px #ffffff;
+  
+  
+    opacity: 0;
+    visibility: hidden;
+  
+    transform:
+      translateX(var(--popover-distance));
+  
+  
+    transition:
+  
+      opacity var(--popover-duration)
+      var(--popover-easing),
+  
+      transform var(--popover-duration)
+      var(--popover-easing),
+  
+      visibility var(--popover-duration);
+  
+  }
+  
+  
+  /* Slide right animation */
+  
+  .neo-button:hover .popover,
+  .neo-button:focus .popover {
+  
+    opacity: 1;
+  
+    visibility: visible;
+  
+    transform: translateX(0);
+  
+  }
+  
+  
+  .popover h3 {
+  
+    margin-bottom: 10px;
+  
+  }
+  
+  
+  .popover p {
+  
+    font-size: 14px;
+  
+    line-height: 1.5;
+  
+  }
+  
+  
+  /* Responsive */
+  
+  @media(max-width:600px){
+  
+    .popover {
+  
+      left: 0;
+  
+      top: 120%;
+  
+      margin-left: 0;
+  
+      transform:
+        translateY(var(--popover-distance));
+  
+    }
+  
+  
+    .neo-button:hover .popover,
+    .neo-button:focus .popover {
+  
+      transform: translateY(0);
+  
+    }
+  
+  }


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS Slide-Right Popover component for Neumorphic Soft Layout interfaces.

This component provides a smooth slide-right animation, responsive behavior, keyboard accessibility, and customizable CSS variables for animation timing, easing, and movement distance.

Closes #46603

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A CSS-only Slide-Right Popover animation component styled for Neumorphic Soft UI layouts.

### How does a developer use it?

```html
<button class="neo-button">
  View Report

  <div class="popover">
    Dashboard information
  </div>
</button>