### PR TITLE
feat: add ease-copy-class-button component

### DIFF
--- a/submissions/examples/ease-copy-class-button/README.md
+++ b/submissions/examples/ease-copy-class-button/README.md
@@ -1,0 +1,41 @@
+﻿# ease-copy-class-button
+
+A small "copy to clipboard" button designed to sit next to a CSS class name on demo/showcase cards — click it to copy the class name and see a brief "Copied!" confirmation toast.
+
+## Preview
+
+- Displays a class name in a monospace pill alongside a small clipboard icon button.
+- Clicking the button copies the class name to the clipboard via the Clipboard API (with a `document.execCommand('copy')` fallback for non-secure contexts).
+- The icon swaps to a checkmark and a "Copied!" toast fades in above the button for ~1.6s.
+- Fully supports light and dark themes via `[data-theme]`.
+- Respects `prefers-reduced-motion` by disabling the toast/icon transitions.
+
+## Usage
+
+```html
+<div class="ease-copy-class-button" data-class-name="ease-fade-up">
+  <code class="ease-copy-class-button__name">ease-fade-up</code>
+  <button class="ease-copy-class-button__btn" type="button" aria-label="Copy class name">
+    <span class="ease-copy-class-button__icon" aria-hidden="true">📋</span>
+  </button>
+  <span class="ease-copy-class-button__toast" role="status">Copied!</span>
+</div>
+```
+
+Wire up the click handler in JavaScript to read `data-class-name` and write it to the clipboard — see `demo.html` for a complete example, including the icon swap and toast timing.
+
+## Files
+
+- `demo.html` — three example cards (each showing a different animation class name) with working copy-to-clipboard behavior and a light/dark theme toggle.
+- `style.css` — component styles, using CSS custom properties for full light/dark theme support.
+- `README.md` — this file.
+
+## Accessibility
+
+- The button has an explicit `aria-label="Copy class name"` since its only visible content is a decorative icon.
+- The toast uses `role="status"` so screen readers announce the "Copied!" confirmation.
+- All transitions are disabled under `prefers-reduced-motion: reduce`.
+
+## Origin
+
+Based on the pattern requested in issue #48321 ("Add a Copy Class Name Button to Animation Demo Cards"), built as a standalone example component so it can be added independently of the shared docs gallery.

