### PR TITLE
Add slide rule component

### DIFF
--- a/submissions/examples/slide-rule-as/README.md
+++ b/submissions/examples/slide-rule-as/README.md
@@ -1,0 +1,38 @@
+# Slide Rule
+
+A pure CSS/HTML slide rule working 2 x 3, with scales that are genuinely logarithmic.
+
+## What it shows
+
+A slide rule multiplies by adding lengths. If you space the marks so that the distance from 1 to any number *n* is proportional to log(n), then sliding one scale along another physically adds two logarithms, and log(2) + log(3) = log(6) does the multiplication for you.
+
+That is the whole machine. There are no gears and nothing to compute. The answer is a distance.
+
+## How it is built
+
+- **The scales are actually logarithmic.** Every tick's position is `left: var(--p)`, where `--p` is that number's real `log10` as a percentage: 2 sits at 30.103%, 3 at 47.712%, 6 at 77.815%. They are not evenly spaced, which is why the marks crowd toward 10 exactly the way a real rule does.
+- **The arithmetic falls out of the geometry.** The slide's travel is `78.27px`, which is `log10(2) x 260px`, so C's 1 lands on D's 2. The cursor's travel is `202.32px`, which is `log10(6) x 260px`. Nothing rounds those to look right; they are the log values.
+- **C and D touch.** C hangs off the bottom edge of the slide and D rises off the top edge of the stock, so the two scales meet at the seam and can be read against each other, which is the only reason the instrument works.
+- **The groove**: the slide rides in a dark channel. Without it, sliding right just opened a hole to the background.
+- **The cursor**: a bevelled glass window with a red hairline, so one vertical line reads both scales at once.
+
+## Verified, not asserted
+
+Measured in the browser with the slide and cursor at their set positions:
+
+- C's **1** sits over D's **2**, offset **0.00px**
+- the hairline sits over C's **3** (off by 0.01px) and over D's **6** (off by 0.02px) at the same time
+- distance(1→2) + distance(1→3) = 78.27 + 124.05 = **202.31px** = distance(1→6)
+
+The last line is the point. The rule adds two lengths and the sum is the answer.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables the keyframes and parks the slide and cursor at the solved position, so the finished calculation still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/slide-rule-as/demo.html
+++ b/submissions/examples/slide-rule-as/demo.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Slide Rule</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="ruleS">
+      <span class="stockS stTop"></span>
+      <span class="grooveS"></span>
+
+      <div class="slideS">
+        <span class="faceS"></span>
+        <div class="scaleS scC">
+        <span class="tickS majS" style="--p: 0%%"></span>
+        <span class="numS" style="--p: 0%">1</span>
+        <span class="tickS minS" style="--p: 4.1393%"></span>
+        <span class="tickS minS" style="--p: 7.9181%"></span>
+        <span class="tickS minS" style="--p: 11.3943%"></span>
+        <span class="tickS minS" style="--p: 14.6128%"></span>
+        <span class="tickS minS" style="--p: 17.6091%"></span>
+        <span class="tickS minS" style="--p: 20.4120%"></span>
+        <span class="tickS minS" style="--p: 23.0449%"></span>
+        <span class="tickS minS" style="--p: 25.5273%"></span>
+        <span class="tickS minS" style="--p: 27.8754%"></span>
+        <span class="tickS majS" style="--p: 30.1030%"></span>
+        <span class="numS" style="--p: 30.1030%">2</span>
+        <span class="tickS minS" style="--p: 32.2219%"></span>
+        <span class="tickS minS" style="--p: 34.2423%"></span>
+        <span class="tickS minS" style="--p: 36.1728%"></span>
+        <span class="tickS minS" style="--p: 38.0211%"></span>
+        <span class="tickS minS" style="--p: 39.7940%"></span>
+        <span class="tickS minS" style="--p: 41.4973%"></span>
+        <span class="tickS minS" style="--p: 43.1364%"></span>
+        <span class="tickS minS" style="--p: 44.7158%"></span>
+        <span class="tickS minS" style="--p: 46.2398%"></span>
+        <span class="tickS majS" style="--p: 47.7121%"></span>
+        <span class="numS" style="--p: 47.7121%">3</span>
+        <span class="tickS minS" style="--p: 49.1362%"></span>
+        <span class="tickS minS" style="--p: 50.5150%"></span>
+        <span class="tickS minS" style="--p: 51.8514%"></span>
+        <span class="tickS minS" style="--p: 53.1479%"></span>
+        <span class="tickS minS" style="--p: 54.4068%"></span>
+        <span class="tickS minS" style="--p: 55.6303%"></span>
+        <span class="tickS minS" style="--p: 56.8202%"></span>
+        <span class="tickS minS" style="--p: 57.9784%"></span>
+        <span class="tickS minS" style="--p: 59.1065%"></span>
+        <span class="tickS majS" style="--p: 60.2060%"></span>
+        <span class="numS" style="--p: 60.2060%">4</span>
+        <span class="tickS minS" style="--p: 61.2784%"></span>
+        <span class="tickS minS" style="--p: 62.3249%"></span>
+        <span class="tickS minS" style="--p: 63.3468%"></span>
+        <span class="tickS minS" style="--p: 64.3453%"></span>
+        <span class="tickS minS" style="--p: 65.3213%"></span>
+        <span class="tickS minS" style="--p: 66.2758%"></span>
+        <span class="tickS minS" style="--p: 67.2098%"></span>
+        <span class="tickS minS" style="--p: 68.1241%"></span>
+        <span class="tickS minS" style="--p: 69.0196%"></span>
+        <span class="tickS majS" style="--p: 69.8970%"></span>
+        <span class="numS" style="--p: 69.8970%">5</span>
+        <span class="tickS minS" style="--p: 70.7570%"></span>
+        <span class="tickS minS" style="--p: 71.6003%"></span>
+        <span class="tickS minS" style="--p: 72.4276%"></span>
+        <span class="tickS minS" style="--p: 73.2394%"></span>
+        <span class="tickS minS" style="--p: 74.0363%"></span>
+        <span class="tickS minS" style="--p: 74.8188%"></span>
+        <span class="tickS minS" style="--p: 75.5875%"></span>
+        <span class="tickS minS" style="--p: 76.3428%"></span>
+        <span class="tickS minS" style="--p: 77.0852%"></span>
+        <span class="tickS majS" style="--p: 77.8151%"></span>
+        <span class="numS" style="--p: 77.8151%">6</span>
+        <span class="tickS minS" style="--p: 78.5330%"></span>
+        <span class="tickS minS" style="--p: 79.2392%"></span>
+        <span class="tickS minS" style="--p: 79.9341%"></span>
+        <span class="tickS minS" style="--p: 80.6180%"></span>
+        <span class="tickS minS" style="--p: 81.2913%"></span>
+        <span class="tickS minS" style="--p: 81.9544%"></span>
+        <span class="tickS minS" style="--p: 82.6075%"></span>
+        <span class="tickS minS" style="--p: 83.2509%"></span>
+        <span class="tickS minS" style="--p: 83.8849%"></span>
+        <span class="tickS majS" style="--p: 84.5098%"></span>
+        <span class="numS" style="--p: 84.5098%">7</span>
+        <span class="tickS minS" style="--p: 85.1258%"></span>
+        <span class="tickS minS" style="--p: 85.7332%"></span>
+        <span class="tickS minS" style="--p: 86.3323%"></span>
+        <span class="tickS minS" style="--p: 86.9232%"></span>
+        <span class="tickS minS" style="--p: 87.5061%"></span>
+        <span class="tickS minS" style="--p: 88.0814%"></span>
+        <span class="tickS minS" style="--p: 88.6491%"></span>
+        <span class="tickS minS" style="--p: 89.2095%"></span>
+        <span class="tickS minS" style="--p: 89.7627%"></span>
+        <span class="tickS majS" style="--p: 90.3090%"></span>
+        <span class="numS" style="--p: 90.3090%">8</span>
+        <span class="tickS minS" style="--p: 90.8485%"></span>
+        <span class="tickS minS" style="--p: 91.3814%"></span>
+        <span class="tickS minS" style="--p: 91.9078%"></span>
+        <span class="tickS minS" style="--p: 92.4279%"></span>
+        <span class="tickS minS" style="--p: 92.9419%"></span>
+        <span class="tickS minS" style="--p: 93.4498%"></span>
+        <span class="tickS minS" style="--p: 93.9519%"></span>
+        <span class="tickS minS" style="--p: 94.4483%"></span>
+        <span class="tickS minS" style="--p: 94.9390%"></span>
+        <span class="tickS majS" style="--p: 95.4243%"></span>
+        <span class="numS" style="--p: 95.4243%">9</span>
+        <span class="tickS minS" style="--p: 95.9041%"></span>
+        <span class="tickS minS" style="--p: 96.3788%"></span>
+        <span class="tickS minS" style="--p: 96.8483%"></span>
+        <span class="tickS minS" style="--p: 97.3128%"></span>
+        <span class="tickS minS" style="--p: 97.7724%"></span>
+        <span class="tickS minS" style="--p: 98.2271%"></span>
+        <span class="tickS minS" style="--p: 98.6772%"></span>
+        <span class="tickS minS" style="--p: 99.1226%"></span>
+        <span class="tickS minS" style="--p: 99.5635%"></span>
+        <span class="tickS majS" style="--p: 100%%"></span>
+        <span class="numS" style="--p: 100%">1</span>
+        </div>
+        <span class="tagS">C</span>
+      </div>
+
+      <div class="lowerS">
+        <span class="faceS"></span>
+        <div class="scaleS scD">
+        <span class="tickS majS" style="--p: 0%%"></span>
+        <span class="numS" style="--p: 0%">1</span>
+        <span class="tickS minS" style="--p: 4.1393%"></span>
+        <span class="tickS minS" style="--p: 7.9181%"></span>
+        <span class="tickS minS" style="--p: 11.3943%"></span>
+        <span class="tickS minS" style="--p: 14.6128%"></span>
+        <span class="tickS minS" style="--p: 17.6091%"></span>
+        <span class="tickS minS" style="--p: 20.4120%"></span>
+        <span class="tickS minS" style="--p: 23.0449%"></span>
+        <span class="tickS minS" style="--p: 25.5273%"></span>
+        <span class="tickS minS" style="--p: 27.8754%"></span>
+        <span class="tickS majS" style="--p: 30.1030%"></span>
+        <span class="numS" style="--p: 30.1030%">2</span>
+        <span class="tickS minS" style="--p: 32.2219%"></span>
+        <span class="tickS minS" style="--p: 34.2423%"></span>
+        <span class="tickS minS" style="--p: 36.1728%"></span>
+        <span class="tickS minS" style="--p: 38.0211%"></span>
+        <span class="tickS minS" style="--p: 39.7940%"></span>
+        <span class="tickS minS" style="--p: 41.4973%"></span>
+        <span class="tickS minS" style="--p: 43.1364%"></span>
+        <span class="tickS minS" style="--p: 44.7158%"></span>
+        <span class="tickS minS" style="--p: 46.2398%"></span>
+        <span class="tickS majS" style="--p: 47.7121%"></span>
+        <span class="numS" style="--p: 47.7121%">3</span>
+        <span class="tickS minS" style="--p: 49.1362%"></span>
+        <span class="tickS minS" style="--p: 50.5150%"></span>
+        <span class="tickS minS" style="--p: 51.8514%"></span>
+        <span class="tickS minS" style="--p: 53.1479%"></span>
+        <span class="tickS minS" style="--p: 54.4068%"></span>
+        <span class="tickS minS" style="--p: 55.6303%"></span>
+        <span class="tickS minS" style="--p: 56.8202%"></span>
+        <span class="tickS minS" style="--p: 57.9784%"></span>
+        <span class="tickS minS" style="--p: 59.1065%"></span>
+        <span class="tickS majS" style="--p: 60.2060%"></span>
+        <span class="numS" style="--p: 60.2060%">4</span>
+        <span class="tickS minS" style="--p: 61.2784%"></span>
+        <span class="tickS minS" style="--p: 62.3249%"></span>
+        <span class="tickS minS" style="--p: 63.3468%"></span>
+        <span class="tickS minS" style="--p: 64.3453%"></span>
+        <span class="tickS minS" style="--p: 65.3213%"></span>
+        <span class="tickS minS" style="--p: 66.2758%"></span>
+        <span class="tickS minS" style="--p: 67.2098%"></span>
+        <span class="tickS minS" style="--p: 68.1241%"></span>
+        <span class="tickS minS" style="--p: 69.0196%"></span>
+        <span class="tickS majS" style="--p: 69.8970%"></span>
+        <span class="numS" style="--p: 69.8970%">5</span>
+        <span class="tickS minS" style="--p: 70.7570%"></span>
+        <span class="tickS minS" style="--p: 71.6003%"></span>
+        <span class="tickS minS" style="--p: 72.4276%"></span>
+        <span class="tickS minS" style="--p: 73.2394%"></span>
+        <span class="tickS minS" style="--p: 74.0363%"></span>
+        <span class="tickS minS" style="--p: 74.8188%"></span>
+        <span class="tickS minS" style="--p: 75.5875%"></span>
+        <span class="tickS minS" style="--p: 76.3428%"></span>
+        <span class="tickS minS" style="--p: 77.0852%"></span>
+        <span class="tickS majS" style="--p: 77.8151%"></span>
+        <span class="numS" style="--p: 77.8151%">6</span>
+        <span class="tickS minS" style="--p: 78.5330%"></span>
+        <span class="tickS minS" style="--p: 79.2392%"></span>
+        <span class="tickS minS" style="--p: 79.9341%"></span>
+        <span class="tickS minS" style="--p: 80.6180%"></span>
+        <span class="tickS minS" style="--p: 81.2913%"></span>
+        <span class="tickS minS" style="--p: 81.9544%"></span>
+        <span class="tickS minS" style="--p: 82.6075%"></span>
+        <span class="tickS minS" style="--p: 83.2509%"></span>
+        <span class="tickS minS" style="--p: 83.8849%"></span>
+        <span class="tickS majS" style="--p: 84.5098%"></span>
+        <span class="numS" style="--p: 84.5098%">7</span>
+        <span class="tickS minS" style="--p: 85.1258%"></span>
+        <span class="tickS minS" style="--p: 85.7332%"></span>
+        <span class="tickS minS" style="--p: 86.3323%"></span>
+        <span class="tickS minS" style="--p: 86.9232%"></span>
+        <span class="tickS minS" style="--p: 87.5061%"></span>
+        <span class="tickS minS" style="--p: 88.0814%"></span>
+        <span class="tickS minS" style="--p: 88.6491%"></span>
+        <span class="tickS minS" style="--p: 89.2095%"></span>
+        <span class="tickS minS" style="--p: 89.7627%"></span>
+        <span class="tickS majS" style="--p: 90.3090%"></span>
+        <span class="numS" style="--p: 90.3090%">8</span>
+        <span class="tickS minS" style="--p: 90.8485%"></span>
+        <span class="tickS minS" style="--p: 91.3814%"></span>
+        <span class="tickS minS" style="--p: 91.9078%"></span>
+        <span class="tickS minS" style="--p: 92.4279%"></span>
+        <span class="tickS minS" style="--p: 92.9419%"></span>
+        <span class="tickS minS" style="--p: 93.4498%"></span>
+        <span class="tickS minS" style="--p: 93.9519%"></span>
+        <span class="tickS minS" style="--p: 94.4483%"></span>
+        <span class="tickS minS" style="--p: 94.9390%"></span>
+        <span class="tickS majS" style="--p: 95.4243%"></span>
+        <span class="numS" style="--p: 95.4243%">9</span>
+        <span class="tickS minS" style="--p: 95.9041%"></span>
+        <span class="tickS minS" style="--p: 96.3788%"></span>
+        <span class="tickS minS" style="--p: 96.8483%"></span>
+        <span class="tickS minS" style="--p: 97.3128%"></span>
+        <span class="tickS minS" style="--p: 97.7724%"></span>
+        <span class="tickS minS" style="--p: 98.2271%"></span>
+        <span class="tickS minS" style="--p: 98.6772%"></span>
+        <span class="tickS minS" style="--p: 99.1226%"></span>
+        <span class="tickS minS" style="--p: 99.5635%"></span>
+        <span class="tickS majS" style="--p: 100%%"></span>
+        <span class="numS" style="--p: 100%">1</span>
+        </div>
+        <span class="tagS">D</span>
+      </div>
+
+      <div class="cursorS">
+        <span class="glassS"></span>
+        <span class="hairS"></span>
+      </div>
+    </div>
+
+    <span class="readS rdA">set C&#8201;1 over D&#8201;2</span>
+    <span class="readS rdB">read D under C&#8201;3 &#8594; 6</span>
+    <span class="capS">2 &#215; 3 by adding two logarithms</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/slide-rule-as/style.css
+++ b/submissions/examples/slide-rule-as/style.css
@@ -1,0 +1,247 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 28%, #3a3a42, #0e0e12 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 34%, #4a4a54, #101014 82%);
+}
+
+.ruleS {
+  position: absolute;
+  top: 78px;
+  left: 50%;
+  width: 300px;
+  height: 104px;
+  margin-left: -150px;
+  z-index: 3;
+}
+
+.stockS {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 26px;
+  border-radius: 3px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(180, 150, 90, 0.14) 0 1px,
+      transparent 1px 9px
+    ),
+    linear-gradient(180deg, #f2e6c2, #cbb98e);
+  box-shadow: inset 0 -2px 4px rgba(90, 70, 30, 0.3);
+  z-index: 2;
+}
+
+.stTop { top: 0; }
+
+.grooveS {
+  position: absolute;
+  top: 27px;
+  left: 0;
+  right: 0;
+  height: 38px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #2a2118, #4a3a28 50%, #241c12);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.7);
+  z-index: 1;
+}
+
+.slideS {
+  position: absolute;
+  top: 27px;
+  left: 0;
+  width: 300px;
+  height: 38px;
+  z-index: 3;
+  animation: setS 9s cubic-bezier(0.5, 0, 0.2, 1) infinite;
+}
+
+.lowerS {
+  position: absolute;
+  top: 66px;
+  left: 0;
+  width: 300px;
+  height: 38px;
+  z-index: 2;
+}
+
+.faceS {
+  position: absolute;
+  inset: 0;
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(180, 150, 90, 0.12) 0 1px,
+      transparent 1px 11px
+    ),
+    linear-gradient(180deg, #fbf3d8, #e2d3a6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 240, 0.8), inset 0 -2px 4px rgba(110, 88, 40, 0.24);
+  z-index: 1;
+}
+
+/* the scale body: 0% is 1 and 100% is 10, so every tick sits at its own log10 */
+.scaleS {
+  position: absolute;
+  left: 20px;
+  right: 20px;
+  height: 100%;
+  z-index: 2;
+}
+
+.tickS {
+  position: absolute;
+  left: var(--p, 0%);
+  width: 1px;
+  background: #2a241a;
+}
+
+.majS {
+  width: 1.4px;
+  height: 13px;
+  background: #14100a;
+}
+
+.minS { height: 6px; }
+
+.numS {
+  position: absolute;
+  left: var(--p, 0%);
+  font-size: 0.44rem;
+  font-weight: 600;
+  color: #14100a;
+  transform: translateX(-50%);
+}
+
+/* C reads off the bottom edge of the slide, D off the top edge of the stock, so they touch */
+.scC .tickS { bottom: 0; }
+.scC .numS { bottom: 14px; }
+.scD .tickS { top: 0; }
+.scD .numS { top: 14px; }
+
+.tagS {
+  position: absolute;
+  left: 5px;
+  font-size: 0.5rem;
+  font-weight: 700;
+  color: #6a3018;
+  z-index: 3;
+}
+
+.scC + .tagS { bottom: 2px; }
+.lowerS .tagS { top: 2px; }
+
+.cursorS {
+  position: absolute;
+  top: -6px;
+  left: 20px;
+  width: 44px;
+  height: 116px;
+  margin-left: -22px;
+  z-index: 6;
+  animation: readS 9s cubic-bezier(0.5, 0, 0.2, 1) infinite;
+}
+
+.glassS {
+  position: absolute;
+  inset: 0;
+  border-radius: 3px;
+  border: 2px solid #9aa2ac;
+  background: linear-gradient(126deg, rgba(226, 240, 250, 0.3), rgba(150, 180, 200, 0.12) 52%, rgba(226, 240, 250, 0.24));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+.hairS {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  left: 50%;
+  width: 1.4px;
+  margin-left: -0.7px;
+  background: #d8202c;
+  box-shadow: 0 0 4px rgba(216, 32, 44, 0.7);
+}
+
+.readS {
+  position: absolute;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  color: rgba(240, 232, 200, 0.9);
+  z-index: 8;
+}
+
+.rdA {
+  top: 34px;
+  animation: cueAS 9s ease-in-out infinite;
+}
+
+.rdB {
+  bottom: 42px;
+  animation: cueBS 9s ease-in-out infinite;
+}
+
+.capS {
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.1em;
+  color: rgba(200, 208, 220, 0.5);
+  z-index: 8;
+}
+
+/* slide right by log10(2) of the scale length: 0.30103 x 260px */
+@keyframes setS {
+  0%, 6% { transform: translateX(0); }
+  24%, 90% { transform: translateX(78.27px); }
+  97%, 100% { transform: translateX(0); }
+}
+
+/* cursor to log10(6) of the scale length: 0.77815 x 260px */
+@keyframes readS {
+  0%, 34% { transform: translateX(0); }
+  56%, 90% { transform: translateX(202.32px); }
+  97%, 100% { transform: translateX(0); }
+}
+
+@keyframes cueAS {
+  0%, 4% { opacity: 0; }
+  10%, 30% { opacity: 1; }
+  38%, 100% { opacity: 0.2; }
+}
+
+@keyframes cueBS {
+  0%, 44% { opacity: 0.2; }
+  58%, 88% { opacity: 1; }
+  96%, 100% { opacity: 0.2; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slideS,
+  .cursorS,
+  .rdA,
+  .rdB {
+    animation: none;
+  }
+
+  .slideS { transform: translateX(78.27px); }
+  .cursorS { transform: translateX(202.32px); }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/slide-rule-as/`, a self-contained pure CSS/HTML slide rule working 2 x 3 on genuinely logarithmic scales.

Closes #47879

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The scales are actually logarithmic.** Every tick's position is `left: var(--p)`, where `--p` is that number's real `log10` as a percentage: 2 sits at 30.103%, 3 at 47.712%, 6 at 77.815%. They are not evenly spaced, which is why the marks crowd toward 10 the way a real rule does. A decorative ruler with even ticks would look similar and mean nothing.
- **The arithmetic falls out of the geometry.** The slide's travel is `78.27px`, which is `log10(2) x 260px`, so C's 1 lands on D's 2. The cursor's travel is `202.32px`, which is `log10(6) x 260px`. Nothing is rounded to look right; they are the log values.
- **C and D touch.** C hangs off the bottom edge of the slide and D rises off the top edge of the stock, so the two scales meet at the seam and can be read against each other, which is the only reason the instrument works.
- **The groove**: the slide rides in a dark channel. Without it, sliding right just opened a hole to the background, which the browser check caught.
- **The cursor**: a bevelled glass window with a red hairline, so one vertical line reads both scales at once.

## Verification

Opened `demo.html` in the browser and measured the rendered geometry with the slide and cursor at their set positions:

- C's **1** sits over D's **2**, offset **0.00px**
- the hairline sits over C's **3** (off by 0.01px) and over D's **6** (off by 0.02px) at the same time
- distance(1→2) + distance(1→3) = 78.27 + 124.05 = **202.31px** = distance(1→6), and the cursor's programmed travel is 202.32px

That last line is the point: the rule adds two lengths and the sum is the answer. This is measured rather than eyeballed. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
