### PR TITLE
feat(submission): add spring-physics-popover component (#46676)

### DIFF
--- a/submissions/examples/spring-physics-popover-ksk/README.md
+++ b/submissions/examples/spring-physics-popover-ksk/README.md
@@ -1,0 +1,30 @@
+# Spring Physics Popover (`spring-physics-popover-ksk`)
+
+1. What does this do?  
+An annotated-artwork popover where glowing `✦` hotspots breathe with an idle scale animation. On click, the popover card springs open from below — combining `scale`, `translateY`, and `rotate` in a single spring transition using `cubic-bezier(0.34, 1.56, 0.64, 1)`. Stat chips inside stagger-spring in sequentially after the card lands.
+
+2. How is it used?  
+Place `.ease-spring-wrap` containing a checkbox toggle, `.ease-spring-trigger` label and `.ease-spring-popover` wherever you want a hotspot. The popover opens via `:checked` state. Tune physics via CSS custom properties:
+
+```css
+.ease-spring-wrap {
+  --ease-spring-duration:    0.5s;
+  --ease-spring-scale-from:  0.7;
+  --ease-spring-y-from:      16px;
+  --ease-spring-rotate-from: -4deg;
+  --ease-spring-accent:      #e879f9;
+  --ease-spring-width:       310px;
+  --ease-spring-radius:      18px;
+}
+```
+
+Three easing presets are defined in `:root`:
+- `--ease-spring-1` — standard overshoot `cubic-bezier(0.34, 1.56, 0.64, 1)`
+- `--ease-spring-2` — elastic hard overshoot `cubic-bezier(0.68, -0.55, 0.27, 1.55)`
+- `--ease-spring-3` — gentle decelerate `cubic-bezier(0.22, 1, 0.36, 1)`
+
+3. Why is it useful?  
+The spring triple-transform (scale + translate + rotate simultaneously) creates a physically convincing "pop" that feels alive. The stat-chip stagger-spring inside the card adds a secondary layer of physical feedback after the card lands — ideal for creative portfolio and case study showcases.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #46676.*

--- a/submissions/examples/spring-physics-popover-ksk/demo.html
+++ b/submissions/examples/spring-physics-popover-ksk/demo.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Spring Physics Popover — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #060813;
+      background-image:
+        radial-gradient(ellipse at 20% 45%, rgba(232,121,249,0.1) 0%, transparent 55%),
+        radial-gradient(ellipse at 80% 55%, rgba(168,85,247,0.08) 0%, transparent 55%);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px 80px;
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, #f0abfc, #c084fc);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin: 0 0 0.4rem;
+    }
+    .page-header p {
+      color: #334155;
+      font-size: 0.88rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-header">
+    <h1>Spring Physics Popover</h1>
+    <p>Click the glowing ✦ hotspots on the portfolio artwork to reveal project details with spring physics.</p>
+  </div>
+
+  <!-- Portfolio artwork canvas with annotation hotspots -->
+  <div class="portfolio-canvas">
+
+    <!-- SVG artwork: abstract creative portfolio piece -->
+    <svg class="portfolio-canvas-art" viewBox="0 0 720 405" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="bg-grad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stop-color="#0c0d1a"/>
+          <stop offset="100%" stop-color="#130a1f"/>
+        </linearGradient>
+        <radialGradient id="glow1" cx="30%" cy="40%" r="40%">
+          <stop offset="0%" stop-color="#e879f9" stop-opacity="0.25"/>
+          <stop offset="100%" stop-color="transparent"/>
+        </radialGradient>
+        <radialGradient id="glow2" cx="70%" cy="60%" r="35%">
+          <stop offset="0%" stop-color="#818cf8" stop-opacity="0.2"/>
+          <stop offset="100%" stop-color="transparent"/>
+        </radialGradient>
+        <radialGradient id="glow3" cx="55%" cy="25%" r="30%">
+          <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.18"/>
+          <stop offset="100%" stop-color="transparent"/>
+        </radialGradient>
+      </defs>
+      <!-- Background -->
+      <rect width="720" height="405" fill="url(#bg-grad)"/>
+      <rect width="720" height="405" fill="url(#glow1)"/>
+      <rect width="720" height="405" fill="url(#glow2)"/>
+      <rect width="720" height="405" fill="url(#glow3)"/>
+
+      <!-- Abstract geometry: spirals, circles, arcs -->
+      <circle cx="215" cy="165" r="120" fill="none" stroke="#e879f9" stroke-width="0.8" opacity="0.25"/>
+      <circle cx="215" cy="165" r="90"  fill="none" stroke="#e879f9" stroke-width="0.6" opacity="0.2"/>
+      <circle cx="215" cy="165" r="55"  fill="none" stroke="#e879f9" stroke-width="1"   opacity="0.3"/>
+      <circle cx="215" cy="165" r="28"  fill="rgba(232,121,249,0.12)" stroke="#f0abfc" stroke-width="1" opacity="0.5"/>
+      <line x1="95" y1="45" x2="335" y2="285" stroke="#e879f9" stroke-width="0.6" opacity="0.2"/>
+      <line x1="335" y1="45" x2="95"  y2="285" stroke="#e879f9" stroke-width="0.6" opacity="0.2"/>
+      <polygon points="215,80 290,200 140,200" fill="rgba(232,121,249,0.08)" stroke="#e879f9" stroke-width="0.8" opacity="0.4"/>
+
+      <!-- Right cluster: geometric shapes -->
+      <rect x="490" y="100" width="100" height="100" rx="12"
+            fill="rgba(99,102,241,0.12)" stroke="#818cf8" stroke-width="0.8" opacity="0.5"
+            transform="rotate(15 540 150)"/>
+      <rect x="510" y="120" width="60" height="60" rx="8"
+            fill="rgba(99,102,241,0.08)" stroke="#a5b4fc" stroke-width="0.6" opacity="0.4"
+            transform="rotate(15 540 150)"/>
+      <circle cx="540" cy="150" r="20" fill="rgba(99,102,241,0.2)" stroke="#818cf8" stroke-width="1" opacity="0.6"/>
+
+      <!-- Top arc: cyan -->
+      <path d="M 380 80 Q 460 30 540 80" fill="none" stroke="#38bdf8" stroke-width="1.2" opacity="0.4"/>
+      <path d="M 370 100 Q 460 40 550 100" fill="none" stroke="#38bdf8" stroke-width="0.6" opacity="0.25"/>
+      <circle cx="460" cy="55" r="12" fill="rgba(56,189,248,0.15)" stroke="#38bdf8" stroke-width="1" opacity="0.5"/>
+
+      <!-- Dots / stars -->
+      <circle cx="100" cy="340" r="2.5" fill="#e879f9" opacity="0.5"/>
+      <circle cx="620" cy="80"  r="2"   fill="#818cf8" opacity="0.5"/>
+      <circle cx="350" cy="350" r="2"   fill="#38bdf8" opacity="0.4"/>
+      <circle cx="660" cy="300" r="3"   fill="#e879f9" opacity="0.3"/>
+      <circle cx="60"  cy="200" r="2"   fill="#a5b4fc" opacity="0.35"/>
+
+      <!-- Grid lines -->
+      <line x1="0"   y1="200" x2="720" y2="200" stroke="rgba(255,255,255,0.03)" stroke-width="1"/>
+      <line x1="360" y1="0"   x2="360" y2="405" stroke="rgba(255,255,255,0.03)" stroke-width="1"/>
+    </svg>
+
+    <!-- Hotspot 1: Radial Geometry (left cluster, ~30% x, 40% y) -->
+    <div class="sp-hotspot" style="left:30%;top:40%;">
+      <input type="checkbox" id="sp1" class="ease-spring-toggle">
+      <div class="ease-spring-wrap">
+        <label for="sp1" class="ease-spring-trigger" tabindex="0" role="button" aria-haspopup="dialog">✦</label>
+        <div class="ease-spring-popover" role="dialog" aria-label="Radial Geometry project details">
+          <!-- SVG thumbnail -->
+          <div class="sp-header">
+            <svg class="sp-header-art" viewBox="0 0 310 110" xmlns="http://www.w3.org/2000/svg">
+              <rect width="310" height="110" fill="#0c0d1a"/>
+              <circle cx="155" cy="55" r="45" fill="none" stroke="#e879f9" stroke-width="1" opacity="0.4"/>
+              <circle cx="155" cy="55" r="28" fill="rgba(232,121,249,0.15)" stroke="#f0abfc" stroke-width="1" opacity="0.5"/>
+              <polygon points="155,25 185,75 125,75" fill="rgba(232,121,249,0.12)" stroke="#e879f9" stroke-width="0.8" opacity="0.5"/>
+            </svg>
+            <div class="sp-header-overlay"></div>
+            <div class="sp-header-tags">
+              <span class="sp-tag">Sacred Geometry</span>
+              <span class="sp-tag">2026</span>
+            </div>
+          </div>
+          <div class="sp-body">
+            <p class="sp-title">Radial Geometry</p>
+            <p class="sp-desc">Concentric circles and triangle overlays inspired by Platonic solids and golden ratio proportions.</p>
+            <div class="sp-stats">
+              <div class="sp-stat"><div class="sp-stat-dot"></div>52k views</div>
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#f0abfc;box-shadow:0 0 4px #f0abfc;"></div>3.8k likes</div>
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#a855f7;box-shadow:0 0 4px #a855f7;"></div>Digital</div>
+            </div>
+            <div class="sp-actions">
+              <label for="sp1" class="sp-btn sp-btn-ghost">Close</label>
+              <button class="sp-btn sp-btn-primary">View Case Study</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hotspot 2: Geometric Rotation (right cluster, ~75% x, 37% y) -->
+    <div class="sp-hotspot" style="left:75%;top:37%;">
+      <input type="checkbox" id="sp2" class="ease-spring-toggle">
+      <div class="ease-spring-wrap" style="--ease-spring-accent:#818cf8;">
+        <label for="sp2" class="ease-spring-trigger" tabindex="0" role="button" aria-haspopup="dialog"
+               style="background:rgba(129,140,248,0.15);border-color:rgba(129,140,248,0.45);color:#c7d2fe;animation-name:none;">✦</label>
+        <div class="ease-spring-popover" role="dialog" aria-label="Geometric Rotation project details">
+          <div class="sp-header">
+            <svg class="sp-header-art" viewBox="0 0 310 110" xmlns="http://www.w3.org/2000/svg">
+              <rect width="310" height="110" fill="#0a0b18"/>
+              <rect x="115" y="30" width="80" height="80" rx="10" fill="rgba(99,102,241,0.15)" stroke="#818cf8" stroke-width="1" opacity="0.6" transform="rotate(20 155 70)"/>
+              <rect x="130" y="45" width="50" height="50" rx="6" fill="rgba(99,102,241,0.1)" stroke="#a5b4fc" stroke-width="0.8" opacity="0.5" transform="rotate(20 155 70)"/>
+            </svg>
+            <div class="sp-header-overlay"></div>
+            <div class="sp-header-tags">
+              <span class="sp-tag" style="background:rgba(129,140,248,0.2);border-color:rgba(129,140,248,0.35);color:#c7d2fe;">3D Motion</span>
+              <span class="sp-tag" style="background:rgba(129,140,248,0.2);border-color:rgba(129,140,248,0.35);color:#c7d2fe;">2025</span>
+            </div>
+          </div>
+          <div class="sp-body">
+            <p class="sp-title">Geometric Rotation</p>
+            <p class="sp-desc">Nested rectangle rotations exploring perspective and dimensional depth without a 3D engine.</p>
+            <div class="sp-stats">
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#818cf8;box-shadow:0 0 4px #818cf8;"></div>38k views</div>
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#a5b4fc;box-shadow:0 0 4px #a5b4fc;"></div>2.2k likes</div>
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#6366f1;box-shadow:0 0 4px #6366f1;"></div>CSS</div>
+            </div>
+            <div class="sp-actions">
+              <label for="sp2" class="sp-btn sp-btn-ghost">Close</label>
+              <button class="sp-btn sp-btn-primary" style="background:linear-gradient(135deg,#818cf8,#6366f1);box-shadow:0 4px 14px rgba(99,102,241,0.3);">View Case Study</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hotspot 3: Arc Frequency (center-top, ~64% x, 14% y) -->
+    <div class="sp-hotspot" style="left:64%;top:14%;">
+      <input type="checkbox" id="sp3" class="ease-spring-toggle">
+      <div class="ease-spring-wrap" style="--ease-spring-accent:#38bdf8;">
+        <label for="sp3" class="ease-spring-trigger" tabindex="0" role="button" aria-haspopup="dialog"
+               style="background:rgba(56,189,248,0.12);border-color:rgba(56,189,248,0.4);color:#7dd3fc;animation-name:none;">✦</label>
+        <div class="ease-spring-popover" role="dialog" aria-label="Arc Frequency project details">
+          <div class="sp-header">
+            <svg class="sp-header-art" viewBox="0 0 310 110" xmlns="http://www.w3.org/2000/svg">
+              <rect width="310" height="110" fill="#060e18"/>
+              <path d="M60 80 Q155 10 250 80" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+              <path d="M50 95 Q155 20 260 95" fill="none" stroke="#38bdf8" stroke-width="0.8" opacity="0.3"/>
+              <circle cx="155" cy="42" r="14" fill="rgba(56,189,248,0.2)" stroke="#7dd3fc" stroke-width="1" opacity="0.6"/>
+            </svg>
+            <div class="sp-header-overlay"></div>
+            <div class="sp-header-tags">
+              <span class="sp-tag" style="background:rgba(56,189,248,0.15);border-color:rgba(56,189,248,0.35);color:#7dd3fc;">Frequency</span>
+              <span class="sp-tag" style="background:rgba(56,189,248,0.15);border-color:rgba(56,189,248,0.35);color:#7dd3fc;">2026</span>
+            </div>
+          </div>
+          <div class="sp-body">
+            <p class="sp-title">Arc Frequency</p>
+            <p class="sp-desc">Sine-wave arc compositions layered to create interference patterns and visual harmonics.</p>
+            <div class="sp-stats">
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#38bdf8;box-shadow:0 0 4px #38bdf8;"></div>29k views</div>
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#7dd3fc;box-shadow:0 0 4px #7dd3fc;"></div>1.6k likes</div>
+              <div class="sp-stat"><div class="sp-stat-dot" style="background:#0ea5e9;box-shadow:0 0 4px #0ea5e9;"></div>SVG</div>
+            </div>
+            <div class="sp-actions">
+              <label for="sp3" class="sp-btn sp-btn-ghost">Close</label>
+              <button class="sp-btn sp-btn-primary" style="background:linear-gradient(135deg,#38bdf8,#0ea5e9);color:#082f49;box-shadow:0 4px 14px rgba(56,189,248,0.3);">View Case Study</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /portfolio-canvas -->
+
+</body>
+</html>

--- a/submissions/examples/spring-physics-popover-ksk/style.css
+++ b/submissions/examples/spring-physics-popover-ksk/style.css
@@ -1,0 +1,324 @@
+/* ============================================================
+   EaseMotion CSS — Spring Physics Popover (Creative Portfolio)
+   submissions/examples/spring-physics-popover-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .ease-spring-wrap or any ancestor to tune.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  /* Spring feel: overshoot then settle */
+  --ease-spring-1: cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* Elastic: harder overshoot */
+  --ease-spring-2: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+  /* Gentle decelerate */
+  --ease-spring-3: cubic-bezier(0.22, 1, 0.36, 1);
+
+  --ease-spring-duration:   0.5s;
+  --ease-spring-delay:      0s;
+  --ease-spring-scale-from: 0.7;
+  --ease-spring-y-from:     16px;
+  --ease-spring-rotate-from: -4deg;
+  --ease-spring-bg:         #0c0d1a;
+  --ease-spring-border:     rgba(255,255,255,0.08);
+  --ease-spring-radius:     18px;
+  --ease-spring-width:      310px;
+  --ease-spring-accent:     #e879f9;
+}
+
+/* ── Toggle (checkbox hack) ─────────────────────────────── */
+.ease-spring-toggle { display: none; }
+
+/* ── Anchor ─────────────────────────────────────────────── */
+.ease-spring-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Trigger: artwork "+" hotspot ───────────────────────── */
+.ease-spring-trigger {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: rgba(232,121,249,0.15);
+  border: 2px solid rgba(232,121,249,0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #f0abfc;
+  font-size: 1.3rem;
+  line-height: 1;
+  font-weight: 300;
+  user-select: none;
+  outline-offset: 3px;
+  /* Physics: spring scale on hover */
+  transition:
+    transform var(--ease-spring-duration) var(--ease-spring-1),
+    background   0.2s ease,
+    box-shadow   0.3s ease;
+  animation: spring-idle-breathe 3s ease-in-out infinite;
+}
+
+.ease-spring-trigger:hover,
+.ease-spring-trigger:focus {
+  transform: scale(1.2) rotate(45deg);
+  background: rgba(232,121,249,0.25);
+  box-shadow: 0 0 0 8px rgba(232,121,249,0.12),
+              0 0 20px rgba(232,121,249,0.25);
+  animation-play-state: paused;
+  outline: 2px solid rgba(232,121,249,0.4);
+}
+
+/* When open: stay rotated */
+.ease-spring-toggle:checked + .ease-spring-wrap .ease-spring-trigger,
+.ease-spring-toggle:checked ~ .ease-spring-wrap .ease-spring-trigger {
+  transform: scale(1.1) rotate(45deg);
+  animation-play-state: paused;
+  background: rgba(232,121,249,0.3);
+  box-shadow: 0 0 0 10px rgba(232,121,249,0.1),
+              0 0 28px rgba(232,121,249,0.3);
+}
+
+/* ── Popover Card ───────────────────────────────────────── */
+.ease-spring-popover {
+  position: absolute;
+  bottom: calc(100% + 14px);
+  left: 50%;
+  /* Spring open state: starts scaled + rotated + shifted */
+  transform:
+    translateX(-50%)
+    translateY(var(--ease-spring-y-from))
+    scale(var(--ease-spring-scale-from))
+    rotate(var(--ease-spring-rotate-from));
+  transform-origin: bottom center;
+  width: var(--ease-spring-width);
+  background: var(--ease-spring-bg);
+  border: 1px solid var(--ease-spring-border);
+  border-radius: var(--ease-spring-radius);
+  box-shadow:
+    0 24px 60px rgba(0,0,0,0.6),
+    0 0 0 1px rgba(232,121,249,0.1),
+    inset 0 1px 0 rgba(255,255,255,0.05);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity   0.25s ease,
+    transform var(--ease-spring-duration) var(--ease-spring-1);
+  transition-delay: var(--ease-spring-delay);
+  z-index: 200;
+}
+
+/* Caret arrow */
+.ease-spring-popover::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 9px solid transparent;
+  border-top-color: var(--ease-spring-bg);
+  z-index: 2;
+}
+
+/* Open: spring in */
+.ease-spring-toggle:checked + .ease-spring-wrap .ease-spring-popover,
+.ease-spring-toggle:checked ~ .ease-spring-wrap .ease-spring-popover {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+  pointer-events: auto;
+}
+
+/* ── Spring exit on close (reverse spring) ──────────────── */
+/* Use a faster, snappier transition on close */
+.ease-spring-popover {
+  /* Closing: quick shrink-away */
+  transition:
+    opacity  0.18s ease,
+    transform 0.28s var(--ease-spring-3);
+}
+
+.ease-spring-toggle:checked + .ease-spring-wrap .ease-spring-popover,
+.ease-spring-toggle:checked ~ .ease-spring-wrap .ease-spring-popover {
+  transition:
+    opacity  0.25s ease,
+    transform var(--ease-spring-duration) var(--ease-spring-1);
+}
+
+/* ── Popover: header with artwork thumbnail ─────────────── */
+.sp-header {
+  position: relative;
+  height: 110px;
+  overflow: hidden;
+}
+
+.sp-header-art {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.sp-header-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, transparent 40%, var(--ease-spring-bg) 100%);
+}
+
+.sp-header-tags {
+  position: absolute;
+  bottom: 10px;
+  left: 14px;
+  display: flex;
+  gap: 6px;
+}
+
+.sp-tag {
+  padding: 3px 9px;
+  border-radius: 99px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  background: rgba(232,121,249,0.2);
+  border: 1px solid rgba(232,121,249,0.35);
+  color: #f0abfc;
+}
+
+/* ── Body ───────────────────────────────────────────────── */
+.sp-body {
+  padding: 0 16px 16px;
+}
+
+.sp-title {
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0 0 5px;
+}
+
+.sp-desc {
+  color: #64748b;
+  font-size: 0.78rem;
+  line-height: 1.65;
+  margin: 0 0 14px;
+}
+
+/* Spring-animated stat chips */
+.sp-stats {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.sp-stat {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 99px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  font-size: 0.75rem;
+  color: #94a3b8;
+  /* Each chip bounces in with stagger */
+  opacity: 0;
+  transform: scale(0.7) translateY(6px);
+  transition:
+    opacity   0.3s ease,
+    transform 0.4s var(--ease-spring-1);
+}
+
+.ease-spring-toggle:checked + .ease-spring-wrap .sp-stat,
+.ease-spring-toggle:checked ~ .ease-spring-wrap .sp-stat {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+
+/* Stagger via nth-child */
+.ease-spring-toggle:checked + .ease-spring-wrap .sp-stat:nth-child(1),
+.ease-spring-toggle:checked ~ .ease-spring-wrap .sp-stat:nth-child(1) { transition-delay: 0.15s; }
+.ease-spring-toggle:checked + .ease-spring-wrap .sp-stat:nth-child(2),
+.ease-spring-toggle:checked ~ .ease-spring-wrap .sp-stat:nth-child(2) { transition-delay: 0.22s; }
+.ease-spring-toggle:checked + .ease-spring-wrap .sp-stat:nth-child(3),
+.ease-spring-toggle:checked ~ .ease-spring-wrap .sp-stat:nth-child(3) { transition-delay: 0.29s; }
+
+.sp-stat-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ease-spring-accent);
+  box-shadow: 0 0 4px var(--ease-spring-accent);
+}
+
+/* Actions */
+.sp-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.sp-btn {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 11px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-align: center;
+  border: none;
+  cursor: pointer;
+  transition:
+    transform var(--ease-spring-duration) var(--ease-spring-1),
+    box-shadow 0.2s ease;
+}
+
+.sp-btn:hover { transform: scale(1.04) translateY(-2px); }
+.sp-btn:active { transform: scale(0.97); }
+
+.sp-btn-ghost {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  color: #475569;
+}
+
+.sp-btn-primary {
+  background: linear-gradient(135deg, var(--ease-spring-accent), #a855f7);
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(232,121,249,0.3);
+}
+
+.sp-btn-primary:hover {
+  box-shadow: 0 8px 22px rgba(232,121,249,0.45);
+}
+
+/* ── Demo: Portfolio canvas ─────────────────────────────── */
+.portfolio-canvas {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  aspect-ratio: 16/9;
+  border-radius: 22px;
+  overflow: visible;
+  box-shadow: 0 24px 56px rgba(0,0,0,0.55);
+}
+
+.portfolio-canvas-art {
+  width: 100%;
+  height: 100%;
+  border-radius: 22px;
+  display: block;
+}
+
+/* Hotspot positions */
+.sp-hotspot {
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+
+/* ── Keyframes ───────────────────────────────────────────── */
+@keyframes spring-idle-breathe {
+  0%, 100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(232,121,249,0.3); }
+  50%       { transform: scale(1.08); box-shadow: 0 0 0 10px rgba(232,121,249,0); }
+}


### PR DESCRIPTION
Closes #46676

Adds a Spring Physics Popover under `submissions/examples/spring-physics-popover-ksk/`.

#### Key Features

1. **Triple-Transform Spring Open** — Card opens via simultaneous `scale(0.7→1)` + `translateY(16px→0)` + `rotate(-4deg→0deg)` in a single `cubic-bezier(0.34, 1.56, 0.64, 1)` transition — creating a convincing spring overshoot without keyframes.
2. **Idle Breathe Animation** — Triggers pulsate gently with `spring-idle-breathe` keyframe (scale + box-shadow glow) while waiting; pauses on hover/open.
3. **`+`→`×` Rotation** — Trigger rotates 45° on hover and stays rotated when open, visually communicating state.
4. **Staggered Stat Chips** — Three stat chips inside the card each spring in independently with sequential `transition-delay` (0.15s, 0.22s, 0.29s) after the card settles.
5. **Three Easing Presets** — `--ease-spring-1` (standard), `--ease-spring-2` (elastic), `--ease-spring-3` (gentle) defined in `:root` and swappable via custom property.
6. **Creative Portfolio Demo** — Abstract SVG artwork canvas with 3 colour-themed hotspots (pink/purple/cyan) each opening a project detail card.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Triple-transform spring, idle breathe keyframe, staggered chip transitions, 3 easing presets |
| `demo.html` | Abstract SVG portfolio canvas with 3 positioned spring-physics hotspot popovers |
| `README.md` | Usage guide with easing preset table, resolving `#46676` |