### PR TITLE
feat: add accordion panel glow example

### DIFF
--- a/submissions/examples/accordion-panel-glow/README.md
+++ b/submissions/examples/accordion-panel-glow/README.md
@@ -1,0 +1,15 @@
+# Accordion Panel Glow
+
+This example adds an interactive accordion panel with a glow transition for the open state.
+
+## Files
+
+- `demo.html` uses native `details` and `summary` elements.
+- `style.css` defines the glow, icon rotation, content reveal, and reduced-motion fallback.
+
+## Highlights
+
+- Uses native accessible disclosure controls.
+- Adds visible open-state styling with a warm glow.
+- Animates content entry without changing surrounding layout unexpectedly.
+- Respects `prefers-reduced-motion`.

--- a/submissions/examples/accordion-panel-glow/demo.html
+++ b/submissions/examples/accordion-panel-glow/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion Panel Glow</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="accordion-stage" aria-label="Accordion panel glow animation demo">
+      <section class="accordion-card">
+        <h1>Release notes</h1>
+        <details open>
+          <summary>Motion presets</summary>
+          <p>New utility examples now include hover, focus, and reduced-motion states.</p>
+        </details>
+        <details>
+          <summary>Accessibility</summary>
+          <p>Keyboard focus states are visible and content remains readable without animation.</p>
+        </details>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/accordion-panel-glow/style.css
+++ b/submissions/examples/accordion-panel-glow/style.css
@@ -1,0 +1,117 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #16151f;
+  --panel: #242331;
+  --ink: #f8fafc;
+  --muted: #b7bdc9;
+  --accent: #f97316;
+  --line: rgba(255, 255, 255, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, #16151f, #2f1728);
+  color: var(--ink);
+}
+
+.accordion-stage {
+  width: min(92vw, 32rem);
+  padding: 2rem;
+}
+
+.accordion-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.4rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(36, 35, 49, 0.92);
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.24);
+}
+
+h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.7rem;
+}
+
+details {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  transition:
+    border-color 240ms ease,
+    box-shadow 240ms ease,
+    background 240ms ease;
+}
+
+details[open] {
+  border-color: rgba(249, 115, 22, 0.58);
+  background: rgba(249, 115, 22, 0.08);
+  box-shadow: 0 0 0 0.25rem rgba(249, 115, 22, 0.12);
+}
+
+summary {
+  min-height: 3.3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+summary::after {
+  content: "+";
+  width: 1.6rem;
+  height: 1.6rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  transition: transform 240ms ease, background 240ms ease;
+}
+
+details[open] summary::after {
+  background: var(--accent);
+  color: #1f1308;
+  transform: rotate(45deg);
+}
+
+p {
+  margin: 0;
+  padding: 0 1rem 1rem;
+  color: var(--muted);
+  line-height: 1.55;
+  animation: panel-rise 320ms ease both;
+}
+
+@keyframes panel-rise {
+  from {
+    opacity: 0;
+    transform: translateY(-0.45rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  details,
+  summary::after,
+  p {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add an accordion panel glow motion example
- use native details and summary controls
- document reduced-motion support

## Verification
- git diff --cached --check