### PR TITLE
feat: add accessible blur entrance popover

### DIFF
--- a/submissions/examples/46476-blur-entrance-popover-accessible-web/README.md
+++ b/submissions/examples/46476-blur-entrance-popover-accessible-web/README.md
@@ -1,0 +1,29 @@
+# Blur Entrance Popover for Accessible Web Layouts
+
+A pure CSS popover demo that uses a native `details` disclosure element for keyboard and screen-reader friendly interaction. The panel enters with a soft blur, scale, and opacity transition while keeping the markup semantic and responsive.
+
+## Features
+
+- Native `details` and `summary` interaction, so the popover works with keyboard navigation without JavaScript.
+- Blur-entrance motion controlled by CSS custom properties for timing, easing, scale, and blur distance.
+- Accessible focus states, visible target sizing, semantic headings, and helper text.
+- Responsive layout that keeps the trigger and popover readable on narrow screens.
+- `prefers-reduced-motion` support to remove transform and blur animation for motion-sensitive users.
+
+## CSS Custom Properties
+
+```css
+:root {
+  --popover-duration: 280ms;
+  --popover-easing: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --popover-start-scale: 0.94;
+  --popover-start-blur: 14px;
+}
+```
+
+## Usage
+
+1. Open `demo.html` in a browser.
+2. Tab to the "Open accessibility checklist" trigger.
+3. Press `Enter` or `Space` to toggle the popover.
+4. Adjust the custom properties in `style.css` to change the animation feel.

