### PR TITLE
Add basilisk lizard component

### DIFF
--- a/submissions/examples/basilisk-lizard-as/README.md
+++ b/submissions/examples/basilisk-lizard-as/README.md
@@ -1,0 +1,29 @@
+# Basilisk Lizard
+
+A pure CSS/HTML common basilisk sprinting across open water, throwing a fan of spray at every footfall.
+
+## What it shows
+
+The basilisk is the animal behind the "Jesus Christ lizard" nickname. Startled, it rears onto its hind legs and runs straight across the surface of a stream.
+
+It works in three strokes, and none of them is surface tension. The foot **slaps** down hard enough to push water aside, the leg **strokes** down into the air cavity that slap opened, and then the foot **pulls out** before the cavity collapses. Do it fast enough, and each stride buys enough lift to keep going. The lizard has to run about 1.5 m/s to stay up; adults are heavy enough that they mostly sink partway and swim.
+
+## How it is built
+
+- **Three-segment legs**: hip, knee, and ankle are separately nested and each carries its own keyframe, so the stride actually folds and extends rather than swinging as a rigid stick. The foot is nested *inside* the shin so it inherits the knee rotation.
+- **Stride timing**: the cycle runs at 0.44s, and the two legs share it with a half-cycle offset, so the gait alternates instead of hopping.
+- **The slap**: a `repeating-conic-gradient` fan bursts at the waterline on the same 0.44s cycle as the footfall, masked with a `radial-gradient` so it reads as spray rather than a filled box. Beads fling outward on per-drop `--bx`/`--by` vectors.
+- **Wake**: trailing streaks stretch and fade behind the lizard on a `scaleX` keyframe.
+- **The crest**: a `repeating-conic-gradient` under a `clip-path` gives the spiky dorsal sail. Drawn tall it read as a turtle shell, so it is deliberately thin.
+- **Water**: horizontal ripple lines only. Crossing them with vertical stripes turned the whole river into bathroom tile, so the sheen is a soft drifting gradient instead.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the lizard mid-stride, so the pose still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/basilisk-lizard-as/demo.html
+++ b/submissions/examples/basilisk-lizard-as/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Basilisk Lizard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="bankB"></span>
+    <span class="waterB"></span>
+    <span class="glintB"></span>
+    <div class="rigB">
+      <span class="wakeB wkA"></span>
+      <span class="wakeB wkB"></span>
+      <span class="wakeB wkC"></span>
+      <div class="lizB">
+        <span class="tailB"></span>
+        <span class="bodyB"></span>
+        <span class="crestB"></span>
+        <span class="armB arL"></span>
+        <span class="armB arR"></span>
+        <div class="legB lgB2">
+          <span class="thighB"></span>
+          <div class="shinB"><span class="footB"></span></div>
+        </div>
+        <div class="legB lgB1">
+          <span class="thighB"></span>
+          <div class="shinB"><span class="footB"></span></div>
+        </div>
+        <span class="headB"></span>
+        <span class="sailB"></span>
+        <span class="eyeB"></span>
+      </div>
+      <span class="splashB spA"></span>
+      <span class="splashB spB"></span>
+      <span class="beadB bdA"></span>
+      <span class="beadB bdB"></span>
+      <span class="beadB bdC"></span>
+      <span class="beadB bdD"></span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/basilisk-lizard-as/style.css
+++ b/submissions/examples/basilisk-lizard-as/style.css
@@ -1,0 +1,377 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #79a88a, #2f4f46 60%, #12211f);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #8fbf9a, #4d7f6a 44%, #2a4c46 58%, #16302e);
+}
+
+.bankB {
+  position: absolute;
+  bottom: 118px;
+  left: 0;
+  right: 0;
+  height: 46px;
+  background:
+    radial-gradient(circle at 12% 90%, rgba(30, 60, 30, 0.6) 0 24px, transparent 32px),
+    radial-gradient(circle at 88% 96%, rgba(30, 60, 30, 0.5) 0 30px, transparent 40px),
+    linear-gradient(180deg, #3f6a44, #1e3a28);
+  z-index: 1;
+}
+
+.waterB {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 122px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(220, 240, 232, 0.1) 0 1px,
+      transparent 1px 11px
+    ),
+    linear-gradient(180deg, #4e8478, #12292a);
+  z-index: 2;
+}
+
+.waterB::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: rgba(226, 246, 238, 0.55);
+}
+
+.glintB {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 122px;
+  background:
+    linear-gradient(
+      92deg,
+      transparent,
+      rgba(232, 250, 242, 0.09) 30%,
+      transparent 54%,
+      rgba(232, 250, 242, 0.06) 76%,
+      transparent
+    );
+  z-index: 3;
+  animation: driftB 9s linear infinite;
+}
+
+.rigB {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 240px;
+  height: 160px;
+  margin-left: -120px;
+  z-index: 6;
+}
+
+.lizB {
+  position: absolute;
+  bottom: 30px;
+  left: 42px;
+  width: 156px;
+  height: 92px;
+  animation: bobB 0.44s linear infinite;
+}
+
+.bodyB {
+  position: absolute;
+  bottom: 28px;
+  left: 34px;
+  width: 86px;
+  height: 34px;
+  border-radius: 42% 58% 46% 54% / 56% 56% 44% 44%;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(16, 46, 26, 0.34) 0 2px,
+      transparent 2px 7px
+    ),
+    linear-gradient(180deg, #5f9a5a, #21401f);
+  box-shadow: inset -4px -4px 10px rgba(10, 30, 12, 0.5);
+  z-index: 5;
+}
+
+.crestB {
+  position: absolute;
+  bottom: 58px;
+  left: 42px;
+  width: 66px;
+  height: 13px;
+  background:
+    repeating-conic-gradient(
+      from 178deg at 50% 100%,
+      #7fbf6e 0 1.4deg,
+      #2f5a2a 1.4deg 3.4deg
+    );
+  clip-path: polygon(0 100%, 12% 34%, 36% 4%, 64% 18%, 88% 48%, 100% 100%);
+  z-index: 4;
+}
+
+.tailB {
+  position: absolute;
+  bottom: 34px;
+  left: 110px;
+  width: 74px;
+  height: 12px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(14, 36, 18, 0.5) 0 4px,
+      transparent 4px 11px
+    ),
+    linear-gradient(90deg, #3f6f3c, #7fae6a);
+  clip-path: polygon(0 0, 100% 40%, 100% 60%, 0 100%);
+  border-radius: 0 4px 4px 0;
+  transform-origin: 0 50%;
+  z-index: 4;
+  animation: lashB 0.88s ease-in-out infinite;
+}
+
+.headB {
+  position: absolute;
+  bottom: 40px;
+  left: 4px;
+  width: 42px;
+  height: 24px;
+  border-radius: 58% 22% 30% 46% / 62% 40% 46% 58%;
+  background: linear-gradient(170deg, #6faa62, #274a22 82%);
+  z-index: 6;
+}
+
+.sailB {
+  position: absolute;
+  bottom: 60px;
+  left: 12px;
+  width: 26px;
+  height: 18px;
+  background:
+    repeating-conic-gradient(
+      from 180deg at 50% 100%,
+      #58955024 0 2deg,
+      #2a4f26 2deg 5deg
+    );
+  clip-path: polygon(0 100%, 24% 22%, 62% 6%, 100% 44%, 100% 100%);
+  z-index: 5;
+}
+
+.eyeB {
+  position: absolute;
+  bottom: 54px;
+  left: 16px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #f0d46a, #241a06 68%);
+  box-shadow: 0 0 0 1.5px rgba(20, 40, 16, 0.8);
+  z-index: 7;
+}
+
+.armB {
+  position: absolute;
+  bottom: 30px;
+  width: 8px;
+  height: 22px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #4f8a4a, #1d3a1a);
+  transform-origin: 50% 0;
+  z-index: 6;
+  animation: paddleB 0.44s linear infinite;
+}
+
+.arL { left: 44px; }
+.arR { left: 58px; filter: brightness(0.78); animation-delay: -0.22s; z-index: 4; }
+
+.legB {
+  position: absolute;
+  bottom: 6px;
+  width: 11px;
+  height: 30px;
+  transform-origin: 50% 0;
+  animation: hipB 0.44s linear infinite;
+}
+
+.thighB {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 12px;
+  height: 30px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #8fd07e, #3f7038);
+}
+
+.shinB {
+  position: absolute;
+  top: 26px;
+  left: 1.5px;
+  width: 8px;
+  height: 28px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #86c876, #366030);
+  transform-origin: 50% 0;
+  animation: kneeB 0.44s linear infinite;
+  animation-delay: inherit;
+}
+
+.footB {
+  position: absolute;
+  top: 24px;
+  left: -13px;
+  width: 32px;
+  height: 8px;
+  background: linear-gradient(180deg, #9adc86, #3c6c34);
+  clip-path: polygon(0 22%, 100% 0, 100% 46%, 62% 100%, 34% 100%, 0 62%);
+  transform-origin: 62% 0;
+  animation: ankleB 0.44s linear infinite;
+  animation-delay: inherit;
+}
+
+.lgB1 { left: 74px; z-index: 7; }
+.lgB2 { left: 86px; z-index: 3; filter: brightness(0.62); animation-delay: -0.22s; }
+
+.wakeB {
+  position: absolute;
+  bottom: 22px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, transparent, rgba(230, 250, 242, 0.6));
+  z-index: 4;
+  animation: trailB 0.88s linear infinite;
+}
+
+.wkA { left: 108px; width: 56px; }
+.wkB { left: 96px; width: 82px; bottom: 14px; animation-delay: -0.3s; opacity: 0.7; }
+.wkC { left: 118px; width: 40px; bottom: 30px; animation-delay: -0.6s; opacity: 0.5; }
+
+.splashB {
+  position: absolute;
+  bottom: 10px;
+  width: 56px;
+  height: 42px;
+  background:
+    repeating-conic-gradient(
+      from 202deg at 50% 100%,
+      rgba(244, 255, 250, 0.95) 0 2.4deg,
+      transparent 2.4deg 7.5deg
+    );
+  mask-image: radial-gradient(ellipse 96% 128% at 50% 100%, #000 0 74%, transparent 100%);
+  transform-origin: 50% 100%;
+  z-index: 8;
+  animation: burstB 0.44s ease-out infinite;
+}
+
+.spA { left: 56px; }
+.spB { left: 84px; animation-delay: -0.22s; }
+
+.beadB {
+  position: absolute;
+  width: 5px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(240, 254, 248, 0.9);
+  z-index: 9;
+  animation: flingB 0.88s ease-out infinite;
+}
+
+.bdA { bottom: 30px; left: 72px; --bx: -34px; --by: -30px; }
+.bdB { bottom: 30px; left: 78px; --bx: 26px; --by: -38px; animation-delay: -0.22s; }
+.bdC { bottom: 30px; left: 92px; --bx: 40px; --by: -22px; animation-delay: -0.44s; }
+.bdD { bottom: 30px; left: 66px; --bx: -44px; --by: -14px; animation-delay: -0.66s; }
+
+@keyframes bobB {
+  0%, 100% { transform: translateY(0) rotate(-3deg); }
+  50% { transform: translateY(-5px) rotate(-1deg); }
+}
+
+@keyframes hipB {
+  0% { transform: rotate(-38deg); }
+  50% { transform: rotate(32deg); }
+  100% { transform: rotate(-38deg); }
+}
+
+@keyframes kneeB {
+  0% { transform: rotate(52deg); }
+  32% { transform: rotate(4deg); }
+  62% { transform: rotate(18deg); }
+  100% { transform: rotate(52deg); }
+}
+
+@keyframes ankleB {
+  0% { transform: rotate(28deg); }
+  36% { transform: rotate(-14deg); }
+  100% { transform: rotate(28deg); }
+}
+
+@keyframes paddleB {
+  0%, 100% { transform: rotate(24deg); }
+  50% { transform: rotate(-22deg); }
+}
+
+@keyframes lashB {
+  0%, 100% { transform: rotate(6deg); }
+  50% { transform: rotate(-8deg); }
+}
+
+@keyframes burstB {
+  0% { transform: scaleY(0.2) scaleX(0.6); opacity: 0; }
+  18% { transform: scaleY(1) scaleX(1); opacity: 0.95; }
+  100% { transform: scaleY(0.3) scaleX(1.5); opacity: 0; }
+}
+
+@keyframes flingB {
+  0% { transform: translate(0, 0) scale(1); opacity: 0; }
+  14% { opacity: 1; }
+  100% { transform: translate(var(--bx, 0), var(--by, 0)) scale(0.4); opacity: 0; }
+}
+
+@keyframes trailB {
+  0% { transform: translateX(0) scaleX(0.5); opacity: 0.8; }
+  100% { transform: translateX(52px) scaleX(1.3); opacity: 0; }
+}
+
+@keyframes driftB {
+  0% { transform: translateX(-40px); }
+  100% { transform: translateX(40px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lizB,
+  .legB,
+  .shinB,
+  .footB,
+  .armB,
+  .tailB,
+  .splashB,
+  .beadB,
+  .wakeB,
+  .glintB {
+    animation: none;
+  }
+
+  .beadB,
+  .splashB {
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/basilisk-lizard-as/`, a self-contained pure CSS/HTML basilisk sprinting across open water.

Closes #47869

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **Three-segment legs**: hip, knee and ankle are separately nested and each carries its own keyframe, so the stride folds and extends rather than swinging as a rigid stick. The foot is nested *inside* the shin so it inherits the knee rotation.
- **Stride timing**: the cycle runs at 0.44s and the two legs share it with a half-cycle offset, so the gait alternates instead of hopping.
- **The slap**: a `repeating-conic-gradient` fan bursts at the waterline on the same 0.44s cycle as the footfall, masked with a `radial-gradient` so it reads as spray rather than a filled rectangle. Beads fling outward on per-drop `--bx`/`--by` vectors.
- **Wake**: trailing streaks stretch and fade behind the lizard on a `scaleX` keyframe.
- **The crest**: a `repeating-conic-gradient` under a `clip-path` gives the spiky dorsal sail. Drawn tall it read as a turtle shell in the browser, so it is deliberately thin.
- **Water**: horizontal ripple lines only. Crossing them with vertical stripes turned the river into bathroom tile, which the browser check caught, so the sheen is a soft drifting gradient instead.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the lizard mid-stride, so the pose still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the legs articulate at all three joints, the two legs alternate, the spray fires at the waterline in time with the footfall, and the reduced-motion path renders a static pose. Checked the computed stride duration is shared across hip, knee and ankle so the joints cannot drift out of phase. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
