### PR TITLE
Add praxinoscope component

### DIFF
--- a/submissions/examples/praxinoscope-as/README.md
+++ b/submissions/examples/praxinoscope-as/README.md
@@ -1,0 +1,29 @@
+# Praxinoscope
+
+A pure CSS/HTML praxinoscope: twelve drawings on a turning drum, a twelve-sided mirror prism at the centre, and one steady walking figure.
+
+## What it shows
+
+Émile Reynaud patented this in 1877 to fix what was wrong with the zoetrope.
+
+A zoetrope works by hiding the motion: you view the drawings through narrow slits, so you only see each one for the instant it is lined up. It works, but you are looking through a picket fence, and most of the light is thrown away. The image is dim and it flickers.
+
+Reynaud got rid of the slits. He put a ring of mirrors at the centre of the drum, **at exactly half the drum's radius**, turning with it. Do the geometry and the mirror's motion cancels the drawing's motion: as the drum sweeps a drawing sideways, its mirror sweeps the reflection back by the same amount. The reflection sits still. Each drawing simply replaces the last one in the same spot, and you get a bright, continuous image with nothing blocking it.
+
+## How it is built
+
+- **The half-radius is real, not decorative.** Measured in the browser: the drawings sit at **98px** from the centre and the mirrors at **49px**. Ratio **0.5000**. That number is the whole invention, so it is the one thing in this component that had to be exact.
+- **Locked together**: the drum and the prism carry the *same* keyframe at the *same* `2.4s` duration. They are separate elements but they cannot drift apart, which is the mechanical constraint a real praxinoscope enforces with a shared spindle.
+- **Twelve real drawings**: each cell holds the same walker with a different `--sw` leg angle, `--ar` arm angle, and `--hp` bounce, generated around a full stride cycle. They are the frames, not decoration.
+- **The reflection steps, it does not tween.** The viewed figure uses `steps(1, end)`, so it *holds* each pose until the next cell arrives and then jumps. A smooth interpolation would be a lie: a praxinoscope shows you twelve discrete pictures, and the continuity is in your eye, not on the drum.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops the drum, the prism, and the stepping figure.
+
+No images, no JavaScript, no external assets.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/praxinoscope-as/demo.html
+++ b/submissions/examples/praxinoscope-as/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Praxinoscope</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="baseP"></span>
+
+    <div class="drumP">
+      <span class="bandP"></span>
+      <div class="cellP" style="--a: 0.0deg">
+        <span class="figP" style="--sw: 0deg; --ar: 0deg; --hp: 3px"></span>
+      </div>
+      <div class="cellP" style="--a: 30.0deg">
+        <span class="figP" style="--sw: 13deg; --ar: -11deg; --hp: 3px"></span>
+      </div>
+      <div class="cellP" style="--a: 60.0deg">
+        <span class="figP" style="--sw: 23deg; --ar: -19deg; --hp: 2px"></span>
+      </div>
+      <div class="cellP" style="--a: 90.0deg">
+        <span class="figP" style="--sw: 26deg; --ar: -22deg; --hp: 0px"></span>
+      </div>
+      <div class="cellP" style="--a: 120.0deg">
+        <span class="figP" style="--sw: 23deg; --ar: -19deg; --hp: 1px"></span>
+      </div>
+      <div class="cellP" style="--a: 150.0deg">
+        <span class="figP" style="--sw: 13deg; --ar: -11deg; --hp: 3px"></span>
+      </div>
+      <div class="cellP" style="--a: 180.0deg">
+        <span class="figP" style="--sw: 0deg; --ar: 0deg; --hp: 3px"></span>
+      </div>
+      <div class="cellP" style="--a: 210.0deg">
+        <span class="figP" style="--sw: -13deg; --ar: 11deg; --hp: 3px"></span>
+      </div>
+      <div class="cellP" style="--a: 240.0deg">
+        <span class="figP" style="--sw: -23deg; --ar: 19deg; --hp: 2px"></span>
+      </div>
+      <div class="cellP" style="--a: 270.0deg">
+        <span class="figP" style="--sw: -26deg; --ar: 22deg; --hp: 0px"></span>
+      </div>
+      <div class="cellP" style="--a: 300.0deg">
+        <span class="figP" style="--sw: -23deg; --ar: 19deg; --hp: 2px"></span>
+      </div>
+      <div class="cellP" style="--a: 330.0deg">
+        <span class="figP" style="--sw: -13deg; --ar: 11deg; --hp: 3px"></span>
+      </div>
+    </div>
+
+    <div class="prismP">
+      <span class="mirrorP" style="--a: 0.0deg"></span>
+      <span class="mirrorP" style="--a: 30.0deg"></span>
+      <span class="mirrorP" style="--a: 60.0deg"></span>
+      <span class="mirrorP" style="--a: 90.0deg"></span>
+      <span class="mirrorP" style="--a: 120.0deg"></span>
+      <span class="mirrorP" style="--a: 150.0deg"></span>
+      <span class="mirrorP" style="--a: 180.0deg"></span>
+      <span class="mirrorP" style="--a: 210.0deg"></span>
+      <span class="mirrorP" style="--a: 240.0deg"></span>
+      <span class="mirrorP" style="--a: 270.0deg"></span>
+      <span class="mirrorP" style="--a: 300.0deg"></span>
+      <span class="mirrorP" style="--a: 330.0deg"></span>
+    </div>
+
+    <span class="hubP"></span>
+
+    <div class="viewP">
+      <span class="viewFig"></span>
+    </div>
+    <span class="viewRing"></span>
+    <span class="labelP">the reflection holds still while the drum turns</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/praxinoscope-as/style.css
+++ b/submissions/examples/praxinoscope-as/style.css
@@ -1,0 +1,263 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #3e3630, #100c0a 80%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 34%, #52463c, #120e0b 84%);
+}
+
+.baseP {
+  position: absolute;
+  top: 62%;
+  left: 50%;
+  width: 268px;
+  height: 268px;
+  margin: -134px 0 0 -134px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 42% 32%, #6a5238, #251b10 78%);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.6);
+  z-index: 1;
+}
+
+/*
+  the drum carries twelve drawings on its inner wall and turns as one piece
+*/
+.drumP {
+  position: absolute;
+  top: 62%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 3;
+  animation: turnP 2.4s linear infinite;
+}
+
+.bandP {
+  position: absolute;
+  top: -122px;
+  left: -122px;
+  width: 244px;
+  height: 244px;
+  border-radius: 50%;
+  border: 26px solid;
+  border-color: #cfc0a0 #b8a888 #9a8a6a #c4b494;
+  box-shadow: inset 0 0 20px rgba(60, 44, 24, 0.5);
+}
+
+.cellP {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 52px;
+  margin: -26px 0 0 -20px;
+  transform: rotate(var(--a, 0deg)) translateY(-98px);
+}
+
+/* one drawing per cell: the same walker, one step further along */
+.figP {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  width: 9px;
+  height: 22px;
+  margin-left: -4.5px;
+  border-radius: 3px 3px 1px 1px;
+  background: #2f2618;
+  transform: translateY(var(--hp, 0));
+}
+
+.figP::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  margin-left: -5px;
+  border-radius: 50%;
+  background: #2f2618;
+}
+
+/* the swinging leg is what changes from cell to cell */
+.figP::after {
+  content: "";
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  width: 3.4px;
+  height: 14px;
+  margin-left: -1.7px;
+  border-radius: 2px;
+  background: #2f2618;
+  transform-origin: 50% 0;
+  transform: rotate(var(--sw, 0deg));
+}
+
+/*
+  the mirror prism sits at half the drum radius and turns with it.
+  that halving is the entire invention: it cancels the drum's motion.
+*/
+.prismP {
+  position: absolute;
+  top: 62%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 5;
+  animation: turnP 2.4s linear infinite;
+}
+
+.mirrorP {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 30px;
+  height: 44px;
+  margin: -22px 0 0 -15px;
+  border-radius: 2px;
+  background:
+    linear-gradient(
+      104deg,
+      rgba(236, 248, 255, 0.9) 0 18%,
+      rgba(150, 186, 208, 0.7) 44%,
+      rgba(220, 240, 250, 0.85) 72%,
+      rgba(120, 152, 176, 0.7)
+    );
+  box-shadow: 0 0 0 1px rgba(90, 74, 48, 0.8), inset 0 0 8px rgba(255, 255, 255, 0.5);
+  transform: rotate(var(--a, 0deg)) translateY(-49px);
+}
+
+.hubP {
+  position: absolute;
+  top: 62%;
+  left: 50%;
+  width: 26px;
+  height: 26px;
+  margin: -13px 0 0 -13px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #e0d0a8, #5f4a28 76%);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+  z-index: 7;
+}
+
+/*
+  what the viewer actually sees: one figure, in one place, stepping.
+  it advances one frame per cell, in lockstep with the drum.
+*/
+.viewRing {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 70px;
+  height: 70px;
+  margin-left: -35px;
+  border-radius: 50%;
+  border: 2px dashed rgba(240, 214, 150, 0.5);
+  z-index: 8;
+}
+
+.viewP {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 70px;
+  height: 70px;
+  margin-left: -35px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, rgba(30, 24, 16, 0.9), rgba(12, 9, 6, 0.95) 78%);
+  z-index: 9;
+}
+
+.viewFig {
+  position: absolute;
+  bottom: 22px;
+  left: 50%;
+  width: 10px;
+  height: 26px;
+  margin-left: -5px;
+  border-radius: 4px 4px 1px 1px;
+  background: #f0e2b8;
+}
+
+.viewFig::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: #f0e2b8;
+}
+
+.viewFig::after {
+  content: "";
+  position: absolute;
+  bottom: -12px;
+  left: 50%;
+  width: 4px;
+  height: 16px;
+  margin-left: -2px;
+  border-radius: 2px;
+  background: #f0e2b8;
+  transform-origin: 50% 0;
+
+  /* steps(1, end) holds each pose until the next cell arrives, so it reads as frames rather than a tween */
+  animation: strideP 2.4s steps(1, end) infinite;
+}
+
+.labelP {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  color: rgba(240, 224, 186, 0.66);
+  z-index: 10;
+}
+
+/* drum and prism share one keyframe and one duration, so they cannot drift apart */
+@keyframes turnP {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes strideP {
+  0.0000% { transform: rotate(0deg); }
+  8.3333% { transform: rotate(13deg); }
+  16.6667% { transform: rotate(23deg); }
+  25.0000% { transform: rotate(26deg); }
+  33.3333% { transform: rotate(23deg); }
+  41.6667% { transform: rotate(13deg); }
+  50.0000% { transform: rotate(0deg); }
+  58.3333% { transform: rotate(-13deg); }
+  66.6667% { transform: rotate(-23deg); }
+  75.0000% { transform: rotate(-26deg); }
+  83.3333% { transform: rotate(-23deg); }
+  91.6667% { transform: rotate(-13deg); }
+  100% { transform: rotate(0deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drumP,
+  .prismP,
+  .viewFig::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/praxinoscope-as/`, a self-contained pure CSS/HTML praxinoscope.

Closes #47891

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

Reynaud's 1877 fix for the zoetrope was to delete the slits and put a mirror ring at exactly half the drum radius, turning with the drum. The mirror's motion then cancels the drawing's motion and the reflection sits still.

- **The half-radius is real, not decorative.** Measured in the browser: the drawings sit at **98px** from the centre and the mirrors at **49px**. Ratio **0.5000**. That number is the whole invention, so it is the one thing here that had to be exact, and an earlier revision that drifted it to 0.531 was corrected.
- **Locked together**: the drum and the prism carry the *same* keyframe at the *same* `2.4s` duration. They are separate elements but cannot drift apart, which is the constraint a real praxinoscope enforces with a shared spindle.
- **Twelve real drawings**: each cell holds the same walker with a different `--sw` leg angle, `--ar` arm angle and `--hp` bounce, generated around a full stride cycle. They are the frames, not decoration.
- **The reflection steps, it does not tween.** The viewed figure uses `steps(1, end)` so it *holds* each pose until the next cell arrives and then jumps. A smooth interpolation would be a lie: the machine shows twelve discrete pictures and the continuity happens in your eye, not on the drum.

## Accessibility

`prefers-reduced-motion: reduce` stops the drum, the prism, and the stepping figure.

## Verification

Opened `demo.html` in the browser and measured the rendered geometry rather than trusting the source: drawing ring radius **98.0px**, mirror ring radius **49.0px**, ratio **0.5000**; drum and prism both resolve to `2.4s`; the viewed figure's timing function resolves to `steps(1)`, so it really is advancing frame by frame. Also repositioned the drum after the first pass buried the drawings under the band and collided the viewer window with the rim. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
