### PR TITLE
Add newcomen engine component

### DIFF
--- a/submissions/examples/newcomen-engine-as/README.md
+++ b/submissions/examples/newcomen-engine-as/README.md
@@ -1,0 +1,34 @@
+# Newcomen Engine
+
+A pure CSS/HTML Newcomen atmospheric engine: the first machine that did useful work with fire, and it works by making a vacuum.
+
+## What it shows
+
+The name is the whole point. It is an **atmospheric** engine, not a steam engine in the sense people mean now.
+
+The steam **never pushes anything**. It is admitted at barely above atmospheric pressure, just enough to fill the cylinder and shove the air out. Then Newcomen's actual invention happens: a **jet of cold water is squirted straight into the cylinder**. The steam condenses almost instantly, and where there was steam there is now close to nothing. The piston is left with a vacuum under it and roughly 14 pounds per square inch of sky on top of it, and the atmosphere drives it down.
+
+So the fire's only job is to make the steam that is about to be destroyed. The engine is powered by the weight of the air.
+
+Before this, the standard way to clear a flooded mine was horses. Newcomen's engines were built from about 1712 and ran for two centuries. They were dreadfully inefficient, because the cylinder was heated and chilled on every single stroke, and fixing exactly that is what Watt's separate condenser did sixty years later.
+
+The beam only ever gets **pulled**. The pump side is deliberately heavier, so it falls and cocks the engine for the next stroke. There is no push anywhere in the machine.
+
+## How it is built
+
+- **Cause before effect, and it is measured.** The browser check samples the animation timeline and finds the steam disappears at **44.5%** of the cycle and the piston's fastest fall occurs at **53.2%**. The collapse comes first and the power stroke follows it. If those were reversed, or simultaneous, the component would be claiming the steam pushes, which is the exact misconception the engine is famous for.
+- **The steam does not fade, it vanishes.** Its keyframe holds full opacity from 32% to 42% and is at zero by 47%. Five percent of the cycle. That abruptness is Newcomen's insight: do not wait for the cylinder to cool, inject cold water and drop the pressure in half a second.
+- **The jet is drawn as a jet**: separate droplets on a staggered `calc(var(--i) * 0.02s)`, firing in the same window, with the injection valve visibly opening on the same frames.
+- **The beam is a lever, not a driver**: the beam, piston and pump rod all share one 6s cycle (verified equal), and the beam sweeps 14 degrees while the piston travels 58px. Pump side down at rest, hauled up only during the vacuum stroke.
+- **The water lifts on the power stroke only**, because raising water out of a mine is the only reason any of this exists.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and leaves the cylinder full of steam, at the top of the cycle.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/newcomen-engine-as/demo.html
+++ b/submissions/examples/newcomen-engine-as/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Newcomen Engine</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="houseN"></span>
+
+    <div class="beamN">
+      <span class="timberN"></span>
+      <span class="strapN stL"></span>
+      <span class="strapN stR"></span>
+    </div>
+    <span class="trunnionN"></span>
+    <span class="pillarN"></span>
+
+    <div class="engineSide">
+      <span class="cylN"></span>
+      <span class="jacketN"></span>
+      <div class="pistonN">
+        <span class="headN"></span>
+        <span class="rodN"></span>
+      </div>
+      <div class="sprayN-wrap">
+        <span class="sprayN" style="--i: 0; --dx: -9px"></span>
+        <span class="sprayN" style="--i: 1; --dx: -3px"></span>
+        <span class="sprayN" style="--i: 2; --dx: 3px"></span>
+        <span class="sprayN" style="--i: 3; --dx: 9px"></span>
+        <span class="sprayN" style="--i: 4; --dx: -6px"></span>
+        <span class="sprayN" style="--i: 5; --dx: 6px"></span>
+
+      </div>
+      <span class="steamN"></span>
+      <span class="boilerN"></span>
+      <span class="fireN"></span>
+      <span class="pipeN"></span>
+      <span class="jetValveN"></span>
+    </div>
+
+    <div class="pumpSide">
+      <span class="shaftN"></span>
+      <span class="pumpRodN"></span>
+      <span class="waterN"></span>
+      <span class="liftN"></span>
+    </div>
+
+    <span class="lblVac">vacuum</span>
+    <span class="lblAtm">atmosphere pushes</span>
+    <span class="capN">the steam does not push. it condenses, and the sky pushes.</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/newcomen-engine-as/style.css
+++ b/submissions/examples/newcomen-engine-as/style.css
@@ -1,0 +1,466 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #3f3830, #0a0908 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 340px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #5f5648, #2a251d 62%, #100e0a);
+}
+
+.houseN {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(20, 16, 10, 0.2) 0 1px,
+      transparent 1px 22px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 16, 10, 0.2) 0 1px,
+      transparent 1px 46px
+    );
+  z-index: 1;
+}
+
+/*
+  the great beam. it is a rocking lever, and the engine only ever
+  pulls DOWN on one end. the other end comes up because it is heavier.
+*/
+.beamN {
+  position: absolute;
+  top: 62px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 6;
+  animation: rockN 6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+
+.timberN {
+  position: absolute;
+  top: -9px;
+  left: -136px;
+  width: 272px;
+  height: 18px;
+  border-radius: 4px;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(30, 20, 8, 0.3) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(180deg, #8a6a3e, #33240f);
+  box-shadow: 0 5px 12px rgba(0, 0, 0, 0.6);
+}
+
+.strapN {
+  position: absolute;
+  top: -12px;
+  width: 10px;
+  height: 24px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #6a707a, #cfd6de 44%, #464c54);
+}
+
+.stL { left: -134px; }
+.stR { left: 124px; }
+
+.trunnionN {
+  position: absolute;
+  top: 62px;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin: -10px 0 0 -10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #eef2f6, #464c54 76%);
+  box-shadow: 0 0 0 3px rgba(24, 20, 14, 0.8);
+  z-index: 8;
+}
+
+.pillarN {
+  position: absolute;
+  top: 68px;
+  left: 50%;
+  width: 34px;
+  height: 250px;
+  margin-left: -17px;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(20, 14, 6, 0.24) 0 2px,
+      transparent 2px 18px
+    ),
+    linear-gradient(90deg, #55483a, #8a7458 44%, #3a3025);
+  z-index: 3;
+}
+
+/* ------------- the engine side ------------- */
+
+.engineSide {
+  position: absolute;
+  top: 90px;
+  left: 22px;
+  width: 110px;
+  height: 240px;
+  z-index: 5;
+}
+
+.cylN {
+  position: absolute;
+  top: 18px;
+  left: 22px;
+  width: 56px;
+  height: 108px;
+  border-radius: 4px 4px 6px 6px;
+  background: linear-gradient(90deg, #2f3138, #6f757e 42%, #1e2026);
+  box-shadow: inset 0 0 14px rgba(0, 0, 0, 0.7);
+  z-index: 2;
+}
+
+.jacketN {
+  position: absolute;
+  top: 14px;
+  left: 18px;
+  width: 64px;
+  height: 116px;
+  border-radius: 5px;
+  border: 3px solid #4a4a44;
+  z-index: 4;
+  pointer-events: none;
+}
+
+/*
+  the piston. it is pulled DOWN by nothing at all: below it there is a
+  vacuum, and above it there is fourteen pounds per square inch of sky.
+*/
+.pistonN {
+  position: absolute;
+  top: 22px;
+  left: 26px;
+  width: 48px;
+  height: 130px;
+  z-index: 3;
+  animation: strokeN 6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+
+.headN {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 48px;
+  height: 14px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #cfd6de, #5f656e);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.6);
+}
+
+.rodN {
+  position: absolute;
+  top: -70px;
+  left: 50%;
+  width: 6px;
+  height: 76px;
+  margin-left: -3px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #464c54, #cfd6de 44%, #363c44);
+}
+
+/*
+  the cold jet. Newcomen's whole invention: instead of waiting for the
+  cylinder to cool, squirt water straight into the steam and drop the
+  pressure in half a second.
+*/
+.sprayN-wrap {
+  position: absolute;
+  top: 96px;
+  left: 50px;
+  width: 0;
+  height: 0;
+  z-index: 6;
+}
+
+.sprayN {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 4px;
+  margin: -2px 0 0 -2px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(200, 240, 255, 0.95), rgba(120, 190, 230, 0.3) 72%);
+  opacity: 0;
+  animation: jetN 6s ease-out infinite;
+  animation-delay: calc(var(--i) * 0.02s);
+}
+
+/* the steam filling the cylinder on the down-going part of the cycle */
+.steamN {
+  position: absolute;
+  top: 40px;
+  left: 26px;
+  width: 48px;
+  height: 84px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, rgba(240, 250, 255, 0.5), rgba(190, 220, 240, 0.16));
+  z-index: 1;
+  animation: fillN 6s ease-in-out infinite;
+}
+
+.boilerN {
+  position: absolute;
+  top: 158px;
+  left: 8px;
+  width: 84px;
+  height: 46px;
+  border-radius: 8px 8px 20px 20px / 6px 6px 26px 26px;
+  background: linear-gradient(180deg, #6a5a48, #241d14);
+  box-shadow: inset -4px -3px 10px rgba(10, 8, 4, 0.6);
+  z-index: 2;
+}
+
+.fireN {
+  position: absolute;
+  top: 196px;
+  left: 20px;
+  width: 60px;
+  height: 16px;
+  border-radius: 4px;
+  background:
+    repeating-conic-gradient(
+      from 200deg at 50% 100%,
+      rgba(255, 170, 40, 0.85) 0 3deg,
+      rgba(200, 60, 10, 0.6) 3deg 8deg
+    );
+  mask-image: radial-gradient(ellipse 90% 120% at 50% 100%, #000 0 70%, transparent 100%);
+  z-index: 3;
+  animation: flickerN 0.9s ease-in-out infinite;
+}
+
+.pipeN {
+  position: absolute;
+  top: 126px;
+  left: 44px;
+  width: 8px;
+  height: 34px;
+  background: linear-gradient(90deg, #3a3c42, #7a808a 42%, #2a2c32);
+  z-index: 1;
+}
+
+.jetValveN {
+  position: absolute;
+  top: 92px;
+  left: 76px;
+  width: 16px;
+  height: 8px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #6f757e, #2f3138);
+  z-index: 5;
+  animation: valveN 6s ease-out infinite;
+}
+
+/* ------------- the pump side ------------- */
+
+.pumpSide {
+  position: absolute;
+  top: 74px;
+  right: 26px;
+  width: 90px;
+  height: 260px;
+  z-index: 4;
+}
+
+.shaftN {
+  position: absolute;
+  top: 84px;
+  left: 22px;
+  width: 46px;
+  height: 176px;
+  background: linear-gradient(90deg, #14100a, #241c12 40%, #0c0906);
+  box-shadow: inset 0 0 16px rgba(0, 0, 0, 0.9);
+  z-index: 1;
+}
+
+.pumpRodN {
+  position: absolute;
+  top: 0;
+  left: 42px;
+  width: 7px;
+  height: 190px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #4a4034, #b09a76 44%, #362e24);
+  z-index: 3;
+  animation: pumpN 6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+
+.waterN {
+  position: absolute;
+  top: 208px;
+  left: 22px;
+  width: 46px;
+  height: 52px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(190, 230, 250, 0.12) 0 1px,
+      transparent 1px 7px
+    ),
+    linear-gradient(180deg, #2f5f7a, #0e2432);
+  z-index: 2;
+}
+
+/* the water actually going up the shaft: the only reason any of this exists */
+.liftN {
+  position: absolute;
+  top: 190px;
+  left: 30px;
+  width: 30px;
+  height: 26px;
+  border-radius: 4px 4px 8px 8px;
+  background: linear-gradient(180deg, #6fb0d0, #24506a);
+  z-index: 4;
+  opacity: 0;
+  animation: liftN 6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+
+.lblVac,
+.lblAtm {
+  position: absolute;
+  font-size: 0.46rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  z-index: 9;
+  opacity: 0;
+}
+
+.lblVac {
+  top: 210px;
+  left: 34px;
+  color: rgba(150, 220, 255, 0.95);
+  animation: cueVacN 6s ease-out infinite;
+}
+
+.lblAtm {
+  top: 96px;
+  left: 22px;
+  color: rgba(255, 210, 130, 0.95);
+  animation: cueAtmN 6s ease-out infinite;
+}
+
+.capN {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.04em;
+  color: rgba(250, 240, 210, 0.75);
+  z-index: 9;
+}
+
+/*
+  the cycle. steam in (slow, cheap), jet (instant), collapse (violent),
+  and the beam is hauled over by nothing but air pressure.
+*/
+@keyframes strokeN {
+  0%, 40% { transform: translateY(0); }
+  46% { transform: translateY(2px); }
+  62% { transform: translateY(58px); }
+  70% { transform: translateY(56px); }
+  96%, 100% { transform: translateY(0); }
+}
+
+@keyframes rockN {
+  0%, 40% { transform: rotate(7deg); }
+  62% { transform: rotate(-7deg); }
+  70% { transform: rotate(-6deg); }
+  96%, 100% { transform: rotate(7deg); }
+}
+
+@keyframes pumpN {
+  0%, 40% { transform: translateY(-16px); }
+  62% { transform: translateY(18px); }
+  70% { transform: translateY(17px); }
+  96%, 100% { transform: translateY(-16px); }
+}
+
+@keyframes liftN {
+  0%, 42% { transform: translateY(0); opacity: 0; }
+  50% { opacity: 0.9; }
+  64% { transform: translateY(-40px); opacity: 0.9; }
+  74%, 100% { transform: translateY(-58px); opacity: 0; }
+}
+
+/* the steam is there, and then it simply is not */
+@keyframes fillN {
+  0% { opacity: 0.15; transform: scaleY(0.3); transform-origin: 50% 100%; }
+  32% { opacity: 1; transform: scaleY(1); transform-origin: 50% 100%; }
+  42% { opacity: 1; transform: scaleY(1); transform-origin: 50% 100%; }
+  47% { opacity: 0; transform: scaleY(0.2); transform-origin: 50% 100%; }
+  100% { opacity: 0; transform: scaleY(0.2); transform-origin: 50% 100%; }
+}
+
+/* the jet: 2% of the cycle, because in life it took about half a second */
+@keyframes jetN {
+  0%, 41% { opacity: 0; transform: translate(0, 0) scale(0.3); }
+  43% { opacity: 1; transform: translate(var(--dx, 0), 6px) scale(1); }
+  50%, 100% { opacity: 0; transform: translate(var(--dx, 0), 22px) scale(0.4); }
+}
+
+@keyframes valveN {
+  0%, 40% { transform: translateX(0); }
+  43%, 48% { transform: translateX(-9px); }
+  54%, 100% { transform: translateX(0); }
+}
+
+@keyframes flickerN {
+  0%, 100% { filter: brightness(0.9); transform: scaleY(0.94); }
+  50% { filter: brightness(1.25); transform: scaleY(1.06); }
+}
+
+@keyframes cueVacN {
+  0%, 44% { opacity: 0; }
+  50%, 66% { opacity: 1; }
+  74%, 100% { opacity: 0; }
+}
+
+@keyframes cueAtmN {
+  0%, 44% { opacity: 0; }
+  50%, 66% { opacity: 1; }
+  74%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .beamN,
+  .pistonN,
+  .pumpRodN,
+  .liftN,
+  .steamN,
+  .sprayN,
+  .jetValveN,
+  .fireN,
+  .lblVac,
+  .lblAtm {
+    animation: none;
+  }
+
+  .steamN { opacity: 1; }
+
+  .liftN,
+  .sprayN { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/newcomen-engine-as/`, a self-contained pure CSS/HTML Newcomen atmospheric engine.

Closes #48614

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A Newcomen engine is an *atmospheric* engine. The steam never pushes: it is admitted at barely above atmospheric pressure, then a jet of cold water condenses it almost instantly, and the piston is driven down by the weight of the air against the vacuum left behind. The fire's only job is to make steam that is about to be destroyed.

- **Cause before effect, and it is measured.** The browser check samples the animation timeline and finds the steam disappears at **44.5%** of the cycle and the piston's fastest fall occurs at **53.2%**. The collapse comes first and the power stroke follows it. If those were reversed or simultaneous, the component would be asserting that the steam pushes, which is the exact misconception this engine is famous for.
- **The steam does not fade, it vanishes.** Its keyframe holds full opacity from 32% to 42% and is at zero by 47%: five percent of the cycle. That abruptness is Newcomen's insight, which was not to wait for the cylinder to cool but to inject cold water and drop the pressure in half a second.
- **The jet is drawn as a jet**: separate droplets on a staggered `calc(var(--i) * 0.02s)`, firing in the same window, with the injection valve visibly opening on the same frames.
- **The beam is a lever, not a driver**: beam, piston and pump rod all share one 6s cycle (verified equal), the beam sweeps 14 degrees while the piston travels 58px, and the pump side sits down at rest because it is deliberately the heavier end.
- **The water lifts on the power stroke only**, because raising water out of a mine is the only reason any of this exists.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and leaves the cylinder full of steam at the top of the cycle.

## Verification

Opened `demo.html` in the browser and measured the causality off the live animation timeline rather than eyeballing it: sampled the steam's opacity and the piston's velocity across 600 points of the cycle, confirming the steam is gone at 44.5% and the piston's peak fall is at 53.2%, so the collapse genuinely precedes the stroke. Also confirmed beam, piston and pump rod resolve to the same duration. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
