### PR TITLE
Add hagfish component

### DIFF
--- a/submissions/examples/hagfish-as/README.md
+++ b/submissions/examples/hagfish-as/README.md
@@ -1,0 +1,33 @@
+# Hagfish
+
+A pure CSS/HTML hagfish being bitten, and instantly filling the attacker's mouth with slime.
+
+## What it shows
+
+A hagfish is a jawless, eyeless, boneless scavenger that has been doing this for 300 million years, and its defence is one of the fastest chemical events in biology.
+
+Bitten, it fires a hundred pores along its flanks at once. What comes out is about a teaspoon of concentrated exudate: coiled protein thread and mucin vesicles. It hits seawater and **hydrates into litres of slime in well under a second**. The threads are ten microns wide and up to 15cm long, and they knit the mucus into a cohesive net rather than a puddle.
+
+It goes straight into the attacker's gills. A shark that bites a hagfish lets go and leaves, gagging. Footage exists of exactly this happening to sharks mid-bite.
+
+Then the hagfish has a problem, because it is now in its own slime. So it **ties itself in an overhand knot and pushes the knot down its own body** to scrape itself clean. It uses the same trick in reverse for leverage when tearing food off a carcass, since it has no jaw to pull against.
+
+## How it is built
+
+- **The release takes 4% of the cycle.** From nothing to a cloud in a handful of frames, because in life it is under a second. The rest of the animation is the wait and the aftermath. That ratio is the fact worth encoding.
+- **Pores fire together, not in sequence.** The per-pore delay is `calc(var(--i) * 0.012s)`, deliberately tiny, so the flank goes off as one event. This is the opposite of the travelling-wave stagger, and it is the correct choice here.
+- **Thread, not just cloud**: the slime is soft merged pore blooms *plus* radiating threads that snap taut with `scaleX(0 → 1)`, because hagfish slime is a fibre net and drawing only mucus would miss what makes it work.
+- **The knot travels.** It is a partial `border` ring that slides along the body on its own keyframe: the actual behaviour, used both for cleaning and for leverage.
+- **No eyes, no jaw**: the head has barbels that cast around on their own delays, and a rasping plate instead of a mandible.
+- **The shark commits and regrets it**: it lunges, its jaw opens on the frame the pores fire, and it backs off with the jaw working.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the slime released and the threads drawn, so the defence still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/hagfish-as/demo.html
+++ b/submissions/examples/hagfish-as/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hagfish</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="waterH"></span>
+    <span class="floorH"></span>
+    <span class="snowH swA"></span>
+    <span class="snowH swB"></span>
+    <span class="snowH swC"></span>
+
+    <div class="sharkH">
+      <span class="sharkTail"></span>
+      <span class="sharkBody"></span>
+      <span class="sharkFin"></span>
+      <span class="sharkHead"></span>
+      <span class="sharkEye"></span>
+      <span class="sharkJaw"></span>
+    </div>
+
+    <div class="slimeH">
+      <span class="threadH" style="--t: -58deg; --d: 0s"></span>
+      <span class="threadH" style="--t: -34deg; --d: -0.12s"></span>
+      <span class="threadH" style="--t: -10deg; --d: -0.24s"></span>
+      <span class="threadH" style="--t: 14deg; --d: -0.36s"></span>
+      <span class="threadH" style="--t: 38deg; --d: -0.48s"></span>
+      <span class="threadH" style="--t: 62deg; --d: -0.6s"></span>
+    </div>
+
+    <div class="fishH">
+      <span class="tailH"></span>
+      <span class="bodyH"></span>
+      <span class="finH"></span>
+      <span class="poreH" style="--i: 0"></span>
+      <span class="poreH" style="--i: 1"></span>
+      <span class="poreH" style="--i: 2"></span>
+      <span class="poreH" style="--i: 3"></span>
+      <span class="poreH" style="--i: 4"></span>
+      <span class="poreH" style="--i: 5"></span>
+      <span class="poreH" style="--i: 6"></span>
+      <span class="poreH" style="--i: 7"></span>
+      <span class="poreH" style="--i: 8"></span>
+      <div class="headH">
+        <span class="skullH"></span>
+        <span class="barbH bbA"></span>
+        <span class="barbH bbB"></span>
+        <span class="barbH bbC"></span>
+        <span class="barbH bbD"></span>
+        <span class="rakeH"></span>
+      </div>
+      <div class="knotH"></div>
+    </div>
+
+    <span class="capH">a teaspoon of slime becomes a litre in a second</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/hagfish-as/style.css
+++ b/submissions/examples/hagfish-as/style.css
@@ -1,0 +1,407 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #10222e, #01050a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #163a4e, #0a2030 46%, #030a12 86%);
+}
+
+.waterH {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 46% 18%, rgba(120, 190, 220, 0.14), transparent 58%);
+  z-index: 1;
+}
+
+.floorH {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 54px;
+  background:
+    radial-gradient(circle at 22% 40%, rgba(120, 130, 130, 0.14) 0 5px, transparent 8px),
+    radial-gradient(circle at 76% 62%, rgba(120, 130, 130, 0.12) 0 6px, transparent 9px),
+    linear-gradient(180deg, #3a4a4e, #0c1418);
+  z-index: 2;
+}
+
+.snowH {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(200, 224, 236, 0.5);
+  z-index: 3;
+  animation: driftH 15s linear infinite;
+}
+
+.swA { left: 40px; top: -10px; }
+.swB { left: 176px; top: -50px; animation-delay: -5s; }
+.swC { left: 288px; top: -30px; animation-delay: -10s; }
+
+/* ---------------- the attacker ---------------- */
+
+.sharkH {
+  position: absolute;
+  top: 26px;
+  left: 50%;
+  width: 190px;
+  height: 90px;
+  margin-left: -30px;
+  z-index: 5;
+  animation: lungeH 7s cubic-bezier(0.3, 0, 0.35, 1) infinite;
+}
+
+.sharkBody {
+  position: absolute;
+  top: 24px;
+  left: 44px;
+  width: 116px;
+  height: 40px;
+  border-radius: 50% 44% 44% 50% / 50% 50% 50% 50%;
+  background: linear-gradient(180deg, #6f8896, #223440);
+  z-index: 3;
+}
+
+.sharkHead {
+  position: absolute;
+  top: 26px;
+  left: 12px;
+  width: 46px;
+  height: 34px;
+  border-radius: 60% 30% 30% 60% / 56% 46% 46% 56%;
+  background: linear-gradient(180deg, #7f96a4, #263a46);
+  z-index: 4;
+}
+
+.sharkJaw {
+  position: absolute;
+  top: 44px;
+  left: 12px;
+  width: 30px;
+  height: 12px;
+  background: #0c1418;
+  clip-path: polygon(0 0, 100% 22%, 100% 100%, 0 66%);
+  z-index: 5;
+  animation: bitedH 7s cubic-bezier(0.3, 0, 0.35, 1) infinite;
+}
+
+.sharkJaw::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: 4px;
+  width: 22px;
+  height: 4px;
+  background: repeating-linear-gradient(90deg, #eaf2f6 0 2px, transparent 2px 5px);
+}
+
+.sharkEye {
+  position: absolute;
+  top: 34px;
+  left: 26px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #060c10;
+  z-index: 6;
+}
+
+.sharkFin {
+  position: absolute;
+  top: 6px;
+  left: 78px;
+  width: 30px;
+  height: 24px;
+  background: linear-gradient(180deg, #5f7684, #22323c);
+  clip-path: polygon(0 100%, 62% 0, 100% 100%);
+  z-index: 3;
+}
+
+.sharkTail {
+  position: absolute;
+  top: 18px;
+  left: 150px;
+  width: 40px;
+  height: 50px;
+  background: linear-gradient(90deg, #334752, #6a8290);
+  clip-path: polygon(0 34%, 100% 0, 76% 50%, 100% 100%, 0 66%);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: beatH 0.8s ease-in-out infinite;
+}
+
+/* ---------------- the hagfish ---------------- */
+
+.fishH {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 230px;
+  height: 90px;
+  margin-left: -140px;
+  z-index: 7;
+  animation: writheH 7s ease-in-out infinite;
+}
+
+.bodyH {
+  position: absolute;
+  bottom: 22px;
+  left: 26px;
+  width: 172px;
+  height: 19px;
+  border-radius: 10px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(30, 20, 26, 0.2) 0 1px,
+      transparent 1px 9px
+    ),
+    linear-gradient(180deg, #b8869a, #4a2a38);
+  box-shadow: inset 0 -3px 6px rgba(20, 10, 16, 0.5);
+  z-index: 4;
+}
+
+.finH {
+  position: absolute;
+  bottom: 18px;
+  left: 30px;
+  width: 168px;
+  height: 7px;
+  border-radius: 0 0 6px 6px;
+  background: linear-gradient(180deg, rgba(200, 150, 170, 0.7), rgba(120, 70, 90, 0.2));
+  z-index: 3;
+}
+
+.headH {
+  position: absolute;
+  bottom: 18px;
+  left: 0;
+  width: 40px;
+  height: 30px;
+  z-index: 6;
+  animation: rootH 3.2s ease-in-out infinite;
+}
+
+.skullH {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  width: 32px;
+  height: 22px;
+  border-radius: 56% 30% 30% 56% / 54% 46% 46% 54%;
+  background: radial-gradient(circle at 62% 34%, #c8929e, #4a2a34 80%);
+  z-index: 3;
+}
+
+/* no jaws and no eyes: it finds carrion by smell and touch */
+.barbH {
+  position: absolute;
+  width: 13px;
+  height: 1.6px;
+  border-radius: 1px;
+  background: #8a5a68;
+  transform-origin: 100% 50%;
+  transform: rotate(var(--bb, 0deg));
+  z-index: 4;
+  animation: feelH 2.1s ease-in-out infinite;
+}
+
+.bbA { --bb: -32deg; bottom: 20px; left: -6px; }
+.bbB { --bb: -10deg; bottom: 15px; left: -8px; animation-delay: -0.5s; }
+.bbC { --bb: 12deg; bottom: 10px; left: -8px; animation-delay: -1s; }
+.bbD { --bb: 32deg; bottom: 5px; left: -6px; animation-delay: -1.5s; }
+
+/* the rasping plate it uses instead of a jaw */
+.rakeH {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  width: 10px;
+  height: 8px;
+  background: #f0dcc8;
+  clip-path: polygon(0 0, 100% 22%, 100% 78%, 0 100%, 30% 76%, 12% 50%, 30% 24%);
+  z-index: 5;
+  animation: raspH 2.1s ease-in-out infinite;
+}
+
+/*
+  the knot: it ties itself in an overhand knot and drives the knot
+  down its own body, to scrape off its own slime and to get leverage
+*/
+.knotH {
+  position: absolute;
+  bottom: 14px;
+  left: 60px;
+  width: 34px;
+  height: 34px;
+  border: 8px solid;
+  border-color: #a8768a #a8768a transparent transparent;
+  border-radius: 50%;
+  transform: rotate(-40deg);
+  z-index: 5;
+  animation: slideKnotH 7s ease-in-out infinite;
+}
+
+/* ---------------- the slime ---------------- */
+
+.slimeH {
+  position: absolute;
+  bottom: 84px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  margin-left: -108px;
+  z-index: 8;
+}
+
+/*
+  a hundred pores fire at once. the exudate is a teaspoon, and it hydrates
+  into litres of fibre and mucus in well under a second.
+*/
+.poreH {
+  position: absolute;
+  bottom: 0;
+  left: calc(var(--i) * 19px);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(232, 250, 252, 0.5) 0 24%, rgba(160, 206, 220, 0.22) 56%, transparent 88%);
+  transform-origin: 50% 50%;
+  z-index: 3;
+  animation: burstH 7s cubic-bezier(0.1, 0.8, 0.3, 1) infinite;
+  animation-delay: calc(var(--i) * 0.012s);
+}
+
+.threadH {
+  position: absolute;
+  bottom: 4px;
+  left: 96px;
+  width: 74px;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, rgba(226, 246, 250, 0.8), rgba(180, 220, 234, 0.1));
+  transform-origin: 0 50%;
+  transform: rotate(var(--t, 0deg)) scaleX(0);
+  z-index: 4;
+  animation: spinH 7s cubic-bezier(0.1, 0.8, 0.3, 1) infinite;
+  animation-delay: var(--d, 0s);
+}
+
+.capH {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.08em;
+  color: rgba(200, 236, 246, 0.66);
+  z-index: 9;
+}
+
+/* the shark commits, hits slime, and backs off gagging */
+@keyframes lungeH {
+  0%, 24% { transform: translate(0, 0) rotate(0deg); }
+  40% { transform: translate(-96px, 108px) rotate(24deg); }
+  44% { transform: translate(-92px, 104px) rotate(20deg); }
+  62% { transform: translate(-30px, 30px) rotate(-8deg); }
+  86%, 100% { transform: translate(0, 0) rotate(0deg); }
+}
+
+@keyframes bitedH {
+  0%, 34% { transform: rotate(0deg); }
+  40% { transform: rotate(-26deg); }
+  46% { transform: rotate(-4deg); }
+  58% { transform: rotate(-22deg); }
+  70%, 100% { transform: rotate(0deg); }
+}
+
+@keyframes beatH {
+  0%, 100% { transform: rotate(-9deg); }
+  50% { transform: rotate(9deg); }
+}
+
+/*
+  the release is the point. it takes 4% of the cycle to go
+  from nothing to a cloud, because in life it is under a second.
+*/
+@keyframes burstH {
+  0%, 40% { transform: scale(0.2); opacity: 0; }
+  44% { transform: scale(6); opacity: 0.95; }
+  60% { transform: scale(13); opacity: 0.5; }
+  80%, 100% { transform: scale(16); opacity: 0; }
+}
+
+@keyframes spinH {
+  0%, 40% { transform: rotate(var(--t, 0deg)) scaleX(0); opacity: 0; }
+  46% { transform: rotate(var(--t, 0deg)) scaleX(1); opacity: 0.9; }
+  70% { transform: rotate(calc(var(--t, 0deg) + 6deg)) scaleX(1.3); opacity: 0.4; }
+  84%, 100% { transform: rotate(calc(var(--t, 0deg) + 8deg)) scaleX(1.4); opacity: 0; }
+}
+
+@keyframes writheH {
+  0%, 100% { transform: translateY(0) rotate(-1deg); }
+  42% { transform: translateY(-5px) rotate(2deg); }
+  70% { transform: translateY(2px) rotate(-2deg); }
+}
+
+/* the knot travels along the body */
+@keyframes slideKnotH {
+  0%, 100% { transform: translateX(0) rotate(-40deg); }
+  50% { transform: translateX(74px) rotate(-40deg); }
+}
+
+@keyframes feelH {
+  0%, 100% { transform: rotate(var(--bb, 0deg)); }
+  50% { transform: rotate(calc(var(--bb, 0deg) + 9deg)); }
+}
+
+@keyframes raspH {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-3px); }
+}
+
+@keyframes rootH {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-7deg); }
+}
+
+@keyframes driftH {
+  0% { transform: translate(0, 0); opacity: 0; }
+  10% { opacity: 0.6; }
+  90% { opacity: 0.6; }
+  100% { transform: translate(-16px, 360px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sharkH,
+  .sharkJaw,
+  .sharkTail,
+  .fishH,
+  .headH,
+  .barbH,
+  .rakeH,
+  .knotH,
+  .poreH,
+  .threadH,
+  .snowH {
+    animation: none;
+  }
+
+  .poreH { transform: scale(9); opacity: 0.8; }
+  .threadH { transform: rotate(var(--t, 0deg)) scaleX(1); opacity: 0.7; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/hagfish-as/`, a self-contained pure CSS/HTML hagfish sliming a shark mid-bite.

Closes #47906

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The release takes 4% of the cycle.** From nothing to a cloud in a handful of frames, because in life it is under a second: a teaspoon of exudate hits seawater and hydrates into litres. The rest of the animation is the wait and the aftermath, and that ratio is the fact worth encoding.
- **Pores fire together, not in sequence.** The per-pore delay is `calc(var(--i) * 0.012s)`, deliberately tiny, so the flank goes off as one event. This is the opposite of the travelling-wave stagger and it is the correct choice here, since a hundred pores really do fire at once.
- **Thread, not just cloud**: the slime is soft merged pore blooms *plus* radiating threads that snap taut with `scaleX(0 → 1)`. Hagfish slime is a fibre net (ten-micron threads up to 15cm long knitting the mucus together), so drawing only mucus would miss what makes it work.
- **The knot travels.** It is a partial `border` ring that slides along the body on its own keyframe. That is real behaviour: the hagfish knots itself and drives the knot down its length to scrape off its own slime, and uses the same move for leverage when feeding, having no jaw to pull against.
- **No eyes, no jaw**: the head has barbels casting around on their own delays and a rasping plate instead of a mandible.
- **The shark commits and regrets it**: it lunges, its jaw opens on the frame the pores fire, and it backs off with the jaw working.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the slime released with the threads drawn, so the defence still reads without motion.

## Verification

Opened `demo.html` in the browser and stepped the cycle: confirmed the shark lunges, the pores go off as one burst rather than a ripple, the threads snap out, and the shark withdraws. Softened the pore falloff after the first pass rendered the slime as a row of distinct bubbles instead of a cloud, and repositioned it over the flank. Confirmed all 9 pores and 6 threads resolve to their own keyframes. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
