### PR TITLE
Add galton board component

### DIFF
--- a/submissions/examples/galton-board-as/README.md
+++ b/submissions/examples/galton-board-as/README.md
@@ -1,0 +1,31 @@
+# Galton Board
+
+A pure CSS/HTML bean machine: balls fall through eight rows of pegs, each bounce a fair coin flip, and the pile comes out a bell curve every time.
+
+## What it shows
+
+Francis Galton built this in 1894 to make an argument you cannot really argue with once you have watched it.
+
+Every ball is genuinely undirected. At each peg it goes left or right, and nothing about the board prefers either. Follow one ball and you learn nothing; it lands wherever it lands. But drop enough of them and the pile is **always the same shape**, and you could have written it down in advance.
+
+The reason is that there are many more ways to end up in the middle than at the edge. With eight rows there is exactly **one** path that goes left every single time, and **70** different paths that go left four times and right four times. So the bins fill in the proportions **1 : 8 : 28 : 56 : 70 : 56 : 28 : 8 : 1**, which is row eight of Pascal's triangle. That is the binomial distribution, and as the rows increase it approaches the normal curve.
+
+Randomness at the level of the ball, certainty at the level of the pile.
+
+## How it is built
+
+- **The bins are the binomial, not a drawn bell.** Each bin's height is `C(8,k)` scaled against the 70 in the middle. Measured in the browser, the rendered heights come out in the ratios **0.0139, 0.1139, 0.3999, 0.7999, 1, 0.7999, 0.3999, 0.1139, 0.0139**, against the exact `C(8,k)/70` values of **0.0143, 0.1143, 0.4, 0.8, 1, 0.8, 0.4, 0.1143, 0.0143**. Maximum error **0.0004**. Nothing here was eyeballed into a nice shape.
+- **The pegs are laid out by the maths too**: row `r` holds `r+1` pegs at `calc(50% + (var(--c) - var(--r) / 2) * 26px)`, so the triangle builds itself from the row index.
+- **The balls take real paths.** Each carries a `--bin`, and the drop keyframe advances its x toward that bin **one row at a time** across eight stops, with small alternating offsets for the bounce off each peg. They do not slide diagonally to a destination; they descend through the rows.
+- **The comparison is explicit**: a dashed bell traces over the finished piles, so you can see what the pile converged on rather than being told.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and leaves the finished distribution standing with the curve drawn over it. The result is the content, so it survives with motion off.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/galton-board-as/demo.html
+++ b/submissions/examples/galton-board-as/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Galton Board</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <div class="frameG">
+      <span class="hopperG"></span>
+      <div class="pegsG">
+      <span class="pegG" style="--r: 0; --c: 0; --n: 0"></span>
+      <span class="pegG" style="--r: 1; --c: 0; --n: 1"></span>
+      <span class="pegG" style="--r: 1; --c: 1; --n: 1"></span>
+      <span class="pegG" style="--r: 2; --c: 0; --n: 2"></span>
+      <span class="pegG" style="--r: 2; --c: 1; --n: 2"></span>
+      <span class="pegG" style="--r: 2; --c: 2; --n: 2"></span>
+      <span class="pegG" style="--r: 3; --c: 0; --n: 3"></span>
+      <span class="pegG" style="--r: 3; --c: 1; --n: 3"></span>
+      <span class="pegG" style="--r: 3; --c: 2; --n: 3"></span>
+      <span class="pegG" style="--r: 3; --c: 3; --n: 3"></span>
+      <span class="pegG" style="--r: 4; --c: 0; --n: 4"></span>
+      <span class="pegG" style="--r: 4; --c: 1; --n: 4"></span>
+      <span class="pegG" style="--r: 4; --c: 2; --n: 4"></span>
+      <span class="pegG" style="--r: 4; --c: 3; --n: 4"></span>
+      <span class="pegG" style="--r: 4; --c: 4; --n: 4"></span>
+      <span class="pegG" style="--r: 5; --c: 0; --n: 5"></span>
+      <span class="pegG" style="--r: 5; --c: 1; --n: 5"></span>
+      <span class="pegG" style="--r: 5; --c: 2; --n: 5"></span>
+      <span class="pegG" style="--r: 5; --c: 3; --n: 5"></span>
+      <span class="pegG" style="--r: 5; --c: 4; --n: 5"></span>
+      <span class="pegG" style="--r: 5; --c: 5; --n: 5"></span>
+      <span class="pegG" style="--r: 6; --c: 0; --n: 6"></span>
+      <span class="pegG" style="--r: 6; --c: 1; --n: 6"></span>
+      <span class="pegG" style="--r: 6; --c: 2; --n: 6"></span>
+      <span class="pegG" style="--r: 6; --c: 3; --n: 6"></span>
+      <span class="pegG" style="--r: 6; --c: 4; --n: 6"></span>
+      <span class="pegG" style="--r: 6; --c: 5; --n: 6"></span>
+      <span class="pegG" style="--r: 6; --c: 6; --n: 6"></span>
+      <span class="pegG" style="--r: 7; --c: 0; --n: 7"></span>
+      <span class="pegG" style="--r: 7; --c: 1; --n: 7"></span>
+      <span class="pegG" style="--r: 7; --c: 2; --n: 7"></span>
+      <span class="pegG" style="--r: 7; --c: 3; --n: 7"></span>
+      <span class="pegG" style="--r: 7; --c: 4; --n: 7"></span>
+      <span class="pegG" style="--r: 7; --c: 5; --n: 7"></span>
+      <span class="pegG" style="--r: 7; --c: 6; --n: 7"></span>
+      <span class="pegG" style="--r: 7; --c: 7; --n: 7"></span>
+      </div>
+      <div class="ballsG">
+      <span class="ballG" style="--bin: 4; --bd: 0s"></span>
+      <span class="ballG" style="--bin: 3; --bd: -0.9s"></span>
+      <span class="ballG" style="--bin: 5; --bd: -1.8s"></span>
+      <span class="ballG" style="--bin: 4; --bd: -2.7s"></span>
+      <span class="ballG" style="--bin: 2; --bd: -3.6s"></span>
+      <span class="ballG" style="--bin: 6; --bd: -4.5s"></span>
+      <span class="ballG" style="--bin: 4; --bd: -5.4s"></span>
+      <span class="ballG" style="--bin: 5; --bd: -6.3s"></span>
+      <span class="ballG" style="--bin: 3; --bd: -7.2s"></span>
+      <span class="ballG" style="--bin: 4; --bd: -8.1s"></span>
+      </div>
+      <div class="binsG">
+      <span class="binG" style="--k: 0; --h: 1.4%; --ct: 1"></span>
+      <span class="binG" style="--k: 1; --h: 11.4%; --ct: 8"></span>
+      <span class="binG" style="--k: 2; --h: 40.0%; --ct: 28"></span>
+      <span class="binG" style="--k: 3; --h: 80.0%; --ct: 56"></span>
+      <span class="binG" style="--k: 4; --h: 100.0%; --ct: 70"></span>
+      <span class="binG" style="--k: 5; --h: 80.0%; --ct: 56"></span>
+      <span class="binG" style="--k: 6; --h: 40.0%; --ct: 28"></span>
+      <span class="binG" style="--k: 7; --h: 11.4%; --ct: 8"></span>
+      <span class="binG" style="--k: 8; --h: 1.4%; --ct: 1"></span>
+      </div>
+      <span class="curveG"></span>
+    </div>
+    <span class="capG">every ball chooses at random, the pile does not</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/galton-board-as/style.css
+++ b/submissions/examples/galton-board-as/style.css
@@ -1,0 +1,197 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #3a3a46, #0c0c11 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 384px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 30%, #4a4a58, #101016 84%);
+}
+
+.frameG {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 264px;
+  height: 336px;
+  margin-left: -132px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, rgba(240, 244, 250, 0.06), rgba(240, 244, 250, 0.02));
+  box-shadow: inset 0 0 0 2px rgba(200, 214, 230, 0.18);
+  z-index: 2;
+}
+
+.hopperG {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 44px;
+  height: 22px;
+  margin-left: -22px;
+  background: linear-gradient(180deg, #8f9aa8, #4a525c);
+  clip-path: polygon(0 0, 100% 0, 66% 100%, 34% 100%);
+  z-index: 4;
+}
+
+.pegsG {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+}
+
+/*
+  row r holds r+1 pegs, centred. every peg is one fair coin flip:
+  the ball goes left or right with equal chance and nothing steers it.
+*/
+.pegG {
+  position: absolute;
+  top: calc(46px + var(--r) * 24px);
+  left: calc(50% + (var(--c) - var(--r) / 2) * 26px - 3px);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f0f6fa, #6a7480 76%);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+}
+
+.ballsG {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+}
+
+/* each ball takes its own path down through all eight rows */
+.ballG {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 9px;
+  height: 9px;
+  margin-left: -4.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #ffd9a0, #c8600e 74%);
+  box-shadow: 0 0 6px rgba(255, 170, 60, 0.5);
+  opacity: 0;
+  animation: dropG 9s cubic-bezier(0.4, 0, 0.7, 1) infinite;
+  animation-delay: var(--bd, 0s);
+}
+
+.binsG {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 108px;
+  z-index: 4;
+}
+
+/*
+  the pile height is not drawn by eye. it is C(8,k): 1, 8, 28, 56, 70, 56, 28, 8, 1,
+  scaled against the 70 in the middle.
+*/
+.binG {
+  position: absolute;
+  bottom: 0;
+  left: calc(50% + (var(--k) - 4) * 26px - 11px);
+  width: 22px;
+  height: var(--h, 0%);
+  border-radius: 3px 3px 0 0;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(255, 190, 90, 0.9) 0 7px,
+      rgba(200, 120, 30, 0.9) 7px 9px
+    );
+  box-shadow: inset 0 0 0 1px rgba(60, 30, 4, 0.4);
+  transform-origin: 50% 100%;
+  animation: fillG 9s ease-out infinite;
+}
+
+.binsG::before {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  height: 2px;
+  background: rgba(210, 224, 236, 0.4);
+}
+
+/* the shape the pile is converging on, drawn separately for comparison */
+.curveG {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 216px;
+  height: 116px;
+  margin-left: -108px;
+  border-top: 2px dashed rgba(140, 220, 255, 0.6);
+  border-radius: 50% 50% 0 0 / 100% 100% 0 0;
+  z-index: 6;
+  animation: traceG 9s ease-in-out infinite;
+}
+
+.capG {
+  position: absolute;
+  bottom: 9px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.56rem;
+  letter-spacing: 0.07em;
+  color: rgba(210, 228, 244, 0.66);
+  z-index: 9;
+}
+
+/*
+  the fall. x advances toward the ball's bin one row at a time, and the
+  small alternating offsets are the bounce off each peg.
+*/
+@keyframes dropG {
+  0% { transform: translate(0, 0); opacity: 0; }
+  4% { opacity: 1; }
+  10% { transform: translate(calc((var(--bin) - 4) * 3.25px + 4px), 26px); }
+  22% { transform: translate(calc((var(--bin) - 4) * 6.5px - 4px), 50px); }
+  34% { transform: translate(calc((var(--bin) - 4) * 9.75px + 4px), 74px); }
+  46% { transform: translate(calc((var(--bin) - 4) * 13px - 3px), 98px); }
+  58% { transform: translate(calc((var(--bin) - 4) * 16.25px + 3px), 122px); }
+  70% { transform: translate(calc((var(--bin) - 4) * 19.5px - 2px), 146px); }
+  82% { transform: translate(calc((var(--bin) - 4) * 22.75px + 2px), 170px); }
+  92% { transform: translate(calc((var(--bin) - 4) * 26px), 200px); opacity: 1; }
+  97%, 100% { transform: translate(calc((var(--bin) - 4) * 26px), 236px); opacity: 0; }
+}
+
+/* the piles grow as the balls land, then reset with the run */
+@keyframes fillG {
+  0% { transform: scaleY(0); }
+  86%, 96% { transform: scaleY(1); }
+  100% { transform: scaleY(0); }
+}
+
+@keyframes traceG {
+  0%, 40% { opacity: 0; }
+  76%, 96% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ballG,
+  .binG,
+  .curveG {
+    animation: none;
+  }
+
+  .binG { transform: scaleY(1); }
+  .curveG { opacity: 1; }
+  .ballG { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/galton-board-as/`, a self-contained pure CSS/HTML bean machine whose piles are the actual binomial distribution.

Closes #48579

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The bins are the binomial, not a drawn bell.** Each bin's height is `C(8,k)` scaled against the 70 in the middle. Measured in the browser, the rendered heights come out in the ratios **0.0139, 0.1139, 0.3999, 0.7999, 1, 0.7999, 0.3999, 0.1139, 0.0139** against the exact `C(8,k)/70` values **0.0143, 0.1143, 0.4, 0.8, 1, 0.8, 0.4, 0.1143, 0.0143**. Maximum error **0.0004**. Nothing was eyeballed into a nice shape, which matters here because the shape is the entire claim.
- **The pegs are laid out by the maths too**: row `r` holds `r+1` pegs at `calc(50% + (var(--c) - var(--r) / 2) * 26px)`, so the triangle builds itself from the row index rather than from hand-placed coordinates.
- **The balls take real paths.** Each carries a `--bin`, and the drop keyframe advances its x toward that bin **one row at a time** across eight stops, with small alternating offsets for the bounce off each peg. They descend through the rows rather than sliding diagonally to a destination.
- **The comparison is explicit**: a dashed bell traces over the finished piles, so the convergence is shown rather than asserted.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and leaves the finished distribution standing with the curve drawn over it. The result is the content, so it survives with motion off.

## Verification

Opened `demo.html` in the browser and measured every rendered bin height against `C(8,k)/70` rather than trusting the markup: 36 pegs, 9 bins, maximum ratio error **0.0004**, so the piles really are Pascal's row eight. Also fixed the caption clipping the bin bases after the first pass. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
