### PR TITLE
feat: add data quality gauge demo

### DIFF
--- a/submissions/examples/data-quality-gauge-sm/README.md
+++ b/submissions/examples/data-quality-gauge-sm/README.md
@@ -1,0 +1,5 @@
+# Data Quality Gauge
+
+1. What does this do? Adds responsive data quality cards with animated conic gauges, readiness labels, issue summaries, and hover or focus feedback.
+2. How is it used? Apply `.quality-grid` to the wrapper and use `.quality-card` with state classes like `.strong-quality`, `.review-quality`, or `.weak-quality` for each dataset.
+3. Why is it useful? It helps teams compare dataset readiness quickly with purposeful CSS-only motion and readable quality states.

--- a/submissions/examples/data-quality-gauge-sm/demo.html
+++ b/submissions/examples/data-quality-gauge-sm/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Quality Gauge</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="quality-panel" aria-labelledby="quality-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Data health</p>
+        <h1 id="quality-title">Quality gauges for dataset readiness</h1>
+        <p>
+          Gauge cards use animated conic arcs, issue chips, and focus-friendly rows to make data
+          readiness easier to review before publishing.
+        </p>
+      </div>
+
+      <div class="quality-grid" aria-label="Data quality gauge cards">
+        <article class="quality-card strong-quality" tabindex="0">
+          <div class="gauge-wrap" aria-hidden="true">
+            <span class="quality-gauge"></span>
+            <span class="gauge-value">94</span>
+          </div>
+          <div class="quality-copy">
+            <span class="quality-label">Ready</span>
+            <h2>Customer profiles</h2>
+            <p>Required fields are complete and duplicate checks are below the warning threshold.</p>
+            <div class="issue-row">
+              <span>2 minor gaps</span>
+              <strong>Publish safe</strong>
+            </div>
+          </div>
+        </article>
+
+        <article class="quality-card review-quality" tabindex="0">
+          <div class="gauge-wrap" aria-hidden="true">
+            <span class="quality-gauge"></span>
+            <span class="gauge-value">76</span>
+          </div>
+          <div class="quality-copy">
+            <span class="quality-label">Review</span>
+            <h2>Usage events</h2>
+            <p>Event names are consistent, but several source tags need normalization.</p>
+            <div class="issue-row">
+              <span>9 mappings pending</span>
+              <strong>Needs pass</strong>
+            </div>
+          </div>
+        </article>
+
+        <article class="quality-card weak-quality" tabindex="0">
+          <div class="gauge-wrap" aria-hidden="true">
+            <span class="quality-gauge"></span>
+            <span class="gauge-value">58</span>
+          </div>
+          <div class="quality-copy">
+            <span class="quality-label">Blocked</span>
+            <h2>Billing exports</h2>
+            <p>Missing invoice references and stale currency values require cleanup before sync.</p>
+            <div class="issue-row">
+              <span>18 issues found</span>
+              <strong>Hold release</strong>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/data-quality-gauge-sm/style.css
+++ b/submissions/examples/data-quality-gauge-sm/style.css
@@ -1,0 +1,284 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --strong: #12805c;
+  --strong-soft: #e7f7ef;
+  --review: #a95d00;
+  --review-soft: #fff5e5;
+  --weak: #d92d20;
+  --weak-soft: #fff1f0;
+  --track: #e8edf4;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(18, 128, 92, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 82%, rgba(217, 45, 32, 0.1), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.quality-panel {
+  width: min(100%, 1080px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--strong);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.quality-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.quality-card {
+  --tone: var(--strong);
+  --tone-soft: var(--strong-soft);
+  --score: 80%;
+  position: relative;
+  overflow: hidden;
+  min-height: 27rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1.2rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+  animation: card-enter 580ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.quality-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--tone-soft), transparent 62%);
+  opacity: 0.78;
+}
+
+.quality-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.quality-card:nth-child(3) {
+  animation-delay: 180ms;
+}
+
+.quality-card:hover,
+.quality-card:focus-visible {
+  border-color: color-mix(in srgb, var(--tone) 42%, var(--line));
+  box-shadow: var(--shadow);
+  transform: translateY(-5px);
+}
+
+.quality-card:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  outline-offset: 5px;
+}
+
+.strong-quality {
+  --tone: var(--strong);
+  --tone-soft: var(--strong-soft);
+  --score: 94%;
+}
+
+.review-quality {
+  --tone: var(--review);
+  --tone-soft: var(--review-soft);
+  --score: 76%;
+}
+
+.weak-quality {
+  --tone: var(--weak);
+  --tone-soft: var(--weak-soft);
+  --score: 58%;
+}
+
+.gauge-wrap,
+.quality-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.gauge-wrap {
+  display: grid;
+  width: 11rem;
+  height: 11rem;
+  place-items: center;
+  margin: 0.25rem auto 1.25rem;
+}
+
+.quality-gauge {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, #ffffff 0 56%, transparent 57%),
+    conic-gradient(var(--tone) var(--score), var(--track) 0);
+  filter: drop-shadow(0 14px 24px rgba(31, 42, 68, 0.12));
+  animation: gauge-rise 760ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.quality-gauge::after {
+  content: "";
+  position: absolute;
+  inset: 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--tone) 20%, transparent);
+  border-radius: inherit;
+}
+
+.gauge-value {
+  color: var(--tone);
+  font-size: 2.6rem;
+  font-weight: 950;
+}
+
+.gauge-value::after {
+  content: "%";
+  font-size: 1rem;
+  vertical-align: super;
+}
+
+.quality-label {
+  display: inline-flex;
+  margin-bottom: 0.8rem;
+  border-radius: 999px;
+  padding: 0.32rem 0.72rem;
+  color: var(--tone);
+  background: color-mix(in srgb, var(--tone-soft) 78%, #ffffff);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.quality-copy h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.quality-copy p {
+  min-height: 5rem;
+  margin: 0.7rem 0 1rem;
+  color: var(--muted);
+  line-height: 1.58;
+}
+
+.issue-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--line);
+  padding-top: 1rem;
+}
+
+.issue-row span {
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.issue-row strong {
+  color: var(--tone);
+  white-space: nowrap;
+}
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes gauge-rise {
+  from {
+    opacity: 0;
+    transform: rotate(-18deg) scale(0.88);
+  }
+
+  to {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .quality-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .quality-card {
+    min-height: auto;
+  }
+
+  .quality-copy p {
+    min-height: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quality-card,
+  .quality-gauge {
+    animation: none;
+    transition: none;
+  }
+
+  .quality-card:hover,
+  .quality-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #48755

## Pull Request Description

Adds a self-contained Data Quality Gauge demo with responsive data readiness cards, animated conic gauges, readiness labels, issue summaries, hover/focus feedback, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Responsive data quality cards with animated conic gauges, dataset readiness labels, issue summaries, and hover/focus motion feedback.

**How does a developer use it?**

```html
<div class="quality-grid">
  <article class="quality-card strong-quality" tabindex="0">
    <div class="gauge-wrap" aria-hidden="true">
      <span class="quality-gauge"></span>
      <span class="gauge-value">94</span>
    </div>
    <div class="quality-copy">
      <span class="quality-label">Ready</span>
      <h2>Customer profiles</h2>
      <p>Required fields are complete and duplicate checks are below the warning threshold.</p>
    </div>
  </article>
</div>