### PR TITLE
feat: add pulse-active popover for analytics dashboard layouts (#46522)

### DIFF
--- a/submissions/examples/pulse-active-popover-analytics-rs/README.md
+++ b/submissions/examples/pulse-active-popover-analytics-rs/README.md
@@ -1,0 +1,60 @@
+# Pulse-Active Popover — Dashboard Analytics
+
+A pure CSS animated popover with pulse-active interaction, styled for analytics dashboard interfaces.
+
+## Features
+
+- **4 dashboard metric cards** — Visitors, Conversion Rate, Bounce Rate, Avg. Session
+- **4 channel breakdown cards** — Direct, Organic, Social, Referral traffic
+- **Analytics-rich popovers** — Metric breakdowns, trend indicators, mini bar charts
+- **Pulse-active animation** — Smooth scale pulse on open
+- **4 position variants** — Bottom, Top, Right, Left (switchable via radio buttons)
+- **Dark/light mode** — Automatic via `prefers-color-scheme`
+- **Reduced motion** — Respects `prefers-reduced-motion: reduce`
+- **Forced colors** — Respects `forced-colors: active`
+- **Keyboard accessible** — Tab navigation, Space/Enter to toggle
+- **No JavaScript dependency** — Checkbox hack for toggle behavior
+
+## Custom Properties
+
+| Variable                   | Default                     | Description                     |
+| -------------------------- | --------------------------- | ------------------------------- |
+| `--popover-duration`       | `0.3s`                      | Open/close transition duration  |
+| `--popover-ease`           | `cubic-bezier(0.4,0,0.2,1)` | Transition easing               |
+| `--popover-pulse-duration` | `2s`                        | Pulse animation cycle time      |
+| `--popover-pulse-scale`    | `1.03`                      | Scale factor at pulse peak      |
+| `--popover-max-width`      | `320px`                     | Maximum popover width           |
+| `--popover-gap`            | `8px`                       | Gap between trigger and popover |
+
+## Usage
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css"
+/>
+<link rel="stylesheet" href="style.css" />
+
+<div class="analytics-card">
+  <div class="pulse-popover-an">
+    <input type="checkbox" id="my-popover" class="pulse-popover-toggle-an" />
+    <label for="my-popover" class="pulse-popover-trigger-an"
+      >View Details</label
+    >
+    <div class="pulse-popover-content-an" data-position="bottom" role="dialog">
+      <div class="popover-header">
+        <h4>Breakdown</h4>
+        <button type="button" class="popover-close">×</button>
+      </div>
+      <div class="metric-row">
+        <span class="metric-label">Metric</span>
+        <span class="metric-value">1,234</span>
+      </div>
+      <div class="popover-footer">
+        <span class="popover-footer-label">Footer label</span>
+        <button type="button" class="popover-btn">Action</button>
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/submissions/examples/pulse-active-popover-analytics-rs/demo.html
+++ b/submissions/examples/pulse-active-popover-analytics-rs/demo.html
@@ -1,0 +1,613 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pulse-Active Popover — Analytics Dashboard</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>
+          <svg
+            width="28"
+            height="28"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M3 3v18h18" />
+            <path d="M7 16l4-8 4 4 4-6" />
+          </svg>
+          Pulse-Active Analytics
+        </h1>
+        <p>Interactive popover cards for dashboard analytics insights</p>
+      </div>
+
+      <div class="dashboard-header">
+        <h2>Key Metrics</h2>
+        <span class="period">Last 30 days</span>
+      </div>
+
+      <div class="grid">
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Total Visitors</span>
+            <span class="card-trend trend-up">+12.5%</span>
+          </div>
+          <div class="card-value">284.3K</div>
+          <div class="card-sub">vs 252.7K previous period</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-blue" style="width: 85%"></div>
+          </div>
+          <div class="pulse-popover-an">
+            <input
+              type="checkbox"
+              id="popover-visitors"
+              class="pulse-popover-toggle-an"
+            />
+            <label for="popover-visitors" class="pulse-popover-trigger-an">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              View Details
+            </label>
+            <div
+              class="pulse-popover-content-an"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Visitors breakdown"
+            >
+              <div class="popover-header">
+                <h4>Visitors Breakdown</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="
+                    document.getElementById('popover-visitors').checked = false
+                  "
+                >
+                  ×
+                </button>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label"
+                  ><span class="metric-dot" style="background: #3b82f6"></span
+                  >Direct</span
+                ><span class="metric-value">98.2K</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label"
+                  ><span class="metric-dot" style="background: #8b5cf6"></span
+                  >Organic Search</span
+                ><span class="metric-value">112.5K</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label"
+                  ><span class="metric-dot" style="background: #16a34a"></span
+                  >Social Media</span
+                ><span class="metric-value">45.8K</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label"
+                  ><span class="metric-dot" style="background: #d97706"></span
+                  >Referral</span
+                ><span class="metric-value">27.8K</span>
+              </div>
+              <hr
+                style="
+                  border: none;
+                  border-top: 1px dashed var(--border);
+                  margin: 6px 0;
+                "
+              />
+              <div class="metric-row">
+                <span class="metric-label" style="font-weight: 600">Total</span
+                ><span class="metric-value">284.3K</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">Updated 2 min ago</span>
+                <button type="button" class="popover-btn">Full Report</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Conversion Rate</span>
+            <span class="card-trend trend-up">+2.1%</span>
+          </div>
+          <div class="card-value">4.8%</div>
+          <div class="card-sub">Target: 4.5% — exceeding goal</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-purple" style="width: 72%"></div>
+          </div>
+          <div class="pulse-popover-an">
+            <input
+              type="checkbox"
+              id="popover-conversion"
+              class="pulse-popover-toggle-an"
+            />
+            <label for="popover-conversion" class="pulse-popover-trigger-an">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              View Details
+            </label>
+            <div
+              class="pulse-popover-content-an"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Conversion breakdown"
+            >
+              <div class="popover-header">
+                <h4>Conversion Breakdown</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="
+                    document.getElementById('popover-conversion').checked =
+                      false
+                  "
+                >
+                  ×
+                </button>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Sign-up Rate</span
+                ><span class="metric-value good">6.2%</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Checkout Rate</span
+                ><span class="metric-value good">3.1%</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Newsletter</span
+                ><span class="metric-value warn">2.4%</span>
+              </div>
+              <div class="chart-mini">
+                <div class="chart-bar-mini bar-blue" style="height: 24px"></div>
+                <div
+                  class="chart-bar-mini bar-purple"
+                  style="height: 18px"
+                ></div>
+                <div
+                  class="chart-bar-mini bar-green"
+                  style="height: 28px"
+                ></div>
+                <div
+                  class="chart-bar-mini bar-amber"
+                  style="height: 14px"
+                ></div>
+                <div class="chart-bar-mini bar-blue" style="height: 22px"></div>
+                <div
+                  class="chart-bar-mini bar-purple"
+                  style="height: 16px"
+                ></div>
+                <div
+                  class="chart-bar-mini bar-green"
+                  style="height: 30px"
+                ></div>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">Daily avg: 4.8%</span>
+                <button type="button" class="popover-btn">Optimize</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Bounce Rate</span>
+            <span class="card-trend trend-down">+5.3%</span>
+          </div>
+          <div class="card-value" style="color: var(--danger)">32.1%</div>
+          <div class="card-sub">Increased from 26.8% — needs attention</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-amber" style="width: 48%"></div>
+          </div>
+          <div class="pulse-popover-an">
+            <input
+              type="checkbox"
+              id="popover-bounce"
+              class="pulse-popover-toggle-an"
+            />
+            <label for="popover-bounce" class="pulse-popover-trigger-an">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              View Details
+            </label>
+            <div
+              class="pulse-popover-content-an"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Bounce rate details"
+            >
+              <div class="popover-header">
+                <h4>Bounce Rate by Page</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="
+                    document.getElementById('popover-bounce').checked = false
+                  "
+                >
+                  ×
+                </button>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Landing Page</span
+                ><span class="metric-value bad">41.3%</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Blog Posts</span
+                ><span class="metric-value warn">34.7%</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Product Pages</span
+                ><span class="metric-value good">22.5%</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Pricing Page</span
+                ><span class="metric-value warn">28.9%</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">30-day trend</span>
+                <button type="button" class="popover-btn-outline">
+                  Investigate
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Avg. Session</span>
+            <span class="card-trend trend-up">+8.2%</span>
+          </div>
+          <div class="card-value">4m 23s</div>
+          <div class="card-sub">vs 4m 03s previous period</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-green" style="width: 66%"></div>
+          </div>
+          <div class="pulse-popover-an">
+            <input
+              type="checkbox"
+              id="popover-session"
+              class="pulse-popover-toggle-an"
+            />
+            <label for="popover-session" class="pulse-popover-trigger-an">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              View Details
+            </label>
+            <div
+              class="pulse-popover-content-an"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Session details"
+            >
+              <div class="popover-header">
+                <h4>Session Details</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="
+                    document.getElementById('popover-session').checked = false
+                  "
+                >
+                  ×
+                </button>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Desktop</span
+                ><span class="metric-value">5m 12s</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Mobile</span
+                ><span class="metric-value">3m 48s</span>
+              </div>
+              <div class="metric-row">
+                <span class="metric-label">Tablet</span
+                ><span class="metric-value">4m 01s</span>
+              </div>
+              <div class="chart-mini">
+                <div class="chart-bar-mini bar-blue" style="height: 28px"></div>
+                <div
+                  class="chart-bar-mini bar-green"
+                  style="height: 20px"
+                ></div>
+                <div
+                  class="chart-bar-mini bar-purple"
+                  style="height: 22px"
+                ></div>
+                <div
+                  class="chart-bar-mini bar-amber"
+                  style="height: 18px"
+                ></div>
+                <div class="chart-bar-mini bar-blue" style="height: 26px"></div>
+                <div
+                  class="chart-bar-mini bar-green"
+                  style="height: 24px"
+                ></div>
+                <div
+                  class="chart-bar-mini bar-purple"
+                  style="height: 16px"
+                ></div>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">Pages/session: 6.2</span>
+                <button type="button" class="popover-btn-outline">
+                  Full Analysis
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="dashboard-header" style="margin-top: 8px">
+        <h2>Top Channels</h2>
+        <span class="period">vs previous period</span>
+      </div>
+
+      <div class="grid">
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Direct Traffic</span>
+            <span class="card-trend trend-up">+9.8%</span>
+          </div>
+          <div class="card-value">34.6%</div>
+          <div class="card-sub">Of total traffic share</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-blue" style="width: 90%"></div>
+          </div>
+        </div>
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Organic Search</span>
+            <span class="card-trend trend-up">+4.2%</span>
+          </div>
+          <div class="card-value">39.6%</div>
+          <div class="card-sub">Of total traffic share</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-purple" style="width: 78%"></div>
+          </div>
+        </div>
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Social</span>
+            <span class="card-trend trend-neutral">+0.3%</span>
+          </div>
+          <div class="card-value">16.1%</div>
+          <div class="card-sub">Of total traffic share</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-green" style="width: 55%"></div>
+          </div>
+        </div>
+        <div class="analytics-card">
+          <div class="card-top">
+            <span class="card-label">Referral</span>
+            <span class="card-trend trend-up">+6.7%</span>
+          </div>
+          <div class="card-value">9.7%</div>
+          <div class="card-sub">Of total traffic share</div>
+          <div class="card-bar">
+            <div class="card-bar-fill bar-amber" style="width: 40%"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="dashboard-header" style="margin-top: 8px">
+        <h2>Position Controls</h2>
+        <span class="period">Demo only</span>
+      </div>
+      <div
+        style="
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
+          margin-bottom: 32px;
+          padding: 16px;
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: var(--radius);
+          box-shadow: var(--shadow);
+        "
+      >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="an-pos"
+            value="bottom"
+            checked
+            onchange="
+              document
+                .querySelectorAll('.pulse-popover-content-an')
+                .forEach((el) => (el.dataset.position = 'bottom'))
+            "
+          />
+          Bottom</label
+        >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="an-pos"
+            value="top"
+            onchange="
+              document
+                .querySelectorAll('.pulse-popover-content-an')
+                .forEach((el) => (el.dataset.position = 'top'))
+            "
+          />
+          Top</label
+        >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="an-pos"
+            value="right"
+            onchange="
+              document
+                .querySelectorAll('.pulse-popover-content-an')
+                .forEach((el) => (el.dataset.position = 'right'))
+            "
+          />
+          Right</label
+        >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="an-pos"
+            value="left"
+            onchange="
+              document
+                .querySelectorAll('.pulse-popover-content-an')
+                .forEach((el) => (el.dataset.position = 'left'))
+            "
+          />
+          Left</label
+        >
+      </div>
+
+      <div class="dashboard-header" style="margin-top: 8px">
+        <h2>Custom Properties</h2>
+        <span class="period">Override via CSS</span>
+      </div>
+      <div
+        style="
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+          gap: 8px;
+          margin-bottom: 32px;
+        "
+      >
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-duration</strong><br />
+          <span style="color: var(--muted)">0.3s</span>
+        </div>
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-ease</strong><br />
+          <span style="color: var(--muted)">cubic-bezier(0.4,0,0.2,1)</span>
+        </div>
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-pulse-duration</strong><br />
+          <span style="color: var(--muted)">2s</span>
+        </div>
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-pulse-scale</strong><br />
+          <span style="color: var(--muted)">1.03</span>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/pulse-active-popover-analytics-rs/style.css
+++ b/submissions/examples/pulse-active-popover-analytics-rs/style.css
@@ -1,0 +1,479 @@
+:root {
+  --bg: #f8fafc;
+  --surface: #fff;
+  --border: #e2e8f0;
+  --text: #1e293b;
+  --muted: #64748b;
+  --primary: #3b82f6;
+  --primary-light: #93c5fd;
+  --success: #16a34a;
+  --warning: #d97706;
+  --danger: #ef4444;
+  --accent: #8b5cf6;
+  --shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  --radius: 12px;
+  --popover-duration: 0.3s;
+  --popover-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --popover-pulse-duration: 2s;
+  --popover-pulse-scale: 1.03;
+  --popover-max-width: 320px;
+  --popover-gap: 8px;
+}
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 24px;
+}
+.container {
+  max-width: 960px;
+  width: 100%;
+}
+.header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+.header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.header h1 svg {
+  color: var(--primary);
+}
+.header p {
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid var(--border);
+}
+.dashboard-header h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+.dashboard-header .period {
+  font-size: 0.75rem;
+  color: var(--muted);
+  background: var(--bg);
+  padding: 4px 12px;
+  border-radius: 9999px;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 32px;
+}
+.analytics-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  transition: box-shadow 0.2s ease;
+}
+.analytics-card:hover {
+  box-shadow: var(--shadow-lg);
+}
+.card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+.card-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+.card-trend {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 9999px;
+}
+.trend-up {
+  color: var(--success);
+  background: rgba(22, 163, 74, 0.1);
+}
+.trend-down {
+  color: var(--danger);
+  background: rgba(239, 68, 68, 0.1);
+}
+.trend-neutral {
+  color: var(--muted);
+  background: var(--bg);
+}
+.card-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 4px;
+}
+.card-sub {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+.card-bar {
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  margin-top: 12px;
+  overflow: hidden;
+}
+.card-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.6s ease;
+}
+.bar-blue {
+  background: var(--primary);
+}
+.bar-purple {
+  background: var(--accent);
+}
+.bar-green {
+  background: var(--success);
+}
+.bar-amber {
+  background: var(--warning);
+}
+
+.pulse-popover-an {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+.pulse-popover-toggle-an {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+.pulse-popover-trigger-an {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 16px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  transition:
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+  user-select: none;
+  margin-top: 12px;
+}
+.pulse-popover-trigger-an:hover {
+  background: #2563eb;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+.pulse-popover-trigger-an svg {
+  width: 14px;
+  height: 14px;
+}
+
+.pulse-popover-content-an {
+  position: absolute;
+  z-index: 100;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  padding: 16px;
+  min-width: 260px;
+  max-width: var(--popover-max-width);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px) scale(0.95);
+  transition:
+    opacity var(--popover-duration) var(--popover-ease),
+    visibility var(--popover-duration) var(--popover-ease),
+    transform var(--popover-duration) var(--popover-ease);
+  text-align: left;
+  pointer-events: none;
+}
+.pulse-popover-content-an[data-position="bottom"] {
+  top: calc(100% + var(--popover-gap));
+  left: 50%;
+  transform: translateX(-50%) translateY(8px) scale(0.95);
+}
+.pulse-popover-content-an[data-position="top"] {
+  bottom: calc(100% + var(--popover-gap));
+  left: 50%;
+  transform: translateX(-50%) translateY(-8px) scale(0.95);
+}
+.pulse-popover-content-an[data-position="right"] {
+  left: calc(100% + var(--popover-gap));
+  top: 50%;
+  transform: translateY(-50%) translateX(8px) scale(0.95);
+}
+.pulse-popover-content-an[data-position="left"] {
+  right: calc(100% + var(--popover-gap));
+  top: 50%;
+  transform: translateY(-50%) translateX(-8px) scale(0.95);
+}
+.pulse-popover-toggle-an:checked ~ .pulse-popover-content-an {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.pulse-popover-content-an::before {
+  content: "";
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  transform: rotate(45deg);
+  z-index: -1;
+}
+.pulse-popover-content-an[data-position="bottom"]::before {
+  top: -6px;
+  left: 50%;
+  margin-left: -5px;
+  border-right: none;
+  border-bottom: none;
+}
+.pulse-popover-content-an[data-position="top"]::before {
+  bottom: -6px;
+  left: 50%;
+  margin-left: -5px;
+  border-left: none;
+  border-top: none;
+}
+.pulse-popover-content-an[data-position="right"]::before {
+  left: -6px;
+  top: 50%;
+  margin-top: -5px;
+  border-left: none;
+  border-bottom: none;
+}
+.pulse-popover-content-an[data-position="left"]::before {
+  right: -6px;
+  top: 50%;
+  margin-top: -5px;
+  border-right: none;
+  border-top: none;
+}
+
+.popover-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+.popover-header h4 {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--text);
+}
+.popover-close {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1.125rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition:
+    color 0.2s ease,
+    background 0.2s ease;
+}
+.popover-close:hover {
+  color: var(--text);
+  background: var(--bg);
+}
+
+.metric-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  font-size: 0.8125rem;
+}
+.metric-row:not(:last-child) {
+  border-bottom: 1px solid var(--border);
+}
+.metric-label {
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.metric-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.metric-value {
+  font-weight: 600;
+  color: var(--text);
+}
+.metric-value.good {
+  color: var(--success);
+}
+.metric-value.warn {
+  color: var(--warning);
+}
+.metric-value.bad {
+  color: var(--danger);
+}
+
+.chart-mini {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 32px;
+  margin: 10px 0;
+  padding: 0 2px;
+}
+.chart-bar-mini {
+  width: 100%;
+  border-radius: 2px;
+  min-height: 4px;
+  transition: height 0.6s ease;
+}
+
+.popover-footer {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.popover-footer-label {
+  font-size: 0.6875rem;
+  color: var(--muted);
+}
+.popover-btn {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.popover-btn:hover {
+  background: #2563eb;
+}
+.popover-btn-outline {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.popover-btn-outline:hover {
+  background: var(--bg);
+}
+
+@keyframes an-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(var(--popover-pulse-scale));
+  }
+}
+.pulse-popover-toggle-an:checked ~ .pulse-popover-content-an {
+  animation: an-pulse var(--popover-pulse-duration) ease-in-out;
+}
+.pulse-popover-toggle-an:checked ~ .pulse-popover-trigger-an {
+  animation: an-pulse var(--popover-pulse-duration) ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse-popover-toggle-an:checked ~ .pulse-popover-content-an,
+  .pulse-popover-toggle-an:checked ~ .pulse-popover-trigger-an {
+    animation: none;
+  }
+  .pulse-popover-content-an {
+    transition: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --border: #334155;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
+  }
+  .trend-up {
+    background: rgba(22, 163, 74, 0.2);
+  }
+  .trend-down {
+    background: rgba(239, 68, 68, 0.2);
+  }
+  .trend-neutral {
+    background: rgba(148, 163, 184, 0.1);
+  }
+}
+
+@media (forced-colors: active) {
+  .pulse-popover-content-an {
+    border: 2px solid CanvasText;
+  }
+  .pulse-popover-content-an::before {
+    border: 2px solid CanvasText;
+    background: Canvas;
+  }
+  .pulse-popover-trigger-an {
+    border: 1px solid CanvasText;
+  }
+}


### PR DESCRIPTION
Adds a pure CSS pulse-active popover component styled for analytics dashboard interfaces to \submissions/examples/pulse-active-popover-analytics-rs/\.

## Features
- **8 dashboard cards**: 4 key metric cards (Visitors, Conversion Rate, Bounce Rate, Avg. Session) + 4 channel breakdown cards (Direct, Organic, Social, Referral)
- **Analytics-rich popovers**: Metric breakdowns with trend indicators (good/warn/bad), mini bar charts, and actionable footer buttons
- **Position switcher**: Radio controls to switch between Bottom/Top/Right/Left
- **Pulse-active animation**: Smooth scale pulse on open with customizable properties
- **Dark/light mode**, **reduced motion**, **forced colors** support
- **Keyboard accessible**: Tab navigation, Space/Enter toggle, close button
- **6 customizable CSS properties**
- **No JavaScript dependency**: Checkbox hack for toggle behavior

## Files
- \style.css\: Analytics-themed pulse-active popover CSS
- \demo.html\: Interactive dashboard demo with 8 metric cards and position switcher
- \README.md\: Documentation and usage guide

Closes #46522