### PR TITLE
docs(scss): add SCSS @use load-path guide with interactive demo

### DIFF
--- a/submissions/scss/ease-scss-load-paths-hr18/README.md
+++ b/submissions/scss/ease-scss-load-paths-hr18/README.md
@@ -1,0 +1,161 @@
+﻿# SCSS `@use 'easemotion-css/scss'` Path Failures in Vite
+
+A setup-focused SCSS submission documenting why `@use 'easemotion-css/scss'` fails in some Vite/Next.js projects, and how to fix it with reliable load-path patterns — including a live interactive demo.
+
+> Submission track: `submissions/scss/ease-scss-load-paths-hr18/`  
+> Contributor suffix: `hr18`  
+> Resolves: Issue #47644
+
+---
+
+## What does this do?
+
+This guide closes a common setup gap: SCSS path resolution failures when importing the official EaseMotion SCSS layer.
+
+It provides:
+
+- failure pattern explanations (`includePaths`, alias confusion, workspace paths)
+- copy-ready Vite and Next.js snippets
+- mini troubleshooting recipes (`error -> cause -> fix`)
+- an interactive `demo.html` that shows the error/fix side by side, lets you copy either config snippet, replays the EaseMotion animation utilities the fix unlocks, and includes a live setup-validation checklist
+
+---
+
+## Common error symptoms
+
+Typical failures beginners see:
+
+```text
+Can't find stylesheet to import.
+  @use 'easemotion-css/scss';
+```
+
+```text
+[sass] Can't find stylesheet to import.
+```
+
+---
+
+## Why path failures happen
+
+1. **Missing package install** — `easemotion-css` is not in `node_modules`.
+2. **Wrong resolver context** — Sass runs from a different working directory (monorepo/workspace).
+3. **Custom `includePaths` hides defaults** — Loader config points only to `src/styles`, not `node_modules`.
+4. **Alias mismatch** — Trying `@use '@/scss/easemotion-css'` without a valid alias mapping.
+5. **Mixing `@import` and `@use` incorrectly** — Legacy import patterns can produce duplicate-load or config errors.
+
+---
+
+## Working Vite snippet
+
+```scss
+/* src/styles/main.scss */
+@use 'easemotion-css/scss' as ease;
+
+.hero {
+  @include ease.fade-in();
+}
+```
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        loadPaths: ['node_modules'],
+      },
+    },
+  },
+});
+```
+
+---
+
+## Working Next.js snippet
+
+```scss
+/* app/globals.scss */
+@use 'easemotion-css/scss' as ease;
+
+.card {
+  @include ease.slide-up();
+}
+```
+
+```js
+// next.config.js
+const nextConfig = {
+  sassOptions: {
+    includePaths: ['./node_modules'],
+  },
+};
+
+module.exports = nextConfig;
+```
+
+---
+
+## Mini recipes (`error -> cause -> fix`)
+
+### Recipe 1
+- **Error:** `Can't find stylesheet to import` on `@use 'easemotion-css/scss'`
+- **Cause:** Package missing
+- **Fix:** `npm install easemotion-css`
+
+### Recipe 2
+- **Error:** Works locally, fails in CI
+- **Cause:** CI runs from a different working directory in monorepo
+- **Fix:** Ensure install in the app package and set consistent workspace root for Sass build
+
+### Recipe 3
+- **Error:** Sass resolves local files but not package paths
+- **Cause:** Narrow `includePaths` excludes `node_modules`
+- **Fix:** Add `node_modules` to the load path (see Vite snippet)
+
+### Recipe 4
+- **Error:** `Undefined mixin` after import succeeds
+- **Cause:** Imported without the `as` namespace
+- **Fix:** Use the namespaced call, e.g. `@include ease.fade-in();`
+
+---
+
+## Try it live — `demo.html`
+
+Open `demo.html` directly in a browser (no build step). It walks through the same story as this README, interactively: a build-log transcript showing the failing `@use` next to the passing one, tabs to copy the Vite/Next.js snippets, live replays of `.ease-fade-in`, `.ease-slide-up`, and `.ease-scale-in`, and an interactive validation checklist with a running counter.
+
+---
+
+## Validation checklist
+
+- [ ] `easemotion-css` is listed under `dependencies` in `package.json`
+- [ ] Sass load path includes `node_modules`
+- [ ] `@use` statement matches the package's documented export path exactly
+- [ ] Lockfile is committed so CI installs match local installs
+- [ ] Mixins/functions are called with the namespace (`ease.mixin-name()`), not bare
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Interactive, self-contained walkthrough of the error, fix, and resulting animations |
+| `style.css` | Styling and the demoed `.ease-fade-in` / `.ease-slide-up` / `.ease-scale-in` utility classes |
+| `README.md` | Path-failure troubleshooting guide |
+
+---
+
+## Note on this submission
+
+Issue #47644 already has scaffold content under `submissions/scss/ease-scss-load-paths-sp/` (a partial README and an `_ease-scss-load-paths-sp.scss` helper). This submission is offered as a complementary, self-contained addition under its own folder — it does not modify or replace any existing files, and adds the interactive `demo.html` walkthrough that was not part of the original scaffold.
+
+---
+
+## Compliance notes
+
+- Only new files inside `submissions/scss/ease-scss-load-paths-hr18/`
+- No edits to `core/`, `components/`, workflows, root configs, or any other contributor's files
+- Focused on setup/docs gap (not a mixin cookbook replacement)

