### PR TITLE
feat: add deployment window countdown demo

### DIFF
--- a/submissions/examples/deployment-window-countdown-sm/README.md
+++ b/submissions/examples/deployment-window-countdown-sm/README.md
@@ -1,0 +1,5 @@
+# Deployment Window Countdown
+
+1. What does this do? Adds a responsive deployment countdown panel with animated time blocks, readiness rows, pulsing status dots, and hover or focus feedback.
+2. How is it used? Apply `.time-grid` for countdown blocks and `.readiness-list` with `.ready-row` state classes like `.ready`, `.watch`, or `.locked` for release checks.
+3. Why is it useful? It helps release teams scan deployment timing and readiness signals with purposeful CSS-only motion.

--- a/submissions/examples/deployment-window-countdown-sm/demo.html
+++ b/submissions/examples/deployment-window-countdown-sm/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deployment Window Countdown</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="deployment-panel" aria-labelledby="deployment-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Release window</p>
+        <h1 id="deployment-title">Deployment countdown with readiness signals</h1>
+        <p>
+          Countdown blocks and readiness rows animate into place so a release window feels
+          scannable, calm, and action-oriented without JavaScript.
+        </p>
+      </div>
+
+      <div class="countdown-card" aria-label="Deployment countdown">
+        <div class="release-summary">
+          <div>
+            <span class="summary-chip">Production release</span>
+            <strong>Motion Engine v1.2 rollout</strong>
+          </div>
+          <span class="window-pill">Starts 21:30 IST</span>
+        </div>
+
+        <div class="time-grid" aria-label="Time remaining">
+          <div class="time-block">
+            <strong>02</strong>
+            <span>Hours</span>
+          </div>
+          <div class="time-block">
+            <strong>18</strong>
+            <span>Minutes</span>
+          </div>
+          <div class="time-block">
+            <strong>44</strong>
+            <span>Seconds</span>
+          </div>
+        </div>
+
+        <div class="readiness-list" aria-label="Deployment readiness checks">
+          <article class="ready-row ready" tabindex="0">
+            <span class="status-dot"></span>
+            <div>
+              <strong>Smoke tests</strong>
+              <span>All critical flows passed in preview.</span>
+            </div>
+            <span class="state-chip">Ready</span>
+          </article>
+
+          <article class="ready-row watch" tabindex="0">
+            <span class="status-dot"></span>
+            <div>
+              <strong>Traffic ramp</strong>
+              <span>Start at 10%, then increase after metrics settle.</span>
+            </div>
+            <span class="state-chip">Watch</span>
+          </article>
+
+          <article class="ready-row locked" tabindex="0">
+            <span class="status-dot"></span>
+            <div>
+              <strong>Rollback plan</strong>
+              <span>Previous bundle and release notes are pinned.</span>
+            </div>
+            <span class="state-chip">Locked</span>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/deployment-window-countdown-sm/style.css
+++ b/submissions/examples/deployment-window-countdown-sm/style.css
@@ -1,0 +1,352 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --ready: #12805c;
+  --ready-soft: #e7f7ef;
+  --watch: #a95d00;
+  --watch-soft: #fff5e5;
+  --locked: #3158e8;
+  --locked-soft: #e9eeff;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(49, 88, 232, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 82%, rgba(18, 128, 92, 0.12), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.deployment-panel {
+  width: min(100%, 980px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--locked);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.countdown-card {
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: var(--shadow);
+}
+
+.release-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 1rem;
+}
+
+.release-summary div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.release-summary strong {
+  font-size: 1.3rem;
+}
+
+.summary-chip,
+.window-pill,
+.state-chip {
+  display: inline-flex;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.34rem 0.72rem;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.summary-chip {
+  color: var(--locked);
+  background: var(--locked-soft);
+}
+
+.window-pill {
+  color: var(--ready);
+  background: var(--ready-soft);
+  white-space: nowrap;
+}
+
+.time-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+.time-block {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--surface);
+  box-shadow: 0 10px 26px rgba(31, 42, 68, 0.08);
+  animation: time-pop 580ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.time-block::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--locked-soft), transparent 62%);
+  opacity: 0.75;
+}
+
+.time-block:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.time-block:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.time-block strong,
+.time-block span {
+  position: relative;
+  z-index: 1;
+  display: block;
+}
+
+.time-block strong {
+  color: var(--locked);
+  font-size: clamp(2.6rem, 8vw, 5rem);
+  line-height: 0.9;
+}
+
+.time-block span {
+  margin-top: 0.5rem;
+  color: var(--muted);
+  font-weight: 850;
+}
+
+.readiness-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ready-row {
+  --tone: var(--ready);
+  --tone-soft: var(--ready-soft);
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.9rem;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 0.9rem;
+  background: var(--surface);
+  box-shadow: 0 10px 26px rgba(31, 42, 68, 0.08);
+  animation: row-enter 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.ready-row::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--tone-soft), transparent 58%);
+  opacity: 0;
+  transition: opacity 230ms ease;
+}
+
+.ready-row:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.ready-row:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.ready-row:hover,
+.ready-row:focus-visible {
+  border-color: color-mix(in srgb, var(--tone) 42%, var(--line));
+  box-shadow: 0 16px 38px rgba(31, 42, 68, 0.13);
+  transform: translateY(-3px);
+}
+
+.ready-row:hover::before,
+.ready-row:focus-visible::before {
+  opacity: 1;
+}
+
+.ready-row:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  outline-offset: 4px;
+}
+
+.ready {
+  --tone: var(--ready);
+  --tone-soft: var(--ready-soft);
+}
+
+.watch {
+  --tone: var(--watch);
+  --tone-soft: var(--watch-soft);
+}
+
+.locked {
+  --tone: var(--locked);
+  --tone-soft: var(--locked-soft);
+}
+
+.status-dot,
+.ready-row div,
+.state-chip {
+  position: relative;
+  z-index: 1;
+}
+
+.status-dot {
+  display: block;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 999px;
+  background: var(--tone);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--tone) 30%, transparent);
+  animation: dot-pulse 1.8s ease-out infinite;
+}
+
+.ready-row div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.ready-row div span {
+  color: var(--muted);
+}
+
+.state-chip {
+  color: var(--tone);
+  background: var(--tone-soft);
+  white-space: nowrap;
+}
+
+@keyframes time-pop {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes row-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.99);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes dot-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--tone) 30%, transparent);
+  }
+
+  72%,
+  100% {
+    box-shadow: 0 0 0 0.8rem transparent;
+  }
+}
+
+@media (max-width: 720px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .release-summary,
+  .ready-row {
+    grid-template-columns: 1fr;
+  }
+
+  .release-summary {
+    align-items: start;
+  }
+
+  .time-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .state-chip {
+    justify-self: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .time-block,
+  .ready-row,
+  .ready-row::before,
+  .status-dot {
+    animation: none;
+    transition: none;
+  }
+
+  .ready-row:hover,
+  .ready-row:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #48734

## Pull Request Description

Adds a self-contained Deployment Window Countdown demo with animated time blocks, readiness rows, pulsing status dots, hover/focus feedback, responsive layout, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A responsive deployment countdown panel with animated time blocks, release readiness rows, pulsing status dots, and hover/focus motion feedback.

**How does a developer use it?**

```html
<div class="time-grid">
  <div class="time-block">
    <strong>02</strong>
    <span>Hours</span>
  </div>
</div>

<div class="readiness-list">
  <article class="ready-row watch" tabindex="0">
    <span class="status-dot"></span>
    <div>
      <strong>Traffic ramp</strong>
      <span>Start at 10%, then increase after metrics settle.</span>
    </div>
    <span class="state-chip">Watch</span>
  </article>
</div>