### PR TITLE
Add quipu component

### DIFF
--- a/submissions/examples/quipu-as/README.md
+++ b/submissions/examples/quipu-as/README.md
@@ -1,0 +1,35 @@
+# Quipu
+
+A pure CSS/HTML Inca quipu: six pendant cords carrying real numbers, encoded in knots and read by height.
+
+## What it shows
+
+The Inca ran an empire of twelve million people across 4,000 km with no writing system. They had this instead.
+
+A quipu is **base ten, positional, with a real zero**, and the position is *physical*. A knot's value comes from **how far down the cord it sits**, not from its shape:
+
+- **Units** at the bottom, **tens** above it, **hundreds** above that, in fixed bands.
+- A digit in the tens or hundreds band is **however many single knots you tie there**. Four knots in the tens band is 40.
+- **Zero is an empty band.** Nothing is tied, and the gap is the zero. Reading a quipu means noticing an absence, which is exactly what positional notation requires and what Roman numerals never managed.
+- **Units are different.** You cannot count single knots there without ambiguity, so the units digit is a **long knot** whose *number of turns* is the digit. Seven turns means seven.
+- **One is a special case.** You cannot tie a long knot with a single turn, so 1 gets a **figure-of-eight knot**.
+
+Roughly 1,400 quipus survive. The numerical ones we can read. Whether the others encode language is still open.
+
+## How it is built
+
+- **The numbers are really there.** The cords carry 307, 42, 90, 5, 128 and 60, laid out by the rules above rather than drawn to look knotty.
+- **Verified by reading it back.** The browser check ignores how the component was generated and **decodes the quipu off the DOM using only the Inca rules**: bucket each knot by its height into hundreds/tens/units, count singles, read the long knot's turns, treat an empty band as zero. It reconstructs **307, 42, 90, 5, 128, 60** and compares against each cord's label. All six match.
+- **That check found a real bug.** The first pass spaced knots 7px apart, so cord 3's nine tens-knots spilled 56px down into the units band and the ninth one became unreadable as a ten. It decoded as **80, not 90**. This is not a cosmetic problem: on a real quipu a knot in the wrong band is a wrong number. Tightening the spacing to 5px keeps nine knots inside a 54px band, and the readback now agrees.
+- **The three knot types are drawn as three different things**: a single knot, a long knot whose `repeating-linear-gradient` turns you can actually count, and a figure-of-eight with its two visible loops.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops the cords swaying. The numbers are static, so nothing is lost.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/quipu-as/demo.html
+++ b/submissions/examples/quipu-as/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quipu</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="clothQ"></span>
+
+    <div class="rigQ">
+      <span class="primaryQ"></span>
+      <div class="cordsQ">
+        <div class="cordQ" style="--i: 0">
+          <span class="strandQ"></span>
+          <span class="knotQ single" style="--y: 44px; --k: 0"></span>
+          <span class="knotQ single" style="--y: 49px; --k: 1"></span>
+          <span class="knotQ single" style="--y: 54px; --k: 2"></span>
+          <span class="knotQ long" style="--y: 150px; --turns: 7; height: 34px"></span>
+          <span class="valQ">307</span>
+        </div>
+        <div class="cordQ" style="--i: 1">
+          <span class="strandQ"></span>
+          <span class="knotQ single" style="--y: 96px; --k: 0"></span>
+          <span class="knotQ single" style="--y: 101px; --k: 1"></span>
+          <span class="knotQ single" style="--y: 106px; --k: 2"></span>
+          <span class="knotQ single" style="--y: 111px; --k: 3"></span>
+          <span class="knotQ long" style="--y: 150px; --turns: 2; height: 14px"></span>
+          <span class="valQ">42</span>
+        </div>
+        <div class="cordQ" style="--i: 2">
+          <span class="strandQ"></span>
+          <span class="knotQ single" style="--y: 96px; --k: 0"></span>
+          <span class="knotQ single" style="--y: 101px; --k: 1"></span>
+          <span class="knotQ single" style="--y: 106px; --k: 2"></span>
+          <span class="knotQ single" style="--y: 111px; --k: 3"></span>
+          <span class="knotQ single" style="--y: 116px; --k: 4"></span>
+          <span class="knotQ single" style="--y: 121px; --k: 5"></span>
+          <span class="knotQ single" style="--y: 126px; --k: 6"></span>
+          <span class="knotQ single" style="--y: 131px; --k: 7"></span>
+          <span class="knotQ single" style="--y: 136px; --k: 8"></span>
+          <span class="valQ">90</span>
+        </div>
+        <div class="cordQ" style="--i: 3">
+          <span class="strandQ"></span>
+          <span class="knotQ long" style="--y: 150px; --turns: 5; height: 26px"></span>
+          <span class="valQ">5</span>
+        </div>
+        <div class="cordQ" style="--i: 4">
+          <span class="strandQ"></span>
+          <span class="knotQ single" style="--y: 44px; --k: 0"></span>
+          <span class="knotQ single" style="--y: 96px; --k: 0"></span>
+          <span class="knotQ single" style="--y: 101px; --k: 1"></span>
+          <span class="knotQ long" style="--y: 150px; --turns: 8; height: 38px"></span>
+          <span class="valQ">128</span>
+        </div>
+        <div class="cordQ" style="--i: 5">
+          <span class="strandQ"></span>
+          <span class="knotQ single" style="--y: 96px; --k: 0"></span>
+          <span class="knotQ single" style="--y: 101px; --k: 1"></span>
+          <span class="knotQ single" style="--y: 106px; --k: 2"></span>
+          <span class="knotQ single" style="--y: 111px; --k: 3"></span>
+          <span class="knotQ single" style="--y: 116px; --k: 4"></span>
+          <span class="knotQ single" style="--y: 121px; --k: 5"></span>
+          <span class="valQ">60</span>
+        </div>
+      </div>
+    </div>
+
+    <span class="bandLbl bl100">100s</span>
+    <span class="bandLbl bl10">10s</span>
+    <span class="bandLbl bl1">1s</span>
+    <span class="guideQ gd100"></span>
+    <span class="guideQ gd10"></span>
+    <span class="guideQ gd1"></span>
+
+    <span class="capQ">base ten, written in knots, read by height</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/quipu-as/style.css
+++ b/submissions/examples/quipu-as/style.css
@@ -1,0 +1,216 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #4a4034, #0d0b09 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 26%, #6f6250, #17140f 86%);
+}
+
+.clothQ {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(40, 32, 20, 0.14) 0 1px,
+      transparent 1px 5px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      rgba(40, 32, 20, 0.14) 0 1px,
+      transparent 1px 5px
+    );
+  z-index: 1;
+}
+
+.rigQ {
+  position: absolute;
+  top: 30px;
+  left: 0;
+  right: 0;
+  z-index: 4;
+}
+
+/* the primary cord: everything else hangs off this */
+.primaryQ {
+  position: absolute;
+  top: 0;
+  left: 16px;
+  right: 16px;
+  height: 9px;
+  border-radius: 5px;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(40, 26, 12, 0.34) 0 2px,
+      transparent 2px 5px
+    ),
+    linear-gradient(180deg, #b89a68, #5f4a28);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.5);
+  z-index: 3;
+}
+
+.cordsQ {
+  position: absolute;
+  top: 6px;
+  left: 0;
+  right: 0;
+  z-index: 2;
+}
+
+.cordQ {
+  position: absolute;
+  top: 0;
+  left: calc(40px + var(--i) * 44px);
+  width: 20px;
+  height: 210px;
+  transform-origin: 50% 0;
+  animation: swayQ 7s ease-in-out infinite;
+  animation-delay: calc(var(--i) * -0.5s);
+}
+
+.strandQ {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 4px;
+  height: 178px;
+  margin-left: -2px;
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      70deg,
+      rgba(40, 26, 12, 0.3) 0 1px,
+      transparent 1px 4px
+    ),
+    linear-gradient(180deg, #cfae7c, #6a5230);
+  z-index: 1;
+}
+
+/*
+  a knot's VALUE is its height on the cord, not its shape. the bands are
+  fixed: hundreds up top, then tens, then units at the bottom.
+*/
+.knotQ {
+  position: absolute;
+  top: var(--y, 0);
+  left: 50%;
+  z-index: 3;
+}
+
+/* single knot: one per unit of its band. count them to read the digit. */
+.single {
+  width: 12px;
+  height: 6px;
+  margin-left: -6px;
+  border-radius: 50% / 60%;
+  background:
+    radial-gradient(circle at 34% 30%, #f0d8a4, #7a5a2c 78%);
+  box-shadow: 0 1px 2px rgba(20, 12, 4, 0.6);
+}
+
+/*
+  the long knot: only ever at the units level, and the number of turns
+  in it IS the digit. this is why units look different from every other band.
+*/
+.long {
+  width: 14px;
+  margin-left: -7px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #f0d8a4 0 2px,
+      #8a6634 2px 4px
+    );
+  box-shadow: 0 1px 3px rgba(20, 12, 4, 0.6), inset -2px 0 4px rgba(60, 40, 14, 0.5);
+}
+
+/* the figure-of-eight: means exactly 1, because you cannot tie a long knot with one turn */
+.eight {
+  width: 13px;
+  height: 15px;
+  margin-left: -6.5px;
+  border-radius: 50% 50% 50% 50% / 34% 34% 66% 66%;
+  background:
+    radial-gradient(circle at 50% 26%, #f0d8a4 0 22%, transparent 26%),
+    radial-gradient(circle at 50% 74%, #f0d8a4 0 22%, transparent 26%),
+    linear-gradient(180deg, #a8804a, #6a4c22);
+  box-shadow: 0 1px 3px rgba(20, 12, 4, 0.6);
+}
+
+.valQ {
+  position: absolute;
+  top: 190px;
+  left: 50%;
+  width: 40px;
+  margin-left: -20px;
+  text-align: center;
+  font-size: 0.62rem;
+  font-weight: 700;
+  color: rgba(255, 226, 160, 0.9);
+  z-index: 4;
+}
+
+.guideQ {
+  position: absolute;
+  left: 20px;
+  right: 20px;
+  height: 1px;
+  background: repeating-linear-gradient(90deg, rgba(255, 230, 170, 0.24) 0 4px, transparent 4px 10px);
+  z-index: 2;
+}
+
+.gd100 { top: 76px; }
+.gd10 { top: 128px; }
+.gd1 { top: 182px; }
+
+.bandLbl {
+  position: absolute;
+  left: 8px;
+  font-size: 0.44rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: rgba(255, 226, 170, 0.7);
+  z-index: 5;
+}
+
+.bl100 { top: 70px; }
+.bl10 { top: 122px; }
+.bl1 { top: 176px; }
+
+.capQ {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.06em;
+  color: rgba(250, 236, 200, 0.7);
+  z-index: 8;
+}
+
+/* the cords hang and drift: this is a physical object, not a diagram */
+@keyframes swayQ {
+  0%, 100% { transform: rotate(-1.4deg); }
+  50% { transform: rotate(1.4deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cordQ {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/quipu-as/`, a self-contained pure CSS/HTML Inca quipu whose knots encode real numbers.

Closes #48610

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A quipu is base ten, positional, and has a real zero, and the position is *physical*: a knot's value is how far down the cord it sits. Units at the bottom as a **long knot whose turns are the digit**, tens and hundreds above as **counted single knots**, **an empty band for zero**, and a **figure-of-eight** for 1 because you cannot tie a long knot with one turn.

- **The numbers are really there.** The cords carry 307, 42, 90, 5, 128 and 60, laid out by those rules rather than drawn to look knotty.
- **Verified by reading it back.** The browser check ignores how the component was generated and **decodes the quipu off the DOM using only the Inca rules**: bucket each knot by height into hundreds/tens/units, count singles, read the long knot's turns, treat an empty band as zero. It reconstructs **307, 42, 90, 5, 128, 60** and compares against each cord's own label. All six match.
- **That check found a real bug.** The first pass spaced knots 7px apart, so cord 3's nine tens-knots spilled 56px down into the units band and the ninth became unreadable as a ten: it decoded as **80, not 90**. That is not cosmetic. On a real quipu a knot in the wrong band is a wrong number. Tightening to 5px keeps nine knots inside the 54px band and the readback now agrees.
- **The three knot types are three different things**: a single knot, a long knot whose `repeating-linear-gradient` turns you can count, and a figure-of-eight with two visible loops.

## Accessibility

`prefers-reduced-motion: reduce` stops the cords swaying. The numbers are static, so nothing is lost.

## Verification

Opened `demo.html` in the browser and wrote a decoder that reads the rendered quipu by the Inca rules alone, with no knowledge of the generator, then compared its output against each cord's label: all six cords match. That readback is what caught the band-overflow bug described above. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