--- a/submissions/examples/ease-copy-class-button/demo.html
+++ b/submissions/examples/ease-copy-class-button/demo.html
@@ -1,0 +1,101 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Copy Class Button</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body data-theme="light">
+
+  <div class="ease-demo-wrapper">
+
+    <h1 class="ease-demo-title">Copy Class Name Button</h1>
+    <p class="ease-demo-subtitle">A small copy-to-clipboard button for demo cards, so visitors can grab a class name with one click.</p>
+
+    <div class="ease-demo-grid">
+
+      <!-- Example 1: fade-up -->
+      <div class="ease-demo-card">
+        <div class="ease-copy-class-card__preview ease-demo-preview-box ease-fade-up-preview"></div>
+        <div class="ease-copy-class-button" data-class-name="ease-fade-up">
+          <code class="ease-copy-class-button__name">ease-fade-up</code>
+          <button class="ease-copy-class-button__btn" type="button" aria-label="Copy class name">
+            <span class="ease-copy-class-button__icon" aria-hidden="true">📋</span>
+          </button>
+          <span class="ease-copy-class-button__toast" role="status">Copied!</span>
+        </div>
+      </div>
+
+      <!-- Example 2: bounce-in -->
+      <div class="ease-demo-card">
+        <div class="ease-copy-class-card__preview ease-demo-preview-box ease-bounce-in-preview"></div>
+        <div class="ease-copy-class-button" data-class-name="ease-bounce-in">
+          <code class="ease-copy-class-button__name">ease-bounce-in</code>
+          <button class="ease-copy-class-button__btn" type="button" aria-label="Copy class name">
+            <span class="ease-copy-class-button__icon" aria-hidden="true">📋</span>
+          </button>
+          <span class="ease-copy-class-button__toast" role="status">Copied!</span>
+        </div>
+      </div>
+
+      <!-- Example 3: slide-in-right -->
+      <div class="ease-demo-card">
+        <div class="ease-copy-class-card__preview ease-demo-preview-box ease-slide-in-right-preview"></div>
+        <div class="ease-copy-class-button" data-class-name="ease-slide-in-right">
+          <code class="ease-copy-class-button__name">ease-slide-in-right</code>
+          <button class="ease-copy-class-button__btn" type="button" aria-label="Copy class name">
+            <span class="ease-copy-class-button__icon" aria-hidden="true">📋</span>
+          </button>
+          <span class="ease-copy-class-button__toast" role="status">Copied!</span>
+        </div>
+      </div>
+
+    </div>
+
+    <button class="ease-demo-theme-toggle" id="themeToggle" type="button">Toggle Light / Dark</button>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ease-copy-class-button').forEach((wrapper) => {
+      const className = wrapper.getAttribute('data-class-name');
+      const btn = wrapper.querySelector('.ease-copy-class-button__btn');
+      const toast = wrapper.querySelector('.ease-copy-class-button__toast');
+      let toastTimeout = null;
+
+      btn.addEventListener('click', async () => {
+        try {
+          if (navigator.clipboard && window.isSecureContext) {
+            await navigator.clipboard.writeText(className);
+          } else {
+            // Fallback for non-secure contexts / older browsers
+            const textarea = document.createElement('textarea');
+            textarea.value = className;
+            textarea.style.position = 'fixed';
+            textarea.style.opacity = '0';
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textarea);
+          }
+
+          wrapper.classList.add('is-copied');
+          clearTimeout(toastTimeout);
+          toastTimeout = setTimeout(() => {
+            wrapper.classList.remove('is-copied');
+          }, 1600);
+        } catch (err) {
+          console.error('Copy failed:', err);
+        }
+      });
+    });
+
+    // Theme toggle for demo purposes
+    document.getElementById('themeToggle').addEventListener('click', () => {
+      const body = document.body;
+      body.setAttribute('data-theme', body.getAttribute('data-theme') === 'light' ? 'dark' : 'light');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-copy-class-button/style.css
+++ b/submissions/examples/ease-copy-class-button/style.css
@@ -1,0 +1,231 @@
+﻿/* =========================================================
+   ease-copy-class-button
+   A copy-to-clipboard button for pairing with demo class names.
+   ========================================================= */
+
+:root {
+  --ecb-bg: #ffffff;
+  --ecb-card-bg: #f7f8fa;
+  --ecb-border: #e2e5ea;
+  --ecb-text: #1a1d23;
+  --ecb-text-muted: #6b7280;
+  --ecb-code-bg: #eef1f5;
+  --ecb-code-text: #d6336c;
+  --ecb-btn-hover-bg: #e2e5ea;
+  --ecb-success: #2f9e44;
+  --ecb-success-bg: #ebfbee;
+  --ecb-accent: #5c7cfa;
+  --ecb-shadow: 0 4px 14px rgba(20, 24, 32, 0.06);
+}
+
+[data-theme="dark"] {
+  --ecb-bg: #14161a;
+  --ecb-card-bg: #1c1f26;
+  --ecb-border: #2a2e37;
+  --ecb-text: #f1f2f4;
+  --ecb-text-muted: #9aa1ab;
+  --ecb-code-bg: #262a33;
+  --ecb-code-text: #ff8fab;
+  --ecb-btn-hover-bg: #2f3440;
+  --ecb-success: #69db7c;
+  --ecb-success-bg: #163a25;
+  --ecb-accent: #91a7ff;
+  --ecb-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+}
+
+/* ---------- Demo page scaffolding (not part of the component) ---------- */
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ecb-bg);
+  color: var(--ecb-text);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.ease-demo-wrapper {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+.ease-demo-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.ease-demo-subtitle {
+  color: var(--ecb-text-muted);
+  margin-bottom: 32px;
+}
+
+.ease-demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.ease-demo-card {
+  background: var(--ecb-card-bg);
+  border: 1px solid var(--ecb-border);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--ecb-shadow);
+}
+
+.ease-demo-theme-toggle {
+  margin-top: 40px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: 1px solid var(--ecb-border);
+  background: var(--ecb-card-bg);
+  color: var(--ecb-text);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.ease-demo-theme-toggle:hover {
+  border-color: var(--ecb-accent);
+}
+
+/* Decorative preview boxes, just to give the demo cards something to show off */
+
+.ease-demo-preview-box {
+  height: 72px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--ecb-accent), var(--ecb-code-text));
+  animation-duration: 1.6s;
+  animation-timing-function: ease-out;
+  animation-iteration-count: infinite;
+}
+
+@keyframes ease-fade-up-preview-anim {
+  0% { opacity: 0; transform: translateY(12px); }
+  30% { opacity: 1; transform: translateY(0); }
+  70% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(12px); }
+}
+.ease-fade-up-preview {
+  animation-name: ease-fade-up-preview-anim;
+}
+
+@keyframes ease-bounce-in-preview-anim {
+  0% { transform: scale(0.4); opacity: 0; }
+  40% { transform: scale(1.08); opacity: 1; }
+  60% { transform: scale(0.96); }
+  80% { transform: scale(1.02); }
+  100% { transform: scale(1); opacity: 1; }
+}
+.ease-bounce-in-preview {
+  animation-name: ease-bounce-in-preview-anim;
+  animation-duration: 1.8s;
+}
+
+@keyframes ease-slide-in-right-preview-anim {
+  0% { transform: translateX(40px); opacity: 0; }
+  30% { transform: translateX(0); opacity: 1; }
+  70% { transform: translateX(0); opacity: 1; }
+  100% { transform: translateX(-40px); opacity: 0; }
+}
+.ease-slide-in-right-preview {
+  animation-name: ease-slide-in-right-preview-anim;
+}
+
+/* =========================================================
+   Component: ease-copy-class-button
+   ========================================================= */
+
+.ease-copy-class-button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: var(--ecb-code-bg);
+  border: 1px solid var(--ecb-border);
+  border-radius: 10px;
+  padding: 8px 8px 8px 14px;
+}
+
+.ease-copy-class-button__name {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 13px;
+  color: var(--ecb-code-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ease-copy-class-button__btn {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 6px;
+  border-radius: 6px;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.ease-copy-class-button__btn:hover {
+  background: var(--ecb-btn-hover-bg);
+  transform: scale(1.12);
+}
+
+.ease-copy-class-button__btn:active {
+  transform: scale(0.92);
+}
+
+.ease-copy-class-button__icon {
+  display: inline-block;
+}
+
+/* Swap the icon to a checkmark once copied */
+.ease-copy-class-button.is-copied .ease-copy-class-button__icon::before {
+  content: "✅";
+}
+.ease-copy-class-button.is-copied .ease-copy-class-button__icon {
+  font-size: 0;
+}
+.ease-copy-class-button.is-copied .ease-copy-class-button__icon::before {
+  font-size: 16px;
+}
+
+/* Toast: "Copied!" success message */
+
+.ease-copy-class-button__toast {
+  position: absolute;
+  top: -34px;
+  right: 8px;
+  background: var(--ecb-success-bg);
+  color: var(--ecb-success);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  opacity: 0;
+  transform: translateY(4px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.ease-copy-class-button.is-copied .ease-copy-class-button__toast {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ---------- Reduced motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-demo-preview-box,
+  .ease-copy-class-button__btn,
+  .ease-copy-class-button__toast {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Adds the `ease-copy-class-button` component — a small copy-to-clipboard button designed to pair with a CSS class name on demo cards, addressing #48321.

## Features
- Displays a class name in a monospace pill next to a clipboard icon button
- Click copies the class name to clipboard (Clipboard API with a legacy fallback)
- Icon swaps to a checkmark + "Copied!" toast appears briefly on success
- Full light/dark theme support via `[data-theme]`
- Uses `aria-label` and `role="status"` for accessibility; respects `prefers-reduced-motion`

## Approach
Built as a standalone example component (rather than editing the shared docs gallery) so it can merge independently of the other assignees' work on #48321, with zero risk of file conflicts.

## Files added
- `submissions/examples/ease-copy-class-button/demo.html`
- `submissions/examples/ease-copy-class-button/style.css`
- `submissions/examples/ease-copy-class-button/README.md`

Relates to #48321