### PR TITLE
Add saguaro component

### DIFF
--- a/submissions/examples/saguaro-as/README.md
+++ b/submissions/examples/saguaro-as/README.md
@@ -1,0 +1,33 @@
+# Saguaro
+
+A pure CSS/HTML saguaro at sunset: pleats swelling after rain, night flowers opening at the crown, and an elf owl looking out of an old woodpecker hole.
+
+## What it shows
+
+A saguaro is a water tank with an accordion for a skin.
+
+The trunk is fluted into vertical pleats. When rain comes, the cactus drinks hard through a shallow root mat that spreads out as far as the plant is tall, and the pleats **open out like a bellows**. A full-grown saguaro can take on a tonne of water in a few days and gain roughly a quarter of its width. It does not get taller. It gets fatter, then lives off that for a year.
+
+It is slow beyond belief. A saguaro is often 30 years old before it flowers and **can be 75 before it grows its first arm**. The flowers open at night for bats and moths and are shut again by the next afternoon.
+
+The holes are someone else's work. A Gila woodpecker drills a nest cavity, the cactus scars the wound over into a hard waterproof shell (a "saguaro boot"), and years later an elf owl moves into it.
+
+## How it is built
+
+- **The swell is horizontal only, and it is measured.** The trunk animates `scaleX` alone. In the browser it goes from **53.3px to 62.0px wide, a 16.3% gain, with 0.00% height change**. That constraint is the whole biology: the pleats are the only thing that gives, so a uniform `scale` would have been wrong.
+- **The pleats spread with it**: the ribs are a `repeating-linear-gradient` inside the trunk, so when the trunk scales, the spacing between pleats genuinely widens. Nothing separately animates the ribs.
+- **The arms rebuild their own lean**: they swell too, and their keyframe is `rotate(var(--lean)) scaleX(...)`, because a bare `scaleX` keyframe would have wiped each arm's tilt and snapped it upright.
+- **Spine crown**: a `repeating-conic-gradient` of areole spines, masked to a band around the growing tip.
+- **The flowers** open and shut on the same long cycle, waxy white and only briefly.
+- **The owl** rises into the nest hole and settles back, two yellow eyes in the dark.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and parks the cactus fully swollen, with each arm's lean preserved.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/saguaro-as/demo.html
+++ b/submissions/examples/saguaro-as/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Saguaro</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="skyS"></span>
+    <span class="sunS"></span>
+    <span class="mesaS msA"></span>
+    <span class="mesaS msB"></span>
+    <span class="floorS"></span>
+
+    <div class="cactusS">
+      <div class="armS amL">
+        <span class="ribS"></span>
+        <span class="crownS"></span>
+      </div>
+      <div class="armS amR">
+        <span class="ribS"></span>
+        <span class="crownS"></span>
+      </div>
+      <div class="trunkS">
+        <span class="ribS"></span>
+        <span class="pleatS"></span>
+        <span class="crownS"></span>
+        <span class="bloomS blA"></span>
+        <span class="bloomS blB"></span>
+        <span class="holeS hlA"></span>
+        <span class="holeS hlB"></span>
+        <span class="owlS"></span>
+      </div>
+    </div>
+
+    <span class="heatS htA"></span>
+    <span class="heatS htB"></span>
+    <span class="capS">the pleats swell after rain and the trunk gets fatter</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/saguaro-as/style.css
+++ b/submissions/examples/saguaro-as/style.css
@@ -1,0 +1,316 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #e8a86a, #a86a5a 56%, #4a3a44);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  --skin: #4f7a3a;
+  --shade: #1e3a18;
+
+  position: relative;
+  width: 340px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f8c98a, #e08a62 40%, #a05a58 62%, #58414a);
+}
+
+.skyS {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 72% 22%, rgba(255, 246, 200, 0.5), transparent 48%);
+  z-index: 1;
+}
+
+.sunS {
+  position: absolute;
+  top: 52px;
+  right: 52px;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe0, #ffd05a 58%, rgba(255, 190, 80, 0) 78%);
+  z-index: 2;
+}
+
+.mesaS {
+  position: absolute;
+  background: linear-gradient(180deg, #9a6a62, #5f4048);
+  z-index: 2;
+}
+
+.msA {
+  bottom: 76px;
+  left: -30px;
+  width: 190px;
+  height: 52px;
+  clip-path: polygon(0 100%, 8% 26%, 40% 18%, 62% 34%, 100% 30%, 100% 100%);
+  opacity: 0.7;
+}
+
+.msB {
+  bottom: 74px;
+  right: -40px;
+  width: 210px;
+  height: 40px;
+  clip-path: polygon(0 100%, 14% 40%, 48% 24%, 78% 40%, 100% 34%, 100% 100%);
+  opacity: 0.55;
+}
+
+.floorS {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background:
+    radial-gradient(circle at 18% 40%, rgba(70, 40, 30, 0.34) 0 5px, transparent 8px),
+    radial-gradient(circle at 74% 66%, rgba(70, 40, 30, 0.3) 0 6px, transparent 9px),
+    linear-gradient(180deg, #c08a5a, #5f4030);
+  z-index: 6;
+}
+
+.cactusS {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 180px;
+  height: 268px;
+  margin-left: -90px;
+  z-index: 5;
+}
+
+/*
+  the trunk is an accordion. after rain it takes on tonnes of water,
+  the pleats open out, and the whole column gets measurably fatter.
+*/
+.trunkS {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 62px;
+  height: 250px;
+  margin-left: -31px;
+  border-radius: 31px 31px 8px 8px / 44px 44px 6px 6px;
+  background: linear-gradient(90deg, #33582a, var(--skin) 42%, #6f9a4e 58%, #23411c);
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: swellS 11s ease-in-out infinite;
+}
+
+.armS {
+  position: absolute;
+  width: 40px;
+  border-radius: 20px 20px 0 0 / 32px 32px 0 0;
+  background: linear-gradient(90deg, #2f5226, var(--skin) 44%, #6a9449 60%, #1f3a19);
+  transform-origin: 50% 100%;
+  animation: swellArmS 11s ease-in-out infinite;
+}
+
+.amL {
+  --lean: -9deg;
+
+  bottom: 92px;
+  left: 34px;
+  height: 126px;
+  transform: rotate(-9deg);
+  z-index: 4;
+}
+
+.amR {
+  --lean: 8deg;
+
+  bottom: 116px;
+  right: 30px;
+  height: 100px;
+  transform: rotate(8deg);
+  filter: brightness(0.9);
+  z-index: 4;
+  animation-delay: -1.4s;
+}
+
+/* the ribs: vertical pleats that spread apart as the trunk fills */
+.ribS {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(18, 38, 12, 0.42) 0 1.5px,
+      transparent 1.5px 3px,
+      rgba(210, 235, 170, 0.18) 3px 4.5px,
+      transparent 4.5px 8px
+    );
+  z-index: 2;
+}
+
+.pleatS {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow:
+    inset 9px 0 16px rgba(12, 28, 8, 0.5),
+    inset -9px 0 14px rgba(12, 28, 8, 0.4);
+  z-index: 3;
+}
+
+/* areoles and spine tufts around the growing tip */
+.crownS {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 30px;
+  border-radius: inherit;
+  background:
+    repeating-conic-gradient(
+      from 190deg at 50% 100%,
+      rgba(240, 232, 170, 0.6) 0 0.5deg,
+      transparent 0.5deg 4deg
+    );
+  mask-image: radial-gradient(ellipse 80% 100% at 50% 100%, transparent 0 44%, #000 58% 92%, transparent 100%);
+  z-index: 4;
+}
+
+/* the flowers open at night and are shut again by the next afternoon */
+.bloomS {
+  position: absolute;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      #fffdf4 0 9deg,
+      #f0e8c8 9deg 18deg
+    );
+  box-shadow: 0 0 0 2px rgba(200, 220, 150, 0.5), 0 0 8px rgba(255, 250, 220, 0.6);
+  transform-origin: 50% 100%;
+  z-index: 6;
+  animation: openS 11s ease-in-out infinite;
+}
+
+.blA { top: 4px; left: 10px; }
+.blB { top: 10px; right: 8px; animation-delay: -1.1s; }
+
+/*
+  a gila woodpecker drills the hole, the cactus scars it over into a hard
+  shell, and an elf owl moves in years later
+*/
+.holeS {
+  position: absolute;
+  border-radius: 50% 50% 46% 46%;
+  background: radial-gradient(ellipse at 50% 26%, #2a1c0e, #080502 74%);
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.9), 0 0 0 2px rgba(90, 120, 60, 0.5);
+  z-index: 6;
+}
+
+.hlA { bottom: 118px; left: 14px; width: 24px; height: 30px; }
+.hlB { bottom: 62px; right: 12px; width: 18px; height: 22px; filter: brightness(0.8); }
+
+.owlS {
+  position: absolute;
+  bottom: 122px;
+  left: 18px;
+  width: 16px;
+  height: 15px;
+  border-radius: 50% 50% 44% 44%;
+  background: radial-gradient(circle at 44% 34%, #8a7a5a, #33291a 78%);
+  z-index: 7;
+  animation: peepS 11s ease-in-out infinite;
+}
+
+.owlS::before,
+.owlS::after {
+  content: "";
+  position: absolute;
+  top: 5px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #f4e06a;
+  box-shadow: 0 0 3px rgba(244, 224, 106, 0.8);
+}
+
+.owlS::before { left: 3px; }
+.owlS::after { right: 3px; }
+
+.heatS {
+  position: absolute;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 244, 210, 0.4), transparent);
+  z-index: 7;
+  animation: shimmerS 8s linear infinite;
+}
+
+.htA { bottom: 96px; left: -120px; width: 120px; }
+.htB { bottom: 70px; left: -170px; width: 150px; animation-delay: -4s; }
+
+.capS {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.55rem;
+  letter-spacing: 0.07em;
+  color: rgba(255, 244, 220, 0.7);
+  z-index: 9;
+}
+
+/*
+  the swell is horizontal only. a saguaro does not get taller when it drinks,
+  it gets wider, because the pleats are the only thing that gives.
+*/
+@keyframes swellS {
+  0%, 100% { transform: scaleX(0.86); }
+  46%, 68% { transform: scaleX(1); }
+}
+
+/* arms swell too, and must rebuild their own lean or the keyframe wipes it */
+@keyframes swellArmS {
+  0%, 100% { transform: rotate(var(--lean, 0deg)) scaleX(0.88); }
+  46%, 68% { transform: rotate(var(--lean, 0deg)) scaleX(1); }
+}
+
+@keyframes openS {
+  0%, 34% { transform: scale(0.15); opacity: 0; }
+  46%, 62% { transform: scale(1); opacity: 1; }
+  76%, 100% { transform: scale(0.15); opacity: 0; }
+}
+
+@keyframes peepS {
+  0%, 40% { transform: translateY(11px); opacity: 0; }
+  52%, 82% { transform: translateY(0); opacity: 1; }
+  94%, 100% { transform: translateY(11px); opacity: 0; }
+}
+
+@keyframes shimmerS {
+  0% { transform: translateX(0); opacity: 0; }
+  16% { opacity: 1; }
+  84% { opacity: 1; }
+  100% { transform: translateX(560px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trunkS,
+  .armS,
+  .bloomS,
+  .owlS,
+  .heatS {
+    animation: none;
+  }
+
+  .trunkS { transform: scaleX(1); }
+  .amL { transform: rotate(-9deg) scaleX(1); }
+  .amR { transform: rotate(8deg) scaleX(1); }
+  .heatS { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/saguaro-as/`, a self-contained pure CSS/HTML saguaro at sunset.

Closes #47896

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The swell is horizontal only, and it is measured.** The trunk animates `scaleX` alone. In the browser it goes from **53.3px to 62.0px wide: a 16.3% gain, with 0.00% height change**. That constraint is the whole biology. A saguaro drinks a tonne of water in a few days and gets *fatter*, not taller, because the pleats are the only thing that gives. A uniform `scale` would have been the wrong animation.
- **The pleats spread with it**: the ribs are a `repeating-linear-gradient` inside the trunk, so when the trunk scales the spacing between pleats genuinely widens. Nothing separately animates the ribs.
- **The arms rebuild their own lean**: they swell too, and their keyframe is `rotate(var(--lean)) scaleX(...)`, because a bare `scaleX` keyframe would have wiped each arm's tilt and snapped it upright.
- **Spine crown**: a `repeating-conic-gradient` of areole spines masked to a band around the growing tip.
- **The flowers** open and shut on the same long cycle, waxy white and only briefly, which is what they do (night-blooming, closed by the next afternoon).
- **The owl** rises into the nest hole and settles back. The hole is a Gila woodpecker's, scarred over by the cactus into a hard shell, which an elf owl takes over years later.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and parks the cactus fully swollen with each arm's lean preserved.

## Verification

Opened `demo.html` in the browser and measured the swell at both ends of the keyframe rather than eyeballing it: width 53.3px dry to 62.0px wet (+16.3%), height change 0.00%, so the trunk really does only widen. Confirmed the flowers open, the owl's eyes appear in the hole, and the reduced-motion path holds the swollen pose. Also fixed the arms after the first pass left them floating detached beside the trunk. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
