### PR TITLE
Add scroll-progress-bar component submission

### DIFF
--- a/submissions/examples/scroll-progress-bar/README.md
+++ b/submissions/examples/scroll-progress-bar/README.md
@@ -1,0 +1,13 @@
+# Scroll Progress Bar
+
+1. **What does this do?**
+   A thin bar fixed to the top of the page that fills horizontally as the user scrolls down, showing how far they are through the page.
+
+2. **How is it used?**
+   Add a fixed div and toggle its width via a scroll listener:
+```html
+   <div class="scroll-progress-bar" id="progress"></div>
+```
+
+3. **Why is it useful?**
+   It gives readers a clear, glanceable sense of progress on long pages (articles, docs), fitting EaseMotion's animation-first, human-readable philosophy — the class name says exactly what it does.

--- a/submissions/examples/scroll-progress-bar/demo.html
+++ b/submissions/examples/scroll-progress-bar/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Scroll Progress Bar Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scroll-progress-bar" id="progress"></div>
+
+  <div style="height: 2000px; padding: 2rem; font-family: sans-serif;">
+    <h1>Scroll down to see the progress bar fill</h1>
+    <p>Keep scrolling...</p>
+  </div>
+
+  <script>
+    window.addEventListener('scroll', () => {
+      const scrollTop = document.documentElement.scrollTop;
+      const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      const percent = (scrollTop / scrollHeight) * 100;
+      document.getElementById('progress').style.width = percent + '%';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/scroll-progress-bar/style.css
+++ b/submissions/examples/scroll-progress-bar/style.css
@@ -1,0 +1,10 @@
+.scroll-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 4px;
+  width: 0%;
+  background: #f97316;
+  z-index: 9999;
+  transition: width 0.1s linear;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new component submission: a scroll progress bar that fills horizontally across the top of the page as the user scrolls, giving a visual indicator of reading progress. Closes #48206.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/scroll-progress-bar/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A thin fixed bar at the top of the page that fills from 0% to 100% width as the user scrolls down, showing reading/scroll progress.

**How does a developer use it?**

```html
<div class="scroll-progress-bar" id="progress"></div>
```

The width is updated via a scroll event listener (see `demo.html`) that calculates scroll percentage and applies it as the bar's width.

**Why does it fit EaseMotion CSS?**
It's a small, self-contained, purely visual/animated utility — a single class that does exactly what its name says, no configuration needed. Fits the human-readable, animation-first, zero-dependency philosophy directly.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

Kept the CSS minimal and un-prefixed per the submission rules — happy to adjust colors/timing/naming however fits the framework's design tokens.