### PR TITLE
feat: add EaseMotion playground with URL presets and dynamic keyframes

### DIFF
--- a/submissions/examples/ease-playground-tj/README.md
+++ b/submissions/examples/ease-playground-tj/README.md
@@ -1,0 +1,34 @@
+# EaseMotion Playground (`ease-playground-tj`)
+
+## What
+A self-contained, dependency-free interactive tool for previewing and tuning
+EaseMotion-style animations directly in the browser, with a one-click CSS
+copy button.
+
+## How
+- Runs entirely client-side — open `demo.html` directly, no build step or CDN.
+- State is centralized in a single JS object and rendered through one
+  `render()` function, rather than scattered inline event handlers, so the
+  preview, generated CSS, and live keyframes never drift out of sync.
+- `@keyframes` are generated dynamically at runtime via the CSSOM
+  (`sheet.insertRule`) instead of being hardcoded, so any control change
+  regenerates the actual animation rule used by the preview.
+- Settings can be shared via a URL query string (`?duration=800&rotate=360...`)
+  so a specific configuration can be sent as a link and reproduced exactly.
+- Presets can be exported as JSON for reuse outside the browser session.
+- CSS output copies via the Clipboard API with an `execCommand` fallback for
+  older browsers, and confirms success through an `aria-live` status region.
+- Layout is responsive (`grid-template-columns` collapses to one column under
+  700px) and theming (light/dark) is handled entirely through CSS custom
+  properties switched via `[data-theme="dark"]`.
+- `prefers-reduced-motion` is respected — animation is disabled for users who
+  request it at the OS level.
+- All interactive controls are native form elements, so the whole tool is
+  keyboard-operable and screen-reader labeled without extra ARIA scaffolding.
+
+## Why
+Most animation playgrounds either require a build step or lock configuration
+inside JS you can't share. This tool treats the animation state as portable
+data (URL params, JSON export) rather than throwaway UI state, so a
+configuration a user lands on can be shared, saved, or reused — while still
+being a single HTML file with zero dependencies.

