### PR TITLE
Add click beetle component

### DIFF
--- a/submissions/examples/click-beetle-as/README.md
+++ b/submissions/examples/click-beetle-as/README.md
@@ -1,0 +1,31 @@
+# Click Beetle
+
+A pure CSS/HTML click beetle: stuck on its back, it arches, latches, and fires itself into the air.
+
+## What it shows
+
+A click beetle on its back cannot right itself with its legs. Instead it uses a latch.
+
+A peg on the underside of its prothorax sits against a notch on the abdomen. The beetle arches its body so the peg catches on the lip of the notch, then contracts its muscles hard against that latch. The muscles cannot move the body, so the energy goes into deforming the cuticle itself. When the peg finally slips off the lip, everything stored comes out at once: the body snaps straight, the beetle slams the ground, and it is thrown into the air with a sharp audible click.
+
+This is **latch-mediated spring actuation**, and it beats muscle by a wide margin. Muscle is slow. A latch lets you load slowly and release all at once, so peak acceleration can exceed 300 g, far more than any muscle could deliver directly. The beetle does not aim, so it tumbles.
+
+## How it is built
+
+- **Load slow, release in one frame.** The arch builds across 32% of the cycle and the snap takes **2%**. That ratio is the entire point of a latch, so the keyframe is deliberately lopsided instead of eased evenly.
+- **A real hinge**: the fore-body (prothorax, head, antennae, peg) is a nested element whose `transform-origin` is pinned to the hinge point. Rotating it lifts the front and cocks the mechanism, exactly where the beetle bends.
+- **The latch is drawn**: the peg rides on the fore-body and the notch sits on the abdomen. The notch compresses and brightens as the strain builds, then releases on the same frame the arch fires.
+- **Overshoot**: the snap does not stop at flat, it goes past and rebounds, because the recoil is what launches the beetle.
+- **Ballistics**: launch and tumble are separate nested keyframes, so the beetle rises and falls on one and rotates 540 degrees on the other. It lands on its feet by luck, which is honest.
+- **Dust** puffs from the strike point on the frame the click lands.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the beetle fully arched and latched, so the loaded mechanism still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/click-beetle-as/demo.html
+++ b/submissions/examples/click-beetle-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Click Beetle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="leafK lkA"></span>
+    <span class="leafK lkB"></span>
+    <span class="groundK"></span>
+    <span class="dustK dsA"></span>
+    <span class="dustK dsB"></span>
+    <span class="dustK dsC"></span>
+    <div class="hopK">
+      <div class="spinK">
+        <div class="beetleK">
+          <span class="elytraK"></span>
+          <span class="sutureK"></span>
+          <span class="legK lgA"></span>
+          <span class="legK lgB"></span>
+          <div class="foreK">
+            <span class="pronK"></span>
+            <span class="headK"></span>
+            <span class="antK anL"></span>
+            <span class="antK anR"></span>
+            <span class="legK lgC"></span>
+            <span class="pegK"></span>
+          </div>
+          <span class="notchK"></span>
+        </div>
+      </div>
+    </div>
+    <span class="capK">peg slips the notch: 300 g in one click</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/click-beetle-as/style.css
+++ b/submissions/examples/click-beetle-as/style.css
@@ -1,0 +1,302 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 28%, #4a4230, #100e08 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #8f9a68, #5f6a42 56%, #2f3620);
+}
+
+.leafK {
+  position: absolute;
+  border-radius: 60% 20% 60% 20%;
+  background: linear-gradient(140deg, #6f8f44, #2f4a1c);
+  z-index: 1;
+}
+
+.lkA { bottom: 44px; left: -14px; width: 96px; height: 40px; transform: rotate(-12deg); }
+.lkB { bottom: 52px; right: -20px; width: 110px; height: 44px; transform: rotate(8deg) scaleX(-1); filter: brightness(0.86); }
+
+.groundK {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 62px;
+  background:
+    radial-gradient(circle at 16% 40%, rgba(30, 24, 10, 0.4) 0 4px, transparent 6px),
+    radial-gradient(circle at 62% 66%, rgba(30, 24, 10, 0.36) 0 5px, transparent 7px),
+    radial-gradient(circle at 88% 32%, rgba(30, 24, 10, 0.4) 0 4px, transparent 6px),
+    linear-gradient(180deg, #55532e, #221f10);
+  z-index: 5;
+}
+
+.groundK::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: rgba(200, 210, 140, 0.4);
+}
+
+/* the ballistic arc: the beetle is airborne only because of the click */
+.hopK {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 150px;
+  height: 46px;
+  margin-left: -75px;
+  z-index: 6;
+  animation: launchK 5s cubic-bezier(0.3, 0, 0.4, 1) infinite;
+}
+
+.spinK {
+  position: absolute;
+  inset: 0;
+  animation: tumbleK 5s cubic-bezier(0.3, 0, 0.4, 1) infinite;
+}
+
+.beetleK {
+  position: absolute;
+  inset: 0;
+  transform: scale(1.75);
+  transform-origin: 50% 100%;
+}
+
+/* the beetle lies on its back, so the elytra are underneath */
+.elytraK {
+  position: absolute;
+  bottom: 4px;
+  left: 52px;
+  width: 92px;
+  height: 34px;
+  border-radius: 26% 46% 44% 22% / 44% 50% 50% 44%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 12, 4, 0.3) 0 1px,
+      transparent 1px 7px
+    ),
+    linear-gradient(180deg, #6a4a20, #2a1a08);
+  box-shadow: inset -4px -3px 8px rgba(14, 8, 2, 0.6);
+  z-index: 3;
+}
+
+.sutureK {
+  position: absolute;
+  bottom: 19px;
+  left: 54px;
+  width: 88px;
+  height: 1.6px;
+  border-radius: 1px;
+  background: rgba(232, 208, 150, 0.34);
+  z-index: 4;
+}
+
+/* the hinge: the fore-body pivots here, which is the whole mechanism */
+.foreK {
+  position: absolute;
+  bottom: 2px;
+  left: 0;
+  width: 60px;
+  height: 40px;
+  transform-origin: 100% 60%;
+  z-index: 4;
+  animation: archK 5s cubic-bezier(0.25, 0, 0.3, 1) infinite;
+}
+
+.pronK {
+  position: absolute;
+  bottom: 2px;
+  right: 0;
+  width: 42px;
+  height: 32px;
+  border-radius: 40% 16% 18% 46% / 54% 42% 42% 54%;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(20, 12, 4, 0.26) 0 1px,
+      transparent 1px 6px
+    ),
+    linear-gradient(180deg, #7a5624, #33200a);
+  box-shadow: inset -3px -2px 6px rgba(12, 6, 2, 0.6);
+  z-index: 3;
+}
+
+.headK {
+  position: absolute;
+  bottom: 7px;
+  left: 4px;
+  width: 18px;
+  height: 17px;
+  border-radius: 50% 40% 40% 50%;
+  background: radial-gradient(circle at 60% 34%, #5f4018, #1c1006 78%);
+  z-index: 2;
+}
+
+.antK {
+  position: absolute;
+  width: 20px;
+  height: 2px;
+  border-radius: 1px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #3a260c 0 2px,
+      transparent 2px 3.4px
+    ),
+    #24170a;
+  transform-origin: 100% 50%;
+  transform: rotate(var(--an, 0deg));
+  z-index: 1;
+  animation: feelK 1.9s ease-in-out infinite;
+}
+
+.anL { --an: -24deg; bottom: 18px; left: -12px; }
+.anR { --an: 16deg; bottom: 8px; left: -13px; animation-delay: -0.9s; }
+
+/* the peg that rides in the notch and then slips out of it */
+.pegK {
+  position: absolute;
+  bottom: -3px;
+  right: 6px;
+  width: 7px;
+  height: 9px;
+  border-radius: 2px 2px 4px 4px;
+  background: linear-gradient(180deg, #c8a45c, #6a4818);
+  z-index: 5;
+}
+
+.notchK {
+  position: absolute;
+  bottom: -1px;
+  left: 54px;
+  width: 13px;
+  height: 8px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #241708, #0e0904);
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.8), 0 0 0 1px rgba(210, 170, 90, 0.3);
+  z-index: 2;
+  animation: strainK 5s ease-in-out infinite;
+}
+
+.legK {
+  position: absolute;
+  width: 3px;
+  height: 15px;
+  border-radius: 2px;
+  background: #2a1a08;
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: kickK 5s ease-in-out infinite;
+}
+
+.lgA { top: -2px; left: 78px; }
+.lgB { top: -2px; left: 116px; animation-delay: -0.2s; }
+.lgC { top: -2px; left: 30px; animation-delay: -0.4s; }
+
+.dustK {
+  position: absolute;
+  bottom: 56px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: rgba(216, 210, 160, 0.85);
+  z-index: 7;
+  animation: puffK 5s ease-out infinite;
+}
+
+.dsA { left: 152px; --dx: -34px; --dy: -30px; }
+.dsB { left: 170px; --dx: 30px; --dy: -38px; animation-delay: -0.06s; }
+.dsC { left: 186px; --dx: 44px; --dy: -18px; animation-delay: -0.12s; }
+
+.capK {
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  color: rgba(232, 240, 190, 0.62);
+  z-index: 9;
+}
+
+/*
+  load slowly, release in a single frame.
+  the arch builds over two seconds and the snap is 2% of the cycle.
+*/
+@keyframes archK {
+  0%, 8% { transform: rotate(0deg); }
+  40% { transform: rotate(-30deg); }
+  42% { transform: rotate(8deg); }
+  46% { transform: rotate(-4deg); }
+  58%, 100% { transform: rotate(0deg); }
+}
+
+@keyframes launchK {
+  0%, 42% { transform: translateY(0); }
+  52% { transform: translateY(-118px); }
+  66% { transform: translateY(0); }
+  70% { transform: translateY(-14px); }
+  76%, 100% { transform: translateY(0); }
+}
+
+@keyframes tumbleK {
+  0%, 42% { transform: rotate(0deg); }
+  66% { transform: rotate(468deg); }
+  76%, 100% { transform: rotate(540deg); }
+}
+
+@keyframes strainK {
+  0%, 8% { transform: scaleY(1); filter: brightness(1); }
+  40% { transform: scaleY(0.7); filter: brightness(1.6); }
+  42%, 100% { transform: scaleY(1); filter: brightness(1); }
+}
+
+@keyframes kickK {
+  0%, 40% { transform: rotate(0deg); }
+  44% { transform: rotate(38deg); }
+  60% { transform: rotate(-14deg); }
+  80%, 100% { transform: rotate(0deg); }
+}
+
+@keyframes feelK {
+  0%, 100% { transform: rotate(var(--an, 0deg)); }
+  50% { transform: rotate(calc(var(--an, 0deg) + 12deg)); }
+}
+
+@keyframes puffK {
+  0%, 41% { transform: translate(0, 0) scale(0.4); opacity: 0; }
+  44% { opacity: 0.9; }
+  60%, 100% { transform: translate(var(--dx, 0), var(--dy, 0)) scale(1.3); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hopK,
+  .spinK,
+  .foreK,
+  .notchK,
+  .legK,
+  .antK,
+  .dustK {
+    animation: none;
+  }
+
+  .foreK { transform: rotate(-30deg); }
+  .dustK { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/click-beetle-as/`, a self-contained pure CSS/HTML click beetle launching itself off its back with a latch.

Closes #47883

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **Load slow, release in one frame.** The arch builds across 32% of the cycle and the snap takes **2%**. That ratio is the entire point of a latch: muscle is slow, but a latch lets you load slowly and dump it all at once, which is how the beetle clears 300 g. An evenly eased animation would be describing a different animal.
- **A real hinge**: the fore-body (prothorax, head, antennae, peg) is a nested element whose `transform-origin` is pinned to the hinge point, so rotating it lifts the front and cocks the mechanism exactly where the beetle bends.
- **The latch is drawn**: the peg rides on the fore-body and the notch sits on the abdomen. The notch compresses and brightens as strain builds, then releases on the same frame the arch fires.
- **Overshoot**: the snap does not stop at flat, it goes past and rebounds, because the recoil is what launches the beetle.
- **Ballistics**: launch and tumble are separate nested keyframes, so the beetle rises and falls on one and rotates 540 degrees on the other. It lands on its feet by luck, which is honest to the animal.
- **Antennae**: each carries its own `--an` angle and the shared keyframe rebuilds it with `rotate(calc(var(--an) + 12deg))`, so the sweep cannot flatten both antennae onto the same angle.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the beetle fully arched and latched, so the loaded mechanism still reads without motion.

## Verification

Opened `demo.html` in the browser and stepped the cycle: confirmed the beetle rests on its back with legs up, arches at the hinge under load, then leaves the ground and tumbles before landing. Checked the fore-body's computed `transform-origin` resolves to the hinge rather than the element centre, and that launch and tumble resolve to separate keyframes. Also caught and fixed a malformed hex colour in the peg before linting. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
