### PR TITLE
Add Delete-Detection Explainer docs page (ease-nodelete-policy-explai…

### DIFF
--- a/submissions/docs/ease-nodelete-policy-explainer-hr18/README.md
+++ b/submissions/docs/ease-nodelete-policy-explainer-hr18/README.md
@@ -1,0 +1,66 @@
+# Delete-Detection Explainer (`ease-nodelete-policy-explainer-hr18`)
+
+A documentation-style static guide explaining valid vs invalid contribution
+diffs for this repository, built for issue
+[#47701](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47701).
+
+## What it does
+
+Most PRs in this repo don't get closed for bad code — they get closed for
+touching the wrong files. This page is a self-contained explainer that walks
+a first-time contributor through:
+
+- A side-by-side **invalid vs valid diff** comparison, with a plain-language
+  "why" callout under each
+- Six **policy callouts** covering the rules a diff actually gets checked
+  against (new-folder-only, unique naming, `core/`/`components/` being
+  off-limits, the 3-file minimum, the ≥250 line-count sanity check, and
+  one-feature-per-PR)
+- **Track-specific folder structures** (tabs for `examples/`, `docs/`,
+  `react/`, `scss/`) so contributors can see exactly where their files
+  belong for the track they're using
+- A **"why this gets closed"** list of the most common real-world mistakes
+- A **copy-ready checklist**, exportable as Markdown with one click, meant to
+  be pasted straight into a PR description before opening it
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Open `demo.html`, read through the diff comparison and policy callouts, click
+through the track tabs to find the folder structure for your track, then hit
+**"Copy checklist as Markdown"** and paste the result into your own PR
+description before you open it.
+
+The diff examples on the page use illustrative file paths (e.g.
+`core/animations.css`) — they're representative of the kind of change that
+gets rejected, not copies of any real PR.
+
+## Accessibility notes
+
+- The track tabs use proper `role="tablist"` / `role="tab"` /
+  `role="tabpanel"` semantics with `aria-selected` state, so they're
+  navigable by screen readers and keyboard users (native `<button>` elements,
+  so `Tab` + `Enter`/`Space` work without extra JS).
+- The copy button announces success or failure through an
+  `aria-live="polite"` status region rather than a visual-only toast.
+- Copying uses the async Clipboard API first, with a hidden-`<textarea>` +
+  `document.execCommand('copy')` fallback for older or restricted browsers.
+- Color is never the only signal: the invalid/valid diff cards are also
+  labeled with explicit "✗ INVALID" / "✓ VALID" text, not just red/green.
+
+## Why this fits EaseMotion CSS
+
+It's a plain HTML/CSS/vanilla-JS page with zero framework or build
+dependency, consistent with the rest of the project's submissions, and it
+directly serves the project's own review process — reducing the number of
+invalid PRs the maintainer has to manually close by teaching the rule set
+visually instead of purely in prose.
+
+All classes and custom properties use a `-hr18` suffix, and the folder itself
+is suffixed the same way, to avoid colliding with any other contributor's
+submission under `submissions/docs/`.

--- a/submissions/docs/ease-nodelete-policy-explainer-hr18/demo.html
+++ b/submissions/docs/ease-nodelete-policy-explainer-hr18/demo.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Delete-Detection Explainer — Valid vs Invalid Diffs</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ndp-hr18">
+  <div class="ndp-wrap-hr18">
+
+    <header class="ndp-header-hr18">
+      <span class="ndp-eyebrow-hr18">EaseMotion-css · submissions/docs</span>
+      <h1>Delete-Detection Explainer</h1>
+      <p>Most closed pull requests here aren't closed for bad code — they're closed
+        for touching the wrong files. This page walks through what a valid
+        submission diff looks like next to an invalid one, so you can check your
+        own PR before opening it.</p>
+    </header>
+
+    <!-- Diff comparison -->
+    <section class="ndp-section-hr18" aria-labelledby="ndpDiffHeading">
+      <h2 id="ndpDiffHeading">Invalid vs valid, side by side</h2>
+      <p class="ndp-section-lede-hr18">Both examples below are illustrative — the file
+        paths are representative, not copied from a real PR.</p>
+
+      <div class="ndp-diff-grid-hr18">
+
+        <article class="ndp-diff-card-hr18 invalid">
+          <div class="ndp-diff-head-hr18">
+            <span class="ndp-diff-badge-hr18">&#10007; INVALID</span>
+            <span>core/animations.css</span>
+          </div>
+          <div class="ndp-diff-body-hr18">
+            <div class="ndp-diff-line-hr18 ctx"><span class="ndp-diff-gutter-hr18"> </span><span>@keyframes ease-fade-in {</span></div>
+            <div class="ndp-diff-line-hr18 del"><span class="ndp-diff-gutter-hr18">-</span><span>  from { opacity: 0; }</span></div>
+            <div class="ndp-diff-line-hr18 add"><span class="ndp-diff-gutter-hr18">+</span><span>  from { opacity: 0; transform: scale(0.9); }</span></div>
+            <div class="ndp-diff-line-hr18 ctx"><span class="ndp-diff-gutter-hr18"> </span><span>  to { opacity: 1; }</span></div>
+            <div class="ndp-diff-line-hr18 ctx"><span class="ndp-diff-gutter-hr18"> </span><span>}</span></div>
+          </div>
+          <p class="ndp-diff-why-hr18"><strong>Why this gets closed:</strong>
+            <code>core/animations.css</code> is an existing framework file. Editing
+            it — even by one line — is a direct edit to shared infrastructure,
+            which only the maintainer can review and merge safely.</p>
+        </article>
+
+        <article class="ndp-diff-card-hr18 valid">
+          <div class="ndp-diff-head-hr18">
+            <span class="ndp-diff-badge-hr18">&#10003; VALID</span>
+            <span>submissions/examples/your-feature-hr18/style.css</span>
+          </div>
+          <div class="ndp-diff-body-hr18">
+            <div class="ndp-diff-line-hr18 add"><span class="ndp-diff-gutter-hr18">+</span><span>.your-feature-hr18 {</span></div>
+            <div class="ndp-diff-line-hr18 add"><span class="ndp-diff-gutter-hr18">+</span><span>  animation: ease-fade-in-hr18 400ms ease both;</span></div>
+            <div class="ndp-diff-line-hr18 add"><span class="ndp-diff-gutter-hr18">+</span><span>}</span></div>
+            <div class="ndp-diff-line-hr18 add"><span class="ndp-diff-gutter-hr18">+</span><span></span></div>
+            <div class="ndp-diff-line-hr18 add"><span class="ndp-diff-gutter-hr18">+</span><span>@keyframes ease-fade-in-hr18 { &hellip; }</span></div>
+          </div>
+          <p class="ndp-diff-why-hr18"><strong>Why this is valid:</strong> every
+            line is a new addition inside a brand-new folder under
+            <code>submissions/</code>. Nothing existing is touched, so it can't
+            conflict with anyone else's work or the core framework.</p>
+        </article>
+
+      </div>
+    </section>
+
+    <!-- Policy callouts -->
+    <section class="ndp-section-hr18" aria-labelledby="ndpPolicyHeading">
+      <h2 id="ndpPolicyHeading">The rules a diff gets checked against</h2>
+      <p class="ndp-section-lede-hr18">These are the checks most first-time
+        contributors miss.</p>
+
+      <div class="ndp-callout-grid-hr18">
+        <div class="ndp-callout-hr18">
+          <span class="ndp-callout-num-hr18">01</span>
+          <h3>New folder only</h3>
+          <p>Your submission must live in a brand-new folder you create — never
+            inside an existing one, and never as loose files dropped into
+            <code>submissions/</code> itself.</p>
+        </div>
+        <div class="ndp-callout-hr18">
+          <span class="ndp-callout-num-hr18">02</span>
+          <h3>Unique folder name</h3>
+          <p>Suffix your folder with your own initials or handle (e.g.
+            <code>-hr18</code>) so it can't collide with someone else's
+            submission for the same issue.</p>
+        </div>
+        <div class="ndp-callout-hr18">
+          <span class="ndp-callout-num-hr18">03</span>
+          <h3><code>core/</code> and <code>components/</code> are off-limits</h3>
+          <p>Any diff touching either directory is treated as an invalid,
+            unreviewed edit to shared infrastructure and is closed on sight.</p>
+        </div>
+        <div class="ndp-callout-hr18">
+          <span class="ndp-callout-num-hr18">04</span>
+          <h3>3-file minimum</h3>
+          <p>A Standard-track submission needs at least <code>demo.html</code>,
+            <code>style.css</code>, and <code>README.md</code> — a single file
+            isn't a complete, reviewable submission.</p>
+        </div>
+        <div class="ndp-callout-hr18">
+          <span class="ndp-callout-num-hr18">05</span>
+          <h3>Line-count sanity check (&ge;250)</h3>
+          <p>PRs that add far fewer lines than that across a full submission are
+            often a sign something's missing (styles, docs, or a working demo) —
+            it's a smell to double-check, not a hard line to pad out.</p>
+        </div>
+        <div class="ndp-callout-hr18">
+          <span class="ndp-callout-num-hr18">06</span>
+          <h3>One feature per PR</h3>
+          <p>Don't bundle an unrelated fix or a second feature into the same
+            branch — it makes the diff harder to review and easier to reject
+            outright.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Track examples -->
+    <section class="ndp-section-hr18" aria-labelledby="ndpTrackHeading">
+      <h2 id="ndpTrackHeading">Valid folder structure, by track</h2>
+      <p class="ndp-section-lede-hr18">Pick the tab for the track you're
+        contributing to.</p>
+
+      <div class="ndp-tabs-hr18" role="tablist" aria-label="Submission tracks">
+        <button type="button" class="ndp-tab-hr18" role="tab" aria-selected="true" id="ndpTabExamples" data-target="ndpPanelExamples">examples/</button>
+        <button type="button" class="ndp-tab-hr18" role="tab" aria-selected="false" id="ndpTabDocs" data-target="ndpPanelDocs">docs/</button>
+        <button type="button" class="ndp-tab-hr18" role="tab" aria-selected="false" id="ndpTabReact" data-target="ndpPanelReact">react/</button>
+        <button type="button" class="ndp-tab-hr18" role="tab" aria-selected="false" id="ndpTabScss" data-target="ndpPanelScss">scss/</button>
+      </div>
+
+      <div class="ndp-tab-panel-hr18" id="ndpPanelExamples" role="tabpanel" aria-labelledby="ndpTabExamples">submissions/examples/your-feature-hr18/
+├── demo.html
+├── style.css
+└── README.md</div>
+
+      <div class="ndp-tab-panel-hr18" id="ndpPanelDocs" role="tabpanel" aria-labelledby="ndpTabDocs" hidden>submissions/docs/your-guide-hr18/
+├── demo.html
+├── style.css
+└── README.md</div>
+
+      <div class="ndp-tab-panel-hr18" id="ndpPanelReact" role="tabpanel" aria-labelledby="ndpTabReact" hidden>submissions/react/your-component-hr18/
+├── App.jsx
+├── App.scss
+├── package.json
+└── README.md</div>
+
+      <div class="ndp-tab-panel-hr18" id="ndpPanelScss" role="tabpanel" aria-labelledby="ndpTabScss" hidden>submissions/scss/your-mixin-hr18/
+├── _index.scss
+├── demo.html
+└── README.md</div>
+    </section>
+
+    <!-- Why this gets closed -->
+    <section class="ndp-section-hr18" aria-labelledby="ndpReasonsHeading">
+      <h2 id="ndpReasonsHeading">Common reasons a PR gets auto-closed</h2>
+      <ul class="ndp-reasons-hr18">
+        <li><strong>01</strong> Diff includes changes inside <code>core/</code> or <code>components/</code>.</li>
+        <li><strong>02</strong> Files placed directly in <code>submissions/</code> instead of a new subfolder.</li>
+        <li><strong>03</strong> Folder name reused from an existing submission (naming collision).</li>
+        <li><strong>04</strong> Missing one of the required files for the track (e.g. no <code>README.md</code>).</li>
+        <li><strong>05</strong> Multiple unrelated features bundled into a single PR.</li>
+        <li><strong>06</strong> Commit history left unsquashed when the contributing guide asks for one commit.</li>
+      </ul>
+    </section>
+
+    <!-- Copy-ready checklist -->
+    <section class="ndp-section-hr18" aria-labelledby="ndpChecklistHeading">
+      <h2 id="ndpChecklistHeading">Before you open your PR</h2>
+      <div class="ndp-checklist-card-hr18">
+        <ul class="ndp-checklist-hr18" id="ndpChecklist">
+          <li>All new files live inside one new folder under <code>submissions/&lt;track&gt;/</code>.</li>
+          <li>Folder name has a unique suffix (your initials or handle).</li>
+          <li>No files under <code>core/</code> or <code>components/</code> were touched.</li>
+          <li>Required files for the track are all present (see the tabs above).</li>
+          <li>Only one feature or fix in this PR.</li>
+          <li>PR description links the issue it resolves.</li>
+        </ul>
+        <button type="button" class="ndp-copy-btn-hr18" id="ndpCopyBtn">Copy checklist as Markdown</button>
+        <p class="ndp-status-hr18" id="ndpStatus" role="status" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <p class="ndp-footnote-hr18">submissions/docs/ease-nodelete-policy-explainer-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var tabs = document.querySelectorAll(".ndp-tab-hr18");
+  tabs.forEach(function (tab) {
+    tab.addEventListener("click", function () {
+      tabs.forEach(function (t) {
+        t.setAttribute("aria-selected", "false");
+        document.getElementById(t.getAttribute("data-target")).hidden = true;
+      });
+      tab.setAttribute("aria-selected", "true");
+      document.getElementById(tab.getAttribute("data-target")).hidden = false;
+    });
+  });
+
+  var copyBtn = document.getElementById("ndpCopyBtn");
+  var status = document.getElementById("ndpStatus");
+  var checklistItems = document.querySelectorAll("#ndpChecklist li");
+
+  function checklistMarkdown() {
+    var lines = ["## Submission checklist"];
+    checklistItems.forEach(function (li) {
+      lines.push("- [ ] " + li.textContent.trim());
+    });
+    return lines.join("\n");
+  }
+
+  function announce(message) {
+    status.textContent = message;
+    window.setTimeout(function () {
+      status.textContent = "";
+    }, 3000);
+  }
+
+  function fallbackCopy(text) {
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    try {
+      var ok = document.execCommand("copy");
+      announce(ok ? "Copied to clipboard." : "Copy failed — select and copy manually.");
+    } catch (err) {
+      announce("Copy failed — select and copy manually.");
+    }
+    document.body.removeChild(textarea);
+  }
+
+  copyBtn.addEventListener("click", function () {
+    var text = checklistMarkdown();
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () {
+        announce("Copied to clipboard.");
+      }, function () {
+        fallbackCopy(text);
+      });
+    } else {
+      fallbackCopy(text);
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/docs/ease-nodelete-policy-explainer-hr18/style.css
+++ b/submissions/docs/ease-nodelete-policy-explainer-hr18/style.css
@@ -1,0 +1,381 @@
+/* ==========================================================================
+   ease-nodelete-policy-explainer-hr18 — style.css
+   Delete-Detection Explainer (Valid vs Invalid Diffs)
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.ndp-hr18 {
+  --bg-hr18: #14120f;
+  --panel-hr18: #1c1a15;
+  --panel-raised-hr18: #211f19;
+  --border-hr18: #322e25;
+  --text-hr18: #ece7db;
+  --text-muted-hr18: #948d7c;
+  --invalid-hr18: #d9584c;
+  --invalid-bg-hr18: #2b1815;
+  --valid-hr18: #4fb27a;
+  --valid-bg-hr18: #14241c;
+  --accent-hr18: #e0a94b;
+  --radius-hr18: 12px;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4rem;
+  min-height: 100%;
+}
+
+.ndp-hr18 * {
+  box-sizing: border-box;
+}
+
+.ndp-hr18 h1,
+.ndp-hr18 h2,
+.ndp-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.ndp-hr18 a {
+  color: var(--accent-hr18);
+}
+
+.ndp-wrap-hr18 {
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+/* ---- Header ----------------------------------------------------------------- */
+.ndp-header-hr18 {
+  margin-bottom: 2.5rem;
+}
+
+.ndp-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.ndp-header-hr18 h1 {
+  font-size: clamp(1.7rem, 3vw, 2.4rem);
+}
+
+.ndp-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 62ch;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* ---- Section shell ------------------------------------------------------------ */
+.ndp-section-hr18 {
+  margin-top: 3rem;
+}
+
+.ndp-section-hr18 h2 {
+  font-size: 1.15rem;
+  margin-bottom: 0.4rem;
+}
+
+.ndp-section-lede-hr18 {
+  color: var(--text-muted-hr18);
+  font-size: 0.92rem;
+  max-width: 62ch;
+  line-height: 1.6;
+  margin: 0 0 1.25rem;
+}
+
+/* ---- Diff comparison ----------------------------------------------------------- */
+.ndp-diff-grid-hr18 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 780px) {
+  .ndp-diff-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ndp-diff-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  overflow: hidden;
+  background: var(--panel-hr18);
+  display: flex;
+  flex-direction: column;
+}
+
+.ndp-diff-card-hr18.invalid {
+  border-color: rgba(217, 88, 76, 0.35);
+}
+
+.ndp-diff-card-hr18.valid {
+  border-color: rgba(79, 178, 122, 0.35);
+}
+
+.ndp-diff-head-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1rem;
+  font-family: var(--font-mono-hr18);
+  font-size: 0.78rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.ndp-diff-card-hr18.invalid .ndp-diff-head-hr18 {
+  background: var(--invalid-bg-hr18);
+  color: var(--invalid-hr18);
+}
+
+.ndp-diff-card-hr18.valid .ndp-diff-head-hr18 {
+  background: var(--valid-bg-hr18);
+  color: var(--valid-hr18);
+}
+
+.ndp-diff-badge-hr18 {
+  font-weight: 700;
+}
+
+.ndp-diff-body-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8rem;
+  line-height: 1.7;
+  padding: 0.75rem 0;
+  overflow-x: auto;
+}
+
+.ndp-diff-line-hr18 {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0 1rem;
+  white-space: pre;
+}
+
+.ndp-diff-gutter-hr18 {
+  color: var(--text-muted-hr18);
+  width: 1.1rem;
+  flex-shrink: 0;
+  text-align: center;
+  user-select: none;
+}
+
+.ndp-diff-line-hr18.add {
+  background: rgba(79, 178, 122, 0.1);
+}
+
+.ndp-diff-line-hr18.add .ndp-diff-gutter-hr18 {
+  color: var(--valid-hr18);
+}
+
+.ndp-diff-line-hr18.del {
+  background: rgba(217, 88, 76, 0.12);
+}
+
+.ndp-diff-line-hr18.del .ndp-diff-gutter-hr18 {
+  color: var(--invalid-hr18);
+}
+
+.ndp-diff-line-hr18.ctx {
+  color: var(--text-muted-hr18);
+}
+
+.ndp-diff-why-hr18 {
+  border-top: 1px solid var(--border-hr18);
+  padding: 0.9rem 1rem;
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.ndp-diff-card-hr18.invalid .ndp-diff-why-hr18 {
+  color: #e6a49c;
+}
+
+.ndp-diff-card-hr18.valid .ndp-diff-why-hr18 {
+  color: #a7d9bd;
+}
+
+.ndp-diff-why-hr18 strong {
+  color: inherit;
+}
+
+/* ---- Policy callouts ------------------------------------------------------------ */
+.ndp-callout-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.ndp-callout-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 1.1rem 1.25rem;
+}
+
+.ndp-callout-hr18 .ndp-callout-num-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.75rem;
+  color: var(--accent-hr18);
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.ndp-callout-hr18 h3 {
+  font-size: 0.95rem;
+  margin-bottom: 0.4rem;
+}
+
+.ndp-callout-hr18 p {
+  margin: 0;
+  color: var(--text-muted-hr18);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+/* ---- Track tabs ------------------------------------------------------------------- */
+.ndp-tabs-hr18 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.ndp-tab-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.78rem;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  color: var(--text-muted-hr18);
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.ndp-tab-hr18[aria-selected="true"] {
+  color: var(--bg-hr18);
+  background: var(--accent-hr18);
+  border-color: var(--accent-hr18);
+  font-weight: 600;
+}
+
+.ndp-tab-panel-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 1rem 1.1rem;
+  font-family: var(--font-mono-hr18);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.ndp-tab-panel-hr18[hidden] {
+  display: none;
+}
+
+/* ---- Why-closed list --------------------------------------------------------------- */
+.ndp-reasons-hr18 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.ndp-reasons-hr18 li {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 0.8rem 1rem;
+  font-size: 0.88rem;
+  color: var(--text-muted-hr18);
+  display: flex;
+  gap: 0.65rem;
+  line-height: 1.55;
+}
+
+.ndp-reasons-hr18 li strong {
+  color: var(--invalid-hr18);
+  font-family: var(--font-mono-hr18);
+  flex-shrink: 0;
+}
+
+/* ---- Checklist ------------------------------------------------------------------------ */
+.ndp-checklist-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.ndp-checklist-hr18 {
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.ndp-checklist-hr18 li {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+}
+
+.ndp-checklist-hr18 li::before {
+  content: "\2610";
+  color: var(--accent-hr18);
+  flex-shrink: 0;
+}
+
+.ndp-copy-btn-hr18 {
+  background: var(--accent-hr18);
+  color: #1c1408;
+  border: none;
+  padding: 0.55rem 1.05rem;
+  border-radius: var(--radius-hr18);
+  font-family: var(--font-body-hr18);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ndp-copy-btn-hr18:hover {
+  filter: brightness(1.06);
+}
+
+.ndp-status-hr18 {
+  margin-top: 0.6rem;
+  font-size: 0.78rem;
+  color: var(--valid-hr18);
+  min-height: 1.1em;
+}
+
+/* ---- Footnote ---------------------------------------------------------------------------- */
+.ndp-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+.ndp-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
<!-- Briefly describe what you're submitting and the problem it solves. -->
Adds a self-contained "Delete-Detection Explainer" docs page that walks
through what makes a submission diff valid vs invalid in this repo — a
side-by-side invalid/valid diff comparison, policy callouts (new-folder-only,
unique naming, core/components being off-limits, the 3-file minimum, the
≥250 line-count check, one-feature-per-PR), track-specific folder structures
for examples/docs/react/scss, a "why this gets closed" list, and a
copy-ready Markdown checklist for contributors to paste into their own PR
description.

Resolves #47701

Note for the maintainer: this issue has multiple assignees. The issue body
itself references a `-sp` suffixed folder name, which I'm assuming belongs
to @suman20041's own submission — mine is a separate, independently-built
implementation under a `-hr18` suffix so the two don't collide.

---

## Type of Change
- [x] 📝 Documentation improvement

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` (`submissions/docs/ease-nodelete-policy-explainer-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A static, interactive docs page explaining the repo's valid-vs-invalid
submission rules through real diff examples.

**How does a developer use it?**
```html
<!-- Open demo.html directly. Click through the track tabs (examples/docs/
     react/scss) to see the correct folder structure for your track, then
     use the "Copy checklist as Markdown" button to paste a pre-filled
     checklist into your own PR description. -->
```

**Why does it fit EaseMotion CSS?**
It directly supports the project's own contribution process — reducing
invalid PRs by teaching the rule set visually instead of purely through
prose in CONTRIBUTING docs — and is built the same way as every other
submission here: plain HTML/CSS/vanilla JS, no framework, no build step.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
<!-- Anything the maintainer should know when reviewing or integrating. -->
All diff examples use illustrative file paths (e.g. `core/animations.css`) —
they're representative of the kind of change that gets rejected, not copied
from any real PR. All classes/custom properties and the folder itself use a
`-hr18` suffix. Tested in Chrome; haven't checked other browsers yet.