### PR TITLE
feat(submission): add draw-border-tech-popover component (#46751)

### DIFF
--- a/submissions/examples/draw-border-tech-popover-ksk/README.md
+++ b/submissions/examples/draw-border-tech-popover-ksk/README.md
@@ -1,0 +1,25 @@
+# Draw-Border Tech Popover (`draw-border-tech-popover-ksk`)
+
+1. What does this do?  
+A minimal, monospace-styled popover for API docs and developer tool interfaces. The trigger is a compact `ref` badge that draws a fine border on hover then opens a terminal-style popover with function signatures, parameter tables, and version badges.
+
+2. How is it used?  
+Pair `<input class="ease-tech-toggle">` + `.ease-tech-wrap` with a `.ease-tech-trigger` label and `.ease-tech-popover` card. Configure per-instance via CSS custom properties:
+
+```css
+.ease-tech-wrap {
+  --ease-tech-color:     #4ade80;   /* draw line + accent colour  */
+  --ease-tech-duration:  0.4s;
+  --ease-tech-thickness: 1.5px;     /* thin = minimalist          */
+  --ease-tech-radius:    6px;       /* sharp corners = tech feel  */
+  --ease-tech-width:     320px;
+  --ease-tech-easing:    cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-tech-spring:    cubic-bezier(0.22, 1, 0.36, 1);
+}
+```
+
+3. Why is it useful?  
+Provides an inline API reference popover pattern — no page navigation required. The thin draw-border and monospace typography signal "developer tool" while the clip-path animation keeps the interaction feeling modern and intentional. Three colour themes (green, blue, purple) ship ready to use.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #46751.*

--- a/submissions/examples/draw-border-tech-popover-ksk/demo.html
+++ b/submissions/examples/draw-border-tech-popover-ksk/demo.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Draw-Border Tech Popover — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #050608;
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+    .page-header h1 {
+      font-size: 1.6rem;
+      font-weight: 800;
+      color: #4ade80;
+      font-family: 'Courier New', monospace;
+      margin: 0 0 0.4rem;
+      letter-spacing: -0.01em;
+    }
+    .page-header p {
+      color: #1e293b;
+      font-size: 0.82rem;
+      margin: 0;
+      font-family: 'Courier New', monospace;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-header">
+    <h1>// draw-border-tech-popover</h1>
+    <p>/* hover to draw border · click to open API reference popover */</p>
+  </div>
+
+  <!-- API Docs Sidebar Demo -->
+  <div class="api-sidebar" role="navigation" aria-label="API reference">
+    <p class="api-sidebar-title">// EaseMotion API Reference</p>
+
+    <!-- Animation Methods -->
+    <div class="api-section">
+      <p class="api-section-label">// Animation</p>
+
+      <div class="api-row">
+        <span class="api-method method-get">fn</span>
+        <span class="api-path">ease.animate()</span>
+        <!-- Popover 1: ease.animate() -->
+        <input type="checkbox" id="tech1" class="ease-tech-toggle">
+        <div class="ease-tech-wrap">
+          <label for="tech1" class="ease-tech-trigger" tabindex="0" role="button" aria-haspopup="dialog">
+            <span class="tech-trigger-dot"></span>ref
+          </label>
+          <div class="ease-tech-popover" role="dialog" aria-label="ease.animate() reference">
+            <div class="tech-pop-titlebar">
+              <div class="tech-titlebar-dots">
+                <div class="tech-dot tech-dot-red"></div>
+                <div class="tech-dot tech-dot-amber"></div>
+                <div class="tech-dot tech-dot-green"></div>
+              </div>
+              <span class="tech-titlebar-label">ease.animate() — reference</span>
+              <label for="tech1" class="tech-pop-close" aria-label="Close">✕</label>
+            </div>
+            <div class="tech-pop-body">
+              <div class="tech-signature">
+                <span class="tech-kw">function</span>
+                <span class="tech-fn"> ease</span><span class="tech-type">.</span><span class="tech-fn">animate</span>(<br>
+                &nbsp;&nbsp;<span class="tech-arg">target</span><span class="tech-type">: string | Element</span>,<br>
+                &nbsp;&nbsp;<span class="tech-arg">keyframe</span><span class="tech-type">: EaseKeyframe</span>,<br>
+                &nbsp;&nbsp;<span class="tech-arg">options</span><span class="tech-type">?: AnimateOptions</span><br>
+                )<span class="tech-type">: </span><span class="tech-ret">Promise&lt;void&gt;</span>
+              </div>
+              <p class="tech-pop-desc">Applies an EaseMotion keyframe animation to the target element(s). Returns a promise that resolves when the animation completes.</p>
+              <table class="tech-params" aria-label="Parameters">
+                <thead>
+                  <tr><th>param</th><th>type</th><th>description</th></tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>target</td>
+                    <td>string</td>
+                    <td>CSS selector or Element reference</td>
+                  </tr>
+                  <tr>
+                    <td>keyframe</td>
+                    <td>EaseKeyframe</td>
+                    <td>Named keyframe from EaseMotion library</td>
+                  </tr>
+                  <tr>
+                    <td>options</td>
+                    <td>object?</td>
+                    <td>duration, delay, easing, fill</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="tech-badges">
+                <span class="tech-badge tech-badge-green">async</span>
+                <span class="tech-badge tech-badge-blue">v1.0+</span>
+                <span class="tech-badge tech-badge-purple">stable</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="api-row">
+        <span class="api-method method-get">fn</span>
+        <span class="api-path">ease.sequence()</span>
+        <!-- Popover 2: ease.sequence() -->
+        <input type="checkbox" id="tech2" class="ease-tech-toggle">
+        <div class="ease-tech-wrap" style="--ease-tech-color:#60a5fa;">
+          <label for="tech2" class="ease-tech-trigger" tabindex="0" role="button" aria-haspopup="dialog"
+                 style="border-color:rgba(96,165,250,0.12);">
+            <span class="tech-trigger-dot" style="background:#60a5fa;"></span>ref
+          </label>
+          <div class="ease-tech-popover" role="dialog" aria-label="ease.sequence() reference">
+            <div class="tech-pop-titlebar">
+              <div class="tech-titlebar-dots">
+                <div class="tech-dot tech-dot-red"></div>
+                <div class="tech-dot tech-dot-amber"></div>
+                <div class="tech-dot tech-dot-green"></div>
+              </div>
+              <span class="tech-titlebar-label">ease.sequence() — reference</span>
+              <label for="tech2" class="tech-pop-close" aria-label="Close">✕</label>
+            </div>
+            <div class="tech-pop-body">
+              <div class="tech-signature">
+                <span class="tech-kw">function</span>
+                <span class="tech-fn"> ease</span><span class="tech-type">.</span><span class="tech-fn">sequence</span>(<br>
+                &nbsp;&nbsp;<span class="tech-arg">steps</span><span class="tech-type">: AnimateStep[]</span>,<br>
+                &nbsp;&nbsp;<span class="tech-arg">options</span><span class="tech-type">?: SequenceOptions</span><br>
+                )<span class="tech-type">: </span><span class="tech-ret">Promise&lt;void&gt;</span>
+              </div>
+              <p class="tech-pop-desc">Runs a series of animation steps in order. Each step waits for the previous to finish before starting. Supports stagger delay between items.</p>
+              <table class="tech-params" aria-label="Parameters">
+                <thead>
+                  <tr><th>param</th><th>type</th><th>description</th></tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>steps</td>
+                    <td>array</td>
+                    <td>Array of {target, keyframe, options}</td>
+                  </tr>
+                  <tr>
+                    <td>options</td>
+                    <td>object?</td>
+                    <td>stagger, direction, repeat</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="tech-badges">
+                <span class="tech-badge tech-badge-blue">async</span>
+                <span class="tech-badge tech-badge-blue">v1.2+</span>
+                <span class="tech-badge tech-badge-amber">beta</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="api-row">
+        <span class="api-method method-post">fn</span>
+        <span class="api-path">ease.register()</span>
+        <!-- Popover 3: ease.register() -->
+        <input type="checkbox" id="tech3" class="ease-tech-toggle">
+        <div class="ease-tech-wrap" style="--ease-tech-color:#c084fc;">
+          <label for="tech3" class="ease-tech-trigger" tabindex="0" role="button" aria-haspopup="dialog"
+                 style="border-color:rgba(192,132,252,0.12);">
+            <span class="tech-trigger-dot" style="background:#c084fc;"></span>ref
+          </label>
+          <div class="ease-tech-popover" role="dialog" aria-label="ease.register() reference">
+            <div class="tech-pop-titlebar">
+              <div class="tech-titlebar-dots">
+                <div class="tech-dot tech-dot-red"></div>
+                <div class="tech-dot tech-dot-amber"></div>
+                <div class="tech-dot tech-dot-green"></div>
+              </div>
+              <span class="tech-titlebar-label">ease.register() — reference</span>
+              <label for="tech3" class="tech-pop-close" aria-label="Close">✕</label>
+            </div>
+            <div class="tech-pop-body">
+              <div class="tech-signature">
+                <span class="tech-kw">function</span>
+                <span class="tech-fn"> ease</span><span class="tech-type">.</span><span class="tech-fn">register</span>(<br>
+                &nbsp;&nbsp;<span class="tech-arg">name</span><span class="tech-type">: string</span>,<br>
+                &nbsp;&nbsp;<span class="tech-arg">keyframes</span><span class="tech-type">: Keyframe[]</span>,<br>
+                &nbsp;&nbsp;<span class="tech-arg">defaults</span><span class="tech-type">?: AnimateOptions</span><br>
+                )<span class="tech-type">: </span><span class="tech-ret">void</span>
+              </div>
+              <p class="tech-pop-desc">Registers a custom named keyframe animation into the EaseMotion library. Once registered, use the name as any built-in keyframe string.</p>
+              <table class="tech-params" aria-label="Parameters">
+                <thead>
+                  <tr><th>param</th><th>type</th><th>description</th></tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>name</td>
+                    <td>string</td>
+                    <td>Unique keyframe identifier</td>
+                  </tr>
+                  <tr>
+                    <td>keyframes</td>
+                    <td>array</td>
+                    <td>Web Animations API keyframe array</td>
+                  </tr>
+                  <tr>
+                    <td>defaults</td>
+                    <td>object?</td>
+                    <td>Default timing options for this keyframe</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="tech-badges">
+                <span class="tech-badge tech-badge-purple">sync</span>
+                <span class="tech-badge tech-badge-blue">v1.0+</span>
+                <span class="tech-badge tech-badge-green">stable</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/draw-border-tech-popover-ksk/style.css
+++ b/submissions/examples/draw-border-tech-popover-ksk/style.css
@@ -1,0 +1,406 @@
+/* ============================================================
+   EaseMotion CSS — Draw-Border Line Popover (Minimalist Tech)
+   submissions/examples/draw-border-tech-popover-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .ease-tech-wrap or any ancestor to tune.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-tech-duration:    0.4s;
+  --ease-tech-stagger:     calc(var(--ease-tech-duration) * 0.35);
+  --ease-tech-easing:      cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-tech-spring:      cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-tech-color:       #4ade80;       /* draw line colour        */
+  --ease-tech-thickness:   1.5px;         /* thinner = more minimal  */
+  --ease-tech-bg:          #08090f;
+  --ease-tech-surface:     #0d0f1a;
+  --ease-tech-border:      rgba(255,255,255,0.06);
+  --ease-tech-radius:      6px;           /* sharp corners: tech feel*/
+  --ease-tech-width:       320px;
+  --ease-tech-offset:      6px;
+}
+
+/* ── Toggle ─────────────────────────────────────────────── */
+.ease-tech-toggle { display: none; }
+
+/* ── Wrapper ────────────────────────────────────────────── */
+.ease-tech-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* ── Trigger: minimal monospace badge ───────────────────── */
+.ease-tech-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--ease-tech-radius);
+  background: transparent;
+  /* Base border — very subtle */
+  border: var(--ease-tech-thickness) solid rgba(74,222,128,0.12);
+  color: #4b5563;
+  font-family: 'Courier New', 'Menlo', monospace;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: color 0.2s ease, background 0.2s ease;
+  outline-offset: 3px;
+  user-select: none;
+  letter-spacing: 0.04em;
+}
+
+/* Draw-border pseudo — top+right */
+.ease-tech-trigger::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-tech-radius);
+  border-top: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  border-right: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  clip-path: inset(0 100% 100% 0);
+  pointer-events: none;
+  transition: clip-path var(--ease-tech-duration) var(--ease-tech-easing);
+}
+
+/* Draw-border pseudo — bottom+left */
+.ease-tech-trigger::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-tech-radius);
+  border-bottom: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  border-left: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  clip-path: inset(100% 0 0 100%);
+  pointer-events: none;
+  transition: clip-path var(--ease-tech-duration) var(--ease-tech-easing);
+  transition-delay: var(--ease-tech-stagger);
+}
+
+.ease-tech-trigger:hover::before,
+.ease-tech-trigger:focus::before {
+  clip-path: inset(0 0 100% 0);
+}
+.ease-tech-trigger:hover::after,
+.ease-tech-trigger:focus::after {
+  clip-path: inset(100% 0 0 0);
+}
+.ease-tech-toggle:checked + .ease-tech-wrap .ease-tech-trigger::before,
+.ease-tech-toggle:checked ~ .ease-tech-wrap .ease-tech-trigger::before {
+  clip-path: inset(0 0 0 0);
+}
+.ease-tech-toggle:checked + .ease-tech-wrap .ease-tech-trigger::after,
+.ease-tech-toggle:checked ~ .ease-tech-wrap .ease-tech-trigger::after {
+  clip-path: inset(0 0 0 0);
+}
+
+.ease-tech-trigger:hover,
+.ease-tech-trigger:focus {
+  color: var(--ease-tech-color);
+  background: rgba(74,222,128,0.04);
+  outline: 2px solid rgba(74,222,128,0.2);
+}
+
+/* Status dot */
+.tech-trigger-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ease-tech-color);
+  opacity: 0.5;
+  transition: opacity 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-tech-trigger:hover .tech-trigger-dot,
+.ease-tech-trigger:focus .tech-trigger-dot {
+  opacity: 1;
+  box-shadow: 0 0 6px var(--ease-tech-color);
+}
+
+.ease-tech-toggle:checked + .ease-tech-wrap .ease-tech-trigger,
+.ease-tech-toggle:checked ~ .ease-tech-wrap .ease-tech-trigger {
+  color: var(--ease-tech-color);
+  background: rgba(74,222,128,0.06);
+}
+
+.ease-tech-toggle:checked + .ease-tech-wrap .ease-tech-trigger .tech-trigger-dot,
+.ease-tech-toggle:checked ~ .ease-tech-wrap .ease-tech-trigger .tech-trigger-dot {
+  opacity: 1;
+  box-shadow: 0 0 8px var(--ease-tech-color);
+}
+
+/* ── Popover Card ───────────────────────────────────────── */
+.ease-tech-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: var(--ease-tech-width);
+  background: var(--ease-tech-bg);
+  border-radius: var(--ease-tech-radius);
+  box-shadow:
+    0 16px 40px rgba(0,0,0,0.6),
+    0 0 0 1px rgba(74,222,128,0.05);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(var(--ease-tech-offset));
+  transition:
+    opacity  0.2s ease,
+    transform var(--ease-tech-duration) var(--ease-tech-spring);
+  transition-delay: 0s;
+  z-index: 200;
+}
+
+/* Draw border on card */
+.ease-tech-popover::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-tech-radius);
+  border-top: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  border-right: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  clip-path: inset(0 100% 100% 0 round var(--ease-tech-radius));
+  pointer-events: none;
+  z-index: 10;
+  transition: clip-path var(--ease-tech-duration) var(--ease-tech-easing);
+}
+.ease-tech-popover::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-tech-radius);
+  border-bottom: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  border-left: var(--ease-tech-thickness) solid var(--ease-tech-color);
+  clip-path: inset(100% 0 0 100% round var(--ease-tech-radius));
+  pointer-events: none;
+  z-index: 10;
+  transition: clip-path var(--ease-tech-duration) var(--ease-tech-easing);
+  transition-delay: var(--ease-tech-stagger);
+}
+
+/* Open state */
+.ease-tech-toggle:checked + .ease-tech-wrap .ease-tech-popover,
+.ease-tech-toggle:checked ~ .ease-tech-wrap .ease-tech-popover {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.ease-tech-toggle:checked + .ease-tech-wrap .ease-tech-popover::before,
+.ease-tech-toggle:checked ~ .ease-tech-wrap .ease-tech-popover::before {
+  clip-path: inset(0 0 50% 0 round var(--ease-tech-radius));
+}
+.ease-tech-toggle:checked + .ease-tech-wrap .ease-tech-popover::after,
+.ease-tech-toggle:checked ~ .ease-tech-wrap .ease-tech-popover::after {
+  clip-path: inset(50% 0 0 0 round var(--ease-tech-radius));
+}
+
+/* ── Popover inner: terminal header bar ─────────────────── */
+.tech-pop-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px 8px;
+  background: #0a0b14;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+
+.tech-titlebar-dots {
+  display: flex;
+  gap: 5px;
+}
+
+.tech-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+
+.tech-dot-red   { background: #ff5f57; }
+.tech-dot-amber { background: #ffbd2e; }
+.tech-dot-green { background: #28c840; }
+
+.tech-titlebar-label {
+  margin-left: 4px;
+  color: #1e293b;
+  font-family: 'Courier New', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+}
+
+.tech-pop-close {
+  margin-left: auto;
+  color: #1e293b;
+  font-size: 0.85rem;
+  cursor: pointer;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.tech-pop-close:hover { background: rgba(255,255,255,0.05); color: #64748b; }
+
+/* ── Popover body ───────────────────────────────────────── */
+.tech-pop-body { padding: 14px; }
+
+/* Function signature block */
+.tech-signature {
+  background: var(--ease-tech-surface);
+  border: 1px solid rgba(255,255,255,0.05);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.78rem;
+  line-height: 1.7;
+}
+
+.tech-kw   { color: #c084fc; }
+.tech-fn   { color: #60a5fa; }
+.tech-arg  { color: #f9a8d4; }
+.tech-type { color: #94a3b8; }
+.tech-ret  { color: var(--ease-tech-color); }
+.tech-str  { color: #fbbf24; }
+.tech-num  { color: #fb923c; }
+.tech-cmt  { color: #374151; font-style: italic; }
+
+/* Description */
+.tech-pop-desc {
+  color: #475569;
+  font-size: 0.79rem;
+  line-height: 1.65;
+  margin: 0 0 12px;
+}
+
+/* Param table */
+.tech-params {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+  margin-bottom: 12px;
+}
+
+.tech-params th {
+  color: #1e293b;
+  font-weight: 700;
+  text-align: left;
+  padding: 0 8px 6px 0;
+  font-family: 'Courier New', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+.tech-params td {
+  padding: 5px 8px 5px 0;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+  color: #475569;
+}
+
+.tech-params td:first-child {
+  font-family: 'Courier New', monospace;
+  color: #f9a8d4;
+  white-space: nowrap;
+}
+
+.tech-params td:nth-child(2) {
+  font-family: 'Courier New', monospace;
+  color: var(--ease-tech-color);
+  white-space: nowrap;
+}
+
+/* Badges row */
+.tech-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.tech-badge {
+  padding: 3px 8px;
+  border-radius: 3px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.04em;
+}
+
+.tech-badge-green  { background: rgba(74,222,128,0.1);  border: 1px solid rgba(74,222,128,0.2);  color: #4ade80; }
+.tech-badge-blue   { background: rgba(96,165,250,0.1);  border: 1px solid rgba(96,165,250,0.2);  color: #60a5fa; }
+.tech-badge-purple { background: rgba(192,132,252,0.1); border: 1px solid rgba(192,132,252,0.2); color: #c084fc; }
+.tech-badge-amber  { background: rgba(251,191,36,0.1);  border: 1px solid rgba(251,191,36,0.2);  color: #fbbf24; }
+
+/* ── Demo: API docs nav ──────────────────────────────────── */
+.api-sidebar {
+  background: #08090f;
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 10px;
+  padding: 16px;
+  width: 100%;
+  max-width: 560px;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.5);
+  box-sizing: border-box;
+}
+
+.api-sidebar-title {
+  color: #1e293b;
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-family: 'Courier New', monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0 0 12px;
+}
+
+.api-section {
+  margin-bottom: 16px;
+}
+
+.api-section-label {
+  color: #1e293b;
+  font-size: 0.68rem;
+  font-family: 'Courier New', monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 8px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+.api-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.api-method {
+  font-family: 'Courier New', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 3px;
+  width: 32px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.method-get  { background: rgba(74,222,128,0.12); color: #4ade80; border: 1px solid rgba(74,222,128,0.2); }
+.method-post { background: rgba(96,165,250,0.12); color: #60a5fa; border: 1px solid rgba(96,165,250,0.2); }
+.method-del  { background: rgba(248,113,113,0.12);color: #f87171; border: 1px solid rgba(248,113,113,0.2);}
+
+.api-path {
+  font-family: 'Courier New', monospace;
+  font-size: 0.78rem;
+  color: #334155;
+  flex: 1;
+}


### PR DESCRIPTION
Closes #46751

Adds a Draw-Border Minimalist Tech Popover under `submissions/examples/draw-border-tech-popover-ksk/`.

#### How this differs from other draw-border variants
| Feature | #46759 (Accessible) | #46747 (SaaS) | #46751 (Tech) |
|---------|---------------------|---------------|----------------|
| Context | A11y toolbar | Pricing cards | API docs sidebar |
| Popover direction | Down | Up | Down |
| Border thickness | 2px | 2px | **1.5px** (thinner) |
| Corner radius | 14px | 16px | **6px** (sharp) |
| Typography | System UI | System UI | **Monospace** |
| Content | Feature lists | Plan features | **Function signatures + param tables** |
| Accent colours | Indigo, Green, Amber | Purple, Green, Amber | **Green, Blue, Purple** |

#### Key Techniques
- **`clip-path` draw** — same half-split draw technique (top+right → then bottom+left with stagger delay)
- **Terminal header bar** — macOS-style red/amber/green dots with monospace filename label
- **Function signature syntax** — colour-coded `keyword`, `function`, `argument`, `type`, `return` spans  
- **Parameter table** — compact `<table>` with monospace type column and description
- **Version