### PR TITLE
feat: add glassmorphism neon glow popover

### DIFF
--- a/submissions/examples/46485-neon-glow-popover-glassmorphism-ui/README.md
+++ b/submissions/examples/46485-neon-glow-popover-glassmorphism-ui/README.md
@@ -1,0 +1,29 @@
+# Neon Glow Popover for Glassmorphism UI Layouts
+
+A pure CSS popover demo that pairs a frosted-glass surface with a soft neon glow entrance. The example uses the native `details` and `summary` elements, so the interaction remains keyboard accessible without JavaScript.
+
+## Features
+
+- Native disclosure behavior for keyboard and screen-reader friendly toggling.
+- Glassmorphism panel styling with backdrop blur, translucent borders, and layered gradients.
+- Neon glow entrance animation controlled with CSS custom properties.
+- Responsive layout that keeps the popover readable on narrow screens.
+- Reduced-motion support that removes glow and transform animation when requested.
+
+## CSS Custom Properties
+
+```css
+:root {
+  --popover-duration: 320ms;
+  --popover-easing: cubic-bezier(0.2, 0.85, 0.25, 1);
+  --popover-glow-color: #22d3ee;
+  --popover-start-scale: 0.92;
+}
+```
+
+## Usage
+
+1. Open `demo.html` in a browser.
+2. Tab to the "Open neon status card" trigger.
+3. Press `Enter` or `Space` to reveal the popover.
+4. Adjust the custom properties in `style.css` to tune the glow, scale, and timing.

