### PR TITLE
Add scale-hover popover CSS component

### DIFF
--- a/submissions/examples/scale-hover-popover/README.md
+++ b/submissions/examples/scale-hover-popover/README.md
@@ -1,0 +1,22 @@
+\# Scale Hover Popover
+
+
+
+A pure CSS popover component that reveals with a smooth scale-in transition on hover or keyboard focus.
+
+
+
+\## Features
+
+\- Zero JavaScript — built entirely with `:hover` and `:focus-within`
+
+\- Fully keyboard accessible (tabbing into the container reveals the popover)
+
+\- Customizable via CSS variables: `--popover-scale-factor`, `--popover-transition-speed`, `--popover-ease`
+
+
+
+\## Usage
+
+Open `demo.html` in a browser to see it in action.
+

--- a/submissions/examples/scale-hover-popover/demo.html
+++ b/submissions/examples/scale-hover-popover/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Scale Hover Popover</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="popover-container" tabindex="0">
+    <button class="popover-trigger">Hover or Focus Me</button>
+    <div class="popover-box">
+      <p>This is a pure CSS popover that scales in on hover or keyboard focus.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/scale-hover-popover/style.css
+++ b/submissions/examples/scale-hover-popover/style.css
@@ -1,0 +1,51 @@
+:root {
+  --popover-scale-factor: 1;
+  --popover-transition-speed: 0.25s;
+  --popover-ease: ease-out;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #121212;
+  font-family: sans-serif;
+}
+
+.popover-container {
+  position: relative;
+  outline: none;
+}
+
+.popover-trigger {
+  padding: 10px 18px;
+  background: #1e1e1e;
+  color: #f5f5f5;
+  border: 1px solid #333;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.popover-box {
+  position: absolute;
+  top: 110%;
+  left: 50%;
+  transform: translateX(-50%) scale(0);
+  transform-origin: top center;
+  background: #1e1e1e;
+  color: #f5f5f5;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 12px 16px;
+  width: 220px;
+  opacity: 0;
+  transition: transform var(--popover-transition-speed) var(--popover-ease),
+              opacity var(--popover-transition-speed) var(--popover-ease);
+}
+
+.popover-container:hover .popover-box,
+.popover-container:focus-within .popover-box {
+  transform: translateX(-50%) scale(var(--popover-scale-factor, 1));
+  opacity: 1;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS scale-hover popover component built entirely with `:hover` and `:focus-within`, with no JavaScript required.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS popover that scales in smoothly on hover or keyboard focus.

**How does a developer use it?**

```html
<div class="popover-container" tabindex="0">
  <button class="popover-trigger">Hover or Focus Me</button>
  <div class="popover-box">
    <p>Popover content here.</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

It's a lightweight, dependency-free hover animation that follows the project's human-readable, animation-first CSS philosophy, and is fully keyboard accessible via `:focus-within`.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

First-time contribution — happy to adjust styling or timing based on feedback.