### PR TITLE
Add orchid mantis component

### DIFF
--- a/submissions/examples/orchid-mantis-as/README.md
+++ b/submissions/examples/orchid-mantis-as/README.md
@@ -1,0 +1,30 @@
+# Orchid Mantis
+
+A pure CSS/HTML *Hymenopus coronatus* sitting on a bare stem, being a flower, and taking a bee.
+
+## What it shows
+
+The usual description is wrong. The orchid mantis is not hiding on an orchid. There is no orchid. **The mantis is the flower.**
+
+Its four walking legs have femurs flattened and lobed into petals, and the whole animal is arranged into a bloom. It sits on a bare stem, and pollinators come to it.
+
+This was tested rather than assumed. O'Hanlon and colleagues found in 2014 that the mantis attracts *more* pollinators than real flowers growing nearby do. It is not camouflage, which hides you from something. It is **aggressive mimicry**: a lure that works better than the thing it imitates. The insects are not fooled into missing it; they are fooled into coming to it.
+
+## How it is built
+
+- **The petals are legs.** They are drawn as four lobed femurs radiating from the thorax, not as a flower with a mantis on it. There is nothing behind them but a bare stem, because that is the honest picture.
+- **Symmetric splay, verified.** The left and right pairs hinge on opposite edges, which means their rotation signs must be opposite too. The first pass used the same sign for both and the left pair collapsed into each other. Measured after the fix: petal centres at x = 371/371/429/429 and y = 199/252/199/252, so both pairs open by the same 53px and the bloom is genuinely symmetric.
+- **A still flower is a suspicious flower**: the whole animal nods on a slow breeze keyframe, and each petal drifts on its own delay while keeping its own `--p` angle via `rotate(calc(var(--p) + 4deg))`.
+- **The strike is 2% of the cycle.** A real mantis strike is around 60 milliseconds. Everything else in this component is the wait. The forelegs cock, the femur reaches, and the tibia snaps shut against the femur's tooth row in a single frame; the bee is gone on the next one.
+- **Mirrored foreleg**: the right raptorial arm carries `scaleX(-1)` and gets its own keyframe rebuilding it at every stop, so the strike cannot flip it.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the bloom open with the bee hidden, so the mimicry still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/orchid-mantis-as/demo.html
+++ b/submissions/examples/orchid-mantis-as/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Orchid Mantis</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="glowO"></span>
+    <span class="foliageO fgA"></span>
+    <span class="foliageO fgB"></span>
+    <span class="stemO"></span>
+
+    <div class="beeO">
+      <span class="beeWing bwA"></span>
+      <span class="beeWing bwB"></span>
+      <span class="beeBody"></span>
+      <span class="beeHead"></span>
+    </div>
+
+    <div class="mantisO">
+      <span class="abdomenO"></span>
+      <span class="wingO"></span>
+      <span class="thoraxO"></span>
+
+      <span class="petalO ptA"></span>
+      <span class="petalO ptB"></span>
+      <span class="petalO ptC"></span>
+      <span class="petalO ptD"></span>
+
+      <div class="raptorO rpL">
+        <span class="coxaO"></span>
+        <div class="femurO">
+          <span class="spineO"></span>
+          <div class="tibiaO"><span class="hookO"></span></div>
+        </div>
+      </div>
+      <div class="raptorO rpR">
+        <span class="coxaO"></span>
+        <div class="femurO">
+          <span class="spineO"></span>
+          <div class="tibiaO"><span class="hookO"></span></div>
+        </div>
+      </div>
+
+      <span class="headO"></span>
+      <span class="eyeO eyL"></span>
+      <span class="eyeO eyR"></span>
+      <span class="antO anL"></span>
+      <span class="antO anR"></span>
+    </div>
+
+    <span class="capO">it is not hiding on a flower. it is the flower.</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/orchid-mantis-as/style.css
+++ b/submissions/examples/orchid-mantis-as/style.css
@@ -1,0 +1,385 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #2f4433, #060d08 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 48% 34%, #46654a, #0a140c 84%);
+}
+
+.glowO {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 50% 40%, rgba(255, 240, 250, 0.14), transparent 54%);
+  z-index: 1;
+}
+
+.foliageO {
+  position: absolute;
+  border-radius: 60% 14% 60% 14%;
+  background: linear-gradient(140deg, #3f6a34, #16290f);
+  z-index: 2;
+}
+
+.fgA { bottom: -18px; left: -30px; width: 150px; height: 60px; transform: rotate(14deg); }
+.fgB { bottom: -14px; right: -34px; width: 160px; height: 56px; transform: rotate(-12deg) scaleX(-1); filter: brightness(0.8); }
+
+.stemO {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 9px;
+  height: 116px;
+  margin-left: -4px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #4f7a3a, #24421c);
+  z-index: 3;
+}
+
+/* ---------------- the lure ---------------- */
+
+.mantisO {
+  position: absolute;
+  bottom: 104px;
+  left: 50%;
+  width: 170px;
+  height: 150px;
+  margin-left: -85px;
+  z-index: 6;
+  animation: nodO 6.5s ease-in-out infinite;
+}
+
+.abdomenO {
+  position: absolute;
+  bottom: 6px;
+  left: 62px;
+  width: 46px;
+  height: 34px;
+  border-radius: 46% 46% 50% 50% / 40% 40% 60% 60%;
+  background: radial-gradient(circle at 42% 34%, #fff4f8, #d8a8c0 76%);
+  z-index: 3;
+}
+
+.wingO {
+  position: absolute;
+  bottom: 16px;
+  left: 60px;
+  width: 50px;
+  height: 40px;
+  border-radius: 50% 46% 40% 46%;
+  background:
+    repeating-linear-gradient(
+      74deg,
+      rgba(210, 160, 190, 0.34) 0 1px,
+      transparent 1px 6px
+    ),
+    linear-gradient(170deg, #fffafc, #f0cfe0);
+  z-index: 4;
+}
+
+.thoraxO {
+  position: absolute;
+  bottom: 36px;
+  left: 76px;
+  width: 18px;
+  height: 40px;
+  border-radius: 40% 40% 30% 30%;
+  background: linear-gradient(90deg, #f8dce8, #cfa0ba);
+  z-index: 5;
+}
+
+/*
+  the petals are the mantis. each is a walking leg whose femur has been
+  flattened and lobed into a petal, so there is no flower under it.
+*/
+.petalO {
+  position: absolute;
+  width: 46px;
+  height: 30px;
+  border-radius: 60% 40% 46% 54% / 66% 62% 38% 34%;
+  background:
+    radial-gradient(ellipse at 32% 34%, #fffdff, #f4c8dc 60%, #cf90b2 92%);
+  box-shadow: inset -3px -3px 8px rgba(180, 110, 150, 0.34);
+  transform: rotate(var(--p, 0deg));
+  z-index: 6;
+  animation: driftO 6.5s ease-in-out infinite;
+  animation-delay: var(--d, 0s);
+}
+
+.ptA { --p: 32deg; --d: 0s; bottom: 60px; left: 30px; transform-origin: 100% 50%; }
+.ptB { --p: -30deg; --d: -1.6s; bottom: 30px; left: 30px; transform-origin: 100% 50%; }
+.ptC { --p: -30deg; --d: -0.8s; bottom: 60px; left: 94px; transform-origin: 0 50%; }
+.ptD { --p: 28deg; --d: -2.4s; bottom: 30px; left: 94px; transform-origin: 0 50%; }
+
+.headO {
+  position: absolute;
+  bottom: 74px;
+  left: 74px;
+  width: 22px;
+  height: 17px;
+  border-radius: 44% 44% 40% 40%;
+  background: linear-gradient(180deg, #fff8fb, #dcaec6);
+  z-index: 7;
+}
+
+.eyeO {
+  position: absolute;
+  bottom: 82px;
+  width: 9px;
+  height: 11px;
+  border-radius: 50% 50% 44% 44%;
+  background: radial-gradient(circle at 36% 32%, #f4dcea, #7a4a62 78%);
+  z-index: 8;
+}
+
+.eyL { left: 72px; }
+.eyR { left: 89px; }
+
+.antO {
+  position: absolute;
+  bottom: 88px;
+  width: 15px;
+  height: 1.6px;
+  border-radius: 1px;
+  background: #8a5a72;
+  transform-origin: 100% 50%;
+  transform: rotate(var(--an, 0deg));
+  z-index: 7;
+  animation: feelO 2.2s ease-in-out infinite;
+}
+
+.anL { --an: -26deg; left: 62px; }
+.anR { --an: 24deg; left: 92px; transform-origin: 0 50%; animation-delay: -1.1s; }
+
+/*
+  the raptorial forelegs. the strike is roughly 60 milliseconds in life,
+  so here it is 2% of the cycle: everything else is the wait.
+*/
+.raptorO {
+  position: absolute;
+  bottom: 62px;
+  width: 40px;
+  height: 14px;
+  z-index: 9;
+  animation: cockO 6.5s ease-in-out infinite;
+}
+
+.rpL { left: 58px; transform-origin: 100% 50%; }
+.rpR { left: 92px; transform-origin: 0 50%; transform: scaleX(-1); animation-name: cockOr; }
+
+.coxaO {
+  position: absolute;
+  top: 4px;
+  right: 0;
+  width: 12px;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #e8bcd2, #b07894);
+}
+
+.femurO {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 30px;
+  height: 12px;
+  transform-origin: 100% 50%;
+  animation: reachO 6.5s ease-in-out infinite;
+  animation-delay: inherit;
+}
+
+.femurO::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 40% 8% 8% 40% / 60% 30% 30% 60%;
+  background: linear-gradient(180deg, #fff4f9, #cf9cb8);
+}
+
+/* the femur's tooth row: what the tibia clamps the prey against */
+.spineO {
+  position: absolute;
+  bottom: 0;
+  left: 3px;
+  width: 24px;
+  height: 4px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #7a4a62 0 1.2px,
+      transparent 1.2px 4px
+    );
+  z-index: 3;
+}
+
+.tibiaO {
+  position: absolute;
+  bottom: 1px;
+  left: 0;
+  width: 24px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #b07894, #f0d0e0);
+  transform-origin: 100% 50%;
+  z-index: 4;
+  animation: snapO 6.5s ease-in-out infinite;
+  animation-delay: inherit;
+}
+
+.hookO {
+  position: absolute;
+  top: -2px;
+  left: -4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50% 0 50% 50%;
+  background: #6a3a52;
+}
+
+/* ---------------- the prey ---------------- */
+
+.beeO {
+  position: absolute;
+  bottom: 190px;
+  left: 44px;
+  width: 30px;
+  height: 18px;
+  z-index: 5;
+  animation: approachO 6.5s ease-in-out infinite;
+}
+
+.beeBody {
+  position: absolute;
+  bottom: 0;
+  left: 4px;
+  width: 20px;
+  height: 12px;
+  border-radius: 46% 54% 50% 50%;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      #2a1c08 0 3px,
+      #e8b83a 3px 6px
+    );
+  z-index: 3;
+}
+
+.beeHead {
+  position: absolute;
+  bottom: 2px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #241806;
+  z-index: 4;
+}
+
+.beeWing {
+  position: absolute;
+  width: 14px;
+  height: 6px;
+  border-radius: 50% 50% 40% 40%;
+  background: rgba(226, 244, 250, 0.6);
+  transform-origin: 20% 100%;
+  z-index: 5;
+  animation: buzzO 0.09s linear infinite;
+}
+
+.bwA { bottom: 10px; left: 8px; }
+.bwB { bottom: 9px; left: 12px; animation-delay: -0.045s; }
+
+.capO {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.07em;
+  color: rgba(250, 226, 240, 0.66);
+  z-index: 10;
+}
+
+/* the flower sways in the breeze, because a still flower is a suspicious flower */
+@keyframes nodO {
+  0%, 100% { transform: translateY(0) rotate(-1.5deg); }
+  50% { transform: translateY(-4px) rotate(1.5deg); }
+}
+
+@keyframes driftO {
+  0%, 100% { transform: rotate(var(--p, 0deg)); }
+  50% { transform: rotate(calc(var(--p, 0deg) + 4deg)); }
+}
+
+@keyframes feelO {
+  0%, 100% { transform: rotate(var(--an, 0deg)); }
+  50% { transform: rotate(calc(var(--an, 0deg) + 10deg)); }
+}
+
+/* the bee comes in, and is gone one frame after the strike */
+@keyframes approachO {
+  0% { transform: translate(0, 0); opacity: 0; }
+  10% { opacity: 1; }
+  56% { transform: translate(56px, 74px); opacity: 1; }
+  62% { transform: translate(62px, 82px); opacity: 1; }
+  64%, 100% { transform: translate(62px, 82px); opacity: 0; }
+}
+
+/* fold, hold, then 2% of the cycle to close */
+@keyframes cockO {
+  0%, 54% { transform: rotate(0deg); }
+  62% { transform: rotate(-18deg); }
+  64% { transform: rotate(-4deg); }
+  76%, 100% { transform: rotate(0deg); }
+}
+
+@keyframes cockOr {
+  0%, 54% { transform: scaleX(-1) rotate(0deg); }
+  62% { transform: scaleX(-1) rotate(-18deg); }
+  64% { transform: scaleX(-1) rotate(-4deg); }
+  76%, 100% { transform: scaleX(-1) rotate(0deg); }
+}
+
+@keyframes reachO {
+  0%, 54% { transform: rotate(18deg); }
+  62% { transform: rotate(-26deg); }
+  76%, 100% { transform: rotate(18deg); }
+}
+
+@keyframes snapO {
+  0%, 60% { transform: rotate(-58deg); }
+  62%, 74% { transform: rotate(0deg); }
+  84%, 100% { transform: rotate(-58deg); }
+}
+
+@keyframes buzzO {
+  0%, 100% { transform: rotate(-16deg); }
+  50% { transform: rotate(16deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mantisO,
+  .petalO,
+  .antO,
+  .raptorO,
+  .femurO,
+  .tibiaO,
+  .beeO,
+  .beeWing {
+    animation: none;
+  }
+
+  .beeO { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/orchid-mantis-as/`, a self-contained pure CSS/HTML orchid mantis luring and taking a bee.

Closes #47902

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The petals are legs.** They are drawn as four lobed femurs radiating from the thorax, not as a flower with a mantis sitting on it. There is nothing behind them but a bare stem, because that is the honest picture: the mantis *is* the flower, and it attracts more pollinators than the real flowers nearby (O'Hanlon et al., 2014). This is aggressive mimicry, not camouflage.
- **Symmetric splay, verified.** The left and right pairs hinge on opposite edges, so their rotation signs have to be opposite too. The first pass used the same sign for both and the left pair collapsed into each other, which the browser check caught. Measured after the fix: petal centres at x = 371/371/429/429 and y = 199/252/199/252, so both pairs open by the same 53px and the bloom is genuinely symmetric.
- **A still flower is a suspicious flower**: the animal nods on a slow breeze keyframe, and each petal drifts on its own delay while keeping its own `--p` angle via `rotate(calc(var(--p) + 4deg))`.
- **The strike is 2% of the cycle.** A real mantis strike is around 60 milliseconds; everything else here is the wait. The forelegs cock, the femur reaches, and the tibia snaps shut against the femur's tooth row in a single frame. The bee is gone on the next.
- **Mirrored foreleg**: the right raptorial arm carries `scaleX(-1)` and gets its own keyframe rebuilding it at every stop, so the strike cannot flip it.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the bloom open with the bee hidden, so the mimicry still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the bloom reads as a flower, the bee approaches, and the strike closes the tibiae. Measured the four petal centres to confirm the splay is symmetric rather than eyeballing it, after the first pass collapsed the left pair. Confirmed the mirrored foreleg resolves to its own keyframe so the `scaleX(-1)` survives. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
