### PR TITLE
Add sandgrouse component

### DIFF
--- a/submissions/examples/sandgrouse-as/README.md
+++ b/submissions/examples/sandgrouse-as/README.md
@@ -1,0 +1,30 @@
+# Sandgrouse
+
+A pure CSS/HTML male sandgrouse rocking belly-down into a desert puddle to load his feathers with water.
+
+## What it shows
+
+Sandgrouse nest in deserts, far from any water, and their chicks cannot fly. So the male commits to one of the strangest daily errands in biology: he **carries water home in his own feathers**.
+
+His belly feathers are unlike anything else. The barbs are tightly coiled when dry, and when they get wet they **uncoil and interlock into a dense mat** that holds water by capillary action instead of shedding it. He wades in, rocks forward, and rubs his belly in the puddle for several minutes to charge them.
+
+Then he flies up to 30km home carrying **25 to 40ml of water** in his plumage, in dry desert air, and the chicks strip it out of him with their beaks.
+
+## How it is built
+
+- **The barbs uncoil in a wave.** All 16 barbs run the same keyframe, each delayed by `calc(var(--i) * 0.045s)`. Measured in the browser, the phase steps exactly **0.045s per barb**, so the belly wets progressively across its width instead of all at once. That is what soaking looks like.
+- **Coiled versus loaded.** The barbs sit at `scaleY(0.72)` dry and open to `scaleY(1)` wet, which is the actual mechanism: the barb geometry changes state when it takes on water.
+- **The rock is a hold, not a dip.** The keyframe drops the bird belly-down and then **stays there for 38% of the cycle** before rising. A real male rubs his belly in the puddle for minutes. A quick bob would be the wrong behaviour.
+- **The belly is a patch, not sticks**: a soft feather base under the barbs, so the tract reads as plumage.
+- **Drips** fall from the loaded belly as he lifts, because the mat is not perfect.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the bird belly-down with the barbs open, so the loading pose still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/sandgrouse-as/demo.html
+++ b/submissions/examples/sandgrouse-as/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sandgrouse</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="hazeS"></span>
+    <span class="duneS dnA"></span>
+    <span class="duneS dnB"></span>
+    <span class="gravelS"></span>
+    <span class="poolS"></span>
+    <span class="wetS"></span>
+
+    <div class="birdS">
+      <span class="tailS"></span>
+      <span class="bodyS"></span>
+      <span class="wingS"></span>
+      <div class="bellyS">
+        <span class="barbS" style="--i: 0"></span>
+        <span class="barbS" style="--i: 1"></span>
+        <span class="barbS" style="--i: 2"></span>
+        <span class="barbS" style="--i: 3"></span>
+        <span class="barbS" style="--i: 4"></span>
+        <span class="barbS" style="--i: 5"></span>
+        <span class="barbS" style="--i: 6"></span>
+        <span class="barbS" style="--i: 7"></span>
+        <span class="barbS" style="--i: 8"></span>
+        <span class="barbS" style="--i: 9"></span>
+        <span class="barbS" style="--i: 10"></span>
+        <span class="barbS" style="--i: 11"></span>
+        <span class="barbS" style="--i: 12"></span>
+        <span class="barbS" style="--i: 13"></span>
+        <span class="barbS" style="--i: 14"></span>
+        <span class="barbS" style="--i: 15"></span>
+      </div>
+      <span class="legS lgB"></span>
+      <span class="legS lgF"></span>
+      <span class="neckS"></span>
+      <span class="headS"></span>
+      <span class="eyeS"></span>
+      <span class="billS"></span>
+    </div>
+
+    <div class="dripS">
+      <span class="dropS" style="left: 30px; animation-delay: 0s"></span>
+      <span class="dropS" style="left: 46px; animation-delay: -0.5s"></span>
+      <span class="dropS" style="left: 62px; animation-delay: -1.0s"></span>
+      <span class="dropS" style="left: 38px; animation-delay: -1.5s"></span>
+      <span class="dropS" style="left: 54px; animation-delay: -2.0s"></span>
+    </div>
+
+    <span class="capS">belly feathers that hold water like a sponge</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sandgrouse-as/style.css
+++ b/submissions/examples/sandgrouse-as/style.css
@@ -1,0 +1,342 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #dcb886, #a07a5a 58%, #4f3f36);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f0d49a, #d8a877 44%, #9f7a58 62%, #6a5140);
+}
+
+.hazeS {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 70% 16%, rgba(255, 250, 220, 0.5), transparent 48%);
+  z-index: 1;
+}
+
+.duneS {
+  position: absolute;
+  border-radius: 50% 50% 0 0 / 100% 100% 0 0;
+  background: linear-gradient(180deg, #cfa476, #8a6a4e);
+  z-index: 2;
+}
+
+.dnA { bottom: 96px; left: -40px; width: 230px; height: 44px; }
+.dnB { bottom: 96px; right: -50px; width: 250px; height: 34px; filter: brightness(0.9); }
+
+.gravelS {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 100px;
+  background:
+    radial-gradient(circle at 12% 30%, rgba(80, 60, 40, 0.4) 0 3px, transparent 5px),
+    radial-gradient(circle at 84% 62%, rgba(80, 60, 40, 0.36) 0 4px, transparent 6px),
+    radial-gradient(circle at 46% 82%, rgba(80, 60, 40, 0.3) 0 3px, transparent 5px),
+    linear-gradient(180deg, #b08658, #5f4632);
+  z-index: 3;
+}
+
+/* the whole point of the journey: a puddle, up to 30km from the nest */
+.poolS {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  width: 176px;
+  height: 32px;
+  margin-left: -88px;
+  border-radius: 50%;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(230, 246, 250, 0.14) 0 1px,
+      transparent 1px 6px
+    ),
+    radial-gradient(ellipse at 46% 34%, #6f9aa8, #2a4650 80%);
+  box-shadow: inset 0 3px 8px rgba(20, 40, 48, 0.5);
+  z-index: 4;
+}
+
+.wetS {
+  position: absolute;
+  bottom: 22px;
+  left: 50%;
+  width: 208px;
+  height: 42px;
+  margin-left: -104px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(70, 46, 30, 0.42), transparent 72%);
+  z-index: 3;
+}
+
+.birdS {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 190px;
+  height: 150px;
+  margin-left: -92px;
+  z-index: 7;
+  animation: rockS 5s ease-in-out infinite;
+}
+
+.bodyS {
+  position: absolute;
+  bottom: 26px;
+  left: 34px;
+  width: 106px;
+  height: 52px;
+  border-radius: 44% 56% 44% 56% / 58% 58% 42% 42%;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(70, 46, 22, 0.26) 0 3px,
+      transparent 3px 11px
+    ),
+    radial-gradient(circle at 40% 32%, #d8b478, #7a5a34 78%);
+  box-shadow: inset -6px -5px 14px rgba(50, 34, 14, 0.44);
+  z-index: 5;
+}
+
+.wingS {
+  position: absolute;
+  bottom: 34px;
+  left: 62px;
+  width: 74px;
+  height: 38px;
+  border-radius: 44% 56% 50% 44% / 56% 44% 50% 50%;
+  background:
+    repeating-linear-gradient(
+      70deg,
+      rgba(60, 40, 16, 0.34) 0 3px,
+      transparent 3px 10px
+    ),
+    linear-gradient(150deg, #c8a066, #6a4c28);
+  transform-origin: 22% 26%;
+  z-index: 6;
+  animation: settleS 5s ease-in-out infinite;
+}
+
+.tailS {
+  position: absolute;
+  bottom: 32px;
+  left: 124px;
+  width: 62px;
+  height: 22px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(60, 40, 16, 0.36) 0 4px,
+      transparent 4px 13px
+    ),
+    linear-gradient(90deg, #7a5a30, #dcc08a);
+  clip-path: polygon(0 12%, 100% 40%, 100% 60%, 0 88%);
+  transform-origin: 0 50%;
+  z-index: 4;
+  animation: cockS 5s ease-in-out infinite;
+}
+
+/*
+  the belly feathers. the barbs are coiled and unlock when wet, so the
+  feather holds water by capillary action instead of shedding it.
+  a male carries 25-40ml home in these, 30km, in the air.
+*/
+.bellyS {
+  position: absolute;
+  bottom: 12px;
+  left: 46px;
+  width: 76px;
+  height: 26px;
+  border-radius: 40% 40% 46% 46% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, rgba(196, 158, 104, 0.95) 0 34%, rgba(214, 184, 134, 0.5) 60%, transparent 88%);
+  z-index: 7;
+  animation: rockS 5s ease-in-out infinite;
+}
+
+.barbS {
+  position: absolute;
+  top: 0;
+  left: calc(var(--i) * 4.6px);
+  width: 3px;
+  height: 22px;
+  border-radius: 0 0 2px 2px;
+  background: linear-gradient(180deg, #a8804c, #e8dcb8);
+  transform-origin: 50% 0;
+
+  /* each barb uncoils a beat after the one before it, as the water spreads */
+  animation: soakS 5s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.045s);
+}
+
+.legS {
+  position: absolute;
+  bottom: -8px;
+  width: 6px;
+  height: 22px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #b8a882, #6a5a3a);
+  z-index: 5;
+}
+
+.legS::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: -6px;
+  width: 18px;
+  height: 4px;
+  background: #6a5a3a;
+  clip-path: polygon(0 0, 30% 100%, 54% 0, 78% 100%, 100% 0, 100% 60%);
+}
+
+.lgF { left: 66px; }
+.lgB { left: 88px; filter: brightness(0.74); z-index: 4; }
+
+.neckS {
+  position: absolute;
+  bottom: 62px;
+  left: 30px;
+  width: 22px;
+  height: 26px;
+  border-radius: 44% 40% 30% 34%;
+  background: linear-gradient(200deg, #e0bc84, #8a6838);
+  transform-origin: 50% 100%;
+  transform: rotate(-14deg);
+  z-index: 6;
+}
+
+.headS {
+  position: absolute;
+  bottom: 78px;
+  left: 16px;
+  width: 30px;
+  height: 24px;
+  border-radius: 50% 46% 40% 44%;
+  background: radial-gradient(circle at 56% 34%, #e8c894, #7a5a30 78%);
+  z-index: 7;
+}
+
+.headS::after {
+  content: "";
+  position: absolute;
+  bottom: 2px;
+  left: 4px;
+  width: 20px;
+  height: 8px;
+  border-radius: 50%;
+  background: #b8641c;
+}
+
+.eyeS {
+  position: absolute;
+  bottom: 90px;
+  left: 26px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #6a5a3a, #0e0a04 68%);
+  box-shadow: 0 0 0 1.5px rgba(240, 226, 180, 0.5);
+  z-index: 8;
+}
+
+.billS {
+  position: absolute;
+  bottom: 82px;
+  left: 6px;
+  width: 13px;
+  height: 6px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #7a6a4a, #33291a);
+  clip-path: polygon(0 40%, 100% 0, 100% 100%, 0 70%);
+  z-index: 7;
+}
+
+.dripS {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  width: 100px;
+  height: 40px;
+  margin-left: -22px;
+  z-index: 8;
+}
+
+.dropS {
+  position: absolute;
+  top: 0;
+  width: 4px;
+  height: 6px;
+  border-radius: 50% 50% 50% 50% / 62% 62% 38% 38%;
+  background: radial-gradient(circle at 36% 30%, #e8fbff, #6f9aa8 74%);
+  animation: dripS 5s ease-in infinite;
+}
+
+.capS {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 246, 214, 0.72);
+  z-index: 9;
+}
+
+/* the bird rocks belly-down into the water and holds there while it loads */
+@keyframes rockS {
+  0%, 14% { transform: translateY(0) rotate(0deg); }
+  30%, 68% { transform: translateY(11px) rotate(4deg); }
+  86%, 100% { transform: translateY(0) rotate(0deg); }
+}
+
+/* barbs coiled when dry, splayed and holding water when soaked */
+@keyframes soakS {
+  0%, 16% { transform: rotate(0deg) scaleY(0.72); }
+  34%, 70% { transform: rotate(0deg) scaleY(1); }
+  88%, 100% { transform: rotate(0deg) scaleY(0.72); }
+}
+
+@keyframes settleS {
+  0%, 100% { transform: rotate(2deg); }
+  40%, 68% { transform: rotate(-5deg); }
+}
+
+@keyframes cockS {
+  0%, 100% { transform: rotate(-4deg); }
+  40%, 68% { transform: rotate(7deg); }
+}
+
+@keyframes dripS {
+  0%, 70% { transform: translateY(0); opacity: 0; }
+  76% { opacity: 0.9; }
+  100% { transform: translateY(34px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .birdS,
+  .bellyS,
+  .barbS,
+  .wingS,
+  .tailS,
+  .dropS {
+    animation: none;
+  }
+
+  .birdS,
+  .bellyS { transform: translateY(11px) rotate(4deg); }
+  .barbS { transform: scaleY(1); }
+  .dropS { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/sandgrouse-as/`, a self-contained pure CSS/HTML sandgrouse loading water into its belly feathers.

Closes #47904

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The barbs uncoil in a wave.** All 16 barbs run the same keyframe, each delayed by `calc(var(--i) * 0.045s)`. Measured in the browser the phase steps exactly **0.045s per barb**, so the belly wets progressively across its width instead of all at once. That is what soaking actually looks like.
- **Coiled versus loaded.** The barbs sit at `scaleY(0.72)` dry and open to `scaleY(1)` wet, which is the real mechanism: sandgrouse belly barbs are coiled when dry and uncoil and interlock into a mat that holds water by capillary action when wet.
- **The rock is a hold, not a dip.** The keyframe drops the bird belly-down and then **stays there for 38% of the cycle** before rising. A real male rubs his belly in the puddle for minutes before flying up to 30km home with 25-40ml of water in his plumage. A quick bob would be describing different behaviour.
- **The belly is a patch, not sticks**: a soft feather base under the barbs so the tract reads as plumage.
- **Drips** fall from the loaded belly as he lifts, because the mat is not perfect.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the bird belly-down with the barbs open, so the loading pose still reads without motion.

## Verification

Opened `demo.html` in the browser and confirmed the bird rocks down so the belly tract is genuinely in the water, the barbs splay while it is down, and the reduced-motion path holds the loaded pose. Measured the per-barb delay to confirm the wave is real: 16 barbs, phase step exactly 0.045s, total spread 0.675s. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
