### PR TITLE
feat: add ease-high-score-display component example (#43083)

### DIFF
--- a/submissions/examples/ease-high-score-display-rs/README.md
+++ b/submissions/examples/ease-high-score-display-rs/README.md
@@ -1,0 +1,29 @@
+# ease-high-score-display
+
+A CSS animation component for displaying animated high-score leaderboards with pulse effects.
+
+## Usage
+
+Open demo.html in a browser. Click the **Toggle** button to reveal score rows with staggered slide-in animation. The top score pulses with a golden glow effect.
+
+## Custom Properties
+
+| Property         | Default | Description              |
+| ---------------- | ------- | ------------------------ |
+| --primary        | #6c63ff | Primary accent color     |
+| --bg             | #f8fafc | Page background          |
+| --surface        | #fff    | Card background          |
+| --text           | #1e293b | Text color               |
+| --muted          | #64748b | Muted text color         |
+| --border         | #e2e8f0 | Border color             |
+| --gold           | #f59e0b | Gold (1st place) color   |
+| --silver         | #94a3b8 | Silver (2nd place) color |
+| --bronze         | #d97706 | Bronze (3rd place) color |
+| --score-color    | #6c63ff | Score number color       |
+| --rank-size      | 32px    | Rank badge diameter      |
+| --duration       | 0.5s    | Transition speed         |
+| --pulse-duration | 2s      | Pulse animation cycle    |
+
+## Notes
+
+CSS handles slide-in and pulse animations. JavaScript toggles visibility state and staggered delays.

--- a/submissions/examples/ease-high-score-display-rs/demo.html
+++ b/submissions/examples/ease-high-score-display-rs/demo.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>ease-high-score-display</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5C5 4 6 3 7.5 3c1 0 1.5.5 2 1" />
+          <path
+            d="M18 9h1.5a2.5 2.5 0 0 0 0-5C19 4 18 3 16.5 3c-1 0-1.5.5-2 1"
+          />
+          <path d="M4 22h16" />
+          <path d="M10 22V8h4v14" />
+          <path d="M4 22V12h6" />
+          <path d="M14 22V12h6" /></svg
+        >high-score-display
+      </h1>
+      <p class="subtitle">Click to toggle animation</p>
+      <div class="demo-box" id="demoBox">
+        <div class="scoreboard" id="scoreboard">
+          <div class="score-row rank-1" data-delay="0">
+            <div class="rank-badge">1</div>
+            <span class="player-name">Player One</span
+            ><span class="player-score" data-score="9850">9,850</span>
+          </div>
+          <div class="score-row rank-2" data-delay="100">
+            <div class="rank-badge">2</div>
+            <span class="player-name">MasterBlade</span
+            ><span class="player-score" data-score="7200">7,200</span>
+          </div>
+          <div class="score-row rank-3" data-delay="200">
+            <div class="rank-badge">3</div>
+            <span class="player-name">SpeedRunner</span
+            ><span class="player-score" data-score="5100">5,100</span>
+          </div>
+          <div class="score-row rank-4" data-delay="300">
+            <div class="rank-badge">4</div>
+            <span class="player-name">PixelWizard</span
+            ><span class="player-score" data-score="3200">3,200</span>
+          </div>
+          <div class="score-row rank-5" data-delay="400">
+            <div class="rank-badge">5</div>
+            <span class="player-name">NeonKnight</span
+            ><span class="player-score" data-score="1800">1,800</span>
+          </div>
+        </div>
+      </div>
+      <button class="trigger" id="trigger">Toggle</button>
+    </div>
+    <script>
+      const s = document.getElementById("scoreboard");
+      const b = document.getElementById("trigger");
+      let a = false,
+        interval = null;
+      function showRows() {
+        const r = s.querySelectorAll(".score-row");
+        r.forEach((row, i) => {
+          setTimeout(
+            () => {
+              row.classList.add("visible");
+              const sc = row.querySelector(".player-score");
+              if (sc) {
+                sc.classList.add("score-pulse");
+              }
+            },
+            i * 100 + 50
+          );
+        });
+      }
+      function hideRows() {
+        const r = s.querySelectorAll(".score-row");
+        r.forEach((row) => {
+          row.classList.remove("visible");
+          const sc = row.querySelector(".player-score");
+          if (sc) {
+            sc.classList.remove("score-pulse");
+          }
+        });
+      }
+      b.addEventListener("click", () => {
+        a = !a;
+        if (a) {
+          showRows();
+        } else {
+          hideRows();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-high-score-display-rs/style.css
+++ b/submissions/examples/ease-high-score-display-rs/style.css
@@ -1,0 +1,194 @@
+:root {
+  --primary: #6c63ff;
+  --bg: #f8fafc;
+  --surface: #fff;
+  --text: #1e293b;
+  --muted: #64748b;
+  --border: #e2e8f0;
+  --gold: #f59e0b;
+  --silver: #94a3b8;
+  --bronze: #d97706;
+  --score-color: #6c63ff;
+  --rank-size: 32px;
+  --score-glow: rgba(108, 99, 255, 0.3);
+  --duration: 0.5s;
+  --pulse-duration: 2s;
+}
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 20px;
+}
+.container {
+  max-width: 480px;
+  width: 100%;
+  text-align: center;
+}
+h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+  text-transform: capitalize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+h1 svg {
+  color: var(--gold);
+}
+.subtitle {
+  font-size: 0.875rem;
+  color: var(--muted);
+  margin-bottom: 24px;
+}
+.demo-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 16px;
+  min-height: 320px;
+  overflow: hidden;
+}
+.scoreboard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px;
+}
+.score-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--bg);
+  transition: all var(--duration) ease;
+  opacity: 0;
+  transform: translateX(-20px);
+}
+.score-row.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+.score-row.rank-1 {
+  background: linear-gradient(135deg, #fef3c7, #fde68a);
+  order: 0;
+}
+.score-row.rank-2 {
+  background: linear-gradient(135deg, #f1f5f9, #e2e8f0);
+  order: 1;
+}
+.score-row.rank-3 {
+  background: linear-gradient(135deg, #fff7ed, #fed7aa);
+  order: 2;
+}
+.score-row.rank-4 {
+  order: 3;
+}
+.score-row.rank-5 {
+  order: 4;
+}
+.rank-badge {
+  width: var(--rank-size);
+  height: var(--rank-size);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  background: var(--border);
+  color: var(--muted);
+}
+.rank-1 .rank-badge {
+  background: var(--gold);
+  color: #fff;
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.4);
+}
+.rank-2 .rank-badge {
+  background: var(--silver);
+  color: #fff;
+}
+.rank-3 .rank-badge {
+  background: var(--bronze);
+  color: #fff;
+}
+.player-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex: 1;
+  text-align: left;
+  color: var(--text);
+}
+.player-score {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--score-color);
+  font-variant-numeric: tabular-nums;
+  transition: all var(--duration) ease;
+  min-width: 48px;
+  text-align: right;
+  position: relative;
+}
+.rank-1 .player-score {
+  color: #b45309;
+  text-shadow: 0 0 8px var(--score-glow);
+}
+.score-pulse {
+  animation: hs-pulse var(--pulse-duration) ease-in-out infinite;
+}
+.rank-1 .score-pulse {
+  animation: hs-pulse-gold var(--pulse-duration) ease-in-out infinite;
+}
+.trigger {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--duration) ease;
+}
+.trigger:hover {
+  background: #5a52e0;
+}
+.trigger:active {
+  transform: scale(0.97);
+}
+@keyframes hs-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.08);
+  }
+}
+@keyframes hs-pulse-gold {
+  0%,
+  100% {
+    transform: scale(1);
+    text-shadow: 0 0 4px var(--score-glow);
+  }
+  50% {
+    transform: scale(1.12);
+    text-shadow:
+      0 0 16px var(--score-glow),
+      0 0 32px rgba(245, 158, 11, 0.3);
+  }
+}


### PR DESCRIPTION
Adds an animated high-score leaderboard component to \submissions/examples/ease-high-score-display-rs/\.

## Features
- **5-player leaderboard** with rank badges (gold/silver/bronze styling for top 3)
- **Staggered slide-in animation** for each score row
- **Pulse animation** on all scores, enhanced golden glow for 1st place
- **Rank-specific styling**: gold (#1), silver (#2), bronze (#3) with gradient backgrounds
- **Uses EaseMotion CSS variables** for colors, spacing, and shadows
- **13 customizable CSS properties** for full theme control

## Files
- \style.css\: 2KB component CSS with keyframe animations
- \demo.html\: self-contained demo with scoreboard layout
- \README.md\: documentation and custom properties table

Closes #43083