### PR TITLE
fix: add Typewriter component with proper useEffect cleanup (#40254)

### DIFF
--- a/submissions/react/fix-typewriter-cleanup-eranmol/README.md
+++ b/submissions/react/fix-typewriter-cleanup-eranmol/README.md
@@ -1,0 +1,41 @@
+# Typewriter Cleanup Fix (#40254)
+
+Fixes the memory leak in the Typewriter Effect component by adding proper `useEffect` cleanup.
+
+## What does this do?
+
+A React Typewriter component that types out text character by character. This version fixes the memory leak from issue #40254 by ensuring all `setTimeout` calls are properly cleaned up when the component unmounts or the `text` prop changes.
+
+## How is it used?
+
+```jsx
+import Typewriter from './Typewriter';
+
+function App() {
+  return <Typewriter text="Hello, World!" speed={50} />;
+}
+```
+
+## Why is it useful?
+
+Without proper cleanup, pending `setTimeout` callbacks can fire after a component unmounts, causing memory leaks and stale `setState` calls. This fix uses `useRef` to store the timer reference and always returns a cleanup function from `useEffect`, following React best practices.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | string | required | The text to type out |
+| `speed` | number | 50 | Milliseconds between each character |
+
+## Changes from original
+
+1. **`useRef` for timer storage** — prevents stale closure issues
+2. **Always returns cleanup** — `useEffect` now unconditionally clears the timer
+3. **Reset on `text` change** — separate `useEffect` resets state when `text` prop updates
+
+## Files
+
+- `Typewriter.jsx` — Fixed React component with proper cleanup
+- `demo.html` — Self-contained demo with Babel + React CDN
+- `style.css` — Demo styles
+- `README.md` — This file

--- a/submissions/react/fix-typewriter-cleanup-eranmol/Typewriter.jsx
+++ b/submissions/react/fix-typewriter-cleanup-eranmol/Typewriter.jsx
@@ -1,0 +1,38 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Animate } from 'easemotion-react';
+
+export default function Typewriter({ text, speed = 50 }) {
+  const [displayedText, setDisplayedText] = useState('');
+  const [index, setIndex] = useState(0);
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    setDisplayedText('');
+    setIndex(0);
+  }, [text]);
+
+  useEffect(() => {
+    if (index < text.length) {
+      timerRef.current = setTimeout(() => {
+        setDisplayedText((prev) => prev + text.charAt(index));
+        setIndex((prev) => prev + 1);
+      }, speed);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [index, text, speed]);
+
+  return (
+    <div className="flex items-center text-3xl font-mono text-gray-800">
+      <Animate type="fade-in" duration="fast">
+        {displayedText}
+      </Animate>
+      <Animate type="pulse" duration="fast" className="ml-1 w-3 h-8 bg-blue-600 inline-block" />
+    </div>
+  );
+}

--- a/submissions/react/fix-typewriter-cleanup-eranmol/demo.html
+++ b/submissions/react/fix-typewriter-cleanup-eranmol/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typewriter Cleanup Fix — React Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel">
+    const { useState, useEffect, useRef } = React;
+
+    function Typewriter({ text, speed = 50 }) {
+      const [displayedText, setDisplayedText] = useState('');
+      const [index, setIndex] = useState(0);
+      const timerRef = useRef(null);
+
+      useEffect(() => {
+        setDisplayedText('');
+        setIndex(0);
+      }, [text]);
+
+      useEffect(() => {
+        if (index < text.length) {
+          timerRef.current = setTimeout(() => {
+            setDisplayedText((prev) => prev + text.charAt(index));
+            setIndex((prev) => prev + 1);
+          }, speed);
+        }
+        return () => {
+          if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+          }
+        };
+      }, [index, text, speed]);
+
+      return (
+        <div style={{fontFamily:'monospace',fontSize:'2rem',color:'#1e293b',display:'flex',alignItems:'center'}}>
+          <span>{displayedText}</span>
+          <span style={{display:'inline-block',width:3,height:'2rem',background:'#6366f1',marginLeft:4,animation:'blink 1s step-end infinite'}} />
+        </div>
+      );
+    }
+
+    function App() {
+      const [msg, setMsg] = useState('Hello, EaseMotion CSS!');
+      const phrases = [
+        'Hello, EaseMotion CSS!',
+        'Memory leak free typing',
+        'Proper useEffect cleanup',
+        'React best practices'
+      ];
+
+      return (
+        <div style={{minHeight:'100vh',background:'#f1f5f9',display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',padding:'2rem',fontFamily:'Inter,system-ui,sans-serif'}}>
+          <h1 style={{fontSize:'1.5rem',fontWeight:800,color:'#1e293b',marginBottom:'0.5rem'}}>Typewriter Cleanup Fix</h1>
+          <p style={{color:'#64748b',marginBottom:'2rem',fontSize:'0.9rem'}}>Proper useEffect cleanup prevents memory leaks on unmount</p>
+          <div style={{background:'#fff',borderRadius:12,padding:'2rem',boxShadow:'0 4px 24px rgba(0,0,0,0.08)',minWidth:320}}>
+            <Typewriter text={msg} speed={60} />
+          </div>
+          <div style={{display:'flex',gap:'0.5rem',marginTop:'1.5rem',flexWrap:'wrap',justifyContent:'center'}}>
+            {phrases.map((p) => (
+              <button key={p} onClick={() => setMsg(p)} style={{padding:'0.5rem 1rem',borderRadius:8,border:'1px solid #e2e8f0',background:'#fff',cursor:'pointer',fontSize:'0.8rem',color:'#6366f1',fontWeight:600}}>
+                {p}
+              </button>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+  <style>
+    @keyframes blink { 50% { opacity: 0; } }
+  </style>
+</body>
+</html>

--- a/submissions/react/fix-typewriter-cleanup-eranmol/style.css
+++ b/submissions/react/fix-typewriter-cleanup-eranmol/style.css
@@ -1,0 +1,44 @@
+.tw-demo {
+  min-height: 100vh;
+  background: #f1f5f9;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.tw-demo__title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #1e293b;
+  margin-bottom: 0.5rem;
+}
+
+.tw-demo__sub {
+  color: #64748b;
+  margin-bottom: 2rem;
+  font-size: 0.9rem;
+}
+
+.tw-demo__card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+  min-width: 320px;
+}
+
+.tw-demo__cursor {
+  display: inline-block;
+  width: 3px;
+  height: 2rem;
+  background: #6366f1;
+  margin-left: 4px;
+  animation: tw-blink 1s step-end infinite;
+}
+
+@keyframes tw-blink {
+  50% { opacity: 0; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a fixed Typewriter React component with proper `useEffect` cleanup to prevent memory leaks, solving issue #40254.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are new files inside `submissions/react/fix-typewriter-cleanup-eranmol/`
- [x] Includes `Typewriter.jsx` — React component with proper cleanup
- [x] Includes `demo.html` — self-contained demo
- [x] Includes `README.md` — description, props table, usage example
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] No modifications to any existing files
- [x] One feature per PR

---

## What was broken? (Issue #40254)

The Typewriter Effect component's `useEffect` lacked proper cleanup. When the component unmounted or `text` prop changed mid-animation, pending `setTimeout` callbacks could fire after unmount, causing memory leaks and stale `setState` calls.

## What was fixed?

1. **Timer stored in `useRef`** — prevents stale closure references
2. **Cleanup always runs** — `useEffect` unconditionally returns cleanup function
3. **Reset on `text` change** — separate `useEffect` resets state when prop changes

```jsx
// Before (conditional cleanup)
useEffect(() => {
  if (index < text.length) {
    const timeout = setTimeout(() => { ... }, speed);
    return () => clearTimeout(timeout);
  }
}, [index, text, speed]);

// After (always cleans up)
useEffect(() => {
  if (index < text.length) {
    timerRef.current = setTimeout(() => { ... }, speed);
  }
  return () => {
    if (timerRef.current) {
      clearTimeout(timerRef.current);
      timerRef.current = null;
    }
  };
}, [index, text, speed]);