### PR TITLE
feat(submission): add draw-border-neumorphic-popover component (#46755)

### DIFF
--- a/submissions/examples/draw-border-neumorphic-popover-ksk/README.md
+++ b/submissions/examples/draw-border-neumorphic-popover-ksk/README.md
@@ -1,0 +1,36 @@
+# Draw-Border Neumorphic Popover (`draw-border-neumorphic-popover-ksk`)
+
+1. What does this do?  
+A pure CSS neumorphic popover component. The trigger is a soft, extruded neumorphic button that draws a clockwise border indicator on hover/focus. When clicked, it displays a matching neumorphic popover card with a spring entrance and a clockwise border sweep, supporting both light and dark neumorphic themes.
+
+2. How is it used?  
+Wrap `<input class="ease-neu-toggle">` + `.ease-neu-wrap` together. Inside, place a `.ease-neu-trigger` label and `.ease-neu-popover` card. Theme variables can be easily tuned via CSS custom properties:
+
+```css
+.ease-neu-wrap {
+  --ease-neu-color:       #3b82f6;          /* draw border color */
+  --ease-neu-bg:          #e0e8f6;          /* base neumorphic background */
+  --ease-neu-shadow-dark: #becee4;          /* shadow dark offset */
+  --ease-neu-shadow-lite: #ffffff;          /* shadow light offset */
+  --ease-neu-radius:      20px;
+  --ease-neu-width:       310px;
+  --ease-neu-offset:      12px;
+}
+```
+
+Support for dark mode is built in simply by overriding the background and shadow variables inside a theme parent class (e.g. `.theme-checkbox:checked ~ .page-wrapper`):
+
+```css
+.dark-theme-parent {
+  --ease-neu-bg:          #1b1e2a;
+  --ease-neu-shadow-dark: #12141c;
+  --ease-neu-shadow-lite: #242838;
+  --ease-neu-color:       #a855f7;          /* purple accent in dark mode */
+}
+```
+
+3. Why is it useful?  
+Neumorphic components often suffer from poor visual borders and accessibility boundaries. The clockwise draw-border technique acts as a strong visual indicator for both hover and active/open states, solving the "soft boundaries" problem of neumorphic designs. Keyboard accessibility is fully supported out of the box using checkbox and label focus patterns.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #46755.*

--- a/submissions/examples/draw-border-neumorphic-popover-ksk/demo.html
+++ b/submissions/examples/draw-border-neumorphic-popover-ksk/demo.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic Draw-Border Popover — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    /* Full-page wrapper matching theme color */
+    .page-wrapper {
+      background: var(--ease-neu-bg);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, sans-serif;
+      transition: background 0.3s ease;
+      position: relative;
+    }
+
+    /* Page-header styling */
+    .page-header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+
+    .page-header h1 {
+      font-size: 1.7rem;
+      font-weight: 800;
+      color: #374151;
+      margin: 0 0 0.4rem;
+    }
+
+    .page-header p {
+      color: #6b7280;
+      font-size: 0.86rem;
+      margin: 0;
+    }
+
+    /* Apply theme properties to page-wrapper when dark mode is checked */
+    .theme-checkbox:checked ~ .page-wrapper {
+      --ease-neu-bg:          #1b1e2a;
+      --ease-neu-shadow-dark: #12141c;
+      --ease-neu-shadow-lite: #242838;
+      --ease-neu-color:       #a855f7;
+    }
+
+    .theme-checkbox:checked ~ .page-wrapper .page-header h1 {
+      color: #f9fafb;
+    }
+
+    .theme-checkbox:checked ~ .page-wrapper .page-header p {
+      color: #9ca3af;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Theme selector toggle (pure CSS) -->
+  <input type="checkbox" id="theme-toggle" class="theme-checkbox">
+
+  <!-- Content wrapper -->
+  <div class="page-wrapper">
+
+    <div class="page-header">
+      <h1>Neumorphic Draw-Border Popover</h1>
+      <p>Click any button to open a soft extruded popover with a smooth clockwise drawing border.</p>
+    </div>
+
+    <!-- Neumorphic Dashboard Card -->
+    <div class="neu-dashboard">
+
+      <!-- Theme Switcher control inside the card -->
+      <div class="theme-switch-wrap">
+        <span class="theme-switch-label">Dark Mode</span>
+        <label for="theme-toggle" class="theme-switch" aria-label="Toggle dark mode" role="button" tabindex="0">
+          <span class="theme-switch-dot"></span>
+        </label>
+      </div>
+
+      <p class="dashboard-title">System Status</p>
+      <p class="dashboard-desc">
+        Click to open the control settings. Both trigger buttons and card boundaries animate their borders on hover &amp; open.
+      </p>
+
+      <div class="dashboard-controls">
+
+        <!-- ── Popover 1: Server Config ── -->
+        <input type="checkbox" id="neu1" class="ease-neu-toggle">
+        <div class="ease-neu-wrap">
+          <label for="neu1" class="ease-neu-trigger" tabindex="0" role="button" aria-haspopup="dialog">
+            ⚙️ Server Config
+          </label>
+          <div class="ease-neu-popover" role="dialog" aria-label="Server Configuration">
+            <div class="neu-pop-arrow"></div>
+            <div class="neu-pop-head">
+              <div class="neu-pop-icon-slot">⚙️</div>
+              <div class="neu-pop-details">
+                <p class="neu-pop-title">Server Config</p>
+                <p class="neu-pop-sub">Active nodes &amp; region</p>
+              </div>
+              <label for="neu1" class="neu-pop-close" aria-label="Close">✕</label>
+            </div>
+            <div class="neu-pop-body">
+              <p class="neu-pop-desc">
+                Current resource allocation and virtual machine nodes running on the cluster.
+              </p>
+              <div class="neu-pop-list">
+                <div class="neu-pop-item"><span class="neu-pop-bullet">▪</span>Region: us-east-1 (N. Virginia)</div>
+                <div class="neu-pop-item"><span class="neu-pop-bullet">▪</span>Active Nodes: 12 / 16 online</div>
+                <div class="neu-pop-item"><span class="neu-pop-bullet">▪</span>CPU Load: 34.2% stable</div>
+                <div class="neu-pop-item"><span class="neu-pop-bullet">▪</span>Memory: 64 GB ECC allocated</div>
+              </div>
+              <div class="neu-pop-actions">
+                <label for="neu1" class="neu-pop-btn">Dismiss</label>
+                <button class="neu-pop-btn neu-pop-btn-primary">View Cluster</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ── Popover 2: Database Sync ── -->
+        <input type="checkbox" id="neu2" class="ease-neu-toggle">
+        <div class="ease-neu-wrap" style="--ease-neu-color: #10b981;">
+          <label for="neu2" class="ease-neu-trigger" tabindex="0" role="button" aria-haspopup="dialog"
+                 style="color:#10b981;">
+            📁 Database Sync
+          </label>
+          <div class="ease-neu-popover" role="dialog" aria-label="Database Synchronization">
+            <div class="neu-pop-arrow"></div>
+            <div class="neu-pop-head">
+              <div class="neu-pop-icon-slot" style="color:#10b981;">📁</div>
+              <div class="neu-pop-details">
+                <p class="neu-pop-title">Database Sync</p>
+                <p class="neu-pop-sub">Replication &amp; backups</p>
+              </div>
+              <label for="neu2" class="neu-pop-close" aria-label="Close">✕</label>
+            </div>
+            <div class="neu-pop-body">
+              <p class="neu-pop-desc">
+                Status of read replicas, write volume buffering, and the schedule for cold-storage backups.
+              </p>
+              <div class="neu-pop-list">
+                <div class="neu-pop-item"><span class="neu-pop-bullet" style="color:#10b981;">▪</span>Replication: Synchronized</div>
+                <div class="neu-pop-item"><span class="neu-pop-bullet" style="color:#10b981;">▪</span>Backup status: Completed (4h ago)</div>
+                <div class="neu-pop-item"><span class="neu-pop-bullet" style="color:#10b981;">▪</span>Replica Delay: 8ms avg latency</div>
+                <div class="neu-pop-item"><span class="neu-pop-bullet" style="color:#10b981;">▪</span>Integrity check: 100% passed</div>
+              </div>
+              <div class="neu-pop-actions">
+                <label for="neu2" class="neu-pop-btn">Dismiss</label>
+                <button class="neu-pop-btn neu-pop-btn-primary" style="color:#10b981;">Run Backup</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/draw-border-neumorphic-popover-ksk/style.css
+++ b/submissions/examples/draw-border-neumorphic-popover-ksk/style.css
@@ -1,0 +1,467 @@
+/* ============================================================
+   EaseMotion CSS — Draw-Border Line Popover (Neumorphic Soft)
+   submissions/examples/draw-border-neumorphic-popover-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .ease-neu-wrap or any ancestor to tune.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-neu-duration:   0.45s;
+  --ease-neu-easing:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-neu-spring:     cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-neu-delay:      0s;
+  --ease-neu-color:      #3b82f6;         /* draw line color        */
+  --ease-neu-thickness:  2.5px;
+  --ease-neu-bg:         #e0e8f6;         /* base neumorphic color  */
+  --ease-neu-shadow-dark:#becee4;         /* dark shadow component  */
+  --ease-neu-shadow-lite:#ffffff;         /* light shadow component */
+  --ease-neu-radius:     20px;
+  --ease-neu-width:      310px;
+  --ease-neu-offset:     12px;
+}
+
+/* ── Toggle ─────────────────────────────────────────────── */
+.ease-neu-toggle { display: none; }
+
+/* ── Wrapper ────────────────────────────────────────────── */
+.ease-neu-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Trigger: Soft Neumorphic Button ────────────────────── */
+.ease-neu-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: var(--ease-neu-radius);
+  background: var(--ease-neu-bg);
+  border: none;
+  color: #4b5563;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  position: relative;
+  /* Neumorphic convex shadow */
+  box-shadow:
+    6px 6px 12px var(--ease-neu-shadow-dark),
+    -6px -6px 12px var(--ease-neu-shadow-lite);
+  transition:
+    color 0.2s ease,
+    box-shadow 0.25s ease,
+    transform 0.2s ease;
+  outline-offset: 4px;
+  user-select: none;
+}
+
+/* Draw lines on trigger hover/focus */
+.ease-neu-trigger::before,
+.ease-neu-trigger::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+/* Top + Right lines */
+.ease-neu-trigger::before {
+  border-top: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  border-right: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  clip-path: inset(0 100% 100% 0);
+  transition: clip-path var(--ease-neu-duration) var(--ease-neu-easing);
+}
+
+/* Bottom + Left lines */
+.ease-neu-trigger::after {
+  border-bottom: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  border-left: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  clip-path: inset(100% 0 0 100%);
+  transition: clip-path var(--ease-neu-duration) var(--ease-neu-easing);
+  transition-delay: calc(var(--ease-neu-duration) * 0.3);
+}
+
+/* Hover / focus states */
+.ease-neu-trigger:hover,
+.ease-neu-trigger:focus {
+  color: var(--ease-neu-color);
+  box-shadow:
+    8px 8px 16px var(--ease-neu-shadow-dark),
+    -8px -8px 16px var(--ease-neu-shadow-lite);
+  outline: 2px solid rgba(59,130,246,0.3);
+}
+
+.ease-neu-trigger:hover::before,
+.ease-neu-trigger:focus::before {
+  clip-path: inset(0 0 100% 0);
+}
+.ease-neu-trigger:hover::after,
+.ease-neu-trigger:focus::after {
+  clip-path: inset(100% 0 0 0);
+}
+
+/* Active / Open state: sunken neumorphic shadow */
+.ease-neu-toggle:checked + .ease-neu-wrap .ease-neu-trigger,
+.ease-neu-toggle:checked ~ .ease-neu-wrap .ease-neu-trigger {
+  color: var(--ease-neu-color);
+  box-shadow:
+    inset 4px 4px 8px var(--ease-neu-shadow-dark),
+    inset -4px -4px 8px var(--ease-neu-shadow-lite);
+  transform: scale(0.98);
+}
+
+/* Keep borders fully drawn when checked */
+.ease-neu-toggle:checked + .ease-neu-wrap .ease-neu-trigger::before,
+.ease-neu-toggle:checked ~ .ease-neu-wrap .ease-neu-trigger::before {
+  clip-path: inset(0 0 0 0);
+}
+.ease-neu-toggle:checked + .ease-neu-wrap .ease-neu-trigger::after,
+.ease-neu-toggle:checked ~ .ease-neu-wrap .ease-neu-trigger::after {
+  clip-path: inset(0 0 0 0);
+}
+
+/* ── Popover Card ───────────────────────────────────────── */
+.ease-neu-popover {
+  position: absolute;
+  bottom: calc(100% + 14px);
+  left: 50%;
+  transform: translateX(-50%) translateY(var(--ease-neu-offset));
+  transform-origin: bottom center;
+  width: var(--ease-neu-width);
+  background: var(--ease-neu-bg);
+  border-radius: var(--ease-neu-radius);
+  /* Convex card shadow */
+  box-shadow:
+    12px 12px 28px var(--ease-neu-shadow-dark),
+    -12px -12px 28px var(--ease-neu-shadow-lite);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity 0.22s ease,
+    transform 0.4s var(--ease-neu-spring);
+  transition-delay: var(--ease-neu-delay);
+  z-index: 200;
+}
+
+/* Popover card draw-border overlay */
+.ease-neu-popover::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-neu-radius);
+  border-top: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  border-right: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  clip-path: inset(0 100% 100% 0 round var(--ease-neu-radius));
+  pointer-events: none;
+  z-index: 10;
+  transition: clip-path var(--ease-neu-duration) var(--ease-neu-easing);
+}
+
+.ease-neu-popover::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--ease-neu-radius);
+  border-bottom: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  border-left: var(--ease-neu-thickness) solid var(--ease-neu-color);
+  clip-path: inset(100% 0 0 100% round var(--ease-neu-radius));
+  pointer-events: none;
+  z-index: 10;
+  transition: clip-path var(--ease-neu-duration) var(--ease-neu-easing);
+  transition-delay: calc(var(--ease-neu-duration) * 0.35);
+}
+
+/* Popover arrow */
+.ease-neu-popover .neu-pop-arrow {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border: 9px solid transparent;
+  border-top-color: var(--ease-neu-bg);
+  z-index: 2;
+  filter: drop-shadow(4px 4px 3px var(--ease-neu-shadow-dark));
+}
+
+/* Open states */
+.ease-neu-toggle:checked + .ease-neu-wrap .ease-neu-popover,
+.ease-neu-toggle:checked ~ .ease-neu-wrap .ease-neu-popover {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+.ease-neu-toggle:checked + .ease-neu-wrap .ease-neu-popover::before,
+.ease-neu-toggle:checked ~ .ease-neu-wrap .ease-neu-popover::before {
+  clip-path: inset(0 0 50% 0 round var(--ease-neu-radius));
+}
+
+.ease-neu-toggle:checked + .ease-neu-wrap .ease-neu-popover::after,
+.ease-neu-toggle:checked ~ .ease-neu-wrap .ease-neu-popover::after {
+  clip-path: inset(50% 0 0 0 round var(--ease-neu-radius));
+}
+
+/* ── Inner content components ───────────────────────────── */
+.neu-pop-head {
+  padding: 20px 20px 14px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border-bottom: 1px dashed rgba(75,85,99,0.08);
+}
+
+/* Concave / sunken icon slot */
+.neu-pop-icon-slot {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--ease-neu-bg);
+  box-shadow:
+    inset 3px 3px 6px var(--ease-neu-shadow-dark),
+    inset -3px -3px 6px var(--ease-neu-shadow-lite);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.neu-pop-details { flex: 1; }
+
+.neu-pop-title {
+  color: #1f2937;
+  font-size: 0.95rem;
+  font-weight: 800;
+  margin: 0;
+}
+
+.neu-pop-sub {
+  color: #6b7280;
+  font-size: 0.76rem;
+  margin: 2px 0 0;
+  font-weight: 500;
+}
+
+.neu-pop-close {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--ease-neu-bg);
+  box-shadow:
+    2px 2px 5px var(--ease-neu-shadow-dark),
+    -2px -2px 5px var(--ease-neu-shadow-lite);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: bold;
+  transition: box-shadow 0.2s ease, transform 0.1s ease;
+  user-select: none;
+}
+
+.neu-pop-close:hover {
+  box-shadow:
+    1px 1px 3px var(--ease-neu-shadow-dark),
+    -1px -1px 3px var(--ease-neu-shadow-lite);
+}
+
+.neu-pop-close:active {
+  box-shadow:
+    inset 2px 2px 4px var(--ease-neu-shadow-dark),
+    inset -2px -2px 4px var(--ease-neu-shadow-lite);
+}
+
+/* Body */
+.neu-pop-body {
+  padding: 16px 20px 20px;
+}
+
+.neu-pop-desc {
+  color: #4b5563;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  margin: 0 0 16px;
+}
+
+/* Sunken list container */
+.neu-pop-list {
+  background: var(--ease-neu-bg);
+  box-shadow:
+    inset 4px 4px 8px var(--ease-neu-shadow-dark),
+    inset -4px -4px 8px var(--ease-neu-shadow-lite);
+  border-radius: 14px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.neu-pop-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.8rem;
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.neu-pop-bullet {
+  color: var(--ease-neu-color);
+  font-weight: bold;
+  font-size: 0.9rem;
+}
+
+/* Actions */
+.neu-pop-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.neu-pop-btn {
+  flex: 1;
+  padding: 11px;
+  border-radius: 12px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+  cursor: pointer;
+  border: none;
+  background: var(--ease-neu-bg);
+  color: #4b5563;
+  box-shadow:
+    4px 4px 8px var(--ease-neu-shadow-dark),
+    -4px -4px 8px var(--ease-neu-shadow-lite);
+  transition: box-shadow 0.2s ease, transform 0.15s ease, color 0.2s ease;
+  user-select: none;
+}
+
+.neu-pop-btn:hover {
+  transform: translateY(-1px);
+  color: var(--ease-neu-color);
+}
+
+.neu-pop-btn:active {
+  transform: translateY(0);
+  box-shadow:
+    inset 3px 3px 6px var(--ease-neu-shadow-dark),
+    inset -3px -3px 6px var(--ease-neu-shadow-lite);
+}
+
+.neu-pop-btn-primary {
+  background: var(--ease-neu-bg);
+  color: var(--ease-neu-color);
+  box-shadow:
+    6px 6px 12px var(--ease-neu-shadow-dark),
+    -6px -6px 12px var(--ease-neu-shadow-lite),
+    inset 0 0 0 1px rgba(59,130,246,0.15);
+}
+
+.neu-pop-btn-primary:hover {
+  color: #2563eb;
+}
+
+/* ── Dark mode support ───────────────────────────────────── */
+.dark-mode {
+  --ease-neu-bg:          #1b1e2a;
+  --ease-neu-shadow-dark: #12141c;
+  --ease-neu-shadow-lite: #242838;
+  --ease-neu-color:       #a855f7;        /* purple accent for dark */
+}
+
+/* ── Demo Dashboard layout ──────────────────────────────── */
+.neu-dashboard {
+  background: var(--ease-neu-bg);
+  box-shadow:
+    14px 14px 30px var(--ease-neu-shadow-dark),
+    -14px -14px 30px var(--ease-neu-shadow-lite);
+  border-radius: 28px;
+  padding: 2.25rem;
+  width: 100%;
+  max-width: 600px;
+  box-sizing: border-box;
+  text-align: center;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.dashboard-title {
+  color: #1f2937;
+  font-size: 1.4rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+}
+
+.dark-mode .dashboard-title { color: #f9fafb; }
+
+.dashboard-desc {
+  color: #6b7280;
+  font-size: 0.86rem;
+  margin: 0 0 2rem;
+  line-height: 1.6;
+}
+
+.dashboard-controls {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* Theme toggle switch */
+.theme-switch-wrap {
+  margin-bottom: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+}
+
+.theme-switch-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.theme-switch {
+  position: relative;
+  width: 54px;
+  height: 28px;
+  background: var(--ease-neu-bg);
+  border-radius: 99px;
+  box-shadow:
+    inset 3px 3px 6px var(--ease-neu-shadow-dark),
+    inset -3px -3px 6px var(--ease-neu-shadow-lite);
+  cursor: pointer;
+}
+
+.theme-switch-dot {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #cbd5e1;
+  box-shadow:
+    2px 2px 4px var(--ease-neu-shadow-dark),
+    -1px -1px 3px var(--ease-neu-shadow-lite);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.3s ease;
+}
+
+.theme-checkbox { display: none; }
+.theme-checkbox:checked + .theme-switch .theme-switch-dot {
+  transform: translateX(26px);
+  background: #a855f7;
+  box-shadow: 0 0 8px rgba(168,85,247,0.5);
+}


### PR DESCRIPTION
Closes #46755

Adds a Draw-Border Neumorphic Popover under `submissions/examples/draw-border-neumorphic-popover-ksk/`.

#### Key Features

1. **Draw-Border Focus Boundary** — Employs a clockwise `clip-path` transition over `::before` & `::after` pseudo-elements. It solves the classic neumorphic problem of soft, blurry boundary states by overlaying a precise, sharp drawing border on hover/focus/open states.
2. **Neumorphic Soft Physics** — Soft convex outer shadows on standard buttons and card layers, which transition to inset concave shadows on pressed/active states.
3. **Pure CSS Theme Toggling** — Uses a checkbox theme switch hack to swap Neumorphic variables `--ease-neu-bg`, `--ease-neu-shadow-dark`, and `--ease-neu-shadow-lite` on the wrapper level — dynamically switching the entire layout between soft light mode (blue-grey) and dark mode (slate-navy) with zero JS.
4. **Accessible Monospace Specs** — Includes a close button (`✕`) with active inset physics, dashed item boundaries, and clear contrast levels in both themes.
5. **7 CSS Custom Properties** — Configurable `--ease-neu-color`, `--ease-neu-thickness`, `--ease-neu-duration`, `--ease-neu-easing`, `--ease-neu-spring`, `--ease-neu-width`, and `--ease-neu-offset`.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Neumorphic shadows, clip-path border-draw mechanism, active inset transitions, theme variable definitions |
| `demo.html` | Interactive dashboard containing a theme toggle switch and two popover examples (Server Config & Database Sync) |
| `README.md` | Usage guide with CSS variables list, resolving `#46755` |