### PR TITLE
Add tuning fork component

### DIFF
--- a/submissions/examples/tuning-fork-as/README.md
+++ b/submissions/examples/tuning-fork-as/README.md
@@ -1,0 +1,33 @@
+# Tuning Fork
+
+A pure CSS/HTML tuning fork ringing on a bench block, drawn so the standing wave is visible.
+
+## What it shows
+
+A tuning fork is not two bars that wobble. It is a standing wave with a fixed shape:
+
+- The tines move in **antiphase**, toward each other and then apart. That symmetry is why the fork is so pure: the two tines' sideways momentum cancels, so almost no energy leaks out through the handle and the note rings for a long time.
+- Displacement is **zero at the yoke and largest at the tips**. The bend point near the base of each tine is the node; the tips are the antinode.
+- Because both tines pull inward at the same instant and outward at the same instant, the **stem pumps up and down at twice the tine frequency**. That is the vibration you feel in the handle, and it is what drives a resonator box when you stand the fork on one.
+
+## How it is built
+
+- **Bending, not rotating**: each tine's `transform-origin` is `50% 100%`, its base at the yoke. Rotating about that point gives zero displacement at the base and maximum at the tip, which is exactly the mode shape. It is the cheapest honest way to draw a cantilever in CSS.
+- **Antiphase**: two mirrored keyframes, so the tines always move toward or away from each other, never in parallel.
+- **The 2:1 stem**: the stem's keyframe runs at `0.25s` against the tines' `0.5s`, so the frequency doubling is in the timing rather than asserted in a comment.
+- **The envelope**: blurred ghost tines parked at a wider angle than the live swing, showing where the tips reach at full amplitude.
+- **Node markers**: rings pinned at the yoke, the one part of the fork that barely moves.
+- **Metal**: a multi-stop horizontal `linear-gradient` per part gives the cylindrical highlight, brightest off-centre rather than in the middle.
+
+The swing is exaggerated and slowed. A real A440 fork moves a fraction of a millimetre, 440 times a second, which renders as a static grey bar.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and parks the tines at full deflection, so the mode shape still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/tuning-fork-as/demo.html
+++ b/submissions/examples/tuning-fork-as/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tuning Fork</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="benchT">
+    <span class="waveT wvA"></span>
+    <span class="waveT wvB"></span>
+    <span class="waveT wvC"></span>
+    <div class="forkT">
+      <span class="ghostT ghL"></span>
+      <span class="ghostT ghR"></span>
+      <span class="tineT tnL"></span>
+      <span class="tineT tnR"></span>
+      <span class="yokeT"></span>
+      <span class="stemT"></span>
+      <span class="footT"></span>
+      <span class="stampT">A 440 Hz</span>
+    </div>
+    <span class="blockT"></span>
+    <span class="nodeT ndL"></span>
+    <span class="nodeT ndR"></span>
+    <span class="capT">antinode at the tips, node at the yoke</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tuning-fork-as/style.css
+++ b/submissions/examples/tuning-fork-as/style.css
@@ -1,0 +1,257 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #2f3944, #0b0e12 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.benchT {
+  position: relative;
+  width: 320px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 28%, #3c4a58, #0d1116 82%);
+}
+
+.waveT {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  margin-left: -20px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(150, 210, 240, 0.5);
+  opacity: 0;
+  z-index: 1;
+  animation: radiateT 2.4s ease-out infinite;
+}
+
+.wvA { animation-delay: 0s; }
+.wvB { animation-delay: -0.8s; }
+.wvC { animation-delay: -1.6s; }
+
+.forkT {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 140px;
+  height: 262px;
+  margin-left: -70px;
+  z-index: 4;
+}
+
+/* the swing envelope: where the tips reach at full amplitude */
+.ghostT {
+  position: absolute;
+  bottom: 92px;
+  width: 17px;
+  height: 156px;
+  border-radius: 9px 9px 2px 2px;
+  background: linear-gradient(180deg, rgba(206, 232, 250, 0.55), rgba(120, 150, 176, 0.12));
+  filter: blur(3px);
+  z-index: 2;
+}
+
+.ghL {
+  left: 34px;
+  transform-origin: 50% 100%;
+  transform: rotate(-7deg);
+}
+
+.ghR {
+  right: 34px;
+  transform-origin: 50% 100%;
+  transform: rotate(7deg);
+}
+
+/* a tine pivots at the yoke, so displacement is zero at the base and largest at the tip */
+.tineT {
+  position: absolute;
+  bottom: 92px;
+  width: 17px;
+  height: 156px;
+  border-radius: 9px 9px 2px 2px;
+  background:
+    linear-gradient(
+      90deg,
+      #6f7f8e 0 16%,
+      #e8f2f8 34%,
+      #b4c4d2 58%,
+      #58656f 100%
+    );
+  box-shadow: 0 0 8px rgba(160, 210, 240, 0.24);
+  transform-origin: 50% 100%;
+  z-index: 4;
+}
+
+.tineT::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 16px;
+  border-radius: 9px 9px 40% 40%;
+  background: linear-gradient(180deg, #f4fbff, rgba(244, 251, 255, 0));
+}
+
+.tnL { left: 34px; animation: swingLT 0.5s ease-in-out infinite; }
+.tnR { right: 34px; animation: swingRT 0.5s ease-in-out infinite; }
+
+.yokeT {
+  position: absolute;
+  bottom: 56px;
+  left: 50%;
+  width: 72px;
+  height: 32px;
+  margin-left: -36px;
+  border-radius: 3px 3px 22px 22px / 2px 2px 30px 30px;
+  background:
+    linear-gradient(
+      90deg,
+      #66737f 0 14%,
+      #dfeaf2 36%,
+      #a8b8c6 62%,
+      #4f5a64 100%
+    );
+  z-index: 5;
+}
+
+.stemT {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  width: 15px;
+  height: 52px;
+  margin-left: -7.5px;
+  border-radius: 2px;
+  background:
+    linear-gradient(
+      90deg,
+      #5e6a76 0 18%,
+      #d4e0ea 40%,
+      #96a6b4 64%,
+      #454f58 100%
+    );
+  transform-origin: 50% 100%;
+  z-index: 3;
+  animation: pumpT 0.25s ease-in-out infinite;
+}
+
+.footT {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 30px;
+  height: 10px;
+  margin-left: -15px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #b8c6d2, #4e5860);
+  z-index: 3;
+}
+
+.stampT {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 72px;
+  margin-left: -36px;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.06em;
+  color: rgba(30, 40, 48, 0.62);
+  z-index: 6;
+}
+
+.blockT {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(60, 40, 20, 0.24) 0 2px,
+      transparent 2px 22px
+    ),
+    linear-gradient(180deg, #5f472c, #241a10);
+  z-index: 2;
+}
+
+/* the node: the one place on the fork that barely moves */
+.nodeT {
+  position: absolute;
+  bottom: 138px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(240, 180, 90, 0.85);
+  z-index: 7;
+  animation: markT 2.4s ease-in-out infinite;
+}
+
+.ndL { left: 50%; margin-left: -44px; }
+.ndR { left: 50%; margin-left: 35px; }
+
+.capT {
+  position: absolute;
+  bottom: 18px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: rgba(200, 224, 240, 0.62);
+  z-index: 8;
+}
+
+/* the two tines run in antiphase: toward each other, then apart */
+@keyframes swingLT {
+  0%, 100% { transform: rotate(-4.5deg); }
+  50% { transform: rotate(4.5deg); }
+}
+
+@keyframes swingRT {
+  0%, 100% { transform: rotate(4.5deg); }
+  50% { transform: rotate(-4.5deg); }
+}
+
+/* the stem pumps at twice the tine frequency, which is why it drives a resonator */
+@keyframes pumpT {
+  0%, 100% { transform: scaleY(1); }
+  50% { transform: scaleY(0.97); }
+}
+
+@keyframes radiateT {
+  0% { transform: scale(0.4); opacity: 0; }
+  16% { opacity: 0.75; }
+  100% { transform: scale(6); opacity: 0; }
+}
+
+@keyframes markT {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tineT,
+  .stemT,
+  .waveT,
+  .nodeT {
+    animation: none;
+  }
+
+  .tnL { transform: rotate(-4.5deg); }
+  .tnR { transform: rotate(4.5deg); }
+
+  .waveT {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/tuning-fork-as/`, a self-contained pure CSS/HTML tuning fork ringing on a bench block.

Closes #47875

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

The point of this one is that the physics lives in the CSS rather than in a comment.

- **Bending, not rotating**: each tine's `transform-origin` is `50% 100%`, its base at the yoke. Rotating about that point gives zero displacement at the base and maximum at the tip, which is exactly the mode shape of the fork. It is the cheapest honest way to draw a cantilever in CSS.
- **Antiphase**: two mirrored keyframes, so the tines always move toward or away from each other and never in parallel. That symmetry is why a real fork rings so long.
- **The 2:1 stem**: the stem's keyframe runs at `0.25s` against the tines' `0.5s`, so the frequency doubling is in the timing rather than asserted.
- **The envelope**: blurred ghost tines parked at a wider angle than the live swing, showing where the tips reach at full amplitude.
- **Node markers**: rings pinned at the yoke, the one part of the fork that barely moves.
- **Metal**: a multi-stop horizontal `linear-gradient` per part gives the cylindrical highlight, brightest off-centre rather than in the middle.

The swing is exaggerated and slowed on purpose, and the README says so. A real A440 fork moves a fraction of a millimetre 440 times a second, which renders as a static grey bar.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and parks the tines at full deflection, so the mode shape still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the tines converge and diverge rather than swinging in parallel, the envelope ghosts bracket the live swing, and the reduced-motion path holds the deflected pose. Checked the computed values: each tine's `transform-origin` resolves to its base at the yoke, and the stem's `animation-duration` is `0.25s` against the tines' `0.5s`, so the 2:1 relationship is real. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