--- a/submissions/examples/46476-blur-entrance-popover-accessible-web/demo.html
+++ b/submissions/examples/46476-blur-entrance-popover-accessible-web/demo.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blur Entrance Popover for Accessible Web Layouts</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="hero-card" aria-labelledby="demo-title">
+        <p class="eyebrow">EaseMotion CSS Example</p>
+        <h1 id="demo-title">Blur-entrance popover for accessible interfaces</h1>
+        <p class="intro">
+          A native disclosure popover that keeps the interaction keyboard-ready
+          while adding a calm, polished entrance motion with zero JavaScript.
+        </p>
+
+        <details class="popover">
+          <summary class="popover-trigger">
+            <span>Open accessibility checklist</span>
+            <span class="trigger-icon" aria-hidden="true">+</span>
+          </summary>
+
+          <div
+            class="popover-panel"
+            role="group"
+            aria-labelledby="popover-heading"
+          >
+            <p class="panel-kicker">Before you ship</p>
+            <h2 id="popover-heading">Accessible motion checklist</h2>
+            <ul class="checklist" aria-label="Accessible motion requirements">
+              <li>
+                <strong>Keyboard first:</strong>
+                The native summary trigger can be reached and toggled without a
+                mouse.
+              </li>
+              <li>
+                <strong>Visible focus:</strong>
+                Focus rings remain high contrast against the panel and page
+                surfaces.
+              </li>
+              <li>
+                <strong>Reduced motion:</strong>
+                Users who prefer less motion receive an instant, blur-free
+                transition.
+              </li>
+            </ul>
+            <a class="panel-link" href="#demo-title">Return to overview</a>
+          </div>
+        </details>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/46476-blur-entrance-popover-accessible-web/style.css
+++ b/submissions/examples/46476-blur-entrance-popover-accessible-web/style.css
@@ -1,0 +1,253 @@
+:root {
+  --page-bg: #f4f7fb;
+  --card-bg: #ffffff;
+  --ink: #14213d;
+  --muted: #526071;
+  --accent: #0f766e;
+  --accent-dark: #0b4f4a;
+  --ring: #f59e0b;
+  --panel-bg: #f8fffd;
+  --panel-border: rgba(15, 118, 110, 0.22);
+  --shadow: 0 24px 70px rgba(20, 33, 61, 0.18);
+  --popover-duration: 280ms;
+  --popover-easing: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --popover-start-scale: 0.94;
+  --popover-start-blur: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(15, 118, 110, 0.16),
+      transparent 34rem
+    ),
+    linear-gradient(135deg, #f4f7fb 0%, #e8f4f1 100%);
+}
+
+.page-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 3rem);
+}
+
+.hero-card {
+  width: min(100%, 46rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid rgba(20, 33, 61, 0.08);
+  border-radius: 2rem;
+  background: var(--card-bg);
+  box-shadow: var(--shadow);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--accent-dark);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 12ch;
+  margin-bottom: 1rem;
+  font-size: clamp(2.35rem, 7vw, 4.8rem);
+  line-height: 0.94;
+  letter-spacing: -0.08em;
+}
+
+.intro {
+  max-width: 40rem;
+  margin-bottom: 2rem;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  line-height: 1.7;
+}
+
+.popover {
+  position: relative;
+  width: min(100%, 30rem);
+}
+
+.popover-trigger {
+  display: flex;
+  min-height: 3.25rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem 0.9rem 1.2rem;
+  border: 2px solid var(--accent);
+  border-radius: 999px;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 800;
+  list-style: none;
+  background: var(--accent);
+  box-shadow: 0 12px 28px rgba(15, 118, 110, 0.28);
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.popover-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.popover-trigger::marker {
+  content: "";
+}
+
+.popover-trigger:hover {
+  background: var(--accent-dark);
+  border-color: var(--accent-dark);
+  transform: translateY(-2px);
+}
+
+.popover-trigger:focus-visible,
+.panel-link:focus-visible {
+  outline: 4px solid var(--ring);
+  outline-offset: 4px;
+}
+
+.trigger-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent-dark);
+  background: #ffffff;
+  font-size: 1.35rem;
+  line-height: 1;
+  transition: transform var(--popover-duration) var(--popover-easing);
+}
+
+.popover[open] .trigger-icon {
+  transform: rotate(45deg);
+}
+
+.popover-panel {
+  margin-top: 1rem;
+  padding: clamp(1rem, 4vw, 1.5rem);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.35rem;
+  background: var(--panel-bg);
+  box-shadow: 0 18px 42px rgba(15, 118, 110, 0.16);
+  transform-origin: top center;
+}
+
+.popover[open] .popover-panel {
+  animation: blur-popover-in var(--popover-duration) var(--popover-easing) both;
+}
+
+.panel-kicker {
+  margin-bottom: 0.4rem;
+  color: var(--accent-dark);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h2 {
+  margin-bottom: 1rem;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  letter-spacing: -0.04em;
+}
+
+.checklist {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  list-style: none;
+}
+
+.checklist li {
+  padding-left: 1.6rem;
+  color: var(--muted);
+  line-height: 1.6;
+  background: radial-gradient(
+      circle at 0.35rem 0.75rem,
+      var(--accent) 0.22rem,
+      transparent 0.24rem
+    )
+    no-repeat;
+}
+
+.checklist strong {
+  color: var(--ink);
+}
+
+.panel-link {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.8rem;
+  color: var(--accent-dark);
+  font-weight: 800;
+  text-decoration: none;
+  background: rgba(15, 118, 110, 0.11);
+}
+
+.panel-link:hover {
+  text-decoration: underline;
+}
+
+@keyframes blur-popover-in {
+  from {
+    opacity: 0;
+    filter: blur(var(--popover-start-blur));
+    transform: translateY(-0.75rem) scale(var(--popover-start-scale));
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 36rem) {
+  .hero-card {
+    border-radius: 1.4rem;
+  }
+
+  .popover-trigger {
+    border-radius: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto;
+    transition-duration: 1ms;
+    animation-duration: 1ms;
+    animation-iteration-count: 1;
+  }
+
+  .popover[open] .popover-panel {
+    animation-name: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #46476
- Added a pure CSS blur-entrance popover demo under `submissions/examples/46476-blur-entrance-popover-accessible-web`
- Uses native `details` / `summary` interaction for keyboard-friendly toggling
- Includes visible focus styles, responsive layout, CSS custom properties, and `prefers-reduced-motion` support

## Validation
- Parsed `demo.html` with Python HTML parser
- Ran `git diff --check`
- Ran Prettier check on the new files
- Ran Stylelint on `style.css` with the repository config