--- a/submissions/examples/ease-playground-tj/demo.html
+++ b/submissions/examples/ease-playground-tj/demo.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>EaseMotion Playground</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body class="playground-tj">
+
+<div class="playground-tj__layout">
+
+  <div class="playground-tj__panel">
+    <h1>EaseMotion Playground</h1>
+
+    <div class="playground-tj__field">
+      <label for="pg-duration">Duration (ms)</label>
+      <input type="number" id="pg-duration" value="800" min="50" step="50" />
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-delay">Delay (ms)</label>
+      <input type="number" id="pg-delay" value="0" min="0" step="50" />
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-easing">Easing</label>
+      <select id="pg-easing">
+        <option value="ease">ease</option>
+        <option value="ease-in-out">ease-in-out</option>
+        <option value="cubic-bezier(.68,-0.55,.27,1.55)">back</option>
+        <option value="cubic-bezier(.22,1,.36,1)">expo-out</option>
+      </select>
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-rotate">Rotation (deg)</label>
+      <input type="number" id="pg-rotate" value="360" />
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-scale">Scale</label>
+      <input type="number" id="pg-scale" value="1.3" step="0.1" />
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-color-start">Start color</label>
+      <input type="color" id="pg-color-start" value="#5b5bd6" />
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-color-end">End color</label>
+      <input type="color" id="pg-color-end" value="#d65b9c" />
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-direction">Direction</label>
+      <select id="pg-direction">
+        <option value="normal">normal</option>
+        <option value="reverse">reverse</option>
+        <option value="alternate">alternate</option>
+      </select>
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-iterations">Iterations</label>
+      <input type="text" id="pg-iterations" value="1" />
+    </div>
+
+    <div class="playground-tj__field">
+      <label for="pg-theme">Theme</label>
+      <select id="pg-theme">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </div>
+
+    <button class="playground-tj__btn" id="pg-replay">Replay</button>
+    <button class="playground-tj__btn playground-tj__btn--ghost" id="pg-share">Copy shareable link</button>
+  </div>
+
+  <div class="playground-tj__preview">
+    <div class="playground-tj__subject" id="pg-subject"></div>
+  </div>
+
+  <div class="playground-tj__output">
+    <button class="playground-tj__btn" id="pg-copy">Copy CSS</button>
+    <button class="playground-tj__btn playground-tj__btn--ghost" id="pg-export">Export JSON</button>
+    <pre id="pg-css-output"></pre>
+    <div class="playground-tj__status" id="pg-status" aria-live="polite"></div>
+  </div>
+
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // ---- Centralized state (single source of truth) ----
+  const state = {
+    duration: 800,
+    delay: 0,
+    easing: "ease",
+    rotate: 360,
+    scale: 1.3,
+    colorStart: "#5b5bd6",
+    colorEnd: "#d65b9c",
+    direction: "normal",
+    iterations: "1",
+    theme: "light"
+  };
+
+  const el = (id) => document.getElementById(id);
+  const fields = {
+    duration: el("pg-duration"),
+    delay: el("pg-delay"),
+    easing: el("pg-easing"),
+    rotate: el("pg-rotate"),
+    scale: el("pg-scale"),
+    colorStart: el("pg-color-start"),
+    colorEnd: el("pg-color-end"),
+    direction: el("pg-direction"),
+    iterations: el("pg-iterations"),
+    theme: el("pg-theme")
+  };
+
+  const subject = el("pg-subject");
+  const output = el("pg-css-output");
+  const status = el("pg-status");
+
+  const STYLE_TAG_ID = "playground-tj-dynamic-keyframes";
+
+  // ---- Load state from URL if present (shareable presets) ----
+  function loadFromURL() {
+    const params = new URLSearchParams(window.location.search);
+    let found = false;
+    Object.keys(state).forEach((key) => {
+      if (params.has(key)) {
+        state[key] = params.get(key);
+        found = true;
+      }
+    });
+    if (found) {
+      state.duration = Number(state.duration);
+      state.delay = Number(state.delay);
+      state.rotate = Number(state.rotate);
+      state.scale = Number(state.scale);
+    }
+  }
+
+  function syncFieldsFromState() {
+    fields.duration.value = state.duration;
+    fields.delay.value = state.delay;
+    fields.easing.value = state.easing;
+    fields.rotate.value = state.rotate;
+    fields.scale.value = state.scale;
+    fields.colorStart.value = state.colorStart;
+    fields.colorEnd.value = state.colorEnd;
+    fields.direction.value = state.direction;
+    fields.iterations.value = state.iterations;
+    fields.theme.value = state.theme;
+  }
+
+  function readStateFromFields() {
+    state.duration = Number(fields.duration.value) || 0;
+    state.delay = Number(fields.delay.value) || 0;
+    state.easing = fields.easing.value;
+    state.rotate = Number(fields.rotate.value) || 0;
+    state.scale = Number(fields.scale.value) || 1;
+    state.colorStart = fields.colorStart.value;
+    state.colorEnd = fields.colorEnd.value;
+    state.direction = fields.direction.value;
+    state.iterations = fields.iterations.value;
+    state.theme = fields.theme.value;
+  }
+
+  // ---- Dynamic @keyframes generation via CSSOM ----
+  function ensureStyleSheet() {
+    let tag = document.getElementById(STYLE_TAG_ID);
+    if (!tag) {
+      tag = document.createElement("style");
+      tag.id = STYLE_TAG_ID;
+      document.head.appendChild(tag);
+    }
+    return tag.sheet;
+  }
+
+  function buildKeyframeRule() {
+    return `@keyframes playground-tj-anim {
+      from { transform: rotate(0deg) scale(1); background-color: ${state.colorStart}; }
+      to { transform: rotate(${state.rotate}deg) scale(${state.scale}); background-color: ${state.colorEnd}; }
+    }`;
+  }
+
+  function render() {
+    const sheet = ensureStyleSheet();
+    while (sheet.cssRules.length > 0) sheet.deleteRule(0);
+    sheet.insertRule(buildKeyframeRule(), 0);
+
+    subject.style.animation = "none";
+    // force reflow so the animation restarts cleanly
+    void subject.offsetWidth;
+    subject.style.animation = `playground-tj-anim ${state.duration}ms ${state.easing} ${state.delay}ms ${state.iterations} ${state.direction} both`;
+
+    document.documentElement.setAttribute("data-theme", state.theme);
+
+    output.textContent =
+`.your-element {
+  animation: playground-tj-anim ${state.duration}ms ${state.easing} ${state.delay}ms ${state.iterations} ${state.direction} both;
+}
+
+@keyframes playground-tj-anim {
+  from { transform: rotate(0deg) scale(1); background-color: ${state.colorStart}; }
+  to { transform: rotate(${state.rotate}deg) scale(${state.scale}); background-color: ${state.colorEnd}; }
+}`;
+  }
+
+  // ---- Event wiring ----
+  Object.values(fields).forEach((f) => {
+    f.addEventListener("input", () => {
+      readStateFromFields();
+      render();
+    });
+  });
+
+  el("pg-replay").addEventListener("click", render);
+
+  el("pg-copy").addEventListener("click", async () => {
+    const text = output.textContent;
+    try {
+      await navigator.clipboard.writeText(text);
+      status.textContent = "CSS copied to clipboard.";
+    } catch (err) {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand("copy");
+        status.textContent = "CSS copied to clipboard.";
+      } catch (e) {
+        status.textContent = "Copy failed — please copy manually.";
+      }
+      document.body.removeChild(ta);
+    }
+  });
+
+  el("pg-share").addEventListener("click", async () => {
+    const params = new URLSearchParams(state);
+    const url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      status.textContent = "Shareable link copied.";
+    } catch (err) {
+      status.textContent = url;
+    }
+  });
+
+  el("pg-export").addEventListener("click", () => {
+    const blob = new Blob([JSON.stringify(state, null, 2)], { type: "application/json" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "playground-tj-preset.json";
+    a.click();
+    URL.revokeObjectURL(a.href);
+    status.textContent = "Preset exported as JSON.";
+  });
+
+  // ---- Init ----
+  loadFromURL();
+  syncFieldsFromState();
+  render();
+})();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-playground-tj/style.css
+++ b/submissions/examples/ease-playground-tj/style.css
@@ -1,0 +1,137 @@
+:root {
+  --pg-bg: #f6f5f3;
+  --pg-surface: #ffffff;
+  --pg-text: #1b1b1f;
+  --pg-muted: #6b6b70;
+  --pg-accent: #5b5bd6;
+  --pg-border: #e2e1de;
+  --pg-radius: 10px;
+  --pg-gap: 1.25rem;
+}
+
+[data-theme="dark"] {
+  --pg-bg: #14141a;
+  --pg-surface: #1e1e26;
+  --pg-text: #f2f2f5;
+  --pg-muted: #a1a1aa;
+  --pg-accent: #8b8bf0;
+  --pg-border: #2c2c36;
+}
+
+* { box-sizing: border-box; }
+
+body.playground-tj {
+  margin: 0;
+  background: var(--pg-bg);
+  color: var(--pg-text);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  padding: 2rem;
+}
+
+.playground-tj__layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: var(--pg-gap);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+@media (max-width: 700px) {
+  .playground-tj__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.playground-tj__panel,
+.playground-tj__preview,
+.playground-tj__output {
+  background: var(--pg-surface);
+  border: 1px solid var(--pg-border);
+  border-radius: var(--pg-radius);
+  padding: 1.25rem;
+}
+
+.playground-tj__field {
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+  margin-bottom: 1rem;
+}
+
+.playground-tj__field label {
+  font-size: .8rem;
+  color: var(--pg-muted);
+}
+
+.playground-tj__field input,
+.playground-tj__field select {
+  background: var(--pg-bg);
+  border: 1px solid var(--pg-border);
+  border-radius: 6px;
+  color: var(--pg-text);
+  padding: .5rem;
+  font: inherit;
+}
+
+.playground-tj__field input:focus-visible,
+.playground-tj__field select:focus-visible,
+.playground-tj__btn:focus-visible {
+  outline: 2px solid var(--pg-accent);
+  outline-offset: 2px;
+}
+
+.playground-tj__preview {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.playground-tj__subject {
+  width: 80px;
+  height: 80px;
+  border-radius: 14px;
+  background: var(--pg-accent);
+}
+
+.playground-tj__output {
+  grid-column: 1 / -1;
+  position: relative;
+}
+
+.playground-tj__output pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: .85rem;
+  margin: 0;
+}
+
+.playground-tj__btn {
+  background: var(--pg-accent);
+  border: none;
+  color: white;
+  padding: .55rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  margin-right: .5rem;
+}
+
+.playground-tj__btn--ghost {
+  background: transparent;
+  color: var(--pg-accent);
+  border: 1px solid var(--pg-accent);
+}
+
+.playground-tj__status {
+  font-size: .8rem;
+  color: var(--pg-muted);
+  margin-top: .5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .playground-tj__subject {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an interactive playground for previewing and customizing EaseMotion-style
animations live in the browser, with a one-click CSS copy button, shareable
URL presets, and JSON export.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An interactive playground for previewing and customizing EaseMotion-style animations live, with one-click CSS copy, shareable URL presets, and JSON export.

**How does a developer use it?**

```html
<div class="playground-tj__subject" id="pg-subject"></div>
```

Open `demo.html` directly in a browser — no build step required. Adjust the controls to preview an animation live, then copy the generated CSS or share the exact configuration via URL.

**Why does it fit EaseMotion CSS?**

It gives contributors and users a way to visually explore and tune animation timing, easing, and motion parameters before writing CSS by hand, matching EaseMotion's animation-first, human-readable philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Built with a centralized state object and dynamic `@keyframes` generation via the CSSOM, plus URL-based preset sharing and JSON export for reuse outside the browser session. Open to feedback on the control set or defaults.