### PR TITLE
Add tapir component

### DIFF
--- a/submissions/examples/tapir-as/README.md
+++ b/submissions/examples/tapir-as/README.md
@@ -1,0 +1,30 @@
+# Tapir
+
+A pure CSS/HTML lowland tapir wading a forest pool with a striped calf alongside.
+
+## What it shows
+
+A tapir looks like a pig designed by someone who had only heard about elephants, but it is neither. Its closest relatives are horses and rhinos, and the lineage has barely changed in 20 million years.
+
+**The nose is the interesting part.** It is not a lip and not a snout. The upper lip and nose are fused into a short, muscular, genuinely prehensile proboscis that moves independently of the head. The tapir uses it like a finger: to pull leaves down, to sort food, and as a snorkel when it walks along the bottom of a river, which it does routinely.
+
+**The calf is the other part.** Tapir calves are patterned in cream stripes and spots, described as looking like a walking watermelon. It breaks up the outline on a dappled forest floor. The pattern fades out by about six months.
+
+## How it is built
+
+- **The proboscis has its own animation.** `.trunkT` is nested inside the head but runs `gropeT` while the head runs `sniffT`. It casts around, stretches with `scaleX`, and does not simply follow the skull. That independence is the anatomical point, so giving it a shared keyframe would have made it just a snout.
+- **The calf's pattern is dashes, not a grid.** The first pass crossed two `repeating-linear-gradient`s and the calf came out looking like it was in a cage. It is now a single set of bands running head-to-tail, broken into dashes by a second mask layer, with `mask-composite: intersect` confining them to the body. That is what the real pattern looks like.
+- **White ear rims**: an `inset` `box-shadow` on the lower edge of each ear, which is the field mark you actually pick out first at night.
+- **The mane**: a `repeating-conic-gradient` under a `clip-path`, the short stiff crest along the neck.
+- **Gait**: legs alternate on half-cycle offsets and the two animals plod at slightly different rates, so they do not move as one rigid unit.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds both animals standing, so the proboscis and the calf's pattern still read without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/tapir-as/demo.html
+++ b/submissions/examples/tapir-as/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tapir</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="canopyT"></span>
+    <span class="leafT lfA"></span>
+    <span class="leafT lfB"></span>
+    <span class="mudT"></span>
+    <span class="poolT"></span>
+
+    <div class="adultT">
+      <span class="legT lgBB"></span>
+      <span class="legT lgBF"></span>
+      <span class="rumpT"></span>
+      <span class="bodyT"></span>
+      <span class="legT lgFB"></span>
+      <span class="legT lgFF"></span>
+      <span class="neckT"></span>
+      <span class="maneT"></span>
+      <div class="headT">
+        <span class="skullT"></span>
+        <span class="earT eaL"></span>
+        <span class="earT eaR"></span>
+        <span class="eyeT"></span>
+        <div class="trunkT">
+          <span class="proboT"></span>
+          <span class="nostrilT"></span>
+        </div>
+      </div>
+      <span class="tailT"></span>
+    </div>
+
+    <div class="calfT">
+      <span class="calfLeg clA"></span>
+      <span class="calfLeg clB"></span>
+      <span class="calfBody"></span>
+      <span class="calfStripe"></span>
+      <span class="calfHead"></span>
+      <span class="calfEye"></span>
+      <span class="calfNose"></span>
+    </div>
+
+    <span class="rippleT rpA"></span>
+    <span class="rippleT rpB"></span>
+    <span class="capT">a nose that is neither lip nor snout, and a calf in melon stripes</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tapir-as/style.css
+++ b/submissions/examples/tapir-as/style.css
@@ -1,0 +1,470 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #33452c, #080d07 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #6f8f52, #40603a 46%, #24381f 66%, #14200f);
+}
+
+.canopyT {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 24% 10%, rgba(180, 230, 150, 0.2) 0 34px, transparent 52px),
+    radial-gradient(circle at 78% 16%, rgba(180, 230, 150, 0.14) 0 30px, transparent 46px);
+  z-index: 1;
+}
+
+.leafT {
+  position: absolute;
+  border-radius: 60% 14% 60% 14%;
+  background:
+    repeating-conic-gradient(
+      from 130deg at 6% 90%,
+      rgba(14, 34, 14, 0.34) 0 0.7deg,
+      transparent 0.7deg 8deg
+    ),
+    linear-gradient(140deg, #5a8a3c, #1e3a18);
+  z-index: 2;
+}
+
+.lfA { top: -12px; left: -24px; width: 132px; height: 52px; transform: rotate(18deg); }
+.lfB { top: 6px; right: -30px; width: 138px; height: 48px; transform: rotate(-16deg) scaleX(-1); filter: brightness(0.84); }
+
+.poolT {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 52px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(190, 220, 180, 0.08) 0 1px,
+      transparent 1px 10px
+    ),
+    linear-gradient(180deg, #3a5140, #16241a);
+  z-index: 6;
+}
+
+.poolT::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: rgba(214, 240, 210, 0.4);
+}
+
+.mudT {
+  position: absolute;
+  bottom: 44px;
+  left: 0;
+  right: 0;
+  height: 44px;
+  background:
+    radial-gradient(circle at 22% 60%, rgba(30, 22, 10, 0.4) 0 6px, transparent 10px),
+    radial-gradient(circle at 72% 40%, rgba(30, 22, 10, 0.34) 0 7px, transparent 11px),
+    linear-gradient(180deg, #4f4028, #241c10);
+  z-index: 4;
+}
+
+/* ------------- the adult ------------- */
+
+.adultT {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 210px;
+  height: 130px;
+  margin-left: -122px;
+  z-index: 7;
+  animation: plodT 7s ease-in-out infinite;
+}
+
+.bodyT {
+  position: absolute;
+  bottom: 30px;
+  left: 52px;
+  width: 112px;
+  height: 58px;
+  border-radius: 40% 46% 42% 48% / 56% 58% 42% 42%;
+  background:
+    repeating-linear-gradient(
+      66deg,
+      rgba(20, 18, 16, 0.2) 0 3px,
+      transparent 3px 14px
+    ),
+    radial-gradient(circle at 40% 30%, #6a6660, #232120 78%);
+  box-shadow: inset -8px -6px 18px rgba(10, 9, 8, 0.6);
+  z-index: 4;
+}
+
+.rumpT {
+  position: absolute;
+  bottom: 32px;
+  left: 122px;
+  width: 56px;
+  height: 54px;
+  border-radius: 46% 50% 44% 40% / 56% 56% 44% 44%;
+  background: radial-gradient(circle at 40% 32%, #5f5b56, #1e1c1b 78%);
+  z-index: 3;
+}
+
+.neckT {
+  position: absolute;
+  bottom: 56px;
+  left: 34px;
+  width: 40px;
+  height: 34px;
+  border-radius: 44% 30% 30% 44%;
+  background: linear-gradient(200deg, #5f5b56, #221f1e);
+  z-index: 5;
+}
+
+/* tapirs carry a short stiff mane along the crest of the neck */
+.maneT {
+  position: absolute;
+  bottom: 80px;
+  left: 36px;
+  width: 46px;
+  height: 12px;
+  background:
+    repeating-conic-gradient(
+      from 184deg at 50% 100%,
+      #14120f 0 1deg,
+      transparent 1deg 3.6deg
+    );
+  clip-path: polygon(0 100%, 10% 30%, 42% 6%, 76% 22%, 100% 100%);
+  transform: rotate(-8deg);
+  z-index: 6;
+}
+
+.headT {
+  position: absolute;
+  bottom: 48px;
+  left: 0;
+  width: 64px;
+  height: 50px;
+  transform-origin: 88% 30%;
+  z-index: 6;
+  animation: sniffT 7s ease-in-out infinite;
+}
+
+.skullT {
+  position: absolute;
+  bottom: 0;
+  left: 20px;
+  width: 44px;
+  height: 40px;
+  border-radius: 40% 44% 34% 40% / 50% 50% 50% 50%;
+  background: radial-gradient(circle at 56% 32%, #6a6660, #1e1c1b 80%);
+  z-index: 4;
+}
+
+/* the white ear rims are the field mark you see first at night */
+.earT {
+  position: absolute;
+  width: 16px;
+  height: 19px;
+  border-radius: 50% 50% 40% 40%;
+  background: linear-gradient(180deg, #4a4642, #191817);
+  box-shadow: inset 0 -3px 0 rgba(240, 238, 230, 0.85);
+  z-index: 3;
+  animation: flickT 3.1s ease-in-out infinite;
+}
+
+.eaL { bottom: 30px; left: 36px; transform-origin: 50% 100%; }
+.eaR { bottom: 32px; left: 50px; filter: brightness(0.78); animation-delay: -1.5s; transform-origin: 50% 100%; }
+
+.eyeT {
+  position: absolute;
+  bottom: 20px;
+  left: 28px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #6a5f4a, #0a0806 68%);
+  z-index: 6;
+}
+
+/*
+  the proboscis: not a lip, not a snout. it is nose and upper lip fused
+  into a short prehensile trunk, and it moves on its own.
+*/
+.trunkT {
+  position: absolute;
+  bottom: 4px;
+  left: -6px;
+  width: 34px;
+  height: 22px;
+  transform-origin: 100% 40%;
+  z-index: 5;
+  animation: gropeT 3.1s ease-in-out infinite;
+}
+
+.proboT {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 34px;
+  height: 20px;
+  border-radius: 60% 20% 20% 60% / 66% 40% 40% 60%;
+  background:
+    repeating-linear-gradient(
+      82deg,
+      rgba(10, 9, 8, 0.3) 0 1.5px,
+      transparent 1.5px 5px
+    ),
+    linear-gradient(170deg, #5f5b56, #171615);
+}
+
+.nostrilT {
+  position: absolute;
+  bottom: 9px;
+  left: 1px;
+  width: 6px;
+  height: 5px;
+  border-radius: 50%;
+  background: #0a0908;
+  z-index: 2;
+}
+
+.legT {
+  position: absolute;
+  bottom: -10px;
+  width: 15px;
+  height: 44px;
+  border-radius: 6px 6px 3px 3px;
+  background: linear-gradient(90deg, #4a4642, #1a1918);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: stepT 7s ease-in-out infinite;
+}
+
+.legT::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -2px;
+  width: 19px;
+  height: 7px;
+  border-radius: 3px;
+  background: #100f0e;
+}
+
+.lgFF { left: 62px; z-index: 5; }
+.lgFB { left: 80px; filter: brightness(0.66); animation-delay: -3.5s; }
+.lgBF { left: 132px; z-index: 5; animation-delay: -3.5s; }
+.lgBB { left: 152px; filter: brightness(0.66); }
+
+.tailT {
+  position: absolute;
+  bottom: 62px;
+  left: 172px;
+  width: 14px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #3a3733, #14130f);
+  transform-origin: 0 50%;
+  z-index: 3;
+  animation: swishT 3.1s ease-in-out infinite;
+}
+
+/* ------------- the calf ------------- */
+
+.calfT {
+  position: absolute;
+  bottom: 58px;
+  left: 216px;
+  width: 92px;
+  height: 66px;
+  z-index: 5;
+  animation: trotT 7s ease-in-out infinite;
+}
+
+.calfBody {
+  position: absolute;
+  bottom: 12px;
+  left: 18px;
+  width: 56px;
+  height: 30px;
+  border-radius: 42% 48% 44% 46% / 56% 56% 44% 44%;
+  background: radial-gradient(circle at 40% 32%, #6a5a44, #2a2218 78%);
+  z-index: 3;
+}
+
+/*
+  the calf is striped and spotted like a melon. it breaks the outline up
+  on the forest floor, and it fades out by about six months old.
+*/
+.calfStripe {
+  position: absolute;
+  bottom: 12px;
+  left: 18px;
+  width: 56px;
+  height: 30px;
+  border-radius: 42% 48% 44% 46% / 56% 56% 44% 44%;
+  background:
+    repeating-linear-gradient(
+      177deg,
+      rgba(252, 246, 224, 0.9) 0 2.4px,
+      transparent 2.4px 7px
+    );
+  mask-image:
+    repeating-linear-gradient(90deg, #000 0 7px, transparent 7px 11px),
+    radial-gradient(ellipse 96% 96% at 50% 46%, #000 0 70%, transparent 96%);
+  mask-composite: intersect;
+  z-index: 4;
+}
+
+.calfHead {
+  position: absolute;
+  bottom: 26px;
+  left: 4px;
+  width: 24px;
+  height: 20px;
+  border-radius: 42% 44% 34% 40% / 50% 50% 50% 50%;
+  background: radial-gradient(circle at 56% 34%, #6a5a44, #241d14 80%);
+  z-index: 5;
+}
+
+.calfNose {
+  position: absolute;
+  bottom: 26px;
+  left: -6px;
+  width: 16px;
+  height: 10px;
+  border-radius: 60% 20% 20% 60% / 66% 40% 40% 60%;
+  background: linear-gradient(170deg, #5f5140, #17140f);
+  transform-origin: 100% 40%;
+  z-index: 4;
+  animation: gropeT 3.1s ease-in-out infinite;
+  animation-delay: -1.1s;
+}
+
+.calfEye {
+  position: absolute;
+  bottom: 38px;
+  left: 10px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #0a0806;
+  z-index: 6;
+}
+
+.calfLeg {
+  position: absolute;
+  bottom: -6px;
+  width: 8px;
+  height: 24px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #4a4034, #16130e);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: stepT 7s ease-in-out infinite;
+}
+
+.clA { left: 26px; }
+.clB { left: 56px; animation-delay: -3.5s; }
+
+.rippleT {
+  position: absolute;
+  bottom: 30px;
+  height: 9px;
+  border: 1.2px solid rgba(220, 244, 214, 0.34);
+  border-radius: 50%;
+  opacity: 0;
+  z-index: 8;
+  animation: spreadT 7s ease-out infinite;
+}
+
+.rpA { left: 96px; width: 44px; }
+.rpB { left: 178px; width: 34px; animation-delay: -3.5s; }
+
+.capT {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.06em;
+  color: rgba(226, 244, 200, 0.62);
+  z-index: 9;
+}
+
+@keyframes plodT {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-6px, -2px); }
+}
+
+@keyframes trotT {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-9px, -2px); }
+}
+
+@keyframes stepT {
+  0%, 100% { transform: rotate(9deg); }
+  50% { transform: rotate(-9deg); }
+}
+
+/* the proboscis casts around independently of the head */
+@keyframes gropeT {
+  0%, 100% { transform: rotate(4deg) scaleX(1); }
+  32% { transform: rotate(-14deg) scaleX(1.14); }
+  64% { transform: rotate(10deg) scaleX(0.94); }
+}
+
+@keyframes sniffT {
+  0%, 100% { transform: rotate(0deg); }
+  40% { transform: rotate(-6deg); }
+  72% { transform: rotate(3deg); }
+}
+
+@keyframes flickT {
+  0%, 76%, 100% { transform: rotate(0deg); }
+  86% { transform: rotate(-14deg); }
+}
+
+@keyframes swishT {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(8deg); }
+}
+
+@keyframes spreadT {
+  0% { transform: scale(0.3); opacity: 0; }
+  16% { opacity: 0.8; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .adultT,
+  .calfT,
+  .headT,
+  .trunkT,
+  .calfNose,
+  .legT,
+  .calfLeg,
+  .earT,
+  .tailT,
+  .rippleT {
+    animation: none;
+  }
+
+  .rippleT { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/tapir-as/`, a self-contained pure CSS/HTML lowland tapir with a striped calf.

Closes #47900

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The proboscis has its own animation.** `.trunkT` is nested inside the head but runs `gropeT` while the head runs `sniffT`. It casts around, stretches with `scaleX`, and does not simply follow the skull. A tapir's nose is upper lip and nose fused into a genuinely prehensile trunk that moves independently, so sharing the head's keyframe would have reduced it to a snout.
- **The calf's pattern is dashes, not a grid.** The first pass crossed two `repeating-linear-gradient`s and the calf came out looking like it was standing behind a fence, which the browser check caught. It is now a single set of bands running head-to-tail, broken into dashes by a second mask layer, with `mask-composite: intersect` confining them to the body. That is what the real melon pattern looks like, and it fades by six months old.
- **White ear rims**: an `inset` `box-shadow` on the lower edge of each ear, which is the field mark you actually pick out first at night.
- **The mane**: a `repeating-conic-gradient` under a `clip-path`, the short stiff crest along the neck.
- **Gait**: legs alternate on half-cycle offsets and the two animals plod at slightly different rates, so they do not move as one rigid unit.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds both animals standing, so the proboscis and the calf's pattern still read without motion.

## Verification

Opened `demo.html` in the browser and confirmed the proboscis moves independently of the head, the ear rims read, the legs alternate, and the reduced-motion path holds a static pose. Checked the computed values to confirm the trunk and head resolve to *different* keyframes rather than sharing one, which is the whole anatomical claim. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
