### PR TITLE
feat: add webhook delivery retry demo

### DIFF
--- a/submissions/examples/webhook-delivery-retry-sm/README.md
+++ b/submissions/examples/webhook-delivery-retry-sm/README.md
@@ -1,0 +1,35 @@
+# Webhook Delivery Retry
+
+## What does this do?
+
+Webhook Delivery Retry is a self-contained HTML and CSS monitoring pattern with animated retry steps, delivery status cards, endpoint health meters, and clear action states.
+
+## How is it used?
+
+Create a `retry-panel` with a `retry-list`, then add `retry-card` items with delivery state classes such as `retry-success`, `retry-active`, or `retry-warning`.
+
+```html
+<article class="retry-card retry-active">
+  <div class="retry-marker" aria-hidden="true"></div>
+  <div class="retry-content">
+    <div class="retry-topline">
+      <p>Invoice paid</p>
+      <span>Retrying</span>
+    </div>
+    <h3>https://billing.partner.app/events</h3>
+    <div class="retry-meter" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available retry classes:
+
+- `retry-success`
+- `retry-active`
+- `retry-warning`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make delivery state easier to scan: retry cards enter gently, meters show delivery progress, markers pulse for attention, and long endpoints remain readable. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/webhook-delivery-retry-sm/demo.html
+++ b/submissions/examples/webhook-delivery-retry-sm/demo.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Webhook Delivery Retry Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="webhook-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Webhook Delivery Retry</h1>
+        <p>
+          A self-contained webhook monitoring pattern with animated retry steps,
+          delivery status cards, endpoint health meters, and clear action
+          states.
+        </p>
+      </section>
+
+      <section class="webhook-summary" aria-label="Webhook delivery summary">
+        <article>
+          <span class="summary-value">97.2%</span>
+          <span class="summary-label">Delivery success</span>
+        </article>
+        <article>
+          <span class="summary-value">06</span>
+          <span class="summary-label">Retries pending</span>
+        </article>
+        <article>
+          <span class="summary-value">1.8s</span>
+          <span class="summary-label">Median latency</span>
+        </article>
+      </section>
+
+      <section class="retry-panel" aria-label="Webhook retry queue">
+        <header class="panel-header">
+          <div>
+            <p class="panel-kicker">Delivery Queue</p>
+            <h2>Webhook endpoint retry status</h2>
+          </div>
+          <span class="sync-pill">Live sync</span>
+        </header>
+
+        <div class="retry-list">
+          <article class="retry-card retry-success">
+            <div class="retry-marker" aria-hidden="true"></div>
+            <div class="retry-content">
+              <div class="retry-topline">
+                <p>Order created</p>
+                <span>Delivered</span>
+              </div>
+              <h3>https://api.storefront.dev/hooks/orders</h3>
+              <p>
+                The endpoint returned a 200 response after the first delivery
+                attempt and acknowledged the payload signature.
+              </p>
+              <div class="retry-meter" aria-hidden="true"><span></span></div>
+            </div>
+          </article>
+
+          <article class="retry-card retry-active">
+            <div class="retry-marker" aria-hidden="true"></div>
+            <div class="retry-content">
+              <div class="retry-topline">
+                <p>Invoice paid</p>
+                <span>Retrying</span>
+              </div>
+              <h3>https://billing.partner.app/events</h3>
+              <p>
+                The endpoint timed out twice. The next retry is scheduled with
+                exponential backoff and a shortened payload preview.
+              </p>
+              <div class="retry-meter" aria-hidden="true"><span></span></div>
+            </div>
+          </article>
+
+          <article class="retry-card retry-warning">
+            <div class="retry-marker" aria-hidden="true"></div>
+            <div class="retry-content">
+              <div class="retry-topline">
+                <p>User updated</p>
+                <span>Warning</span>
+              </div>
+              <h3>https://crm.example.net/webhooks/user</h3>
+              <p>
+                The endpoint responded with a 429 rate limit and needs a slower
+                delivery window before the final retry.
+              </p>
+              <div class="retry-meter" aria-hidden="true"><span></span></div>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/webhook-delivery-retry-sm/style.css
+++ b/submissions/examples/webhook-delivery-retry-sm/style.css
@@ -1,0 +1,354 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.webhook-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.panel-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.webhook-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.webhook-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.retry-panel {
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+  padding: 22px;
+}
+
+.panel-header h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.sync-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 11px;
+  border-radius: 999px;
+  color: var(--blue);
+  background: rgba(37, 99, 235, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.sync-pill::before {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  content: "";
+  background: currentColor;
+  box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.2);
+  animation: sync-pulse 1.6s ease-out infinite;
+}
+
+.retry-list {
+  display: grid;
+  gap: 14px;
+  padding: 22px;
+}
+
+.retry-card {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 18px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: card-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.retry-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.retry-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.retry-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 16px 34px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.retry-marker {
+  width: 38px;
+  height: 38px;
+  border: 5px solid #ffffff;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 12px 24px var(--accent-soft);
+  animation: marker-pulse 2s ease-out infinite;
+}
+
+.retry-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.retry-topline p {
+  margin-bottom: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.retry-topline span {
+  display: inline-flex;
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 850;
+}
+
+.retry-content h3 {
+  margin-bottom: 8px;
+  overflow-wrap: anywhere;
+  font-size: 1.02rem;
+  line-height: 1.25;
+}
+
+.retry-content > p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.retry-meter {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin-top: 18px;
+}
+
+.retry-meter span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--retry);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: meter-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.retry-success {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --retry: 100%;
+}
+
+.retry-active {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --retry: 62%;
+}
+
+.retry-warning {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --retry: 38%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes meter-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes marker-pulse {
+  70% {
+    box-shadow:
+      0 0 0 12px rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+}
+
+@keyframes sync-pulse {
+  70% {
+    box-shadow: 0 0 0 10px rgba(37, 99, 235, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
+  }
+}
+
+@media (max-width: 720px) {
+  .webhook-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .webhook-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-header {
+    flex-direction: column;
+  }
+
+  .retry-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48738


**PR Text**

Title: `feat: add cache warmup status demo`

```md
## Pull Request Description
Adds a self-contained Cache Warmup Status demo under `submissions/examples/`, featuring animated warmup rings, cache layer cards, fill meters, and service readiness states.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only cache warmup dashboard pattern for infrastructure readiness.

**How does a developer use it?**
Use a `cache-board` wrapper with `cache-card` items and layer classes like `layer-edge`, `layer-api`, or `layer-search`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate cache progress, layer status, and readiness while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The layer naming, warmup colors, and meter timing can be standardized during framework integration.