### PR TITLE
Add velvet worm component

### DIFF
--- a/submissions/examples/velvet-worm-as/README.md
+++ b/submissions/examples/velvet-worm-as/README.md
@@ -1,0 +1,30 @@
+# Velvet Worm
+
+A pure CSS/HTML velvet worm firing two oscillating slime jets over a cricket.
+
+## What it shows
+
+Velvet worms (Onychophora) have barely changed in 500 million years and hunt with something no other animal has: **two squirt guns on their face**.
+
+The remarkable part is not that they spray glue. It is *how*. Each papilla fires a jet of slime under pressure, and the nozzle itself is soft and unanchored, so the outgoing jet makes it **whip from side to side at around 40 times a second**. The worm does not aim the oscillation. It is a passive instability, driven by the jet's own momentum, the same way a loose garden hose thrashes. The result is that the slime lands as a **zigzag ribbon** rather than a line, and the two ribbons cross into a net that pins the prey down. The slime sets in seconds.
+
+The worm is also unwettable. Its skin is covered in the microscopic papillae that give it its name, and its own slime does not stick to it.
+
+## How it is built
+
+- **The jets are ribbons, not sprays.** Each is 26 slime segments placed along `y = A·sin(3.2πt)·t`, an oscillation whose amplitude grows with distance, which is what a whipping nozzle actually lays down. The taper toward the nozzle is not stylistic; the jet has barely started deviating there.
+- **Mirrored, and checked.** The upper and lower ribbons are exact mirrors: the browser check compares every pair of `--y` values and confirms `up[i] + lo[i] = 0` for all 26. That is why they cross into a net rather than overlapping into a blob.
+- **40 Hz is the real number.** The nozzle keyframe is `0.025s`, measured at exactly **40.0 Hz**. The caption says forty times a second, and the CSS runs at forty times a second.
+- **The net reaches the prey.** Measured in the browser: the net's right edge at 510px against the cricket's left at 476px. A net that stops short of the animal would be describing a miss.
+- **Hydrostatic legs**: 15 stubby unjointed lobopods on a staggered `calc(var(--i) * -0.09s)` delay, so the walk runs as a wave down the body rather than in lockstep.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and leaves the net laid down over the prey.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/velvet-worm-as/demo.html
+++ b/submissions/examples/velvet-worm-as/demo.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Velvet Worm</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="litterV"></span>
+    <span class="logV"></span>
+
+    <div class="cricketV">
+      <span class="ckBody"></span>
+      <span class="ckHead"></span>
+      <span class="ckLeg clA"></span>
+      <span class="ckLeg clB"></span>
+      <span class="ckAnt"></span>
+    </div>
+
+    <div class="netV nvU">
+        <span class="gobV" style="--x: 18.0px; --y: -0.0px; --i: 0"></span>
+        <span class="gobV" style="--x: 24.6px; --y: -0.4px; --i: 1"></span>
+        <span class="gobV" style="--x: 31.1px; --y: -1.4px; --i: 2"></span>
+        <span class="gobV" style="--x: 37.7px; --y: -2.7px; --i: 3"></span>
+        <span class="gobV" style="--x: 44.2px; --y: -3.8px; --i: 4"></span>
+        <span class="gobV" style="--x: 50.8px; --y: -4.3px; --i: 5"></span>
+        <span class="gobV" style="--x: 57.4px; --y: -3.8px; --i: 6"></span>
+        <span class="gobV" style="--x: 63.9px; --y: -2.2px; --i: 7"></span>
+        <span class="gobV" style="--x: 70.5px; --y: 0.6px; --i: 8"></span>
+        <span class="gobV" style="--x: 77.0px; --y: 4.0px; --i: 9"></span>
+        <span class="gobV" style="--x: 83.6px; --y: 7.4px; --i: 10"></span>
+        <span class="gobV" style="--x: 90.2px; --y: 10.1px; --i: 11"></span>
+        <span class="gobV" style="--x: 96.7px; --y: 11.4px; --i: 12"></span>
+        <span class="gobV" style="--x: 103.3px; --y: 10.9px; --i: 13"></span>
+        <span class="gobV" style="--x: 109.8px; --y: 8.2px; --i: 14"></span>
+        <span class="gobV" style="--x: 116.4px; --y: 3.6px; --i: 15"></span>
+        <span class="gobV" style="--x: 123.0px; --y: -2.3px; --i: 16"></span>
+        <span class="gobV" style="--x: 129.5px; --y: -8.6px; --i: 17"></span>
+        <span class="gobV" style="--x: 136.1px; --y: -14.1px; --i: 18"></span>
+        <span class="gobV" style="--x: 142.6px; --y: -17.8px; --i: 19"></span>
+        <span class="gobV" style="--x: 149.2px; --y: -18.9px; --i: 20"></span>
+        <span class="gobV" style="--x: 155.8px; --y: -16.7px; --i: 21"></span>
+        <span class="gobV" style="--x: 162.3px; --y: -11.5px; --i: 22"></span>
+        <span class="gobV" style="--x: 168.9px; --y: -3.9px; --i: 23"></span>
+        <span class="gobV" style="--x: 175.4px; --y: 5.2px; --i: 24"></span>
+        <span class="gobV" style="--x: 182.0px; --y: 14.1px; --i: 25"></span>
+    </div>
+    <div class="netV nvL">
+        <span class="gobV" style="--x: 18.0px; --y: 0.0px; --i: 0"></span>
+        <span class="gobV" style="--x: 24.6px; --y: 0.4px; --i: 1"></span>
+        <span class="gobV" style="--x: 31.1px; --y: 1.4px; --i: 2"></span>
+        <span class="gobV" style="--x: 37.7px; --y: 2.7px; --i: 3"></span>
+        <span class="gobV" style="--x: 44.2px; --y: 3.8px; --i: 4"></span>
+        <span class="gobV" style="--x: 50.8px; --y: 4.3px; --i: 5"></span>
+        <span class="gobV" style="--x: 57.4px; --y: 3.8px; --i: 6"></span>
+        <span class="gobV" style="--x: 63.9px; --y: 2.2px; --i: 7"></span>
+        <span class="gobV" style="--x: 70.5px; --y: -0.6px; --i: 8"></span>
+        <span class="gobV" style="--x: 77.0px; --y: -4.0px; --i: 9"></span>
+        <span class="gobV" style="--x: 83.6px; --y: -7.4px; --i: 10"></span>
+        <span class="gobV" style="--x: 90.2px; --y: -10.1px; --i: 11"></span>
+        <span class="gobV" style="--x: 96.7px; --y: -11.4px; --i: 12"></span>
+        <span class="gobV" style="--x: 103.3px; --y: -10.9px; --i: 13"></span>
+        <span class="gobV" style="--x: 109.8px; --y: -8.2px; --i: 14"></span>
+        <span class="gobV" style="--x: 116.4px; --y: -3.6px; --i: 15"></span>
+        <span class="gobV" style="--x: 123.0px; --y: 2.3px; --i: 16"></span>
+        <span class="gobV" style="--x: 129.5px; --y: 8.6px; --i: 17"></span>
+        <span class="gobV" style="--x: 136.1px; --y: 14.1px; --i: 18"></span>
+        <span class="gobV" style="--x: 142.6px; --y: 17.8px; --i: 19"></span>
+        <span class="gobV" style="--x: 149.2px; --y: 18.9px; --i: 20"></span>
+        <span class="gobV" style="--x: 155.8px; --y: 16.7px; --i: 21"></span>
+        <span class="gobV" style="--x: 162.3px; --y: 11.5px; --i: 22"></span>
+        <span class="gobV" style="--x: 168.9px; --y: 3.9px; --i: 23"></span>
+        <span class="gobV" style="--x: 175.4px; --y: -5.2px; --i: 24"></span>
+        <span class="gobV" style="--x: 182.0px; --y: -14.1px; --i: 25"></span>
+    </div>
+
+    <div class="wormV">
+      <span class="tailV"></span>
+      <span class="bodyV"></span>
+      <span class="skinV"></span>
+      <span class="legV" style="--i: 0"></span>
+      <span class="legV" style="--i: 1"></span>
+      <span class="legV" style="--i: 2"></span>
+      <span class="legV" style="--i: 3"></span>
+      <span class="legV" style="--i: 4"></span>
+      <span class="legV" style="--i: 5"></span>
+      <span class="legV" style="--i: 6"></span>
+      <span class="legV" style="--i: 7"></span>
+      <span class="legV" style="--i: 8"></span>
+      <span class="legV" style="--i: 9"></span>
+      <span class="legV" style="--i: 10"></span>
+      <span class="legV" style="--i: 11"></span>
+      <span class="legV" style="--i: 12"></span>
+      <span class="legV" style="--i: 13"></span>
+      <span class="legV" style="--i: 14"></span>
+
+      <div class="headV">
+        <span class="domeV"></span>
+        <span class="eyeV"></span>
+        <span class="antV avA"></span>
+        <span class="antV avB"></span>
+        <span class="papV pvU"></span>
+        <span class="papV pvL"></span>
+      </div>
+    </div>
+
+    <span class="capV">two nozzles, oscillating, forty times a second</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/velvet-worm-as/style.css
+++ b/submissions/examples/velvet-worm-as/style.css
@@ -1,0 +1,358 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #3a3a28, #090a07 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 42% 36%, #5f5f42, #12140e 86%);
+}
+
+.litterV {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 62px;
+  background:
+    radial-gradient(circle at 16% 40%, rgba(90, 70, 30, 0.4) 0 9px, transparent 14px),
+    radial-gradient(circle at 62% 66%, rgba(90, 70, 30, 0.34) 0 11px, transparent 16px),
+    radial-gradient(circle at 88% 34%, rgba(90, 70, 30, 0.3) 0 8px, transparent 13px),
+    linear-gradient(180deg, #4a4028, #16150d);
+  z-index: 2;
+}
+
+.logV {
+  position: absolute;
+  bottom: 44px;
+  left: -20px;
+  right: -20px;
+  height: 22px;
+  border-radius: 11px;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(20, 14, 6, 0.3) 0 2px,
+      transparent 2px 15px
+    ),
+    linear-gradient(180deg, #5f4a2a, #241a0c);
+  z-index: 3;
+}
+
+/* ---------------- the prey ---------------- */
+
+.cricketV {
+  position: absolute;
+  bottom: 66px;
+  right: 34px;
+  width: 60px;
+  height: 34px;
+  z-index: 6;
+  animation: strugV 5s ease-in-out infinite;
+}
+
+.ckBody {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 38px;
+  height: 20px;
+  border-radius: 46% 54% 50% 50%;
+  background: radial-gradient(circle at 40% 32%, #7a5a2a, #2a1c08 78%);
+  z-index: 2;
+}
+
+.ckHead {
+  position: absolute;
+  bottom: 4px;
+  right: 34px;
+  width: 14px;
+  height: 13px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 44% 34%, #6a4c22, #1e1406 78%);
+  z-index: 3;
+}
+
+.ckAnt {
+  position: absolute;
+  bottom: 14px;
+  right: 42px;
+  width: 20px;
+  height: 1.4px;
+  background: #4a3410;
+  transform-origin: 100% 50%;
+  transform: rotate(-18deg);
+  z-index: 2;
+}
+
+.ckLeg {
+  position: absolute;
+  bottom: -6px;
+  width: 2px;
+  height: 14px;
+  background: #33240c;
+  transform-origin: 50% 0;
+  z-index: 1;
+  animation: kickV 0.5s ease-in-out infinite;
+}
+
+.clA { right: 14px; }
+.clB { right: 28px; animation-delay: -0.25s; }
+
+/* ---------------- the net ---------------- */
+
+/*
+  the two jets do not spray. each papilla whips side to side about
+  forty times a second, so the slime lands as an oscillating ribbon,
+  and the two ribbons cross into a net.
+*/
+.netV {
+  position: absolute;
+  bottom: 96px;
+  left: 96px;
+  width: 0;
+  height: 0;
+  z-index: 7;
+}
+
+.gobV {
+  position: absolute;
+  top: var(--y, 0);
+  left: var(--x, 0);
+  width: 4px;
+  height: 4px;
+  margin: -2px 0 0 -2px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(244, 252, 240, 0.95), rgba(180, 220, 190, 0.35) 72%);
+  opacity: 0;
+  animation: flingV 5s cubic-bezier(0.15, 0.7, 0.4, 1) infinite;
+  animation-delay: calc(var(--i) * 0.008s);
+}
+
+.nvL .gobV { animation-name: flingVb; }
+
+/* ---------------- the worm ---------------- */
+
+.wormV {
+  position: absolute;
+  bottom: 62px;
+  left: 6px;
+  width: 130px;
+  height: 60px;
+  z-index: 8;
+  animation: aimV 5s ease-in-out infinite;
+}
+
+.bodyV {
+  position: absolute;
+  bottom: 12px;
+  left: 6px;
+  width: 104px;
+  height: 24px;
+  border-radius: 14px 10px 10px 14px;
+  background: linear-gradient(180deg, #4a7fa0, #14283a);
+  z-index: 3;
+}
+
+/*
+  the velvet: rows of tiny papillae, which is why it is not wettable
+  and why its own slime does not stick to it
+*/
+.skinV {
+  position: absolute;
+  bottom: 12px;
+  left: 6px;
+  width: 104px;
+  height: 24px;
+  border-radius: 14px 10px 10px 14px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(150, 210, 240, 0.22) 0 1px,
+      transparent 1px 5px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      rgba(10, 20, 30, 0.3) 0 1px,
+      transparent 1px 5px
+    );
+  z-index: 4;
+}
+
+.tailV {
+  position: absolute;
+  bottom: 14px;
+  left: 100px;
+  width: 26px;
+  height: 18px;
+  border-radius: 4px 10px 10px 4px;
+  background: linear-gradient(90deg, #35617e, #0e1e2c);
+  z-index: 2;
+}
+
+/* stubby unjointed legs: hydrostatic, not hinged */
+.legV {
+  position: absolute;
+  bottom: 2px;
+  left: calc(12px + var(--i) * 6.6px);
+  width: 4px;
+  height: 12px;
+  border-radius: 2px 2px 3px 3px;
+  background: linear-gradient(180deg, #3f7192, #12222f);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: walkV 1.6s ease-in-out infinite;
+  animation-delay: calc(var(--i) * -0.09s);
+}
+
+.headV {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  width: 40px;
+  height: 34px;
+  z-index: 5;
+}
+
+.domeV {
+  position: absolute;
+  bottom: 2px;
+  left: 0;
+  width: 30px;
+  height: 24px;
+  border-radius: 60% 26% 26% 60% / 60% 40% 40% 60%;
+  background: radial-gradient(circle at 62% 34%, #5f93b4, #16293a 80%);
+}
+
+.eyeV {
+  position: absolute;
+  bottom: 16px;
+  left: 14px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #05080c;
+  z-index: 3;
+}
+
+.antV {
+  position: absolute;
+  width: 18px;
+  height: 2px;
+  border-radius: 1px;
+  background:
+    repeating-linear-gradient(90deg, #2f5670 0 2px, transparent 2px 3.4px),
+    #234055;
+  transform-origin: 100% 50%;
+  transform: rotate(var(--av, 0deg));
+  z-index: 2;
+  animation: feelV 2.3s ease-in-out infinite;
+}
+
+.avA { --av: -22deg; bottom: 22px; left: -14px; }
+.avB { --av: 14deg; bottom: 14px; left: -15px; animation-delay: -1.15s; }
+
+/* the papillae: the nozzles the slime comes out of */
+.papV {
+  position: absolute;
+  left: 14px;
+  width: 12px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #4a7fa0, #a8d4e8);
+  transform-origin: 0 50%;
+  z-index: 6;
+  animation: whipV 0.025s linear infinite;
+}
+
+.pvU { bottom: 20px; }
+.pvL { bottom: 8px; animation-delay: -0.0125s; }
+
+.capV {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.07em;
+  color: rgba(214, 240, 230, 0.66);
+  z-index: 9;
+}
+
+/*
+  the slime is fired, not sprayed. it is out and landed inside
+  1/25th of the cycle, then it sits there as a net.
+*/
+@keyframes flingV {
+  0%, 30% { opacity: 0; transform: translate(-14px, 0) scale(0.3); }
+  34% { opacity: 1; transform: translate(0, 0) scale(1); }
+  82% { opacity: 1; transform: translate(0, 0) scale(1); }
+  92%, 100% { opacity: 0; transform: translate(0, 4px) scale(0.7); }
+}
+
+@keyframes flingVb {
+  0%, 30% { opacity: 0; transform: translate(-14px, 0) scale(0.3); }
+  35% { opacity: 1; transform: translate(0, 0) scale(1); }
+  82% { opacity: 1; transform: translate(0, 0) scale(1); }
+  92%, 100% { opacity: 0; transform: translate(0, 4px) scale(0.7); }
+}
+
+/* 0.025s per sweep is 40Hz: the rate the real papilla whips at */
+@keyframes whipV {
+  0%, 100% { transform: rotate(-26deg); }
+  50% { transform: rotate(26deg); }
+}
+
+@keyframes aimV {
+  0%, 24% { transform: translateX(0) rotate(0deg); }
+  32% { transform: translateX(6px) rotate(-3deg); }
+  70%, 100% { transform: translateX(0) rotate(0deg); }
+}
+
+@keyframes walkV {
+  0%, 100% { transform: rotate(14deg); }
+  50% { transform: rotate(-14deg); }
+}
+
+@keyframes feelV {
+  0%, 100% { transform: rotate(var(--av, 0deg)); }
+  50% { transform: rotate(calc(var(--av, 0deg) + 12deg)); }
+}
+
+@keyframes strugV {
+  0%, 30% { transform: translate(0, 0) rotate(0deg); }
+  38% { transform: translate(-3px, 0) rotate(-6deg); }
+  46% { transform: translate(2px, 0) rotate(5deg); }
+  56% { transform: translate(-2px, 0) rotate(-4deg); }
+  70%, 100% { transform: translate(0, 0) rotate(0deg); }
+}
+
+@keyframes kickV {
+  0%, 100% { transform: rotate(20deg); }
+  50% { transform: rotate(-20deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gobV,
+  .papV,
+  .wormV,
+  .legV,
+  .antV,
+  .cricketV,
+  .ckLeg {
+    animation: none;
+  }
+
+  .gobV { opacity: 1; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/velvet-worm-as/`, a self-contained pure CSS/HTML velvet worm netting a cricket with two oscillating slime jets.

Closes #48589

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The jets are ribbons, not sprays.** Each is 26 slime segments placed along `y = A·sin(3.2πt)·t`, an oscillation whose amplitude grows with distance, which is what a whipping nozzle actually lays down. The taper near the nozzle is not stylistic: the jet has barely started deviating there. The oscillation is a passive instability driven by the jet's own momentum, not something the worm aims.
- **Mirrored, and checked.** The upper and lower ribbons are exact mirrors: the browser check compares every pair of `--y` values and confirms `up[i] + lo[i] = 0` for all 26. That is why they cross into a net rather than overlapping into a blob.
- **40 Hz is the real number.** The nozzle keyframe is `0.025s`, measured at exactly **40.0 Hz**. The first pass ran at 16.7 Hz while the caption claimed forty times a second, so the timing was corrected to match the claim rather than the caption softened.
- **The net reaches the prey.** Measured in the browser: net right edge 510px against the cricket's left edge 476px. The first pass stopped 4px short, which would have been a picture of a miss.
- **Hydrostatic legs**: 15 stubby unjointed lobopods on a staggered `calc(var(--i) * -0.09s)` delay, so the walk runs as a wave down the body rather than in lockstep.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and leaves the net laid down over the prey.

## Verification

Opened `demo.html` in the browser and measured rather than eyeballed: confirmed the two ribbons are exact mirrors across all 26 segment pairs, the nozzle resolves to exactly 40.0 Hz, and the net's right edge now overlaps the cricket. Also brightened the scene after the first render came out too dark to read. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
