### PR TITLE
feat: add ease-record-button-red component

### DIFF
--- a/submissions/examples/ease-record-button-red/README.md
+++ b/submissions/examples/ease-record-button-red/README.md
@@ -1,0 +1,40 @@
+﻿# ease-record-button-red
+
+A toggleable record button. Idle state is a neutral gray circle; clicking switches it to a solid red button with a pulsing "live" ring, a morphing dot-to-stop-square icon, a blinking "Recording" label, and an elapsed-time counter. Click again to stop and reset.
+
+## Preview
+
+- Idle: plain gray circular button with a small gray dot.
+- Recording: button turns red, the dot morphs into a small white "stop" square, an animated ring pulses outward continuously, the status label blinks, and a `MM:SS` timer counts up.
+- A `--compact` modifier provides a smaller 48px variant (default is 64px).
+- Fully supports light and dark themes via `[data-theme]`.
+- Respects `prefers-reduced-motion` by disabling the pulse/blink animations.
+
+## Usage
+
+```html
+<button class="ease-record-button-red" type="button" aria-pressed="false">
+  <span class="ease-record-button-red__ring"></span>
+  <span class="ease-record-button-red__dot"></span>
+</button>
+<p class="ease-record-button-red__status">
+  <span class="ease-record-button-red__label">Not recording</span>
+  <span class="ease-record-button-red__timer" aria-hidden="true">00:00</span>
+</p>
+```
+
+Toggle the `is-recording` class (and update `aria-pressed`) via JavaScript on click — see `demo.html` for a complete example that also drives the elapsed-time counter.
+
+Add the `ease-record-button-red--compact` modifier class for a smaller 48px button.
+
+## Files
+
+- `demo.html` — three example buttons (default, compact, and one that starts already recording) with click-to-toggle behavior and a light/dark theme toggle.
+- `style.css` — component styles, using CSS custom properties for full light/dark theme support.
+- `README.md` — this file.
+
+## Accessibility
+
+- The button uses `aria-pressed` to communicate recording state to assistive technology.
+- The ring and dot are purely decorative and do not carry semantic meaning on their own; the status text is the accessible source of truth.
+- All animations (pulse, blink) are disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/ease-record-button-red/demo.html
+++ b/submissions/examples/ease-record-button-red/demo.html
@@ -1,0 +1,118 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Record Button Red</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body data-theme="light">
+
+  <div class="ease-demo-wrapper">
+
+    <h1 class="ease-demo-title">Record Button (Red)</h1>
+    <p class="ease-demo-subtitle">A toggleable record button with a pulsing red "live" state and elapsed timer.</p>
+
+    <div class="ease-demo-grid">
+
+      <!-- Example 1: default size -->
+      <div class="ease-demo-card">
+        <button class="ease-record-button-red" type="button" aria-pressed="false">
+          <span class="ease-record-button-red__ring"></span>
+          <span class="ease-record-button-red__dot"></span>
+        </button>
+        <p class="ease-record-button-red__status">
+          <span class="ease-record-button-red__label">Not recording</span>
+          <span class="ease-record-button-red__timer" aria-hidden="true">00:00</span>
+        </p>
+      </div>
+
+      <!-- Example 2: compact with custom text -->
+      <div class="ease-demo-card">
+        <button class="ease-record-button-red ease-record-button-red--compact" type="button" aria-pressed="false">
+          <span class="ease-record-button-red__ring"></span>
+          <span class="ease-record-button-red__dot"></span>
+        </button>
+        <p class="ease-record-button-red__status">
+          <span class="ease-record-button-red__label">Tap to start</span>
+          <span class="ease-record-button-red__timer" aria-hidden="true">00:00</span>
+        </p>
+      </div>
+
+      <!-- Example 3: starts pre-recording -->
+      <div class="ease-demo-card">
+        <button class="ease-record-button-red is-recording" type="button" aria-pressed="true">
+          <span class="ease-record-button-red__ring"></span>
+          <span class="ease-record-button-red__dot"></span>
+        </button>
+        <p class="ease-record-button-red__status">
+          <span class="ease-record-button-red__label">Recording</span>
+          <span class="ease-record-button-red__timer" aria-hidden="true">00:07</span>
+        </p>
+      </div>
+
+    </div>
+
+    <button class="ease-demo-theme-toggle" id="themeToggle" type="button">Toggle Light / Dark</button>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-record-button-red').forEach((btn) => {
+      const card = btn.closest('.ease-demo-card');
+      const labelEl = card.querySelector('.ease-record-button-red__label');
+      const timerEl = card.querySelector('.ease-record-button-red__timer');
+
+      let seconds = 0;
+      let intervalId = null;
+
+      // If a demo card starts already "recording", kick off its timer immediately
+      if (btn.classList.contains('is-recording')) {
+        seconds = 7;
+        startTimer();
+      }
+
+      function formatTime(totalSeconds) {
+        const m = Math.floor(totalSeconds / 60).toString().padStart(2, '0');
+        const s = (totalSeconds % 60).toString().padStart(2, '0');
+        return `${m}:${s}`;
+      }
+
+      function startTimer() {
+        clearInterval(intervalId);
+        intervalId = setInterval(() => {
+          seconds += 1;
+          timerEl.textContent = formatTime(seconds);
+        }, 1000);
+      }
+
+      function stopTimer() {
+        clearInterval(intervalId);
+      }
+
+      btn.addEventListener('click', () => {
+        const isRecording = btn.classList.toggle('is-recording');
+        btn.setAttribute('aria-pressed', String(isRecording));
+
+        if (isRecording) {
+          seconds = 0;
+          timerEl.textContent = formatTime(seconds);
+          labelEl.textContent = 'Recording';
+          startTimer();
+        } else {
+          stopTimer();
+          labelEl.textContent = 'Not recording';
+          timerEl.textContent = '00:00';
+          seconds = 0;
+        }
+      });
+    });
+
+    // Theme toggle for demo purposes
+    document.getElementById('themeToggle').addEventListener('click', () => {
+      const body = document.body;
+      body.setAttribute('data-theme', body.getAttribute('data-theme') === 'light' ? 'dark' : 'light');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-record-button-red/style.css
+++ b/submissions/examples/ease-record-button-red/style.css
@@ -1,0 +1,236 @@
+﻿/* =========================================================
+   ease-record-button-red
+   A toggleable record button with a pulsing red "live" state.
+   ========================================================= */
+
+:root {
+  --erbr-bg: #ffffff;
+  --erbr-card-bg: #f7f8fa;
+  --erbr-border: #e2e5ea;
+  --erbr-text: #1a1d23;
+  --erbr-text-muted: #6b7280;
+  --erbr-idle-fill: #d8dbe1;
+  --erbr-idle-fill-hover: #c6cad3;
+  --erbr-idle-ring: #b8bfc9;
+  --erbr-red: #e0293e;
+  --erbr-red-dark: #b81f30;
+  --erbr-red-glow: rgba(224, 41, 62, 0.45);
+  --erbr-shadow: 0 4px 14px rgba(20, 24, 32, 0.06);
+}
+
+[data-theme="dark"] {
+  --erbr-bg: #14161a;
+  --erbr-card-bg: #1c1f26;
+  --erbr-border: #2a2e37;
+  --erbr-text: #f1f2f4;
+  --erbr-text-muted: #9aa1ab;
+  --erbr-idle-fill: #3a3f4a;
+  --erbr-idle-fill-hover: #454b58;
+  --erbr-idle-ring: #4b515e;
+  --erbr-red: #ff4d5e;
+  --erbr-red-dark: #d43447;
+  --erbr-red-glow: rgba(255, 77, 94, 0.5);
+  --erbr-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+}
+
+/* ---------- Demo page scaffolding (not part of the component) ---------- */
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--erbr-bg);
+  color: var(--erbr-text);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.ease-demo-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+.ease-demo-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.ease-demo-subtitle {
+  color: var(--erbr-text-muted);
+  margin-bottom: 32px;
+}
+
+.ease-demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 24px;
+}
+
+.ease-demo-card {
+  background: var(--erbr-card-bg);
+  border: 1px solid var(--erbr-border);
+  border-radius: 16px;
+  padding: 28px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  box-shadow: var(--erbr-shadow);
+}
+
+.ease-demo-theme-toggle {
+  margin-top: 40px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: 1px solid var(--erbr-border);
+  background: var(--erbr-card-bg);
+  color: var(--erbr-text);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.ease-demo-theme-toggle:hover {
+  border-color: var(--erbr-red);
+}
+
+/* =========================================================
+   Component: ease-record-button-red
+   ========================================================= */
+
+.ease-record-button-red {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  border: none;
+  border-radius: 50%;
+  background: var(--erbr-idle-fill);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  outline-offset: 4px;
+  transition: background 0.25s ease, transform 0.15s ease;
+}
+
+.ease-record-button-red:hover {
+  background: var(--erbr-idle-fill-hover);
+}
+
+.ease-record-button-red:active {
+  transform: scale(0.94);
+}
+
+.ease-record-button-red--compact {
+  width: 48px;
+  height: 48px;
+}
+
+/* Inner dot: gray circle when idle, red circle (and later, red square) when recording */
+.ease-record-button-red__dot {
+  position: relative;
+  z-index: 2;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--erbr-idle-ring);
+  transition: background 0.25s ease, border-radius 0.25s ease, width 0.25s ease, height 0.25s ease;
+}
+
+.ease-record-button-red--compact .ease-record-button-red__dot {
+  width: 16px;
+  height: 16px;
+}
+
+/* Outer pulsing ring, only visible while recording */
+.ease-record-button-red__ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  box-shadow: 0 0 0 0 var(--erbr-red-glow);
+  opacity: 0;
+}
+
+/* ---------- Recording state ---------- */
+
+.ease-record-button-red.is-recording {
+  background: var(--erbr-red);
+}
+
+.ease-record-button-red.is-recording:hover {
+  background: var(--erbr-red-dark);
+}
+
+.ease-record-button-red.is-recording .ease-record-button-red__dot {
+  background: #ffffff;
+  border-radius: 5px; /* dot morphs into a small "stop" square */
+  width: 16px;
+  height: 16px;
+}
+
+.ease-record-button-red--compact.is-recording .ease-record-button-red__dot {
+  width: 12px;
+  height: 12px;
+}
+
+.ease-record-button-red.is-recording .ease-record-button-red__ring {
+  opacity: 1;
+  animation: erbr-pulse 1.6s ease-out infinite;
+}
+
+@keyframes erbr-pulse {
+  0% {
+    box-shadow: 0 0 0 0 var(--erbr-red-glow);
+  }
+  70% {
+    box-shadow: 0 0 0 16px rgba(224, 41, 62, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(224, 41, 62, 0);
+  }
+}
+
+/* ---------- Status text ---------- */
+
+.ease-record-button-red__status {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.ease-record-button-red__label {
+  color: var(--erbr-text-muted);
+  font-weight: 600;
+}
+
+.ease-demo-card:has(.ease-record-button-red.is-recording) .ease-record-button-red__label {
+  color: var(--erbr-red);
+  animation: erbr-blink 1.6s ease-in-out infinite;
+}
+
+@keyframes erbr-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+.ease-record-button-red__timer {
+  font-variant-numeric: tabular-nums;
+  color: var(--erbr-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+/* ---------- Reduced motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-record-button-red,
+  .ease-record-button-red__dot,
+  .ease-record-button-red__ring,
+  .ease-record-button-red__label {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Adds the `ease-record-button-red` component — a toggleable record button with a pulsing red "live" state and elapsed-time counter.

## Features
- Idle gray circular button that switches to solid red on click
- Pulsing outward ring animation while recording
- Dot morphs into a small "stop" square when active
- Blinking status label + `MM:SS` elapsed timer
- `--compact` modifier for a smaller 48px variant
- Full light/dark theme support via `[data-theme]`
- Uses `aria-pressed` for accessibility; respects `prefers-reduced-motion`

## Files added
- `submissions/examples/ease-record-button-red/demo.html`
- `submissions/examples/ease-record-button-red/style.css`
- `submissions/examples/ease-record-button-red/README.md`

Closes #48014