--- a/submissions/examples/46485-neon-glow-popover-glassmorphism-ui/demo.html
+++ b/submissions/examples/46485-neon-glow-popover-glassmorphism-ui/demo.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Neon Glow Popover for Glassmorphism UI Layouts</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="scene-shell">
+      <section class="glass-card" aria-labelledby="demo-title">
+        <p class="eyebrow">EaseMotion CSS Example</p>
+        <h1 id="demo-title">Neon popover for frosted interfaces</h1>
+        <p class="intro">
+          A zero-JavaScript popover pattern that blends keyboard-safe native
+          disclosure with glass panels, glowing borders, and responsive motion.
+        </p>
+
+        <details class="popover">
+          <summary class="popover-trigger">
+            <span>Open neon status card</span>
+            <span class="trigger-orb" aria-hidden="true"></span>
+          </summary>
+
+          <div
+            class="popover-panel"
+            role="group"
+            aria-labelledby="popover-heading"
+          >
+            <p class="panel-kicker">Live preview</p>
+            <h2 id="popover-heading">Glassmorphism-ready motion</h2>
+            <p>
+              The panel fades, scales, and glows into place while preserving a
+              native focusable trigger and a readable content hierarchy.
+            </p>
+            <ul class="feature-list" aria-label="Popover implementation notes">
+              <li>Backdrop blur and translucent borders create depth.</li>
+              <li>
+                CSS variables expose timing, easing, scale, and glow color.
+              </li>
+              <li>Reduced-motion users receive a calm, instant transition.</li>
+            </ul>
+          </div>
+        </details>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/46485-neon-glow-popover-glassmorphism-ui/style.css
+++ b/submissions/examples/46485-neon-glow-popover-glassmorphism-ui/style.css
@@ -1,0 +1,268 @@
+:root {
+  --page-bg: #06121f;
+  --card-bg: rgba(12, 26, 45, 0.7);
+  --glass-bg: rgba(255, 255, 255, 0.1);
+  --glass-border: rgba(255, 255, 255, 0.26);
+  --ink: #f8fbff;
+  --muted: #b7c8d8;
+  --accent: #22d3ee;
+  --accent-hot: #f472b6;
+  --ring: #fde68a;
+  --popover-duration: 320ms;
+  --popover-easing: cubic-bezier(0.2, 0.85, 0.25, 1);
+  --popover-glow-color: #22d3ee;
+  --popover-start-scale: 0.92;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(34, 211, 238, 0.22),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 82% 12%,
+      rgba(244, 114, 182, 0.2),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #06121f 0%, #0a1c30 48%, #190b2b 100%);
+}
+
+.scene-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 3rem);
+}
+
+.glass-card {
+  width: min(100%, 48rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  border: 1px solid var(--glass-border);
+  border-radius: 2rem;
+  background: var(--card-bg);
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(24px);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 12ch;
+  margin-bottom: 1rem;
+  font-size: clamp(2.4rem, 7vw, 5rem);
+  line-height: 0.94;
+  letter-spacing: -0.08em;
+}
+
+.intro {
+  max-width: 42rem;
+  margin-bottom: 2rem;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.16rem);
+  line-height: 1.7;
+}
+
+.popover {
+  position: relative;
+  width: min(100%, 32rem);
+}
+
+.popover-trigger {
+  display: flex;
+  min-height: 3.4rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem 0.9rem 1.2rem;
+  border: 1px solid rgba(34, 211, 238, 0.68);
+  border-radius: 999px;
+  color: var(--ink);
+  cursor: pointer;
+  font-weight: 800;
+  list-style: none;
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.28), rgba(244, 114, 182, 0.2)),
+    var(--glass-bg);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08) inset,
+    0 0 28px rgba(34, 211, 238, 0.28);
+  backdrop-filter: blur(18px);
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.popover-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.popover-trigger::marker {
+  content: "";
+}
+
+.popover-trigger:hover {
+  border-color: var(--accent-hot);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.12) inset,
+    0 0 36px rgba(244, 114, 182, 0.32);
+  transform: translateY(-2px);
+}
+
+.popover-trigger:focus-visible {
+  outline: 4px solid var(--ring);
+  outline-offset: 4px;
+}
+
+.trigger-orb {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow:
+    0 0 12px var(--accent),
+    0 0 28px var(--accent);
+  transition:
+    background-color var(--popover-duration) var(--popover-easing),
+    box-shadow var(--popover-duration) var(--popover-easing),
+    transform var(--popover-duration) var(--popover-easing);
+}
+
+.popover[open] .trigger-orb {
+  background: var(--accent-hot);
+  box-shadow:
+    0 0 16px var(--accent-hot),
+    0 0 38px var(--accent-hot);
+  transform: scale(1.18);
+}
+
+.popover-panel {
+  margin-top: 1rem;
+  padding: clamp(1rem, 4vw, 1.6rem);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 1.4rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.16),
+      rgba(255, 255, 255, 0.06)
+    ),
+    rgba(7, 19, 33, 0.72);
+  box-shadow:
+    0 20px 46px rgba(0, 0, 0, 0.3),
+    0 0 42px rgba(34, 211, 238, 0.2);
+  backdrop-filter: blur(22px);
+  transform-origin: top center;
+}
+
+.popover[open] .popover-panel {
+  animation: neon-popover-in var(--popover-duration) var(--popover-easing) both;
+}
+
+.panel-kicker {
+  margin-bottom: 0.4rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h2 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.45rem, 3vw, 2rem);
+  letter-spacing: -0.04em;
+}
+
+.popover-panel p {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.feature-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.15rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.feature-list li {
+  padding-left: 1.55rem;
+  color: var(--muted);
+  line-height: 1.55;
+  background: radial-gradient(
+      circle at 0.35rem 0.72rem,
+      var(--accent) 0.22rem,
+      transparent 0.24rem
+    )
+    no-repeat;
+}
+
+@keyframes neon-popover-in {
+  from {
+    opacity: 0;
+    filter: blur(12px);
+    box-shadow:
+      0 10px 28px rgba(0, 0, 0, 0.24),
+      0 0 0 rgba(34, 211, 238, 0);
+    transform: translateY(-0.7rem) scale(var(--popover-start-scale));
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
+    box-shadow:
+      0 20px 46px rgba(0, 0, 0, 0.3),
+      0 0 42px color-mix(in srgb, var(--popover-glow-color) 42%, transparent);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 36rem) {
+  .glass-card {
+    border-radius: 1.4rem;
+  }
+
+  .popover-trigger {
+    border-radius: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto;
+    transition-duration: 1ms;
+    animation-duration: 1ms;
+    animation-iteration-count: 1;
+  }
+
+  .popover[open] .popover-panel {
+    animation-name: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #46485
- Added a pure CSS neon glow popover demo for glassmorphism UI layouts
- Uses native `details` / `summary` interaction for keyboard-friendly toggling
- Exposes timing, easing, scale, and glow color through CSS custom properties
- Includes responsive styling and `prefers-reduced-motion` support

## Validation
- Parsed `demo.html` with Python HTML parser
- Ran `git diff --check`
- Ran Prettier check on the new files
- Ran Stylelint on `style.css` with the repository config