### PR TITLE
Add maltese cross component

### DIFF
--- a/submissions/examples/maltese-cross-as/README.md
+++ b/submissions/examples/maltese-cross-as/README.md
@@ -1,0 +1,31 @@
+# Maltese Cross
+
+A pure CSS/HTML Geneva drive: a wheel turning at a constant speed, and a cross that moves in four hard quarter-turns and is locked solid the rest of the time.
+
+## What it shows
+
+This is the mechanism that made cinema work.
+
+Film cannot be pulled through a projector smoothly. Each frame has to be **slammed into the gate, held perfectly still while the shutter is open, and then jerked away** in the dark. If the film moved while you were looking at it you would see a smear. So you need something that converts continuous rotation into a stop-and-go, with a long stop and a short go, and which holds the film *rigidly* during the stop rather than just slowly.
+
+The Geneva drive does exactly that with no electronics and no brakes. A pin on the continuously turning drive wheel drops into one of four slots and sweeps the cross round by 90 degrees. Then the pin leaves the slot, and a **locking disc** on the same drive, with one bite cut out of it, rolls against the cross's concave flank and physically jams it. The cross cannot move even if you push it.
+
+It also came from watchmaking, where it was used the other way round: to stop a mainspring being wound too far.
+
+## How it is built
+
+- **The duty cycle is real, and it is measured.** The check samples the cross's actual animation timeline and computes how much of the time it is turning. Result: **moving 24.9%, locked 75.1%**. That 1:3 split is the defining property of a four-slot Geneva, and it is what buys the shutter its open window.
+- **Four steps per revolution, from the timings.** The drive is `2s` and the cross is `8s`, so the measured ratio is **exactly 4**. Each step holds for 18.75% of the cross cycle and turns in 6.25%, and that 6.25% of 8s is 0.5s, precisely a quarter of one drive turn: the window the pin is inside a slot.
+- **The film is slaved to the cross.** Same duration, same keyframe shape, so the strip advances only while the cross turns and is dead still while it is locked. That is the entire point of the mechanism.
+- **Geneva geometry**: the wheel is a square with a concave arc bitten out of each corner (four composited `radial-gradient` masks with `mask-composite: intersect`) and four radial slots between them. The concave flanks are what the locking disc rides against.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and leaves the mechanism at rest, pin clear of the slots and disc locked.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/maltese-cross-as/demo.html
+++ b/submissions/examples/maltese-cross-as/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Maltese Cross</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="plateM"></span>
+
+    <div class="crossM">
+      <span class="bodyM"></span>
+      <span class="slotM" style="--s: 0deg"></span>
+      <span class="slotM" style="--s: 90deg"></span>
+      <span class="slotM" style="--s: 180deg"></span>
+      <span class="slotM" style="--s: 270deg"></span>
+      <span class="hubM"></span>
+    </div>
+
+    <div class="driveM">
+      <span class="lockM"></span>
+      <span class="camM"></span>
+      <span class="pinM"></span>
+      <span class="bossM"></span>
+    </div>
+
+    <div class="gateM">
+      <span class="wellM"></span>
+      <div class="stripM">
+        <span class="frameM" style="--f: 0"></span>
+        <span class="frameM" style="--f: 1"></span>
+        <span class="frameM" style="--f: 2"></span>
+        <span class="frameM" style="--f: 3"></span>
+        <span class="frameM" style="--f: 4"></span>
+        <span class="frameM" style="--f: 5"></span>
+      </div>
+      <span class="maskM"></span>
+    </div>
+
+    <span class="tagDrive">drive : continuous</span>
+    <span class="tagCross">film : one frame per turn</span>
+    <span class="capM">the pin turns the cross a quarter, then the disc locks it</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/maltese-cross-as/style.css
+++ b/submissions/examples/maltese-cross-as/style.css
@@ -1,0 +1,297 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #34383f, #0a0b0d 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 44% 30%, #454b54, #0c0e11 84%);
+}
+
+.plateM {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      44deg,
+      rgba(255, 255, 255, 0.02) 0 2px,
+      transparent 2px 9px
+    );
+  z-index: 1;
+}
+
+/*
+  the cross. four slots, so it takes four steps to come round once.
+*/
+.crossM {
+  position: absolute;
+  top: 116px;
+  left: 96px;
+  width: 0;
+  height: 0;
+  z-index: 5;
+  animation: stepM 8s linear infinite;
+}
+
+.bodyM {
+  position: absolute;
+  top: -46px;
+  left: -46px;
+  width: 92px;
+  height: 92px;
+  border-radius: 12px;
+  background:
+    repeating-linear-gradient(
+      52deg,
+      rgba(255, 255, 255, 0.04) 0 1px,
+      transparent 1px 6px
+    ),
+    radial-gradient(circle at 36% 32%, #8d97a3, #39404a 78%);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(210, 224, 236, 0.2);
+  mask-image:
+    radial-gradient(circle 26px at 0 0, transparent 0 26px, #000 26px),
+    radial-gradient(circle 26px at 100% 0, transparent 0 26px, #000 26px),
+    radial-gradient(circle 26px at 100% 100%, transparent 0 26px, #000 26px),
+    radial-gradient(circle 26px at 0 100%, transparent 0 26px, #000 26px);
+  mask-composite: intersect;
+}
+
+/* the slots the pin drops into, one per quarter */
+.slotM {
+  position: absolute;
+  top: -46px;
+  left: -4px;
+  width: 8px;
+  height: 34px;
+  border-radius: 4px 4px 5px 5px;
+  background: linear-gradient(180deg, #10131a, #262c34);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.9);
+  transform-origin: 50% 46px;
+  transform: rotate(var(--s, 0deg));
+  z-index: 3;
+}
+
+.hubM {
+  position: absolute;
+  top: -9px;
+  left: -9px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #e8eef4, #4a525c 76%);
+  box-shadow: 0 0 0 2px rgba(16, 20, 24, 0.8);
+  z-index: 6;
+}
+
+/*
+  the drive turns at a constant speed and never stops. the pin is only
+  in a slot for a quarter of each turn; the disc holds the cross for the rest.
+*/
+.driveM {
+  position: absolute;
+  top: 116px;
+  left: 214px;
+  width: 0;
+  height: 0;
+  z-index: 4;
+  animation: spinM 2s linear infinite;
+}
+
+.camM {
+  position: absolute;
+  top: -34px;
+  left: -34px;
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #b8c2ce, #3e454f 78%);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.6);
+}
+
+/* the locking disc: a full circle with one bite cut out for the cross to pass */
+.lockM {
+  position: absolute;
+  top: -46px;
+  left: -46px;
+  width: 92px;
+  height: 92px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #6f7884, #262c33 80%);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 62%, 32% 50%, 0 38%);
+  z-index: 2;
+}
+
+.pinM {
+  position: absolute;
+  top: -4px;
+  left: -62px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #ffd48a, #a05c10 74%);
+  box-shadow: 0 0 8px rgba(255, 180, 70, 0.7);
+  z-index: 5;
+}
+
+.bossM {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #e8eef4, #4a525c 76%);
+  box-shadow: 0 0 0 2px rgba(16, 20, 24, 0.8);
+  z-index: 6;
+}
+
+/* the film gate: this is what the whole mechanism exists to serve */
+.gateM {
+  position: absolute;
+  top: 24px;
+  right: 16px;
+  width: 62px;
+  height: 272px;
+  overflow: hidden;
+  border-radius: 3px;
+  z-index: 6;
+}
+
+.wellM {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #0e1013, #1c2026 40%, #0a0c0f);
+  z-index: 1;
+}
+
+.stripM {
+  position: absolute;
+  top: -46px;
+  left: 4px;
+  width: 54px;
+  height: 384px;
+  z-index: 2;
+  animation: pullM 8s linear infinite;
+}
+
+.frameM {
+  position: absolute;
+  top: calc(var(--f) * 64px);
+  left: 0;
+  width: 54px;
+  height: 60px;
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.5) 0 2px,
+      transparent 2px 8px
+    ),
+    linear-gradient(150deg, #d8cfae, #7f7a5e);
+  box-shadow: inset 0 0 0 1px rgba(30, 26, 14, 0.6);
+}
+
+.frameM::before,
+.frameM::after {
+  content: "";
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  width: 5px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #14161a 0 5px,
+      transparent 5px 14px
+    );
+}
+
+.frameM::before { left: -4px; }
+.frameM::after { right: -4px; }
+
+.maskM {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(6, 8, 10, 0.9) 0 14%, transparent 30% 70%, rgba(6, 8, 10, 0.9) 86%);
+  z-index: 4;
+  pointer-events: none;
+}
+
+.tagDrive,
+.tagCross {
+  position: absolute;
+  font-size: 0.5rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  z-index: 8;
+}
+
+.tagDrive {
+  top: 216px;
+  left: 182px;
+  color: rgba(255, 200, 120, 0.8);
+}
+
+.tagCross {
+  top: 216px;
+  left: 26px;
+  color: rgba(170, 220, 250, 0.8);
+}
+
+.capM {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.06em;
+  color: rgba(210, 224, 236, 0.62);
+  z-index: 8;
+}
+
+/* the drive never stops and never changes speed */
+@keyframes spinM {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(-360deg); }
+}
+
+/*
+  four quarter-turns per cross revolution. each one holds for 18.75%
+  of the cycle and then turns in 6.25%, which is a quarter of one 2s
+  drive turn: exactly the window the pin is inside a slot.
+*/
+@keyframes stepM {
+  0%, 18.75% { transform: rotate(0deg); }
+  25%, 43.75% { transform: rotate(90deg); }
+  50%, 68.75% { transform: rotate(180deg); }
+  75%, 93.75% { transform: rotate(270deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* the film moves only while the cross moves, and is still while it is locked */
+@keyframes pullM {
+  0%, 18.75% { transform: translateY(0); }
+  25%, 43.75% { transform: translateY(64px); }
+  50%, 68.75% { transform: translateY(128px); }
+  75%, 93.75% { transform: translateY(192px); }
+  100% { transform: translateY(256px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crossM,
+  .driveM,
+  .stripM {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/maltese-cross-as/`, a self-contained pure CSS/HTML Geneva drive with a measured 1:3 duty cycle.

Closes #48585

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The duty cycle is real, and it is measured.** The browser check samples the cross's actual animation timeline (via `getAnimations()`), reads the resolved transform matrix at 800 points across a full cycle, and computes how much of the time the cross is turning. Result: **moving 24.9%, locked 75.1%**. That 1:3 split is the defining property of a four-slot Geneva and it is what buys a projector shutter its open window.
- **Four steps per revolution, from the timings.** The drive is `2s` and the cross is `8s`, so the measured ratio is **exactly 4**. Each step holds for 18.75% of the cross cycle and turns in 6.25%; that 6.25% of 8s is 0.5s, precisely a quarter of one drive turn, which is the window the pin is inside a slot.
- **The film is slaved to the cross.** Same duration, same keyframe shape, so the strip advances only while the cross turns and is dead still while it is locked. That is the entire reason the mechanism exists.
- **Geneva geometry**: the wheel is a square with a concave arc bitten out of each corner (four composited `radial-gradient` masks with `mask-composite: intersect`) and four radial slots between them. The concave flanks are what the locking disc rides against.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and leaves the mechanism at rest.

## Verification

Opened `demo.html` in the browser and measured the mechanism rather than eyeballing it: sampled the cross's live animation timeline to get moving 24.9% / locked 75.1%, and confirmed drive 2s against cross 8s for exactly 4 steps per turn with the film on a matching duration.

The browser check also caught a real bug: the four slot angles were written as unitless custom properties (`--s: 90`), which makes `rotate(var(--s))` invalid, so all four slots silently collapsed onto 0deg and stacked. After adding units the check confirms angles 0/90/180/-90 at four distinct positions. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
