### PR TITLE
feat: add feature flag rollout meter demo

### DIFF
--- a/submissions/examples/feature-flag-rollout-meter-sm/README.md
+++ b/submissions/examples/feature-flag-rollout-meter-sm/README.md
@@ -1,0 +1,31 @@
+# Feature Flag Rollout Meter
+
+## What does this do?
+
+Feature Flag Rollout Meter is a self-contained HTML and CSS rollout dashboard pattern with animated exposure meters, flag state cards, rollout stages, and accessible action states.
+
+## How is it used?
+
+Create a `rollout-board` wrapper and add `flag-card` items with state classes such as `flag-active`, `flag-paused`, or `flag-ready`.
+
+```html
+<article class="flag-card flag-active">
+  <div class="meter-ring" aria-hidden="true">
+    <span>42%</span>
+  </div>
+  <div class="flag-content">
+    <p class="flag-kicker">Active rollout</p>
+    <h2>New checkout summary</h2>
+  </div>
+</article>
+```
+
+Available flag classes:
+
+- `flag-active`
+- `flag-paused`
+- `flag-ready`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make rollout state easier to scan: cards enter gently, meter rings reveal exposure, stage dots pulse for attention, and focus states keep actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/feature-flag-rollout-meter-sm/demo.html
+++ b/submissions/examples/feature-flag-rollout-meter-sm/demo.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Feature Flag Rollout Meter Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="rollout-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Feature Flag Rollout Meter</h1>
+        <p>
+          A self-contained rollout dashboard pattern with animated exposure
+          meters, flag state cards, rollout stages, and accessible action
+          states.
+        </p>
+      </section>
+
+      <section class="rollout-summary" aria-label="Feature flag summary">
+        <article>
+          <span class="summary-value">42%</span>
+          <span class="summary-label">Audience exposed</span>
+        </article>
+        <article>
+          <span class="summary-value">08</span>
+          <span class="summary-label">Segments active</span>
+        </article>
+        <article>
+          <span class="summary-value">0.3%</span>
+          <span class="summary-label">Error delta</span>
+        </article>
+      </section>
+
+      <section class="rollout-board" aria-label="Feature flag rollout cards">
+        <article class="flag-card flag-active">
+          <div class="meter-ring" aria-hidden="true">
+            <span>42%</span>
+          </div>
+          <div class="flag-content">
+            <p class="flag-kicker">Active rollout</p>
+            <h2>New checkout summary</h2>
+            <p>
+              The summary view is enabled for paid accounts in two regions while
+              support monitors conversion and latency.
+            </p>
+            <div class="stage-list">
+              <span>Internal</span>
+              <span>Beta</span>
+              <span>Public</span>
+            </div>
+            <button type="button">Review flag</button>
+          </div>
+        </article>
+
+        <article class="flag-card flag-paused">
+          <div class="meter-ring" aria-hidden="true">
+            <span>18%</span>
+          </div>
+          <div class="flag-content">
+            <p class="flag-kicker">Paused</p>
+            <h2>Smart invoice export</h2>
+            <p>
+              Rollout is paused until CSV edge cases and larger workspace
+              exports finish verification.
+            </p>
+            <div class="stage-list">
+              <span>Internal</span>
+              <span>Beta</span>
+              <span>Hold</span>
+            </div>
+            <button type="button">Open notes</button>
+          </div>
+        </article>
+
+        <article class="flag-card flag-ready">
+          <div class="meter-ring" aria-hidden="true">
+            <span>76%</span>
+          </div>
+          <div class="flag-content">
+            <p class="flag-kicker">Ready</p>
+            <h2>Command menu refresh</h2>
+            <p>
+              New navigation shortcuts are stable across target cohorts and
+              ready for the final ramp-up.
+            </p>
+            <div class="stage-list">
+              <span>Internal</span>
+              <span>Beta</span>
+              <span>Ramp</span>
+            </div>
+            <button type="button">Increase ramp</button>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/feature-flag-rollout-meter-sm/style.css
+++ b/submissions/examples/feature-flag-rollout-meter-sm/style.css
@@ -1,0 +1,350 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.rollout-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.rollout-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.rollout-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.rollout-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.flag-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.flag-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.flag-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.flag-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.flag-card:hover,
+.flag-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.meter-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--meter), #e4edf8 var(--meter) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-pop 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.meter-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.55rem;
+  font-weight: 950;
+}
+
+.flag-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.flag-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.flag-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.flag-content > p:not(.flag-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.stage-list {
+  display: grid;
+  gap: 8px;
+  margin: 18px 0 24px;
+}
+
+.stage-list span {
+  position: relative;
+  padding: 8px 10px 8px 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: #40506a;
+  background: rgba(255, 255, 255, 0.72);
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.stage-list span::before {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  content: "";
+  background: var(--accent);
+  box-shadow: 0 0 0 0 var(--accent-soft);
+  transform: translateY(-50%);
+  animation: stage-pulse 1.8s ease-out infinite;
+}
+
+.flag-content button {
+  min-height: 42px;
+  margin-top: auto;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.flag-content button:hover,
+.flag-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.flag-active {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --meter: 42%;
+}
+
+.flag-paused {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --meter: 18%;
+}
+
+.flag-ready {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --meter: 76%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-pop {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes stage-pulse {
+  70% {
+    box-shadow: 0 0 0 10px rgba(255, 255, 255, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+  }
+}
+
+@media (max-width: 860px) {
+  .rollout-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .rollout-summary,
+  .rollout-board {
+    grid-template-columns: 1fr;
+  }
+
+  .flag-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48296



**PR Text**

Title: `feat: add feature flag rollout meter demo`

```md
## Pull Request Description
Adds a self-contained Feature Flag Rollout Meter demo under `submissions/examples/`, featuring animated exposure meters, flag state cards, rollout stages, and accessible action states.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only feature flag rollout dashboard pattern.

**How does a developer use it?**
Use a `rollout-board` wrapper with `flag-card` items and state classes like `flag-active`, `flag-paused`, or `flag-ready`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate rollout exposure, state, and staged progress while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The flag naming, rollout colors, and meter animation timing can be standardized during framework integration.