### PR TITLE
docs: fix internal contradictions in CONTRIBUTING.md (issue limits an…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ EaseMotion CSS has four distinct contribution subdirectories depending on your c
 
 To maintain repository stability, review quality, and fair contribution distribution, EaseMotion CSS enforces a soft daily rate limit:
 
-- Contributors may submit up to **150 PRs per day**
+- Contributors may submit up to **25 PRs per day**
 - Focus on quality, originality, accessibility, and proper testing
 - Low-effort, repetitive, or mass-generated PRs may be closed without review
 
@@ -216,16 +216,16 @@ Small fixes (documentation typos, broken demo links) can go directly to a PR.
 
 ## 🕑 Issue Cooldown Rule
 
-**Maximum 25 active assigned issues per contributor at any time.**
+**Maximum 2 active assigned issues per contributor at any time.**
 
 This rule exists to keep assignments fair and ensure active contributors can always pick up work.
 
 ### What this means
 
 ```
-✅ You have 0–24 active assignments → request a new issue freely
-✅ You have 25 active assignments  → finish or unassign one first
-❌ You have 25+ active assignments → new assignment requests will be declined
+✅ You have 0–1 active assignments → request a new issue freely
+✅ You have 2 active assignments  → finish or unassign one first
+❌ You have 2+ active assignments → new assignment requests will be declined
 ```
 
 ### Inactivity


### PR DESCRIPTION
## Pull Request Description
Fixes internal contradictions in CONTRIBUTING.md where the prose sections stated different limits than the "Strict Repository Rules" table in the same file (issue #48666). Updated the prose to match the table: issue assignment limit (25 → 2) and PR rate limit (150/day → 25/day).

## Type of Change
- [x] 📝 Documentation improvement

## Submission Checklist
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Notes for Maintainer
This PR only edits CONTRIBUTING.md to resolve issue #48666. It doesn't add a submission, so the demo/style/README checklist items and browser testing section don't apply here — happy to adjust the format if you'd prefer this handled differently.