### PR TITLE
Add bombardier beetle component

### DIFF
--- a/submissions/examples/bombardier-beetle-as/README.md
+++ b/submissions/examples/bombardier-beetle-as/README.md
@@ -1,0 +1,34 @@
+# Bombardier Beetle
+
+A pure CSS/HTML bombardier beetle turning its rear turret on a frog and firing boiling quinones at it.
+
+## What it shows
+
+The beetle carries a working chemical weapon, and the interesting parts are the engineering, not the chemistry.
+
+**It stores the reagents apart.** Hydroquinones in one sac, hydrogen peroxide in another. Both are stable and the beetle is in no danger from either.
+
+**The reaction happens in a chamber, on demand.** Squeeze the reagents into a thick-walled vestibule lined with catalase and peroxidase, and the peroxide decomposes explosively. The mixture reaches **100°C** and blows itself out of the beetle.
+
+**The spray is pulsed, not sprayed.** This is the part people get wrong. High-speed film shows a train of **roughly 500 discrete explosions per second**. Each blast raises the chamber pressure enough to slam its own inlet valve shut, the chamber empties, the pressure drops, the valve reopens, and it fires again. It is a pulse jet, and the pulsing is what keeps the beetle from cooking itself: each explosion is over before the heat can conduct back.
+
+**And it aims.** The turret swivels, and the beetle can put the jet almost anywhere, including forward over its own back.
+
+## How it is built
+
+- **500 Hz is the real number, and it is measured.** The 18 pulses fire on `animation-delay: calc(var(--i) * 0.002s)`. The browser check reads the resolved delays and reports a step of **0.002s, exactly 500 Hz**, with the whole train lasting **34ms**. A first pass ran at 250 Hz while the caption claimed five hundred a second, so the timing was corrected rather than the caption softened.
+- **Discrete, not continuous.** The jet is 18 separate elements that each pop and fade. There is no gradient stream anywhere in it, because a stream would be the wrong picture of the animal.
+- **The chemistry is staged in order**: the reservoir visibly empties at 38-44%, the chamber flashes at 46%, and the pulses leave from 46%. Cause before effect.
+- **The turret aims** on its own keyframe, swinging round before the blast rather than firing wherever it happened to be pointing.
+- **The frog commits and regrets it**: the tongue extends, the blast lands, and it recoils backwards.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the turret aimed with the pulse train laid out, so the mechanism still reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/bombardier-beetle-as/demo.html
+++ b/submissions/examples/bombardier-beetle-as/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bombardier Beetle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="groundB"></span>
+    <span class="stoneB"></span>
+
+    <div class="frogB">
+      <span class="fgBody"></span>
+      <span class="fgHead"></span>
+      <span class="fgEye"></span>
+      <span class="fgLeg"></span>
+      <span class="fgTongue"></span>
+    </div>
+
+    <div class="beetleB">
+      <span class="elytraB"></span>
+      <span class="sutureB"></span>
+      <span class="pronB"></span>
+      <span class="headB"></span>
+      <span class="antB abA"></span>
+      <span class="antB abB"></span>
+      <span class="legB" style="--i: 0"></span>
+      <span class="legB" style="--i: 1"></span>
+      <span class="legB" style="--i: 2"></span>
+
+      <div class="glandB">
+        <span class="resB"></span>
+        <span class="chamB"></span>
+      </div>
+      <div class="turretB">
+        <span class="tipB"></span>
+        <div class="jetB">
+        <span class="pulseB" style="--i: 0"></span>
+        <span class="pulseB" style="--i: 1"></span>
+        <span class="pulseB" style="--i: 2"></span>
+        <span class="pulseB" style="--i: 3"></span>
+        <span class="pulseB" style="--i: 4"></span>
+        <span class="pulseB" style="--i: 5"></span>
+        <span class="pulseB" style="--i: 6"></span>
+        <span class="pulseB" style="--i: 7"></span>
+        <span class="pulseB" style="--i: 8"></span>
+        <span class="pulseB" style="--i: 9"></span>
+        <span class="pulseB" style="--i: 10"></span>
+        <span class="pulseB" style="--i: 11"></span>
+        <span class="pulseB" style="--i: 12"></span>
+        <span class="pulseB" style="--i: 13"></span>
+        <span class="pulseB" style="--i: 14"></span>
+        <span class="pulseB" style="--i: 15"></span>
+        <span class="pulseB" style="--i: 16"></span>
+        <span class="pulseB" style="--i: 17"></span>
+
+        </div>
+      </div>
+    </div>
+
+    <span class="tagHot">100 C</span>
+    <span class="capB">not a stream. five hundred separate explosions a second.</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/bombardier-beetle-as/style.css
+++ b/submissions/examples/bombardier-beetle-as/style.css
@@ -1,0 +1,404 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #3a3428, #0a0907 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 44% 34%, #6f6349, #16140e 86%);
+}
+
+.groundB {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 66px;
+  background:
+    radial-gradient(circle at 18% 40%, rgba(30, 24, 10, 0.4) 0 5px, transparent 8px),
+    radial-gradient(circle at 74% 62%, rgba(30, 24, 10, 0.34) 0 6px, transparent 10px),
+    linear-gradient(180deg, #574c30, #1c1710);
+  z-index: 2;
+}
+
+.stoneB {
+  position: absolute;
+  bottom: 52px;
+  left: -20px;
+  width: 130px;
+  height: 34px;
+  border-radius: 50% 40% 10% 10%;
+  background: linear-gradient(180deg, #6f6a5c, #2a2822);
+  z-index: 3;
+}
+
+/* ---------------- the attacker ---------------- */
+
+.frogB {
+  position: absolute;
+  bottom: 60px;
+  right: 6px;
+  width: 96px;
+  height: 62px;
+  z-index: 5;
+  animation: recoilB 4s cubic-bezier(0.2, 0.8, 0.3, 1) infinite;
+}
+
+.fgBody {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 74px;
+  height: 42px;
+  border-radius: 54% 46% 40% 44% / 62% 62% 38% 38%;
+  background: radial-gradient(circle at 40% 32%, #6a8f42, #22381a 78%);
+  z-index: 2;
+}
+
+.fgHead {
+  position: absolute;
+  bottom: 6px;
+  right: 62px;
+  width: 30px;
+  height: 26px;
+  border-radius: 60% 30% 30% 60% / 56% 44% 44% 56%;
+  background: radial-gradient(circle at 56% 34%, #7a9f4e, #26401c 78%);
+  z-index: 3;
+}
+
+.fgEye {
+  position: absolute;
+  bottom: 24px;
+  right: 72px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #f0d060, #2a1c04 70%);
+  box-shadow: 0 0 0 1.5px rgba(20, 40, 12, 0.8);
+  z-index: 4;
+}
+
+.fgLeg {
+  position: absolute;
+  bottom: -4px;
+  right: 12px;
+  width: 26px;
+  height: 10px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #4f7030, #1a2c12);
+  z-index: 1;
+}
+
+.fgTongue {
+  position: absolute;
+  bottom: 12px;
+  right: 88px;
+  width: 34px;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #d8607a, #8a2440);
+  transform-origin: 100% 50%;
+  z-index: 5;
+  animation: lickB 4s cubic-bezier(0.2, 0.8, 0.3, 1) infinite;
+}
+
+/* ---------------- the beetle ---------------- */
+
+.beetleB {
+  position: absolute;
+  bottom: 66px;
+  left: 62px;
+  width: 128px;
+  height: 54px;
+  z-index: 6;
+  animation: braceB 4s ease-out infinite;
+}
+
+.elytraB {
+  position: absolute;
+  bottom: 8px;
+  left: 34px;
+  width: 74px;
+  height: 30px;
+  border-radius: 26% 46% 44% 22% / 44% 50% 50% 44%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(10, 20, 40, 0.34) 0 1px,
+      transparent 1px 6px
+    ),
+    linear-gradient(180deg, #33507a, #101e34);
+  box-shadow: inset -4px -3px 8px rgba(6, 12, 22, 0.6);
+  z-index: 4;
+}
+
+.sutureB {
+  position: absolute;
+  bottom: 22px;
+  left: 36px;
+  width: 70px;
+  height: 1.4px;
+  background: rgba(180, 210, 240, 0.34);
+  z-index: 5;
+}
+
+.pronB {
+  position: absolute;
+  bottom: 12px;
+  left: 20px;
+  width: 24px;
+  height: 22px;
+  border-radius: 40% 20% 20% 44% / 54% 44% 44% 54%;
+  background: linear-gradient(180deg, #c8632a, #6a2a0c);
+  z-index: 5;
+}
+
+.headB {
+  position: absolute;
+  bottom: 14px;
+  left: 6px;
+  width: 18px;
+  height: 16px;
+  border-radius: 50% 40% 40% 50%;
+  background: radial-gradient(circle at 60% 34%, #b8551f, #4a1c06 78%);
+  z-index: 4;
+}
+
+.antB {
+  position: absolute;
+  width: 18px;
+  height: 1.6px;
+  border-radius: 1px;
+  background: #3a1c08;
+  transform-origin: 100% 50%;
+  transform: rotate(var(--ab, 0deg));
+  z-index: 3;
+}
+
+.abA { --ab: -22deg; bottom: 26px; left: -10px; }
+.abB { --ab: 16deg; bottom: 16px; left: -11px; }
+
+.legB {
+  position: absolute;
+  bottom: -2px;
+  left: calc(34px + var(--i) * 26px);
+  width: 3px;
+  height: 14px;
+  border-radius: 2px;
+  background: #2a1608;
+  transform-origin: 50% 0;
+  z-index: 3;
+}
+
+.legB::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: -4px;
+  width: 11px;
+  height: 2px;
+  background: #2a1608;
+}
+
+/*
+  the chemistry. two reagents are stored apart and are completely stable:
+  hydroquinones in one sac, hydrogen peroxide in the other.
+*/
+.glandB {
+  position: absolute;
+  bottom: 12px;
+  left: 78px;
+  width: 30px;
+  height: 24px;
+  z-index: 6;
+}
+
+.resB {
+  position: absolute;
+  bottom: 2px;
+  left: 0;
+  width: 16px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #d8e86a, #6a7a10 78%);
+  z-index: 2;
+  animation: dumpB 4s ease-in infinite;
+}
+
+/*
+  the reaction chamber. catalase and peroxidase are added here and nowhere
+  else, and the mixture goes to 100 C and blows itself out of the beetle.
+*/
+.chamB {
+  position: absolute;
+  bottom: 4px;
+  left: 14px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 32%, #fff0c0, #a03c08 76%);
+  z-index: 3;
+  animation: fireB 4s ease-out infinite;
+}
+
+/*
+  the turret. it aims, and the beetle can swivel it almost anywhere,
+  including straight forward over its own back.
+*/
+.turretB {
+  position: absolute;
+  bottom: 10px;
+  left: 104px;
+  width: 16px;
+  height: 10px;
+  transform-origin: 0 50%;
+  z-index: 7;
+  animation: aimB 4s ease-out infinite;
+}
+
+.tipB {
+  position: absolute;
+  top: 2px;
+  left: 0;
+  width: 16px;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #33507a, #8fb0d8);
+}
+
+.jetB {
+  position: absolute;
+  top: 5px;
+  left: 16px;
+  width: 0;
+  height: 0;
+}
+
+/*
+  the spray is not a stream. it is a train of discrete pulses, because the
+  chamber's inlet valve slams shut on each blast and has to refill.
+*/
+.pulseB {
+  position: absolute;
+  top: 0;
+  left: calc(var(--i) * 7px);
+  width: 8px;
+  height: 8px;
+  margin: -4px 0 0 -4px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 246, 220, 0.95), rgba(255, 170, 60, 0.34) 68%, transparent 82%);
+  opacity: 0;
+  animation: popB 4s ease-out infinite;
+  animation-delay: calc(var(--i) * 0.002s);
+}
+
+.tagHot {
+  position: absolute;
+  bottom: 138px;
+  left: 176px;
+  font-size: 0.52rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: rgba(255, 190, 90, 0.9);
+  z-index: 8;
+  opacity: 0;
+  animation: cueB 4s ease-out infinite;
+}
+
+.capB {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.05em;
+  color: rgba(250, 240, 210, 0.7);
+  z-index: 9;
+}
+
+/*
+  2ms between pulses is 500Hz: the rate the real chamber's inlet valve
+  slams and refills. the whole train is over in 36ms.
+*/
+@keyframes popB {
+  0%, 44% { opacity: 0; transform: scale(0.2); }
+  46% { opacity: 1; transform: scale(1.3); }
+  56% { opacity: 0.8; transform: scale(1); }
+  70%, 100% { opacity: 0; transform: scale(0.5) translateY(-8px); }
+}
+
+@keyframes fireB {
+  0%, 42% { transform: scale(0.8); filter: brightness(0.6); }
+  46% { transform: scale(1.4); filter: brightness(2.4); }
+  60% { transform: scale(1); filter: brightness(1.2); }
+  74%, 100% { transform: scale(0.8); filter: brightness(0.6); }
+}
+
+/* the reservoir empties into the chamber just before the blast */
+@keyframes dumpB {
+  0%, 38% { transform: scale(1); }
+  44% { transform: scale(0.62); }
+  80%, 100% { transform: scale(1); }
+}
+
+/* the turret swings round to point at whatever touched the beetle */
+@keyframes aimB {
+  0%, 30% { transform: rotate(0deg); }
+  42%, 66% { transform: rotate(-16deg); }
+  84%, 100% { transform: rotate(0deg); }
+}
+
+@keyframes braceB {
+  0%, 42% { transform: translateX(0); }
+  48% { transform: translateX(-5px); }
+  70%, 100% { transform: translateX(0); }
+}
+
+/* the frog commits, gets hit, and leaves */
+@keyframes lickB {
+  0%, 24% { transform: scaleX(0.2); opacity: 0; }
+  38% { transform: scaleX(1); opacity: 1; }
+  46% { transform: scaleX(1); opacity: 1; }
+  52%, 100% { transform: scaleX(0.2); opacity: 0; }
+}
+
+@keyframes recoilB {
+  0%, 40% { transform: translateX(0) rotate(0deg); }
+  50% { transform: translateX(26px) rotate(6deg); }
+  62% { transform: translateX(18px) rotate(3deg); }
+  86%, 100% { transform: translateX(0) rotate(0deg); }
+}
+
+@keyframes cueB {
+  0%, 44% { opacity: 0; }
+  48%, 62% { opacity: 1; }
+  72%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulseB,
+  .chamB,
+  .resB,
+  .turretB,
+  .beetleB,
+  .frogB,
+  .fgTongue,
+  .tagHot {
+    animation: none;
+  }
+
+  .pulseB { opacity: 1; }
+  .tagHot { opacity: 1; }
+  .turretB { transform: rotate(-16deg); }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/bombardier-beetle-as/`, a self-contained pure CSS/HTML bombardier beetle firing a pulsed chemical jet at a frog.

Closes #48593

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **500 Hz is the real number, and it is measured.** The 18 pulses fire on `animation-delay: calc(var(--i) * 0.002s)`. The browser check reads the resolved delays and reports a step of **0.002s, exactly 500 Hz**, with the whole train lasting **34ms**. A first pass ran at 250 Hz while the caption claimed five hundred a second, so the timing was corrected rather than the caption softened.
- **Discrete, not continuous.** The jet is 18 separate elements that each pop and fade; there is no gradient stream anywhere in it. High-speed film of the real beetle shows a train of separate explosions, each one slamming its own inlet valve shut before the chamber refills, and that pulsing is what stops the beetle cooking itself. A smooth stream would be the wrong picture of the animal.
- **The chemistry is staged in order**: the reservoir visibly empties at 38-44%, the chamber flashes at 46%, and the pulses leave from 46%. Cause before effect.
- **The turret aims** on its own keyframe, swinging round before the blast rather than firing wherever it happened to be pointing.
- **The frog commits and regrets it**: the tongue extends, the blast lands, and it recoils backwards.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the turret aimed with the pulse train laid out.

## Verification

Opened `demo.html` in the browser and stepped to the blast frame to confirm the jet reads as a train of separate explosions reaching the frog, with the chamber flashing and the turret already swung round. Measured the resolved per-pulse delay to confirm the rate is exactly 500 Hz rather than approximately right. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
