### PR TITLE
feat: add deployment readiness lights demo

### DIFF
--- a/submissions/examples/deployment-readiness-lights-sm/README.md
+++ b/submissions/examples/deployment-readiness-lights-sm/README.md
@@ -1,0 +1,32 @@
+# Deployment Readiness Lights
+
+## What does this do?
+
+Deployment Readiness Lights is a self-contained HTML and CSS launch checklist pattern with animated readiness lights, progress bars, status cards, and accessible hover/focus states.
+
+## How is it used?
+
+Create a `deployment-board` wrapper and add `readiness-card` items with state classes such as `ready`, `warning`, or `active`.
+
+```html
+<article class="readiness-card ready">
+  <div class="status-light" aria-hidden="true"></div>
+  <div class="card-content">
+    <p class="card-kicker">Build</p>
+    <h2>Production bundle verified</h2>
+    <div class="progress-line" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available state classes:
+
+- `ready`
+- `warning`
+- `active`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make release readiness easier to scan: lights pulse for attention, progress bars reveal completion, cards enter gently, and focus states keep the pattern accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/deployment-readiness-lights-sm/demo.html
+++ b/submissions/examples/deployment-readiness-lights-sm/demo.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deployment Readiness Lights Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="deploy-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Deployment Readiness Lights</h1>
+        <p>
+          A self-contained launch checklist pattern with animated readiness
+          lights, progress bars, status cards, and accessible hover/focus
+          states.
+        </p>
+      </section>
+
+      <section
+        class="readiness-summary"
+        aria-label="Deployment readiness summary"
+      >
+        <article>
+          <span class="summary-value">11</span>
+          <span class="summary-label">Checks complete</span>
+        </article>
+        <article>
+          <span class="summary-value">02</span>
+          <span class="summary-label">Warnings open</span>
+        </article>
+        <article>
+          <span class="summary-value">91%</span>
+          <span class="summary-label">Ready to deploy</span>
+        </article>
+      </section>
+
+      <section
+        class="deployment-board"
+        aria-label="Deployment readiness checks"
+      >
+        <article class="readiness-card ready">
+          <div class="status-light" aria-hidden="true"></div>
+          <div class="card-content">
+            <p class="card-kicker">Build</p>
+            <h2>Production bundle verified</h2>
+            <p>
+              The release artifact passed size checks, dependency validation,
+              and smoke tests across the supported runtime.
+            </p>
+            <div class="progress-line" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Ready</span>
+              <button type="button">View checks</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="readiness-card warning">
+          <div class="status-light" aria-hidden="true"></div>
+          <div class="card-content">
+            <p class="card-kicker">Monitoring</p>
+            <h2>Alert routing needs review</h2>
+            <p>
+              Two low-priority monitors still point to the staging escalation
+              channel and should be switched before rollout.
+            </p>
+            <div class="progress-line" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Warning</span>
+              <button type="button">Fix route</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="readiness-card active">
+          <div class="status-light" aria-hidden="true"></div>
+          <div class="card-content">
+            <p class="card-kicker">Database</p>
+            <h2>Migration rehearsal running</h2>
+            <p>
+              The rehearsal is validating rollback time, index creation cost,
+              and data consistency after the simulated deploy.
+            </p>
+            <div class="progress-line" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>In progress</span>
+              <button type="button">Track run</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/deployment-readiness-lights-sm/style.css
+++ b/submissions/examples/deployment-readiness-lights-sm/style.css
@@ -1,0 +1,342 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.deploy-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.readiness-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.readiness-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.deployment-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.readiness-card {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 430px;
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.readiness-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.readiness-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.readiness-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.readiness-card:hover,
+.readiness-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.status-light {
+  width: 68px;
+  height: 68px;
+  margin-bottom: 24px;
+  border: 8px solid #ffffff;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 18px 38px var(--accent-soft);
+  animation: light-pulse 2s ease-out infinite;
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.card-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.card-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.card-content > p:not(.card-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.progress-line {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.progress-line span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--progress);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: progress-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.card-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.card-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.card-content button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.card-content button:hover,
+.card-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.ready {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --progress: 94%;
+}
+
+.warning {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --progress: 68%;
+}
+
+.active {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --progress: 82%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes progress-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes light-pulse {
+  70% {
+    box-shadow:
+      0 0 0 14px rgba(255, 255, 255, 0),
+      0 18px 38px var(--accent-soft);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(255, 255, 255, 0),
+      0 18px 38px var(--accent-soft);
+  }
+}
+
+@media (max-width: 860px) {
+  .deploy-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .readiness-summary,
+  .deployment-board {
+    grid-template-columns: 1fr;
+  }
+
+  .readiness-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48290


**PR Text**

Title: `feat: add deployment readiness lights demo`

```md
## Pull Request Description
Adds a self-contained Deployment Readiness Lights demo under `submissions/examples/`, featuring animated readiness lights, progress bars, status cards, and hover/focus states.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only deployment readiness checklist pattern.

**How does a developer use it?**
Use a `deployment-board` wrapper with `readiness-card` items and state classes like `ready`, `warning`, or `active`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to show readiness, progress, and active status while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The state naming, readiness colors, and animation timing can be standardized during framework integration.