### PR TITLE
feat: add quota usage threshold demo

### DIFF
--- a/submissions/examples/quota-usage-threshold-sm/README.md
+++ b/submissions/examples/quota-usage-threshold-sm/README.md
@@ -1,0 +1,34 @@
+# Quota Usage Threshold
+
+## What does this do?
+
+Quota Usage Threshold is a self-contained HTML and CSS usage dashboard pattern with animated quota meters, threshold badges, progress rings, and clear upgrade or review actions.
+
+## How is it used?
+
+Create a `quota-board` wrapper and add `quota-card` items with threshold classes such as `quota-safe`, `quota-warning`, or `quota-critical`.
+
+```html
+<article class="quota-card quota-warning">
+  <div class="quota-ring" aria-hidden="true">
+    <span>83%</span>
+  </div>
+  <div class="quota-content">
+    <p class="quota-kicker">API calls</p>
+    <h2>Request volume is near cap</h2>
+    <div class="quota-bar" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available threshold classes:
+
+- `quota-safe`
+- `quota-warning`
+- `quota-critical`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make usage limits easier to scan: cards enter gently, rings show quota level, bars reveal threshold pressure, and focus states keep actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/quota-usage-threshold-sm/demo.html
+++ b/submissions/examples/quota-usage-threshold-sm/demo.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quota Usage Threshold Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="quota-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Quota Usage Threshold</h1>
+        <p>
+          A self-contained usage dashboard pattern with animated quota meters,
+          threshold badges, progress rings, and clear upgrade or review actions.
+        </p>
+      </section>
+
+      <section class="quota-summary" aria-label="Quota usage summary">
+        <article>
+          <span class="summary-value">81%</span>
+          <span class="summary-label">Total quota used</span>
+        </article>
+        <article>
+          <span class="summary-value">14d</span>
+          <span class="summary-label">Billing cycle left</span>
+        </article>
+        <article>
+          <span class="summary-value">03</span>
+          <span class="summary-label">Limits near cap</span>
+        </article>
+      </section>
+
+      <section class="quota-board" aria-label="Quota threshold cards">
+        <article class="quota-card quota-safe">
+          <div class="quota-ring" aria-hidden="true">
+            <span>54%</span>
+          </div>
+          <div class="quota-content">
+            <p class="quota-kicker">Storage</p>
+            <h2>Project files are healthy</h2>
+            <p>
+              Static assets, snapshots, and generated reports are comfortably
+              below the monthly storage limit.
+            </p>
+            <div class="quota-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Safe</span>
+              <button type="button">View files</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="quota-card quota-warning">
+          <div class="quota-ring" aria-hidden="true">
+            <span>83%</span>
+          </div>
+          <div class="quota-content">
+            <p class="quota-kicker">API calls</p>
+            <h2>Request volume is near cap</h2>
+            <p>
+              Peak traffic from scheduled sync jobs is using most of the
+              included API allowance for this billing cycle.
+            </p>
+            <div class="quota-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Warning</span>
+              <button type="button">Tune jobs</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="quota-card quota-critical">
+          <div class="quota-ring" aria-hidden="true">
+            <span>96%</span>
+          </div>
+          <div class="quota-content">
+            <p class="quota-kicker">Seats</p>
+            <h2>Team seats almost full</h2>
+            <p>
+              Only two seats remain available after the latest workspace invites
+              and pending contractor access requests.
+            </p>
+            <div class="quota-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Critical</span>
+              <button type="button">Upgrade</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/quota-usage-threshold-sm/style.css
+++ b/submissions/examples/quota-usage-threshold-sm/style.css
@@ -1,0 +1,354 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.quota-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.quota-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.quota-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.quota-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.quota-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.quota-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.quota-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.quota-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.quota-card:hover,
+.quota-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.quota-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--quota), #e4edf8 var(--quota) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-enter 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.quota-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.55rem;
+  font-weight: 950;
+}
+
+.quota-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.quota-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.quota-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.quota-content > p:not(.quota-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.quota-bar {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.quota-bar span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--quota);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: bar-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.quota-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.quota-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.quota-content button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.quota-content button:hover,
+.quota-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.quota-safe {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --quota: 54%;
+}
+
+.quota-warning {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --quota: 83%;
+}
+
+.quota-critical {
+  --accent: var(--red);
+  --accent-light: #fb7185;
+  --accent-soft: rgba(220, 38, 38, 0.14);
+  --quota: 96%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-enter {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .quota-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .quota-summary,
+  .quota-board {
+    grid-template-columns: 1fr;
+  }
+
+  .quota-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48719


**PR Text**

Title: `feat: add quota usage threshold demo`

```md
## Pull Request Description
Adds a self-contained Quota Usage Threshold demo under `submissions/examples/`, featuring animated quota rings, threshold cards, usage bars, and review/upgrade actions.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only quota usage dashboard pattern for usage and billing surfaces.

**How does a developer use it?**
Use a `quota-board` wrapper with `quota-card` items and threshold classes like `quota-safe`, `quota-warning`, or `quota-critical`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate usage level, threshold pressure, and action priority while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The threshold naming, quota colors, and meter timing can be standardized during framework integration.