### PR TITLE
feat: add profile card sheen example

### DIFF
--- a/submissions/examples/profile-card-sheen/README.md
+++ b/submissions/examples/profile-card-sheen/README.md
@@ -1,0 +1,14 @@
+# Profile Card Sheen
+
+A profile card with a soft sheen sweep and lift on hover or keyboard focus.
+
+## Files
+
+- `demo.html` - focusable profile card markup.
+- `style.css` - card lift, sheen sweep, focus-visible state, and reduced-motion fallback.
+
+## Highlights
+
+- Keeps the sheen decorative with a pseudo-element.
+- Mirrors hover behavior on keyboard focus.
+- Stops motion for reduced-motion users.

--- a/submissions/examples/profile-card-sheen/demo.html
+++ b/submissions/examples/profile-card-sheen/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Profile Card Sheen</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion profile</p>
+    <h1 id="demo-title">Profile card sheen</h1>
+    <p class="intro">A profile card with a soft sheen sweep and lift on hover or focus.</p>
+    <article class="profile" tabindex="0">
+      <span class="avatar">PK</span>
+      <strong>Project keeper</strong>
+      <span>Maintains reviews and motion examples.</span>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/profile-card-sheen/style.css
+++ b/submissions/examples/profile-card-sheen/style.css
@@ -1,0 +1,71 @@
+* { box-sizing: border-box; }
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc, #eef2ff 52%, #f0fdfa);
+}
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(79, 70, 229, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #4f46e5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+h1 { margin: 0; font-size: clamp(2rem, 6vw, 3.1rem); line-height: 1; }
+.intro { margin: 1rem 0 2rem; color: #526173; line-height: 1.65; }
+.profile {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+  padding: 1.35rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  text-align: center;
+  overflow: hidden;
+  box-shadow: 0 1rem 2rem rgba(79, 70, 229, 0.12);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+.profile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent, rgba(255, 255, 255, 0.65), transparent);
+  transform: translateX(-100%);
+}
+.avatar {
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  color: #ffffff;
+  background: #4f46e5;
+  font-weight: 900;
+}
+.profile span:last-child { color: #64748b; }
+.profile:hover,
+.profile:focus-visible {
+  transform: translateY(-0.28rem);
+  box-shadow: 0 1.3rem 2.5rem rgba(79, 70, 229, 0.2);
+}
+.profile:hover::after,
+.profile:focus-visible::after { animation: sheen 850ms ease; }
+.profile:focus-visible { outline: 0.18rem solid #818cf8; outline-offset: 0.25rem; }
+@keyframes sheen { to { transform: translateX(100%); } }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation: none !important; transition-duration: 1ms !important; }
+}


### PR DESCRIPTION
## Summary
- add a profile card sheen motion example
- include hover and focus-visible sheen states
- document reduced-motion support

## Verification
- git diff --cached --check