### PR TITLE
fix: docs sidebar "Benchmarks" link 404s

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,43 @@
+﻿# Benchmarks
+
+Performance benchmarks for EaseMotion CSS, measured against comparable animation libraries.
+
+## Running Locally
+
+```bash
+# Bundle size (no extra deps)
+node benchmarks/bundle-size.mjs
+
+# FPS benchmark (requires Puppeteer)
+npm install --save-dev puppeteer
+node benchmarks/fps-test.mjs
+```
+
+## CI
+
+Benchmarks run automatically on every release tag (`v*`) via `.github/workflows/benchmarks.yml`.
+Results are committed back to `benchmarks/results/latest.json`.
+
+## Methodology
+
+### Bundle Size
+- Measured as **gzip level 9** compressed size of the minified distribution file.
+- EaseMotion CSS is compared against Animate.css and Framer Motion's JS bundle.
+- Lower is better.
+
+### FPS
+- A Puppeteer headless Chrome session renders **100 simultaneously animated elements**.
+- FPS is sampled every 100ms for 3 seconds using the Chrome DevTools Protocol.
+- Higher is better.
+
+## Latest Results
+
+See [results/latest.json](https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/benchmarks/results/latest.json) for the most recent benchmark run.
+
+## Libraries Compared
+
+| Library | Version tested | Notes |
+|---------|---------------|-------|
+| **EaseMotion CSS** | 1.2.0 | Pure CSS, zero JS |
+| Animate.css | 4.1.1 | Pure CSS |
+| motion (Framer) | latest | JS-based |

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,7 +239,7 @@
           <div class="sidebar-group-label">Performance</div>
           <ul class="sidebar-nav">
             <li><a href="PERFORMANCE.md">Performance Guide</a></li>
-            <li><a href="../benchmarks/README.md">Benchmarks</a></li>
+            <li><a href="BENCHMARKS.md">Benchmarks</a></li>
           </ul>
         </div>
         <div class="sidebar-group">


### PR DESCRIPTION
## Description
Fixes the "Benchmarks" link in the docs page sidebar (under Performance), which 404'd because it pointed outside the `docs/` folder — the only folder GitHub Pages actually publishes for this repo.

## Root cause
`docs/index.html` linked to `../benchmarks/README.md`, resolving to the repo root's `benchmarks/` folder. Since GitHub Pages only serves the contents of `docs/`, that path was never part of the deployed site regardless of the exact relative path used.

## Fix
- Added `docs/BENCHMARKS.md`, a copy of `benchmarks/README.md`'s content, placed inside the published `docs/` folder (matching the existing pattern used by `PERFORMANCE.md` and other sidebar docs).
- Updated the sidebar link in `docs/index.html` to point to `BENCHMARKS.md` instead of the unreachable `../benchmarks/README.md`.
- Updated the "Latest Results" link inside the new file to point to the file's GitHub source (`benchmarks/results/latest.json` isn't published to Pages either, so a relative link there would still 404).

## Files changed
- `docs/BENCHMARKS.md` (new)
- `docs/index.html` (1 line changed)

Closes #48534