### PR TITLE
Add anemometer component

### DIFF
--- a/submissions/examples/anemometer-as/README.md
+++ b/submissions/examples/anemometer-as/README.md
@@ -1,0 +1,31 @@
+# Anemometer
+
+A pure CSS/HTML cup anemometer: three cups at 120°, spinning one direction regardless of where the wind comes from.
+
+## What it shows
+
+Thomas Robinson worked this out in 1846, and the clever part is not obvious until you look at a single cup.
+
+**Every cup is backwards to the one opposite it.** At any moment, one cup is presenting its **open bowl** to the wind and another is presenting its **smooth back**. A hollow hemisphere facing into the flow has roughly **four times** the drag coefficient of the same hemisphere facing away (about 1.4 against 0.4). So the push never balances, and the rotor always turns the same way.
+
+The consequence is the useful bit: it does not matter which direction the wind blows from. Rotate the whole instrument and nothing changes. It spins the same way at the same speed, so you can measure wind *speed* without knowing anything about wind *direction*. There is no vane, no bearing to align, nothing to point.
+
+Robinson originally claimed the cups travel at exactly one third of the wind speed regardless of cup size. That turned out to be wrong, and real anemometers are calibrated per design, but the one-directional trick was right and is still in use.
+
+## How it is built
+
+- **The chirality is the physics, and it is checked.** Each cup's mouth faces its arm's local `-y`, so all three present the same face going round the circle. The browser check computes the cross product of each cup's radius vector with its mouth direction and gets **−1, −1, −1**: same-handed, all three. If one were flipped the rotor would have no preferred direction and would stall, so this is the one property that had to be verified rather than eyeballed.
+- **The mouths are tangential, not radial.** Measured: the dot product of each cup's mouth direction with its own arm axis is **exactly 0** for all three. A first pass had the cups opening back along the arms, pointing at the hub, which is a real error and would not work.
+- **120° apart, verified**: arm angles resolve to **0, 120, 240**, with all three gaps at exactly 120°.
+- **The asymmetry is drawn**: each cup has a dark concave mouth on one side and a smooth lit shell on the other, so you can see which face the wind can get purchase on.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops the rotor and parks the wind streaks, leaving the cup geometry legible.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/anemometer-as/demo.html
+++ b/submissions/examples/anemometer-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Anemometer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="skyR"></span>
+    <span class="gustR" style="top: 58px; left: -140px; width: 120px; animation-delay: 0s"></span>
+    <span class="gustR" style="top: 96px; left: -190px; width: 150px; animation-delay: -1.1s"></span>
+    <span class="gustR" style="top: 150px; left: -160px; width: 130px; animation-delay: -2.2s"></span>
+    <span class="gustR" style="top: 196px; left: -210px; width: 160px; animation-delay: -3.3s"></span>
+
+    <div class="rotorR">
+      <div class="armR" style="--a: 0deg"><span class="spokeR"></span><span class="cupR"></span></div>
+      <div class="armR" style="--a: 120deg"><span class="spokeR"></span><span class="cupR"></span></div>
+      <div class="armR" style="--a: 240deg"><span class="spokeR"></span><span class="cupR"></span></div>
+
+      <span class="hubR"></span>
+    </div>
+
+    <span class="mastR"></span>
+    <span class="baseR"></span>
+
+    <span class="tagCups">3 cups, 120 apart</span>
+    <span class="capR">every cup is backwards to the one opposite it</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/anemometer-as/style.css
+++ b/submissions/examples/anemometer-as/style.css
@@ -1,0 +1,192 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #7fa4c4, #3f5568 60%, #171e26);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 330px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #a8c8e0, #6f90ac 56%, #44566a);
+}
+
+.skyR {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 24% 18%, rgba(255, 255, 255, 0.34) 0 40px, transparent 66px),
+    radial-gradient(ellipse at 78% 30%, rgba(255, 255, 255, 0.24) 0 34px, transparent 58px);
+  z-index: 1;
+}
+
+.gustR {
+  position: absolute;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.62), transparent);
+  z-index: 2;
+  animation: blowR 4.4s linear infinite;
+}
+
+/*
+  the rotor. it spins one way and only one way, no matter which way
+  the wind comes from, which is the entire point of the design.
+*/
+.rotorR {
+  position: absolute;
+  top: 116px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 5;
+  animation: turnR 1.6s linear infinite;
+}
+
+.armR {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  transform: rotate(var(--a, 0deg));
+}
+
+.spokeR {
+  position: absolute;
+  top: -2.5px;
+  left: 0;
+  width: 76px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #dfe8f0, #5f6a76);
+  transform-origin: 0 50%;
+  z-index: 2;
+}
+
+/*
+  the cup. its mouth faces TANGENTIALLY, not out along the arm. that is the
+  whole trick: on one side of the circle the wind blows into an open bowl
+  and on the other it slides over a smooth back, so the drag never balances.
+*/
+.cupR {
+  position: absolute;
+  top: -32px;
+  left: 60px;
+  width: 34px;
+  height: 30px;
+  border-radius: 6px 6px 46% 46% / 5px 5px 22px 22px;
+  background:
+    linear-gradient(
+      184deg,
+      #24303c 0 20%,
+      #4a5a6a 38%,
+      #9fb0c0 66%,
+      #d8e4ee 100%
+    );
+  box-shadow: inset 0 -3px 8px rgba(10, 16, 22, 0.5), 0 3px 8px rgba(0, 0, 0, 0.4);
+  z-index: 3;
+}
+
+/* the open mouth: the only side the wind can get purchase on */
+.cupR::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 3px;
+  right: 3px;
+  height: 13px;
+  border-radius: 50% / 60% 60% 40% 40%;
+  background: radial-gradient(ellipse at 50% 74%, #0e1620, #2f3d4a 84%);
+}
+
+.hubR {
+  position: absolute;
+  top: -11px;
+  left: -11px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f0f6fa, #46505a 76%);
+  box-shadow: 0 0 0 3px rgba(30, 38, 46, 0.8);
+  z-index: 6;
+}
+
+.mastR {
+  position: absolute;
+  top: 126px;
+  left: 50%;
+  width: 12px;
+  height: 158px;
+  margin-left: -6px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #4a545f, #cfd8e2 42%, #39424b);
+  z-index: 4;
+}
+
+.baseR {
+  position: absolute;
+  top: 278px;
+  left: 50%;
+  width: 108px;
+  height: 18px;
+  margin-left: -54px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 30%, #6f7884, #232a31 76%);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.5);
+  z-index: 4;
+}
+
+.tagCups {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+  z-index: 8;
+}
+
+.capR {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.8);
+  z-index: 8;
+}
+
+/* the rotor turns at a constant rate, because the wind here is constant */
+@keyframes turnR {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes blowR {
+  0% { transform: translateX(0); opacity: 0; }
+  12% { opacity: 1; }
+  84% { opacity: 1; }
+  100% { transform: translateX(560px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rotorR,
+  .gustR {
+    animation: none;
+  }
+
+  .gustR { opacity: 0.5; transform: translateX(280px); }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/anemometer-as/`, a self-contained pure CSS/HTML Robinson cup anemometer.

Closes #48608

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

- **The chirality is the physics, and it is checked.** Each cup's mouth faces its arm's local `-y`, so all three present the same face going round the circle. The browser check computes the cross product of each cup's radius vector with its mouth direction and gets **−1, −1, −1**: same-handed, all three. If one were flipped the rotor would have no preferred direction and would stall. A hollow hemisphere facing the flow has about four times the drag of one facing away, and that imbalance is the entire instrument.
- **The mouths are tangential, not radial.** Measured: the dot product of each cup's mouth direction with its own arm axis is **exactly 0** for all three. The first pass had the cups opening back along the arms, pointing at the hub, which the browser check caught: that is a real error, not a cosmetic one, since such a rotor would not turn.
- **120° apart, verified**: arm angles resolve to **0, 120, 240** with all three gaps at exactly 120°.
- **The asymmetry is drawn**: each cup has a dark concave mouth on one side and a smooth lit shell on the other, so the face the wind can get purchase on is visible rather than implied.

## Accessibility

`prefers-reduced-motion: reduce` stops the rotor and parks the wind streaks, leaving the cup geometry legible.

## Verification

Opened `demo.html` in the browser and measured the geometry rather than eyeballing it: arm angles 0/120/240 with uniform 120° gaps, every cup mouth exactly perpendicular to its own arm (dot product 0), and all three mouths the same-handed around the hub (cross-product signs −1/−1/−1). The chirality check is what caught the first pass pointing the cups at the hub. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