--- a/submissions/scss/ease-scss-load-paths-hr18/demo.html
+++ b/submissions/scss/ease-scss-load-paths-hr18/demo.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixing @use 'easemotion-css/scss' path failures</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="wrap">
+
+  <header class="hero">
+    <p class="eyebrow">ease-scss-load-paths-sp</p>
+    <h1>Fixing <code>@use 'easemotion-css/scss'</code> path failures</h1>
+    <p class="lede">
+      A live look at the load-path error, the one-line fix, and the animation
+      utilities it unlocks — for Vite and Next.js.
+    </p>
+  </header>
+
+  <section aria-labelledby="transcript-heading">
+    <h2 id="transcript-heading">The error, and the fix</h2>
+    <div class="transcript">
+      <div class="transcript-bar">
+        <span></span><span></span><span></span>
+        <span class="label">build log</span>
+      </div>
+      <div class="transcript-body">
+        <div class="line plain">$ npm run dev</div>
+        <div class="line removed"><span class="sign">−</span>Error: Can't find stylesheet to import.</div>
+        <div class="line removed"><span class="sign">−</span>  @use 'easemotion-css/scss';</div>
+        <div class="line removed"><span class="sign">−</span>  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^</div>
+        <div class="line plain">&nbsp;</div>
+        <div class="line plain"># add a Sass load path pointing at node_modules, then:</div>
+        <div class="line plain">$ npm run dev</div>
+        <div class="line added"><span class="sign">+</span>✓ compiled successfully</div>
+        <div class="line added"><span class="sign">+</span>✓ @use 'easemotion-css/scss' resolved</div>
+      </div>
+    </div>
+  </section>
+
+  <section aria-labelledby="config-heading">
+    <h2 id="config-heading">The one-line fix</h2>
+    <div class="tabs" role="tablist" aria-label="Bundler config">
+      <button class="tab" role="tab" id="tab-vite" aria-selected="true" aria-controls="panel-vite">vite.config.js</button>
+      <button class="tab" role="tab" id="tab-next" aria-selected="false" aria-controls="panel-next" tabindex="-1">next.config.js</button>
+    </div>
+
+    <div class="code-panel active" id="panel-vite" role="tabpanel" aria-labelledby="tab-vite">
+      <button class="copy-btn" data-copy-target="code-vite" type="button">copy</button>
+      <pre id="code-vite">import { defineConfig } from 'vite';
+
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        loadPaths: ['node_modules'],
+      },
+    },
+  },
+});</pre>
+    </div>
+
+    <div class="code-panel" id="panel-next" role="tabpanel" aria-labelledby="tab-next">
+      <button class="copy-btn" data-copy-target="code-next" type="button">copy</button>
+      <pre id="code-next">/** @type {import('next').NextConfig} */
+const nextConfig = {
+  sassOptions: {
+    includePaths: ['./node_modules'],
+  },
+};
+
+module.exports = nextConfig;</pre>
+    </div>
+  </section>
+
+  <section aria-labelledby="stage-heading">
+    <h2 id="stage-heading">What resolving it unlocks</h2>
+    <p class="lede" style="margin-bottom: 1rem;">
+      Once the import resolves, EaseMotion's animation-first utility classes
+      are just a class name away. Click replay to see each one again.
+    </p>
+    <div class="stage">
+      <div class="stage-card">
+        <div class="stage-box ease-fade-in" id="box-fade"></div>
+        <p>.ease-fade-in</p>
+        <button class="replay-btn" data-replay="box-fade" data-class="ease-fade-in" type="button">replay</button>
+      </div>
+      <div class="stage-card">
+        <div class="stage-box ease-slide-up" id="box-slide"></div>
+        <p>.ease-slide-up</p>
+        <button class="replay-btn" data-replay="box-slide" data-class="ease-slide-up" type="button">replay</button>
+      </div>
+      <div class="stage-card">
+        <div class="stage-box ease-scale-in" id="box-scale"></div>
+        <p>.ease-scale-in</p>
+        <button class="replay-btn" data-replay="box-scale" data-class="ease-scale-in" type="button">replay</button>
+      </div>
+    </div>
+  </section>
+
+  <section aria-labelledby="checklist-heading">
+    <h2 id="checklist-heading">Validation checklist</h2>
+    <div class="checklist" id="checklist">
+      <label><input type="checkbox" data-check /> Package is listed under <code>dependencies</code> in package.json</label>
+      <label><input type="checkbox" data-check /> Sass load path (<code>loadPaths</code> / <code>includePaths</code>) includes <code>node_modules</code></label>
+      <label><input type="checkbox" data-check /> <code>@use</code> statement matches the documented export path exactly</label>
+      <label><input type="checkbox" data-check /> Lockfile is committed so CI installs match local installs</label>
+      <label><input type="checkbox" data-check /> Mixins/functions are called with the namespace, e.g. <code>ease.fade-in()</code></label>
+    </div>
+    <p class="checklist-status" id="checklist-status">0 / 5 checked</p>
+  </section>
+
+  <footer>
+    See README.md in this folder for the full write-up, or the original
+    issue: <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47644">#47644</a>.
+  </footer>
+
+</div>
+
+<script>
+  // Tabs
+  var tabs = document.querySelectorAll('.tab');
+  tabs.forEach(function (tab) {
+    tab.addEventListener('click', function () {
+      tabs.forEach(function (t) {
+        t.setAttribute('aria-selected', 'false');
+        t.tabIndex = -1;
+      });
+      document.querySelectorAll('.code-panel').forEach(function (p) {
+        p.classList.remove('active');
+      });
+      tab.setAttribute('aria-selected', 'true');
+      tab.tabIndex = 0;
+      document.getElementById(tab.getAttribute('aria-controls')).classList.add('active');
+    });
+  });
+
+  // Copy buttons
+  document.querySelectorAll('.copy-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var target = document.getElementById(btn.getAttribute('data-copy-target'));
+      var text = target.textContent;
+      var done = function () {
+        var original = btn.textContent;
+        btn.textContent = 'copied';
+        setTimeout(function () { btn.textContent = original; }, 1200);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done).catch(done);
+      } else {
+        done();
+      }
+    });
+  });
+
+  // Replay animation buttons
+  document.querySelectorAll('.replay-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var box = document.getElementById(btn.getAttribute('data-replay'));
+      var cls = btn.getAttribute('data-class');
+      box.classList.remove(cls);
+      // force reflow so the animation restarts
+      void box.offsetWidth;
+      box.classList.add(cls);
+    });
+  });
+
+  // Checklist status
+  var checks = document.querySelectorAll('#checklist input[data-check]');
+  var status = document.getElementById('checklist-status');
+  function updateStatus() {
+    var count = 0;
+    checks.forEach(function (c) { if (c.checked) count++; });
+    status.textContent = count + ' / ' + checks.length + ' checked';
+    status.classList.toggle('done', count === checks.length);
+  }
+  checks.forEach(function (c) { c.addEventListener('change', updateStatus); });
+  updateStatus();
+</script>
+</body>
+</html>

