### PR TITLE
Add gyroscope component

### DIFF
--- a/submissions/examples/gyroscope-as/README.md
+++ b/submissions/examples/gyroscope-as/README.md
@@ -1,0 +1,37 @@
+# Gyroscope
+
+A pure CSS/HTML gyroscope leaning off vertical and refusing to fall, its axis walking a slow cone instead.
+
+## What it shows
+
+Hang a spinning gyroscope off-centre and it does not topple. It **turns**.
+
+Gravity is pulling down on it the whole time, and the torque that pull creates is perpendicular to the wheel's angular momentum. A torque perpendicular to angular momentum does not change how fast the wheel spins or make it drop. It swings the direction of the axis sideways. So the axis walks a horizontal circle, and the gyroscope hangs there at an angle looking like it has forgotten about gravity.
+
+The faster the wheel spins, the *slower* it precesses, which is the opposite of what intuition suggests.
+
+## How it is built
+
+The structure is the physics. Three nested frames, each doing one rotation:
+
+1. **`.precessG`** rotates about the vertical with `rotateY(0 → 360deg)`. This is the precession.
+2. **`.tiltG`** carries a static `rotateZ(26deg)`. This is the lean gravity is pulling on.
+3. **`.rotorG`** spins fast about its own axis.
+
+Because they are nested with `transform-style: preserve-3d`, the tilted axis genuinely gets carried around the cone by the outer frame. Nothing traces a path by hand; the composition does it.
+
+- **Timescale separation**: the rotor's `0.42s` against the precession's `6s` is roughly 14:1, so the wheel visibly spins many times per lap. That gap is the whole reason a gyroscope is stable.
+- **The disc in perspective**: `.gimbalG` applies `rotateX(72deg)` so the wheel reads as an ellipse rather than a flat circle. Drawn with fine conic bands it looked like a spiderweb, so it is a solid metal `radial-gradient` with a spin streak over it.
+- **The trace**: a dashed ellipse marking the circle the axis walks.
+- **Labels**: gravity pulling down, precession going sideways, which is the counterintuitive part worth pointing at.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables both rotations. The tilt is a static transform, so the gyroscope still reads as leaning and unfallen with motion off.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/gyroscope-as/demo.html
+++ b/submissions/examples/gyroscope-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gyroscope</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="baseG"></span>
+    <span class="pillarG"></span>
+    <span class="pivotG"></span>
+    <span class="traceG"></span>
+
+    <div class="precessG">
+      <div class="tiltG">
+        <span class="spindleG"></span>
+        <div class="gimbalG">
+          <span class="ringG"></span>
+          <div class="rotorG">
+            <span class="discG"></span>
+            <span class="spokeG"></span>
+            <span class="hubG"></span>
+          </div>
+          <span class="forkG fkL"></span>
+          <span class="forkG fkR"></span>
+        </div>
+        <span class="axisG"></span>
+        <span class="tipG"></span>
+      </div>
+    </div>
+
+    <span class="labelG lgSpin">spin</span>
+    <span class="labelG lgPrec">precession</span>
+    <span class="labelG lgGrav">gravity</span>
+    <span class="arrowG arGrav"></span>
+    <span class="capG">gravity does not tip it, it turns it</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gyroscope-as/style.css
+++ b/submissions/examples/gyroscope-as/style.css
@@ -1,0 +1,293 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #333c46, #0a0d11 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 32%, #46525f, #0c0f13 84%);
+  perspective: 760px;
+}
+
+.baseG {
+  position: absolute;
+  bottom: 34px;
+  left: 50%;
+  width: 168px;
+  height: 30px;
+  margin-left: -84px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 34%, #7c6a4e, #241c10 76%);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.6);
+  z-index: 2;
+}
+
+.pillarG {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 13px;
+  height: 74px;
+  margin-left: -6.5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #5f6a76, #cfdae4 42%, #46505a);
+  z-index: 3;
+}
+
+.pivotG {
+  position: absolute;
+  bottom: 116px;
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f0f6fa, #5a6672 74%);
+  box-shadow: 0 0 6px rgba(190, 220, 240, 0.6);
+  z-index: 8;
+}
+
+/* the circle the tilted axis walks around while it refuses to fall */
+.traceG {
+  position: absolute;
+  bottom: 150px;
+  left: 50%;
+  width: 132px;
+  height: 40px;
+  margin-left: -66px;
+  border: 1.5px dashed rgba(120, 200, 240, 0.34);
+  border-radius: 50%;
+  z-index: 3;
+}
+
+/* outer frame: rotation about the vertical. this is the precession itself */
+.precessG {
+  position: absolute;
+  bottom: 123px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  transform-style: preserve-3d;
+  z-index: 6;
+  animation: precessG 6s linear infinite;
+}
+
+/* the lean off vertical. gravity pulls here and the axis turns instead of dropping */
+.tiltG {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  transform-style: preserve-3d;
+  transform: rotateZ(26deg);
+}
+
+.spindleG {
+  position: absolute;
+  bottom: -6px;
+  left: -4px;
+  width: 8px;
+  height: 96px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #4e5862, #d4dfe8 44%, #3c454e);
+  transform-style: preserve-3d;
+}
+
+.axisG {
+  position: absolute;
+  bottom: -34px;
+  left: -1px;
+  width: 2px;
+  height: 168px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(120, 210, 250, 0.85) 0 6px,
+      transparent 6px 12px
+    );
+  transform-style: preserve-3d;
+}
+
+.tipG {
+  position: absolute;
+  bottom: 92px;
+  left: -5px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #e8f6ff, #4a8ab0 74%);
+  box-shadow: 0 0 8px rgba(120, 210, 250, 0.8);
+  transform-style: preserve-3d;
+}
+
+/* laid over so the rotor reads as a disc in perspective rather than a circle */
+.gimbalG {
+  position: absolute;
+  bottom: 58px;
+  left: 0;
+  width: 0;
+  height: 0;
+  transform-style: preserve-3d;
+  transform: rotateX(72deg);
+}
+
+.ringG {
+  position: absolute;
+  top: -58px;
+  left: -58px;
+  width: 116px;
+  height: 116px;
+  border-radius: 50%;
+  border: 4px solid;
+  border-color: #d4dfe8 #94a0ac #626d79 #b0bcc8;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.rotorG {
+  position: absolute;
+  top: -48px;
+  left: -48px;
+  width: 96px;
+  height: 96px;
+  animation: spinG 0.42s linear infinite;
+}
+
+.discG {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(255, 255, 255, 0.14) 0 9deg,
+      transparent 9deg 18deg
+    ),
+    radial-gradient(circle, #e4edf4 0 16%, #a4b0bc 42%, #626d79 78%, #333c45 100%);
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.55);
+}
+
+.spokeG {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(250, 254, 255, 0.7) 0 2deg,
+      transparent 2deg 45deg
+    );
+  mask-image: radial-gradient(circle, transparent 0 24%, #000 30% 90%, transparent 100%);
+}
+
+.hubG {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin: -10px 0 0 -10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #eef4f8, #46505a 76%);
+}
+
+.forkG {
+  position: absolute;
+  top: -4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #b4bfc9, #4e5860);
+}
+
+.fkL { left: -62px; }
+.fkR { left: 54px; }
+
+.labelG {
+  position: absolute;
+  font-size: 0.54rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  z-index: 9;
+}
+
+.lgSpin {
+  top: 84px;
+  right: 26px;
+  color: rgba(240, 248, 252, 0.7);
+}
+
+.lgPrec {
+  top: 196px;
+  left: 20px;
+  color: rgba(120, 210, 250, 0.85);
+}
+
+.lgGrav {
+  top: 128px;
+  left: 24px;
+  color: rgba(250, 190, 120, 0.85);
+}
+
+.arrowG {
+  position: absolute;
+  width: 2px;
+  background: rgba(250, 190, 120, 0.75);
+  z-index: 9;
+}
+
+.arGrav {
+  top: 144px;
+  left: 44px;
+  height: 40px;
+}
+
+.arGrav::after {
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  left: -3px;
+  border: 4px solid transparent;
+  border-top-color: rgba(250, 190, 120, 0.75);
+}
+
+.capG {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  color: rgba(200, 224, 240, 0.6);
+  z-index: 9;
+}
+
+/* the rotor spins fast about its own axis */
+@keyframes spinG {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* the axis walks a slow cone about the vertical instead of falling over */
+@keyframes precessG {
+  from { transform: rotateY(0deg); }
+  to { transform: rotateY(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rotorG,
+  .precessG {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/gyroscope-as/`, a self-contained pure CSS/HTML gyroscope precessing instead of falling.

Closes #47885

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

The structure is the physics. Three nested frames, each doing exactly one rotation:

1. **`.precessG`** rotates about the vertical with `rotateY(0 → 360deg)`. This is the precession.
2. **`.tiltG`** carries a static `rotateZ(26deg)`. This is the lean gravity is pulling on.
3. **`.rotorG`** spins fast about its own axis.

Because they nest with `transform-style: preserve-3d`, the tilted axis genuinely gets carried around the cone by the outer frame. Nothing traces a path by hand; the composition does it.

- **Timescale separation**: the rotor's `0.42s` against the precession's `6s` is roughly 14:1, so the wheel visibly spins many times per lap. That gap is the whole reason a gyroscope is stable, and the faster it spins the slower it precesses.
- **The disc in perspective**: `.gimbalG` applies `rotateX(72deg)` so the wheel reads as an ellipse rather than a flat circle. Drawn with fine conic bands it looked like a spiderweb in the browser, so it became a solid metal `radial-gradient` with a spin streak over it.
- **The trace**: a dashed ellipse marking the circle the axis walks.
- **Labels**: gravity pulling down, precession going sideways, which is the counterintuitive part worth pointing at.

## Accessibility

`prefers-reduced-motion: reduce` disables both rotations. The tilt is a static transform, so the gyroscope still reads as leaning and unfallen with motion off.

## Verification

Opened `demo.html` in the browser and confirmed the wheel spins in its own plane while the whole assembly sweeps the vertical, tracing the marked circle rather than tipping. Checked the computed values: `.precessG` and `.rotorG` resolve to separate keyframes at `6s` and `0.42s`, `.tiltG` resolves to a real rotation matrix, `.gimbalG` to a `matrix3d`, and `transform-style` stays `preserve-3d` so the nesting composes in 3D rather than flattening. Also caught and fixed a malformed hex colour in the disc before linting. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
