### PR TITLE
Add oarfish component

### DIFF
--- a/submissions/examples/oarfish-as/README.md
+++ b/submissions/examples/oarfish-as/README.md
@@ -1,0 +1,32 @@
+# Oarfish
+
+A pure CSS/HTML giant oarfish hanging head-up in the mesopelagic, driving itself with the dorsal fin alone.
+
+## What it shows
+
+The giant oarfish is the longest bony fish there is, reaching eleven metres. It has no scales, no swim bladder, and no teeth. It is a ribbon of silver guanine that eats krill.
+
+Two things about it are worth drawing:
+
+**It swims vertically.** Submersible footage found oarfish hanging head-up in the water column, not lying horizontal like a normal fish. The old "sea serpent" sightings are almost always dying ones that have come to the surface and gone sideways.
+
+**It swims by its fin, not its body.** This is **amiiform locomotion**: the body stays nearly rigid while a wave travels along the long dorsal fin, and that wave does all the work. It is precise and quiet and lets the animal hover.
+
+## How it is built
+
+- **The travelling wave is `animation-delay`, and nothing else.** All 26 dorsal rays run the *same* keyframe. Each one is offset by `calc(var(--i) * -0.085s)` from the ray above it. Measured in the browser, the phase advances **exactly 0.085s per ray**, so across the fin the total offset is 2.125s against a 1.7s period, giving about **1.25 wavelengths** visible along the body at any moment. That stagger is the entire propulsion effect.
+- **Fin large, body small.** The rays throw ±20 degrees while the body segments shift by 2.5px. That ratio is what makes it amiiform rather than an eel: if the body undulated as much as the fin, this would be the wrong animal.
+- **A real ribbon**: 26 stacked segments, tapering **31%** from head to tail, so the wave has something to travel along and the tail does not end in a blunt stub.
+- **The oars**: long pelvic rays with a paddle at the tip, hanging off the belly (the side opposite the dorsal fin). They are what the fish is named for and they do not propel it.
+- **The crest**: the first dorsal rays drawn out over the head, each keeping its own `--pl` lean through the shared keyframe.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe. The fin holds its staggered pose, so the wave shape is still visible frozen.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/oarfish-as/demo.html
+++ b/submissions/examples/oarfish-as/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Oarfish</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="beamO bmA"></span>
+    <span class="beamO bmB"></span>
+    <span class="snowO swA"></span>
+    <span class="snowO swB"></span>
+    <span class="snowO swC"></span>
+    <span class="snowO swD"></span>
+
+    <div class="fishO">
+      <span class="segO" style="--i: 0"></span>
+      <span class="segO" style="--i: 1"></span>
+      <span class="segO" style="--i: 2"></span>
+      <span class="segO" style="--i: 3"></span>
+      <span class="segO" style="--i: 4"></span>
+      <span class="segO" style="--i: 5"></span>
+      <span class="segO" style="--i: 6"></span>
+      <span class="segO" style="--i: 7"></span>
+      <span class="segO" style="--i: 8"></span>
+      <span class="segO" style="--i: 9"></span>
+      <span class="segO" style="--i: 10"></span>
+      <span class="segO" style="--i: 11"></span>
+      <span class="segO" style="--i: 12"></span>
+      <span class="segO" style="--i: 13"></span>
+      <span class="segO" style="--i: 14"></span>
+      <span class="segO" style="--i: 15"></span>
+      <span class="segO" style="--i: 16"></span>
+      <span class="segO" style="--i: 17"></span>
+      <span class="segO" style="--i: 18"></span>
+      <span class="segO" style="--i: 19"></span>
+      <span class="segO" style="--i: 20"></span>
+      <span class="segO" style="--i: 21"></span>
+      <span class="segO" style="--i: 22"></span>
+      <span class="segO" style="--i: 23"></span>
+      <span class="segO" style="--i: 24"></span>
+      <span class="segO" style="--i: 25"></span>
+      <span class="finO" style="--i: 0"></span>
+      <span class="finO" style="--i: 1"></span>
+      <span class="finO" style="--i: 2"></span>
+      <span class="finO" style="--i: 3"></span>
+      <span class="finO" style="--i: 4"></span>
+      <span class="finO" style="--i: 5"></span>
+      <span class="finO" style="--i: 6"></span>
+      <span class="finO" style="--i: 7"></span>
+      <span class="finO" style="--i: 8"></span>
+      <span class="finO" style="--i: 9"></span>
+      <span class="finO" style="--i: 10"></span>
+      <span class="finO" style="--i: 11"></span>
+      <span class="finO" style="--i: 12"></span>
+      <span class="finO" style="--i: 13"></span>
+      <span class="finO" style="--i: 14"></span>
+      <span class="finO" style="--i: 15"></span>
+      <span class="finO" style="--i: 16"></span>
+      <span class="finO" style="--i: 17"></span>
+      <span class="finO" style="--i: 18"></span>
+      <span class="finO" style="--i: 19"></span>
+      <span class="finO" style="--i: 20"></span>
+      <span class="finO" style="--i: 21"></span>
+      <span class="finO" style="--i: 22"></span>
+      <span class="finO" style="--i: 23"></span>
+      <span class="finO" style="--i: 24"></span>
+      <span class="finO" style="--i: 25"></span>
+      <span class="headO"></span>
+      <span class="eyeO"></span>
+      <span class="jawO"></span>
+      <span class="plumeO plA"></span>
+      <span class="plumeO plB"></span>
+      <span class="oarO oaL"></span>
+      <span class="oarO oaR"></span>
+    </div>
+
+    <span class="capO">it swims vertically, head up, rippling one fin</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/oarfish-as/style.css
+++ b/submissions/examples/oarfish-as/style.css
@@ -1,0 +1,255 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 8%, #123048, #01040a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #17415f, #0a2338 42%, #030a14 84%);
+}
+
+.beamO {
+  position: absolute;
+  top: -40px;
+  width: 60px;
+  height: 300px;
+  background: linear-gradient(180deg, rgba(150, 210, 240, 0.16), transparent 72%);
+  transform-origin: 50% 0;
+  z-index: 1;
+  animation: sweepO 14s ease-in-out infinite;
+}
+
+.bmA { left: 40px; transform: rotate(7deg); }
+.bmB { right: 30px; transform: rotate(-9deg); animation-delay: -7s; }
+
+.snowO {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(200, 224, 240, 0.55);
+  z-index: 2;
+  animation: fallO 16s linear infinite;
+}
+
+.swA { left: 46px; top: -10px; }
+.swB { left: 132px; top: -60px; animation-delay: -4s; }
+.swC { left: 244px; top: -30px; animation-delay: -8s; }
+.swD { left: 296px; top: -80px; animation-delay: -12s; }
+
+/*
+  the whole animal hangs vertical, head up. the body barely bends.
+*/
+.fishO {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  width: 120px;
+  height: 310px;
+  margin-left: -46px;
+  z-index: 5;
+  animation: hoverO 9s ease-in-out infinite;
+}
+
+/* the silver ribbon, stacked as segments so the wave can travel down it */
+.segO {
+  position: absolute;
+  top: calc(24px + var(--i) * 10.6px);
+  left: calc(40px + var(--i) * 0.17px);
+  width: calc(27px - var(--i) * 0.34px);
+  height: 12px;
+  border-radius: 7px;
+  background:
+    linear-gradient(
+      90deg,
+      #3f5f74 0 12%,
+      #dfeef6 34%,
+      #9fb8c8 58%,
+      #35505f 100%
+    );
+  box-shadow: inset 0 -1px 2px rgba(10, 24, 34, 0.5);
+  z-index: 4;
+  animation: swayO 3.4s ease-in-out infinite;
+  animation-delay: calc(var(--i) * -0.085s);
+}
+
+/*
+  the propulsion: every dorsal ray runs the same keyframe, each one
+  a fraction later than the ray above it. that stagger IS the travelling wave.
+*/
+.finO {
+  position: absolute;
+  top: calc(26px + var(--i) * 10.6px);
+  left: 12px;
+  width: 30px;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #ff5a6a, #b81830);
+  box-shadow: 0 0 4px rgba(255, 70, 90, 0.4);
+  transform-origin: 100% 50%;
+  z-index: 3;
+  animation: rippleO 1.7s ease-in-out infinite;
+  animation-delay: calc(var(--i) * -0.085s);
+}
+
+.headO {
+  position: absolute;
+  top: 0;
+  left: 38px;
+  width: 30px;
+  height: 34px;
+  border-radius: 46% 46% 30% 30% / 62% 62% 38% 38%;
+  background: radial-gradient(circle at 40% 32%, #e8f4fa, #4a6a7e 78%);
+  z-index: 6;
+}
+
+.eyeO {
+  position: absolute;
+  top: 8px;
+  left: 44px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f4fbff 0 24%, #1c3a4e 60%, #050c14 84%);
+  box-shadow: 0 0 6px rgba(180, 226, 250, 0.5);
+  z-index: 7;
+}
+
+/* the mouth protrudes into a tube to suck in krill */
+.jawO {
+  position: absolute;
+  top: 24px;
+  left: 44px;
+  width: 15px;
+  height: 12px;
+  border-radius: 3px 3px 5px 5px;
+  background: linear-gradient(180deg, #6a8496, #22384a);
+  transform-origin: 50% 0;
+  z-index: 5;
+  animation: gulpO 3.4s ease-in-out infinite;
+}
+
+/* the first dorsal rays are drawn out into a red crest over the head */
+.plumeO {
+  position: absolute;
+  width: 4px;
+  border-radius: 2px 2px 0 0;
+  background: linear-gradient(180deg, #ff7080, #a01428);
+  transform-origin: 50% 100%;
+  z-index: 5;
+  animation: crestO 3.4s ease-in-out infinite;
+}
+
+.plA { top: -18px; left: 42px; height: 30px; --pl: -9deg; transform: rotate(-9deg); }
+.plB { top: -12px; left: 52px; height: 24px; --pl: 7deg; transform: rotate(7deg); animation-delay: -0.5s; }
+
+/*
+  the oars: long pelvic rays with a paddle on the end.
+  they are what the fish is named for and they do not propel it.
+*/
+.oarO {
+  position: absolute;
+  width: 2.4px;
+  height: 96px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #d84a5c, #6a1020);
+  transform-origin: 50% 0;
+  z-index: 4;
+  animation: trailO 5.2s ease-in-out infinite;
+}
+
+.oarO::after {
+  content: "";
+  position: absolute;
+  bottom: -12px;
+  left: 50%;
+  width: 9px;
+  height: 18px;
+  margin-left: -4.5px;
+  border-radius: 50% 50% 44% 44%;
+  background: linear-gradient(180deg, #ff6070, #8a1024);
+}
+
+.oaL { top: 30px; left: 60px; --ol: 5deg; transform: rotate(5deg); }
+.oaR { top: 32px; left: 65px; --ol: -13deg; transform: rotate(-13deg); animation-delay: -2.6s; }
+
+.capO {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.08em;
+  color: rgba(200, 232, 250, 0.62);
+  z-index: 9;
+}
+
+/*
+  amiiform swimming: the fin does the work, the body holds still.
+  so the body sway is tiny and the fin throw is large.
+*/
+@keyframes swayO {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(2.5px); }
+}
+
+@keyframes rippleO {
+  0%, 100% { transform: rotate(20deg); }
+  50% { transform: rotate(-20deg); }
+}
+
+@keyframes crestO {
+  0%, 100% { transform: rotate(var(--pl, 0deg)); }
+  50% { transform: rotate(calc(var(--pl, 0deg) + 8deg)); }
+}
+
+@keyframes trailO {
+  0%, 100% { transform: rotate(var(--ol, 0deg)); }
+  50% { transform: rotate(calc(var(--ol, 0deg) - 7deg)); }
+}
+
+@keyframes gulpO {
+  0%, 70%, 100% { transform: scaleY(1); }
+  84% { transform: scaleY(1.5); }
+}
+
+@keyframes hoverO {
+  0%, 100% { transform: translateY(0) rotate(-1.5deg); }
+  50% { transform: translateY(-12px) rotate(1.5deg); }
+}
+
+@keyframes fallO {
+  0% { transform: translate(0, 0); opacity: 0; }
+  10% { opacity: 0.7; }
+  90% { opacity: 0.7; }
+  100% { transform: translate(-14px, 400px); opacity: 0; }
+}
+
+@keyframes sweepO {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .segO,
+  .finO,
+  .plumeO,
+  .oarO,
+  .jawO,
+  .fishO,
+  .snowO,
+  .beamO {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/oarfish-as/`, a self-contained pure CSS/HTML giant oarfish swimming vertically on a dorsal fin wave.

Closes #47898

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The travelling wave is `animation-delay`, and nothing else.** All 26 dorsal rays run the *same* keyframe, each offset by `calc(var(--i) * -0.085s)` from the ray above it. Measured in the browser the phase advances **exactly 0.085s per ray**, so the total offset across the fin is 2.125s against a 1.7s period: about **1.25 wavelengths** visible along the body at any moment. That stagger is the entire propulsion effect, which is the right way to build it because that is literally how the animal swims.
- **Fin large, body small.** The rays throw plus or minus 20 degrees while the body segments shift by 2.5px. That ratio is what makes it amiiform rather than an eel: if the body undulated as much as the fin, this would be a different animal.
- **A real ribbon**: 26 stacked segments tapering **31%** from head to tail, so the wave has something to travel along and the tail does not end in a blunt stub.
- **The oars**: long pelvic rays with a paddle at the tip, hanging off the belly, the side opposite the dorsal fin. They are what the fish is named for and they do not propel it. The first pass put one behind the body where it was invisible.
- **The crest**: the first dorsal rays drawn out over the head, each keeping its own `--pl` lean through the shared keyframe.
- **Vertical**: the animal hangs head-up, which is how submersibles actually find them.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe. The fin keeps its staggered pose, so the wave shape stays visible frozen.

## Verification

Opened `demo.html` in the browser and confirmed the wave visibly travels down the fin while the body stays near-rigid. Measured rather than eyeballed: 26 rays and 26 segments, per-ray phase step exactly -0.085s, fin period 1.7s against body period 3.4s, and body taper 27.3px to 18.8px (31.1%). `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
