### PR TITLE
feat: add sla breach countdown demo

### DIFF
--- a/submissions/examples/sla-breach-countdown-sm/README.md
+++ b/submissions/examples/sla-breach-countdown-sm/README.md
@@ -1,0 +1,34 @@
+# SLA Breach Countdown
+
+## What does this do?
+
+SLA Breach Countdown is a self-contained HTML and CSS support operations pattern with animated countdown rings, urgency cards, progress bars, and accessible escalation actions.
+
+## How is it used?
+
+Create an `sla-board` wrapper and add `sla-card` items with urgency classes such as `sla-safe`, `sla-warning`, or `sla-critical`.
+
+```html
+<article class="sla-card sla-critical">
+  <div class="countdown-ring" aria-hidden="true">
+    <span>23m</span>
+  </div>
+  <div class="sla-content">
+    <p class="sla-kicker">Escalate</p>
+    <h2>Production access outage</h2>
+    <div class="sla-bar" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available urgency classes:
+
+- `sla-safe`
+- `sla-warning`
+- `sla-critical`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make SLA risk easier to scan: cards enter gently, rings show time pressure, bars reveal urgency, and focus states keep escalation actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/sla-breach-countdown-sm/demo.html
+++ b/submissions/examples/sla-breach-countdown-sm/demo.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SLA Breach Countdown Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="sla-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">SLA Breach Countdown</h1>
+        <p>
+          A self-contained support operations pattern with animated countdown
+          rings, urgency cards, progress bars, and accessible escalation
+          actions.
+        </p>
+      </section>
+
+      <section class="sla-summary" aria-label="SLA summary">
+        <article>
+          <span class="summary-value">23m</span>
+          <span class="summary-label">Closest breach</span>
+        </article>
+        <article>
+          <span class="summary-value">08</span>
+          <span class="summary-label">Tickets at risk</span>
+        </article>
+        <article>
+          <span class="summary-value">94%</span>
+          <span class="summary-label">SLA health</span>
+        </article>
+      </section>
+
+      <section class="sla-board" aria-label="SLA breach countdown cards">
+        <article class="sla-card sla-safe">
+          <div class="countdown-ring" aria-hidden="true">
+            <span>4h</span>
+          </div>
+          <div class="sla-content">
+            <p class="sla-kicker">Low urgency</p>
+            <h2>Password reset follow-up</h2>
+            <p>
+              Customer replied with confirmation details and is waiting for a
+              standard support response.
+            </p>
+            <div class="sla-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Healthy</span>
+              <button type="button">Open</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="sla-card sla-warning">
+          <div class="countdown-ring" aria-hidden="true">
+            <span>58m</span>
+          </div>
+          <div class="sla-content">
+            <p class="sla-kicker">Needs owner</p>
+            <h2>Billing export mismatch</h2>
+            <p>
+              Finance needs a corrected invoice export before the response
+              window reaches the warning threshold.
+            </p>
+            <div class="sla-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Warning</span>
+              <button type="button">Assign</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="sla-card sla-critical">
+          <div class="countdown-ring" aria-hidden="true">
+            <span>23m</span>
+          </div>
+          <div class="sla-content">
+            <p class="sla-kicker">Escalate</p>
+            <h2>Production access outage</h2>
+            <p>
+              A high-priority workspace cannot access production dashboards and
+              needs immediate escalation.
+            </p>
+            <div class="sla-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Critical</span>
+              <button type="button">Escalate</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/sla-breach-countdown-sm/style.css
+++ b/submissions/examples/sla-breach-countdown-sm/style.css
@@ -1,0 +1,354 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.sla-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.sla-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.sla-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.sla-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.sla-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.sla-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.sla-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.sla-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.sla-card:hover,
+.sla-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.countdown-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--time), #e4edf8 var(--time) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-enter 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.countdown-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.45rem;
+  font-weight: 950;
+}
+
+.sla-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.sla-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.sla-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.sla-content > p:not(.sla-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.sla-bar {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.sla-bar span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--time);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: bar-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.sla-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.sla-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.sla-content button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.sla-content button:hover,
+.sla-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.sla-safe {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --time: 42%;
+}
+
+.sla-warning {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --time: 72%;
+}
+
+.sla-critical {
+  --accent: var(--red);
+  --accent-light: #fb7185;
+  --accent-soft: rgba(220, 38, 38, 0.14);
+  --time: 91%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-enter {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .sla-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .sla-summary,
+  .sla-board {
+    grid-template-columns: 1fr;
+  }
+
+  .sla-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48748


**PR Text**

Title: `feat: add sla breach countdown demo`

```md
## Pull Request Description
Adds a self-contained SLA Breach Countdown demo under `submissions/examples/`, featuring animated countdown rings, urgency cards, progress bars, and escalation actions.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only SLA risk dashboard pattern for support operations.

**How does a developer use it?**
Use an `sla-board` wrapper with `sla-card` items and urgency classes like `sla-safe`, `sla-warning`, or `sla-critical`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate time pressure, urgency, and escalation priority while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The SLA naming, urgency colors, and countdown timing can be standardized during framework integration.