### PR TITLE
Add camera obscura component

### DIFF
--- a/submissions/examples/camera-obscura-as/README.md
+++ b/submissions/examples/camera-obscura-as/README.md
@@ -1,0 +1,28 @@
+# Camera Obscura
+
+A pure CSS/HTML camera obscura: a sunlit landscape outside, a pinhole in the wall, and the same scene landing upside down on the wall of the dark room.
+
+## What it shows
+
+Light travels in straight lines. A ray from the top of the balloon can only reach the far wall by passing through the pinhole and continuing downward, and a ray from the ground can only reach it by continuing upward. The rays cross at the hole, so the image lands inverted. That is the entire device, and it has been known since at least Mozi in the 4th century BC.
+
+A smaller hole gives a sharper but dimmer image, a larger one gives brighter but blurrier. There is no lens and nothing to focus.
+
+## How it is built
+
+- **The projection is not a drawing of an inverted scene. It is the scene.** The room's wall panel contains the same markup as the world outside, wrapped in a `.projO` element carrying `transform: rotate(180deg)`. The balloon is deliberately asymmetric top-to-bottom, so the inversion is unmistakable: in the projection the basket sits above the envelope.
+- **Automatic sync**: because both copies run the same `liftO` keyframe with the same timing, the projected balloon drifts in step with the real one for free. Nothing coordinates them.
+- **Crossed rays**: two thin beams pivot from the pinhole at equal and opposite angles, meeting exactly at the hole, which is what makes the geometry legible rather than asserted.
+- **Not a filter wipe**: the aperture pulse animates `filter`, which would have wiped the projection's own dim/blur filter. The projection gets its own keyframe that rebuilds `brightness(...) saturate(...) sepia(...) blur(...)` at every stop instead.
+- **The look**: a `repeating-linear-gradient` scanline grain over the panel, and a heavy dim so the image reads as light on plaster rather than as a window.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe. The inversion is a static `transform`, so the whole point of the component survives with motion off.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/camera-obscura-as/demo.html
+++ b/submissions/examples/camera-obscura-as/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Camera Obscura</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="outsideO">
+      <span class="skyO"></span>
+      <span class="sunO"></span>
+      <span class="hillO"></span>
+      <span class="treeO"></span>
+      <div class="balloonO">
+        <span class="bulbO"></span>
+        <span class="ropeO"></span>
+        <span class="basketO"></span>
+      </div>
+    </div>
+
+    <span class="coneO"></span>
+    <span class="rayO ryTop"></span>
+    <span class="rayO ryBot"></span>
+
+    <div class="roomO">
+      <span class="floorO"></span>
+      <div class="screenO">
+        <div class="projO">
+          <span class="skyO"></span>
+          <span class="sunO"></span>
+          <span class="hillO"></span>
+          <span class="treeO"></span>
+          <div class="balloonO">
+            <span class="bulbO"></span>
+            <span class="ropeO"></span>
+            <span class="basketO"></span>
+          </div>
+        </div>
+        <span class="grainO"></span>
+      </div>
+      <span class="figureO"></span>
+    </div>
+
+    <span class="wallO"></span>
+    <span class="holeO"></span>
+    <span class="labelO labA">outside</span>
+    <span class="labelO labB">inverted on the wall</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/camera-obscura-as/style.css
+++ b/submissions/examples/camera-obscura-as/style.css
@@ -1,0 +1,321 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 30%, #35302a, #0c0a08 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: #0a0908;
+}
+
+/* ---------- the world outside ---------- */
+
+.outsideO {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 128px;
+  height: 300px;
+  overflow: hidden;
+  z-index: 2;
+}
+
+.skyO {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, #8fc8e8, #cfe4ea 62%, #e6dcbc);
+  z-index: 1;
+}
+
+.sunO {
+  position: absolute;
+  top: 26px;
+  left: 18px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe0, #ffd45a 60%, rgba(255, 200, 70, 0) 80%);
+  z-index: 2;
+}
+
+.hillO {
+  position: absolute;
+  bottom: 0;
+  left: -30px;
+  right: -30px;
+  height: 96px;
+  border-radius: 50% 50% 0 0 / 60% 60% 0 0;
+  background: linear-gradient(180deg, #74a84e, #2f5a24);
+  z-index: 3;
+}
+
+.treeO {
+  position: absolute;
+  bottom: 54px;
+  left: 78px;
+  width: 30px;
+  height: 52px;
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 40% 32%, #4f8f3a, #1c3c14 78%);
+  z-index: 4;
+}
+
+.treeO::after {
+  content: "";
+  position: absolute;
+  bottom: -14px;
+  left: 50%;
+  width: 5px;
+  height: 16px;
+  margin-left: -2.5px;
+  background: #3a2a16;
+}
+
+.balloonO {
+  position: absolute;
+  top: 74px;
+  left: 30px;
+  width: 44px;
+  height: 76px;
+  z-index: 5;
+  animation: liftO 9s ease-in-out infinite;
+}
+
+.bulbO {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 44px;
+  height: 50px;
+  border-radius: 50% 50% 42% 42% / 56% 56% 44% 44%;
+  background:
+    repeating-conic-gradient(
+      from 176deg at 50% 88%,
+      #e2464a 0 9deg,
+      #f4e2b0 9deg 18deg
+    );
+  box-shadow: inset -6px -4px 10px rgba(90, 20, 20, 0.4);
+}
+
+.ropeO {
+  position: absolute;
+  top: 48px;
+  left: 50%;
+  width: 22px;
+  height: 12px;
+  margin-left: -11px;
+  border-left: 1.5px solid #4a3a22;
+  border-right: 1.5px solid #4a3a22;
+  transform: perspective(20px) rotateX(6deg);
+}
+
+.basketO {
+  position: absolute;
+  top: 58px;
+  left: 50%;
+  width: 18px;
+  height: 14px;
+  margin-left: -9px;
+  border-radius: 2px 2px 4px 4px;
+  background: linear-gradient(180deg, #b07c3c, #5f3d16);
+}
+
+/* ---------- pinhole wall ---------- */
+
+.wallO {
+  position: absolute;
+  top: 0;
+  left: 128px;
+  width: 15px;
+  height: 300px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(20, 12, 6, 0.5) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(90deg, #6a4e30, #2a1c0e);
+  z-index: 9;
+}
+
+.holeO {
+  position: absolute;
+  top: 148px;
+  left: 133px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fffbe4;
+  box-shadow: 0 0 10px 3px rgba(255, 246, 200, 0.8);
+  z-index: 10;
+  animation: apertureO 9s ease-in-out infinite;
+}
+
+/* ---------- the dark room ---------- */
+
+.roomO {
+  position: absolute;
+  top: 0;
+  left: 143px;
+  right: 0;
+  height: 300px;
+  overflow: hidden;
+  background: linear-gradient(90deg, #100c08, #1c1610 60%, #0b0806);
+  z-index: 3;
+}
+
+.floorO {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 54px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(120, 90, 50, 0.14) 0 2px,
+      transparent 2px 20px
+    ),
+    linear-gradient(180deg, #241a10, #0c0806);
+  z-index: 8;
+}
+
+.coneO {
+  position: absolute;
+  top: 40px;
+  left: 136px;
+  width: 172px;
+  height: 220px;
+  background: linear-gradient(90deg, rgba(255, 244, 200, 0.24), rgba(255, 244, 200, 0.05));
+  clip-path: polygon(0 49%, 100% 0, 100% 100%, 0 51%);
+  z-index: 6;
+  animation: apertureO 9s ease-in-out infinite;
+}
+
+.rayO {
+  position: absolute;
+  left: 136px;
+  width: 174px;
+  height: 1.5px;
+  background: linear-gradient(90deg, rgba(255, 250, 214, 0.85), rgba(255, 250, 214, 0.15));
+  transform-origin: 0 50%;
+  z-index: 7;
+}
+
+/* the two rays cross at the hole, which is why the image lands upside down */
+.ryTop { top: 150px; transform: rotate(-19.5deg); }
+.ryBot { top: 150px; transform: rotate(19.5deg); }
+
+.screenO {
+  position: absolute;
+  top: 40px;
+  right: 8px;
+  width: 156px;
+  height: 220px;
+  overflow: hidden;
+  border-radius: 2px;
+  background: #17120c;
+  box-shadow: 0 0 0 2px #2c2016, 0 0 26px rgba(0, 0, 0, 0.8);
+  z-index: 7;
+}
+
+/* the projection is the same markup as the world outside, turned through 180deg */
+.projO {
+  position: absolute;
+  inset: 0;
+  transform: rotate(180deg);
+  filter: brightness(0.4) saturate(0.5) sepia(0.3) blur(0.9px);
+  opacity: 0.85;
+  animation: pulseProjO 9s ease-in-out infinite;
+}
+
+.grainO {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.34) 0 1px,
+      transparent 1px 3px
+    );
+  z-index: 6;
+}
+
+.figureO {
+  position: absolute;
+  bottom: 40px;
+  left: 12px;
+  width: 20px;
+  height: 62px;
+  border-radius: 8px 8px 3px 3px;
+  background: linear-gradient(180deg, #2a2018, #0d0906);
+  z-index: 9;
+}
+
+.figureO::before {
+  content: "";
+  position: absolute;
+  top: -13px;
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  border-radius: 50%;
+  background: #2a2018;
+}
+
+.labelO {
+  position: absolute;
+  font-size: 0.56rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  z-index: 11;
+}
+
+.labA {
+  top: 8px;
+  left: 8px;
+  color: rgba(30, 40, 30, 0.62);
+}
+
+.labB {
+  bottom: 8px;
+  right: 10px;
+  color: rgba(226, 208, 168, 0.5);
+}
+
+@keyframes liftO {
+  0%, 100% { transform: translate(0, 0); }
+  34% { transform: translate(10px, -34px); }
+  68% { transform: translate(-6px, 16px); }
+}
+
+@keyframes apertureO {
+  0%, 100% { filter: brightness(1); }
+  46% { filter: brightness(1.22); }
+}
+
+/* rebuilds the projection's own dim/blur so the shared brighten cannot wipe it */
+@keyframes pulseProjO {
+  0%, 100% { filter: brightness(0.4) saturate(0.5) sepia(0.3) blur(0.9px); }
+  46% { filter: brightness(0.52) saturate(0.5) sepia(0.3) blur(0.9px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .balloonO,
+  .holeO,
+  .coneO,
+  .projO {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/camera-obscura-as/`, a self-contained pure CSS/HTML camera obscura projecting an inverted landscape onto the wall of a dark room.

Closes #47871

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The projection is not a drawing of an inverted scene. It is the scene.** The room's wall panel contains the same markup as the world outside, wrapped in a `.projO` element carrying `transform: rotate(180deg)`. So the optics are modelled rather than illustrated.
- **Unmistakable inversion**: the subject is a hot-air balloon, deliberately asymmetric top-to-bottom. In the projection the basket sits above the envelope, which is the tell that it is really upside down and not just a second drawing.
- **Automatic sync**: both copies run the same `liftO` keyframe with the same timing, so the projected balloon drifts in step with the real one for free. Nothing coordinates them.
- **Crossed rays**: two thin beams pivot from the pinhole at equal and opposite angles, meeting exactly at the hole, which makes the geometry legible rather than asserted.
- **Not a filter wipe**: the aperture pulse animates `filter`, which would have wiped the projection's own dim/blur filter. The projection gets its own keyframe that rebuilds `brightness(...) saturate(...) sepia(...) blur(...)` at every stop instead.
- **The look**: a `repeating-linear-gradient` scanline grain over the panel plus a heavy dim, so the image reads as light on plaster rather than as a window.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe. The inversion is a static `transform`, so the entire point of the component survives with motion off.

## Verification

Opened `demo.html` in the browser and confirmed the projection reads upside down (basket above envelope, hill along the top), the two balloons drift in step, the rays cross at the pinhole, and the reduced-motion path keeps the inversion. Checked the computed values: the projection's `transform` resolves to `matrix(-1, 0, 0, -1, 0, 0)` and its `filter` still carries the dim and blur while the pulse runs, so the animation is not wiping it. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
