### PR TITLE
feat: add backup restore progress demo

### DIFF
--- a/submissions/examples/backup-restore-progress-sm/README.md
+++ b/submissions/examples/backup-restore-progress-sm/README.md
@@ -1,0 +1,34 @@
+# Backup Restore Progress
+
+## What does this do?
+
+Backup Restore Progress is a self-contained HTML and CSS recovery dashboard pattern with animated restore meters, staged progress cards, status chips, and readable restore checkpoints.
+
+## How is it used?
+
+Create a `restore-board` wrapper and add `restore-card` items with stage classes such as `stage-done`, `stage-active`, or `stage-waiting`.
+
+```html
+<article class="restore-card stage-active">
+  <div class="stage-ring" aria-hidden="true">
+    <span>68%</span>
+  </div>
+  <div class="stage-content">
+    <p class="stage-kicker">Restore</p>
+    <h2>Records are being replayed</h2>
+    <div class="stage-bar" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available stage classes:
+
+- `stage-done`
+- `stage-active`
+- `stage-waiting`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make recovery progress easier to scan: cards enter gently, rings show stage completion, bars reveal restore progress, and focus states keep actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/backup-restore-progress-sm/demo.html
+++ b/submissions/examples/backup-restore-progress-sm/demo.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backup Restore Progress Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="restore-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Backup Restore Progress</h1>
+        <p>
+          A self-contained restore dashboard pattern with animated recovery
+          meters, staged progress cards, status chips, and readable restore
+          checkpoints.
+        </p>
+      </section>
+
+      <section class="restore-summary" aria-label="Backup restore summary">
+        <article>
+          <span class="summary-value">68%</span>
+          <span class="summary-label">Restore complete</span>
+        </article>
+        <article>
+          <span class="summary-value">04</span>
+          <span class="summary-label">Stages verified</span>
+        </article>
+        <article>
+          <span class="summary-value">18m</span>
+          <span class="summary-label">Estimated remaining</span>
+        </article>
+      </section>
+
+      <section class="restore-board" aria-label="Restore progress stages">
+        <article class="restore-card stage-done">
+          <div class="stage-ring" aria-hidden="true">
+            <span>100%</span>
+          </div>
+          <div class="stage-content">
+            <p class="stage-kicker">Snapshot</p>
+            <h2>Backup image selected</h2>
+            <p>
+              The latest verified snapshot was selected and matched against the
+              expected workspace checksum.
+            </p>
+            <div class="stage-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Verified</span>
+              <button type="button">Details</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="restore-card stage-active">
+          <div class="stage-ring" aria-hidden="true">
+            <span>68%</span>
+          </div>
+          <div class="stage-content">
+            <p class="stage-kicker">Restore</p>
+            <h2>Records are being replayed</h2>
+            <p>
+              Transaction logs are replaying in order while indexes and search
+              views rebuild in the background.
+            </p>
+            <div class="stage-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Running</span>
+              <button type="button">Monitor</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="restore-card stage-waiting">
+          <div class="stage-ring" aria-hidden="true">
+            <span>24%</span>
+          </div>
+          <div class="stage-content">
+            <p class="stage-kicker">Validation</p>
+            <h2>Integrity checks queued</h2>
+            <p>
+              Row counts, permissions, and audit trails will be compared before
+              the workspace is returned to users.
+            </p>
+            <div class="stage-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Queued</span>
+              <button type="button">Review</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/backup-restore-progress-sm/style.css
+++ b/submissions/examples/backup-restore-progress-sm/style.css
@@ -1,0 +1,354 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.restore-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.restore-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.restore-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.restore-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.restore-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.restore-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.restore-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.restore-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.restore-card:hover,
+.restore-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.stage-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--stage), #e4edf8 var(--stage) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-enter 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.stage-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.45rem;
+  font-weight: 950;
+}
+
+.stage-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.stage-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.stage-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.stage-content > p:not(.stage-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.stage-bar {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.stage-bar span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--stage);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: bar-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.stage-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.stage-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.stage-content button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.stage-content button:hover,
+.stage-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.stage-done {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --stage: 100%;
+}
+
+.stage-active {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --stage: 68%;
+}
+
+.stage-waiting {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --stage: 24%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-enter {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .restore-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .restore-summary,
+  .restore-board {
+    grid-template-columns: 1fr;
+  }
+
+  .restore-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48728


**PR Text**

Title: `feat: add backup restore progress demo`

```md
## Pull Request Description
Adds a self-contained Backup Restore Progress demo under `submissions/examples/`, featuring animated restore rings, staged progress cards, status chips, and restore checkpoint details.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only backup restore progress dashboard pattern.

**How does a developer use it?**
Use a `restore-board` wrapper with `restore-card` items and stage classes like `stage-done`, `stage-active`, or `stage-waiting`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate recovery stages, progress, and queued validation while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The stage naming, recovery colors, and meter timing can be standardized during framework integration.