### PR TITLE
feat: add draw-border line tooltip component

### DIFF
--- a/submissions/examples/draw-border-line-tooltip-saas/README.md
+++ b/submissions/examples/draw-border-line-tooltip-saas/README.md
@@ -1,0 +1,36 @@
+# Draw-Border Line Tooltip for SaaS Showcase
+
+A pure CSS tooltip component for SaaS showcase cards. The tooltip reveals with a smooth line-drawing border animation, works on hover and keyboard focus, and exposes custom properties for timing, easing, offset, scale, and color.
+
+## Features
+
+- Pure HTML and CSS, no JavaScript required
+- Keyboard accessible with `:focus-visible` and `:focus-within`
+- Responsive layout for compact screens
+- Configurable via CSS custom properties
+- Reduced-motion fallback for users who prefer less animation
+
+## Usage
+
+```html
+<span class="draw-tooltip" style="--tooltip-accent: #38bdf8">
+  <button class="draw-tooltip__trigger" aria-describedby="analytics-tooltip">
+    Analytics API
+  </button>
+  <span id="analytics-tooltip" class="draw-tooltip__content" role="tooltip">
+    Real-time cohort, funnel, and usage signals for product teams.
+  </span>
+</span>
+```
+
+## Custom Properties
+
+- `--tooltip-accent`: border and highlight color
+- `--tooltip-duration`: draw/reveal animation duration
+- `--tooltip-ease`: animation easing
+- `--tooltip-offset`: distance between trigger and tooltip
+- `--tooltip-scale-start`: starting scale for the reveal motion
+
+## Accessibility Notes
+
+Each trigger uses `aria-describedby` to reference its tooltip content. The tooltip is revealed on hover and when the trigger receives keyboard focus, so keyboard and pointer users receive the same information.

