### PR TITLE
feat: add kbd shortcut ripple example

### DIFF
--- a/submissions/examples/kbd-shortcut-ripple/README.md
+++ b/submissions/examples/kbd-shortcut-ripple/README.md
@@ -1,0 +1,15 @@
+# Kbd Shortcut Ripple
+
+This example adds a keyboard-shortcut action with a soft focus and hover ripple.
+
+## Files
+
+- `demo.html` contains the command shortcut markup.
+- `style.css` defines the ripple, keyboard key styling, and reduced-motion fallback.
+
+## Highlights
+
+- Uses semantic `kbd` elements for shortcut keys.
+- Keeps button height stable while the ripple animates.
+- Includes visible keyboard focus styling.
+- Removes transition timing for reduced-motion users.

--- a/submissions/examples/kbd-shortcut-ripple/demo.html
+++ b/submissions/examples/kbd-shortcut-ripple/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kbd Shortcut Ripple</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shortcut-stage" aria-label="Keyboard shortcut ripple animation demo">
+      <section class="shortcut-card">
+        <p class="eyebrow">Command palette</p>
+        <h1>Quick action</h1>
+        <button type="button">
+          <kbd>Ctrl</kbd>
+          <kbd>K</kbd>
+          <span>Open search</span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/kbd-shortcut-ripple/style.css
+++ b/submissions/examples/kbd-shortcut-ripple/style.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #f8fafc;
+  --muted: #b6c2d6;
+  --panel: #151c2e;
+  --accent: #60a5fa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #111827, #0f766e);
+  color: var(--ink);
+}
+
+.shortcut-stage {
+  width: min(92vw, 30rem);
+  padding: 2rem;
+}
+
+.shortcut-card {
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(21, 28, 46, 0.94);
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 1.4rem;
+  font-size: 2rem;
+}
+
+button {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  width: 100%;
+  min-height: 4.2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+button::before {
+  content: "";
+  position: absolute;
+  inset: auto auto -2.8rem -2.8rem;
+  z-index: -1;
+  width: 5.6rem;
+  height: 5.6rem;
+  border-radius: 50%;
+  background: rgba(96, 165, 250, 0.28);
+  transform: scale(0);
+  transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+button:hover::before,
+button:focus-visible::before {
+  transform: scale(4.2);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.5);
+  outline-offset: 3px;
+}
+
+kbd {
+  min-width: 2.5rem;
+  min-height: 2.2rem;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  background: #f8fafc;
+  color: #172033;
+  font: inherit;
+  font-weight: 900;
+}
+
+span {
+  margin-left: auto;
+  color: var(--muted);
+  font-weight: 750;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a keyboard shortcut ripple example
- include semantic kbd controls and focus styling
- document reduced-motion support

## Verification
- git diff --cached --check