### PR TITLE
fix: bump docs.css cache-busting version to resolve stale theme-toggl…

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
     />
 
     <!-- Link to external docs.css -->
-    <link rel="stylesheet" href="docs.css?v=2" />
+    <link rel="stylesheet" href="docs.css?v=3" />
 
     <!-- Apply stored theme before first paint to avoid flash -->
     <script>


### PR DESCRIPTION
## Pull Request Description
Fixes #47290. Root cause: the theme-toggle icon fix already exists correctly in docs.css (SVGs use `stroke="currentColor"`, CSS variables and selectors are correctly theme-aware, and the JS toggle logic correctly flips `data-theme`). The problem was that `docs/index.html` still linked `docs.css?v=2`, so browsers with a cached copy from before the icon fix was merged never re-fetched the updated stylesheet — meaning visitors kept seeing the old, low-visibility moon icon. Bumped the cache-busting query param to `?v=3` to force browsers to fetch the current stylesheet.

## Type of Change
- [x] 🐛 Bug fix in an existing submission

## Submission Checklist
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Notes for Maintainer
This is a one-line cache-busting fix in docs/index.html (not inside submissions/), similar to a previous CONTRIBUTING.md fix that got auto-closed by the validator bot for the same reason. Flagging in advance in case this needs a manual merge rather than going through the automated submission check.