### PR TITLE
Add bristlecone pine component

### DIFF
--- a/submissions/examples/bristlecone-pine-as/README.md
+++ b/submissions/examples/bristlecone-pine-as/README.md
@@ -1,0 +1,30 @@
+# Bristlecone Pine
+
+A pure CSS/HTML Great Basin bristlecone on an exposed dolomite scarp: mostly dead wood, kept alive by a single strip of bark.
+
+## What it shows
+
+The oldest bristlecones are around 4,800 years old, which means they were already standing when the pyramids were built. They manage it by being terrible at growing.
+
+They live where nothing else will: high, dry, windswept dolomite that other trees cannot tolerate, so nothing crowds them and fire has no fuel to spread through. The wood they lay down is dense and resinous enough that insects and rot cannot get into it. And they practise **sectoral dieback**: as conditions worsen, the tree lets most of itself die and keeps one narrow ribbon of living bark running from a surviving root to a surviving limb. A tree that is 95% dead is not dying. That is the strategy.
+
+The dead wood does not rot at that altitude. It gets sandblasted by ice and grit into polished, twisted sculpture that can stand for millennia after the tree finally goes.
+
+## How it is built
+
+- **Mostly dead**: the bulk of the trunk is bare, polished heartwood. The single living strip is one narrow ribbon of bark drawn over it, faintly pulsing. That ratio is the tree's whole biography, so the drawing had to be dominated by dead wood.
+- **A gnarled column, not a plank**: the trunk is carved with an irregular `clip-path` polygon. Drawn as a rounded rectangle it read as a fence post.
+- **The spiral grain**: a `repeating-linear-gradient` at 74 degrees runs the grain diagonally, because these trees grow in a slow twist and the sandblasted wood shows it.
+- **Snags**: dead limbs that stopped growing centuries ago and are still attached, drawn in the same bleached wood as the trunk.
+- **Needles**: `repeating-conic-gradient` bottlebrush tufts, only at the tips of the limbs the live strip still feeds. Each keeps its own `--r` splay and `--s` size through the sway, because the shared keyframe rebuilds them with `rotate(calc(var(--r) + 5deg)) scale(var(--s))`.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe. The tree is nearly static anyway, which is the point.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/bristlecone-pine-as/demo.html
+++ b/submissions/examples/bristlecone-pine-as/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bristlecone Pine</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="skyB"></span>
+    <span class="ridgeB rgFar"></span>
+    <span class="ridgeB rgNear"></span>
+    <span class="scarpB"></span>
+    <div class="treeB">
+      <span class="deadB"></span>
+      <span class="grainB"></span>
+      <span class="stripB"></span>
+      <span class="limbB lmA"></span>
+      <span class="limbB lmB"></span>
+      <span class="limbB lmC"></span>
+      <span class="snagB snA"></span>
+      <span class="snagB snB"></span>
+      <span class="tuftB" style="left: 157px; bottom: 196px; --r: -14deg; --s: 1.05; --i: 0"></span>
+      <span class="tuftB" style="left: 135px; bottom: 137px; --r: 8deg; --s: 0.9; --i: 1"></span>
+      <span class="tuftB" style="left: 112px; bottom: 222px; --r: -28deg; --s: 0.85; --i: 2"></span>
+      <span class="tuftB" style="left: 90px; bottom: 200px; --r: 2deg; --s: 1.0; --i: 3"></span>
+      <span class="tuftB" style="left: 172px; bottom: 186px; --r: 18deg; --s: 0.7; --i: 4"></span>
+      <span class="tuftB" style="left: 118px; bottom: 206px; --r: -8deg; --s: 0.8; --i: 5"></span>
+    </div>
+    <span class="gustB gsA"></span>
+    <span class="gustB gsB"></span>
+    <span class="capB">one live strip of bark, four thousand years</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bristlecone-pine-as/style.css
+++ b/submissions/examples/bristlecone-pine-as/style.css
@@ -1,0 +1,220 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #8fb0cc, #6f7f92 58%, #3a3a3e);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #bcd8ea, #8fa8c0 44%, #6a6f70 62%, #45403a);
+}
+
+.skyB {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 74% 16%, rgba(255, 250, 230, 0.5), transparent 46%);
+  z-index: 1;
+}
+
+.ridgeB {
+  position: absolute;
+  background: linear-gradient(180deg, #93a2ae, #5f6a72);
+  clip-path: polygon(0 100%, 12% 44%, 26% 62%, 42% 22%, 58% 56%, 74% 34%, 88% 60%, 100% 40%, 100% 100%);
+  z-index: 2;
+}
+
+.rgFar { bottom: 96px; left: -20px; right: -20px; height: 62px; opacity: 0.55; }
+.rgNear { bottom: 86px; left: -40px; right: -30px; height: 44px; opacity: 0.8; filter: brightness(0.8); }
+
+.scarpB {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 96px;
+  background:
+    radial-gradient(circle at 14% 40%, rgba(60, 50, 36, 0.4) 0 8px, transparent 12px),
+    radial-gradient(circle at 76% 62%, rgba(60, 50, 36, 0.36) 0 10px, transparent 14px),
+    radial-gradient(circle at 44% 78%, rgba(60, 50, 36, 0.3) 0 7px, transparent 11px),
+    linear-gradient(180deg, #9a8f78, #453f34);
+  z-index: 6;
+}
+
+.treeB {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 260px;
+  height: 240px;
+  margin-left: -122px;
+  z-index: 5;
+}
+
+/*
+  most of a bristlecone is dead. the wood does not rot up here,
+  it is sandblasted into a polished spiral instead
+*/
+.deadB {
+  position: absolute;
+  bottom: 0;
+  left: 74px;
+  width: 66px;
+  height: 200px;
+  background:
+    linear-gradient(
+      92deg,
+      #6f6252 0 14%,
+      #d8ccb4 34%,
+      #a2957e 58%,
+      #4a4238 100%
+    );
+  box-shadow: inset -6px 0 14px rgba(40, 34, 24, 0.5);
+  clip-path: polygon(20% 100%, 6% 66%, 18% 40%, 8% 18%, 26% 4%, 46% 12%, 58% 2%, 74% 20%, 66% 46%, 84% 66%, 76% 100%);
+  transform: rotate(-3deg);
+  z-index: 3;
+}
+
+/* the grain runs in a twist, because the tree grew in a slow spiral */
+.grainB {
+  position: absolute;
+  bottom: 0;
+  left: 74px;
+  width: 66px;
+  height: 200px;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(60, 48, 32, 0.34) 0 1.5px,
+      transparent 1.5px 7px
+    );
+  clip-path: polygon(20% 100%, 6% 66%, 18% 40%, 8% 18%, 26% 4%, 46% 12%, 58% 2%, 74% 20%, 66% 46%, 84% 66%, 76% 100%);
+  transform: rotate(-3deg);
+  z-index: 4;
+}
+
+/* the single living strip: a ribbon of bark feeding one limb */
+.stripB {
+  position: absolute;
+  bottom: 0;
+  left: 80px;
+  width: 15px;
+  height: 196px;
+  border-radius: 6px 8px 2px 2px;
+  background:
+    repeating-linear-gradient(
+      80deg,
+      rgba(50, 26, 12, 0.4) 0 2px,
+      transparent 2px 6px
+    ),
+    linear-gradient(90deg, #8a5a30, #c08a4e 46%, #5f3a1c);
+  transform: rotate(-3deg);
+  z-index: 5;
+  animation: sapB 7s ease-in-out infinite;
+}
+
+.limbB {
+  position: absolute;
+  border-radius: 40% 50% 30% 30%;
+  background: linear-gradient(90deg, #7f7060, #cfc3aa 40%, #554c40);
+  transform-origin: 0 50%;
+  z-index: 4;
+}
+
+.lmA { bottom: 176px; left: 96px; width: 88px; height: 11px; transform: rotate(-16deg); }
+.lmB { bottom: 148px; left: 92px; width: 66px; height: 9px; transform: rotate(6deg); }
+.lmC { bottom: 196px; left: 90px; width: 54px; height: 8px; transform: rotate(-34deg); }
+
+/* snags: limbs that died centuries ago and are still standing there */
+.snagB {
+  position: absolute;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #6a5f4e, #b8ab92 44%, #4a4236);
+  transform-origin: 100% 50%;
+  z-index: 3;
+}
+
+.snA { bottom: 162px; left: 24px; width: 58px; height: 7px; transform: rotate(14deg); }
+.snB { bottom: 120px; left: 34px; width: 44px; height: 6px; transform: rotate(-8deg); }
+
+/* the needles: bottlebrush tufts, held for forty years each */
+.tuftB {
+  position: absolute;
+  width: 46px;
+  height: 26px;
+  border-radius: 54% 46% 40% 40% / 72% 72% 34% 34%;
+  background:
+    repeating-conic-gradient(
+      from 184deg at 50% 100%,
+      #33502c 0 1.6deg,
+      #1e3419 1.6deg 3.2deg
+    ),
+    radial-gradient(ellipse at 50% 100%, rgba(44, 74, 38, 0.9), transparent 78%);
+  mask-image: radial-gradient(ellipse 78% 100% at 50% 92%, #000 0 62%, transparent 100%);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--r, 0deg)) scale(var(--s, 1));
+  z-index: 6;
+  animation: swayB 7s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * -0.6s);
+}
+
+.gustB {
+  position: absolute;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, transparent, rgba(240, 248, 255, 0.5), transparent);
+  z-index: 7;
+  animation: bluster 9s linear infinite;
+}
+
+.gsA { top: 84px; left: -120px; width: 120px; }
+.gsB { top: 148px; left: -180px; width: 160px; animation-delay: -4.5s; }
+
+.capB {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.1em;
+  color: rgba(250, 244, 224, 0.66);
+  z-index: 9;
+}
+
+/* the tufts keep their own splay angle and scale through the sway */
+@keyframes swayB {
+  0%, 100% { transform: rotate(var(--r, 0deg)) scale(var(--s, 1)); }
+  50% { transform: rotate(calc(var(--r, 0deg) + 5deg)) scale(var(--s, 1)); }
+}
+
+@keyframes sapB {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(1.14); }
+}
+
+@keyframes bluster {
+  0% { transform: translateX(0); opacity: 0; }
+  14% { opacity: 1; }
+  86% { opacity: 1; }
+  100% { transform: translateX(560px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tuftB,
+  .stripB,
+  .gustB {
+    animation: none;
+  }
+
+  .gustB { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/bristlecone-pine-as/`, a self-contained pure CSS/HTML bristlecone pine on a high dolomite scarp.

Closes #47889

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **Mostly dead**: the bulk of the trunk is bare polished heartwood, and the single living strip is one narrow ribbon of bark drawn over it. That ratio is the tree's entire biography (sectoral dieback: keep one ribbon from a live root to a live limb, let the rest go), so the drawing is deliberately dominated by dead wood. A healthy-looking pine would be a different tree.
- **A gnarled column, not a plank**: the trunk is carved with an irregular `clip-path` polygon. Drawn as a rounded rectangle it read as a fence post in the browser.
- **The spiral grain**: a `repeating-linear-gradient` at 74 degrees runs the grain diagonally, because these trees grow in a slow twist and the sandblasted wood shows it.
- **Snags**: dead limbs that stopped growing centuries ago and are still attached, in the same bleached wood as the trunk. The wood does not rot at that altitude, it gets polished.
- **Needles**: `repeating-conic-gradient` bottlebrush tufts, only at the tips of the limbs the live strip still feeds. Each keeps its own `--r` splay and `--s` size through the sway because the shared keyframe rebuilds them with `rotate(calc(var(--r) + 5deg)) scale(var(--s))`.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe. The tree is nearly static anyway, which is the point of it.

## Verification

Opened `demo.html` in the browser and iterated on what it actually looked like: the first pass had the needle tufts floating in the sky detached from any limb, and the trunk reading as a straight plank. Both fixed and re-checked, with the tufts now sitting at the limb tips and the trunk carved irregular. Confirmed all six tufts render, each on the sway keyframe, and the live strip on its own. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
