### PR TITLE
Add hoatzin component

### DIFF
--- a/submissions/examples/hoatzin-as/README.md
+++ b/submissions/examples/hoatzin-as/README.md
@@ -1,0 +1,30 @@
+# Hoatzin
+
+A pure CSS/HTML hoatzin on a branch over an Amazon oxbow, with a chick hauling itself back up out of the water on the claws of its wings.
+
+## What it shows
+
+The hoatzin is a bird that eats leaves, which almost no bird does, because leaves are not worth the trouble.
+
+To make it work it grew a **crop the size of its chest** and turned it into a fermentation vat, the way a cow uses a rumen. Bacteria break the leaves down over roughly 24 to 48 hours. The cost is enormous: the crop is so big it crowds out the flight muscles, so the hoatzin is a famously poor flier, and the fermentation makes it smell strongly enough to be called the stinkbird. Nobody hunts it.
+
+The chicks are the other half of the story. Threatened by a snake or a monkey, a hoatzin chick **drops out of the nest into the water below**, swims, waits, and then climbs back up the branches using **two functional claws on the leading edge of each wing**. It uses its wings as hands. It loses the claws as an adult.
+
+## How it is built
+
+- **The crop is oversized on purpose.** Measured in the browser it is **42% of the body's area**, drawn as its own bulging element in front of the chest. That absurd proportion is why the bird can barely fly, so under-drawing it would lose the point.
+- **It ferments**: the crop kneads on a non-uniform keyframe, squashing one way and then the other, with a `repeating-radial-gradient` churn layer swirling inside it.
+- **The chick's climb is the composition.** Three nested keyframes: the body hauls up an arc from the water to the branch, the arm reaches and pulls on its own timing, and the claws **open on the reach and close on the pull**. It starts in the river and finishes standing on the branch beside the adult.
+- **The claws are drawn as claws**, hooked and on the leading edge of the wing, because they are the entire reason anyone knows this bird.
+- **The crest**: seven separate quills, each keeping its own `--q` lean through the shared bristle keyframe via `rotate(calc(var(--q) + 6deg))`.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and parks the chick mid-climb with its claws hooked, so the behaviour still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/hoatzin-as/demo.html
+++ b/submissions/examples/hoatzin-as/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hoatzin</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="hazeH"></span>
+    <span class="leafH lfA"></span>
+    <span class="leafH lfB"></span>
+    <span class="leafH lfC"></span>
+    <span class="branchH"></span>
+    <span class="riverH"></span>
+
+    <div class="adultH">
+      <span class="tailH"></span>
+      <span class="bodyH"></span>
+      <span class="cropH"></span>
+      <span class="wingH"></span>
+      <span class="footH ftA"></span>
+      <span class="footH ftB"></span>
+      <div class="headH">
+        <span class="faceH"></span>
+        <span class="eyeH"></span>
+        <span class="billH"></span>
+        <div class="crestH">
+        <span class="quillH" style="--q: -30deg; --qh: 20px; --i: 0"></span>
+        <span class="quillH" style="--q: -18deg; --qh: 26px; --i: 1"></span>
+        <span class="quillH" style="--q: -6deg; --qh: 30px; --i: 2"></span>
+        <span class="quillH" style="--q: 6deg; --qh: 31px; --i: 3"></span>
+        <span class="quillH" style="--q: 18deg; --qh: 27px; --i: 4"></span>
+        <span class="quillH" style="--q: 30deg; --qh: 21px; --i: 5"></span>
+        <span class="quillH" style="--q: 42deg; --qh: 15px; --i: 6"></span>
+        </div>
+      </div>
+      <span class="churnH"></span>
+    </div>
+
+    <div class="chickH">
+      <div class="armH">
+        <span class="upperArm"></span>
+        <div class="handH">
+          <span class="clawH clA"></span>
+          <span class="clawH clB"></span>
+        </div>
+      </div>
+      <span class="chickBody"></span>
+      <span class="chickHead"></span>
+      <span class="chickEye"></span>
+    </div>
+
+    <span class="capH">the chick climbs back with the claws on its wings</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/hoatzin-as/style.css
+++ b/submissions/examples/hoatzin-as/style.css
@@ -1,0 +1,478 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #3f5236, #0b120a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #a8c47e, #5f8450 48%, #33512f 70%, #1c3324);
+}
+
+.hazeH {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 66% 18%, rgba(255, 250, 200, 0.4), transparent 52%);
+  z-index: 1;
+}
+
+.leafH {
+  position: absolute;
+  border-radius: 60% 12% 60% 12%;
+  background:
+    repeating-conic-gradient(
+      from 128deg at 6% 90%,
+      rgba(16, 40, 18, 0.34) 0 0.7deg,
+      transparent 0.7deg 8deg
+    ),
+    linear-gradient(140deg, #5f8f42, #24421e);
+  z-index: 2;
+}
+
+.lfA { top: -10px; left: -20px; width: 130px; height: 54px; transform: rotate(16deg); }
+.lfB { top: 16px; right: -30px; width: 140px; height: 50px; transform: rotate(-14deg) scaleX(-1); filter: brightness(0.86); }
+.lfC { top: 62px; left: 44px; width: 96px; height: 38px; transform: rotate(24deg); filter: brightness(0.74); z-index: 1; }
+
+.branchH {
+  position: absolute;
+  bottom: 78px;
+  left: -14px;
+  right: -14px;
+  height: 17px;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      86deg,
+      rgba(30, 20, 8, 0.34) 0 2px,
+      transparent 2px 13px
+    ),
+    linear-gradient(180deg, #7a5f38, #2f2412);
+  box-shadow: 0 5px 12px rgba(0, 0, 0, 0.5);
+  z-index: 6;
+}
+
+.riverH {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 66px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(190, 220, 190, 0.08) 0 1px,
+      transparent 1px 11px
+    ),
+    linear-gradient(180deg, #3f6250, #14251f);
+  z-index: 3;
+}
+
+.riverH::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: rgba(220, 244, 220, 0.4);
+}
+
+/* ---------------- the adult ---------------- */
+
+.adultH {
+  position: absolute;
+  bottom: 92px;
+  left: 50%;
+  width: 190px;
+  height: 170px;
+  margin-left: -46px;
+  z-index: 7;
+  animation: swayH 6s ease-in-out infinite;
+}
+
+.bodyH {
+  position: absolute;
+  bottom: 6px;
+  left: 30px;
+  width: 92px;
+  height: 62px;
+  border-radius: 46% 54% 44% 56% / 58% 58% 42% 42%;
+  background:
+    repeating-linear-gradient(
+      68deg,
+      rgba(60, 34, 12, 0.24) 0 3px,
+      transparent 3px 12px
+    ),
+    radial-gradient(circle at 40% 32%, #b98d5a, #4a2f16 78%);
+  box-shadow: inset -7px -5px 16px rgba(30, 16, 6, 0.5);
+  z-index: 4;
+}
+
+/*
+  the crop: a fermentation vat the size of the bird's chest.
+  it is why the hoatzin smells and why it can barely fly.
+*/
+.cropH {
+  position: absolute;
+  bottom: 18px;
+  left: 24px;
+  width: 52px;
+  height: 46px;
+  border-radius: 54% 40% 44% 56% / 56% 50% 50% 44%;
+  background: radial-gradient(circle at 40% 34%, #d8a86a, #7a4c22 80%);
+  box-shadow: inset -3px -3px 8px rgba(40, 22, 8, 0.4);
+  z-index: 5;
+  animation: fermentH 6s ease-in-out infinite;
+}
+
+.churnH {
+  position: absolute;
+  bottom: 26px;
+  left: 30px;
+  width: 40px;
+  height: 32px;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(
+      circle at 44% 50%,
+      rgba(255, 240, 190, 0.24) 0 2px,
+      transparent 2px 8px
+    );
+  z-index: 6;
+  animation: churnH 6s ease-in-out infinite;
+}
+
+.wingH {
+  position: absolute;
+  bottom: 16px;
+  left: 62px;
+  width: 68px;
+  height: 44px;
+  border-radius: 44% 56% 50% 44% / 56% 44% 50% 50%;
+  background:
+    repeating-linear-gradient(
+      72deg,
+      rgba(40, 22, 8, 0.3) 0 3px,
+      transparent 3px 11px
+    ),
+    linear-gradient(150deg, #8a6234, #33200e);
+  transform-origin: 22% 26%;
+  z-index: 6;
+  animation: shuffleH 6s ease-in-out infinite;
+}
+
+.tailH {
+  position: absolute;
+  bottom: 14px;
+  left: 112px;
+  width: 68px;
+  height: 34px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(40, 22, 8, 0.34) 0 5px,
+      transparent 5px 16px
+    ),
+    linear-gradient(90deg, #4f3418, #d8c28a);
+  clip-path: polygon(0 16%, 100% 34%, 100% 72%, 0 88%);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: proppedH 6s ease-in-out infinite;
+}
+
+.footH {
+  position: absolute;
+  bottom: -12px;
+  width: 6px;
+  height: 20px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #4a3a24, #1c1409);
+  z-index: 5;
+}
+
+.footH::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: -8px;
+  width: 22px;
+  height: 5px;
+  background: #1c1409;
+  clip-path: polygon(0 0, 26% 100%, 50% 0, 74% 100%, 100% 0, 100% 60%);
+}
+
+.ftA { left: 56px; }
+.ftB { left: 76px; filter: brightness(0.76); z-index: 4; }
+
+.headH {
+  position: absolute;
+  bottom: 56px;
+  left: 4px;
+  width: 60px;
+  height: 60px;
+  z-index: 7;
+  animation: peerH 6s ease-in-out infinite;
+}
+
+.faceH {
+  position: absolute;
+  bottom: 0;
+  left: 14px;
+  width: 32px;
+  height: 30px;
+  border-radius: 54% 44% 40% 46%;
+  background: radial-gradient(circle at 54% 36%, #4fa8d8, #1c5f88 78%);
+  z-index: 4;
+}
+
+.eyeH {
+  position: absolute;
+  bottom: 16px;
+  left: 18px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #f0605a, #4a0808 66%);
+  box-shadow: 0 0 0 1.5px rgba(20, 60, 84, 0.8);
+  z-index: 6;
+}
+
+.billH {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  width: 18px;
+  height: 9px;
+  border-radius: 3px 2px 2px 3px;
+  background: linear-gradient(180deg, #6a5236, #241a0c);
+  clip-path: polygon(0 44%, 100% 0, 100% 100%, 0 74%);
+  z-index: 5;
+}
+
+.crestH {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  width: 0;
+  height: 0;
+  z-index: 3;
+}
+
+/* the crest is a row of loose spiky quills, each keeping its own lean */
+.quillH {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 4px;
+  height: var(--qh, 24px);
+  margin-left: -2px;
+  border-radius: 2px 2px 0 0;
+  background: linear-gradient(180deg, #e8d8a8, #6a4a22);
+  transform-origin: 50% 100%;
+  transform: rotate(var(--q, 0deg));
+  animation: bristleH 6s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * -0.14s);
+}
+
+/* ---------------- the chick ---------------- */
+
+.chickH {
+  position: absolute;
+  bottom: 96px;
+  left: 54px;
+  width: 70px;
+  height: 78px;
+  z-index: 8;
+  animation: climbH 6s cubic-bezier(0.5, 0, 0.4, 1) infinite;
+}
+
+.chickBody {
+  position: absolute;
+  bottom: 0;
+  left: 12px;
+  width: 40px;
+  height: 30px;
+  border-radius: 50% 46% 44% 50% / 56% 56% 44% 44%;
+  background: radial-gradient(circle at 40% 32%, #8a6a44, #33240f 78%);
+  z-index: 3;
+}
+
+.chickHead {
+  position: absolute;
+  bottom: 22px;
+  left: 4px;
+  width: 19px;
+  height: 17px;
+  border-radius: 54% 42% 40% 46%;
+  background: radial-gradient(circle at 54% 34%, #7a6038, #2a1c0a 78%);
+  z-index: 4;
+}
+
+.chickEye {
+  position: absolute;
+  bottom: 31px;
+  left: 8px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #100804;
+  z-index: 5;
+}
+
+/*
+  the whole reason the hoatzin is famous: the chick has working claws
+  on its wings, and it uses them like hands
+*/
+.armH {
+  position: absolute;
+  bottom: 22px;
+  left: 30px;
+  width: 30px;
+  height: 10px;
+  transform-origin: 0 50%;
+  z-index: 5;
+  animation: reachH 6s cubic-bezier(0.5, 0, 0.4, 1) infinite;
+}
+
+.upperArm {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  width: 30px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #6a4e28, #a8834e);
+}
+
+.handH {
+  position: absolute;
+  top: 0;
+  left: 26px;
+  width: 0;
+  height: 0;
+}
+
+.clawH {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 13px;
+  height: 3px;
+  border-radius: 0 2px 2px 0;
+  background: linear-gradient(90deg, #a8834e, #f0e2c0);
+  transform-origin: 0 50%;
+  animation: gripH 6s cubic-bezier(0.5, 0, 0.4, 1) infinite;
+}
+
+.clawH::after {
+  content: "";
+  position: absolute;
+  top: -1px;
+  right: -3px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50% 50% 50% 0;
+  background: #f4ead0;
+}
+
+.clA { --cg: -22deg; transform: rotate(-22deg); }
+.clB { --cg: 16deg; transform: rotate(16deg); animation-delay: -0.12s; }
+
+.capH {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.08em;
+  color: rgba(230, 244, 210, 0.66);
+  z-index: 9;
+}
+
+@keyframes swayH {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-3px) rotate(1deg); }
+}
+
+/* the crop kneads, slowly, all day */
+@keyframes fermentH {
+  0%, 100% { transform: scale(1); }
+  40% { transform: scale(1.06, 0.97); }
+  70% { transform: scale(0.98, 1.04); }
+}
+
+@keyframes churnH {
+  0%, 100% { transform: rotate(0deg); opacity: 0.5; }
+  50% { transform: rotate(18deg); opacity: 0.9; }
+}
+
+@keyframes shuffleH {
+  0%, 100% { transform: rotate(2deg); }
+  50% { transform: rotate(-6deg); }
+}
+
+@keyframes proppedH {
+  0%, 100% { transform: rotate(-3deg); }
+  50% { transform: rotate(4deg); }
+}
+
+@keyframes peerH {
+  0%, 100% { transform: rotate(0deg); }
+  36% { transform: rotate(-7deg); }
+  68% { transform: rotate(3deg); }
+}
+
+/* each quill keeps its own lean through the shared bristle */
+@keyframes bristleH {
+  0%, 100% { transform: rotate(var(--q, 0deg)); }
+  50% { transform: rotate(calc(var(--q, 0deg) + 6deg)); }
+}
+
+/* the chick hauls itself up the branch, arm over body */
+@keyframes climbH {
+  0% { transform: translate(-14px, 62px) rotate(-15deg); }
+  30% { transform: translate(-6px, 44px) rotate(-10deg); }
+  58% { transform: translate(6px, 22px) rotate(-4deg); }
+  84%, 100% { transform: translate(16px, 0) rotate(0deg); }
+}
+
+@keyframes reachH {
+  0% { transform: rotate(-42deg); }
+  26% { transform: rotate(-56deg); }
+  58% { transform: rotate(-18deg); }
+  84%, 100% { transform: rotate(-34deg); }
+}
+
+/* claws open on the reach and close on the pull */
+@keyframes gripH {
+  0%, 20% { transform: rotate(calc(var(--cg, 0deg) - 24deg)); }
+  40%, 100% { transform: rotate(var(--cg, 0deg)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .adultH,
+  .cropH,
+  .churnH,
+  .wingH,
+  .tailH,
+  .headH,
+  .quillH,
+  .chickH,
+  .armH,
+  .clawH {
+    animation: none;
+  }
+
+  .chickH { transform: translate(6px, 22px) rotate(-4deg); }
+  .armH { transform: rotate(-40deg); }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/hoatzin-as/`, a self-contained pure CSS/HTML hoatzin with a chick climbing back up on its wing claws.

Closes #47893

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The crop is oversized on purpose.** Measured in the browser it is **42% of the body's area**, drawn as its own bulging element in front of the chest. The hoatzin ferments leaves in that crop like a cow's rumen, and it is so large it crowds out the flight muscles, which is why the bird can barely fly. Under-drawing it would lose the whole point of the animal.
- **It ferments**: the crop kneads on a non-uniform keyframe, squashing one way then the other, with a `repeating-radial-gradient` churn layer swirling inside it.
- **The chick's climb is the composition.** Three nested keyframes: the body hauls an arc up from the water to the branch, the arm reaches and pulls on its own timing, and the claws **open on the reach and close on the pull**. Checked at both ends of the cycle: it starts in the river and finishes standing on the branch beside the adult.
- **The claws are drawn as claws**, hooked and on the leading edge of the wing, because they are the entire reason anyone knows this bird. A threatened chick drops into the water and climbs back using them as hands.
- **The crest**: seven separate quills, each keeping its own `--q` lean through the shared bristle keyframe via `rotate(calc(var(--q) + 6deg))`, so one animation cannot flatten them all to the same angle.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and parks the chick mid-climb with its claws hooked, so the behaviour still reads without motion.

## Verification

Opened `demo.html` in the browser and stepped the climb at both ends. The first pass ended the chick below the branch, still in the water, which defeated the point; fixed and re-checked, so it now starts in the river and finishes on the branch next to the adult. Measured the crop at 42% of body area to confirm the proportion is actually there, and confirmed all seven crest quills and both wing claws render on their own keyframes. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
