### PR TITLE
Add mimosa pudica component

### DIFF
--- a/submissions/examples/mimosa-pudica-as/README.md
+++ b/submissions/examples/mimosa-pudica-as/README.md
@@ -1,0 +1,28 @@
+# Mimosa Pudica
+
+A pure CSS/HTML sensitive plant. Hover or focus the leaf and the leaflets fold shut in a travelling wave, then the whole leaf collapses at the pulvinus.
+
+## What it shows
+
+*Mimosa pudica* folds when touched, and the interesting part is the **timing**. The leaflets do not all shut at once. The signal starts where the touch landed and travels outward along the rachis at roughly 2 to 3 cm per second, so you watch a wave of closing run down the leaf. Only afterwards does the main pulvinus at the base give way and drop the entire petiole.
+
+There is no muscle involved. Each pulvinus is a swollen joint whose cells dump potassium, lose turgor pressure, and go limp. It takes several minutes to pump back up, which is why the plant cannot do it repeatedly.
+
+## How it is built
+
+- **Real interaction, no JavaScript**: the fold is a `:hover` / `:focus-visible` state on the plant container. Nothing is scripted, and the `tabindex` plus `:focus-visible` branch means it works from the keyboard too.
+- **The travelling wave is `transition-delay`**: every leaflet carries an index `--i`, and its delay is `calc(var(--i) * 0.075s)`. That single line is the whole propagation effect. Leaflet 0 starts immediately, leaflet 6 starts at 0.45s.
+- **Folding in pairs**: the upper leaflet pivots at `50% 100%` and the lower one at `50% 0`, and they rotate in opposite directions so the pair closes toward the rachis tip like a book, which is what the real leaf does.
+- **The pulvinus goes last**: the petiole's own transition carries a `0.34s` delay, so the leaf only collapses after the leaflet wave has passed. Its `transform-origin` is pinned to the joint, and a marked swelling sits there.
+- **The droop overshoots**: the petiole uses a `cubic-bezier` with a negative final control point, so it drops past its resting angle and settles, rather than easing politely into place.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` collapses the transition durations and delays to near zero, so the state change is instant rather than animated. The fold itself still happens, because it is the content, not the decoration.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/mimosa-pudica-as/demo.html
+++ b/submissions/examples/mimosa-pudica-as/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mimosa Pudica</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunM"></span>
+    <span class="soilM"></span>
+    <span class="potM"></span>
+    <div class="plantM" tabindex="0">
+      <span class="stemM"></span>
+      <div class="petioleM">
+        <span class="shaftM"></span>
+        <span class="pulvM"></span>
+        <div class="rachisM rcA">
+          <span class="rodM"></span>
+          <span class="leafM lfT" style="--i: 0"></span>
+          <span class="leafM lfT" style="--i: 1"></span>
+          <span class="leafM lfT" style="--i: 2"></span>
+          <span class="leafM lfT" style="--i: 3"></span>
+          <span class="leafM lfT" style="--i: 4"></span>
+          <span class="leafM lfT" style="--i: 5"></span>
+          <span class="leafM lfT" style="--i: 6"></span>
+          <span class="leafM lfB" style="--i: 0"></span>
+          <span class="leafM lfB" style="--i: 1"></span>
+          <span class="leafM lfB" style="--i: 2"></span>
+          <span class="leafM lfB" style="--i: 3"></span>
+          <span class="leafM lfB" style="--i: 4"></span>
+          <span class="leafM lfB" style="--i: 5"></span>
+          <span class="leafM lfB" style="--i: 6"></span>
+        </div>
+        <div class="rachisM rcB">
+          <span class="rodM"></span>
+          <span class="leafM lfT" style="--i: 0"></span>
+          <span class="leafM lfT" style="--i: 1"></span>
+          <span class="leafM lfT" style="--i: 2"></span>
+          <span class="leafM lfT" style="--i: 3"></span>
+          <span class="leafM lfT" style="--i: 4"></span>
+          <span class="leafM lfT" style="--i: 5"></span>
+          <span class="leafM lfT" style="--i: 6"></span>
+          <span class="leafM lfB" style="--i: 0"></span>
+          <span class="leafM lfB" style="--i: 1"></span>
+          <span class="leafM lfB" style="--i: 2"></span>
+          <span class="leafM lfB" style="--i: 3"></span>
+          <span class="leafM lfB" style="--i: 4"></span>
+          <span class="leafM lfB" style="--i: 5"></span>
+          <span class="leafM lfB" style="--i: 6"></span>
+        </div>
+      </div>
+    </div>
+    <span class="hintM">hover or focus the leaf</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/mimosa-pudica-as/style.css
+++ b/submissions/examples/mimosa-pudica-as/style.css
@@ -1,0 +1,194 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 28%, #3f4e34, #0e1409 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #b8cf94, #7fa262 52%, #3f5432);
+}
+
+.sunM {
+  position: absolute;
+  top: 24px;
+  right: 30px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffce4, #f6e08a 58%, rgba(240, 220, 130, 0) 78%);
+  z-index: 1;
+}
+
+.soilM {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 42px;
+  background:
+    radial-gradient(circle at 20% 40%, rgba(40, 26, 12, 0.5) 0 3px, transparent 4px),
+    radial-gradient(circle at 68% 66%, rgba(40, 26, 12, 0.44) 0 4px, transparent 5px),
+    linear-gradient(180deg, #4f3a22, #1d1409);
+  z-index: 6;
+}
+
+.potM {
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  width: 88px;
+  height: 16px;
+  margin-left: -112px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 30%, #6a5030, #2a1c0e 76%);
+  z-index: 5;
+}
+
+.plantM {
+  position: absolute;
+  bottom: 36px;
+  left: 50%;
+  width: 260px;
+  height: 220px;
+  margin-left: -136px;
+  outline: none;
+  z-index: 4;
+}
+
+.stemM {
+  position: absolute;
+  bottom: 0;
+  left: 26px;
+  width: 7px;
+  height: 84px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #6f9048, #2f4a1c);
+  z-index: 3;
+}
+
+/* the main pulvinus: the whole leaf collapses here, and last */
+.petioleM {
+  position: absolute;
+  bottom: 80px;
+  left: 26px;
+  width: 220px;
+  height: 130px;
+  transform-origin: 3px 100%;
+  transform: rotate(0deg);
+  transition: transform 0.5s cubic-bezier(0.36, 0, 0.66, -0.2) 0.34s;
+  z-index: 4;
+}
+
+.plantM:hover .petioleM,
+.plantM:focus-visible .petioleM {
+  transform: rotate(52deg);
+}
+
+.shaftM {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 6px;
+  height: 46px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #74964c, #33501e);
+  z-index: 3;
+}
+
+.pulvM {
+  position: absolute;
+  bottom: -3px;
+  left: -2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #a8c274, #46621f 76%);
+  box-shadow: 0 0 0 1.5px rgba(240, 200, 90, 0.5);
+  z-index: 5;
+}
+
+.rachisM {
+  position: absolute;
+  bottom: 44px;
+  left: 3px;
+  width: 148px;
+  height: 4px;
+  transform-origin: 0 50%;
+  z-index: 4;
+}
+
+.rcA { transform: rotate(-36deg); }
+.rcB { transform: rotate(4deg); }
+
+.rodM {
+  position: absolute;
+  inset: 0;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #5f8038, #8fb058);
+}
+
+.leafM {
+  position: absolute;
+  left: calc(12px + var(--i) * 16px);
+  width: 9px;
+  height: 21px;
+  border-radius: 54% 46% 40% 40% / 62% 62% 38% 38%;
+  background: linear-gradient(180deg, #8fc45c, #33591c);
+  box-shadow: inset -1px -1px 2px rgba(20, 40, 12, 0.4);
+
+  /* the signal travels outward, so each leaflet folds after the one before it */
+  transition: transform 0.34s cubic-bezier(0.3, 0, 0.5, 1) calc(var(--i) * 0.075s);
+}
+
+.lfT {
+  bottom: 2px;
+  transform-origin: 50% 100%;
+  transform: rotate(-6deg);
+}
+
+.lfB {
+  top: 2px;
+  transform-origin: 50% 0;
+  transform: rotate(6deg);
+}
+
+/* folded: every leaflet swings toward the tip and the pairs close together */
+.plantM:hover .lfT,
+.plantM:focus-visible .lfT {
+  transform: rotate(76deg);
+}
+
+.plantM:hover .lfB,
+.plantM:focus-visible .lfB {
+  transform: rotate(-76deg);
+}
+
+.hintM {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  color: rgba(232, 244, 208, 0.6);
+  z-index: 7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .petioleM,
+  .leafM {
+    transition-duration: 0.001s;
+    transition-delay: 0s;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/mimosa-pudica-as/`, a self-contained pure CSS/HTML sensitive plant that folds when you hover or focus it.

