### PR TITLE
Solved Issue

### DIFF
--- a/submissions/examples/ease-redo-undo-button/README.md
+++ b/submissions/examples/ease-redo-undo-button/README.md
@@ -1,0 +1,74 @@
+# ease-redo-undo-button
+
+## Overview
+
+**What does this do?** A pure-CSS undo/redo button pair — a grouped history control with subtle hover, press, and focus motion, a disabled state, an icon-only variant, and automatic dark-mode support.
+
+**How is it used?** Wrap two buttons in `.ease-redo-undo-group` (see [Usage](#usage) below).
+
+**Why is it useful?** Undo/redo controls appear in every editor-style UI, and this pair delivers them in EaseMotion's animation-first, zero-JS style: readable class names, design-token theming, and purposeful micro-motion that respects `prefers-reduced-motion`.
+
+## Features
+
+- Undo + redo buttons in a single grouped control with a hairline divider
+- Hover/focus tint with a directional icon nudge (undo left, redo right)
+- Press feedback: `scale(0.97)` plus a playful icon "wind" rotation
+- Entrance motion reuses the framework's `ease-kf-slide-up` keyframe
+- Keyboard accessible with a visible `:focus-visible` ring — hover cues are mirrored on focus
+- Disabled state, icon-only variant, and labels that collapse to screen-reader-only text below 480px
+- Light/dark theming via EaseMotion design tokens with self-contained fallbacks
+
+## Folder Structure
+
+```
+ease-redo-undo-button/
+├── demo.html   – self-contained demo (default, icon-only, disabled)
+├── style.css   – component styles + demo scaffolding
+└── README.md
+```
+
+## Usage
+
+```html
+<div class="ease-redo-undo-group" role="group" aria-label="History controls">
+  <button type="button" class="ease-redo-undo-btn">
+    <svg class="ease-redo-undo-icon" ...>…</svg>
+    <span class="ease-redo-undo-label">Undo</span>
+  </button>
+  <button type="button" class="ease-redo-undo-btn">
+    <span class="ease-redo-undo-label">Redo</span>
+    <svg class="ease-redo-undo-icon" ...>…</svg>
+  </button>
+</div>
+```
+
+Add `ease-redo-undo-btn--icon` and an `aria-label` for icon-only buttons; add `disabled` when there is nothing to undo/redo.
+
+## Customization
+
+All values resolve through EaseMotion design tokens, so the component themes itself when loaded alongside the framework. Standalone, override the component tokens:
+
+| Property | Default | Description |
+|---|---|---|
+| `--erb-accent` | `var(--ease-color-primary, #6c63ff)` | Hover/focus accent color |
+| `--erb-accent-soft` | `var(--ease-color-primary-alpha, …)` | Hover/focus background tint |
+| `--erb-surface` | `var(--ease-color-surface, #ffffff)` | Group background |
+| `--erb-border` | `var(--ease-color-neutral-200, #e2e8f0)` | Group border and divider |
+| `--erb-radius` | `var(--ease-radius-md, 0.5rem)` | Group corner radius |
+| `--erb-speed` | `var(--ease-speed-fast, 150ms)` | Transition duration |
+
+## Accessibility
+
+- Semantic `<button type="button">` elements inside a `role="group"` with an `aria-label`
+- Decorative SVGs are `aria-hidden="true"`; icon-only buttons carry an `aria-label`
+- Hover styles are duplicated on `:focus-visible`, plus a 2px offset focus ring
+- 44px minimum touch targets
+- `prefers-reduced-motion: reduce` removes all movement while keeping color and focus feedback
+
+## Browser Support
+
+Works in all modern evergreen browsers (Chrome, Firefox, Safari, Edge, Opera). Uses flexbox, CSS custom properties, transitions, and keyframes only — no JavaScript.
+
+## Preview
+
+A centered card shows three states of the control: the default labeled pair, a compact icon-only pair, and a pair with redo disabled. The group slides up on load; hovering or focusing a button tints it in the primary color and nudges its arrow toward its direction of travel, and pressing it winds the arrow with a gentle bounce.

--- a/submissions/examples/ease-redo-undo-button/demo.html
+++ b/submissions/examples/ease-redo-undo-button/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-redo-undo-button</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-page">
+    <h1>Redo / Undo Buttons</h1>
+    <p class="demo-subtitle">A pure-CSS history control pair with subtle, professional motion.</p>
+
+    <section class="demo-card">
+      <h2 class="demo-label">Default</h2>
+      <div class="ease-redo-undo-group" role="group" aria-label="History controls">
+        <button type="button" class="ease-redo-undo-btn">
+          <svg class="ease-redo-undo-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"/>
+          </svg>
+          <span class="ease-redo-undo-label">Undo</span>
+        </button>
+        <button type="button" class="ease-redo-undo-btn">
+          <span class="ease-redo-undo-label">Redo</span>
+          <svg class="ease-redo-undo-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M18.4 10.6C16.55 8.99 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16c1.05-3.19 4.05-5.5 7.6-5.5 1.95 0 3.73.72 5.12 1.88L13 16h9V7l-3.6 3.6z"/>
+          </svg>
+        </button>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2 class="demo-label">Icon only</h2>
+      <div class="ease-redo-undo-group" role="group" aria-label="History controls (compact)">
+        <button type="button" class="ease-redo-undo-btn ease-redo-undo-btn--icon" aria-label="Undo">
+          <svg class="ease-redo-undo-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"/>
+          </svg>
+        </button>
+        <button type="button" class="ease-redo-undo-btn ease-redo-undo-btn--icon" aria-label="Redo">
+          <svg class="ease-redo-undo-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M18.4 10.6C16.55 8.99 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16c1.05-3.19 4.05-5.5 7.6-5.5 1.95 0 3.73.72 5.12 1.88L13 16h9V7l-3.6 3.6z"/>
+          </svg>
+        </button>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2 class="demo-label">Disabled state</h2>
+      <div class="ease-redo-undo-group" role="group" aria-label="History controls (nothing to redo)">
+        <button type="button" class="ease-redo-undo-btn">
+          <svg class="ease-redo-undo-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"/>
+          </svg>
+          <span class="ease-redo-undo-label">Undo</span>
+        </button>
+        <button type="button" class="ease-redo-undo-btn" disabled>
+          <span class="ease-redo-undo-label">Redo</span>
+          <svg class="ease-redo-undo-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M18.4 10.6C16.55 8.99 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16c1.05-3.19 4.05-5.5 7.6-5.5 1.95 0 3.73.72 5.12 1.88L13 16h9V7l-3.6 3.6z"/>
+          </svg>
+        </button>
+      </div>
+    </section>
+
+    <p class="demo-hint">Fully keyboard accessible — try <kbd>Tab</kbd> then <kbd>Enter</kbd>. Hover, press, and focus each have their own subtle motion.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-redo-undo-button/style.css
+++ b/submissions/examples/ease-redo-undo-button/style.css
@@ -1,0 +1,280 @@
+/*
+ * ease-redo-undo-button
+ *
+ * A pure-CSS undo/redo history control pair styled to match the
+ * EaseMotion button system. Every value reads an --ease-* design token
+ * first and falls back to that token's documented default, so the demo
+ * is self-contained yet inherits the framework theme when loaded with it.
+ */
+
+:root {
+  /* Component tokens — all resolve through EaseMotion design tokens. */
+  --erb-surface:      var(--ease-color-surface, #ffffff);
+  --erb-text:         var(--ease-color-text, #1e293b);
+  --erb-muted:        var(--ease-color-muted, #475569);
+  --erb-border:       var(--ease-color-neutral-200, #e2e8f0);
+  --erb-accent:       var(--ease-color-primary, #6c63ff);
+  --erb-accent-soft:  var(--ease-color-primary-alpha, rgba(108, 99, 255, 0.15));
+  --erb-radius:       var(--ease-radius-md, 0.5rem);
+  --erb-shadow:       var(--ease-shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.05));
+  --erb-speed:        var(--ease-speed-fast, 150ms);
+  --erb-easing:       var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+  --erb-easing-bounce: var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Same tokens, framework dark-theme fallbacks. */
+    --erb-surface: var(--ease-color-surface, #141e33);
+    --erb-text:    var(--ease-color-text, #e2e8f0);
+    --erb-muted:   var(--ease-color-muted, #94a3b8);
+    --erb-border:  var(--ease-color-neutral-700, #334155);
+    --erb-shadow:  var(--ease-shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.30), 0 1px 2px rgba(0, 0, 0, 0.20));
+  }
+}
+
+/* ── Group container ───────────────────────────────────────── */
+
+.ease-redo-undo-group {
+  display: inline-flex;
+  align-items: stretch;
+  background: var(--erb-surface);
+  border: 1px solid var(--erb-border);
+  border-radius: var(--erb-radius);
+  box-shadow: var(--erb-shadow);
+  animation: ease-kf-slide-up var(--ease-speed-medium, 300ms) var(--erb-easing) both;
+}
+
+/* Hairline divider between the two controls. */
+.ease-redo-undo-btn + .ease-redo-undo-btn {
+  border-left: 1px solid var(--erb-border);
+}
+
+/* ── Buttons ───────────────────────────────────────────────── */
+
+.ease-redo-undo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ease-space-2, 0.5rem);
+  min-height: 44px; /* comfortable touch target */
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-4, 1rem);
+  font-family: var(--ease-font-sans, 'Inter', system-ui, -apple-system, sans-serif);
+  font-size: var(--ease-text-sm, 0.875rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  color: var(--erb-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color var(--erb-speed) var(--erb-easing),
+    color            var(--erb-speed) var(--erb-easing),
+    transform        var(--erb-speed) var(--erb-easing-bounce);
+}
+
+/* Keep rounded corners inside the group's radius. */
+.ease-redo-undo-btn:first-child {
+  border-radius: calc(var(--erb-radius) - 1px) 0 0 calc(var(--erb-radius) - 1px);
+}
+
+.ease-redo-undo-btn:last-child {
+  border-radius: 0 calc(var(--erb-radius) - 1px) calc(var(--erb-radius) - 1px) 0;
+}
+
+.ease-redo-undo-icon {
+  flex: none;
+  transition: transform var(--erb-speed) var(--erb-easing-bounce);
+}
+
+/* ── Hover / focus (shared, so keyboard users get the same cue) ── */
+
+.ease-redo-undo-btn:hover:not(:disabled),
+.ease-redo-undo-btn:focus-visible {
+  background-color: var(--erb-accent-soft);
+  color: var(--erb-accent);
+}
+
+/*
+ * Icons nudge toward their direction of travel: undo (first button in
+ * the group) left, redo (last button) right.
+ */
+@media (hover: hover) and (pointer: fine) {
+  .ease-redo-undo-btn:first-child:hover:not(:disabled) .ease-redo-undo-icon,
+  .ease-redo-undo-btn:first-child:focus-visible .ease-redo-undo-icon {
+    transform: translateX(-2px);
+  }
+
+  .ease-redo-undo-btn:last-child:hover:not(:disabled) .ease-redo-undo-icon,
+  .ease-redo-undo-btn:last-child:focus-visible .ease-redo-undo-icon {
+    transform: translateX(2px);
+  }
+}
+
+.ease-redo-undo-btn:focus-visible {
+  outline: 2px solid var(--erb-accent);
+  outline-offset: 3px;
+  border-radius: calc(var(--erb-radius) - 1px);
+  z-index: var(--ease-z-raised, 10); /* keep the ring above the sibling divider */
+}
+
+/* ── Active (press) ────────────────────────────────────────── */
+
+.ease-redo-undo-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+/* The arc icons "wind" in their history direction while pressed. */
+.ease-redo-undo-btn:first-child:active:not(:disabled) .ease-redo-undo-icon {
+  transform: translateX(-2px) rotate(-20deg);
+}
+
+.ease-redo-undo-btn:last-child:active:not(:disabled) .ease-redo-undo-icon {
+  transform: translateX(2px) rotate(20deg);
+}
+
+/* ── Disabled ──────────────────────────────────────────────── */
+
+.ease-redo-undo-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Icon-only variant ─────────────────────────────────────── */
+
+.ease-redo-undo-btn--icon {
+  padding: var(--ease-space-2, 0.5rem) var(--ease-space-3, 0.75rem);
+  min-width: 44px;
+}
+
+/* ── Responsive: collapse to icon-only on narrow screens ───── */
+
+@media (max-width: 480px) {
+  /* Visually hidden but still announced by screen readers. */
+  .ease-redo-undo-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+}
+
+/* ── Entrance keyframe ─────────────────────────────────────── */
+
+/*
+ * Copied verbatim from core/animations.css (ease-kf-slide-up) so the
+ * demo stays self-contained per the submission rules. If the framework
+ * stylesheet is also loaded, the identical definition is a no-op.
+ */
+@keyframes ease-kf-slide-up {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 24px, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+/* ── Reduced motion: drop movement, keep color and focus cues ── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-redo-undo-group {
+    animation: none;
+  }
+
+  .ease-redo-undo-btn,
+  .ease-redo-undo-icon {
+    transition-property: background-color, color;
+  }
+
+  /* Selectors mirror the motion rules above so specificity matches. */
+  .ease-redo-undo-btn:active:not(:disabled),
+  .ease-redo-undo-btn:first-child:active:not(:disabled) .ease-redo-undo-icon,
+  .ease-redo-undo-btn:last-child:active:not(:disabled) .ease-redo-undo-icon,
+  .ease-redo-undo-btn:first-child:hover:not(:disabled) .ease-redo-undo-icon,
+  .ease-redo-undo-btn:last-child:hover:not(:disabled) .ease-redo-undo-icon,
+  .ease-redo-undo-btn:first-child:focus-visible .ease-redo-undo-icon,
+  .ease-redo-undo-btn:last-child:focus-visible .ease-redo-undo-icon {
+    transform: none;
+  }
+}
+
+/* ── Demo page scaffolding ─────────────────────────────────── */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  font-family: var(--ease-font-sans, 'Inter', system-ui, -apple-system, sans-serif);
+  color: var(--erb-text);
+  background: var(--ease-color-bg, #f8fafc);
+  padding: var(--ease-space-6, 1.5rem);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--ease-color-bg, #0b1121);
+  }
+}
+
+.demo-page {
+  width: 100%;
+  max-width: 560px;
+  text-align: center;
+}
+
+h1 {
+  margin: 0 0 var(--ease-space-1, 0.25rem);
+  font-size: var(--ease-text-2xl, 1.5rem);
+  font-weight: 700;
+}
+
+.demo-subtitle {
+  margin: 0 0 var(--ease-space-6, 1.5rem);
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--erb-muted);
+}
+
+.demo-card {
+  background: var(--erb-surface);
+  border: 1px solid var(--erb-border);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-8, 2rem);
+  margin-bottom: var(--ease-space-4, 1rem);
+}
+
+.demo-label {
+  margin: 0 0 var(--ease-space-4, 1rem);
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--erb-muted);
+}
+
+.demo-hint {
+  font-size: var(--ease-text-sm, 0.875rem);
+  color: var(--erb-muted);
+}
+
+kbd {
+  padding: 0.125rem 0.375rem;
+  font-family: var(--ease-font-mono, 'JetBrains Mono', 'Fira Code', monospace);
+  font-size: var(--ease-text-xs, 0.75rem);
+  background: var(--erb-accent-soft);
+  border: 1px solid var(--erb-border);
+  border-radius: var(--ease-radius-sm, 0.25rem);
+}


### PR DESCRIPTION
Adds **`ease-redo-undo-button`** — a pure-CSS undo/redo history control pair styled to match the EaseMotion button system, with subtle hover, press, and focus motion, a disabled state, an icon-only variant, and automatic dark-mode support.

Fixes #48026

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A grouped undo/redo button pair (labeled, icon-only, and disabled states) with purposeful micro-motion: hover/focus tints the button and nudges the arrow toward its direction of travel (undo left, redo right), and pressing "winds" the arc icon with the framework's bounce easing.

**How does a developer use it?**

```html
<div class="ease-redo-undo-group" role="group" aria-label="History controls">
  <button type="button" class="ease-redo-undo-btn">
    <svg class="ease-redo-undo-icon" aria-hidden="true">…</svg>
    <span class="ease-redo-undo-label">Undo</span>
  </button>
  <button type="button" class="ease-redo-undo-btn">
    <span class="ease-redo-undo-label">Redo</span>
    <svg class="ease-redo-undo-icon" aria-hidden="true">…</svg>
  </button>
</div>
```

**Why does it fit EaseMotion CSS?**

- Zero JavaScript, human-readable class names (`ease-redo-undo-group`, `ease-redo-undo-btn`)
- Every value resolves through EaseMotion design tokens using the same `var(--ease-token, fallback)` pattern as `components/buttons.css`, so it inherits the framework theme (including dark mode) when loaded together, yet works standalone
- Follows the framework's button conventions: hover gated behind `@media (hover: hover) and (pointer: fine)`, `scale(0.97)` press, 2px primary focus ring with 3px offset, `--ease-speed-*` / `--ease-ease-bounce` timing
- Entrance reuses the framework keyframe `ease-kf-slide-up` (declared locally, copied verbatim from `core/animations.css`, so it's a no-op if the framework is also loaded)
- Accessible by default: semantic buttons in a `role="group"`, hover cues mirrored on `:focus-visible`, `aria-label`s on icon-only buttons, 44px touch targets, and a `prefers-reduced-motion` fallback that drops movement but keeps color/focus feedback
- Responsive: labels collapse to screen-reader-only text below 480px so the control stays compact on mobile

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- Note: the existing `ease-undo-redo-history-ij` and `ease-redo-undo-stack-ij-v1` folders are copies of the mass-generated JS toggle template — this is a fresh, pure-CSS parallel implementation as encouraged by CONTRIBUTING.md.
- Icon nudge direction is keyed off the button's position in the group (`:first-child` / `:last-child`) rather than icon order, so it works for the icon-only variant too.
- Timing/rotation values (150ms, ±20deg wind) are easy to tune via `--erb-speed` if you prefer something calmer.

One honest caveat: I left the Browser Testing boxes unchecked because the demo hasn't actually been opened in those browsers yet — open demo.html in Chrome/Firefox/Edge and tick them before submitting.