### PR TITLE
feat: add form field focus wave example

### DIFF
--- a/submissions/examples/form-field-focus-wave/README.md
+++ b/submissions/examples/form-field-focus-wave/README.md
@@ -1,0 +1,14 @@
+# Form Field Focus Wave
+
+A text field with a focus underline that sweeps across the input.
+
+## Files
+
+- `demo.html` - labeled text input markup.
+- `style.css` - focus-within underline wave and reduced-motion fallback.
+
+## Highlights
+
+- Uses native input focus behavior.
+- Keeps the label visible while focused.
+- Animates only the underline for a stable layout.

--- a/submissions/examples/form-field-focus-wave/demo.html
+++ b/submissions/examples/form-field-focus-wave/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Form Field Focus Wave</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="panel" aria-labelledby="demo-title">
+    <p class="eyebrow">EaseMotion form</p>
+    <h1 id="demo-title">Form field focus wave</h1>
+    <p class="intro">A text field with a focus underline that sweeps across the input.</p>
+    <label class="field">
+      <span>Workspace name</span>
+      <input type="text" value="EaseMotion" />
+    </label>
+  </main>
+</body>
+</html>

--- a/submissions/examples/form-field-focus-wave/style.css
+++ b/submissions/examples/form-field-focus-wave/style.css
@@ -1,0 +1,60 @@
+* { box-sizing: border-box; }
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #172033;
+  background: linear-gradient(135deg, #f8fafc, #ecfeff 52%, #fff7ed);
+}
+.panel {
+  width: min(92vw, 31rem);
+  padding: 2.2rem;
+  border: 1px solid rgba(8, 145, 178, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+}
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #0891b2;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+h1 { margin: 0; font-size: clamp(2rem, 6vw, 3.1rem); line-height: 1; }
+.intro { margin: 1rem 0 2rem; color: #526173; line-height: 1.65; }
+.field {
+  position: relative;
+  display: grid;
+  gap: 0.55rem;
+  font-weight: 900;
+}
+.field input {
+  width: 100%;
+  border: 0;
+  border-bottom: 0.16rem solid #cbd5e1;
+  padding: 0.85rem 0;
+  color: #172033;
+  background: transparent;
+  font: inherit;
+  font-weight: 800;
+  outline: 0;
+}
+.field::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 0.16rem;
+  background: linear-gradient(90deg, #0891b2, #f97316);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 220ms ease;
+}
+.field:focus-within::after { transform: scaleX(1); }
+.field:focus-within span { color: #0891b2; }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition-duration: 1ms !important; }
+}


### PR DESCRIPTION
## Summary
- add a form field focus wave motion example
- include labeled input and focus-within underline
- document reduced-motion support

## Verification
- git diff --cached --check