### PR TITLE
Add typewriter effect with proper useEffect cleanup

### DIFF
--- a/submissions/react-v1/react-typewriter-effect-cleanup-fix/README.md
+++ b/submissions/react-v1/react-typewriter-effect-cleanup-fix/README.md
@@ -1,0 +1,37 @@
+# Typewriter Effect (with proper cleanup)
+
+A drop-in React typewriter-effect component that correctly cleans up its
+`setInterval` / `setTimeout` on unmount and on every effect re-run.
+
+This is added as a new, standalone example and does not modify or
+replace the existing typewriter submission, per the repo's contribution
+rules (no edits/deletions to existing files — new examples only).
+
+## Fix used here
+
+```js
+useEffect(() => {
+  const timer = setInterval(() => {
+    // advance the typed text
+  }, speed);
+
+  return () => clearInterval(timer); // cleanup
+}, [index, text, speed, loop, pauseMs]);
+```
+
+## Usage
+
+```jsx
+import TypewriterCleanupFix from "./Typewriter";
+
+<TypewriterCleanupFix text="Cleans up after itself." speed={80} loop pauseMs={1500} />
+```
+
+## Props
+
+| Prop      | Type    | Default            | Description                     |
+|-----------|---------|---------------------|----------------------------------|
+| text      | string  | "Hello, world!"     | Text to type out.                |
+| speed     | number  | 100                 | Ms between characters.           |
+| loop      | boolean | false               | Restart after finishing.         |
+| pauseMs   | number  | 1200                | Pause before restart, if looping.|

--- a/submissions/react-v1/react-typewriter-effect-cleanup-fix/Typewriter.jsx
+++ b/submissions/react-v1/react-typewriter-effect-cleanup-fix/Typewriter.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from "react";
+
+function TypewriterCleanupFix({
+  text = "Hello, world!",
+  speed = 100,
+  loop = false,
+  pauseMs = 1200,
+}) {
+  const [displayedText, setDisplayedText] = useState("");
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    setDisplayedText("");
+    setIndex(0);
+  }, [text]);
+
+  useEffect(() => {
+    if (index >= text.length) {
+      if (!loop) return;
+
+      const pauseTimer = setTimeout(() => {
+        setDisplayedText("");
+        setIndex(0);
+      }, pauseMs);
+
+      return () => clearTimeout(pauseTimer);
+    }
+
+    const timer = setInterval(() => {
+      setDisplayedText((prev) => prev + text.charAt(index));
+      setIndex((prev) => prev + 1);
+    }, speed);
+
+    return () => clearInterval(timer);
+  }, [index, text, speed, loop, pauseMs]);
+
+  return (
+    <span style={styles.wrapper}>
+      {displayedText}
+      <span style={styles.cursor}>|</span>
+    </span>
+  );
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: "monospace",
+    fontSize: "1.25rem",
+    color: "#1f2937",
+  },
+  cursor: {
+    display: "inline-block",
+    marginLeft: "2px",
+    animation: "typewriter-cleanup-fix-blink 1s step-end infinite",
+  },
+};
+
+if (typeof document !== "undefined" && !document.getElementById("typewriter-cleanup-fix-style")) {
+  const styleTag = document.createElement("style");
+  styleTag.id = "typewriter-cleanup-fix-style";
+  styleTag.textContent = `
+    @keyframes typewriter-cleanup-fix-blink {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0; }
+    }
+  `;
+  document.head.appendChild(styleTag);
+}
+
+export default TypewriterCleanupFix;


### PR DESCRIPTION
## Pull Request Description

Adds a new, standalone Typewriter Effect React component that properly cleans up its interval/timeout in useEffect, addressing the memory-leak pattern described in issue #40254. This is a new example, not a modification of the existing typewriter submission.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/react-v1/react-typewriter-effect-cleanup-fix/`)
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**
A self-contained React typewriter-effect component (`Typewriter.jsx`) that types out text character-by-character and properly clears its `setInterval`/`setTimeout` on unmount, avoiding the memory leak in the original component from issue #40254.

**How does a developer use it?**

```jsx
import TypewriterCleanupFix from "./Typewriter";

<TypewriterCleanupFix text="Cleans up after itself." speed={80} loop pauseMs={1500} />
```

**Why does it fit EaseMotion CSS?**
It's an animation-driven text effect, matching the repo's animation-first, human-readable philosophy, and demonstrates a correct React cleanup pattern for future contributors to reference.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

This is a React (JSX) component rather than a plain CSS/HTML animation, so `demo.html`/`style.css` aren't a 1:1 fit — happy to add a CDN-based demo.html if that's required for review.