### PR TITLE
feat: add workspace switcher slide demo

### DIFF
--- a/submissions/examples/workspace-switcher-slide-sm/README.md
+++ b/submissions/examples/workspace-switcher-slide-sm/README.md
@@ -1,0 +1,5 @@
+# Workspace Switcher Slide
+
+1. What does this do? Adds responsive workspace switcher rows with a sliding active rail, staggered row entry, role chips, and hover or focus feedback.
+2. How is it used? Apply `.workspace-list` to the wrapper and `.workspace-row` to each focusable workspace option, with `.active-workspace` marking the current account.
+3. Why is it useful? It makes team switching interfaces easier to scan with purposeful CSS-only motion and keyboard-friendly focus treatment.

--- a/submissions/examples/workspace-switcher-slide-sm/demo.html
+++ b/submissions/examples/workspace-switcher-slide-sm/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Workspace Switcher Slide</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="workspace-panel" aria-labelledby="workspace-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Workspace switcher</p>
+        <h1 id="workspace-title">Sliding workspace cards for quick team changes</h1>
+        <p>
+          Workspace rows use a sliding active rail, animated badges, and focus-friendly states so
+          switching between teams feels clear without JavaScript.
+        </p>
+      </div>
+
+      <div class="switcher-card" aria-label="Workspace switcher demo">
+        <div class="switcher-header">
+          <div>
+            <span class="header-chip">Active account</span>
+            <strong>Motion Studio</strong>
+          </div>
+          <span class="sync-pill">Synced</span>
+        </div>
+
+        <div class="workspace-list">
+          <article class="workspace-row active-workspace" tabindex="0">
+            <span class="avatar-badge">MS</span>
+            <div class="workspace-copy">
+              <strong>Motion Studio</strong>
+              <span>Design system and release previews</span>
+            </div>
+            <span class="role-chip">Owner</span>
+          </article>
+
+          <article class="workspace-row" tabindex="0">
+            <span class="avatar-badge">UX</span>
+            <div class="workspace-copy">
+              <strong>UX Research Lab</strong>
+              <span>Prototype studies and interaction notes</span>
+            </div>
+            <span class="role-chip">Editor</span>
+          </article>
+
+          <article class="workspace-row" tabindex="0">
+            <span class="avatar-badge">QA</span>
+            <div class="workspace-copy">
+              <strong>Quality Review</strong>
+              <span>Accessibility checks and motion audits</span>
+            </div>
+            <span class="role-chip">Reviewer</span>
+          </article>
+
+          <article class="workspace-row" tabindex="0">
+            <span class="avatar-badge">RL</span>
+            <div class="workspace-copy">
+              <strong>Release Lane</strong>
+              <span>Changelog drafts and publish readiness</span>
+            </div>
+            <span class="role-chip">Viewer</span>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/workspace-switcher-slide-sm/style.css
+++ b/submissions/examples/workspace-switcher-slide-sm/style.css
@@ -1,0 +1,299 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --accent: #3158e8;
+  --accent-soft: #e9eeff;
+  --success: #147b5a;
+  --success-soft: #e8f7ef;
+  --warning: #a95d00;
+  --warning-soft: #fff5e5;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(49, 88, 232, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 82%, rgba(20, 123, 90, 0.12), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.workspace-panel {
+  width: min(100%, 960px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.switcher-card {
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: var(--shadow);
+}
+
+.switcher-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 1rem;
+}
+
+.switcher-header div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.switcher-header strong {
+  font-size: 1.25rem;
+}
+
+.header-chip,
+.sync-pill {
+  display: inline-flex;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.34rem 0.72rem;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.header-chip {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.sync-pill {
+  color: var(--success);
+  background: var(--success-soft);
+}
+
+.workspace-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.workspace-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.95rem;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 0.95rem;
+  background: var(--surface);
+  box-shadow: 0 10px 26px rgba(31, 42, 68, 0.08);
+  animation: row-enter 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.workspace-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.35rem;
+  background: var(--line);
+  transition:
+    background-color 230ms ease,
+    width 230ms ease;
+}
+
+.workspace-row::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent-soft), transparent 58%);
+  opacity: 0;
+  transition: opacity 230ms ease;
+}
+
+.workspace-row:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.workspace-row:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.workspace-row:nth-child(4) {
+  animation-delay: 240ms;
+}
+
+.workspace-row:hover,
+.workspace-row:focus-visible,
+.active-workspace {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
+  box-shadow: 0 16px 38px rgba(31, 42, 68, 0.13);
+}
+
+.workspace-row:hover,
+.workspace-row:focus-visible {
+  transform: translateX(0.35rem);
+}
+
+.workspace-row:hover::before,
+.workspace-row:focus-visible::before,
+.active-workspace::before {
+  width: 0.62rem;
+  background: var(--accent);
+}
+
+.workspace-row:hover::after,
+.workspace-row:focus-visible::after,
+.active-workspace::after {
+  opacity: 1;
+}
+
+.workspace-row:focus-visible {
+  outline: 3px solid rgba(49, 88, 232, 0.24);
+  outline-offset: 4px;
+}
+
+.avatar-badge,
+.workspace-copy,
+.role-chip {
+  position: relative;
+  z-index: 1;
+}
+
+.avatar-badge {
+  display: grid;
+  width: 3.2rem;
+  height: 3.2rem;
+  place-items: center;
+  border-radius: 0.5rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 950;
+}
+
+.workspace-copy {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.workspace-copy strong,
+.workspace-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-copy span {
+  color: var(--muted);
+}
+
+.role-chip {
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--line));
+  border-radius: 999px;
+  padding: 0.34rem 0.72rem;
+  color: var(--accent);
+  background: rgba(255, 255, 255, 0.72);
+  font-size: 0.82rem;
+  font-weight: 850;
+  white-space: nowrap;
+}
+
+@keyframes row-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.99);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 680px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .switcher-header,
+  .workspace-row {
+    grid-template-columns: 1fr;
+  }
+
+  .switcher-header {
+    align-items: start;
+  }
+
+  .role-chip {
+    justify-self: start;
+  }
+
+  .workspace-row:hover,
+  .workspace-row:focus-visible {
+    transform: translateY(-0.2rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-row,
+  .workspace-row::before,
+  .workspace-row::after {
+    animation: none;
+    transition: none;
+  }
+
+  .workspace-row:hover,
+  .workspace-row:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #48293

## Pull Request Description

Adds a self-contained Workspace Switcher Slide demo with responsive workspace rows, a sliding active rail, staggered row entry, role chips, hover/focus feedback, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Responsive workspace switcher rows with a sliding active rail, animated row entry, role chips, and hover/focus motion feedback.

**How does a developer use it?**

```html
<div class="workspace-list">
  <article class="workspace-row active-workspace" tabindex="0">
    <span class="avatar-badge">MS</span>
    <div class="workspace-copy">
      <strong>Motion Studio</strong>
      <span>Design system and release previews</span>
    </div>
    <span class="role-chip">Owner</span>
  </article>
</div>