### PR TITLE
Add escapement component

### DIFF
--- a/submissions/examples/escapement-as/README.md
+++ b/submissions/examples/escapement-as/README.md
@@ -1,0 +1,35 @@
+# Escapement
+
+A pure CSS/HTML lever escapement: an escape wheel that never rotates, only jumps, released one tooth at a time by a balance beating five times a second.
+
+## What it shows
+
+Every mechanical watch has a mainspring trying to dump all its energy at once. The escapement is the thing that refuses to let it.
+
+The name is literal. The wheel does not turn; it **escapes**, one tooth at a time. At every instant one of the lever's two ruby jewels is holding a tooth completely stationary against the full force of the mainspring. The balance swings, nudges the lever, the jewel lifts, exactly one tooth slips past, and the other jewel catches the next one. That is a beat. Meanwhile the wheel gives the balance a tiny push through the same lever, which is the only thing keeping the balance from dying out.
+
+So the escapement does two jobs at once, and they are in tension: it **counts** time by letting the wheel out in equal packets, and it **pays** the balance just enough energy to keep counting.
+
+The balance itself is why a watch works in your pocket. It is a pendulum whose restoring force is a **hairspring**, not gravity, so it does not care which way up it is.
+
+## How it is built
+
+- **`steps(30)` is the entire idea.** The wheel's keyframe is a plain `rotate(0deg)` to `rotate(360deg)`, but the timing function is `steps(30, end)`. It is physically incapable of being between teeth.
+
+  Verified by sampling the wheel's live animation timeline at **3000 points** across one revolution: exactly **30 distinct angles**, and every single gap between them is **12.00°**. Not approximately stepped. Stepped.
+
+- **One tooth per beat, checked.** The wheel does a revolution in `6s` over 30 teeth, so **0.2s per tooth**. The balance's period is `0.4s`, which is two beats, so **0.2s per beat**. Those two numbers are equal, which is the constraint that makes an escapement an escapement, and the check confirms it rather than the comment claiming it.
+- **5 beats per second** falls out of the same numbers, matching the label rather than being asserted by it.
+- **The lever is locked to the balance**: same duration, verified equal, because a lever that drifted against its balance would be a broken watch.
+- **Drawn as the real parts**: undercut tooth faces via `clip-path`, two ruby pallet jewels, an impulse pin on the balance (the single point where balance and lever touch), and a hairspring as a `repeating-radial-gradient` spiral.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops all three parts, leaving the wheel locked against a jewel, which is where it spends its life anyway.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/escapement-as/demo.html
+++ b/submissions/examples/escapement-as/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Escapement</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="plateE"></span>
+
+    <div class="wheelE">
+      <span class="toothE" style="--t: 0.0000deg"></span>
+      <span class="toothE" style="--t: 12.0000deg"></span>
+      <span class="toothE" style="--t: 24.0000deg"></span>
+      <span class="toothE" style="--t: 36.0000deg"></span>
+      <span class="toothE" style="--t: 48.0000deg"></span>
+      <span class="toothE" style="--t: 60.0000deg"></span>
+      <span class="toothE" style="--t: 72.0000deg"></span>
+      <span class="toothE" style="--t: 84.0000deg"></span>
+      <span class="toothE" style="--t: 96.0000deg"></span>
+      <span class="toothE" style="--t: 108.0000deg"></span>
+      <span class="toothE" style="--t: 120.0000deg"></span>
+      <span class="toothE" style="--t: 132.0000deg"></span>
+      <span class="toothE" style="--t: 144.0000deg"></span>
+      <span class="toothE" style="--t: 156.0000deg"></span>
+      <span class="toothE" style="--t: 168.0000deg"></span>
+      <span class="toothE" style="--t: 180.0000deg"></span>
+      <span class="toothE" style="--t: 192.0000deg"></span>
+      <span class="toothE" style="--t: 204.0000deg"></span>
+      <span class="toothE" style="--t: 216.0000deg"></span>
+      <span class="toothE" style="--t: 228.0000deg"></span>
+      <span class="toothE" style="--t: 240.0000deg"></span>
+      <span class="toothE" style="--t: 252.0000deg"></span>
+      <span class="toothE" style="--t: 264.0000deg"></span>
+      <span class="toothE" style="--t: 276.0000deg"></span>
+      <span class="toothE" style="--t: 288.0000deg"></span>
+      <span class="toothE" style="--t: 300.0000deg"></span>
+      <span class="toothE" style="--t: 312.0000deg"></span>
+      <span class="toothE" style="--t: 324.0000deg"></span>
+      <span class="toothE" style="--t: 336.0000deg"></span>
+      <span class="toothE" style="--t: 348.0000deg"></span>
+
+      <span class="spokeE" style="--s: 0deg"></span>
+      <span class="spokeE" style="--s: 72deg"></span>
+      <span class="spokeE" style="--s: 144deg"></span>
+      <span class="spokeE" style="--s: 216deg"></span>
+      <span class="spokeE" style="--s: 288deg"></span>
+
+      <span class="rimE"></span>
+      <span class="arborE"></span>
+    </div>
+
+    <div class="palletE">
+      <span class="forkE"></span>
+      <span class="jewelE jwIn"></span>
+      <span class="jewelE jwOut"></span>
+      <span class="staffE"></span>
+      <span class="pivotE"></span>
+    </div>
+
+    <div class="balanceE">
+      <span class="hairE"></span>
+      <span class="ringE"></span>
+      <span class="armE"></span>
+      <span class="bossE"></span>
+      <span class="impE"></span>
+    </div>
+
+    <span class="tagTeeth">30 teeth</span>
+    <span class="tagBeat">5 beats / sec</span>
+    <span class="capE">the wheel never runs. it is released one tooth at a time.</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/escapement-as/style.css
+++ b/submissions/examples/escapement-as/style.css
@@ -1,0 +1,309 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #3a3630, #0a0908 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 360px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 26%, #4e4840, #0d0c0a 86%);
+}
+
+.plateE {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-radial-gradient(
+      circle at 50% 30%,
+      rgba(255, 240, 200, 0.03) 0 1px,
+      transparent 1px 6px
+    );
+  z-index: 1;
+}
+
+/*
+  the escape wheel. it is the only part connected to the mainspring,
+  and it is trying to run away the whole time.
+*/
+.wheelE {
+  position: absolute;
+  top: 110px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 4;
+  animation: escapeE 6s steps(30, end) infinite;
+}
+
+.rimE {
+  position: absolute;
+  top: -60px;
+  left: -60px;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 7px solid;
+  border-color: #d8c48a #a89058 #7a6838 #c4ae76;
+  z-index: 2;
+}
+
+.spokeE {
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: 6px;
+  height: 60px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #c8b478, #6a5a30);
+  transform-origin: 50% 3px;
+  transform: rotate(var(--s, 0deg));
+  z-index: 1;
+}
+
+/* one tooth every 12 degrees, with the undercut face a real escape wheel has */
+.toothE {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 9px;
+  height: 74px;
+  margin-left: -4.5px;
+  transform-origin: 50% 0;
+  transform: rotate(var(--t, 0deg));
+  z-index: 3;
+}
+
+.toothE::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 9px;
+  height: 15px;
+  background: linear-gradient(180deg, #f0dca4, #8a7440);
+  clip-path: polygon(0 0, 100% 30%, 100% 100%, 40% 86%);
+}
+
+.arborE {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f4ecd0, #5f5230 76%);
+  box-shadow: 0 0 0 2px rgba(24, 20, 12, 0.8);
+  z-index: 5;
+}
+
+/*
+  the lever. it has two jewels, and at any instant one of them is
+  holding a tooth dead still. this is what "escapement" means.
+*/
+.palletE {
+  position: absolute;
+  top: 212px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 6;
+  animation: leverE 0.4s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+}
+
+.forkE {
+  position: absolute;
+  top: -34px;
+  left: -30px;
+  width: 60px;
+  height: 40px;
+  background: linear-gradient(180deg, #b0bcc8, #4a525c);
+  clip-path: polygon(0 24%, 24% 0, 40% 20%, 60% 20%, 76% 0, 100% 24%, 100% 52%, 56% 100%, 44% 100%, 0 52%);
+  z-index: 2;
+}
+
+.jewelE {
+  position: absolute;
+  top: -36px;
+  width: 8px;
+  height: 13px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #ff8fa6, #b0203c);
+  box-shadow: 0 0 5px rgba(255, 90, 130, 0.6);
+  z-index: 4;
+}
+
+.jwIn { left: -28px; }
+.jwOut { left: 20px; }
+
+.staffE {
+  position: absolute;
+  top: 4px;
+  left: -2px;
+  width: 4px;
+  height: 30px;
+  background: linear-gradient(90deg, #4a525c, #cfd8e2 44%, #39404a);
+  z-index: 1;
+}
+
+.pivotE {
+  position: absolute;
+  top: -5px;
+  left: -5px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #eef4f8, #46505a 76%);
+  z-index: 5;
+}
+
+/*
+  the balance. it is a pendulum that does not care about gravity: the
+  hairspring is the restoring force, so it keeps time in any position.
+*/
+.balanceE {
+  position: absolute;
+  top: 276px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 5;
+  animation: swingE 0.4s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+}
+
+.ringE {
+  position: absolute;
+  top: -52px;
+  left: -52px;
+  width: 104px;
+  height: 104px;
+  border-radius: 50%;
+  border: 6px solid;
+  border-color: #e0c88a #b09a5c #7f6c3a #cdb676;
+  z-index: 2;
+}
+
+.armE {
+  position: absolute;
+  top: -3px;
+  left: -52px;
+  width: 104px;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #7f6c3a, #e8d49a 46%, #6a5a30);
+  z-index: 1;
+}
+
+.hairE {
+  position: absolute;
+  top: -34px;
+  left: -34px;
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(
+      circle at 50% 50%,
+      rgba(200, 214, 226, 0.62) 0 1px,
+      transparent 1px 6px
+    );
+  mask-image: radial-gradient(circle, #000 0 92%, transparent 100%);
+  z-index: 3;
+}
+
+.bossE {
+  position: absolute;
+  top: -7px;
+  left: -7px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f4ecd0, #5f5230 76%);
+  z-index: 5;
+}
+
+/* the impulse pin: the one place the balance and the lever touch */
+.impE {
+  position: absolute;
+  top: -46px;
+  left: -3px;
+  width: 6px;
+  height: 12px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #ff8fa6, #b0203c);
+  box-shadow: 0 0 5px rgba(255, 90, 130, 0.6);
+  z-index: 6;
+}
+
+.tagTeeth,
+.tagBeat {
+  position: absolute;
+  font-size: 0.5rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  z-index: 8;
+}
+
+.tagTeeth {
+  top: 44px;
+  right: 18px;
+  color: rgba(240, 220, 160, 0.85);
+}
+
+.tagBeat {
+  top: 292px;
+  right: 18px;
+  color: rgba(255, 150, 176, 0.85);
+}
+
+.capE {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.05em;
+  color: rgba(240, 232, 210, 0.7);
+  z-index: 9;
+}
+
+/*
+  steps(30) is the whole point. the wheel does not rotate: it jumps
+  360/30 = 12 degrees, once, and then is locked again.
+  6s / 30 steps = one tooth every 0.2s = 5 teeth per second.
+*/
+@keyframes escapeE {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/*
+  0.4s per full swing = two beats = 5 beats per second, so the balance
+  releases exactly one tooth per beat and the two stay locked together.
+*/
+@keyframes swingE {
+  0%, 100% { transform: rotate(-124deg); }
+  50% { transform: rotate(124deg); }
+}
+
+@keyframes leverE {
+  0%, 100% { transform: rotate(-11deg); }
+  50% { transform: rotate(11deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wheelE,
+  .palletE,
+  .balanceE {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/escapement-as/`, a self-contained pure CSS/HTML lever escapement with a genuinely stepped escape wheel.

Closes #48603

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **`steps(30)` is the entire idea.** The wheel's keyframe is a plain `rotate(0deg)` to `rotate(360deg)`, but the timing function is `steps(30, end)`, so it is physically incapable of being between teeth. That is what an escape wheel is: it never runs, it is released.

  Verified by sampling the wheel's live animation timeline at **3000 points** across one revolution: exactly **30 distinct angles**, and every gap between them is **12.00°**. Not approximately stepped, stepped.

- **One tooth per beat, checked.** The wheel completes a revolution in `6s` over 30 teeth, so **0.2s per tooth**. The balance's period is `0.4s`, which is two beats, so **0.2s per beat**. Those numbers are equal, which is the constraint that makes an escapement an escapement, and the browser check confirms it rather than a comment claiming it. **5 beats per second** falls out of the same timings, so the label describes the CSS rather than decorating it.
- **The lever is locked to the balance**: same duration, verified equal. A lever drifting against its balance would be a broken watch.
- **Drawn as the real parts**: undercut tooth faces via `clip-path`, two ruby pallet jewels, an impulse pin on the balance (the single point where balance and lever touch), and a hairspring as a `repeating-radial-gradient` spiral.

## Accessibility

`prefers-reduced-motion: reduce` stops all three parts, leaving the wheel locked against a jewel, which is where it spends its life anyway.

## Verification

Opened `demo.html` in the browser and measured the mechanism off its live animation timeline rather than eyeballing it: 3000 samples across one wheel revolution yielded exactly 30 distinct angles at a uniform 12.00° pitch, seconds-per-tooth (0.2s) exactly equals seconds-per-beat (0.2s), the balance resolves to 5 beats/sec, and the lever's duration matches the balance's. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
