### PR TITLE
feat: add progress ring fill example

### DIFF
--- a/submissions/examples/progress-ring-fill/README.md
+++ b/submissions/examples/progress-ring-fill/README.md
@@ -1,0 +1,15 @@
+# Progress Ring Fill
+
+This example adds a circular progress card where the ring fills to the target percentage.
+
+## Files
+
+- `demo.html` contains the progress card markup.
+- `style.css` defines the conic-gradient ring fill and reduced-motion fallback.
+
+## Highlights
+
+- Uses a stable circular layout with a fixed center label.
+- Animates the ring from empty to the target value.
+- Includes an accessible progress description.
+- Shows the final state instantly for reduced-motion users.

--- a/submissions/examples/progress-ring-fill/demo.html
+++ b/submissions/examples/progress-ring-fill/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Progress Ring Fill</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="ring-stage" aria-label="Progress ring fill animation demo">
+      <section class="ring-card">
+        <div class="ring" role="img" aria-label="Seventy two percent complete">
+          <span>72%</span>
+        </div>
+        <h1>Profile setup</h1>
+        <p>Three tasks left before launch.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/progress-ring-fill/style.css
+++ b/submissions/examples/progress-ring-fill/style.css
@@ -1,0 +1,99 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #172033;
+  --muted: #667085;
+  --panel: #ffffff;
+  --track: #e5e7eb;
+  --accent: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #f5f3ff, #f0f9ff);
+  color: var(--ink);
+}
+
+.ring-stage {
+  width: min(92vw, 26rem);
+  padding: 2rem;
+}
+
+.ring-card {
+  display: grid;
+  justify-items: center;
+  gap: 0.7rem;
+  padding: 2rem;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 1.5rem 3rem rgba(124, 58, 237, 0.14);
+}
+
+.ring {
+  --value: 259deg;
+  width: 10rem;
+  height: 10rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(var(--accent) 0deg, var(--accent) 0deg, var(--track) 0deg);
+  animation: ring-fill 1.1s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.ring::before {
+  content: "";
+  position: absolute;
+}
+
+.ring span {
+  width: 7rem;
+  height: 7rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #ffffff;
+  color: var(--accent);
+  font-size: 2rem;
+  font-weight: 900;
+}
+
+h1,
+p {
+  margin: 0;
+  text-align: center;
+}
+
+h1 {
+  margin-top: 0.7rem;
+  font-size: 1.6rem;
+}
+
+p {
+  color: var(--muted);
+  font-weight: 650;
+}
+
+@keyframes ring-fill {
+  from {
+    background: conic-gradient(var(--accent) 0deg, var(--accent) 0deg, var(--track) 0deg);
+  }
+
+  to {
+    background: conic-gradient(var(--accent) 0deg, var(--accent) var(--value), var(--track) var(--value));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring {
+    animation: none;
+    background: conic-gradient(var(--accent) 0deg, var(--accent) var(--value), var(--track) var(--value));
+  }
+}


### PR DESCRIPTION
## Summary
- add a progress ring fill animation example
- include accessible progress copy and stable center label
- document reduced-motion support

## Verification
- git diff --cached --check