### PR TITLE
Add antlion component

### DIFF
--- a/submissions/examples/antlion-as/README.md
+++ b/submissions/examples/antlion-as/README.md
@@ -1,0 +1,28 @@
+# Antlion
+
+A pure CSS/HTML antlion pit: an ant losing its footing on the funnel wall while the buried larva flicks sand to bring it down.
+
+## What it shows
+
+The antlion larva digs a conical pit in dry sand and buries itself at the apex with nothing showing but its jaws. The trap is not the pit. The trap is the **angle of repose**: the larva excavates the walls to the steepest angle loose sand can hold, so an ant that steps over the rim cannot get purchase. Every step collapses the grain under it.
+
+If the ant is still making progress, the larva flicks sand up the slope with its head to knock it back down. Then the jaws close.
+
+## How it is built
+
+- **The funnel**: a `clip-path` V cut through the sand block, with a `repeating-linear-gradient` running down the slope and an inset shadow to hollow it. Concentric ellipse arcs read as contour rings, which is what makes it a cone rather than a painted triangle.
+- **Losing ground**: the ant's keyframe deliberately gains and then loses. It slides, recovers a little, slides further, recovers less, and ends at the jaws. That stutter is the entire physics of the trap, so a smooth slide would have been the wrong animation.
+- **On the slope**: the ant carries a constant `rotate(-45deg)` matching the wall angle, and the pit is cut so its walls sit at that same 45 degrees.
+- **The flick**: `repeating-conic-gradient` sand fans burst up both walls from the apex, masked with a `radial-gradient` so they read as thrown grain rather than filled wedges. Individual grains arc out on per-grain `--gx`/`--gy` vectors.
+- **The jaws**: two `clip-path` sickles mirrored with `scaleX(-1)`. The mirrored one gets its own keyframe that rebuilds `scaleX(-1)` at every stop, because a shared `rotate` keyframe would have wiped the mirror and flipped the jaw.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and parks the ant partway down the wall, so the trap still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/antlion-as/demo.html
+++ b/submissions/examples/antlion-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Antlion</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunA"></span>
+    <span class="sandA"></span>
+    <span class="pitA"></span>
+    <span class="ringA rgA"></span>
+    <span class="ringA rgB"></span>
+    <span class="ringA rgC"></span>
+    <div class="antA">
+      <span class="abA"></span>
+      <span class="thA"></span>
+      <span class="hdA"></span>
+      <span class="lgA la1"></span>
+      <span class="lgA la2"></span>
+      <span class="lgA la3"></span>
+    </div>
+    <span class="slideA slA"></span>
+    <span class="slideA slB"></span>
+    <span class="slideA slC"></span>
+    <div class="lionA">
+      <span class="jawA jwL"></span>
+      <span class="jawA jwR"></span>
+      <span class="headA"></span>
+    </div>
+    <span class="puffA pfA"></span>
+    <span class="puffA pfB"></span>
+    <span class="grainA gnA"></span>
+    <span class="grainA gnB"></span>
+    <span class="grainA gnC"></span>
+    <span class="rimA"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/antlion-as/style.css
+++ b/submissions/examples/antlion-as/style.css
@@ -1,0 +1,337 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #e8c894, #b08a56 58%, #6a4f30);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f4dca8, #d8b478 52%, #a8834e);
+}
+
+.sunA {
+  position: absolute;
+  top: 22px;
+  right: 34px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe0, #ffd868 58%, rgba(255, 210, 100, 0) 78%);
+  z-index: 1;
+}
+
+.sandA {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 186px;
+  background:
+    radial-gradient(circle at 8% 20%, rgba(140, 106, 60, 0.34) 0 2px, transparent 3px),
+    radial-gradient(circle at 26% 62%, rgba(140, 106, 60, 0.3) 0 2px, transparent 3px),
+    radial-gradient(circle at 74% 34%, rgba(140, 106, 60, 0.32) 0 2px, transparent 3px),
+    radial-gradient(circle at 92% 76%, rgba(140, 106, 60, 0.3) 0 2px, transparent 3px),
+    linear-gradient(180deg, #e8c288, #b98f56);
+  z-index: 2;
+}
+
+.sandA::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: rgba(255, 244, 210, 0.7);
+}
+
+/* the funnel: a V cut into the sand at exactly the angle of repose */
+.pitA {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 292px;
+  height: 146px;
+  margin-left: -146px;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(120, 88, 48, 0.16) 0 2px,
+      transparent 2px 10px
+    ),
+    linear-gradient(180deg, #b8874c, #6a4a26 72%, #3f2c14);
+  clip-path: polygon(0 0, 100% 0, 52% 100%, 48% 100%);
+  box-shadow: inset 0 6px 12px rgba(60, 40, 16, 0.5);
+  z-index: 4;
+}
+
+.rimA {
+  position: absolute;
+  bottom: 180px;
+  left: 50%;
+  width: 296px;
+  height: 14px;
+  margin-left: -148px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 40%, rgba(255, 246, 214, 0.5), transparent 72%);
+  z-index: 5;
+}
+
+.ringA {
+  position: absolute;
+  left: 50%;
+  border-radius: 50%;
+  border-top: 1.5px solid rgba(96, 68, 32, 0.5);
+  z-index: 5;
+}
+
+.rgA { bottom: 122px; width: 196px; height: 40px; margin-left: -98px; }
+.rgB { bottom: 84px; width: 122px; height: 28px; margin-left: -61px; }
+.rgC { bottom: 56px; width: 58px; height: 16px; margin-left: -29px; }
+
+/* the ant fights the slope and keeps losing ground */
+.antA {
+  position: absolute;
+  bottom: 166px;
+  left: 248px;
+  width: 30px;
+  height: 16px;
+  z-index: 7;
+  animation: slipA 5.4s ease-in infinite;
+}
+
+.abA {
+  position: absolute;
+  bottom: 2px;
+  right: 0;
+  width: 14px;
+  height: 11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #6a3a1c, #23100a 76%);
+}
+
+.thA {
+  position: absolute;
+  bottom: 3px;
+  right: 12px;
+  width: 9px;
+  height: 8px;
+  border-radius: 50%;
+  background: #3f1e0e;
+}
+
+.hdA {
+  position: absolute;
+  bottom: 3px;
+  right: 20px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #5a2e14, #1c0c06 76%);
+}
+
+.hdA::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -5px;
+  width: 6px;
+  height: 5px;
+  border-left: 1.2px solid #2a1208;
+  border-top: 1.2px solid #2a1208;
+  border-radius: 3px 0 0 0;
+}
+
+.lgA {
+  position: absolute;
+  bottom: 0;
+  width: 1.6px;
+  height: 8px;
+  background: #2a1208;
+  transform-origin: 50% 0;
+  animation: scrambleA 0.34s linear infinite;
+}
+
+.la1 { right: 6px; }
+.la2 { right: 13px; animation-delay: -0.11s; }
+.la3 { right: 20px; animation-delay: -0.22s; }
+
+/* the antlion itself: nothing but jaws above the sand */
+.lionA {
+  position: absolute;
+  bottom: 36px;
+  left: 50%;
+  width: 54px;
+  height: 26px;
+  margin-left: -27px;
+  z-index: 8;
+}
+
+.headA {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 30px;
+  height: 13px;
+  margin-left: -15px;
+  border-radius: 50% 50% 30% 30%;
+  background: radial-gradient(circle at 44% 30%, #6a4a24, #241608 78%);
+  z-index: 3;
+}
+
+.jawA {
+  position: absolute;
+  bottom: 6px;
+  width: 26px;
+  height: 15px;
+  z-index: 4;
+  animation: snapA 5.4s ease-in-out infinite;
+}
+
+.jawA::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, #4a2e12, #1a0e04);
+  clip-path: polygon(0 74%, 62% 0, 100% 8%, 74% 46%, 40% 100%);
+}
+
+.jawA::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 40%;
+  width: 42%;
+  height: 3px;
+  background: repeating-linear-gradient(90deg, #6a4420 0 1.5px, transparent 1.5px 5px);
+}
+
+.jwL { left: 0; transform-origin: 100% 100%; }
+.jwR { right: 0; transform-origin: 0 100%; transform: scaleX(-1); animation-name: snapAr; }
+
+/* sand the larva flicks up the slope to bring the ant back down */
+.puffA {
+  position: absolute;
+  bottom: 46px;
+  width: 62px;
+  height: 48px;
+  background:
+    repeating-conic-gradient(
+      from 208deg at 50% 100%,
+      rgba(250, 228, 178, 0.95) 0 2.2deg,
+      transparent 2.2deg 7deg
+    );
+  mask-image: radial-gradient(ellipse 92% 120% at 50% 100%, #000 0 70%, transparent 100%);
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: flickA 5.4s ease-out infinite;
+}
+
+.pfA { left: 50%; margin-left: -8px; transform: rotate(34deg); }
+.pfB { left: 50%; margin-left: -54px; transform: rotate(-34deg); animation-delay: -0.4s; }
+
+/* grains giving way under the ant */
+.slideA {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: #8a6434;
+  z-index: 6;
+  animation: rollA 5.4s ease-in infinite;
+}
+
+.slA { bottom: 164px; left: 238px; }
+.slB { bottom: 156px; left: 250px; animation-delay: -1.6s; }
+.slC { bottom: 172px; left: 260px; animation-delay: -3.1s; }
+
+.grainA {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: #d8b47c;
+  z-index: 9;
+  animation: tossA 5.4s ease-out infinite;
+}
+
+.gnA { bottom: 52px; left: 168px; --gx: 52px; --gy: -66px; }
+.gnB { bottom: 52px; left: 160px; --gx: -46px; --gy: -58px; animation-delay: -0.2s; }
+.gnC { bottom: 52px; left: 172px; --gx: 64px; --gy: -40px; animation-delay: -0.4s; }
+
+@keyframes slipA {
+  0% { transform: translate(0, 0) rotate(-45deg); }
+  26% { transform: translate(-16px, 26px) rotate(-45deg); }
+  38% { transform: translate(-9px, 15px) rotate(-45deg); }
+  58% { transform: translate(-38px, 61px) rotate(-45deg); }
+  70% { transform: translate(-30px, 49px) rotate(-45deg); }
+  88%, 100% { transform: translate(-70px, 112px) rotate(-45deg); }
+}
+
+@keyframes scrambleA {
+  0%, 100% { transform: rotate(22deg); }
+  50% { transform: rotate(-22deg); }
+}
+
+@keyframes snapA {
+  0%, 78% { transform: rotate(0deg); }
+  86% { transform: rotate(-26deg); }
+  93% { transform: rotate(4deg); }
+  100% { transform: rotate(0deg); }
+}
+
+@keyframes snapAr {
+  0%, 78% { transform: scaleX(-1) rotate(0deg); }
+  86% { transform: scaleX(-1) rotate(-26deg); }
+  93% { transform: scaleX(-1) rotate(4deg); }
+  100% { transform: scaleX(-1) rotate(0deg); }
+}
+
+@keyframes flickA {
+  0%, 34% { opacity: 0; }
+  40% { opacity: 0.95; }
+  58% { opacity: 0; }
+  100% { opacity: 0; }
+}
+
+@keyframes tossA {
+  0%, 34% { transform: translate(0, 0); opacity: 0; }
+  40% { opacity: 1; }
+  62%, 100% { transform: translate(var(--gx, 0), var(--gy, 0)); opacity: 0; }
+}
+
+@keyframes rollA {
+  0% { transform: translate(0, 0); opacity: 0; }
+  16% { opacity: 0.9; }
+  100% { transform: translate(-64px, 92px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .antA,
+  .lgA,
+  .jawA,
+  .puffA,
+  .grainA,
+  .slideA {
+    animation: none;
+  }
+
+  .antA {
+    transform: translate(-38px, 61px) rotate(-45deg);
+  }
+
+  .puffA,
+  .grainA,
+  .slideA {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/antlion-as/`, a self-contained pure CSS/HTML antlion pit with an ant sliding down the funnel wall into the jaws.

Closes #47873

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The funnel**: a `clip-path` V cut through the sand block, with a `repeating-linear-gradient` running down the slope and an inset shadow to hollow it. Concentric ellipse arcs read as contour rings, which is what makes it a cone rather than a painted triangle.
- **Losing ground**: the ant's keyframe deliberately gains and then loses. It slides, recovers a little, slides further, recovers less, and ends at the jaws. That stutter is the entire physics of the trap, so a smooth slide would have been the wrong animation.
- **On the slope**: the ant carries a constant `rotate(-45deg)` matching the wall angle, and the pit is cut so its walls sit at that same 45 degrees.
- **The flick**: `repeating-conic-gradient` sand fans burst up both walls from the apex, masked with a `radial-gradient` so they read as thrown grain rather than filled wedges. Individual grains arc out on per-grain `--gx`/`--gy` vectors.
- **The jaws**: two `clip-path` sickles mirrored with `scaleX(-1)`. The mirrored jaw gets its own keyframe that rebuilds `scaleX(-1)` at every stop, because a shared `rotate`-only keyframe would have wiped the mirror and flipped the jaw the wrong way round.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and parks the ant partway down the wall, so the trap still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the ant slides down the wall rather than up out of it (the first pass had the sign wrong and it climbed out), the slide stutters instead of running smooth, the sand fans fire from the apex, the jaws snap as the ant arrives, and the reduced-motion path parks it mid-wall. Confirmed the mirrored jaw resolves to its own keyframe so the `scaleX(-1)` survives the snap. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
