### PR TITLE
feat: add cache warmup status demo

### DIFF
--- a/submissions/examples/cache-warmup-status-sm/README.md
+++ b/submissions/examples/cache-warmup-status-sm/README.md
@@ -1,0 +1,34 @@
+# Cache Warmup Status
+
+## What does this do?
+
+Cache Warmup Status is a self-contained HTML and CSS infrastructure dashboard pattern with animated warmup rings, cache layer cards, fill meters, and readable service readiness.
+
+## How is it used?
+
+Create a `cache-board` wrapper and add `cache-card` items with layer classes such as `layer-edge`, `layer-api`, or `layer-search`.
+
+```html
+<article class="cache-card layer-edge">
+  <div class="warm-ring" aria-hidden="true">
+    <span>96%</span>
+  </div>
+  <div class="cache-content">
+    <p class="cache-kicker">Edge layer</p>
+    <h2>Static assets fully primed</h2>
+    <div class="warm-meter" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available layer classes:
+
+- `layer-edge`
+- `layer-api`
+- `layer-search`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make infrastructure readiness easier to scan: cards enter gently, rings show cache progress, meters reveal layer status, and focus states keep actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/cache-warmup-status-sm/demo.html
+++ b/submissions/examples/cache-warmup-status-sm/demo.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cache Warmup Status Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="cache-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Cache Warmup Status</h1>
+        <p>
+          A self-contained infrastructure dashboard pattern with animated warmup
+          rings, cache layer cards, fill meters, and readable service readiness.
+        </p>
+      </section>
+
+      <section class="cache-summary" aria-label="Cache warmup summary">
+        <article>
+          <span class="summary-value">87%</span>
+          <span class="summary-label">Warmup complete</span>
+        </article>
+        <article>
+          <span class="summary-value">12</span>
+          <span class="summary-label">Regions primed</span>
+        </article>
+        <article>
+          <span class="summary-value">42ms</span>
+          <span class="summary-label">Median hit time</span>
+        </article>
+      </section>
+
+      <section class="cache-board" aria-label="Cache layer warmup cards">
+        <article class="cache-card layer-edge">
+          <div class="warm-ring" aria-hidden="true">
+            <span>96%</span>
+          </div>
+          <div class="cache-content">
+            <p class="cache-kicker">Edge layer</p>
+            <h2>Static assets fully primed</h2>
+            <p>
+              Core CSS, icons, and documentation assets are replicated across
+              the closest edge locations.
+            </p>
+            <div class="warm-meter" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Ready</span>
+              <button type="button">Inspect</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="cache-card layer-api">
+          <div class="warm-ring" aria-hidden="true">
+            <span>78%</span>
+          </div>
+          <div class="cache-content">
+            <p class="cache-kicker">API layer</p>
+            <h2>Popular responses warming</h2>
+            <p>
+              High-traffic endpoints are preloading safe response fragments for
+              dashboard and profile screens.
+            </p>
+            <div class="warm-meter" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Warming</span>
+              <button type="button">Monitor</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="cache-card layer-search">
+          <div class="warm-ring" aria-hidden="true">
+            <span>64%</span>
+          </div>
+          <div class="cache-content">
+            <p class="cache-kicker">Search layer</p>
+            <h2>Index shards still loading</h2>
+            <p>
+              Recently updated shard groups are rebuilding query hints before
+              the final traffic ramp.
+            </p>
+            <div class="warm-meter" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Watching</span>
+              <button type="button">Open logs</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/cache-warmup-status-sm/style.css
+++ b/submissions/examples/cache-warmup-status-sm/style.css
@@ -1,0 +1,354 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.cache-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.cache-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.cache-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.cache-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.cache-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.cache-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.cache-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.cache-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.cache-card:hover,
+.cache-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.warm-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--warm), #e4edf8 var(--warm) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-enter 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.warm-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.55rem;
+  font-weight: 950;
+}
+
+.cache-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.cache-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.cache-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.cache-content > p:not(.cache-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.warm-meter {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.warm-meter span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--warm);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: meter-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.cache-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.cache-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.cache-content button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.cache-content button:hover,
+.cache-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.layer-edge {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --warm: 96%;
+}
+
+.layer-api {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --warm: 78%;
+}
+
+.layer-search {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --warm: 64%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-enter {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes meter-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .cache-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .cache-summary,
+  .cache-board {
+    grid-template-columns: 1fr;
+  }
+
+  .cache-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48310


**PR Text**

Title: `feat: add cache warmup status demo`

```md
## Pull Request Description
Adds a self-contained Cache Warmup Status demo under `submissions/examples/`, featuring animated warmup rings, cache layer cards, fill meters, and service readiness states.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only cache warmup dashboard pattern for infrastructure readiness.

**How does a developer use it?**
Use a `cache-board` wrapper with `cache-card` items and layer classes like `layer-edge`, `layer-api`, or `layer-search`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate cache progress, layer status, and readiness while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The layer naming, warmup colors, and meter timing can be standardized during framework integration.