### PR TITLE
feat: add release risk signal demo

### DIFF
--- a/submissions/examples/release-risk-signal-sm/README.md
+++ b/submissions/examples/release-risk-signal-sm/README.md
@@ -1,0 +1,5 @@
+# Release Risk Signal
+
+1. What does this do? Adds responsive release risk cards with animated signal bars, priority tone colors, staggered entry motion, and hover or focus feedback.
+2. How is it used? Apply `.risk-grid` to the wrapper and use `.risk-card` with state classes like `.low-risk`, `.medium-risk`, or `.high-risk` for each release check.
+3. Why is it useful? It helps teams compare launch readiness quickly with purposeful CSS-only motion and readable risk states.

--- a/submissions/examples/release-risk-signal-sm/demo.html
+++ b/submissions/examples/release-risk-signal-sm/demo.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release Risk Signal</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="risk-panel" aria-labelledby="risk-title">
+        <div class="panel-heading">
+          <p class="eyebrow">Release review</p>
+          <h1 id="risk-title">Animated risk signals for launch readiness</h1>
+          <p>
+            Signal cards turn release checks into quick visual cues with
+            animated bars, priority colors, and keyboard-friendly focus
+            feedback.
+          </p>
+        </div>
+
+        <div class="risk-grid" aria-label="Release risk signal cards">
+          <article class="risk-card low-risk" tabindex="0">
+            <span class="risk-label">Low</span>
+            <h2>Documentation</h2>
+            <p>
+              Release notes, usage snippets, and migration details are ready for
+              maintainer review.
+            </p>
+            <div class="signal-bars" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
+            </div>
+            <div class="risk-footer">
+              <span>Confidence</span>
+              <strong>92%</strong>
+            </div>
+          </article>
+
+          <article class="risk-card medium-risk" tabindex="0">
+            <span class="risk-label">Medium</span>
+            <h2>Animation density</h2>
+            <p>
+              Two dashboard sections still need a final reduced-motion and
+              low-power device pass.
+            </p>
+            <div class="signal-bars" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
+            </div>
+            <div class="risk-footer">
+              <span>Confidence</span>
+              <strong>71%</strong>
+            </div>
+          </article>
+
+          <article class="risk-card high-risk" tabindex="0">
+            <span class="risk-label">High</span>
+            <h2>Token drift</h2>
+            <p>
+              Several hard-coded values are still waiting to be mapped back to
+              shared design tokens.
+            </p>
+            <div class="signal-bars" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
+            </div>
+            <div class="risk-footer">
+              <span>Confidence</span>
+              <strong>48%</strong>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/release-risk-signal-sm/style.css
+++ b/submissions/examples/release-risk-signal-sm/style.css
@@ -1,0 +1,326 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --low: #12805c;
+  --low-soft: #e7f7ef;
+  --medium: #a95d00;
+  --medium-soft: #fff5e5;
+  --high: #d92d20;
+  --high-soft: #fff1f0;
+  --empty: #e8edf4;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(
+      circle at 18% 12%,
+      rgba(18, 128, 92, 0.14),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 86% 82%,
+      rgba(217, 45, 32, 0.1),
+      transparent 26rem
+    ),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.risk-panel {
+  width: min(100%, 1060px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--low);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.risk-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.risk-card {
+  --tone: var(--low);
+  --tone-soft: var(--low-soft);
+  --active-bars: 4;
+  position: relative;
+  overflow: hidden;
+  min-height: 24rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1.2rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  animation: risk-enter 580ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.risk-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--tone-soft), transparent 62%);
+  opacity: 0.78;
+}
+
+.risk-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.risk-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.risk-card:hover,
+.risk-card:focus-visible {
+  border-color: color-mix(in srgb, var(--tone) 42%, var(--line));
+  box-shadow: var(--shadow);
+  transform: translateY(-5px);
+}
+
+.risk-card:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  outline-offset: 5px;
+}
+
+.low-risk {
+  --tone: var(--low);
+  --tone-soft: var(--low-soft);
+  --active-bars: 4;
+}
+
+.medium-risk {
+  --tone: var(--medium);
+  --tone-soft: var(--medium-soft);
+  --active-bars: 3;
+}
+
+.high-risk {
+  --tone: var(--high);
+  --tone-soft: var(--high-soft);
+  --active-bars: 2;
+}
+
+.risk-label,
+.risk-card h2,
+.risk-card p,
+.signal-bars,
+.risk-footer {
+  position: relative;
+  z-index: 1;
+}
+
+.risk-label {
+  display: inline-flex;
+  margin-bottom: 0.85rem;
+  border-radius: 999px;
+  padding: 0.32rem 0.72rem;
+  color: var(--tone);
+  background: color-mix(in srgb, var(--tone-soft) 78%, #ffffff);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.risk-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.risk-card p {
+  min-height: 5.2rem;
+  margin: 0.75rem 0 1.2rem;
+  color: var(--muted);
+  line-height: 1.58;
+}
+
+.signal-bars {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  align-items: end;
+  gap: 0.55rem;
+  height: 7.5rem;
+  margin: 1rem 0;
+}
+
+.signal-bars span {
+  display: block;
+  border-radius: 999px 999px 0.35rem 0.35rem;
+  background: var(--empty);
+  overflow: hidden;
+}
+
+.signal-bars span::before {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--tone);
+  transform: scaleY(0);
+  transform-origin: bottom center;
+  animation: signal-rise 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.signal-bars span:nth-child(1) {
+  height: 38%;
+}
+
+.signal-bars span:nth-child(2) {
+  height: 56%;
+}
+
+.signal-bars span:nth-child(3) {
+  height: 76%;
+}
+
+.signal-bars span:nth-child(4) {
+  height: 100%;
+}
+
+.signal-bars span:nth-child(2)::before {
+  animation-delay: 100ms;
+}
+
+.signal-bars span:nth-child(3)::before {
+  animation-delay: 200ms;
+}
+
+.signal-bars span:nth-child(4)::before {
+  animation-delay: 300ms;
+}
+
+.medium-risk .signal-bars span:nth-child(4)::before,
+.high-risk .signal-bars span:nth-child(3)::before,
+.high-risk .signal-bars span:nth-child(4)::before {
+  background: var(--empty);
+}
+
+.risk-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--line);
+  padding-top: 1rem;
+}
+
+.risk-footer span {
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.risk-footer strong {
+  color: var(--tone);
+  font-size: 1.1rem;
+}
+
+@keyframes risk-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes signal-rise {
+  from {
+    transform: scaleY(0);
+  }
+
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .risk-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .risk-card {
+    min-height: auto;
+  }
+
+  .risk-card p {
+    min-height: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .risk-card,
+  .signal-bars span::before {
+    animation: none;
+    transition: none;
+  }
+
+  .signal-bars span::before {
+    transform: scaleY(1);
+  }
+
+  .risk-card:hover,
+  .risk-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #48226




## Pull Request Description

Adds a self-contained Release Risk Signal demo with responsive risk cards, animated signal bars, priority tone colors, staggered entry motion, hover/focus feedback, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Responsive release risk cards with animated signal bars, launch-readiness colors, staggered card entry, and hover/focus motion feedback.

**How does a developer use it?**

```html
<div class="risk-grid">
  <article class="risk-card medium-risk" tabindex="0">
    <span class="risk-label">Medium</span>
    <h2>Animation density</h2>
    <p>Two dashboard sections still need a final reduced-motion pass.</p>
    <div class="signal-bars" aria-hidden="true">
      <span></span>
      <span></span>
      <span></span>
      <span></span>
    </div>
  </article>
</div>