### PR TITLE
fix(docs): fix broken Benchmarks link in sidebar

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,43 @@
+# Benchmarks
+
+Performance benchmarks for EaseMotion CSS, measured against comparable animation libraries.
+
+## Running Locally
+
+```bash
+# Bundle size (no extra deps)
+node benchmarks/bundle-size.mjs
+
+# FPS benchmark (requires Puppeteer)
+npm install --save-dev puppeteer
+node benchmarks/fps-test.mjs
+```
+
+## CI
+
+Benchmarks run automatically on every release tag (`v*`) via `.github/workflows/benchmarks.yml`.
+Results are committed back to `benchmarks/results/latest.json`.
+
+## Methodology
+
+### Bundle Size
+- Measured as **gzip level 9** compressed size of the minified distribution file.
+- EaseMotion CSS is compared against Animate.css and Framer Motion's JS bundle.
+- Lower is better.
+
+### FPS
+- A Puppeteer headless Chrome session renders **100 simultaneously animated elements**.
+- FPS is sampled every 100ms for 3 seconds using the Chrome DevTools Protocol.
+- Higher is better.
+
+## Latest Results
+
+See [results/latest.json](./results/latest.json) for the most recent benchmark run.
+
+## Libraries Compared
+
+| Library | Version tested | Notes |
+|---------|---------------|-------|
+| **EaseMotion CSS** | 1.2.0 | Pure CSS, zero JS |
+| Animate.css | 4.1.1 | Pure CSS |
+| motion (Framer) | latest | JS-based |

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,7 +239,7 @@
           <div class="sidebar-group-label">Performance</div>
           <ul class="sidebar-nav">
             <li><a href="PERFORMANCE.md">Performance Guide</a></li>
-            <li><a href="../benchmarks/README.md">Benchmarks</a></li>
+            <li><a href="BENCHMARKS.md">Benchmarks</a></li>
           </ul>
         </div>
         <div class="sidebar-group">


### PR DESCRIPTION
## Pull Request Description

This PR fixes a broken "Benchmarks" link in the docs sidebar (issue #48534). 
The link used a relative path that GitHub Pages couldn't reach, causing a 404. 
Fixed by copying the benchmarks content into docs/benchmarks.md and updating 
the link to point to it directly.

---

## Type of Change

- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission


---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

N/A — this is a bug fix, not a new feature/component.
---

## Demo

N/A — fix is visible directly on the live docs page once merged.

Before (404):
<img width="1920" height="984" alt="Screenshot" src="https://github.com/user-attachments/assets/14e07d6e-3364-44be-b226-79d5bbac7300" />



After (working):
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/015ddec5-f75d-436f-b87e-56002b83e6da" />


---

## Browser Testing

- [x] Chrome
---

## Notes for Maintainer

-This PR doesn't fit the submissions/ template since it's a direct fix to 
docs/index.html and adds docs/benchmarks.md — not a new component or 
animation. I confirmed via git history that direct docs/ edits have been 
merged before from other contributors (e.g. commits by Dharm3112, 
toufiq00007). Happy to restructure this differently if you'd prefer it 
routed through submissions/ instead — just let me know.

---