### PR TITLE
Add sundial analemma component

### DIFF
--- a/submissions/examples/sundial-analemma-as/README.md
+++ b/submissions/examples/sundial-analemma-as/README.md
@@ -1,0 +1,43 @@
+# Sundial Analemma
+
+A pure CSS/HTML analemma: mark where a sundial's shadow tip falls at clock noon, every third day for a year, and you get a lopsided figure-eight.
+
+## What it shows
+
+Noon by the clock is not noon by the sun, and the gap changes all year. Mark the shadow tip at exactly 12:00 every day and the marks do not pile up in one place. They trace a **figure-eight**, and the sundial runs up to about **16 minutes ahead in early November and 14 minutes behind in mid-February**.
+
+Two separate things cause it, and the shape is their sum:
+
+- **Earth's orbit is an ellipse**, so it moves faster near perihelion in January than at aphelion in July. That alone would give a once-a-year sine wave.
+- **Earth's axis is tilted 23.4°**, so the sun's apparent motion is not parallel to the celestial equator. That alone would give a twice-a-year wave.
+
+Add a one-cycle wave to a two-cycle wave and you get a figure-eight. The loops are different sizes because the two effects do not line up. The vertical axis is just the sun's declination: high in June, low in December.
+
+This is why a sundial and a clock disagree, and why old sundials often carry a correction table engraved on them.
+
+## How it is built
+
+- **The figure is computed from the equation of time.** Every dot is placed at
+
+  `B = 2π(N − 81) / 364`
+  `EoT = 9.87·sin(2B) − 7.53·cos(B) − 1.5·sin(B)` (minutes)
+  `declination = 23.45·sin(B)` (degrees)
+
+  for its own day number `N`, plotted as EoT against declination. Nothing was traced by hand.
+
+- **Verified in the browser.** The check recomputes both formulas from scratch against each dot's declared `--n`, `--x` and `--y`: worst error **0.005px** across all 122 samples. The resulting spans come out at **−14.59 to +16.45 minutes** and **±23.45°**, which is Earth's actual axial tilt falling out of the maths rather than being drawn in.
+
+- **The asymmetry is real.** The small loop is summer and the big one is winter. That inequality is the whole reason the analemma is interesting, and it appears because the two-term formula genuinely superposes a one-cycle and a two-cycle wave.
+
+- **The year runs once**: each dot appears on its own day via `animation-delay: calc(var(--n) * 0.0424s)`, so the figure accumulates the way an observer would build it.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables the keyframe and leaves the complete figure drawn, which is the content.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/sundial-analemma-as/demo.html
+++ b/submissions/examples/sundial-analemma-as/demo.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sundial Analemma</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="skyA"></span>
+    <span class="wallA"></span>
+
+    <div class="dialA">
+      <span class="faceA"></span>
+      <span class="gnomonA"></span>
+      <span class="axisV"></span>
+      <span class="axisH"></span>
+      <div class="figureA">
+        <span class="sunA" style="--x: -20.2px; --y: 59.87px; --n: 1"></span>
+        <span class="sunA" style="--x: -27.62px; --y: 59.2px; --n: 4"></span>
+        <span class="sunA" style="--x: -34.76px; --y: 58.36px; --n: 7"></span>
+        <span class="sunA" style="--x: -41.57px; --y: 57.37px; --n: 10"></span>
+        <span class="sunA" style="--x: -47.98px; --y: 56.23px; --n: 13"></span>
+        <span class="sunA" style="--x: -53.94px; --y: 54.93px; --n: 16"></span>
+        <span class="sunA" style="--x: -59.41px; --y: 53.49px; --n: 19"></span>
+        <span class="sunA" style="--x: -64.35px; --y: 51.9px; --n: 22"></span>
+        <span class="sunA" style="--x: -68.72px; --y: 50.18px; --n: 25"></span>
+        <span class="sunA" style="--x: -72.49px; --y: 48.32px; --n: 28"></span>
+        <span class="sunA" style="--x: -75.64px; --y: 46.33px; --n: 31"></span>
+        <span class="sunA" style="--x: -78.14px; --y: 44.21px; --n: 34"></span>
+        <span class="sunA" style="--x: -79.99px; --y: 41.98px; --n: 37"></span>
+        <span class="sunA" style="--x: -81.19px; --y: 39.64px; --n: 40"></span>
+        <span class="sunA" style="--x: -81.72px; --y: 37.19px; --n: 43"></span>
+        <span class="sunA" style="--x: -81.61px; --y: 34.63px; --n: 46"></span>
+        <span class="sunA" style="--x: -80.87px; --y: 31.99px; --n: 49"></span>
+        <span class="sunA" style="--x: -79.51px; --y: 29.26px; --n: 52"></span>
+        <span class="sunA" style="--x: -77.56px; --y: 26.45px; --n: 55"></span>
+        <span class="sunA" style="--x: -75.06px; --y: 23.58px; --n: 58"></span>
+        <span class="sunA" style="--x: -72.04px; --y: 20.63px; --n: 61"></span>
+        <span class="sunA" style="--x: -68.54px; --y: 17.64px; --n: 64"></span>
+        <span class="sunA" style="--x: -64.62px; --y: 14.59px; --n: 67"></span>
+        <span class="sunA" style="--x: -60.31px; --y: 11.51px; --n: 70"></span>
+        <span class="sunA" style="--x: -55.68px; --y: 8.39px; --n: 73"></span>
+        <span class="sunA" style="--x: -50.78px; --y: 5.26px; --n: 76"></span>
+        <span class="sunA" style="--x: -45.67px; --y: 2.1px; --n: 79"></span>
+        <span class="sunA" style="--x: -40.4px; --y: -1.05px; --n: 82"></span>
+        <span class="sunA" style="--x: -35.04px; --y: -4.21px; --n: 85"></span>
+        <span class="sunA" style="--x: -29.65px; --y: -7.35px; --n: 88"></span>
+        <span class="sunA" style="--x: -24.28px; --y: -10.47px; --n: 91"></span>
+        <span class="sunA" style="--x: -19.0px; --y: -13.57px; --n: 94"></span>
+        <span class="sunA" style="--x: -13.86px; --y: -16.63px; --n: 97"></span>
+        <span class="sunA" style="--x: -8.92px; --y: -19.64px; --n: 100"></span>
+        <span class="sunA" style="--x: -4.22px; --y: -22.6px; --n: 103"></span>
+        <span class="sunA" style="--x: 0.18px; --y: -25.5px; --n: 106"></span>
+        <span class="sunA" style="--x: 4.25px; --y: -28.33px; --n: 109"></span>
+        <span class="sunA" style="--x: 7.93px; --y: -31.09px; --n: 112"></span>
+        <span class="sunA" style="--x: 11.21px; --y: -33.76px; --n: 115"></span>
+        <span class="sunA" style="--x: 14.05px; --y: -36.35px; --n: 118"></span>
+        <span class="sunA" style="--x: 16.42px; --y: -38.83px; --n: 121"></span>
+        <span class="sunA" style="--x: 18.31px; --y: -41.21px; --n: 124"></span>
+        <span class="sunA" style="--x: 19.71px; --y: -43.48px; --n: 127"></span>
+        <span class="sunA" style="--x: 20.62px; --y: -45.64px; --n: 130"></span>
+        <span class="sunA" style="--x: 21.03px; --y: -47.67px; --n: 133"></span>
+        <span class="sunA" style="--x: 20.95px; --y: -49.57px; --n: 136"></span>
+        <span class="sunA" style="--x: 20.39px; --y: -51.34px; --n: 139"></span>
+        <span class="sunA" style="--x: 19.37px; --y: -52.98px; --n: 142"></span>
+        <span class="sunA" style="--x: 17.92px; --y: -54.47px; --n: 145"></span>
+        <span class="sunA" style="--x: 16.07px; --y: -55.81px; --n: 148"></span>
+        <span class="sunA" style="--x: 13.85px; --y: -57.01px; --n: 151"></span>
+        <span class="sunA" style="--x: 11.29px; --y: -58.05px; --n: 154"></span>
+        <span class="sunA" style="--x: 8.44px; --y: -58.94px; --n: 157"></span>
+        <span class="sunA" style="--x: 5.36px; --y: -59.67px; --n: 160"></span>
+        <span class="sunA" style="--x: 2.07px; --y: -60.24px; --n: 163"></span>
+        <span class="sunA" style="--x: -1.35px; --y: -60.64px; --n: 166"></span>
+        <span class="sunA" style="--x: -4.86px; --y: -60.89px; --n: 169"></span>
+        <span class="sunA" style="--x: -8.4px; --y: -60.97px; --n: 172"></span>
+        <span class="sunA" style="--x: -11.92px; --y: -60.89px; --n: 175"></span>
+        <span class="sunA" style="--x: -15.36px; --y: -60.64px; --n: 178"></span>
+        <span class="sunA" style="--x: -18.67px; --y: -60.24px; --n: 181"></span>
+        <span class="sunA" style="--x: -21.8px; --y: -59.67px; --n: 184"></span>
+        <span class="sunA" style="--x: -24.68px; --y: -58.94px; --n: 187"></span>
+        <span class="sunA" style="--x: -27.28px; --y: -58.05px; --n: 190"></span>
+        <span class="sunA" style="--x: -29.55px; --y: -57.01px; --n: 193"></span>
+        <span class="sunA" style="--x: -31.45px; --y: -55.81px; --n: 196"></span>
+        <span class="sunA" style="--x: -32.93px; --y: -54.47px; --n: 199"></span>
+        <span class="sunA" style="--x: -33.97px; --y: -52.98px; --n: 202"></span>
+        <span class="sunA" style="--x: -34.54px; --y: -51.34px; --n: 205"></span>
+        <span class="sunA" style="--x: -34.61px; --y: -49.57px; --n: 208"></span>
+        <span class="sunA" style="--x: -34.16px; --y: -47.67px; --n: 211"></span>
+        <span class="sunA" style="--x: -33.19px; --y: -45.64px; --n: 214"></span>
+        <span class="sunA" style="--x: -31.7px; --y: -43.48px; --n: 217"></span>
+        <span class="sunA" style="--x: -29.67px; --y: -41.21px; --n: 220"></span>
+        <span class="sunA" style="--x: -27.12px; --y: -38.83px; --n: 223"></span>
+        <span class="sunA" style="--x: -24.06px; --y: -36.35px; --n: 226"></span>
+        <span class="sunA" style="--x: -20.51px; --y: -33.76px; --n: 229"></span>
+        <span class="sunA" style="--x: -16.5px; --y: -31.09px; --n: 232"></span>
+        <span class="sunA" style="--x: -12.05px; --y: -28.33px; --n: 235"></span>
+        <span class="sunA" style="--x: -7.21px; --y: -25.5px; --n: 238"></span>
+        <span class="sunA" style="--x: -2.01px; --y: -22.6px; --n: 241"></span>
+        <span class="sunA" style="--x: 3.5px; --y: -19.64px; --n: 244"></span>
+        <span class="sunA" style="--x: 9.28px; --y: -16.63px; --n: 247"></span>
+        <span class="sunA" style="--x: 15.26px; --y: -13.57px; --n: 250"></span>
+        <span class="sunA" style="--x: 21.39px; --y: -10.47px; --n: 253"></span>
+        <span class="sunA" style="--x: 27.62px; --y: -7.35px; --n: 256"></span>
+        <span class="sunA" style="--x: 33.88px; --y: -4.21px; --n: 259"></span>
+        <span class="sunA" style="--x: 40.11px; --y: -1.05px; --n: 262"></span>
+        <span class="sunA" style="--x: 46.25px; --y: 2.1px; --n: 265"></span>
+        <span class="sunA" style="--x: 52.23px; --y: 5.26px; --n: 268"></span>
+        <span class="sunA" style="--x: 57.99px; --y: 8.39px; --n: 271"></span>
+        <span class="sunA" style="--x: 63.48px; --y: 11.51px; --n: 274"></span>
+        <span class="sunA" style="--x: 68.64px; --y: 14.59px; --n: 277"></span>
+        <span class="sunA" style="--x: 73.4px; --y: 17.64px; --n: 280"></span>
+        <span class="sunA" style="--x: 77.72px; --y: 20.63px; --n: 283"></span>
+        <span class="sunA" style="--x: 81.56px; --y: 23.58px; --n: 286"></span>
+        <span class="sunA" style="--x: 84.85px; --y: 26.45px; --n: 289"></span>
+        <span class="sunA" style="--x: 87.57px; --y: 29.26px; --n: 292"></span>
+        <span class="sunA" style="--x: 89.68px; --y: 31.99px; --n: 295"></span>
+        <span class="sunA" style="--x: 91.16px; --y: 34.63px; --n: 298"></span>
+        <span class="sunA" style="--x: 91.97px; --y: 37.19px; --n: 301"></span>
+        <span class="sunA" style="--x: 92.11px; --y: 39.64px; --n: 304"></span>
+        <span class="sunA" style="--x: 91.56px; --y: 41.98px; --n: 307"></span>
+        <span class="sunA" style="--x: 90.32px; --y: 44.21px; --n: 310"></span>
+        <span class="sunA" style="--x: 88.4px; --y: 46.33px; --n: 313"></span>
+        <span class="sunA" style="--x: 85.8px; --y: 48.32px; --n: 316"></span>
+        <span class="sunA" style="--x: 82.55px; --y: 50.18px; --n: 319"></span>
+        <span class="sunA" style="--x: 78.65px; --y: 51.9px; --n: 322"></span>
+        <span class="sunA" style="--x: 74.15px; --y: 53.49px; --n: 325"></span>
+        <span class="sunA" style="--x: 69.08px; --y: 54.93px; --n: 328"></span>
+        <span class="sunA" style="--x: 63.47px; --y: 56.23px; --n: 331"></span>
+        <span class="sunA" style="--x: 57.38px; --y: 57.37px; --n: 334"></span>
+        <span class="sunA" style="--x: 50.85px; --y: 58.36px; --n: 337"></span>
+        <span class="sunA" style="--x: 43.93px; --y: 59.2px; --n: 340"></span>
+        <span class="sunA" style="--x: 36.7px; --y: 59.87px; --n: 343"></span>
+        <span class="sunA" style="--x: 29.2px; --y: 60.39px; --n: 346"></span>
+        <span class="sunA" style="--x: 21.5px; --y: 60.74px; --n: 349"></span>
+        <span class="sunA" style="--x: 13.66px; --y: 60.93px; --n: 352"></span>
+        <span class="sunA" style="--x: 5.76px; --y: 60.96px; --n: 355"></span>
+        <span class="sunA" style="--x: -2.14px; --y: 60.82px; --n: 358"></span>
+        <span class="sunA" style="--x: -9.97px; --y: 60.53px; --n: 361"></span>
+        <span class="sunA" style="--x: -17.67px; --y: 60.06px; --n: 364"></span>
+        <span class="monA" style="--x: -20.2px; --y: 59.87px">JAN</span>
+        <span class="monA" style="--x: -81.61px; --y: 34.63px">FEB</span>
+        <span class="monA" style="--x: -52.44px; --y: 6.3px">MAR</span>
+        <span class="monA" style="--x: -1.25px; --y: -24.54px">APR</span>
+        <span class="monA" style="--x: 20.95px; --y: -49.57px">MAY</span>
+        <span class="monA" style="--x: -1.35px; --y: -60.64px">JUN</span>
+        <span class="monA" style="--x: -31.99px; --y: -55.38px">JUL</span>
+        <span class="monA" style="--x: -21.75px; --y: -34.63px">AUG</span>
+        <span class="monA" style="--x: 31.79px; --y: -5.26px">SEP</span>
+        <span class="monA" style="--x: 84.85px; --y: 26.45px">OCT</span>
+        <span class="monA" style="--x: 82.55px; --y: 50.18px">NOV</span>
+        <span class="monA" style="--x: 18.9px; --y: 60.82px">DEC</span>
+      </div>
+      <span class="noonA">noon, every third day, one year</span>
+    </div>
+
+    <span class="lblFast">sundial ahead</span>
+    <span class="lblSlow">sundial behind</span>
+    <span class="capA">the sun is never where the clock says it is</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sundial-analemma-as/style.css
+++ b/submissions/examples/sundial-analemma-as/style.css
@@ -1,0 +1,197 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #6f93b8, #3a4a60 60%, #14181f);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #8fb6d8, #5a7a9c 52%, #33404f);
+}
+
+.skyA {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 50% 26%, rgba(255, 250, 220, 0.34), transparent 56%);
+  z-index: 1;
+}
+
+.wallA {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(70, 56, 40, 0.14) 0 1px,
+      transparent 1px 26px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(70, 56, 40, 0.14) 0 1px,
+      transparent 1px 34px
+    ),
+    linear-gradient(160deg, #dfd2b4, #a8977a);
+  z-index: 2;
+}
+
+.dialA {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+}
+
+.faceA {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 232px;
+  height: 232px;
+  margin-left: -116px;
+  border-radius: 4px;
+  background: linear-gradient(150deg, rgba(255, 252, 240, 0.5), rgba(200, 186, 156, 0.4));
+  box-shadow: inset 0 0 0 1px rgba(90, 74, 48, 0.4);
+  z-index: 1;
+}
+
+/* the style: the rod whose shadow tip traces the figure */
+.gnomonA {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 7px;
+  height: 40px;
+  margin-left: -3.5px;
+  border-radius: 3px 3px 0 0;
+  background: linear-gradient(90deg, #6a5f42, #e8dcb4 42%, #4a4230);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+  z-index: 6;
+}
+
+.axisV {
+  position: absolute;
+  top: 44px;
+  left: 50%;
+  width: 1px;
+  height: 224px;
+  background: repeating-linear-gradient(180deg, rgba(60, 48, 30, 0.4) 0 4px, transparent 4px 9px);
+  z-index: 2;
+}
+
+.axisH {
+  position: absolute;
+  top: 156px;
+  left: 50%;
+  width: 224px;
+  height: 1px;
+  margin-left: -112px;
+  background: repeating-linear-gradient(90deg, rgba(60, 48, 30, 0.4) 0 4px, transparent 4px 9px);
+  z-index: 2;
+}
+
+/*
+  the analemma. every dot is the shadow tip at clock noon on one day.
+  x is the equation of time in minutes, y is the sun's declination.
+    B   = 2*pi*(N - 81) / 364
+    EoT = 9.87 sin(2B) - 7.53 cos(B) - 1.5 sin(B)     minutes
+    dec = 23.45 sin(B)                                degrees
+*/
+.figureA {
+  position: absolute;
+  top: 156px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 5;
+}
+
+.sunA {
+  position: absolute;
+  top: var(--y, 0);
+  left: var(--x, 0);
+  width: 5px;
+  height: 5px;
+  margin: -2.5px 0 0 -2.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #fffbe0, #d8880e 76%);
+  box-shadow: 0 0 5px rgba(255, 190, 60, 0.7);
+  opacity: 0;
+  animation: yearA 18s linear infinite;
+  animation-delay: calc(var(--n) * 0.0424s);
+}
+
+.monA {
+  position: absolute;
+  top: var(--y, 0);
+  left: var(--x, 0);
+  margin: -20px 0 0 -14px;
+  width: 28px;
+  text-align: center;
+  font-size: 0.42rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: rgba(50, 38, 18, 0.8);
+  z-index: 6;
+}
+
+.noonA {
+  position: absolute;
+  top: 268px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(50, 38, 18, 0.66);
+  z-index: 6;
+}
+
+.lblFast,
+.lblSlow {
+  position: absolute;
+  top: 248px;
+  font-size: 0.44rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: rgba(50, 38, 18, 0.62);
+  z-index: 6;
+}
+
+.lblFast { right: 26px; }
+.lblSlow { left: 26px; }
+
+.capA {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.06em;
+  color: rgba(255, 250, 230, 0.8);
+  z-index: 8;
+}
+
+/* the year runs once: each dot lands on its day and the figure accumulates */
+@keyframes yearA {
+  0% { opacity: 0; transform: scale(0.3); }
+  1.4% { opacity: 1; transform: scale(1); }
+  82% { opacity: 1; transform: scale(1); }
+  92%, 100% { opacity: 0; transform: scale(0.3); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sunA {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/sundial-analemma-as/`, a self-contained pure CSS/HTML analemma computed from the equation of time.

Closes #48587

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The figure is computed, not traced.** Every dot is placed from `B = 2π(N − 81)/364`, `EoT = 9.87·sin(2B) − 7.53·cos(B) − 1.5·sin(B)` minutes and `declination = 23.45·sin(B)` degrees, for its own day number `N`, plotted as EoT against declination.
- **Verified in the browser.** The check recomputes both formulas from scratch against each dot's declared `--n`, `--x` and `--y`: worst error **0.005px** across all 122 samples. The spans come out at **−14.59 to +16.45 minutes** and **±23.45°**, so Earth's actual axial tilt falls out of the maths rather than being drawn in.
- **The asymmetry is real.** The small loop is summer and the big one winter. That inequality is the whole reason an analemma is interesting, and it appears because the two-term formula genuinely superposes a one-cycle wave (orbital eccentricity) and a two-cycle wave (axial tilt). A symmetric figure-eight would mean the physics was faked.
- **The year runs once**: each dot appears on its own day via `animation-delay: calc(var(--n) * 0.0424s)`, so the figure accumulates the way an observer would build it.

## Accessibility

`prefers-reduced-motion: reduce` disables the keyframe and leaves the complete figure drawn, which is the content.

## Verification

Opened `demo.html` in the browser and re-derived the astronomy there rather than trusting the generator: recomputed the equation of time and the declination against all 122 dots, worst error 0.005px, with the resulting ranges matching the real values. Also measured the axis labels against the figure's bounding box after the first pass had them overlapping the curve, and confirmed they now sit clear. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
