### PR TITLE
Add glass frog component

### DIFF
--- a/submissions/examples/glass-frog-as/README.md
+++ b/submissions/examples/glass-frog-as/README.md
@@ -1,0 +1,29 @@
+# Glass Frog
+
+A pure CSS/HTML glass frog resting on a leaf, its heart visibly beating through a transparent belly.
+
+## What it shows
+
+Glass frogs are green on top and glass on the bottom. Turn one over and the ventral skin is genuinely transparent: you can see the heart beating, the white coil of the gut, the dark lobe of the liver, and the bones through it.
+
+It is not a party trick. The transparency is camouflage. Resting on a backlit leaf, the frog's edges glow the same green as the leaf, so it has no silhouette to give it away. Recent work found that sleeping glass frogs pack most of their red blood cells into the liver, which makes them measurably clearer while they sleep.
+
+## How it is built
+
+- **Real transparency**: the body is `rgba(150, 206, 132, 0.36)`, not a solid green. The leaf and its veins are genuinely rendered underneath and read through the frog, which is what makes the camouflage legible instead of implied.
+- **Layered viscera**: gut, liver, and heart sit above the body fill but *below* a translucent skin pane, so they look like organs seen through skin rather than stickers on top of it.
+- **The gut**: a `repeating-conic-gradient` gives the packed intestinal coil its banding.
+- **The heartbeat**: a multi-stop keyframe with a hard systolic spike and a smaller second bump, so it reads as a real cardiac cycle rather than a sine pulse.
+- **Skin sheen**: the pane's highlight is deliberately parked in the upper-left corner. Centred over the chest it washed the heart out completely.
+- **Leaf**: a `repeating-conic-gradient` from an off-centre origin fans the side veins out from the midrib.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the frog at rest, so the anatomy still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/glass-frog-as/demo.html
+++ b/submissions/examples/glass-frog-as/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glass Frog</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="canopyG"></span>
+    <span class="leafG"></span>
+    <span class="veinG"></span>
+    <div class="frogG">
+      <span class="legG lgBL"></span>
+      <span class="legG lgBR"></span>
+      <span class="bodyG"></span>
+      <span class="paneG"></span>
+      <span class="gutG"></span>
+      <span class="liverG"></span>
+      <span class="heartG"></span>
+      <span class="boneG bnL"></span>
+      <span class="boneG bnR"></span>
+      <span class="legG lgFL"></span>
+      <span class="legG lgFR"></span>
+      <span class="headG"></span>
+      <span class="eyeG eyL"></span>
+      <span class="eyeG eyR"></span>
+      <span class="throatG"></span>
+    </div>
+    <span class="dropG drA"></span>
+    <span class="dropG drB"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/glass-frog-as/style.css
+++ b/submissions/examples/glass-frog-as/style.css
@@ -1,0 +1,336 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #23402a, #060d08 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 24%, #2f5a36, #071008 82%);
+}
+
+.canopyG {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(140, 210, 130, 0.16) 0 30px, transparent 46px),
+    radial-gradient(circle at 82% 20%, rgba(140, 210, 130, 0.12) 0 26px, transparent 40px);
+  z-index: 1;
+}
+
+.leafG {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 296px;
+  height: 176px;
+  margin-left: -148px;
+  border-radius: 60% 40% 58% 42% / 46% 52% 48% 54%;
+  background: linear-gradient(150deg, #6fbf5a, #2f7a3a 58%, #14421f);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.veinG {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 296px;
+  height: 176px;
+  margin-left: -148px;
+  border-radius: 60% 40% 58% 42% / 46% 52% 48% 54%;
+  background:
+    repeating-conic-gradient(
+      from 158deg at 12% 76%,
+      rgba(18, 54, 24, 0.42) 0 0.7deg,
+      transparent 0.7deg 9deg
+    );
+  z-index: 3;
+}
+
+.veinG::after {
+  content: "";
+  position: absolute;
+  top: 22%;
+  left: 8%;
+  width: 84%;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(20, 60, 26, 0.7), rgba(120, 190, 110, 0.3));
+  transform: rotate(24deg);
+}
+
+.frogG {
+  position: absolute;
+  bottom: 82px;
+  left: 50%;
+  width: 190px;
+  height: 132px;
+  margin-left: -95px;
+  z-index: 5;
+  animation: breatheG 4.6s ease-in-out infinite;
+}
+
+.legG {
+  position: absolute;
+  height: 15px;
+  border-radius: 8px;
+  background: rgba(168, 214, 150, 0.45);
+  box-shadow: inset 0 -2px 4px rgba(20, 60, 24, 0.4);
+}
+
+.legG::after {
+  content: "";
+  position: absolute;
+  top: -1px;
+  width: 22px;
+  height: 17px;
+  border-radius: 50% 40% 40% 50%;
+  background: rgba(190, 226, 170, 0.5);
+}
+
+.lgBL {
+  bottom: 12px;
+  left: 6px;
+  width: 62px;
+  transform: rotate(20deg);
+  z-index: 2;
+}
+
+.lgBL::after { left: -14px; }
+
+.lgBR {
+  bottom: 12px;
+  right: 6px;
+  width: 62px;
+  transform: rotate(-20deg);
+  z-index: 2;
+}
+
+.lgBR::after { right: -14px; transform: scaleX(-1); }
+
+.lgFL {
+  top: 34px;
+  left: 16px;
+  width: 48px;
+  transform: rotate(-16deg);
+  z-index: 6;
+}
+
+.lgFL::after { left: -14px; }
+
+.lgFR {
+  top: 34px;
+  right: 16px;
+  width: 48px;
+  transform: rotate(16deg);
+  z-index: 6;
+}
+
+.lgFR::after { right: -14px; transform: scaleX(-1); }
+
+.bodyG {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  width: 118px;
+  height: 96px;
+  margin-left: -59px;
+  border-radius: 50% 50% 46% 46% / 44% 44% 56% 56%;
+  background: rgba(150, 206, 132, 0.36);
+  box-shadow: inset 0 6px 14px rgba(230, 250, 220, 0.16);
+  z-index: 3;
+}
+
+.gutG {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  width: 66px;
+  height: 44px;
+  margin-left: -33px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(226, 214, 178, 0.62) 0 8deg,
+      rgba(170, 150, 110, 0.5) 8deg 16deg
+    );
+  z-index: 4;
+}
+
+.liverG {
+  position: absolute;
+  bottom: 52px;
+  left: 50%;
+  width: 50px;
+  height: 24px;
+  margin-left: -36px;
+  border-radius: 46% 54% 40% 60% / 60% 60% 40% 40%;
+  background: rgba(120, 46, 40, 0.66);
+  z-index: 4;
+}
+
+.heartG {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 23px;
+  height: 25px;
+  margin-left: -10px;
+  border-radius: 50% 50% 46% 46% / 40% 40% 60% 60%;
+  background: radial-gradient(circle at 40% 34%, #ff5c7c, #7a0018 80%);
+  box-shadow: 0 0 14px rgba(255, 40, 80, 0.85);
+  transform-origin: 50% 60%;
+  z-index: 5;
+  animation: beatG 1.15s ease-in-out infinite;
+}
+
+.boneG {
+  position: absolute;
+  bottom: 14px;
+  width: 5px;
+  height: 52px;
+  border-radius: 3px;
+  background: rgba(190, 236, 176, 0.6);
+  z-index: 4;
+}
+
+.bnL { left: 50%; margin-left: -22px; transform: rotate(9deg); }
+.bnR { left: 50%; margin-left: 17px; transform: rotate(-9deg); }
+
+.paneG {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  width: 118px;
+  height: 96px;
+  margin-left: -59px;
+  border-radius: 50% 50% 46% 46% / 44% 44% 56% 56%;
+  background:
+    radial-gradient(
+      ellipse at 20% 12%,
+      rgba(236, 252, 226, 0.3) 0 18%,
+      rgba(150, 206, 132, 0.1) 46%,
+      rgba(90, 150, 80, 0.16) 90%
+    );
+  z-index: 6;
+}
+
+.headG {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 92px;
+  height: 56px;
+  margin-left: -46px;
+  border-radius: 50% 50% 40% 40% / 62% 62% 38% 38%;
+  background: rgba(160, 214, 140, 0.62);
+  box-shadow: inset 0 5px 10px rgba(236, 252, 226, 0.2);
+  z-index: 7;
+}
+
+.eyeG {
+  position: absolute;
+  top: 6px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 42% 38%, #f4f0d0 0 26%, #cfae54 40%, #6a4e18 74%);
+  box-shadow: 0 0 0 2px rgba(120, 170, 100, 0.6);
+  z-index: 8;
+  animation: blinkG 4.6s ease-in-out infinite;
+}
+
+.eyeG::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 5px;
+  height: 12px;
+  margin: -6px 0 0 -2.5px;
+  border-radius: 3px;
+  background: #14100a;
+}
+
+.eyL { left: 50%; margin-left: -34px; }
+.eyR { right: 50%; margin-right: -34px; animation-delay: -0.1s; }
+
+.throatG {
+  position: absolute;
+  top: 46px;
+  left: 50%;
+  width: 52px;
+  height: 22px;
+  margin-left: -26px;
+  border-radius: 50% 50% 60% 60% / 30% 30% 70% 70%;
+  background: rgba(180, 224, 160, 0.5);
+  transform-origin: 50% 20%;
+  z-index: 7;
+  animation: gularG 4.6s ease-in-out infinite;
+}
+
+.dropG {
+  position: absolute;
+  width: 7px;
+  height: 9px;
+  border-radius: 50% 50% 50% 50% / 62% 62% 38% 38%;
+  background: radial-gradient(circle at 36% 30%, rgba(240, 255, 240, 0.8), rgba(150, 200, 150, 0.3) 72%);
+  z-index: 9;
+  animation: beadG 6s ease-in infinite;
+}
+
+.drA { top: 34px; left: 74px; }
+.drB { top: 26px; right: 88px; animation-delay: -3s; }
+
+@keyframes beatG {
+  0%, 100% { transform: scale(1); }
+  16% { transform: scale(1.28); }
+  32% { transform: scale(1.04); }
+  46% { transform: scale(1.16); }
+}
+
+@keyframes breatheG {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.025); }
+}
+
+@keyframes gularG {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(1.4); }
+}
+
+@keyframes blinkG {
+  0%, 92%, 100% { transform: scaleY(1); }
+  95% { transform: scaleY(0.1); }
+}
+
+@keyframes beadG {
+  0%, 60% { transform: translateY(0); opacity: 0.9; }
+  100% { transform: translateY(150px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frogG,
+  .heartG,
+  .throatG,
+  .eyeG,
+  .dropG {
+    animation: none;
+  }
+
+  .dropG {
+    opacity: 0.9;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/glass-frog-as/`, a self-contained pure CSS/HTML glass frog on a leaf with its heart beating through a transparent belly.

Closes #47867

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **Real transparency**: the body is `rgba(150, 206, 132, 0.36)`, not a solid green. The leaf and its veins are genuinely rendered underneath and read through the frog. This is the whole point of the animal, so it had to be actual alpha compositing rather than a painted-on effect.
- **Layered viscera**: gut, liver and heart sit above the body fill but *below* a translucent skin pane, so they read as organs seen through skin rather than stickers on top of it.
- **The gut**: a `repeating-conic-gradient` gives the packed intestinal coil its banding.
- **The heartbeat**: a multi-stop keyframe with a hard systolic spike and a smaller second bump, so it reads as a cardiac cycle rather than a sine pulse.
- **Skin sheen**: the pane's highlight is parked in the upper-left corner on purpose. Centred over the chest it washed the heart out entirely, which the browser check caught.
- **Leaf**: a `repeating-conic-gradient` from an off-centre origin fans the side veins out from the midrib.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the frog at rest, so the anatomy still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the leaf reads through the body, the heart beats, the throat pumps, and the reduced-motion path renders a static frog. Confirmed the body's computed `background-color` is an `rgba` value rather than an opaque fill, so the transparency is real. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
