### PR TITLE
feat: add incident impact matrix demo

### DIFF
--- a/submissions/examples/incident-impact-matrix-sm/README.md
+++ b/submissions/examples/incident-impact-matrix-sm/README.md
@@ -1,0 +1,31 @@
+# Incident Impact Matrix
+
+## What does this do?
+
+Incident Impact Matrix is a self-contained HTML and CSS operations dashboard pattern with animated severity cells, impact badges, risk meters, and response ownership cues.
+
+## How is it used?
+
+Create an `impact-grid` wrapper and add `impact-cell` items with impact classes such as `impact-low`, `impact-medium`, `impact-high`, or `impact-critical`.
+
+```html
+<article class="impact-cell impact-high">
+  <span class="impact-label">High</span>
+  <h3>Checkout API</h3>
+  <p>Elevated error rate for payment confirmation requests.</p>
+  <div class="impact-meter" aria-hidden="true">
+    <span></span>
+  </div>
+</article>
+```
+
+Available impact classes:
+
+- `impact-low`
+- `impact-medium`
+- `impact-high`
+- `impact-critical`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make incident impact easier to scan: cells enter gently, badges communicate severity, meters reveal impact level, and hover states help inspect each affected service. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/incident-impact-matrix-sm/demo.html
+++ b/submissions/examples/incident-impact-matrix-sm/demo.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Incident Impact Matrix Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="impact-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Incident Impact Matrix</h1>
+        <p>
+          A self-contained operations matrix with animated severity cells,
+          impact badges, risk meters, and clear response ownership cues.
+        </p>
+      </section>
+
+      <section class="impact-summary" aria-label="Incident impact summary">
+        <article>
+          <span class="summary-value">S2</span>
+          <span class="summary-label">Current severity</span>
+        </article>
+        <article>
+          <span class="summary-value">05</span>
+          <span class="summary-label">Services affected</span>
+        </article>
+        <article>
+          <span class="summary-value">31m</span>
+          <span class="summary-label">Time active</span>
+        </article>
+      </section>
+
+      <section class="matrix-panel" aria-label="Incident impact matrix">
+        <header class="panel-header">
+          <div>
+            <p class="panel-kicker">Impact Review</p>
+            <h2>Service disruption matrix</h2>
+          </div>
+          <span class="review-pill">Active</span>
+        </header>
+
+        <div class="impact-grid">
+          <article class="impact-cell impact-low">
+            <span class="impact-label">Low</span>
+            <h3>Docs portal</h3>
+            <p>Minor page latency for public help articles.</p>
+            <div class="impact-meter" aria-hidden="true"><span></span></div>
+          </article>
+
+          <article class="impact-cell impact-medium">
+            <span class="impact-label">Medium</span>
+            <h3>Notification queue</h3>
+            <p>Delayed outbound notifications for workspace events.</p>
+            <div class="impact-meter" aria-hidden="true"><span></span></div>
+          </article>
+
+          <article class="impact-cell impact-high">
+            <span class="impact-label">High</span>
+            <h3>Checkout API</h3>
+            <p>Elevated error rate for payment confirmation requests.</p>
+            <div class="impact-meter" aria-hidden="true"><span></span></div>
+          </article>
+
+          <article class="impact-cell impact-critical">
+            <span class="impact-label">Critical</span>
+            <h3>Admin access</h3>
+            <p>Some admins cannot reach production control surfaces.</p>
+            <div class="impact-meter" aria-hidden="true"><span></span></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/incident-impact-matrix-sm/style.css
+++ b/submissions/examples/incident-impact-matrix-sm/style.css
@@ -1,0 +1,317 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --green: #16a34a;
+  --blue: #2563eb;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.impact-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.panel-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.impact-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.impact-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.matrix-panel {
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+  padding: 22px;
+}
+
+.panel-header h2 {
+  margin-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.review-pill {
+  display: inline-flex;
+  padding: 8px 11px;
+  border-radius: 999px;
+  color: var(--red);
+  background: rgba(220, 38, 38, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.impact-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  padding: 22px;
+}
+
+.impact-cell {
+  position: relative;
+  isolation: isolate;
+  min-height: 230px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 22px;
+  opacity: 0;
+  transform: translateY(16px) scale(0.98);
+  animation: cell-enter 640ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.impact-cell:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.impact-cell:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.impact-cell:nth-child(4) {
+  animation-delay: 270ms;
+}
+
+.impact-cell::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 44%);
+}
+
+.impact-cell:hover {
+  border-color: var(--accent);
+  box-shadow: 0 18px 42px var(--accent-soft);
+  transform: translateY(-4px);
+}
+
+.impact-label {
+  display: inline-flex;
+  margin-bottom: 16px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.impact-cell h3 {
+  margin-bottom: 10px;
+  font-size: 1.18rem;
+}
+
+.impact-cell p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.impact-meter {
+  position: absolute;
+  right: 22px;
+  bottom: 22px;
+  left: 22px;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+}
+
+.impact-meter span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--impact);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: meter-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.impact-low {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --impact: 28%;
+}
+
+.impact-medium {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --impact: 48%;
+}
+
+.impact-high {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --impact: 72%;
+}
+
+.impact-critical {
+  --accent: var(--red);
+  --accent-light: #fb7185;
+  --accent-soft: rgba(220, 38, 38, 0.14);
+  --impact: 92%;
+}
+
+@keyframes cell-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes meter-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 760px) {
+  .impact-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .impact-summary,
+  .impact-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-header {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48751


**PR Text**

Title: `feat: add incident impact matrix demo`

```md
## Pull Request Description
Adds a self-contained Incident Impact Matrix demo under `submissions/examples/`, featuring animated severity cells, impact badges, risk meters, and affected service details.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only incident impact matrix for operations dashboards.

**How does a developer use it?**
Use an `impact-grid` wrapper with `impact-cell` items and classes like `impact-low`, `impact-medium`, `impact-high`, or `impact-critical`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate severity, service impact, and risk level while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The impact naming, severity colors, and meter timing can be standardized during framework integration.