### PR TITLE
Add jacana component

### DIFF
--- a/submissions/examples/jacana-as/README.md
+++ b/submissions/examples/jacana-as/README.md
@@ -1,0 +1,31 @@
+# Jacana
+
+A pure CSS/HTML jacana standing on lily pads, its weight spread across four absurdly long toes.
+
+## What it shows
+
+The jacana is called the lily-trotter because it walks on floating vegetation that should not hold a bird. It does not do this by being light. It does it by having the longest toes, relative to body size, of any bird.
+
+Pressure is force over area. A lily pad cannot take a bird's weight through a point, but it can take it spread across a footprint wider than the bird itself. The toes splay out over several pads at once, so no single one of them is asked to carry much.
+
+Jacanas are also polyandrous. The female holds a territory containing several males, and each male incubates and raises a clutch on his own, often carrying the chicks tucked under his wings.
+
+## How it is built
+
+- **The footprint is the point, so it is measured.** Each foot is four separately angled toes fanning from the ankle. In the browser the front foot spans **117px** against a body **88px** wide, a ratio of **1.33**. The foot really is wider than the bird, which is the fact the animal is built around.
+- **Toe angles**: the bird faces left, so three toes fan forward around 180 degrees and the hallux points back. A first pass fanned them radially and one toe stabbed straight down through the pad.
+- **The pad bows**: a shadow under the standing foot swells and deepens on the same cycle as the bird's teeter, so the pad reads as flexing under load rather than being a rigid disc.
+- **Pad veins**: a `repeating-conic-gradient` from an off-centre origin fans the radial veins the way a real lily pad grows.
+- **Balance**: wing and tail counter-rotate against the teeter, which is what the bird does on an unstable surface.
+- **The shield**: the pale blue frontal shield and bill are drawn as separate pieces, since that plate of bare skin over the bill is the field mark.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the bird standing, so the splayed foot still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/jacana-as/demo.html
+++ b/submissions/examples/jacana-as/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jacana</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="waterJ"></span>
+    <span class="padJ pdA"></span>
+    <span class="padJ pdB"></span>
+    <span class="padJ pdC"></span>
+    <span class="padJ pdD"></span>
+    <span class="dipJ"></span>
+    <div class="birdJ">
+      <span class="tailJ"></span>
+      <span class="bodyJ"></span>
+      <span class="wingJ"></span>
+      <div class="legJ lgBack">
+        <span class="shankJ"></span>
+        <div class="footJ">
+        <span class="toeJ" style="--t: 160deg; --n: 0"></span>
+        <span class="toeJ" style="--t: 176deg; --n: 1"></span>
+        <span class="toeJ" style="--t: 192deg; --n: 2"></span>
+        <span class="toeJ" style="--t: 6deg; --n: 3"></span>
+        </div>
+      </div>
+      <div class="legJ lgFront">
+        <span class="shankJ"></span>
+        <div class="footJ">
+        <span class="toeJ" style="--t: 160deg; --n: 0"></span>
+        <span class="toeJ" style="--t: 176deg; --n: 1"></span>
+        <span class="toeJ" style="--t: 192deg; --n: 2"></span>
+        <span class="toeJ" style="--t: 6deg; --n: 3"></span>
+        </div>
+      </div>
+      <span class="neckJ"></span>
+      <span class="headJ"></span>
+      <span class="shieldJ"></span>
+      <span class="billJ"></span>
+      <span class="eyeJ"></span>
+    </div>
+    <span class="capJ">the lily-trotter spreads its weight over four toes</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/jacana-as/style.css
+++ b/submissions/examples/jacana-as/style.css
@@ -1,0 +1,290 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 28%, #2f5548, #08130f 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #4f7f6a, #23443c 56%, #0f2420);
+}
+
+.waterJ {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(190, 230, 214, 0.07) 0 1px,
+      transparent 1px 13px
+    ),
+    radial-gradient(ellipse at 46% 30%, rgba(150, 220, 190, 0.16), transparent 62%);
+  z-index: 1;
+}
+
+/* the pads: wide, thin, and only just able to hold anything up */
+.padJ {
+  position: absolute;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 100deg at 52% 50%,
+      rgba(18, 54, 34, 0.34) 0 0.6deg,
+      transparent 0.6deg 11deg
+    ),
+    radial-gradient(ellipse at 44% 36%, #6fae64, #23522e 78%);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.4);
+  z-index: 3;
+}
+
+.pdA { bottom: 66px; left: 96px; width: 148px; height: 40px; }
+.pdB { bottom: 40px; left: 8px; width: 116px; height: 32px; filter: brightness(0.82); z-index: 2; }
+.pdC { bottom: 44px; right: 4px; width: 128px; height: 34px; filter: brightness(0.86); z-index: 2; }
+.pdD { bottom: 128px; left: 210px; width: 92px; height: 24px; filter: brightness(0.7); z-index: 2; }
+
+/* the pad the bird is standing on bows under it, and the water pushes back */
+.dipJ {
+  position: absolute;
+  bottom: 62px;
+  left: 128px;
+  width: 84px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 30%, rgba(10, 30, 22, 0.5), transparent 74%);
+  z-index: 4;
+  animation: bowJ 4.4s ease-in-out infinite;
+}
+
+.birdJ {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 180px;
+  height: 150px;
+  margin-left: -84px;
+  z-index: 6;
+  animation: teeterJ 4.4s ease-in-out infinite;
+}
+
+.bodyJ {
+  position: absolute;
+  bottom: 54px;
+  left: 34px;
+  width: 88px;
+  height: 46px;
+  border-radius: 46% 54% 46% 54% / 58% 58% 42% 42%;
+  background:
+    repeating-linear-gradient(
+      70deg,
+      rgba(70, 20, 10, 0.22) 0 3px,
+      transparent 3px 11px
+    ),
+    radial-gradient(circle at 40% 32%, #a8562c, #4a1d0e 76%);
+  box-shadow: inset -6px -5px 14px rgba(30, 10, 4, 0.5);
+  z-index: 4;
+}
+
+.wingJ {
+  position: absolute;
+  bottom: 58px;
+  left: 56px;
+  width: 62px;
+  height: 34px;
+  border-radius: 44% 56% 50% 44% / 56% 44% 50% 50%;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(40, 12, 6, 0.3) 0 3px,
+      transparent 3px 10px
+    ),
+    linear-gradient(150deg, #b8683a, #5a2410);
+  transform-origin: 22% 24%;
+  z-index: 5;
+  animation: balanceJ 4.4s ease-in-out infinite;
+}
+
+.tailJ {
+  position: absolute;
+  bottom: 62px;
+  left: 108px;
+  width: 44px;
+  height: 18px;
+  background: linear-gradient(90deg, #6a2c14, #3a1608);
+  clip-path: polygon(0 14%, 100% 38%, 100% 64%, 0 88%);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: flickJ 4.4s ease-in-out infinite;
+}
+
+.neckJ {
+  position: absolute;
+  bottom: 92px;
+  left: 32px;
+  width: 16px;
+  height: 30px;
+  border-radius: 46% 46% 30% 30% / 50% 50% 20% 20%;
+  background: linear-gradient(190deg, #2a2a24, #14140f);
+  transform-origin: 50% 100%;
+  transform: rotate(-12deg);
+  z-index: 5;
+}
+
+.headJ {
+  position: absolute;
+  bottom: 114px;
+  left: 20px;
+  width: 28px;
+  height: 22px;
+  border-radius: 50% 46% 40% 44%;
+  background: radial-gradient(circle at 56% 34%, #33332a, #0f0f0a 78%);
+  z-index: 6;
+}
+
+/* the frontal shield, the bit of bare skin over the bill */
+.shieldJ {
+  position: absolute;
+  bottom: 126px;
+  left: 16px;
+  width: 13px;
+  height: 12px;
+  border-radius: 50% 40% 30% 50%;
+  background: linear-gradient(180deg, #d8e8f0, #7fa8c0);
+  z-index: 7;
+}
+
+.billJ {
+  position: absolute;
+  bottom: 116px;
+  left: -2px;
+  width: 24px;
+  height: 7px;
+  border-radius: 3px 2px 2px 3px;
+  background: linear-gradient(180deg, #cfe4ee, #6f96ac);
+  clip-path: polygon(0 40%, 100% 0, 100% 100%, 0 68%);
+  z-index: 6;
+}
+
+.eyeJ {
+  position: absolute;
+  bottom: 126px;
+  left: 32px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #b8b8a0, #080804 68%);
+  z-index: 8;
+}
+
+.legJ {
+  position: absolute;
+  bottom: 0;
+  width: 30px;
+  height: 58px;
+  z-index: 5;
+}
+
+.lgFront { left: 52px; }
+.lgBack { left: 84px; filter: brightness(0.68); z-index: 3; }
+
+.shankJ {
+  position: absolute;
+  top: 0;
+  left: 13px;
+  width: 4px;
+  height: 54px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #7f9a84, #35473a);
+}
+
+/*
+  the whole trick: the toes are absurdly long and splay wide,
+  so the bird's weight lands on a huge footprint instead of a point
+*/
+.footJ {
+  position: absolute;
+  bottom: 0;
+  left: 15px;
+  width: 0;
+  height: 0;
+  animation: spreadJ 4.4s ease-in-out infinite;
+}
+
+.toeJ {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 58px;
+  height: 2.4px;
+  border-radius: 1.5px;
+  background: linear-gradient(90deg, #8fae90, #43594a);
+  transform-origin: 0 50%;
+  transform: rotate(var(--t, 0deg));
+}
+
+.toeJ::after {
+  content: "";
+  position: absolute;
+  top: -1.4px;
+  right: -5px;
+  width: 6px;
+  height: 4px;
+  border-radius: 50%;
+  background: #33463a;
+}
+
+.capJ {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.08em;
+  color: rgba(210, 240, 224, 0.6);
+  z-index: 9;
+}
+
+@keyframes teeterJ {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(3px) rotate(1.5deg); }
+}
+
+@keyframes bowJ {
+  0%, 100% { transform: scaleX(1) scaleY(0.9); opacity: 0.7; }
+  50% { transform: scaleX(1.12) scaleY(1.15); opacity: 1; }
+}
+
+@keyframes balanceJ {
+  0%, 100% { transform: rotate(3deg); }
+  50% { transform: rotate(-7deg); }
+}
+
+@keyframes flickJ {
+  0%, 100% { transform: rotate(-4deg); }
+  50% { transform: rotate(6deg); }
+}
+
+/* the toes flex as the pad shifts, which is how the bird keeps its footing */
+@keyframes spreadJ {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(1.08); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .birdJ,
+  .wingJ,
+  .tailJ,
+  .dipJ,
+  .footJ {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/jacana-as/`, a self-contained pure CSS/HTML jacana standing on lily pads.

Closes #47887

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The footprint is the point, so it is measured.** Each foot is four separately angled toes fanning from the ankle. Measured in the browser, the front foot spans **117px** against a body **88px** wide, a ratio of **1.33**. The foot really is wider than the bird, which is the fact the animal is built around: pressure is force over area, and a lily pad can hold a bird spread over a huge footprint that it could never hold through a point.
- **Toe angles**: the bird faces left, so three toes fan forward around 180 degrees and the hallux points back. The first pass fanned them radially and one toe stabbed straight down through the pad, which the browser check caught.
- **The pad bows**: a shadow under the standing foot swells and deepens on the same cycle as the bird's teeter, so the pad reads as flexing under load rather than as a rigid disc.
- **Pad veins**: a `repeating-conic-gradient` from an off-centre origin fans the radial veins the way a real pad grows.
- **Balance**: wing and tail counter-rotate against the teeter, which is what the bird does on an unstable surface.
- **The shield**: the pale blue frontal shield and bill are separate pieces, since that plate of bare skin over the bill is the field mark.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the bird standing, so the splayed foot still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the bird stands on the pads with the toes fanned along them, the pad shadow flexes under the teeter, and the reduced-motion path renders a static pose. Measured the rendered geometry rather than eyeballing it: front foot span 117.4px against body width 88.4px, ratio 1.33, so the defining proportion is actually there. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
