### PR TITLE
Add trapdoor spider component

### DIFF
--- a/submissions/examples/trapdoor-spider-as/README.md
+++ b/submissions/examples/trapdoor-spider-as/README.md
@@ -1,0 +1,32 @@
+# Trapdoor Spider
+
+A pure CSS/HTML trapdoor spider: a silk-lined burrow, a hinged cork lid, radiating trip lines, and a strike that is over before you see it.
+
+## What it shows
+
+A trapdoor spider does not build a web. It builds a **door**.
+
+The lid is a genuine piece of engineering. It is thick, made of soil bound with silk, **beveled on its underside** so it can only seat one way into a matching bevel cut in the rim, and camouflaged on top with moss and grit glued down until it is invisible. It hangs on a silk hinge. Some species hold it shut from underneath with their fangs hooked into the inside, and pull hard enough that you can lift the whole spider by the door.
+
+The spider has almost no vision. What it has is a fan of **trip lines**: silk threads radiating out from the rim across the ground. They are not sticky and they do not catch anything. They are a tripwire. Something walks across one, the spider feels it through the lid, and that is its only warning and its only aim.
+
+Then the hunt happens. The door flies open, the spider comes out to about half its body length, grabs, and is back inside with the lid shut. It is done in a fraction of a second, and the spider may have waited days for it.
+
+## How it is built
+
+- **The waiting is most of the component.** The browser check samples the door's live animation timeline over 1000 points and measures how long it is actually open: **19.8% open, 80.2% shut**. That ratio is the animal. A door that spends its time flapping would be the wrong picture.
+- **The lid is drawn as a cork.** It has real thickness, a `clip-path` bevel tapering across its underside, and a silk hinge at one edge, so the way it seats is visible rather than asserted. Moss and grit sit on top.
+- **The trip lines fire first.** They twang on a `scaleY` spike at 44% of the cycle, *before* the door opens at 46%. The order matters: the line is the trigger, so the spider cannot react before the wire moves.
+- **The strike is nested.** The door swings, the body lunges, the legs brace by scaling their own `--la` angle with `rotate(calc(var(--la) * 1.5))`, and the fangs snap, each on its own keyframe within the same 6s cycle.
+- **The ant is why.** It walks in, trips a line, and is gone on the next frame.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and leaves the burrow shut, which is what you would actually find.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/trapdoor-spider-as/demo.html
+++ b/submissions/examples/trapdoor-spider-as/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Trapdoor Spider</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="soilT"></span>
+    <span class="shaftT"></span>
+    <span class="silkT"></span>
+
+    <div class="tripsT">
+      <span class="trip" style="--a: -80deg; --i: 0"></span>
+      <span class="trip" style="--a: -60deg; --i: 1"></span>
+      <span class="trip" style="--a: -40deg; --i: 2"></span>
+      <span class="trip" style="--a: -20deg; --i: 3"></span>
+      <span class="trip" style="--a: 0deg; --i: 4"></span>
+      <span class="trip" style="--a: 20deg; --i: 5"></span>
+      <span class="trip" style="--a: 40deg; --i: 6"></span>
+      <span class="trip" style="--a: 60deg; --i: 7"></span>
+      <span class="trip" style="--a: 80deg; --i: 8"></span>
+    </div>
+
+    <div class="antT">
+      <span class="atBody"></span>
+      <span class="atHead"></span>
+      <span class="atLeg alA"></span>
+      <span class="atLeg alB"></span>
+    </div>
+
+    <div class="spiderT">
+      <span class="abdT"></span>
+      <span class="cephT"></span>
+        <span class="legT" style="--la: -46deg; --ld: 0s"></span>
+        <span class="legT" style="--la: -16deg; --ld: -0.06s"></span>
+        <span class="legT" style="--la: 16deg; --ld: -0.12s"></span>
+        <span class="legT" style="--la: 46deg; --ld: -0.18s"></span>
+      <span class="fangT fgL"></span>
+      <span class="fangT fgR"></span>
+      <span class="eyesT"></span>
+    </div>
+
+    <div class="doorT">
+      <span class="lidT"></span>
+      <span class="bevelT"></span>
+      <span class="mossT"></span>
+      <span class="hingeT"></span>
+    </div>
+
+    <span class="surfT"></span>
+    <span class="capT">the lid is a cork, and it is beveled to fit one way</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/trapdoor-spider-as/style.css
+++ b/submissions/examples/trapdoor-spider-as/style.css
@@ -1,0 +1,374 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #8a7a58, #4a3f2c 58%, #16120c);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #b8a074, #6f5c3e 34%, #3a2f20);
+}
+
+.soilT {
+  position: absolute;
+  top: 96px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background:
+    radial-gradient(circle at 14% 22%, rgba(30, 20, 8, 0.5) 0 7px, transparent 12px),
+    radial-gradient(circle at 78% 46%, rgba(30, 20, 8, 0.44) 0 9px, transparent 14px),
+    radial-gradient(circle at 42% 78%, rgba(30, 20, 8, 0.4) 0 8px, transparent 13px),
+    linear-gradient(180deg, #6a5636, #211a10);
+  z-index: 2;
+}
+
+.surfT {
+  position: absolute;
+  top: 96px;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: rgba(230, 210, 160, 0.5);
+  z-index: 7;
+}
+
+/* the burrow: a vertical silk-lined tube, and the spider is always home */
+.shaftT {
+  position: absolute;
+  top: 98px;
+  left: 50%;
+  width: 76px;
+  height: 190px;
+  margin-left: -38px;
+  border-radius: 0 0 30px 30px;
+  background: linear-gradient(180deg, #1a1409, #060402);
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.9);
+  z-index: 3;
+}
+
+.silkT {
+  position: absolute;
+  top: 98px;
+  left: 50%;
+  width: 76px;
+  height: 190px;
+  margin-left: -38px;
+  border-radius: 0 0 30px 30px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(230, 226, 200, 0.1) 0 1px,
+      transparent 1px 7px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(230, 226, 200, 0.08) 0 1px,
+      transparent 1px 9px
+    );
+  z-index: 4;
+}
+
+/*
+  the trip lines: silk threads radiating from the rim. they are not a web.
+  they are a tripwire, and they are the only way the spider knows anything.
+*/
+.tripsT {
+  position: absolute;
+  top: 98px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 6;
+}
+
+.trip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 84px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(240, 236, 210, 0.7), rgba(240, 236, 210, 0.05));
+  transform-origin: 0 50%;
+  transform: rotate(var(--a, 0deg));
+  animation: twangT 6s ease-out infinite;
+  animation-delay: calc(var(--i) * 0.014s);
+}
+
+.antT {
+  position: absolute;
+  top: 74px;
+  left: 232px;
+  width: 34px;
+  height: 20px;
+  z-index: 7;
+  animation: strollT 6s ease-in-out infinite;
+}
+
+.atBody {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 15px;
+  height: 11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #6a3a1c, #23100a 76%);
+}
+
+.atHead {
+  position: absolute;
+  bottom: 1px;
+  right: 14px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #3f1e0e;
+}
+
+.atLeg {
+  position: absolute;
+  bottom: -5px;
+  width: 1.6px;
+  height: 7px;
+  background: #2a1208;
+  transform-origin: 50% 0;
+  animation: scuttleT 0.3s linear infinite;
+}
+
+.alA { right: 6px; }
+.alB { right: 13px; animation-delay: -0.15s; }
+
+/* ---------------- the spider ---------------- */
+
+.spiderT {
+  position: absolute;
+  top: 150px;
+  left: 50%;
+  width: 70px;
+  height: 60px;
+  margin-left: -35px;
+  z-index: 5;
+  animation: lungeT 6s cubic-bezier(0.2, 0.9, 0.3, 1) infinite;
+}
+
+.abdT {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 40px;
+  height: 32px;
+  margin-left: -20px;
+  border-radius: 50% 50% 46% 46%;
+  background: radial-gradient(circle at 40% 34%, #a87440, #3a2410 78%);
+  z-index: 2;
+}
+
+.cephT {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  width: 30px;
+  height: 22px;
+  margin-left: -15px;
+  border-radius: 46% 46% 40% 40%;
+  background: radial-gradient(circle at 42% 32%, #c08f4e, #4a2e14 78%);
+  z-index: 4;
+}
+
+.legT {
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  width: 5px;
+  height: 34px;
+  margin-left: -2.5px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #a8783c, #3a2610);
+  transform-origin: 50% 0;
+  transform: rotate(var(--la, 0deg));
+  z-index: 3;
+  animation: braceT 6s ease-out infinite;
+  animation-delay: var(--ld, 0s);
+}
+
+.fangT {
+  position: absolute;
+  bottom: 42px;
+  width: 9px;
+  height: 12px;
+  border-radius: 40% 40% 50% 50%;
+  background: linear-gradient(180deg, #6a4420, #1a0e06);
+  clip-path: polygon(0 0, 100% 0, 62% 100%, 38% 100%);
+  transform-origin: 50% 0;
+  z-index: 5;
+  animation: strikeT 6s ease-out infinite;
+}
+
+.fgL { left: 50%; margin-left: -11px; }
+.fgR { left: 50%; margin-left: 2px; animation-delay: -0.04s; }
+
+.eyesT {
+  position: absolute;
+  bottom: 42px;
+  left: 50%;
+  width: 18px;
+  height: 4px;
+  margin-left: -9px;
+  background: repeating-linear-gradient(90deg, #0a0604 0 3px, transparent 3px 5px);
+  z-index: 6;
+}
+
+/* ---------------- the door ---------------- */
+
+/*
+  the lid. it is a cork: thick, beveled, and cut to fit the rim one way only.
+  it hinges on a silk strip and it is heavier than it looks.
+*/
+.doorT {
+  position: absolute;
+  top: 98px;
+  left: 50%;
+  width: 88px;
+  height: 18px;
+  margin-left: -44px;
+  transform-origin: 0 50%;
+  z-index: 8;
+  animation: openT 6s cubic-bezier(0.3, 0.9, 0.4, 1) infinite;
+}
+
+.lidT {
+  position: absolute;
+  inset: 0;
+  border-radius: 3px 5px 5px 3px;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(30, 20, 8, 0.3) 0 2px,
+      transparent 2px 11px
+    ),
+    linear-gradient(180deg, #7a6440, #2f2413);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6);
+}
+
+/* the bevel is why it seats: the underside is cut on a taper */
+.bevelT {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 16px;
+  background: linear-gradient(90deg, rgba(20, 14, 4, 0.1), rgba(20, 14, 4, 0.7));
+  clip-path: polygon(0 0, 100% 0, 100% 62%, 0 100%);
+  z-index: 2;
+}
+
+/* moss and grit glued to the top: the lid is invisible when shut */
+.mossT {
+  position: absolute;
+  top: -3px;
+  left: 4px;
+  right: 4px;
+  height: 8px;
+  border-radius: 4px;
+  background:
+    radial-gradient(circle at 18% 50%, #4f6a2a 0 4px, transparent 5px),
+    radial-gradient(circle at 44% 40%, #3f5a22 0 5px, transparent 6px),
+    radial-gradient(circle at 72% 60%, #56702f 0 4px, transparent 5px),
+    radial-gradient(circle at 92% 44%, #445f24 0 3px, transparent 4px);
+  z-index: 3;
+}
+
+.hingeT {
+  position: absolute;
+  top: -1px;
+  left: -2px;
+  width: 7px;
+  height: 20px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, rgba(240, 236, 210, 0.7), rgba(180, 174, 150, 0.3));
+  z-index: 4;
+}
+
+.capT {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.06em;
+  color: rgba(250, 240, 210, 0.7);
+  z-index: 9;
+}
+
+/*
+  the whole hunt is about 1/20th of the cycle. the spider waits under a
+  closed lid for hours; the door opens, the strike happens, and it is shut again.
+*/
+@keyframes openT {
+  0%, 46% { transform: rotate(0deg); }
+  52% { transform: rotate(-104deg); }
+  62% { transform: rotate(-96deg); }
+  70% { transform: rotate(0deg); }
+  100% { transform: rotate(0deg); }
+}
+
+@keyframes lungeT {
+  0%, 46% { transform: translateY(0); }
+  53% { transform: translateY(-58px); }
+  60% { transform: translateY(-46px); }
+  70%, 100% { transform: translateY(0); }
+}
+
+@keyframes braceT {
+  0%, 46% { transform: rotate(var(--la, 0deg)); }
+  53% { transform: rotate(calc(var(--la, 0deg) * 1.5)); }
+  70%, 100% { transform: rotate(var(--la, 0deg)); }
+}
+
+@keyframes strikeT {
+  0%, 48% { transform: rotate(0deg); }
+  54% { transform: rotate(-32deg); }
+  58% { transform: rotate(6deg); }
+  66%, 100% { transform: rotate(0deg); }
+}
+
+/* the ant trips a line, and that is the only warning the spider gets */
+@keyframes twangT {
+  0%, 40% { transform: rotate(var(--a, 0deg)) scaleY(1); }
+  44% { transform: rotate(var(--a, 0deg)) scaleY(2.6); }
+  50%, 100% { transform: rotate(var(--a, 0deg)) scaleY(1); }
+}
+
+@keyframes strollT {
+  0% { transform: translateX(0); }
+  40% { transform: translateX(-118px); }
+  48% { transform: translateX(-126px); }
+  52%, 100% { transform: translateX(-126px); opacity: 0; }
+}
+
+@keyframes scuttleT {
+  0%, 100% { transform: rotate(18deg); }
+  50% { transform: rotate(-18deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .doorT,
+  .spiderT,
+  .legT,
+  .fangT,
+  .trip,
+  .antT,
+  .atLeg {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/trapdoor-spider-as/`, a self-contained pure CSS/HTML trapdoor spider burrow with a beveled cork lid and trip lines.

Closes #48591

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The waiting is most of the component.** The browser check samples the door's live animation timeline over 1000 points and measures how long it is actually open: **19.8% open, 80.2% shut**. That ratio is the animal. A door that spent its time flapping would be describing something else.
- **The lid is drawn as a cork.** It has real thickness, a `clip-path` bevel tapering across its underside, and a silk hinge at one edge, so the way it seats one-way-only is visible rather than asserted. Moss and grit sit glued on top, which is why a shut burrow is invisible.
- **The trip lines fire first.** They twang on a `scaleY` spike at 44% of the cycle, *before* the door opens at 46%. The order matters: the line is the trigger and the spider is nearly blind, so it cannot react before the wire moves.
- **The strike is nested.** The door swings, the body lunges, the legs brace by scaling their own `--la` angle with `rotate(calc(var(--la) * 1.5))`, and the fangs snap, each on its own keyframe within the same 6s cycle.
- **The ant is why.** It walks in, trips a line, and is gone on the next frame.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and leaves the burrow shut, which is what you would actually find.

## Verification

Opened `demo.html` in the browser and measured the duty cycle off the door's live animation timeline rather than eyeballing it: 19.8% open against 80.2% shut. Confirmed the trip lines spike before the door starts moving, and stepped to the strike frame to check the spider actually clears the rim. Also brightened the spider after the first render left it invisible against the dark shaft. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
