### PR TITLE
docs: showcase fix for navbar text unreadable under manual dark theme

### DIFF
--- a/submissions/docs/core_changes-issue-48570/README.md
+++ b/submissions/docs/core_changes-issue-48570/README.md
@@ -1,0 +1,6 @@
+\# Fix: Navbar text unreadable under manual dark theme (#48570)
+
+
+
+Navbar text color didn't update when `\[data-theme="dark"]` was set manually — only responded to `prefers-color-scheme: dark`. Added a matching `\[data-theme="dark"]` selector so both trigger paths update the navbar text/background/border color.
+

--- a/submissions/docs/core_changes-issue-48570/demo.html
+++ b/submissions/docs/core_changes-issue-48570/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Navbar Dark Theme Fix Demo</title>
+<link rel="stylesheet" href="../../../components/navbar.css">
+<link rel="stylesheet" href="style.css">
+<style>
+  body { margin: 0; padding: 2rem; font-family: sans-serif; background: #1e293b; }
+  [data-theme="dark"] { display: contents; }
+</style>
+</head>
+<body data-theme="dark">
+  <nav class="ease-navbar-glass">
+    <div class="ease-navbar-item">Home</div>
+    <div class="ease-navbar-item">About</div>
+    <div class="ease-navbar-item">Contact</div>
+  </nav>
+  <p style="color: white;">This demo shows navbar text staying readable under manually-set <code>data-theme="dark"</code>, using the fix in style.css.</p>
+</body>
+</html>

--- a/submissions/docs/core_changes-issue-48570/style.css
+++ b/submissions/docs/core_changes-issue-48570/style.css
@@ -1,0 +1,5 @@
+[data-theme="dark"] .ease-navbar-glass {
+  background: var(--ease-glass-bg, rgba(15, 23, 42, 0.3));
+  border-color: var(--ease-glass-border, rgba(255, 255, 255, 0.08));
+  color: var(--ease-color-neutral-100, #f1f5f9);
+}


### PR DESCRIPTION
## Pull Request Description
Fixes #48570. The glass navbar text stays dark and unreadable when `[data-theme="dark"]` is set manually — it only responds to the `prefers-color-scheme: dark` media query, not a manual attribute override. This PR adds a docs showcase demonstrating the corrected selector.

## Type of Change
- [x] 🐛 Bug fix in an existing submission

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/core_changes-issue-48570/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A `[data-theme="dark"]` selector for `.ease-navbar-glass`, mirroring the existing `prefers-color-scheme: dark` rule, so manually-set dark theme also updates navbar text/background/border.

**How does a developer use it?**
​```html
<body data-theme="dark">
  <nav class="ease-navbar-glass">...</nav>
</body>
​```

**Why does it fit EaseMotion CSS?**
Keeps the navbar's theme behavior consistent regardless of whether dark mode comes from OS preference or a manual toggle — matching the framework's existing token-based theming approach.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome

## Notes for Maintainer
This shows the fix as a docs-track demo per the `core_changes-issue-*` pattern — the actual selector should be added to `components/navbar.css` by the maintainer.