Closes #47877

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **Real interaction, no JavaScript**: the fold is a `:hover` / `:focus-visible` state on the plant container. The plant responds to the user the way the real one responds to a touch. The `tabindex` plus `:focus-visible` branch means it also works from the keyboard.
- **The travelling wave is `transition-delay`**: every leaflet carries an index `--i` and its delay is `calc(var(--i) * 0.075s)`. That one line is the entire propagation effect. In the real plant the signal moves outward along the rachis at a few centimetres per second, so the leaflets shut in sequence rather than together.
- **Folding in pairs**: the upper leaflet pivots at `50% 100%` and the lower at `50% 0`, rotating in opposite directions so each pair closes toward the rachis tip like a book, which is what the real leaf does.
- **The pulvinus goes last**: the petiole's transition carries a `0.34s` delay, so the leaf only collapses after the leaflet wave has passed. Its `transform-origin` is pinned to the joint and a marked swelling sits there.
- **The droop overshoots**: the petiole uses a `cubic-bezier` with a negative final control point, so it drops past its resting angle and settles instead of easing politely into place.

## Accessibility

`prefers-reduced-motion: reduce` collapses the transition durations and delays to near zero, so the state change is instant rather than animated. The fold itself still happens, because it is the content rather than the decoration.

## Verification

Opened `demo.html` in the browser and confirmed the leaflets close in sequence rather than together, the pairs meet along the rachis, and the petiole drops afterwards at the pulvinus. Checked the computed values: leaflet 0 resolves to `0s` delay and leaflet 6 to `0.45s`, and the petiole to `0.34s`, so the wave and the ordering are real rather than eyeballed. Captured both the open and folded states to confirm the closed pose. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
