### PR TITLE
feat: add queue depth pressure demo

### DIFF
--- a/submissions/examples/queue-depth-pressure-sm/README.md
+++ b/submissions/examples/queue-depth-pressure-sm/README.md
@@ -1,0 +1,34 @@
+# Queue Depth Pressure
+
+## What does this do?
+
+Queue Depth Pressure is a self-contained HTML and CSS operations dashboard pattern with animated queue pressure cards, depth meters, status badges, and readable worker backlog signals.
+
+## How is it used?
+
+Create a `queue-board` wrapper and add `queue-card` items with pressure classes such as `queue-safe`, `queue-watch`, or `queue-critical`.
+
+```html
+<article class="queue-card queue-critical">
+  <div class="queue-ring" aria-hidden="true">
+    <span>94%</span>
+  </div>
+  <div class="queue-content">
+    <p class="queue-kicker">Webhook queue</p>
+    <h2>Delivery backlog is critical</h2>
+    <div class="queue-bar" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available pressure classes:
+
+- `queue-safe`
+- `queue-watch`
+- `queue-critical`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make queue health easier to scan: cards enter gently, rings show backlog pressure, bars reveal depth, and focus states keep scale actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/queue-depth-pressure-sm/demo.html
+++ b/submissions/examples/queue-depth-pressure-sm/demo.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Queue Depth Pressure Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="queue-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Queue Depth Pressure</h1>
+        <p>
+          A self-contained operations pattern with animated queue pressure
+          cards, depth meters, status badges, and readable worker backlog
+          signals.
+        </p>
+      </section>
+
+      <section class="queue-summary" aria-label="Queue pressure summary">
+        <article>
+          <span class="summary-value">18k</span>
+          <span class="summary-label">Jobs waiting</span>
+        </article>
+        <article>
+          <span class="summary-value">72%</span>
+          <span class="summary-label">Worker capacity</span>
+        </article>
+        <article>
+          <span class="summary-value">06m</span>
+          <span class="summary-label">Drain estimate</span>
+        </article>
+      </section>
+
+      <section class="queue-board" aria-label="Queue depth pressure cards">
+        <article class="queue-card queue-safe">
+          <div class="queue-ring" aria-hidden="true">
+            <span>31%</span>
+          </div>
+          <div class="queue-content">
+            <p class="queue-kicker">Email queue</p>
+            <h2>Notifications are flowing</h2>
+            <p>
+              Worker throughput is above the incoming event rate and the backlog
+              remains within the healthy operating range.
+            </p>
+            <div class="queue-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Stable</span>
+              <button type="button">Inspect</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="queue-card queue-watch">
+          <div class="queue-ring" aria-hidden="true">
+            <span>68%</span>
+          </div>
+          <div class="queue-content">
+            <p class="queue-kicker">Import queue</p>
+            <h2>Batch jobs are stacking</h2>
+            <p>
+              Several large workspace imports are competing for shared workers
+              and should be watched during the next drain cycle.
+            </p>
+            <div class="queue-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Watch</span>
+              <button type="button">Balance</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="queue-card queue-critical">
+          <div class="queue-ring" aria-hidden="true">
+            <span>94%</span>
+          </div>
+          <div class="queue-content">
+            <p class="queue-kicker">Webhook queue</p>
+            <h2>Delivery backlog is critical</h2>
+            <p>
+              Retry traffic is close to the queue cap and needs temporary worker
+              capacity before delivery windows are missed.
+            </p>
+            <div class="queue-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Critical</span>
+              <button type="button">Scale</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/queue-depth-pressure-sm/style.css
+++ b/submissions/examples/queue-depth-pressure-sm/style.css
@@ -1,0 +1,354 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.queue-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.queue-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.queue-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.queue-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.queue-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.queue-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.queue-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.queue-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.queue-card:hover,
+.queue-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.queue-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--depth), #e4edf8 var(--depth) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-enter 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.queue-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.45rem;
+  font-weight: 950;
+}
+
+.queue-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.queue-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.queue-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.queue-content > p:not(.queue-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.queue-bar {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.queue-bar span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--depth);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: bar-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.queue-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.queue-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.queue-content button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.queue-content button:hover,
+.queue-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.queue-safe {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --depth: 31%;
+}
+
+.queue-watch {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --depth: 68%;
+}
+
+.queue-critical {
+  --accent: var(--red);
+  --accent-light: #fb7185;
+  --accent-soft: rgba(220, 38, 38, 0.14);
+  --depth: 94%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-enter {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .queue-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .queue-summary,
+  .queue-board {
+    grid-template-columns: 1fr;
+  }
+
+  .queue-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #48760


**PR Text**

Title: `feat: add queue depth pressure demo`

```md
## Pull Request Description
Adds a self-contained Queue Depth Pressure demo under `submissions/examples/`, featuring animated queue pressure cards, depth rings, status badges, and worker backlog signals.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only queue pressure dashboard pattern for operations monitoring.

**How does a developer use it?**
Use a `queue-board` wrapper with `queue-card` items and pressure classes like `queue-safe`, `queue-watch`, or `queue-critical`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate queue depth, backlog pressure, and scale priority while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The queue naming, pressure colors, and meter timing can be standardized during framework integration.