### PR TITLE
feat: add copy class name button demo submission

### DIFF
--- a/submissions/docs/copy-class-button/README.md
+++ b/submissions/docs/copy-class-button/README.md
@@ -1,0 +1,21 @@
+# Copy Class Name Button for Demo Cards
+
+## Description
+This component provides a small Copy button/icon next to each CSS class name displayed in the demo cards. Clicking the button copies the corresponding class name to the user's clipboard and provides visual feedback by temporarily changing the icon to a checkmark (✓).
+
+## Why is this useful for EaseMotion CSS?
+EaseMotion CSS is designed to provide a smooth and developer-friendly experience. Developers frequently copy animation class names from the demo page into their projects. A one-click copy feature:
+- Improves developer productivity.
+- Reduces manual selection errors.
+- Enhances the overall user experience.
+- Makes the animation gallery more interactive and polished.
+
+## How to use
+Add the `copy-btn` styles to the documentation stylesheet (`docs.css`), include the button element next to the class name, and integrate the `copyClassName` JavaScript function.
+
+```html
+<span class="tag">
+  ease-fade-up
+  <button class="copy-btn" onclick="copyClassName('ease-fade-up', this)" aria-label="Copy class name">📋</button>
+</span>
+```

--- a/submissions/docs/copy-class-button/demo.html
+++ b/submissions/docs/copy-class-button/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Copy Class Name Button Demo</title>
+    <!-- Load EaseMotion CSS from CDN (or local if testing) -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <!-- Load the proposed feature CSS -->
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #0f0e17;
+            color: #fffffe;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .demo-container {
+            background: #1e1d2b;
+            padding: 2rem;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+            text-align: center;
+        }
+        .anim-cell {
+            display: inline-block;
+            margin: 1rem;
+        }
+        .anim-box {
+            width: 100px;
+            height: 100px;
+            background: #6c63ff;
+            border-radius: 12px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        .tag {
+            background: rgba(255,255,255,0.1);
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            font-family: monospace;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+    </style>
+</head>
+<body>
+
+    <div class="demo-container">
+        <h2>Copy Class Name Button Demo</h2>
+        <p>Hover and click the clipboard icon to copy the class name.</p>
+        
+        <div class="anim-cell">
+            <div class="anim-box ease-fade-in">F</div>
+            <span class="tag">
+                ease-fade-in
+                <button class="copy-btn" onclick="copyClassName('ease-fade-in', this)" aria-label="Copy class name">📋</button>
+            </span>
+        </div>
+        
+        <div class="anim-cell">
+            <div class="anim-box ease-bounce">↕</div>
+            <span class="tag">
+                ease-bounce
+                <button class="copy-btn" onclick="copyClassName('ease-bounce', this)" aria-label="Copy class name">📋</button>
+            </span>
+        </div>
+    </div>
+
+    <script>
+        function copyClassName(className, btn) {
+            navigator.clipboard.writeText(className).then(() => {
+                if (btn) {
+                    const originalText = btn.innerHTML;
+                    btn.innerHTML = "✓";
+                    setTimeout(() => {
+                        btn.innerHTML = originalText;
+                    }, 1500);
+                }
+                console.log("Class name copied: " + className);
+            }).catch(err => {
+                console.error("Failed to copy text: ", err);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/submissions/docs/copy-class-button/style.css
+++ b/submissions/docs/copy-class-button/style.css
@@ -1,0 +1,17 @@
+/* Copy Class Name Button for Demo Cards */
+.copy-btn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px;
+  transition: transform 0.2s ease;
+}
+
+.copy-btn:hover {
+  transform: scale(1.15);
+}
+
+.copy-btn:active {
+  transform: scale(0.95);
+}


### PR DESCRIPTION
## Pull Request Description

Fixes ##48321

Added a "Copy Class Name" button component demonstration under `submissions/docs/copy-class-button/`. This solves the issue of developers needing to manually select and copy animation class names from the documentation.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a copy-to-clipboard button component to easily copy animation class names, with a checkmark for visual feedback.

**How does a developer use it?**

```html
<span class="tag">
  ease-fade-up
  <button class="copy-btn" onclick="copyClassName('ease-fade-up', this)" aria-label="Copy class name">📋</button>
</span>