--- a/submissions/scss/ease-scss-load-paths-hr18/style.css
+++ b/submissions/scss/ease-scss-load-paths-hr18/style.css
@@ -1,0 +1,377 @@
+/* ==========================================================================
+   ease-scss-load-paths-sp
+   Demo styles for the "@use easemotion-css/scss path resolution" guide.
+   Two parts:
+     1. Page chrome — a terminal/diff transcript look (this IS a build-log
+        debugging story, so the UI borrows the vocabulary of the tool it's
+        explaining: a shell transcript with a removed/added diff).
+     2. .ease-* classes — the actual EaseMotion-style utility classes the
+        guide teaches you to unlock once resolution works, demoed live below.
+   ========================================================================== */
+
+:root {
+  --ink: #14161c;
+  --panel: #1b1e26;
+  --panel-raised: #21242e;
+  --line: #2c303c;
+  --text: #e7e6e1;
+  --text-dim: #8b8d98;
+  --removed: #e2685a;
+  --removed-bg: rgba(226, 104, 90, 0.12);
+  --added: #6bcf9a;
+  --added-bg: rgba(107, 207, 154, 0.12);
+  --accent: #e8a33d;
+  --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--ink);
+  color: var(--text);
+  font-family: var(--sans);
+  line-height: 1.6;
+  padding: 3rem 1.5rem 5rem;
+}
+
+.wrap {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+header.hero {
+  margin-bottom: 2.5rem;
+}
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 0.75rem;
+}
+
+h1 {
+  font-size: clamp(1.6rem, 4vw, 2.1rem);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  letter-spacing: -0.01em;
+}
+
+h1 code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  background: var(--panel-raised);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+.lede {
+  color: var(--text-dim);
+  font-size: 1rem;
+  max-width: 58ch;
+  margin: 0;
+}
+
+/* ---- section headings ---- */
+
+h2 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  margin: 2.75rem 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+h2::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+
+/* ---- terminal transcript ---- */
+
+.transcript {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.transcript-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 0.9rem;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel-raised);
+}
+
+.transcript-bar span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--line);
+}
+
+.transcript-bar .label {
+  width: auto;
+  border-radius: 0;
+  background: none;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  margin-left: 0.4rem;
+}
+
+.transcript-body {
+  padding: 1rem 1.1rem 1.2rem;
+  font-family: var(--mono);
+  font-size: 0.84rem;
+}
+
+.line {
+  display: flex;
+  gap: 0.7rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 5px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.line .sign {
+  flex: none;
+  width: 1ch;
+  opacity: 0.8;
+}
+
+.line.removed {
+  background: var(--removed-bg);
+  color: var(--removed);
+}
+
+.line.added {
+  background: var(--added-bg);
+  color: var(--added);
+}
+
+.line.plain {
+  color: var(--text-dim);
+}
+
+/* ---- tabs (Vite / Next.js) ---- */
+
+.tabs {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.tab {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+}
+
+.tab[aria-selected="true"] {
+  color: var(--ink);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.code-panel {
+  position: relative;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  display: none;
+}
+
+.code-panel.active {
+  display: block;
+}
+
+.code-panel pre {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  background: var(--panel-raised);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.copy-btn:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.copy-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ---- live animation demo ---- */
+
+.stage {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.9rem;
+}
+
+.stage-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+  text-align: center;
+}
+
+.stage-box {
+  width: 44px;
+  height: 44px;
+  border-radius: 9px;
+  background: var(--accent);
+}
+
+.stage-card p {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--text-dim);
+}
+
+.replay-btn {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+}
+
+.replay-btn:hover {
+  color: var(--text);
+}
+
+/* EaseMotion-style utility classes — human-readable, one job each */
+
+.ease-fade-in {
+  animation: easeFadeIn 600ms ease both;
+}
+
+.ease-slide-up {
+  animation: easeSlideUp 600ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.ease-scale-in {
+  animation: easeScaleIn 500ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes easeFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes easeSlideUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes easeScaleIn {
+  from { opacity: 0; transform: scale(0.6); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-in,
+  .ease-slide-up,
+  .ease-scale-in {
+    animation: none !important;
+  }
+}
+
+/* ---- checklist ---- */
+
+.checklist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.checklist label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+
+.checklist input {
+  margin-top: 0.25rem;
+  accent-color: var(--accent);
+}
+
+.checklist-status {
+  margin-top: 1rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+
+.checklist-status.done {
+  color: var(--added);
+}
+
+footer {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--text-dim);
+}
+
+footer a {
+  color: var(--accent);
+}


### PR DESCRIPTION
## Pull Request Description
Adds a documentation guide covering common SCSS `@use 'easemotion-css/scss'`
load-path resolution failures in Vite and Next.js, with working config
snippets, an error → cause → fix troubleshooting table, and an interactive
demo.html walkthrough.

Resolves #47644

Note: Issue #47644 already has scaffold content under
`submissions/scss/ease-scss-load-paths-sp/` (partial README + a helper
partial). This PR adds a complementary, self-contained submission under
its own folder (`ease-scss-load-paths-hr18/`) rather than modifying the
existing scaffold. Happy to consolidate if the maintainer prefers a
single folder.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/scss/ease-scss-load-paths-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A beginner-friendly troubleshooting guide for SCSS load-path resolution
errors when importing EaseMotion's SCSS in Vite and Next.js projects,
with a live interactive demo.

**How does a developer use it?**
```scss
@use 'easemotion-css/scss' as ease;

.button {
  @include ease.fade-in();
}
```

**Why does it fit EaseMotion CSS?**
It removes a common onboarding blocker — `@use` path errors are one of
the most frequent friction points when adopting the package. The demo
mirrors EaseMotion's own philosophy: plain, dependency-free CSS keyframe
animations behind readable class names.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a documentation-focused submission alongside the existing
`ease-scss-load-paths-sp/` scaffold — see the note above. Open to
guidance on whether to merge these into one folder.