--- a/submissions/examples/draw-border-line-tooltip-saas/demo.html
+++ b/submissions/examples/draw-border-line-tooltip-saas/demo.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Draw-Border Line Tooltip for SaaS Showcase</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="showcase-shell">
+      <section class="hero-panel" aria-labelledby="demo-title">
+        <p class="eyebrow">EaseMotion CSS Component</p>
+        <h1 id="demo-title">
+          Draw-border tooltips for polished SaaS showcases
+        </h1>
+        <p class="hero-copy">
+          Hover or tab through the metrics below to reveal contextual product
+          details with a pure CSS line-drawing border transition.
+        </p>
+
+        <div class="metric-grid" aria-label="SaaS platform highlights">
+          <article class="metric-card">
+            <span class="metric-value">98%</span>
+            <span class="draw-tooltip" style="--tooltip-accent: #38bdf8">
+              <button
+                class="draw-tooltip__trigger"
+                aria-describedby="tooltip-uptime"
+              >
+                Uptime SLA
+              </button>
+              <span
+                id="tooltip-uptime"
+                class="draw-tooltip__content"
+                role="tooltip"
+              >
+                Multi-region failover keeps workspaces online during peak
+                traffic.
+              </span>
+            </span>
+          </article>
+
+          <article class="metric-card">
+            <span class="metric-value">42ms</span>
+            <span
+              class="draw-tooltip"
+              style="--tooltip-accent: #a78bfa; --tooltip-duration: 520ms"
+            >
+              <button
+                class="draw-tooltip__trigger"
+                aria-describedby="tooltip-latency"
+              >
+                API latency
+              </button>
+              <span
+                id="tooltip-latency"
+                class="draw-tooltip__content"
+                role="tooltip"
+              >
+                Edge-cached endpoints keep dashboards feeling instant worldwide.
+              </span>
+            </span>
+          </article>
+
+          <article class="metric-card">
+            <span class="metric-value">12k</span>
+            <span
+              class="draw-tooltip"
+              style="--tooltip-accent: #34d399; --tooltip-scale-start: 0.92"
+            >
+              <button
+                class="draw-tooltip__trigger"
+                aria-describedby="tooltip-workflows"
+              >
+                Automations
+              </button>
+              <span
+                id="tooltip-workflows"
+                class="draw-tooltip__content"
+                role="tooltip"
+              >
+                Workflow runs are grouped by team, priority, and release window.
+              </span>
+            </span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/draw-border-line-tooltip-saas/style.css
+++ b/submissions/examples/draw-border-line-tooltip-saas/style.css
@@ -1,0 +1,217 @@
+:root {
+  --page-bg: #07111f;
+  --panel-bg: rgba(12, 23, 42, 0.82);
+  --panel-border: rgba(148, 163, 184, 0.18);
+  --text: #f8fafc;
+  --muted: #9fb0c7;
+  --tooltip-accent: #38bdf8;
+  --tooltip-duration: 440ms;
+  --tooltip-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --tooltip-offset: 0.85rem;
+  --tooltip-scale-start: 0.96;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(56, 189, 248, 0.24),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 82% 12%,
+      rgba(167, 139, 250, 0.22),
+      transparent 24rem
+    ),
+    linear-gradient(135deg, #07111f 0%, #111827 58%, #051019 100%);
+}
+
+.showcase-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: clamp(1.25rem, 5vw, 4rem);
+}
+
+.hero-panel {
+  width: min(100%, 980px);
+  padding: clamp(1.5rem, 4vw, 4rem);
+  overflow: visible;
+  border: 1px solid var(--panel-border);
+  border-radius: 2rem;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), var(--panel-bg));
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #67e8f9;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 760px;
+  margin: 0;
+  font-size: clamp(2.1rem, 6vw, 4.8rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+.hero-copy {
+  max-width: 660px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.7;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: clamp(2rem, 6vw, 4rem);
+}
+
+.metric-card {
+  position: relative;
+  min-height: 180px;
+  padding: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 1.35rem;
+  background: rgba(15, 23, 42, 0.74);
+}
+
+.metric-value {
+  display: block;
+  margin-bottom: 1.7rem;
+  font-size: clamp(2.1rem, 5vw, 3.4rem);
+  font-weight: 900;
+  letter-spacing: -0.05em;
+}
+
+.draw-tooltip {
+  position: relative;
+  display: inline-flex;
+}
+
+.draw-tooltip__trigger {
+  cursor: help;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.72rem 1rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  font: inherit;
+  font-weight: 750;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.11);
+}
+
+.draw-tooltip__trigger:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tooltip-accent), white 22%);
+  outline-offset: 4px;
+}
+
+.draw-tooltip__content {
+  position: absolute;
+  inset-inline-start: 50%;
+  bottom: calc(100% + var(--tooltip-offset));
+  z-index: 10;
+  width: min(18rem, 78vw);
+  padding: 0.95rem 1rem;
+  color: #dbeafe;
+  background: rgba(2, 6, 23, 0.96);
+  border-radius: 1rem;
+  box-shadow: 0 22px 46px rgba(0, 0, 0, 0.38);
+  font-size: 0.92rem;
+  line-height: 1.45;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(-50%) translateY(0.5rem)
+    scale(var(--tooltip-scale-start));
+  transform-origin: bottom center;
+  transition:
+    opacity var(--tooltip-duration) var(--tooltip-ease),
+    transform var(--tooltip-duration) var(--tooltip-ease);
+}
+
+.draw-tooltip__content::before,
+.draw-tooltip__content::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.draw-tooltip__content::before {
+  border-block: 2px solid var(--tooltip-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--tooltip-duration) var(--tooltip-ease);
+}
+
+.draw-tooltip__content::after {
+  border-inline: 2px solid var(--tooltip-accent);
+  transform: scaleY(0);
+  transform-origin: bottom;
+  transition: transform var(--tooltip-duration) var(--tooltip-ease) 120ms;
+}
+
+.draw-tooltip:hover .draw-tooltip__content,
+.draw-tooltip:focus-within .draw-tooltip__content {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+.draw-tooltip:hover .draw-tooltip__content::before,
+.draw-tooltip:hover .draw-tooltip__content::after,
+.draw-tooltip:focus-within .draw-tooltip__content::before,
+.draw-tooltip:focus-within .draw-tooltip__content::after {
+  transform: none;
+}
+
+@media (max-width: 720px) {
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-card {
+    min-height: 150px;
+  }
+
+  .draw-tooltip__content {
+    inset-inline-start: 0;
+    transform: translateY(0.5rem) scale(var(--tooltip-scale-start));
+  }
+
+  .draw-tooltip:hover .draw-tooltip__content,
+  .draw-tooltip:focus-within .draw-tooltip__content {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .draw-tooltip__content,
+  .draw-tooltip__content::before,
+  .draw-tooltip__content::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a pure CSS draw-border line tooltip component for SaaS showcase layouts
- include responsive demo markup with three configurable tooltip examples
- document CSS custom properties, keyboard behavior, and reduced-motion support

## Accessibility
- tooltip triggers use `aria-describedby`
- reveal works on hover and keyboard focus via `:focus-within`
- visible focus ring is included with `:focus-visible`
- reduced-motion users skip animated transitions

Fixes #46343

## Validation
- `python -c "from html.parser import HTMLParser; from pathlib import Path; HTMLParser().feed(Path('submissions/examples/draw-border-line-tooltip-saas/demo.html').read_text(encoding='utf-8')); print('html parse ok')"`
- `git diff --check`
- `npx stylelint "submissions/examples/draw-border-line-tooltip-saas/style.css" --config .github/workflows/stylelint.config.json`
- `npx prettier --check "submissions/examples/draw-border-line-tooltip-saas/**/*.{css,html,md}"`