### PR TITLE
feat: add CSS Zoom-Out Tooltip for Modern SaaS Layouts (#46240)

### DIFF
--- a/submissions/examples/ease-zoom-out-tooltip-saas-pp/README.md
+++ b/submissions/examples/ease-zoom-out-tooltip-saas-pp/README.md
@@ -1,0 +1,140 @@
+# CSS Zoom-Out Tooltip for Modern SaaS Layouts
+
+A pure CSS animated tooltip component that reveals with a smooth **zoom-out**
+interaction transition, styled to complement modern SaaS interface aesthetics.
+It is fully responsive, keyboard accessible, and exposes its timing, easing, and
+scale factors through standard CSS custom properties — with **zero JavaScript
+required** for the animation.
+
+---
+
+## 1. What does this do?
+
+It renders a tooltip that, on hover or keyboard focus, animates from a slightly
+enlarged (zoomed-in) state down to its natural size while fading and sliding
+into place. The reverse happens on dismiss. The look matches modern SaaS UI:
+soft elevation, rounded corners, an optional accent gradient, and crisp
+typography.
+
+---
+
+## 2. How is it used?
+
+Wrap a focusable trigger inside `.pp-tooltip-trigger`, then place a
+`.pp-zoom-tooltip` element inside it with a position modifier
+(`--top`, `--bottom`, `--left`, `--right`):
+
+```html
+<!-- Keyboard-accessible tooltip trigger wrapper -->
+<div class="pp-tooltip-trigger" tabindex="0">
+  <button type="button" class="pp-saas-btn">Hover me</button>
+
+  <!-- Tooltip element with a position class -->
+  <div class="pp-zoom-tooltip pp-zoom-tooltip--top" role="tooltip">
+    Zoom-out tooltip text
+  </div>
+</div>
+```
+
+Optional skins:
+
+```html
+<div class="pp-zoom-tooltip pp-zoom-tooltip--right pp-zoom-tooltip--accent" role="tooltip">
+  Accent gradient skin
+</div>
+
+<div class="pp-zoom-tooltip pp-zoom-tooltip--bottom pp-zoom-tooltip--danger" role="tooltip">
+  This action is irreversible.
+</div>
+```
+
+Rich tooltips with a title + body use the helper classes:
+
+```html
+<div class="pp-zoom-tooltip pp-zoom-tooltip--top" role="tooltip">
+  <span class="pp-zoom-tooltip__title">Storage almost full</span>
+  <span class="pp-zoom-tooltip__body">You have used 92% of your plan.</span>
+</div>
+```
+
+---
+
+## 3. Why is it useful?
+
+- **Zero JavaScript overhead** — the entire zoom-out animation is driven by CSS
+  transitions, so it ships with no runtime cost.
+- **Modern SaaS aesthetic** — soft shadows, rounded surfaces, and an optional
+  indigo→violet accent gradient that fits contemporary dashboards.
+- **Accessible by default** — the trigger wrapper is focusable
+  (`tabindex="0"`) and the tooltip shows on `:focus-within`, so keyboard and
+  screen-reader users get the same experience as mouse users. `role="tooltip"`
+  is applied, and `prefers-reduced-motion` disables the zoom for users who
+  request it.
+- **Fully tunable** — every animation parameter is a CSS custom property, so
+  teams can re-theme timing, scale, travel distance, blur, and easing without
+  touching the markup.
+- **Conflict-free** — the component lives entirely inside
+  `submissions/examples/`, so it never edits core framework files.
+
+---
+
+## Technical Specifications & Suffix
+
+- **Folder Path:** `submissions/examples/ease-zoom-out-tooltip-saas-pp/`
+- **Contributor Suffix:** `pp` (Pratyush Panda)
+- **Resolved Ticket:** [Issue #46240](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46240)
+
+### Included Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Self-contained showcase (open directly in a browser) |
+| `style.css` | The raw component + demo styling |
+| `README.md` | This documentation |
+
+### Tunable CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--tooltip-zoom-duration` | `260ms` | Length of the zoom-out transition |
+| `--tooltip-zoom-easing` | `cubic-bezier(0.22, 1, 0.36, 1)` | Easing curve for the settle |
+| `--tooltip-zoom-scale` | `1.12` | Starting scale (shrinks to `1`) |
+| `--tooltip-zoom-offset` | `10px` | Distance the tooltip travels while zooming |
+| `--tooltip-zoom-blur` | `0px` | Optional blur applied on entry |
+| `--tooltip-bg` | `#0f172a` | Tooltip surface color |
+| `--tooltip-fg` | `#f8fafc` | Tooltip text color |
+| `--tooltip-radius` | `8px` | Corner radius |
+| `--tooltip-padding-y` / `--tooltip-padding-x` | `8px` / `12px` | Inner padding |
+| `--tooltip-font-size` | `0.8125rem` | Text size |
+| `--tooltip-max-width` | `260px` | Max width before wrapping |
+| `--tooltip-gap` | `10px` | Gap between trigger and tooltip |
+| `--tooltip-z-index` | `9999` | Stacking order |
+| `--tooltip-arrow-size` | `7px` | Arrow (caret) size |
+
+### Position Variants
+
+- `.pp-zoom-tooltip--top`
+- `.pp-zoom-tooltip--bottom`
+- `.pp-zoom-tooltip--left`
+- `.pp-zoom-tooltip--right`
+
+### Skin Variants
+
+- `.pp-zoom-tooltip--accent` (indigo→violet gradient)
+- `.pp-zoom-tooltip--success` (green)
+- `.pp-zoom-tooltip--danger` (red)
+
+### Accessibility Notes
+
+- Trigger wrapper carries `tabindex="0"` so it is reachable by keyboard.
+- `:focus-within` reveals the tooltip, mirroring the hover behavior.
+- `role="tooltip"` is set on each bubble.
+- A `prefers-reduced-motion: reduce` block removes the zoom transform and
+  shortens the fade so motion-sensitive users are respected.
+
+### Demo Controls
+
+The `demo.html` includes an optional control dashboard (driven by a tiny,
+non-required script) that live-updates the CSS custom properties — duration,
+start scale, travel offset, entry blur, and easing preset — plus a light/dark
+theme toggle. The tooltip animation itself works without any script.

--- a/submissions/examples/ease-zoom-out-tooltip-saas-pp/demo.html
+++ b/submissions/examples/ease-zoom-out-tooltip-saas-pp/demo.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Zoom-Out Tooltip for Modern SaaS Layouts</title>
+
+  <!-- SEO & Accessibility Metadata -->
+  <meta name="description" content="A pure CSS animated tooltip with a smooth zoom-out interaction transition, styled for modern SaaS interfaces. Responsive, keyboard accessible, and fully tunable via CSS custom properties." />
+  <meta name="author" content="Pratyush Panda (pp)" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <!-- EaseMotion CSS from CDN (optional — component is self-contained) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+
+  <!-- Local Styles -->
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <!-- Theme Toggle Button -->
+  <button class="pp-theme-toggle" id="themeToggleBtn" aria-label="Toggle Dark/Light Mode">
+    <svg id="sunIcon" style="display:none;" viewBox="0 0 24 24">
+      <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41l-1.06-1.06zm1.06-12.37c-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.38.39-1.02 0-1.41zM5.99 18.01l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.39.39-1.03 0-1.41z"/>
+    </svg>
+    <svg id="moonIcon" viewBox="0 0 24 24">
+      <path d="M9.37 5.51c-.18-.64-.86-1.02-1.5-.84-2.32.63-4.13 2.5-4.7 4.88-.66 2.76.62 5.57 3.03 6.77.34.17.65.41.9.7l1.06 1.18c1.3 1.45 3.39 1.83 5.09 1 .73-.36 1.34-.9 1.81-1.57.4-.57.19-1.35-.47-1.63-3.64-1.55-5.91-5.32-5.46-9.45.08-.75-.5-1.4-1.26-1.07z"/>
+    </svg>
+  </button>
+
+  <header class="pp-header">
+    <div class="pp-container">
+      <span class="pp-eyebrow">Interactive Motion Showcase</span>
+      <h1>CSS Zoom-Out Tooltip for Modern SaaS</h1>
+      <p class="pp-subtitle">
+        A pure CSS animated tooltip that settles into place with a smooth
+        <strong>zoom-out</strong> transition, styled for modern SaaS interfaces.
+        Fully responsive, keyboard accessible, and tunable through standard CSS
+        custom properties — zero JavaScript required for the animation.
+      </p>
+      <div class="pp-meta-badge">
+        <span>Resolves</span> Issue #46240
+      </div>
+    </div>
+  </header>
+
+  <main class="pp-container pp-main-grid">
+
+    <!-- ============ Playground ============ -->
+    <section class="pp-card" aria-labelledby="playground-heading">
+      <h2 class="pp-card-title" id="playground-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+        Live Playground
+      </h2>
+      <p class="pp-card-desc">
+        Hover or focus (Tab key) any trigger below. Each tooltip reveals with a
+        zoom-out settle. Try the four positions and the accent / status skins.
+      </p>
+
+      <div class="pp-stage">
+        <!-- Top -->
+        <div class="pp-stage-cell">
+          <div class="pp-tooltip-trigger" tabindex="0">
+            <button type="button" class="pp-saas-btn">Top tooltip</button>
+            <div class="pp-zoom-tooltip pp-zoom-tooltip--top" role="tooltip">
+              Zoom-out tooltip positioned above the trigger.
+            </div>
+          </div>
+        </div>
+
+        <!-- Bottom -->
+        <div class="pp-stage-cell">
+          <div class="pp-tooltip-trigger" tabindex="0">
+            <button type="button" class="pp-saas-btn pp-saas-btn--ghost">Bottom tooltip</button>
+            <div class="pp-zoom-tooltip pp-zoom-tooltip--bottom" role="tooltip">
+              Settles upward from a slightly enlarged state.
+            </div>
+          </div>
+        </div>
+
+        <!-- Left -->
+        <div class="pp-stage-cell">
+          <div class="pp-tooltip-trigger" tabindex="0">
+            <button type="button" class="pp-saas-btn">Left tooltip</button>
+            <div class="pp-zoom-tooltip pp-zoom-tooltip--left pp-zoom-tooltip--accent" role="tooltip">
+              Accent gradient skin, left side.
+            </div>
+          </div>
+        </div>
+
+        <!-- Right (icon trigger) -->
+        <div class="pp-stage-cell">
+          <div class="pp-tooltip-trigger" tabindex="0">
+            <button type="button" class="pp-icon-trigger" aria-label="Settings">
+              <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            </button>
+            <div class="pp-zoom-tooltip pp-zoom-tooltip--right pp-zoom-tooltip--success" role="tooltip">
+              <span class="pp-zoom-tooltip__title">Settings</span>
+              <span class="pp-zoom-tooltip__body">Configure workspace preferences.</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Rich + danger example -->
+      <div class="pp-stage" style="margin-top:18px;">
+        <div class="pp-stage-cell">
+          <div class="pp-tooltip-trigger" tabindex="0">
+            <button type="button" class="pp-saas-btn">Rich tooltip</button>
+            <div class="pp-zoom-tooltip pp-zoom-tooltip--top" role="tooltip">
+              <span class="pp-zoom-tooltip__title">Storage almost full</span>
+              <span class="pp-zoom-tooltip__body">You have used 92% of your plan. Upgrade to keep syncing.</span>
+            </div>
+          </div>
+        </div>
+        <div class="pp-stage-cell">
+          <div class="pp-tooltip-trigger" tabindex="0">
+            <button type="button" class="pp-saas-btn pp-saas-btn--ghost">Danger tooltip</button>
+            <div class="pp-zoom-tooltip pp-zoom-tooltip--bottom pp-zoom-tooltip--danger" role="tooltip">
+              This action is irreversible.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="pp-a11y-note">
+        <strong>Accessibility:</strong> The trigger wrapper uses
+        <code>tabindex="0"</code> and <code>:focus-within</code>, so the tooltip
+        is reachable by keyboard. <code>role="tooltip"</code> is set on each
+        bubble, and <code>prefers-reduced-motion</code> disables the zoom for
+        users who request reduced motion.
+      </div>
+    </section>
+
+    <!-- ============ Control Dashboard ============ -->
+    <aside class="pp-card" aria-labelledby="controls-heading">
+      <h2 class="pp-card-title" id="controls-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16z"/><path d="M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><circle cx="12" cy="12" r="1"/></svg>
+        Parameter Controls
+      </h2>
+      <p class="pp-card-desc">
+        These sliders mutate the CSS custom properties that drive the zoom-out
+        transition. Changes apply live to every tooltip on the page.
+      </p>
+
+      <div class="pp-controls">
+        <div class="pp-control">
+          <label for="c-duration">Duration <span id="v-duration">260ms</span></label>
+          <input type="range" id="c-duration" min="80" max="600" step="10" value="260" />
+        </div>
+
+        <div class="pp-control">
+          <label for="c-scale">Start scale <span id="v-scale">1.12</span></label>
+          <input type="range" id="c-scale" min="1" max="1.6" step="0.01" value="1.12" />
+        </div>
+
+        <div class="pp-control">
+          <label for="c-offset">Travel offset <span id="v-offset">10px</span></label>
+          <input type="range" id="c-offset" min="0" max="40" step="1" value="10" />
+        </div>
+
+        <div class="pp-control">
+          <label for="c-blur">Entry blur <span id="v-blur">0px</span></label>
+          <input type="range" id="c-blur" min="0" max="8" step="0.5" value="0" />
+        </div>
+
+        <div class="pp-control">
+          <label for="c-easing">Easing preset</label>
+          <select id="c-easing">
+            <option value="cubic-bezier(0.22, 1, 0.36, 1)">Soft out (default)</option>
+            <option value="cubic-bezier(0.34, 1.56, 0.64, 1)">Spring back</option>
+            <option value="cubic-bezier(0.4, 0, 0.2, 1)">Standard</option>
+            <option value="ease-out">Ease out</option>
+            <option value="cubic-bezier(0.16, 1, 0.3, 1)">Expo out</option>
+          </select>
+        </div>
+
+        <button class="pp-reset" id="c-reset" type="button">Reset to defaults</button>
+      </div>
+
+      <div class="pp-code" aria-hidden="true">
+<span class="tok-tag">&lt;div</span> <span class="tok-attr">class</span>=<span class="tok-str">"pp-tooltip-trigger"</span> <span class="tok-attr">tabindex</span>=<span class="tok-str">"0"</span><span class="tok-tag">&gt;</span>
+  <span class="tok-tag">&lt;button</span> <span class="tok-attr">class</span>=<span class="tok-str">"pp-saas-btn"</span><span class="tok-tag">&gt;</span>Hover me<span class="tok-tag">&lt;/button&gt;</span>
+  <span class="tok-tag">&lt;div</span> <span class="tok-attr">class</span>=<span class="tok-str">"pp-zoom-tooltip pp-zoom-tooltip--top"</span>
+       <span class="tok-attr">role</span>=<span class="tok-str">"tooltip"</span><span class="tok-tag">&gt;</span>
+    Zoom-out tooltip text
+  <span class="tok-tag">&lt;/div&gt;</span>
+<span class="tok-tag">&lt;/div&gt;</span>
+      </div>
+    </aside>
+  </main>
+
+  <script>
+    // NOTE: The animation itself is 100% CSS. This tiny script only wires the
+    // optional control dashboard + theme toggle. It is NOT required for the
+    // tooltip to function.
+    (function () {
+      var root = document.documentElement;
+
+      var duration = document.getElementById("c-duration");
+      var scale = document.getElementById("c-scale");
+      var offset = document.getElementById("c-offset");
+      var blur = document.getElementById("c-blur");
+      var easing = document.getElementById("c-easing");
+      var reset = document.getElementById("c-reset");
+
+      function apply() {
+        root.style.setProperty("--tooltip-zoom-duration", duration.value + "ms");
+        root.style.setProperty("--tooltip-zoom-scale", scale.value);
+        root.style.setProperty("--tooltip-zoom-offset", offset.value + "px");
+        root.style.setProperty("--tooltip-zoom-blur", blur.value + "px");
+        root.style.setProperty("--tooltip-zoom-easing", easing.value);
+
+        document.getElementById("v-duration").textContent = duration.value + "ms";
+        document.getElementById("v-scale").textContent = parseFloat(scale.value).toFixed(2);
+        document.getElementById("v-offset").textContent = offset.value + "px";
+        document.getElementById("v-blur").textContent = blur.value + "px";
+      }
+
+      [duration, scale, offset, blur, easing].forEach(function (el) {
+        el.addEventListener("input", apply);
+        el.addEventListener("change", apply);
+      });
+
+      reset.addEventListener("click", function () {
+        duration.value = 260; scale.value = 1.12; offset.value = 10;
+        blur.value = 0; easing.selectedIndex = 0;
+        apply();
+      });
+
+      // Theme toggle
+      var toggle = document.getElementById("themeToggleBtn");
+      var sun = document.getElementById("sunIcon");
+      var moon = document.getElementById("moonIcon");
+      toggle.addEventListener("click", function () {
+        var dark = root.getAttribute("data-theme") === "dark";
+        root.setAttribute("data-theme", dark ? "light" : "dark");
+        sun.style.display = dark ? "none" : "block";
+        moon.style.display = dark ? "block" : "none";
+      });
+
+      apply();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-zoom-out-tooltip-saas-pp/style.css
+++ b/submissions/examples/ease-zoom-out-tooltip-saas-pp/style.css
@@ -1,0 +1,610 @@
+/* ==========================================================================
+   EaseMotion CSS — Zoom-Out Tooltip for Modern SaaS Layouts
+   Component : Pure CSS animated tooltip with a smooth Zoom-Out transition
+   Track     : submissions/examples/ease-zoom-out-tooltip-saas-pp
+   Author    : Pratyush Panda (pp)
+   Resolves  : https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46240
+   --------------------------------------------------------------------------
+   Design goals
+   - Pure CSS (zero JavaScript for the animation itself)
+   - Smooth "zoom-out" interaction: the tooltip starts slightly enlarged and
+     settles to its natural size while fading in. On dismiss it reverses.
+   - Modern SaaS aesthetic: soft elevation, rounded corners, subtle accent
+     gradient, crisp typography.
+   - Fully responsive + keyboard accessible (focus-within + tabindex).
+   - Exposes tunable parameters via standard CSS custom properties.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design tokens & CSS custom properties
+   -------------------------------------------------------------------------- */
+:root {
+  /* Typography */
+  --font-sans: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
+    Menlo, monospace;
+
+  /* App surface (light SaaS theme) */
+  --bg-app: #f6f8fb;
+  --bg-surface: #ffffff;
+  --bg-subtle: #eef2f7;
+
+  /* Text */
+  --text-strong: #0f172a;
+  --text-primary: #1e293b;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+
+  /* Brand / accent (modern SaaS indigo→violet) */
+  --accent-1: #6366f1;
+  --accent-2: #8b5cf6;
+  --accent-3: #ec4899;
+  --accent-soft: rgba(99, 102, 241, 0.12);
+
+  /* Status */
+  --success: #10b981;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06),
+    0 1px 3px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 4px 6px -1px rgba(15, 23, 42, 0.08),
+    0 2px 4px -2px rgba(15, 23, 42, 0.06);
+  --shadow-lg: 0 12px 24px -8px rgba(15, 23, 42, 0.18),
+    0 6px 12px -6px rgba(15, 23, 42, 0.12);
+  --shadow-tooltip: 0 10px 30px -8px rgba(79, 70, 229, 0.35),
+    0 4px 10px -4px rgba(15, 23, 42, 0.18);
+
+  /* Radii */
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 22px;
+  --radius-full: 9999px;
+
+  /* Motion */
+  --ease-out-soft: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* ----------------------------------------------------------------------
+     2. Tooltip tunable parameters (override these anywhere)
+     ---------------------------------------------------------------------- */
+  --tooltip-zoom-duration: 260ms;          /* how long the zoom-out takes   */
+  --tooltip-zoom-easing: var(--ease-out-soft);
+  --tooltip-zoom-scale: 1.12;              /* start scale (shrinks to 1)    */
+  --tooltip-zoom-offset: 10px;             /* distance it travels while zoom */
+  --tooltip-zoom-blur: 0px;                /* optional blur on entry         */
+  --tooltip-bg: #0f172a;                   /* tooltip surface               */
+  --tooltip-fg: #f8fafc;                   /* tooltip text                  */
+  --tooltip-radius: var(--radius-sm);
+  --tooltip-padding-y: 8px;
+  --tooltip-padding-x: 12px;
+  --tooltip-font-size: 0.8125rem;
+  --tooltip-max-width: 260px;
+  --tooltip-gap: 10px;                     /* gap from trigger              */
+  --tooltip-z-index: 9999;
+  --tooltip-arrow-size: 7px;
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] {
+  --bg-app: #0b1120;
+  --bg-surface: #111a2e;
+  --bg-subtle: #16213a;
+  --text-strong: #f8fafc;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --accent-soft: rgba(129, 140, 248, 0.16);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 24px -8px rgba(0, 0, 0, 0.6);
+  --tooltip-bg: #e2e8f0;
+  --tooltip-fg: #0f172a;
+  --tooltip-shadow: 0 10px 30px -8px rgba(0, 0, 0, 0.7);
+}
+
+/* --------------------------------------------------------------------------
+   3. Page scaffolding (demo only — not part of the component contract)
+   -------------------------------------------------------------------------- */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background:
+    radial-gradient(1200px 600px at 80% -10%, var(--accent-soft), transparent 60%),
+    radial-gradient(900px 500px at -10% 110%, rgba(236, 72, 153, 0.08), transparent 55%),
+    var(--bg-app);
+  color: var(--text-primary);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.pp-theme-toggle {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 10000;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--bg-subtle);
+  border-radius: var(--radius-full);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  transition: transform 0.2s var(--ease-out-soft), color 0.2s ease;
+}
+.pp-theme-toggle:hover {
+  transform: translateY(-2px) rotate(12deg);
+  color: var(--accent-1);
+}
+.pp-theme-toggle svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.pp-header {
+  padding: 72px 24px 24px;
+  text-align: center;
+}
+.pp-container {
+  width: min(1080px, 100% - 48px);
+  margin-inline: auto;
+}
+.pp-eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-1);
+  background: var(--accent-soft);
+  padding: 6px 12px;
+  border-radius: var(--radius-full);
+}
+.pp-header h1 {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  line-height: 1.1;
+  margin: 16px 0 8px;
+  color: var(--text-strong);
+  letter-spacing: -0.02em;
+}
+.pp-subtitle {
+  max-width: 640px;
+  margin: 0 auto;
+  color: var(--text-secondary);
+  font-size: 1.02rem;
+  line-height: 1.6;
+}
+.pp-meta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding: 8px 16px;
+  border-radius: var(--radius-full);
+  background: var(--bg-surface);
+  border: 1px solid var(--bg-subtle);
+  box-shadow: var(--shadow-sm);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+.pp-meta-badge span {
+  font-weight: 700;
+  color: var(--accent-1);
+}
+
+.pp-main-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 24px;
+  padding: 32px 24px 80px;
+  align-items: start;
+}
+@media (max-width: 880px) {
+  .pp-main-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--bg-subtle);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  box-shadow: var(--shadow-md);
+}
+.pp-card-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1.15rem;
+  margin: 0 0 6px;
+  color: var(--text-strong);
+}
+.pp-card-title svg {
+  color: var(--accent-1);
+}
+.pp-card-desc {
+  margin: 0 0 22px;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* Stage where the tooltip is demonstrated */
+.pp-stage {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+  padding: 28px;
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(180deg, var(--bg-subtle), transparent 70%),
+    var(--bg-app);
+  border: 1px dashed var(--bg-subtle);
+}
+@media (max-width: 520px) {
+  .pp-stage {
+    grid-template-columns: 1fr;
+  }
+}
+.pp-stage-cell {
+  display: grid;
+  place-items: center;
+  min-height: 120px;
+}
+
+/* Modern SaaS trigger button */
+.pp-saas-btn {
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #fff;
+  padding: 12px 20px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(135deg, var(--accent-1), var(--accent-2));
+  box-shadow: 0 8px 20px -8px rgba(99, 102, 241, 0.6);
+  transition: transform 0.2s var(--ease-out-soft), box-shadow 0.2s ease,
+    filter 0.2s ease;
+}
+.pp-saas-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px -10px rgba(99, 102, 241, 0.7);
+  filter: saturate(1.1);
+}
+.pp-saas-btn:active {
+  transform: translateY(0) scale(0.98);
+}
+.pp-saas-btn--ghost {
+  color: var(--accent-1);
+  background: var(--accent-soft);
+  box-shadow: none;
+}
+.pp-saas-btn--ghost:hover {
+  background: var(--accent-soft);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Icon trigger (round) */
+.pp-icon-trigger {
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--bg-subtle);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s var(--ease-out-soft), color 0.2s ease;
+}
+.pp-icon-trigger:hover {
+  transform: translateY(-2px);
+  color: var(--accent-1);
+}
+.pp-icon-trigger svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* --------------------------------------------------------------------------
+   4. THE COMPONENT — Zoom-Out Tooltip
+   --------------------------------------------------------------------------
+   Usage:
+     <div class="pp-tooltip-trigger" tabindex="0">
+       <button class="pp-saas-btn">Hover me</button>
+       <div class="pp-zoom-tooltip pp-zoom-tooltip--top">Tooltip text</div>
+     </div>
+
+   The trigger wrapper is focusable so keyboard users can reveal the tooltip
+   via :focus-within. The tooltip itself animates from a slightly enlarged
+   scale (--tooltip-zoom-scale) down to 1 while fading + sliding in.
+   -------------------------------------------------------------------------- */
+.pp-tooltip-trigger {
+  position: relative;
+  display: inline-flex;
+  outline: none;
+}
+.pp-tooltip-trigger:focus-visible {
+  outline: 2px solid var(--accent-1);
+  outline-offset: 4px;
+  border-radius: var(--radius-full);
+}
+
+.pp-zoom-tooltip {
+  position: absolute;
+  z-index: var(--tooltip-z-index);
+  max-width: var(--tooltip-max-width);
+  padding: var(--tooltip-padding-y) var(--tooltip-padding-x);
+  border-radius: var(--tooltip-radius);
+  background: var(--tooltip-bg);
+  color: var(--tooltip-fg);
+  font-size: var(--tooltip-font-size);
+  font-weight: 500;
+  line-height: 1.45;
+  text-align: center;
+  white-space: normal;
+  box-shadow: var(--tooltip-shadow, var(--shadow-tooltip));
+  pointer-events: none;
+
+  /* Hidden initial state — enlarged + offset + transparent */
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(var(--tooltip-zoom-scale))
+    translateY(var(--tooltip-zoom-offset));
+  filter: blur(var(--tooltip-zoom-blur));
+  transition:
+    opacity var(--tooltip-zoom-duration) var(--tooltip-zoom-easing),
+    transform var(--tooltip-zoom-duration) var(--tooltip-zoom-easing),
+    visibility 0s linear var(--tooltip-zoom-duration),
+    filter var(--tooltip-zoom-duration) var(--tooltip-zoom-easing);
+}
+
+/* Arrow (shared base) */
+.pp-zoom-tooltip::after {
+  content: "";
+  position: absolute;
+  width: var(--tooltip-arrow-size);
+  height: var(--tooltip-arrow-size);
+  background: var(--tooltip-bg);
+  transform: rotate(45deg);
+}
+
+/* Reveal on hover OR keyboard focus */
+.pp-tooltip-trigger:hover .pp-zoom-tooltip,
+.pp-tooltip-trigger:focus-within .pp-zoom-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: scale(1) translateY(0);
+  filter: blur(0);
+  transition:
+    opacity var(--tooltip-zoom-duration) var(--tooltip-zoom-easing),
+    transform var(--tooltip-zoom-duration) var(--tooltip-zoom-easing),
+    visibility 0s linear 0s,
+    filter var(--tooltip-zoom-duration) var(--tooltip-zoom-easing);
+}
+
+/* --- Position variants ------------------------------------------------ */
+.pp-zoom-tooltip--top {
+  bottom: 100%;
+  left: 50%;
+  margin-bottom: var(--tooltip-gap);
+  transform-origin: bottom center;
+  transform: scale(var(--tooltip-zoom-scale))
+    translate(-50%, var(--tooltip-zoom-offset));
+}
+.pp-tooltip-trigger:hover .pp-zoom-tooltip--top,
+.pp-tooltip-trigger:focus-within .pp-zoom-tooltip--top {
+  transform: scale(1) translate(-50%, 0);
+}
+.pp-zoom-tooltip--top::after {
+  top: 100%;
+  left: 50%;
+  margin-left: calc(var(--tooltip-arrow-size) / -2);
+  margin-top: calc(var(--tooltip-arrow-size) / -2);
+}
+
+.pp-zoom-tooltip--bottom {
+  top: 100%;
+  left: 50%;
+  margin-top: var(--tooltip-gap);
+  transform-origin: top center;
+  transform: scale(var(--tooltip-zoom-scale))
+    translate(-50%, calc(var(--tooltip-zoom-offset) * -1));
+}
+.pp-tooltip-trigger:hover .pp-zoom-tooltip--bottom,
+.pp-tooltip-trigger:focus-within .pp-zoom-tooltip--bottom {
+  transform: scale(1) translate(-50%, 0);
+}
+.pp-zoom-tooltip--bottom::after {
+  bottom: 100%;
+  left: 50%;
+  margin-left: calc(var(--tooltip-arrow-size) / -2);
+  margin-bottom: calc(var(--tooltip-arrow-size) / -2);
+}
+
+.pp-zoom-tooltip--left {
+  right: 100%;
+  top: 50%;
+  margin-right: var(--tooltip-gap);
+  transform-origin: right center;
+  transform: scale(var(--tooltip-zoom-scale))
+    translate(var(--tooltip-zoom-offset), -50%);
+}
+.pp-tooltip-trigger:hover .pp-zoom-tooltip--left,
+.pp-tooltip-trigger:focus-within .pp-zoom-tooltip--left {
+  transform: scale(1) translate(0, -50%);
+}
+.pp-zoom-tooltip--left::after {
+  left: 100%;
+  top: 50%;
+  margin-top: calc(var(--tooltip-arrow-size) / -2);
+  margin-left: calc(var(--tooltip-arrow-size) / -2);
+}
+
+.pp-zoom-tooltip--right {
+  left: 100%;
+  top: 50%;
+  margin-left: var(--tooltip-gap);
+  transform-origin: left center;
+  transform: scale(var(--tooltip-zoom-scale))
+    translate(calc(var(--tooltip-zoom-offset) * -1), -50%);
+}
+.pp-tooltip-trigger:hover .pp-zoom-tooltip--right,
+.pp-tooltip-trigger:focus-within .pp-zoom-tooltip--right {
+  transform: scale(1) translate(0, -50%);
+}
+.pp-zoom-tooltip--right::after {
+  right: 100%;
+  top: 50%;
+  margin-top: calc(var(--tooltip-arrow-size) / -2);
+  margin-right: calc(var(--tooltip-arrow-size) / -2);
+}
+
+/* --- Accent / variant skins ------------------------------------------- */
+.pp-zoom-tooltip--accent {
+  background: linear-gradient(135deg, var(--accent-1), var(--accent-2));
+  color: #fff;
+  box-shadow: 0 12px 30px -8px rgba(99, 102, 241, 0.55);
+}
+.pp-zoom-tooltip--accent::after {
+  background: var(--accent-2);
+}
+.pp-zoom-tooltip--success {
+  background: var(--success);
+  color: #fff;
+}
+.pp-zoom-tooltip--success::after {
+  background: var(--success);
+}
+.pp-zoom-tooltip--danger {
+  background: var(--danger);
+  color: #fff;
+}
+.pp-zoom-tooltip--danger::after {
+  background: var(--danger);
+}
+
+/* Rich tooltip with title + body */
+.pp-zoom-tooltip__title {
+  display: block;
+  font-weight: 700;
+  font-size: 0.9rem;
+  margin-bottom: 2px;
+}
+.pp-zoom-tooltip__body {
+  display: block;
+  font-weight: 400;
+  opacity: 0.85;
+  font-size: 0.78rem;
+}
+
+/* --------------------------------------------------------------------------
+   5. Control dashboard (demo only)
+   -------------------------------------------------------------------------- */
+.pp-controls {
+  display: grid;
+  gap: 16px;
+}
+.pp-control {
+  display: grid;
+  gap: 6px;
+}
+.pp-control label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  display: flex;
+  justify-content: space-between;
+}
+.pp-control label span {
+  color: var(--accent-1);
+  font-family: var(--font-mono);
+}
+.pp-control input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent-1);
+}
+.pp-control select {
+  font: inherit;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--bg-subtle);
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+.pp-reset {
+  margin-top: 4px;
+  padding: 10px 14px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--bg-subtle);
+  background: var(--bg-app);
+  color: var(--text-secondary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+.pp-reset:hover {
+  background: var(--accent-soft);
+  color: var(--accent-1);
+}
+
+/* Code preview */
+.pp-code {
+  margin-top: 18px;
+  background: #0b1120;
+  color: #cbd5e1;
+  border-radius: var(--radius-md);
+  padding: 16px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+.pp-code .tok-tag { color: #7dd3fc; }
+.pp-code .tok-attr { color: #fcd34d; }
+.pp-code .tok-str { color: #86efac; }
+
+/* Accessibility note */
+.pp-a11y-note {
+  margin-top: 18px;
+  padding: 14px 16px;
+  border-left: 3px solid var(--accent-1);
+  background: var(--accent-soft);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .pp-zoom-tooltip {
+    transition: opacity 0.01ms linear, visibility 0s linear 0s !important;
+    transform: none !important;
+    filter: none !important;
+  }
+  .pp-tooltip-trigger:hover .pp-zoom-tooltip,
+  .pp-tooltip-trigger:focus-within .pp-zoom-tooltip {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## 📝 Description

This PR resolves **Issue #46240 — Enhancement: Add CSS Zoom-Out Tooltip for Modern SaaS Layouts**.

It adds a **pure CSS animated Tooltip** that reveals with a smooth **Zoom-Out** interaction transition, styled to complement **Modern SaaS** interface aesthetics. The component is fully responsive, keyboard accessible, and exposes its timing, easing, and scale factors via standard CSS custom properties — with **zero JavaScript required** for the animation.

### ✨ Highlights
- **Zoom-out transition** — tooltip settles from a slightly enlarged (`--tooltip-zoom-scale`) state down to natural size while fading + sliding in; reverses on dismiss.
- **Modern SaaS aesthetic** — soft elevation, rounded corners, optional indigo→violet accent gradient, crisp typography.
- **Keyboard accessible** — focusable trigger wrapper (`tabindex="0"`) + `:focus-within` reveal, `role="tooltip"`, and a `prefers-reduced-motion` fallback.
- **Fully tunable** — duration, easing, start scale, travel offset, entry blur, colors, radius, padding, and max-width are all CSS custom properties.
- **Four positions** (`top` / `bottom` / `left` / `right`) and **three skins** (`accent` / `success` / `danger`), plus rich title+body tooltips.
- **Conflict-free** — lives entirely inside `submissions/examples/`, never touches core framework files.

### 📁 Files Added (inside `submissions/examples/ease-zoom-out-tooltip-saas-pp/`)
| File | Purpose |
|------|---------|
| `demo.html` | Self-contained showcase with live parameter controls + light/dark toggle (open directly in a browser) |
| `style.css` | Raw component + demo styling (~580 lines) |
| `README.md` | Documentation answering the 3 required questions + full API reference |

> Total: **1000 lines** across the three required files.

### ✅ Checklist
- [x] No existing issue already covers this idea (new submission folder with unique `pp` suffix)
- [x] Followed the [Contribution Guide](https://github.com/SAPTARSHI-coder/EaseMotion-css/blob/main/CONTRIBUTING.md)
- [x] Files added only inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` · `style.css` · `README.md`
- [x] Single squashed commit, conventional commit message

Resolves #46240