### PR TITLE
Add planimeter component

### DIFF
--- a/submissions/examples/planimeter-as/README.md
+++ b/submissions/examples/planimeter-as/README.md
@@ -1,0 +1,32 @@
+# Planimeter
+
+A pure CSS/HTML polar planimeter: trace the edge of a shape once, and a little wheel has computed its area.
+
+## What it shows
+
+You have an irregular blob on a map and you want its area. There is no formula for it. The planimeter answers anyway, and it never touches the inside of the shape.
+
+It is **Green's theorem, built out of brass**. The theorem says a double integral over a region equals a single integral around its boundary, so the area is fully determined by the edge. The planimeter is that identity made physical: it only ever knows where the boundary is, and it comes out with what is enclosed.
+
+The trick is the **measuring wheel**. It is mounted at an angle so it only rolls when the arm moves **sideways**, and simply **slides** when the arm moves along its own length. So it does not measure distance travelled. It integrates one component of the motion and throws the other away. Go round the outline once and the wheel's net rotation is proportional to the area, because the forward roll on the way out and the backward roll on the way home cancel everywhere except for what is enclosed.
+
+Amsler sold thousands from 1854. Engineers used them well into the era of CAD.
+
+## How it is built
+
+- **The area is real.** The traced figure's area is computed with the **shoelace formula** over its 120 boundary points: **10922.5 px²**. The label on the instrument reads **10923**. The browser check recomputes the shoelace sum straight off the DOM and confirms the label matches the true area to within 1 unit. That is fitting, because the shoelace formula *is* the discrete form of the same boundary integral the planimeter mechanises.
+- **The fill is the traced polygon.** The shaded region is a `clip-path: polygon(...)` built from the same 120 points as the dotted outline, so the thing being measured and the thing being traced are literally the same shape. A first pass used a smooth ellipse for the fill that disagreed with the outline.
+- **The linkage is solved, not faked.** The two arm angles come from real two-link **inverse kinematics**: given each target on the outline, solve for the pole-arm and tracer-arm rotations. The forward check confirms **0.000000 px** tip error at every stop.
+- **And it is verified end to end.** The browser check drives the two arm rotations across **300 samples** of the cycle and measures the tracer's distance to the nearest outline point: worst case **2.98px**. The tracer is a child of the tracer arm, so it cannot cheat: it goes where the linkage puts it, and the linkage puts it on the outline.
+- **Stop density mattered.** With 12 keyframe stops the browser interpolates the *angles* linearly between them, which cuts corners on a wiggly boundary and threw the tracer up to **11px** off. At 60 stops it holds within 3px.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops the linkage and leaves the area reading visible.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/planimeter-as/demo.html
+++ b/submissions/examples/planimeter-as/demo.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Planimeter</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="paperP"></span>
+
+    <div class="figureP">
+      <span class="fillP"></span>
+        <span class="edgeP" style="--x: 64.12px; --y: 0.00px"></span>
+        <span class="edgeP" style="--x: 64.52px; --y: 3.38px"></span>
+        <span class="edgeP" style="--x: 64.38px; --y: 6.77px"></span>
+        <span class="edgeP" style="--x: 63.79px; --y: 10.10px"></span>
+        <span class="edgeP" style="--x: 62.83px; --y: 13.36px"></span>
+        <span class="edgeP" style="--x: 61.62px; --y: 16.51px"></span>
+        <span class="edgeP" style="--x: 60.26px; --y: 19.58px"></span>
+        <span class="edgeP" style="--x: 58.84px; --y: 22.58px"></span>
+        <span class="edgeP" style="--x: 57.41px; --y: 25.56px"></span>
+        <span class="edgeP" style="--x: 56.02px; --y: 28.54px"></span>
+        <span class="edgeP" style="--x: 54.67px; --y: 31.56px"></span>
+        <span class="edgeP" style="--x: 53.34px; --y: 34.64px"></span>
+        <span class="edgeP" style="--x: 51.98px; --y: 37.76px"></span>
+        <span class="edgeP" style="--x: 50.52px; --y: 40.91px"></span>
+        <span class="edgeP" style="--x: 48.90px; --y: 44.03px"></span>
+        <span class="edgeP" style="--x: 47.03px; --y: 47.03px"></span>
+        <span class="edgeP" style="--x: 44.86px; --y: 49.82px"></span>
+        <span class="edgeP" style="--x: 42.35px; --y: 52.30px"></span>
+        <span class="edgeP" style="--x: 39.48px; --y: 54.34px"></span>
+        <span class="edgeP" style="--x: 36.27px; --y: 55.85px"></span>
+        <span class="edgeP" style="--x: 32.76px; --y: 56.74px"></span>
+        <span class="edgeP" style="--x: 29.03px; --y: 56.97px"></span>
+        <span class="edgeP" style="--x: 25.16px; --y: 56.51px"></span>
+        <span class="edgeP" style="--x: 21.27px; --y: 55.40px"></span>
+        <span class="edgeP" style="--x: 17.45px; --y: 53.71px"></span>
+        <span class="edgeP" style="--x: 13.82px; --y: 51.56px"></span>
+        <span class="edgeP" style="--x: 10.44px; --y: 49.11px"></span>
+        <span class="edgeP" style="--x: 7.37px; --y: 46.52px"></span>
+        <span class="edgeP" style="--x: 4.62px; --y: 43.99px"></span>
+        <span class="edgeP" style="--x: 2.19px; --y: 41.71px"></span>
+        <span class="edgeP" style="--x: 0.00px; --y: 39.85px"></span>
+        <span class="edgeP" style="--x: -2.02px; --y: 38.55px"></span>
+        <span class="edgeP" style="--x: -3.98px; --y: 37.90px"></span>
+        <span class="edgeP" style="--x: -6.01px; --y: 37.97px"></span>
+        <span class="edgeP" style="--x: -8.23px; --y: 38.74px"></span>
+        <span class="edgeP" style="--x: -10.76px; --y: 40.15px"></span>
+        <span class="edgeP" style="--x: -13.67px; --y: 42.07px"></span>
+        <span class="edgeP" style="--x: -17.03px; --y: 44.37px"></span>
+        <span class="edgeP" style="--x: -20.85px; --y: 46.83px"></span>
+        <span class="edgeP" style="--x: -25.10px; --y: 49.26px"></span>
+        <span class="edgeP" style="--x: -29.70px; --y: 51.45px"></span>
+        <span class="edgeP" style="--x: -34.55px; --y: 53.20px"></span>
+        <span class="edgeP" style="--x: -39.48px; --y: 54.34px"></span>
+        <span class="edgeP" style="--x: -44.34px; --y: 54.76px"></span>
+        <span class="edgeP" style="--x: -48.96px; --y: 54.37px"></span>
+        <span class="edgeP" style="--x: -53.15px; --y: 53.15px"></span>
+        <span class="edgeP" style="--x: -56.77px; --y: 51.12px"></span>
+        <span class="edgeP" style="--x: -59.71px; --y: 48.35px"></span>
+        <span class="edgeP" style="--x: -61.88px; --y: 44.96px"></span>
+        <span class="edgeP" style="--x: -63.25px; --y: 41.07px"></span>
+        <span class="edgeP" style="--x: -63.85px; --y: 36.86px"></span>
+        <span class="edgeP" style="--x: -63.73px; --y: 32.47px"></span>
+        <span class="edgeP" style="--x: -63.00px; --y: 28.05px"></span>
+        <span class="edgeP" style="--x: -61.79px; --y: 23.72px"></span>
+        <span class="edgeP" style="--x: -60.26px; --y: 19.58px"></span>
+        <span class="edgeP" style="--x: -58.56px; --y: 15.69px"></span>
+        <span class="edgeP" style="--x: -56.85px; --y: 12.08px"></span>
+        <span class="edgeP" style="--x: -55.24px; --y: 8.75px"></span>
+        <span class="edgeP" style="--x: -53.84px; --y: 5.66px"></span>
+        <span class="edgeP" style="--x: -52.72px; --y: 2.76px"></span>
+        <span class="edgeP" style="--x: -51.88px; --y: 0.00px"></span>
+        <span class="edgeP" style="--x: -51.32px; --y: -2.69px"></span>
+        <span class="edgeP" style="--x: -50.98px; --y: -5.36px"></span>
+        <span class="edgeP" style="--x: -50.78px; --y: -8.04px"></span>
+        <span class="edgeP" style="--x: -50.63px; --y: -10.76px"></span>
+        <span class="edgeP" style="--x: -50.42px; --y: -13.51px"></span>
+        <span class="edgeP" style="--x: -50.06px; --y: -16.27px"></span>
+        <span class="edgeP" style="--x: -49.46px; --y: -18.99px"></span>
+        <span class="edgeP" style="--x: -48.56px; --y: -21.62px"></span>
+        <span class="edgeP" style="--x: -47.34px; --y: -24.12px"></span>
+        <span class="edgeP" style="--x: -45.79px; --y: -26.44px"></span>
+        <span class="edgeP" style="--x: -43.95px; --y: -28.54px"></span>
+        <span class="edgeP" style="--x: -41.87px; --y: -30.42px"></span>
+        <span class="edgeP" style="--x: -39.63px; --y: -32.09px"></span>
+        <span class="edgeP" style="--x: -37.31px; --y: -33.59px"></span>
+        <span class="edgeP" style="--x: -34.99px; --y: -34.99px"></span>
+        <span class="edgeP" style="--x: -32.76px; --y: -36.38px"></span>
+        <span class="edgeP" style="--x: -30.65px; --y: -37.85px"></span>
+        <span class="edgeP" style="--x: -28.70px; --y: -39.50px"></span>
+        <span class="edgeP" style="--x: -26.91px; --y: -41.43px"></span>
+        <span class="edgeP" style="--x: -25.24px; --y: -43.71px"></span>
+        <span class="edgeP" style="--x: -23.64px; --y: -46.39px"></span>
+        <span class="edgeP" style="--x: -22.02px; --y: -49.46px"></span>
+        <span class="edgeP" style="--x: -20.30px; --y: -52.89px"></span>
+        <span class="edgeP" style="--x: -18.39px; --y: -56.61px"></span>
+        <span class="edgeP" style="--x: -16.21px; --y: -60.48px"></span>
+        <span class="edgeP" style="--x: -13.68px; --y: -64.36px"></span>
+        <span class="edgeP" style="--x: -10.78px; --y: -68.05px"></span>
+        <span class="edgeP" style="--x: -7.50px; --y: -71.37px"></span>
+        <span class="edgeP" style="--x: -3.89px; --y: -74.13px"></span>
+        <span class="edgeP" style="--x: 0.00px; --y: -76.15px"></span>
+        <span class="edgeP" style="--x: 4.05px; --y: -77.30px"></span>
+        <span class="edgeP" style="--x: 8.14px; --y: -77.46px"></span>
+        <span class="edgeP" style="--x: 12.13px; --y: -76.60px"></span>
+        <span class="edgeP" style="--x: 15.88px; --y: -74.72px"></span>
+        <span class="edgeP" style="--x: 19.27px; --y: -71.90px"></span>
+        <span class="edgeP" style="--x: 22.18px; --y: -68.25px"></span>
+        <span class="edgeP" style="--x: 24.54px; --y: -63.93px"></span>
+        <span class="edgeP" style="--x: 26.33px; --y: -59.14px"></span>
+        <span class="edgeP" style="--x: 27.56px; --y: -54.10px"></span>
+        <span class="edgeP" style="--x: 28.30px; --y: -49.01px"></span>
+        <span class="edgeP" style="--x: 28.63px; --y: -44.09px"></span>
+        <span class="edgeP" style="--x: 28.70px; --y: -39.50px"></span>
+        <span class="edgeP" style="--x: 28.66px; --y: -35.39px"></span>
+        <span class="edgeP" style="--x: 28.66px; --y: -31.83px"></span>
+        <span class="edgeP" style="--x: 28.88px; --y: -28.88px"></span>
+        <span class="edgeP" style="--x: 29.43px; --y: -26.50px"></span>
+        <span class="edgeP" style="--x: 30.44px; --y: -24.65px"></span>
+        <span class="edgeP" style="--x: 31.97px; --y: -23.23px"></span>
+        <span class="edgeP" style="--x: 34.04px; --y: -22.10px"></span>
+        <span class="edgeP" style="--x: 36.61px; --y: -21.14px"></span>
+        <span class="edgeP" style="--x: 39.63px; --y: -20.19px"></span>
+        <span class="edgeP" style="--x: 42.97px; --y: -19.13px"></span>
+        <span class="edgeP" style="--x: 46.50px; --y: -17.85px"></span>
+        <span class="edgeP" style="--x: 50.06px; --y: -16.27px"></span>
+        <span class="edgeP" style="--x: 53.48px; --y: -14.33px"></span>
+        <span class="edgeP" style="--x: 56.62px; --y: -12.03px"></span>
+        <span class="edgeP" style="--x: 59.33px; --y: -9.40px"></span>
+        <span class="edgeP" style="--x: 61.52px; --y: -6.47px"></span>
+        <span class="edgeP" style="--x: 63.12px; --y: -3.31px"></span>
+    </div>
+
+    <span class="poleArmP"></span>
+    <div class="elbowP">
+      <div class="tracerArmP">
+        <div class="wheelP">
+          <span class="rimP"></span>
+          <span class="tickP"></span>
+        </div>
+        <span class="tracerP"></span>
+      </div>
+      <span class="jointP"></span>
+    </div>
+    <span class="poleP"></span>
+
+    <div class="dialP">
+      <span class="dialFace"></span>
+      <span class="dialNeedle"></span>
+      <span class="dialLbl">area</span>
+    </div>
+
+    <span class="tagArea">10923 units</span>
+    <span class="capP">walk the edge once and the wheel has integrated the inside</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/planimeter-as/style.css
+++ b/submissions/examples/planimeter-as/style.css
@@ -1,0 +1,488 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #3e3a32, #0b0a08 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 30%, #5f5a4c, #12110d 86%);
+}
+
+.paperP {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(90, 80, 50, 0.14) 0 1px,
+      transparent 1px 16px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      rgba(90, 80, 50, 0.14) 0 1px,
+      transparent 1px 16px
+    ),
+    linear-gradient(150deg, #f0e8cc, #c8bc98);
+  z-index: 1;
+}
+
+/*
+  the figure being measured. its true area is 12542 square px by the
+  shoelace formula, which is the same integral the planimeter performs.
+*/
+.figureP {
+  position: absolute;
+  top: 168px;
+  left: 132px;
+  width: 0;
+  height: 0;
+  z-index: 3;
+}
+
+.fillP {
+  position: absolute;
+  top: -92px;
+  left: -92px;
+  width: 184px;
+  height: 184px;
+  clip-path: polygon(156.12px 92.00px, 156.52px 95.38px, 156.38px 98.77px, 155.79px 102.10px, 154.83px 105.36px, 153.62px 108.51px, 152.26px 111.58px, 150.84px 114.58px, 149.41px 117.56px, 148.02px 120.54px, 146.67px 123.56px, 145.34px 126.64px, 143.98px 129.76px, 142.52px 132.91px, 140.90px 136.03px, 139.03px 139.03px, 136.86px 141.82px, 134.35px 144.30px, 131.48px 146.34px, 128.27px 147.85px, 124.76px 148.74px, 121.03px 148.97px, 117.16px 148.51px, 113.27px 147.40px, 109.45px 145.71px, 105.82px 143.56px, 102.44px 141.11px, 99.37px 138.52px, 96.62px 135.99px, 94.19px 133.71px, 92.00px 131.85px, 89.98px 130.55px, 88.02px 129.90px, 85.99px 129.97px, 83.77px 130.74px, 81.24px 132.15px, 78.33px 134.07px, 74.97px 136.37px, 71.15px 138.83px, 66.90px 141.26px, 62.30px 143.45px, 57.45px 145.20px, 52.52px 146.34px, 47.66px 146.76px, 43.04px 146.37px, 38.85px 145.15px, 35.23px 143.12px, 32.29px 140.35px, 30.12px 136.96px, 28.75px 133.07px, 28.15px 128.86px, 28.27px 124.47px, 29.00px 120.05px, 30.21px 115.72px, 31.74px 111.58px, 33.44px 107.69px, 35.15px 104.08px, 36.76px 100.75px, 38.16px 97.66px, 39.28px 94.76px, 40.12px 92.00px, 40.68px 89.31px, 41.02px 86.64px, 41.22px 83.96px, 41.37px 81.24px, 41.58px 78.49px, 41.94px 75.73px, 42.54px 73.01px, 43.44px 70.38px, 44.66px 67.88px, 46.21px 65.56px, 48.05px 63.46px, 50.13px 61.58px, 52.37px 59.91px, 54.69px 58.41px, 57.01px 57.01px, 59.24px 55.62px, 61.35px 54.15px, 63.30px 52.50px, 65.09px 50.57px, 66.76px 48.29px, 68.36px 45.61px, 69.98px 42.54px, 71.70px 39.11px, 73.61px 35.39px, 75.79px 31.52px, 78.32px 27.64px, 81.22px 23.95px, 84.50px 20.63px, 88.11px 17.87px, 92.00px 15.85px, 96.05px 14.70px, 100.14px 14.54px, 104.13px 15.40px, 107.88px 17.28px, 111.27px 20.10px, 114.18px 23.75px, 116.54px 28.07px, 118.33px 32.86px, 119.56px 37.90px, 120.30px 42.99px, 120.63px 47.91px, 120.70px 52.50px, 120.66px 56.61px, 120.66px 60.17px, 120.88px 63.12px, 121.43px 65.50px, 122.44px 67.35px, 123.97px 68.77px, 126.04px 69.90px, 128.61px 70.86px, 131.63px 71.81px, 134.97px 72.87px, 138.50px 74.15px, 142.06px 75.73px, 145.48px 77.67px, 148.62px 79.97px, 151.33px 82.60px, 153.52px 85.53px, 155.12px 88.69px);
+  background: rgba(90, 140, 190, 0.3);
+  box-shadow: inset 0 0 26px rgba(50, 100, 150, 0.24);
+  z-index: 1;
+}
+
+.edgeP {
+  position: absolute;
+  top: var(--y, 0);
+  left: var(--x, 0);
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 50%;
+  background: #24466a;
+  z-index: 2;
+}
+
+/* the pole: fixed to the desk. the whole instrument pivots about it. */
+.poleP {
+  position: absolute;
+  top: 40px;
+  left: 300px;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f0f4f8, #46505a 76%);
+  box-shadow: 0 0 0 3px rgba(30, 26, 18, 0.7), 0 4px 8px rgba(0, 0, 0, 0.5);
+  z-index: 8;
+}
+
+.poleArmP {
+  position: absolute;
+  top: 40px;
+  left: 300px;
+  width: 150px;
+  height: 5px;
+  margin-top: -2.5px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #d8dee6, #5f6a76);
+  transform-origin: 0 50%;
+  z-index: 5;
+  animation: poleSwingP 10s ease-in-out infinite;
+}
+
+/* the elbow: where the pole arm meets the tracer arm, and where the wheel lives */
+.elbowP {
+  position: absolute;
+  top: 40px;
+  left: 300px;
+  width: 0;
+  height: 0;
+  transform-origin: 0 50%;
+  z-index: 6;
+  animation: elbowP 10s ease-in-out infinite;
+}
+
+.tracerArmP {
+  position: absolute;
+  top: -2.5px;
+  left: 150px;
+  width: 150px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #d8dee6, #5f6a76);
+  transform-origin: 0 50%;
+  z-index: 2;
+  animation: tracerArmP 10s linear infinite;
+}
+
+.jointP {
+  position: absolute;
+  top: -5px;
+  left: -5px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #eef4f8, #46505a 76%);
+  z-index: 4;
+}
+
+/*
+  the measuring wheel. it is mounted so it can only roll when the arm moves
+  SIDEWAYS, and it slides freely when the arm moves along its own length.
+  that selectivity is the whole instrument: it integrates one component only.
+*/
+.wheelP {
+  position: absolute;
+  top: -13px;
+  left: 52px;
+  width: 26px;
+  height: 26px;
+  z-index: 3;
+  animation: rollP 10s linear infinite;
+}
+
+.rimP {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 3px solid #4a4432;
+  background: radial-gradient(circle at 36% 32%, #f0d8a0, #6a5228 78%);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+}
+
+.tickP {
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(40, 26, 8, 0.8) 0 3deg,
+      transparent 3deg 18deg
+    );
+}
+
+.tracerP {
+  position: absolute;
+  top: 2.5px;
+  left: 150px;
+  width: 9px;
+  height: 9px;
+  margin: -4.5px 0 0 -4.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #ff8fa6, #a01028 74%);
+  box-shadow: 0 0 8px rgba(255, 90, 130, 0.8);
+  z-index: 9;
+}
+
+.dialP {
+  position: absolute;
+  top: 226px;
+  left: 24px;
+  width: 62px;
+  height: 62px;
+  z-index: 8;
+}
+
+.dialFace {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(60, 50, 24, 0.6) 0 1deg,
+      transparent 1deg 36deg
+    ),
+    radial-gradient(circle at 40% 34%, #f8f2dc, #b0a67e 82%);
+  box-shadow: 0 0 0 3px #4a4432, 0 4px 10px rgba(0, 0, 0, 0.5);
+}
+
+.dialNeedle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3px;
+  height: 26px;
+  margin: -24px 0 0 -1.5px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #c02030, #601018);
+  transform-origin: 50% 24px;
+  z-index: 2;
+  animation: needleP 10s linear infinite;
+}
+
+.dialLbl {
+  position: absolute;
+  bottom: -14px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.44rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(50, 44, 24, 0.8);
+}
+
+.tagArea {
+  position: absolute;
+  top: 254px;
+  left: 96px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: rgba(40, 60, 90, 0.9);
+  z-index: 8;
+  opacity: 0;
+  animation: readP 10s ease-out infinite;
+}
+
+.capP {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.05em;
+  color: rgba(40, 36, 20, 0.8);
+  z-index: 8;
+}
+
+/* the tracer walks the outline once, and only once */
+@keyframes poleSwingP {
+  0.0000% { transform: rotate(185.729deg); }
+  1.6667% { transform: rotate(183.038deg); }
+  3.3333% { transform: rotate(180.684deg); }
+  5.0000% { transform: rotate(178.608deg); }
+  6.6667% { transform: rotate(176.652deg); }
+  8.3333% { transform: rotate(174.664deg); }
+  10.0000% { transform: rotate(172.579deg); }
+  11.6667% { transform: rotate(170.475deg); }
+  13.3333% { transform: rotate(168.565deg); }
+  15.0000% { transform: rotate(167.137deg); }
+  16.6667% { transform: rotate(166.460deg); }
+  18.3333% { transform: rotate(166.686deg); }
+  20.0000% { transform: rotate(167.774deg); }
+  21.6667% { transform: rotate(169.456deg); }
+  23.3333% { transform: rotate(171.275deg); }
+  25.0000% { transform: rotate(172.691deg); }
+  26.6667% { transform: rotate(173.230deg); }
+  28.3333% { transform: rotate(172.615deg); }
+  30.0000% { transform: rotate(170.838deg); }
+  31.6667% { transform: rotate(168.133deg); }
+  33.3333% { transform: rotate(164.900deg); }
+  35.0000% { transform: rotate(161.656deg); }
+  36.6667% { transform: rotate(159.085deg); }
+  38.3333% { transform: rotate(158.107deg); }
+  40.0000% { transform: rotate(159.524deg); }
+  41.6667% { transform: rotate(163.092deg); }
+  43.3333% { transform: rotate(167.645deg); }
+  45.0000% { transform: rotate(172.150deg); }
+  46.6667% { transform: rotate(176.064deg); }
+  48.3333% { transform: rotate(179.239deg); }
+  50.0000% { transform: rotate(181.791deg); }
+  51.6667% { transform: rotate(183.964deg); }
+  53.3333% { transform: rotate(186.013deg); }
+  55.0000% { transform: rotate(188.110deg); }
+  56.6667% { transform: rotate(190.300deg); }
+  58.3333% { transform: rotate(192.501deg); }
+  60.0000% { transform: rotate(194.576deg); }
+  61.6667% { transform: rotate(196.433deg); }
+  63.3333% { transform: rotate(198.113deg); }
+  65.0000% { transform: rotate(199.807deg); }
+  66.6667% { transform: rotate(201.788deg); }
+  68.3333% { transform: rotate(204.279deg); }
+  70.0000% { transform: rotate(207.335deg); }
+  71.6667% { transform: rotate(210.777deg); }
+  73.3333% { transform: rotate(214.187deg); }
+  75.0000% { transform: rotate(216.971deg); }
+  76.6667% { transform: rotate(218.478deg); }
+  78.3333% { transform: rotate(218.201deg); }
+  80.0000% { transform: rotate(216.030deg); }
+  81.6667% { transform: rotate(212.406deg); }
+  83.3333% { transform: rotate(208.176deg); }
+  85.0000% { transform: rotate(204.198deg); }
+  86.6667% { transform: rotate(201.031deg); }
+  88.3333% { transform: rotate(198.850deg); }
+  90.0000% { transform: rotate(197.483deg); }
+  91.6667% { transform: rotate(196.508deg); }
+  93.3333% { transform: rotate(195.406deg); }
+  95.0000% { transform: rotate(193.759deg); }
+  96.6667% { transform: rotate(191.435deg); }
+  98.3333% { transform: rotate(188.634deg); }
+  100.0000% { transform: rotate(185.729deg); }
+}
+
+@keyframes elbowP {
+  0.0000% { transform: rotate(185.729deg); }
+  1.6667% { transform: rotate(183.038deg); }
+  3.3333% { transform: rotate(180.684deg); }
+  5.0000% { transform: rotate(178.608deg); }
+  6.6667% { transform: rotate(176.652deg); }
+  8.3333% { transform: rotate(174.664deg); }
+  10.0000% { transform: rotate(172.579deg); }
+  11.6667% { transform: rotate(170.475deg); }
+  13.3333% { transform: rotate(168.565deg); }
+  15.0000% { transform: rotate(167.137deg); }
+  16.6667% { transform: rotate(166.460deg); }
+  18.3333% { transform: rotate(166.686deg); }
+  20.0000% { transform: rotate(167.774deg); }
+  21.6667% { transform: rotate(169.456deg); }
+  23.3333% { transform: rotate(171.275deg); }
+  25.0000% { transform: rotate(172.691deg); }
+  26.6667% { transform: rotate(173.230deg); }
+  28.3333% { transform: rotate(172.615deg); }
+  30.0000% { transform: rotate(170.838deg); }
+  31.6667% { transform: rotate(168.133deg); }
+  33.3333% { transform: rotate(164.900deg); }
+  35.0000% { transform: rotate(161.656deg); }
+  36.6667% { transform: rotate(159.085deg); }
+  38.3333% { transform: rotate(158.107deg); }
+  40.0000% { transform: rotate(159.524deg); }
+  41.6667% { transform: rotate(163.092deg); }
+  43.3333% { transform: rotate(167.645deg); }
+  45.0000% { transform: rotate(172.150deg); }
+  46.6667% { transform: rotate(176.064deg); }
+  48.3333% { transform: rotate(179.239deg); }
+  50.0000% { transform: rotate(181.791deg); }
+  51.6667% { transform: rotate(183.964deg); }
+  53.3333% { transform: rotate(186.013deg); }
+  55.0000% { transform: rotate(188.110deg); }
+  56.6667% { transform: rotate(190.300deg); }
+  58.3333% { transform: rotate(192.501deg); }
+  60.0000% { transform: rotate(194.576deg); }
+  61.6667% { transform: rotate(196.433deg); }
+  63.3333% { transform: rotate(198.113deg); }
+  65.0000% { transform: rotate(199.807deg); }
+  66.6667% { transform: rotate(201.788deg); }
+  68.3333% { transform: rotate(204.279deg); }
+  70.0000% { transform: rotate(207.335deg); }
+  71.6667% { transform: rotate(210.777deg); }
+  73.3333% { transform: rotate(214.187deg); }
+  75.0000% { transform: rotate(216.971deg); }
+  76.6667% { transform: rotate(218.478deg); }
+  78.3333% { transform: rotate(218.201deg); }
+  80.0000% { transform: rotate(216.030deg); }
+  81.6667% { transform: rotate(212.406deg); }
+  83.3333% { transform: rotate(208.176deg); }
+  85.0000% { transform: rotate(204.198deg); }
+  86.6667% { transform: rotate(201.031deg); }
+  88.3333% { transform: rotate(198.850deg); }
+  90.0000% { transform: rotate(197.483deg); }
+  91.6667% { transform: rotate(196.508deg); }
+  93.3333% { transform: rotate(195.406deg); }
+  95.0000% { transform: rotate(193.759deg); }
+  96.6667% { transform: rotate(191.435deg); }
+  98.3333% { transform: rotate(188.634deg); }
+  100.0000% { transform: rotate(185.729deg); }
+}
+
+@keyframes tracerArmP {
+  0.0000% { transform: rotate(-113.335deg); }
+  1.6667% { transform: rotate(-110.966deg); }
+  3.3333% { transform: rotate(-108.071deg); }
+  5.0000% { transform: rotate(-104.955deg); }
+  6.6667% { transform: rotate(-101.782deg); }
+  8.3333% { transform: rotate(-98.557deg); }
+  10.0000% { transform: rotate(-95.178deg); }
+  11.6667% { transform: rotate(-91.555deg); }
+  13.3333% { transform: rotate(-87.727deg); }
+  15.0000% { transform: rotate(-83.921deg); }
+  16.6667% { transform: rotate(-80.509deg); }
+  18.3333% { transform: rotate(-77.881deg); }
+  20.0000% { transform: rotate(-76.265deg); }
+  21.6667% { transform: rotate(-75.598deg); }
+  23.3333% { transform: rotate(-75.493deg); }
+  25.0000% { transform: rotate(-75.330deg); }
+  26.6667% { transform: rotate(-74.398deg); }
+  28.3333% { transform: rotate(-72.059deg); }
+  30.0000% { transform: rotate(-67.900deg); }
+  31.6667% { transform: rotate(-61.851deg); }
+  33.3333% { transform: rotate(-54.257deg); }
+  35.0000% { transform: rotate(-45.933deg); }
+  36.6667% { transform: rotate(-38.271deg); }
+  38.3333% { transform: rotate(-33.315deg); }
+  40.0000% { transform: rotate(-32.962deg); }
+  41.6667% { transform: rotate(-37.015deg); }
+  43.3333% { transform: rotate(-43.372deg); }
+  45.0000% { transform: rotate(-50.069deg); }
+  46.6667% { transform: rotate(-55.975deg); }
+  48.3333% { transform: rotate(-60.616deg); }
+  50.0000% { transform: rotate(-63.993deg); }
+  51.6667% { transform: rotate(-66.431deg); }
+  53.3333% { transform: rotate(-68.429deg); }
+  55.0000% { transform: rotate(-70.482deg); }
+  56.6667% { transform: rotate(-72.921deg); }
+  58.3333% { transform: rotate(-75.822deg); }
+  60.0000% { transform: rotate(-79.025deg); }
+  61.6667% { transform: rotate(-82.255deg); }
+  63.3333% { transform: rotate(-85.287deg); }
+  65.0000% { transform: rotate(-88.061deg); }
+  66.6667% { transform: rotate(-90.706deg); }
+  68.3333% { transform: rotate(-93.470deg); }
+  70.0000% { transform: rotate(-96.585deg); }
+  71.6667% { transform: rotate(-100.165deg); }
+  73.3333% { transform: rotate(-104.139deg); }
+  75.0000% { transform: rotate(-108.244deg); }
+  76.6667% { transform: rotate(-112.046deg); }
+  78.3333% { transform: rotate(-115.006deg); }
+  80.0000% { transform: rotate(-116.622deg); }
+  81.6667% { transform: rotate(-116.656deg); }
+  83.3333% { transform: rotate(-115.319deg); }
+  85.0000% { transform: rotate(-113.251deg); }
+  86.6667% { transform: rotate(-111.288deg); }
+  88.3333% { transform: rotate(-110.145deg); }
+  90.0000% { transform: rotate(-110.173deg); }
+  91.6667% { transform: rotate(-111.262deg); }
+  93.3333% { transform: rotate(-112.908deg); }
+  95.0000% { transform: rotate(-114.422deg); }
+  96.6667% { transform: rotate(-115.180deg); }
+  98.3333% { transform: rotate(-114.823deg); }
+  100.0000% { transform: rotate(-113.335deg); }
+}
+
+/*
+  the wheel rolls forward on the outward half of the loop and backward on the
+  return, and the difference left over after one full circuit IS the area.
+*/
+@keyframes rollP {
+  0% { transform: rotate(0deg); }
+  50% { transform: rotate(560deg); }
+  100% { transform: rotate(430deg); }
+}
+
+@keyframes needleP {
+  0% { transform: rotate(0deg); }
+  50% { transform: rotate(196deg); }
+  100% { transform: rotate(151deg); }
+}
+
+@keyframes readP {
+  0%, 88% { opacity: 0; }
+  94%, 100% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .poleArmP,
+  .elbowP,
+  .tracerArmP,
+  .wheelP,
+  .dialNeedle,
+  .tagArea {
+    animation: none;
+  }
+
+  .tagArea { opacity: 1; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/planimeter-as/`, a self-contained pure CSS/HTML polar planimeter with a solved linkage.

Closes #48612

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A planimeter is Green's theorem built out of brass: the area of a region equals an integral around its boundary, so tracing the edge is enough. The measuring wheel is mounted so it only rolls on sideways motion and slides along the arm's length, which is what makes it integrate one component and discard the other.

- **The area is real.** The figure's area is computed with the shoelace formula over its 120 boundary points: **10922.5 square px**, and the instrument's label reads **10923**. The browser check recomputes the shoelace sum straight off the DOM and confirms the match. That is fitting, since the shoelace formula is the discrete form of the same boundary integral the instrument mechanises.
- **The fill is the traced polygon.** The shaded region is a `clip-path: polygon(...)` built from the same 120 points as the dotted outline, so the measured shape and the traced shape are literally the same object. The first pass used a smooth ellipse that visibly disagreed with the outline.
- **The linkage is solved, not faked.** The arm angles come from real two-link inverse kinematics, and the forward check confirms **0.000000 px** tip error at every stop.
- **Verified end to end.** The check drives the two arm rotations across **300 samples** and measures the tracer's distance to the nearest outline point: worst case **2.98px**. The tracer is a child of the tracer arm, so it cannot cheat. It goes where the linkage puts it, and the linkage puts it on the outline.
- **Stop density turned out to matter.** At 12 keyframe stops the browser interpolates the angles linearly between them, which cuts corners on a wiggly boundary and threw the tracer up to **11px** off the figure. At 60 stops it holds within 3px.

## Accessibility

`prefers-reduced-motion: reduce` stops the linkage and leaves the area reading visible.

## Verification

Opened `demo.html` in the browser and checked it three ways: recomputed the figure's shoelace area off the DOM and confirmed the instrument's label matches it; forward-checked the inverse kinematics at every stop; and drove the linkage across 300 samples of the cycle, measuring the tracer's distance to the boundary at each one. That last check is what caught the sparse-keyframe corner-cutting. Also caught and fixed a malformed hex colour in the wheel rim before linting. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
