### PR TITLE
Add vampire squid component

### DIFF
--- a/submissions/examples/vampire-squid-as/README.md
+++ b/submissions/examples/vampire-squid-as/README.md
@@ -1,0 +1,30 @@
+# Vampire Squid
+
+A pure CSS/HTML *Vampyroteuthis infernalis* pulling its cloak inside out into the pineapple posture.
+
+## What it shows
+
+The vampire squid is neither a squid nor a vampire, and it does not attack anything. It drifts in the oxygen minimum zone, several hundred metres down, eating marine snow.
+
+Threatened, it does the one thing it can: it pulls its webbed arms up and over its own head. The web turns inside out, the body disappears inside it, and the soft spines that were harmlessly lining the inner surface end up bristling on the outside. That is the pineapple posture, and it turns the animal into a ball that appears to be all spines and no squid.
+
+It cannot ink. Living where it does, there is no light to hide from and no energy to spare. Instead it can eject a cloud of glowing mucus, and it carries photophores at its arm tips. Its eyes are the largest of any animal relative to body size.
+
+## How it is built
+
+- **The inversion is a real rotation.** The whole arm cluster is one element with `transform-origin: 50% 0` at the point where the arms meet the head. Rotating it 172 degrees folds it up and over, which is exactly what the animal does. The web, arms, spines and photophores all come along because they are children of it.
+- **The spines end up outside for free.** The cirri layer is drawn on the inner face of the relaxed web. Once the cluster rotates over, that face is on the outside. Nothing repositions them; the rotation does it.
+- **Enveloping, not hiding behind.** The cloak sits above the mantle in the stacking order, so when it inverts it covers the body rather than tucking behind it. That is the entire defence, so it had to read that way.
+- **The web**: a `repeating-conic-gradient` fanning from the arm crown, masked with a `radial-gradient` so it fades at the margin instead of ending in a hard box.
+- **Photophores**: one per arm tip, flashing on a stagger of `calc(var(--i) * 0.07s)` so the light runs around the rim rather than blinking as a block.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and parks the animal in the inverted posture with the spines out, so the defence still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/vampire-squid-as/demo.html
+++ b/submissions/examples/vampire-squid-as/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vampire Squid</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="snowV" style="left: 38px; top: 20px; animation-delay: 0s"></span>
+    <span class="snowV" style="left: 96px; top: 140px; animation-delay: -3s"></span>
+    <span class="snowV" style="left: 172px; top: 60px; animation-delay: -6s"></span>
+    <span class="snowV" style="left: 248px; top: 180px; animation-delay: -9s"></span>
+    <span class="snowV" style="left: 292px; top: 96px; animation-delay: -12s"></span>
+    <span class="snowV" style="left: 64px; top: 230px; animation-delay: -15s"></span>
+    <div class="squidV">
+      <span class="finV fnL"></span>
+      <span class="finV fnR"></span>
+      <span class="mantleV"></span>
+      <span class="headV"></span>
+      <span class="eyeV eyL"></span>
+      <span class="eyeV eyR"></span>
+      <div class="cloakV">
+        <span class="webV"></span>
+          <span class="armV" style="--a: -70deg; --i: 0"></span>
+          <span class="tipV" style="--a: -70deg; --i: 0"></span>
+          <span class="armV" style="--a: -50deg; --i: 1"></span>
+          <span class="tipV" style="--a: -50deg; --i: 1"></span>
+          <span class="armV" style="--a: -30deg; --i: 2"></span>
+          <span class="tipV" style="--a: -30deg; --i: 2"></span>
+          <span class="armV" style="--a: -10deg; --i: 3"></span>
+          <span class="tipV" style="--a: -10deg; --i: 3"></span>
+          <span class="armV" style="--a: 10deg; --i: 4"></span>
+          <span class="tipV" style="--a: 10deg; --i: 4"></span>
+          <span class="armV" style="--a: 30deg; --i: 5"></span>
+          <span class="tipV" style="--a: 30deg; --i: 5"></span>
+          <span class="armV" style="--a: 50deg; --i: 6"></span>
+          <span class="tipV" style="--a: 50deg; --i: 6"></span>
+          <span class="armV" style="--a: 70deg; --i: 7"></span>
+          <span class="tipV" style="--a: 70deg; --i: 7"></span>
+        <span class="cirriV"></span>
+      </div>
+    </div>
+    <span class="capV">the pineapple posture</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/vampire-squid-as/style.css
+++ b/submissions/examples/vampire-squid-as/style.css
@@ -1,0 +1,266 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #1a1024, #04030a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 30%, #23142e, #05040b 84%);
+}
+
+.snowV {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(210, 220, 240, 0.5);
+  z-index: 1;
+  animation: driftV 18s linear infinite;
+}
+
+.squidV {
+  position: absolute;
+  top: 52px;
+  left: 50%;
+  width: 200px;
+  height: 220px;
+  margin-left: -100px;
+  z-index: 4;
+  animation: hoverV 9s ease-in-out infinite;
+}
+
+.mantleV {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 84px;
+  height: 92px;
+  margin-left: -42px;
+  border-radius: 50% 50% 42% 42% / 62% 62% 38% 38%;
+  background: radial-gradient(circle at 42% 30%, #7a2440, #2e0c1c 74%, #14040c 96%);
+  box-shadow: inset -6px -6px 16px rgba(10, 2, 8, 0.7);
+  z-index: 4;
+}
+
+.finV {
+  position: absolute;
+  top: 10px;
+  width: 40px;
+  height: 26px;
+  border-radius: 50% 50% 46% 46%;
+  background: linear-gradient(180deg, #8a2c48, #3a0e20);
+  z-index: 3;
+  animation: flapV 3.2s ease-in-out infinite;
+}
+
+.fnL { left: 50%; margin-left: -70px; transform-origin: 100% 50%; }
+.fnR { left: 50%; margin-left: 30px; transform-origin: 0 50%; animation-delay: -1.6s; }
+
+.headV {
+  position: absolute;
+  top: 76px;
+  left: 50%;
+  width: 66px;
+  height: 44px;
+  margin-left: -33px;
+  border-radius: 44% 44% 40% 40% / 40% 40% 60% 60%;
+  background: radial-gradient(circle at 44% 34%, #6a2038, #260a16 78%);
+  z-index: 5;
+}
+
+/* the largest eye relative to body size of any animal */
+.eyeV {
+  position: absolute;
+  top: 84px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #cfefff 0 22%, #4aa8d8 44%, #10304a 82%);
+  box-shadow: 0 0 12px rgba(90, 190, 240, 0.7), inset 0 0 6px rgba(6, 20, 34, 0.8);
+  z-index: 6;
+  animation: glowV 9s ease-in-out infinite;
+}
+
+.eyL { left: 50%; margin-left: -27px; }
+.eyR { left: 50%; margin-left: 3px; }
+
+/*
+  the whole defence: the arm cluster pivots up over the head,
+  so the web turns inside out and the spines end up on the outside
+*/
+.cloakV {
+  position: absolute;
+  top: 108px;
+  left: 50%;
+  width: 200px;
+  height: 116px;
+  margin-left: -100px;
+  transform-origin: 50% 0;
+  z-index: 7;
+  animation: invertV 9s cubic-bezier(0.5, 0, 0.3, 1) infinite;
+}
+
+.webV {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 172px;
+  height: 106px;
+  margin-left: -86px;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 50% 0,
+      rgba(120, 30, 58, 0.5) 0 1deg,
+      rgba(58, 12, 28, 0.6) 1deg 3.4deg
+    );
+  mask-image: radial-gradient(ellipse 96% 100% at 50% 0, #000 0 82%, transparent 100%);
+  border-radius: 0 0 46% 46% / 0 0 62% 62%;
+  z-index: 2;
+}
+
+.armV {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 8px;
+  height: 100px;
+  margin-left: -4px;
+  border-radius: 0 0 4px 4px;
+  background: linear-gradient(180deg, #8f2c4e, #2a0a18);
+  transform-origin: 50% 0;
+  transform: rotate(var(--a, 0deg));
+  z-index: 3;
+}
+
+.tipV {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 9px;
+  height: 108px;
+  margin-left: -4.5px;
+  transform-origin: 50% 0;
+  transform: rotate(var(--a, 0deg));
+  z-index: 5;
+}
+
+/* photophore at each arm tip: the squid flashes, it has no ink */
+.tipV::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  margin-left: -4px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #eafcff, #46c8f0 52%, rgba(40, 140, 200, 0) 80%);
+  animation: flashV 9s ease-out infinite;
+  animation-delay: calc(var(--i, 0) * 0.07s - 0.4s);
+}
+
+/* the cirri: soft spines that only face outward once the cloak is inverted */
+.cirriV {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 176px;
+  height: 104px;
+  margin-left: -88px;
+  background:
+    repeating-conic-gradient(
+      from 202deg at 50% 0,
+      rgba(240, 190, 210, 0.7) 0 0.5deg,
+      transparent 0.5deg 2.6deg
+    );
+  mask-image: radial-gradient(ellipse 100% 100% at 50% 0, transparent 0 62%, #000 78% 96%, transparent 100%);
+  z-index: 4;
+  animation: bristleV 9s ease-in-out infinite;
+}
+
+.capV {
+  position: absolute;
+  bottom: 14px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.58rem;
+  letter-spacing: 0.12em;
+  color: rgba(220, 180, 210, 0.5);
+  z-index: 9;
+  animation: cueV 9s ease-in-out infinite;
+}
+
+/* relaxed cloak hangs below; alarmed, it folds up over the mantle */
+@keyframes invertV {
+  0%, 26% { transform: rotate(0deg) scale(1); }
+  46%, 72% { transform: rotate(172deg) scale(0.92); }
+  92%, 100% { transform: rotate(0deg) scale(1); }
+}
+
+@keyframes bristleV {
+  0%, 30% { opacity: 0; }
+  50%, 70% { opacity: 1; }
+  88%, 100% { opacity: 0; }
+}
+
+@keyframes flashV {
+  0%, 44% { opacity: 0.15; transform: scale(0.7); }
+  52% { opacity: 1; transform: scale(1.9); }
+  66%, 100% { opacity: 0.15; transform: scale(0.7); }
+}
+
+@keyframes glowV {
+  0%, 30% { filter: brightness(1); }
+  50% { filter: brightness(1.5); }
+  80%, 100% { filter: brightness(1); }
+}
+
+@keyframes hoverV {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-10px) rotate(1deg); }
+}
+
+@keyframes flapV {
+  0%, 100% { transform: rotate(-8deg); }
+  50% { transform: rotate(8deg); }
+}
+
+@keyframes driftV {
+  0% { transform: translate(0, -20px); opacity: 0; }
+  12% { opacity: 0.7; }
+  88% { opacity: 0.7; }
+  100% { transform: translate(-24px, 340px); opacity: 0; }
+}
+
+@keyframes cueV {
+  0%, 32% { opacity: 0; }
+  48%, 70% { opacity: 1; }
+  86%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .squidV,
+  .cloakV,
+  .cirriV,
+  .eyeV,
+  .finV,
+  .snowV,
+  .capV,
+  .tipV::after {
+    animation: none;
+  }
+
+  .cloakV { transform: rotate(172deg) scale(0.92); }
+  .cirriV { opacity: 1; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/vampire-squid-as/`, a self-contained pure CSS/HTML vampire squid inverting its cloak into the pineapple posture.

Closes #47881

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The inversion is a real rotation.** The whole arm cluster is one element with `transform-origin: 50% 0` at the point where the arms meet the head. Rotating it 172 degrees folds it up and over, which is exactly what the animal does. The web, arms, spines and photophores all come along because they are children of it.
- **The spines end up outside for free.** The cirri layer is drawn on the inner face of the relaxed web. Once the cluster rotates over, that face is on the outside. Nothing repositions them; the rotation does it. This is the part that made the component worth building as a transform rather than as two poses.
- **Enveloping, not hiding behind.** The cloak sits above the mantle in the stacking order so that when it inverts it covers the body rather than tucking behind it. The first pass had it underneath and the defence read as the squid standing in front of a fan, which the browser check caught.
- **The web**: a `repeating-conic-gradient` fanning from the arm crown, masked with a `radial-gradient` so it fades at the margin instead of ending in a hard box.
- **Photophores**: one per arm tip, flashing on a stagger of `calc(var(--i) * 0.07s)` so the light runs around the rim rather than blinking as a block. The animal has no ink, so the lights are the whole display.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and parks the animal in the inverted posture with the spines out, so the defence still reads without motion.

## Verification

Opened `demo.html` in the browser and captured both states. Confirmed the relaxed cloak hangs below with the web fanned and the photophores at the tips, and that the inverted state genuinely wraps the mantle with the pale cirri fringing the outside and the lights ringing the rim. Confirmed all eight arms and eight tips render and that the cloak, cirri and photophores each resolve to their own keyframe. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
