### PR TITLE
docs: add css fade-out tooltip for neumorphic layouts (#46235)

### DIFF
--- a/submissions/examples/ease-tooltip-neumorphic-pp/README.md
+++ b/submissions/examples/ease-tooltip-neumorphic-pp/README.md
@@ -1,0 +1,43 @@
+# CSS Fade-Out Tooltip for Neumorphic Soft Layouts
+
+A pure CSS animated tooltip component styled to complement Neumorphic Soft layout aesthetics, featuring smooth fade-out interaction transitions and custom variables overrides.
+
+---
+
+## 1. What does this do?
+This showcase presents a pure CSS tooltip that utilizes visibility step transitions to animate fade-outs on unhover/blur, styled to fit soft inset/outset neumorphic shadows.
+
+---
+
+## 2. How is it used?
+Wrap trigger buttons inside focusable parent elements, and append position classes to configure orientation overlays:
+
+```html
+<!-- Keyboard-accessible tooltip trigger parent -->
+<div class="ease-tooltip-trigger" tabindex="0">
+  <button type="button" class="pp-neu-btn">Action CTA</button>
+  <!-- Tooltip element with top position class -->
+  <div class="ease-tooltip ease-tooltip-top">
+    Tactile Feedback Content
+  </div>
+</div>
+```
+
+---
+
+## 3. Why is it useful?
+It provides standard, modern layout feedback without requiring JavaScript payloads, complies with key accessibility guidelines for screen readers, and offers flexible configurations through standard CSS variables.
+
+---
+
+## Technical Specifications & Suffix
+
+- **Folder Path:** `submissions/examples/ease-tooltip-neumorphic-pp/`
+- **Contributor Suffix:** `pp` (Pratyush Panda)
+- **Resolved Ticket:** [Issue #46235](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46235)
+
+### Included Layout Features:
+1. ** Tactile Playground Grid:** Real-world preview stage containing soft light and dark theme configurations.
+2. **Dynamic Parameter Control Dashboard:** Adjusts timing speed, initial scale size, and easing presets using CSS custom variables.
+3. **Accessibility Validation Logs:** Details visibility transitions, focus-within pseudo-classes, and pointer-events variables.
+4. **Interactive Quiz:** In-app quiz focusing on screen reader compliance and focus structures.

--- a/submissions/examples/ease-tooltip-neumorphic-pp/demo.html
+++ b/submissions/examples/ease-tooltip-neumorphic-pp/demo.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Fade-Out Tooltip for Neumorphic Soft Layouts</title>
+  
+  <!-- SEO & Accessibility Metadata -->
+  <meta name="description" content="An interactive showcase of a pure CSS fade-out tooltip styled for soft Neumorphic layouts, featuring keyboard accessibility and custom properties control." />
+  <meta name="author" content="Pratyush Panda (pp)" />
+  
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  
+  <!-- EaseMotion CSS from CDN -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  
+  <!-- Local Styles -->
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <!-- Theme Toggle Button -->
+  <button class="pp-theme-toggle" id="themeToggleBtn" aria-label="Toggle Dark/Light Mode">
+    <!-- Sun Icon (shown in dark mode) -->
+    <svg id="sunIcon" style="display:none;" viewBox="0 0 24 24">
+      <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41l-1.06-1.06zm1.06-12.37c-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.38.39-1.02 0-1.41zM5.99 18.01l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.39.39-1.03 0-1.41z"/>
+    </svg>
+    <!-- Moon Icon (shown in light mode) -->
+    <svg id="moonIcon" viewBox="0 0 24 24">
+      <path d="M9.37 5.51c-.18-.64-.86-1.02-1.5-.84-2.32.63-4.13 2.5-4.7 4.88-.66 2.76.62 5.57 3.03 6.77.34.17.65.41.9.7l1.06 1.18c1.3 1.45 3.39 1.83 5.09 1 .73-.36 1.34-.9 1.81-1.57.4-.57.19-1.35-.47-1.63-3.64-1.55-5.91-5.32-5.46-9.45.08-.75-.5-1.4-1.26-1.07z"/>
+    </svg>
+  </button>
+
+  <header class="pp-header">
+    <div class="pp-container">
+      <span class="pp-eyebrow">Interactive Motion Showcase</span>
+      <h1>CSS Fade-Out Neumorphic Tooltip</h1>
+      <p class="pp-subtitle">
+        Examine a pure CSS layout pattern utilizing visibility step-timing. 
+        Adjust parameters via CSS variables, trigger hover/focus states, and feel the tactile neumorphic shadows.
+      </p>
+      <div class="pp-meta-badge">
+        <span>Resolves</span> Issue #46235
+      </div>
+    </div>
+  </header>
+
+  <main class="pp-container pp-main-grid">
+
+    <!-- Section: Playground -->
+    <section class="pp-card" aria-labelledby="playground-heading">
+      <h2 class="pp-card-title" id="playground-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="9" cy="9" r="2"></circle><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path></svg>
+        Tactile Playground
+      </h2>
+      <p class="pp-card-desc">
+        Hover or focus (via tab key) the button in the center stage. Use the controls on the right to customize timing, coordinates, and scale factors.
+      </p>
+
+      <div class="pp-playground-grid">
+        <!-- Center Stage -->
+        <div class="pp-stage" id="playgroundStage">
+          <!-- Keyboard accessible trigger container -->
+          <div class="ease-tooltip-trigger" tabindex="0">
+            <button type="button" class="pp-neu-btn" style="pointer-events: none;">
+              Hover or Focus Me
+            </button>
+            <div class="ease-tooltip ease-tooltip-top" id="targetTooltip">
+              Soft Neumorphic Feedback!
+            </div>
+          </div>
+        </div>
+
+        <!-- Controls panel -->
+        <div class="pp-controls-panel">
+          <div class="pp-control-row">
+            <label for="posSelect">Tooltip Direction</label>
+            <select id="posSelect" class="pp-state-select">
+              <option value="top">Top Orientation (Default)</option>
+              <option value="bottom">Bottom Orientation</option>
+              <option value="left">Left Orientation</option>
+              <option value="right">Right Orientation</option>
+            </select>
+          </div>
+
+          <div class="pp-control-row">
+            <label for="speedSlider">Animation Speed (--tooltip-speed)</label>
+            <div class="pp-slider-row">
+              <input type="range" id="speedSlider" class="pp-slider" min="100" max="1000" value="250" step="50" />
+              <span class="pp-slider-val" id="speedVal">250ms</span>
+            </div>
+          </div>
+
+          <div class="pp-control-row">
+            <label for="scaleSlider">Initial Scale Offset (--tooltip-scale)</label>
+            <div class="pp-slider-row">
+              <input type="range" id="scaleSlider" class="pp-slider" min="50" max="100" value="92" step="2" />
+              <span class="pp-slider-val" id="scaleVal">0.92</span>
+            </div>
+          </div>
+
+          <div class="pp-control-row">
+            <label for="easingSelect">Easing Bezier (--tooltip-easing)</label>
+            <select id="easingSelect" class="pp-state-select">
+              <option value="backOut">Back Out Sweep (cubic-bezier(0.34, 1.56, 0.64, 1))</option>
+              <option value="linear">Linear Transition (cubic-bezier(0, 0, 1, 1))</option>
+              <option value="smooth">Smooth Ease (cubic-bezier(0.4, 0, 0.2, 1))</option>
+              <option value="bounce">Bounce Out (cubic-bezier(0.175, 0.885, 0.32, 1.275))</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Accessibility / Diagnostics checklist -->
+    <section class="pp-card" aria-labelledby="checklist-heading">
+      <h2 class="pp-card-title" id="checklist-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--secondary);"><polyline points="9 11 12 14 22 4"></polyline><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg>
+        Accessibility &amp; Specification Guidelines
+      </h2>
+      <p class="pp-card-desc">
+        How this tooltip pattern adheres to modern accessibility rules without script injection.
+      </p>
+
+      <ul class="pp-check-list">
+        <li class="pp-check-item">
+          <div class="pp-check-bullet ok">&checkmark;</div>
+          <div>
+            <strong>Visibility Step Timing:</strong>
+            Using <code>visibility: hidden</code> combined with <code>step-end</code> transition removes the hidden tooltip from the screen readers and accessibility focus tree, preventing ghost hitches.
+          </div>
+        </li>
+        <li class="pp-check-item">
+          <div class="pp-check-bullet ok">&checkmark;</div>
+          <div>
+            <strong>Focus Within Trigger:</strong>
+            Hover events only catch mouse indicators. By declaring <code>:focus-within</code> selectors, users navigating via keyboard (using Tab commands) automatically toggle tooltip visibility.
+          </div>
+        </li>
+        <li class="pp-check-item">
+          <div class="pp-check-bullet ok">&checkmark;</div>
+          <div>
+            <strong>Pointer Events Inhibited:</strong>
+            Declaring <code>pointer-events: none</code> stops the tooltip box from trapping cursor clicks when stacked directly over input elements.
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Section: Animation Quiz -->
+    <section class="pp-card" aria-labelledby="quiz-heading">
+      <h2 class="pp-card-title" id="quiz-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent);"><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line><circle cx="12" cy="12" r="10"></circle></svg>
+        Layout Literacy Quiz
+      </h2>
+      <p class="pp-card-desc">
+        Test your knowledge of keyboard focus and transition layers.
+      </p>
+
+      <div class="pp-quiz-card">
+        <div class="pp-quiz-question" id="quizQuestion">Loading question...</div>
+        <div class="pp-quiz-options" id="quizOptions"></div>
+        <div class="pp-quiz-feedback" id="quizFeedback"></div>
+        <button type="button" class="pp-quiz-next" id="quizNextBtn">Next Question</button>
+      </div>
+    </section>
+
+    <!-- Section: Code Snippets -->
+    <section class="pp-card" id="snippets" aria-labelledby="snippets-heading">
+      <h2 class="pp-card-title" id="snippets-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Production Snippets
+      </h2>
+      <p class="pp-card-desc">
+        Integrate this pattern into your templates using these pre-compiled codes.
+      </p>
+
+      <div class="pp-snippets">
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">HTML Structure</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetHtml">Copy HTML</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetHtml">&lt;!-- Keyboard friendly: add tabindex to trigger --&gt;
+&lt;div class="ease-tooltip-trigger" tabindex="0"&gt;
+  &lt;button&gt;Tactile CTA&lt;/button&gt;
+  &lt;div class="ease-tooltip ease-tooltip-top"&gt;
+    Tooltip Content
+  &lt;/div&gt;
+&lt;/div&gt;</pre>
+        </div>
+
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">Custom Properties overrides</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetCss">Copy CSS</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetCss">/* Override variables on container level */
+.custom-section {
+  --tooltip-speed: 350ms;
+  --tooltip-scale: 0.85;
+  --tooltip-bg: #818cf8;
+}</pre>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Toast Notification -->
+  <div class="pp-toast" id="copyToast" role="status" aria-live="polite">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--success);"><polyline points="20 6 9 17 4 12"></polyline></svg>
+    Snippet copied to clipboard!
+  </div>
+
+  <footer class="pp-footer">
+    <div class="pp-container">
+      <div class="pp-footer-links">
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+        <span>&bull;</span>
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46235" target="_blank" rel="noopener noreferrer">Issue Ticket</a>
+      </div>
+      <p>&copy; 2026 EaseMotion CSS. Neumorphic feedback guidelines.</p>
+    </div>
+  </footer>
+
+  <!-- Interactivity Scripts -->
+  <script>
+    (function() {
+      "use strict";
+
+      // --- Dark Theme Toggle ---
+      const themeToggleBtn = document.getElementById('themeToggleBtn');
+      const sunIcon = document.getElementById('sunIcon');
+      const moonIcon = document.getElementById('moonIcon');
+      const rootHtml = document.documentElement;
+
+      const savedTheme = localStorage.getItem('pp-theme') || 'light';
+      rootHtml.setAttribute('data-theme', savedTheme);
+      updateThemeIcons(savedTheme);
+
+      themeToggleBtn.addEventListener('click', () => {
+        const currentTheme = rootHtml.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        rootHtml.setAttribute('data-theme', newTheme);
+        localStorage.setItem('pp-theme', newTheme);
+        updateThemeIcons(newTheme);
+      });
+
+      function updateThemeIcons(theme) {
+        if (theme === 'dark') {
+          sunIcon.style.display = 'block';
+          moonIcon.style.display = 'none';
+        } else {
+          sunIcon.style.display = 'none';
+          moonIcon.style.display = 'block';
+        }
+      }
+
+      // --- Dynamic Controls System ---
+      const posSelect = document.getElementById('posSelect');
+      const speedSlider = document.getElementById('speedSlider');
+      const speedVal = document.getElementById('speedVal');
+      const scaleSlider = document.getElementById('scaleSlider');
+      const scaleVal = document.getElementById('scaleVal');
+      const easingSelect = document.getElementById('easingSelect');
+      
+      const targetTooltip = document.getElementById('targetTooltip');
+      const playgroundStage = document.getElementById('playgroundStage');
+
+      const easingMap = {
+        backOut: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+        linear: "cubic-bezier(0, 0, 1, 1)",
+        smooth: "cubic-bezier(0.4, 0, 0.2, 1)",
+        bounce: "cubic-bezier(0.175, 0.885, 0.32, 1.275)"
+      };
+
+      function updateParameters() {
+        const direction = posSelect.value;
+        const speed = speedSlider.value;
+        const scale = scaleSlider.value / 100;
+        const easingKey = easingSelect.value;
+
+        // Update UI displays
+        speedVal.textContent = `${speed}ms`;
+        scaleVal.textContent = scale;
+
+        // Apply classes on tooltip
+        targetTooltip.className = `ease-tooltip ease-tooltip-${direction}`;
+
+        // Apply css properties on stage wrapper
+        playgroundStage.style.setProperty('--tooltip-speed', `${speed}ms`);
+        playgroundStage.style.setProperty('--tooltip-scale', scale);
+        playgroundStage.style.setProperty('--tooltip-easing', easingMap[easingKey]);
+      }
+
+      posSelect.addEventListener('change', updateParameters);
+      speedSlider.addEventListener('input', updateParameters);
+      scaleSlider.addEventListener('input', updateParameters);
+      easingSelect.addEventListener('change', updateParameters);
+
+      // Default init
+      updateParameters();
+
+      // --- Accessibility Literacy Quiz ---
+      const quizQuestions = [
+        {
+          question: "Why is a transition on the visibility property (using step-start/step-end) critical for tooltips?",
+          options: [
+            "It speeds up GPU shaders rendering background text",
+            "It ensures the element remains hidden and unclickable when opacity is 0",
+            "It enables compatibility with native scroll events",
+            "It aligns borders under custom themes"
+          ],
+          correct: 1,
+          explanation: "Setting visibility: hidden on unhover disables element mouse pointer-events and hides focus accessibility markers from screen readers."
+        },
+        {
+          question: "Which CSS pseudo-class selector enables tooltips to render when users navigate with tab controls?",
+          options: [
+            ":hover",
+            ":focus-within",
+            ":active",
+            ":invalid"
+          ],
+          correct: 1,
+          explanation: "Declaring :focus-within ensures that when elements inside a container receive focus, tooltip transitions execute correctly."
+        }
+      ];
+
+      let quizIdx = 0;
+      const quizQuestion = document.getElementById('quizQuestion');
+      const quizOptions = document.getElementById('quizOptions');
+      const quizFeedback = document.getElementById('quizFeedback');
+      const quizNextBtn = document.getElementById('quizNextBtn');
+
+      function loadQuiz() {
+        const data = quizQuestions[quizIdx];
+        quizQuestion.textContent = `Question ${quizIdx + 1}: ${data.question}`;
+        quizOptions.innerHTML = '';
+        quizFeedback.style.display = 'none';
+        quizFeedback.className = 'pp-quiz-feedback';
+        quizNextBtn.style.display = 'none';
+
+        data.options.forEach((opt, idx) => {
+          const optBtn = document.createElement('button');
+          optBtn.type = 'button';
+          optBtn.className = 'pp-quiz-option';
+          optBtn.innerHTML = `<span class="pp-option-index">${String.fromCharCode(65 + idx)}</span> <span>${opt}</span>`;
+          optBtn.addEventListener('click', () => selectQuiz(idx));
+          quizOptions.appendChild(optBtn);
+        });
+      }
+
+      function selectQuiz(selIdx) {
+        const data = quizQuestions[quizIdx];
+        const buttons = quizOptions.querySelectorAll('.pp-quiz-option');
+        buttons.forEach(btn => btn.disabled = true);
+
+        if (selIdx === data.correct) {
+          buttons[selIdx].classList.add('correct');
+          quizFeedback.textContent = `Correct! ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback success';
+        } else {
+          buttons[selIdx].classList.add('incorrect');
+          buttons[data.correct].classList.add('correct');
+          quizFeedback.textContent = `Incorrect. ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback error';
+        }
+        quizNextBtn.style.display = 'inline-block';
+      }
+
+      quizNextBtn.addEventListener('click', () => {
+        quizIdx++;
+        if (quizIdx < quizQuestions.length) {
+          loadQuiz();
+        } else {
+          quizQuestion.textContent = 'Diagnostic Complete!';
+          quizOptions.innerHTML = '<p class="pp-text-center pp-mt-4">Excellent! You are now fully literate in accessible transition designs.</p>';
+          quizFeedback.style.display = 'none';
+          quizNextBtn.style.display = 'none';
+        }
+      });
+
+      loadQuiz();
+
+      // --- Snippet Copy System ---
+      const copyBtns = document.querySelectorAll('.pp-copy-btn');
+      const toastEl = document.getElementById('copyToast');
+
+      copyBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const preId = btn.dataset.codeId;
+          const preEl = document.getElementById(preId);
+          if (!preEl) return;
+
+          const text = preEl.textContent.trim();
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(() => showToast(btn));
+          } else {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            showToast(btn);
+          }
+        });
+      });
+
+      function showToast(btn) {
+        btn.classList.add('copied');
+        btn.textContent = 'Copied!';
+        toastEl.classList.add('show');
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.textContent = btn.dataset.codeId === 'snippetHtml' ? 'Copy HTML' : 'Copy CSS';
+          toastEl.classList.remove('show');
+        }, 2000);
+      }
+
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-neumorphic-pp/style.css
+++ b/submissions/examples/ease-tooltip-neumorphic-pp/style.css
@@ -1,0 +1,723 @@
+/* ==========================================================================
+   EaseMotion CSS - Neumorphic Tooltip Lab
+   Component: Pure CSS Fade-Out Tooltip
+   File: style.css
+   Author: Pratyush Panda (pp)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design System & CSS Variables
+   -------------------------------------------------------------------------- */
+:root {
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+
+  /* Neumorphic Baseline - Light Mode */
+  --bg-app: #e2e8f0;
+  --bg-neumorphic: #e2e8f0;
+  --border-color: rgba(255, 255, 255, 0.4);
+  
+  /* Shadows: Light Mode */
+  --shadow-out-light: -6px -6px 12px rgba(255, 255, 255, 0.95);
+  --shadow-out-dark: 6px 6px 12px rgba(163, 177, 198, 0.7);
+  --shadow-in-light: inset -4px -4px 8px rgba(255, 255, 255, 0.9);
+  --shadow-in-dark: inset 4px 4px 8px rgba(163, 177, 198, 0.75);
+
+  --text-primary: #2d3748;
+  --text-secondary: #4a5568;
+  --text-muted: #718096;
+  
+  --primary: #6366f1;
+  --primary-hover: #4f46e5;
+  --primary-glow: rgba(99, 102, 241, 0.12);
+  
+  --secondary: #0ea5e9;
+  --accent: #ec4899;
+  
+  --success: #10b981;
+  --success-bg: #d1fae5;
+  --error: #ef4444;
+  --error-bg: #fee2e2;
+
+  /* Custom Parameters */
+  --tooltip-speed: 250ms;
+  --tooltip-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* backOut */
+  --tooltip-scale: 0.92;
+  --tooltip-bg: #1e293b;
+  --tooltip-color: #f8fafc;
+
+  /* Border Radii */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --radius-full: 9999px;
+  
+  --transition-normal: 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Dark Theme Variables Override */
+[data-theme="dark"] {
+  --bg-app: #121824;
+  --bg-neumorphic: #121824;
+  --border-color: rgba(255, 255, 255, 0.05);
+
+  /* Shadows: Dark Mode */
+  --shadow-out-light: -6px -6px 12px rgba(255, 255, 255, 0.04);
+  --shadow-out-dark: 6px 6px 12px rgba(0, 0, 0, 0.5);
+  --shadow-in-light: inset -4px -4px 8px rgba(255, 255, 255, 0.03);
+  --shadow-in-dark: inset 4px 4px 8px rgba(0, 0, 0, 0.65);
+  
+  --text-primary: #cbd5e1;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  
+  --primary: #818cf8;
+  --primary-hover: #6366f1;
+  --primary-glow: rgba(129, 140, 248, 0.25);
+  
+  --secondary: #38bdf8;
+  --accent: #f472b6;
+  
+  --tooltip-bg: #f8fafc;
+  --tooltip-color: #0f172a;
+}
+
+/* --------------------------------------------------------------------------
+   2. Reset & Core Base Styles
+   -------------------------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background-color: var(--bg-app);
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg-app);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--text-muted);
+  border-radius: 5px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+code, pre {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  border-radius: 4px;
+}
+
+code {
+  background-color: rgba(0,0,0,0.05);
+  padding: 0.2em 0.4em;
+  color: var(--accent);
+}
+[data-theme="dark"] code {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+/* Layout container */
+.pp-container {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Header & Hero Section
+   -------------------------------------------------------------------------- */
+.pp-header {
+  padding: 3rem 0 2rem;
+  text-align: center;
+}
+
+.pp-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+  display: inline-block;
+  background: var(--primary-glow);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-full);
+}
+
+.pp-header h1 {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+  color: var(--text-primary);
+}
+
+.pp-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.15rem);
+  max-width: 68ch;
+  margin: 0 auto 1.5rem;
+}
+
+.pp-meta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-neumorphic);
+  border: 1px solid var(--border-color);
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+}
+
+.pp-meta-badge span {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* Theme Toggle Widget */
+.pp-theme-toggle {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000;
+  background: var(--bg-neumorphic);
+  border: 1px solid var(--border-color);
+  padding: 0.75rem;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition-normal);
+}
+.pp-theme-toggle:hover {
+  transform: scale(1.1);
+}
+.pp-theme-toggle svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: var(--text-secondary);
+}
+
+/* --------------------------------------------------------------------------
+   4. Neumorphic Cards & Layout
+   -------------------------------------------------------------------------- */
+.pp-card {
+  background: var(--bg-neumorphic);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+  position: relative;
+  overflow: hidden;
+}
+
+.pp-card-title {
+  font-size: 1.35rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pp-card-desc {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Neumorphic UI Component Styles */
+.pp-neu-btn {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.85rem 1.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--bg-neumorphic);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  outline: none;
+}
+
+.pp-neu-btn:hover {
+  color: var(--primary);
+}
+
+.pp-neu-btn:active,
+.pp-neu-btn.active {
+  box-shadow: var(--shadow-in-light), var(--shadow-in-dark);
+  transform: scale(0.98);
+}
+
+/* --------------------------------------------------------------------------
+   5. Pure CSS Fade-Out Tooltip Engine
+   -------------------------------------------------------------------------- */
+.ease-tooltip-trigger {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-tooltip {
+  position: absolute;
+  z-index: 100;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-color);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 500;
+  white-space: nowrap;
+  padding: 0.5rem 0.85rem;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
+  
+  /* Initial transition state: hidden */
+  opacity: 0;
+  visibility: hidden;
+  
+  /* Smooth Fade-Out transitions */
+  transition: opacity var(--tooltip-speed) var(--tooltip-easing),
+              transform var(--tooltip-speed) var(--tooltip-easing),
+              visibility var(--tooltip-speed) step-end;
+}
+
+/* CSS Triangles for Tooltip positions */
+.ease-tooltip::after {
+  content: '';
+  position: absolute;
+  border: 5px solid transparent;
+}
+
+/* --- Position: Top --- */
+.ease-tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(8px) scale(var(--tooltip-scale));
+  margin-bottom: 8px;
+}
+.ease-tooltip-top::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tooltip-bg);
+}
+
+/* --- Position: Bottom --- */
+.ease-tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-8px) scale(var(--tooltip-scale));
+  margin-top: 8px;
+}
+.ease-tooltip-bottom::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tooltip-bg);
+}
+
+/* --- Position: Left --- */
+.ease-tooltip-left {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%) translateX(8px) scale(var(--tooltip-scale));
+  margin-right: 8px;
+}
+.ease-tooltip-left::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tooltip-bg);
+}
+
+/* --- Position: Right --- */
+.ease-tooltip-right {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%) translateX(-8px) scale(var(--tooltip-scale));
+  margin-left: 8px;
+}
+.ease-tooltip-right::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tooltip-bg);
+}
+
+/* --- Active triggers: hover and focus-within --- */
+.ease-tooltip-trigger:hover .ease-tooltip,
+.ease-tooltip-trigger:focus-within .ease-tooltip {
+  opacity: 1;
+  visibility: visible;
+  
+  /* Reset transform positioning */
+  transition: opacity var(--tooltip-speed) var(--tooltip-easing),
+              transform var(--tooltip-speed) var(--tooltip-easing),
+              visibility 0s step-start;
+}
+
+.ease-tooltip-trigger:hover .ease-tooltip-top,
+.ease-tooltip-trigger:focus-within .ease-tooltip-top {
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+.ease-tooltip-trigger:hover .ease-tooltip-bottom,
+.ease-tooltip-trigger:focus-within .ease-tooltip-bottom {
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+.ease-tooltip-trigger:hover .ease-tooltip-left,
+.ease-tooltip-trigger:focus-within .ease-tooltip-left {
+  transform: translateY(-50%) translateX(0) scale(1);
+}
+
+.ease-tooltip-trigger:hover .ease-tooltip-right,
+.ease-tooltip-trigger:focus-within .ease-tooltip-right {
+  transform: translateY(-50%) translateX(0) scale(1);
+}
+
+/* --------------------------------------------------------------------------
+   6. Interactive Playground Styles
+   -------------------------------------------------------------------------- */
+.pp-playground-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .pp-playground-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-stage {
+  border-radius: var(--radius-lg);
+  background: var(--bg-neumorphic);
+  box-shadow: var(--shadow-in-light), var(--shadow-in-dark);
+  padding: 3rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  min-height: 300px;
+}
+
+.pp-controls-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.pp-control-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pp-control-row label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.pp-state-select {
+  padding: 0.6rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-neumorphic);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+  outline: none;
+}
+
+/* Range input styled slider */
+.pp-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.pp-slider {
+  flex-grow: 1;
+  height: 6px;
+  background: var(--bg-neumorphic);
+  border-radius: 3px;
+  box-shadow: var(--shadow-in-light), var(--shadow-in-dark);
+  outline: none;
+}
+.pp-slider-val {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  min-width: 50px;
+  text-align: right;
+}
+
+/* --------------------------------------------------------------------------
+   7. Interactive Quiz System
+   -------------------------------------------------------------------------- */
+.pp-quiz-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  background: var(--bg-neumorphic);
+  margin-top: 1rem;
+  box-shadow: var(--shadow-in-light), var(--shadow-in-dark);
+}
+
+.pp-quiz-question {
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+  color: var(--text-primary);
+}
+
+.pp-quiz-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.pp-quiz-option {
+  background: var(--bg-neumorphic);
+  border: 1px solid var(--border-color);
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+}
+.pp-quiz-option:hover {
+  color: var(--primary);
+}
+.pp-quiz-option.correct {
+  border-color: var(--success);
+  background-color: var(--success-bg);
+  color: var(--success);
+  box-shadow: none;
+}
+.pp-quiz-option.incorrect {
+  border-color: var(--error);
+  background-color: var(--error-bg);
+  color: var(--error);
+  box-shadow: none;
+}
+
+.pp-option-index {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-neumorphic);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+.pp-quiz-option.correct .pp-option-index {
+  background: var(--success);
+  color: white;
+  box-shadow: none;
+  border-color: var(--success);
+}
+.pp-quiz-option.incorrect .pp-option-index {
+  background: var(--error);
+  color: white;
+  box-shadow: none;
+  border-color: var(--error);
+}
+
+.pp-quiz-feedback {
+  font-size: 0.88rem;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  margin-top: 1rem;
+  display: none;
+}
+.pp-quiz-feedback.success {
+  background: var(--success-bg);
+  color: var(--success);
+  border: 1px solid var(--success);
+  display: block;
+}
+.pp-quiz-feedback.error {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error);
+  display: block;
+}
+
+.pp-quiz-next {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+}
+.pp-quiz-next:hover {
+  background: var(--primary-hover);
+}
+
+/* --------------------------------------------------------------------------
+   8. Code Snippets & Copy System
+   -------------------------------------------------------------------------- */
+.pp-snippets {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-snippets {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-snippet-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-neumorphic);
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.pp-snippet-header {
+  padding: 0.75rem 1rem;
+  background: rgba(0,0,0,0.03);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pp-snippet-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.pp-snippet-pre {
+  margin: 0;
+  padding: 1.25rem 1rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.pp-copy-btn {
+  background: var(--bg-neumorphic);
+  border: 1px solid var(--border-color);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-out-light), var(--shadow-out-dark);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.pp-copy-btn:hover {
+  color: var(--primary);
+}
+.pp-copy-btn.copied {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+  box-shadow: none;
+}
+
+.pp-toast {
+  position: fixed;
+  bottom: 2.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(100px);
+  background: #1e293b;
+  color: #f8fafc;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-xl);
+  opacity: 0;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.2s ease;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+[data-theme="dark"] .pp-toast {
+  background: #f8fafc;
+  color: #0f172a;
+}
+.pp-toast.show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+/* --------------------------------------------------------------------------
+   9. Footer Section
+   -------------------------------------------------------------------------- */
+.pp-footer {
+  margin-top: 4rem;
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.pp-footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
- Closes #46235
- Adds an interactive neumorphic tooltip lab inside `submissions/examples/ease-tooltip-neumorphic-pp/` detailing pure CSS fade-out animation patterns.
- Includes custom property overrides via CSS custom variables, position orientation selectors, accessibility guidelines, and an interactive quiz.
- Fully self-contained and responsive, with support for local light/dark mode toggling.