### PR TITLE
feat: add confetti bottom sheet component (#41455)

### DIFF
--- a/submissions/examples/41455-confetti-bottom-sheet-ranje/README.md
+++ b/submissions/examples/41455-confetti-bottom-sheet-ranje/README.md
@@ -1,0 +1,59 @@
+# Confetti Bottom Sheet — Neumorphism
+
+A neumorphic bottom sheet component with pure CSS confetti animation for EaseMotion CSS.
+
+## What does this do?
+
+A slide-up bottom sheet panel with neumorphic raised/inset shadows and a celebratory confetti particle burst — implemented entirely in CSS with no JavaScript.
+
+## How is it used?
+
+```html
+<!-- Hidden checkbox drives open/close -->
+<input type="checkbox" id="cbs-open" class="cbs-toggle" aria-hidden="true">
+
+<!-- Confetti particles -->
+<div class="cbs-confetti-container" aria-hidden="true">
+  <span class="cbs-confetti"></span>
+  <!-- repeat for each particle -->
+</div>
+
+<!-- Backdrop overlay -->
+<label for="cbs-open" class="cbs-overlay"></label>
+
+<!-- Bottom Sheet -->
+<div class="cbs-sheet" role="dialog" aria-modal="true" aria-labelledby="cbs-title">
+  <div class="cbs-sheet__panel">
+    <div class="cbs-sheet__handle"></div>
+    <div class="cbs-sheet__header">
+      <h2 class="cbs-sheet__title" id="cbs-title">Sheet Title</h2>
+      <label for="cbs-open" class="cbs-sheet__close">&times;</label>
+    </div>
+    <div class="cbs-sheet__body">
+      <!-- Sheet content here -->
+    </div>
+  </div>
+</div>
+
+<!-- Trigger -->
+<label for="cbs-open" class="cbs-trigger">Open Sheet</label>
+```
+
+## Why is it useful?
+
+Bottom sheets are among the most commonly needed UI elements for mobile-first interfaces. This neumorphic variant provides a polished, reusable building block that contributors can drop directly into their projects using EaseMotion CSS. The pure CSS confetti animation adds a celebratory flourish without any JavaScript dependency, keeping the component lightweight and accessible.
+
+## Features
+
+- **Pure CSS** — no JavaScript required; checkbox toggle for open/close
+- **Neumorphic design** — raised and inset shadow states using `--ease-neu-*` variables
+- **Confetti animation** — 20 colorful particles with fall + sway keyframes
+- **Responsive** — adapts from mobile (full-width) to desktop (centered, max-width 640px)
+- **Accessible** — `role="dialog"`, `aria-modal`, focus styles, `prefers-reduced-motion` support
+- **Uses EaseMotion CSS variables** — colors, spacing, shadows, easing curves, font stack
+
+## Files
+
+- `demo.html` — self-contained demo page
+- `style.css` — component styles and confetti keyframes
+- `README.md` — this file

--- a/submissions/examples/41455-confetti-bottom-sheet-ranje/demo.html
+++ b/submissions/examples/41455-confetti-bottom-sheet-ranje/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confetti Bottom Sheet — Neumorphic | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="cbs-page">
+
+  <!-- Hidden checkbox drives open/close — no JavaScript needed -->
+  <input type="checkbox" id="cbs-open" class="cbs-toggle" aria-hidden="true">
+
+  <!-- Confetti particles (pure CSS animated) -->
+  <div class="cbs-confetti-container" aria-hidden="true">
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+    <span class="cbs-confetti"></span>
+  </div>
+
+  <!-- Backdrop overlay -->
+  <label for="cbs-open" class="cbs-overlay" aria-hidden="true"></label>
+
+  <!-- Bottom Sheet -->
+  <div class="cbs-sheet" role="dialog" aria-modal="true" aria-labelledby="cbs-title">
+    <div class="cbs-sheet__panel">
+      <div class="cbs-sheet__handle" aria-hidden="true"></div>
+      <div class="cbs-sheet__header">
+        <h2 class="cbs-sheet__title" id="cbs-title">Celebrate with Confetti!</h2>
+        <label for="cbs-open" class="cbs-sheet__close" role="button" tabindex="0" aria-label="Close bottom sheet">&times;</label>
+      </div>
+      <div class="cbs-sheet__body">
+        <p>
+          A neumorphic bottom sheet with pure CSS confetti animation.
+          Tap any card below or close the sheet — no JavaScript required.
+        </p>
+        <div class="cbs-sheet__actions">
+          <div class="cbs-action-card" tabindex="0">
+            <span class="cbs-action-card__icon" aria-hidden="true">🎉</span>
+            <span class="cbs-action-card__label">Party</span>
+          </div>
+          <div class="cbs-action-card" tabindex="0">
+            <span class="cbs-action-card__icon" aria-hidden="true">🚀</span>
+            <span class="cbs-action-card__label">Launch</span>
+          </div>
+          <div class="cbs-action-card" tabindex="0">
+            <span class="cbs-action-card__icon" aria-hidden="true">🏆</span>
+            <span class="cbs-action-card__label">Achieve</span>
+          </div>
+          <div class="cbs-action-card" tabindex="0">
+            <span class="cbs-action-card__icon" aria-hidden="true">⭐</span>
+            <span class="cbs-action-card__label">Star</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Main content (trigger button) -->
+  <h1 class="ease-fade-in" style="text-align:center; color:#2d3748; margin-bottom:0.5rem;">Confetti Bottom Sheet</h1>
+  <p class="ease-fade-in" style="text-align:center; color:#718096; margin-bottom:2rem; font-size:0.95rem;">
+    Neumorphism-inspired &middot; Pure CSS &middot; Accessible
+  </p>
+  <label for="cbs-open" class="cbs-trigger ease-fade-in" role="button" tabindex="0">
+    Open Bottom Sheet
+  </label>
+  <span class="cbs-sr-only">Press Enter or Space to open the confetti bottom sheet</span>
+
+</body>
+</html>

--- a/submissions/examples/41455-confetti-bottom-sheet-ranje/style.css
+++ b/submissions/examples/41455-confetti-bottom-sheet-ranje/style.css
@@ -1,0 +1,344 @@
+/* ======================================================
+   Confetti Bottom Sheet — Neumorphism Inspired
+   Pure CSS component for EaseMotion CSS
+   ====================================================== */
+
+:root {
+  --ease-neu-bg: #e0e5ec;
+  --ease-neu-light: rgba(255, 255, 255, 0.8);
+  --ease-neu-dark: rgba(163, 177, 198, 0.6);
+  --ease-neu-raised-shadow: 9px 9px 16px var(--ease-neu-dark),
+                            -9px -9px 16px var(--ease-neu-light);
+  --ease-neu-inset-shadow: inset 3px 3px 6px var(--ease-neu-dark),
+                           inset -3px -3px 6px var(--ease-neu-light);
+  --ease-sheet-radius: 24px;
+  --ease-sheet-max-height: 80vh;
+  --ease-sheet-duration: 0.4s;
+  --ease-confetti-size: 10px;
+}
+
+/* ---- Page ---- */
+.cbs-page {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--ease-neu-bg);
+  font-family: var(--ease-font-sans, 'Inter', system-ui, sans-serif);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+/* ---- Trigger Button (Neumorphic) ---- */
+.cbs-trigger {
+  appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 1rem 2.5rem;
+  border-radius: var(--ease-radius-full, 9999px);
+  background: var(--ease-neu-bg);
+  box-shadow: var(--ease-neu-raised-shadow);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ease-color-text, #2d3748);
+  transition: box-shadow var(--ease-speed-medium, 300ms) var(--ease-ease, ease),
+              transform var(--ease-speed-medium, 300ms) var(--ease-ease, ease);
+}
+
+.cbs-trigger:hover {
+  transform: translateY(-2px);
+  box-shadow: 12px 12px 20px var(--ease-neu-dark),
+              -12px -12px 20px var(--ease-neu-light);
+}
+
+.cbs-trigger:active {
+  transform: translateY(0);
+  box-shadow: var(--ease-neu-inset-shadow);
+}
+
+/* ---- Hidden checkbox toggles sheet ---- */
+.cbs-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ---- Overlay (backdrop) ---- */
+.cbs-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: var(--ease-z-overlay, 100);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--ease-sheet-duration) var(--ease-ease, ease),
+              visibility var(--ease-sheet-duration) var(--ease-ease, ease);
+}
+
+.cbs-toggle:checked ~ .cbs-overlay {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ---- Bottom Sheet Panel ---- */
+.cbs-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--ease-z-modal, 1000);
+  transform: translateY(100%);
+  transition: transform var(--ease-sheet-duration) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+.cbs-toggle:checked ~ .cbs-sheet {
+  transform: translateY(0);
+}
+
+.cbs-sheet__panel {
+  background: var(--ease-neu-bg);
+  border-radius: var(--ease-sheet-radius) var(--ease-sheet-radius) 0 0;
+  max-height: var(--ease-sheet-max-height);
+  overflow-y: auto;
+  padding: 0 1.5rem 2rem;
+  box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.12);
+  position: relative;
+}
+
+/* ---- Drag Handle ---- */
+.cbs-sheet__handle {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--ease-color-muted, #a0aec0);
+  margin: 12px auto 0;
+}
+
+/* ---- Close Button (label for toggling off) ---- */
+.cbs-sheet__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--ease-neu-bg);
+  box-shadow: var(--ease-neu-raised-shadow);
+  cursor: pointer;
+  font-size: 1.25rem;
+  color: var(--ease-color-text, #2d3748);
+  transition: box-shadow var(--ease-speed-medium, 300ms) var(--ease-ease, ease),
+              transform var(--ease-speed-medium, 300ms) var(--ease-ease, ease);
+  flex-shrink: 0;
+}
+
+.cbs-sheet__close:hover {
+  box-shadow: var(--ease-neu-inset-shadow);
+  transform: rotate(90deg);
+}
+
+/* ---- Header ---- */
+.cbs-sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0 0.5rem;
+  gap: 0.75rem;
+}
+
+.cbs-sheet__title {
+  margin: 0;
+  font-size: var(--ease-text-lg, 1.125rem);
+  font-weight: 700;
+  color: var(--ease-color-text, #2d3748);
+}
+
+/* ---- Content ---- */
+.cbs-sheet__body {
+  padding: 0.5rem 0;
+  color: var(--ease-color-muted, #718096);
+  line-height: var(--ease-leading-normal, 1.6);
+  font-size: var(--ease-text-sm, 0.875rem);
+}
+
+.cbs-sheet__body p {
+  margin: 0 0 1rem;
+}
+
+/* Neumorphic action cards inside sheet */
+.cbs-sheet__actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.cbs-action-card {
+  background: var(--ease-neu-bg);
+  border-radius: var(--ease-radius-lg, 1rem);
+  box-shadow: var(--ease-neu-raised-shadow);
+  padding: 1.25rem 1rem;
+  text-align: center;
+  transition: box-shadow var(--ease-speed-medium, 300ms) var(--ease-ease, ease),
+              transform var(--ease-speed-medium, 300ms) var(--ease-ease, ease);
+  cursor: pointer;
+}
+
+.cbs-action-card:hover {
+  box-shadow: var(--ease-neu-inset-shadow);
+  transform: scale(0.97);
+}
+
+.cbs-action-card__icon {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+  display: block;
+}
+
+.cbs-action-card__label {
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  color: var(--ease-color-text, #2d3748);
+}
+
+/* ======================================================
+   CONFETTI ANIMATION — Pure CSS
+   ====================================================== */
+
+.cbs-confetti-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.cbs-toggle:checked ~ .cbs-confetti-container {
+  opacity: 1;
+}
+
+/* Each confetti piece */
+.cbs-confetti {
+  position: absolute;
+  top: -20px;
+  width: var(--ease-confetti-size);
+  height: var(--ease-confetti-size);
+  border-radius: 2px;
+  opacity: 0;
+}
+
+.cbs-toggle:checked ~ .cbs-confetti-container .cbs-confetti {
+  animation: cbs-confetti-fall linear forwards,
+             cbs-confetti-sway ease-in-out infinite alternate;
+}
+
+/* Confetti color palette */
+.cbs-confetti:nth-child(1)  { left: 5%;  background: #ff6b6b; width: 8px; height: 14px; animation-duration: 3.2s, 1.8s; animation-delay: 0s, 0s; }
+.cbs-confetti:nth-child(2)  { left: 12%; background: #feca57; width: 12px; height: 12px; border-radius: 50%; animation-duration: 2.8s, 2.2s; animation-delay: 0.15s, 0.15s; }
+.cbs-confetti:nth-child(3)  { left: 20%; background: #48dbfb; width: 6px; height: 16px; animation-duration: 3.5s, 1.5s; animation-delay: 0.3s, 0.3s; }
+.cbs-confetti:nth-child(4)  { left: 28%; background: #ff9ff3; width: 10px; height: 10px; animation-duration: 2.6s, 2.0s; animation-delay: 0.1s, 0.1s; }
+.cbs-confetti:nth-child(5)  { left: 35%; background: #54a0ff; width: 8px; height: 12px; border-radius: 1px; animation-duration: 3.0s, 1.7s; animation-delay: 0.45s, 0.45s; }
+.cbs-confetti:nth-child(6)  { left: 42%; background: #5f27cd; width: 14px; height: 8px; animation-duration: 3.3s, 2.1s; animation-delay: 0.2s, 0.2s; }
+.cbs-confetti:nth-child(7)  { left: 50%; background: #01a3a4; width: 7px; height: 7px; border-radius: 50%; animation-duration: 2.9s, 1.9s; animation-delay: 0.5s, 0.5s; }
+.cbs-confetti:nth-child(8)  { left: 58%; background: #f368e0; width: 11px; height: 6px; animation-duration: 3.1s, 2.3s; animation-delay: 0.05s, 0.05s; }
+.cbs-confetti:nth-child(9)  { left: 65%; background: #ff9f43; width: 9px; height: 15px; animation-duration: 2.7s, 1.6s; animation-delay: 0.35s, 0.35s; }
+.cbs-confetti:nth-child(10) { left: 73%; background: #ee5a24; width: 10px; height: 10px; border-radius: 50%; animation-duration: 3.4s, 2.0s; animation-delay: 0.25s, 0.25s; }
+.cbs-confetti:nth-child(11) { left: 80%; background: #0abde3; width: 6px; height: 14px; animation-duration: 2.5s, 1.8s; animation-delay: 0.4s, 0.4s; }
+.cbs-confetti:nth-child(12) { left: 88%; background: #10ac84; width: 13px; height: 9px; animation-duration: 3.6s, 2.4s; animation-delay: 0.12s, 0.12s; }
+.cbs-confetti:nth-child(13) { left: 15%; background: #ee5253; width: 8px; height: 8px; border-radius: 50%; animation-duration: 2.4s, 1.4s; animation-delay: 0.55s, 0.55s; }
+.cbs-confetti:nth-child(14) { left: 45%; background: #feca57; width: 10px; height: 6px; animation-duration: 3.0s, 2.1s; animation-delay: 0.08s, 0.08s; }
+.cbs-confetti:nth-child(15) { left: 70%; background: #ff6348; width: 7px; height: 12px; animation-duration: 2.8s, 1.7s; animation-delay: 0.42s, 0.42s; }
+.cbs-confetti:nth-child(16) { left: 8%;  background: #7bed9f; width: 9px; height: 9px; border-radius: 50%; animation-duration: 3.2s, 2.2s; animation-delay: 0.18s, 0.18s; }
+.cbs-confetti:nth-child(17) { left: 55%; background: #e056fd; width: 12px; height: 7px; animation-duration: 2.6s, 1.9s; animation-delay: 0.32s, 0.32s; }
+.cbs-confetti:nth-child(18) { left: 92%; background: #686de0; width: 8px; height: 13px; animation-duration: 3.5s, 2.0s; animation-delay: 0.28s, 0.28s; }
+.cbs-confetti:nth-child(19) { left: 38%; background: #f9ca24; width: 11px; height: 5px; border-radius: 1px; animation-duration: 2.9s, 1.6s; animation-delay: 0.48s, 0.48s; }
+.cbs-confetti:nth-child(20) { left: 62%; background: #ff4757; width: 6px; height: 10px; animation-duration: 3.1s, 2.3s; animation-delay: 0.14s, 0.14s; }
+
+@keyframes cbs-confetti-fall {
+  0% {
+    top: -20px;
+    opacity: 1;
+    transform: rotateZ(0deg) scale(1);
+  }
+  70% {
+    opacity: 1;
+  }
+  100% {
+    top: 105vh;
+    opacity: 0;
+    transform: rotateZ(720deg) scale(0.5);
+  }
+}
+
+@keyframes cbs-confetti-sway {
+  0% {
+    margin-left: -15px;
+  }
+  100% {
+    margin-left: 15px;
+  }
+}
+
+/* ---- Accessibility: reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .cbs-toggle:checked ~ .cbs-confetti-container .cbs-confetti {
+    animation: none;
+  }
+  .cbs-sheet {
+    transition: transform 0.01s linear;
+  }
+  .cbs-overlay {
+    transition: opacity 0.01s linear, visibility 0.01s linear;
+  }
+}
+
+/* ---- Responsive ---- */
+@media (min-width: 640px) {
+  .cbs-sheet__panel {
+    max-width: 560px;
+    margin: 0 auto;
+    border-radius: var(--ease-sheet-radius) var(--ease-sheet-radius) 0 0;
+  }
+}
+
+@media (min-width: 1024px) {
+  .cbs-sheet__panel {
+    max-width: 640px;
+  }
+
+  :root {
+    --ease-sheet-max-height: 70vh;
+  }
+}
+
+/* ---- Focus styles for accessibility ---- */
+.cbs-trigger:focus-visible,
+.cbs-sheet__close:focus-visible,
+.cbs-action-card:focus-visible {
+  outline: 3px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* ---- Screen reader only ---- */
+.cbs-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
## Summary

Adds a neumorphic confetti bottom sheet component to the EaseMotion CSS library as requested in #41455.

## What this PR does

- Adds `submissions/examples/41455-confetti-bottom-sheet-ranje/` with 3 files: `demo.html`, `style.css`, `README.md`
- Implements a slide-up bottom sheet panel with neumorphic raised/inset shadow states
- Includes 20-particle pure CSS confetti animation (no JavaScript required)
- Uses checkbox `:checked` toggle for open/close

## Features

- **Pure CSS** — zero JavaScript; checkbox toggle drives open/close and confetti burst
- **Neumorphic design** — raised and inset shadows using `--ease-neu-*` custom properties
- **Confetti animation** — 20 colorful particles with `cbs-confetti-fall` and `cbs-confetti-sway` keyframes
- **Responsive** — mobile full-width, desktop centered (max-width 640px)
- **Accessible** — `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `prefers-reduced-motion` support, focus-visible outlines
- **Uses EaseMotion variables** — `--ease-color-*`, `--ease-radius-*`, `--ease-speed-*`, `--ease-ease-*`, `--ease-font-sans`, `--ease-text-*`, `--ease-z-*`

## Files added

## Checklist

- [x] Files only inside `submissions/examples/` — no files outside submissions/
- [x] Uses EaseMotion CSS variables and keyframes
- [x] Works without JavaScript (pure CSS)
- [x] Live demo in `demo.html`
- [x] Documented `README.md`
- [x] Responsive and accessible
- [x] No existing files modified

Closes #41455