### PR TITLE
docs: add sticky sidebar fix demonstration (#47378)

### DIFF
--- a/submissions/docs/sticky-sidebar-eranmol/README.md
+++ b/submissions/docs/sticky-sidebar-eranmol/README.md
@@ -1,0 +1,58 @@
+# Sticky Documentation Sidebar
+
+Fixes issue **#47378** — makes the documentation sidebar sticky while scrolling.
+
+## What does this do?
+
+This submission demonstrates the fix for the documentation sidebar. It changes the sidebar from `position: fixed` to `position: sticky`, which keeps the sidebar visible during scroll while maintaining proper document flow.
+
+## How is it used?
+
+Apply `position: sticky` to the `.docs-sidebar` element with `top` set to the header height:
+
+```css
+.docs-sidebar {
+  position: sticky;
+  top: 60px;
+  width: 260px;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+```
+
+The `.docs-shell` parent uses `display: flex` so the sticky sidebar and `.docs-content` sit side by side naturally.
+
+## Why is it useful?
+
+`position: sticky` is the modern, recommended approach for documentation sidebars. It:
+
+- Keeps the sidebar in the normal document flow (no manual offsets needed)
+- Allows the sidebar to scroll independently when its content exceeds the viewport
+- Works correctly in both light and dark themes
+- Respects `prefers-reduced-motion` without extra configuration
+- Is used by Tailwind CSS, React, and Next.js documentation sites
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Self-contained demo with long scrollable content to verify sticky behavior |
+| `style.css` | CSS with `position: sticky` sidebar, responsive breakpoints, and theme support |
+| `README.md` | This file |
+
+## Key Changes from Current Implementation
+
+| Property | Current | Fixed |
+|----------|---------|-------|
+| `position` | `fixed` | `sticky` |
+| `top` | `60px` | `60px` (unchanged) |
+| `height` | `auto` (via `bottom: 0`) | `calc(100vh - 60px)` |
+| `overflow-y` | `auto` | `auto` (unchanged) |
+| `flex-shrink` | not set | `0` |
+
+## Responsive Behavior
+
+- **Desktop (>900px):** Full sticky sidebar at 260px width
+- **Tablet (769-900px):** Narrower sticky sidebar at 220px
+- **Mobile (<768px):** Sidebar converts to a scrollable top panel (relative position)

--- a/submissions/docs/sticky-sidebar-eranmol/demo.html
+++ b/submissions/docs/sticky-sidebar-eranmol/demo.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sticky Documentation Sidebar - EaseMotion CSS</title>
+  <meta name="description" content="Demonstration of the sticky documentation sidebar fix for the EaseMotion CSS documentation site.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Header (fixed) -->
+  <header class="docs-header">
+    <div class="docs-header-inner">
+      <a href="#" class="docs-logo">EaseMotion CSS</a>
+      <span class="docs-header-tag">Docs Sidebar Fix</span>
+    </div>
+  </header>
+
+  <!-- Shell: sidebar + content side by side -->
+  <div class="docs-shell">
+
+    <!-- Sidebar (sticky) -->
+    <aside class="docs-sidebar" id="docsSidebar">
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Introduction</div>
+        <ul class="sidebar-nav">
+          <li><a href="#getting-started" class="active">Getting Started</a></li>
+          <li><a href="#philosophy">Design Philosophy</a></li>
+          <li><a href="#installation">Installation</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Core</div>
+        <ul class="sidebar-nav">
+          <li><a href="#variables">Variables</a></li>
+          <li><a href="#dark-mode">Dark Mode</a></li>
+          <li><a href="#utilities">Utilities</a></li>
+          <li><a href="#animations">Animations</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Components</div>
+        <ul class="sidebar-nav">
+          <li><a href="#buttons">Buttons</a></li>
+          <li><a href="#cards">Cards</a></li>
+          <li><a href="#forms">Forms</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Performance</div>
+        <ul class="sidebar-nav">
+          <li><a href="#performance-guide">Performance Guide</a></li>
+          <li><a href="#benchmarks">Benchmarks</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">Contributing</div>
+        <ul class="sidebar-nav">
+          <li><a href="#contribute">How to Contribute</a></li>
+          <li><a href="#naming">Naming Rules</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="docs-content">
+      <section id="getting-started">
+        <h1 class="docs-h1">Sticky Sidebar Fix</h1>
+        <p class="docs-p">
+          This submission demonstrates the fix for issue <strong>#47378</strong>:
+          making the documentation sidebar sticky so it remains visible while
+          users scroll through long documentation pages.
+        </p>
+      </section>
+
+      <section id="philosophy">
+        <h2 class="docs-h2">The Problem</h2>
+        <p class="docs-p">
+          Previously, the sidebar used <code>position: fixed</code> which, while
+          keeping the sidebar in place, removed it from the document flow entirely.
+          This caused layout issues with the flex container and required manual
+          offset calculations for the main content.
+        </p>
+        <p class="docs-p">
+          On some viewports, the sidebar could overlap content or fail to scroll
+          independently when its own content exceeded the viewport height.
+        </p>
+      </section>
+
+      <section id="installation">
+        <h2 class="docs-h2">The Solution: position: sticky</h2>
+        <p class="docs-p">
+          Switching to <code>position: sticky</code> keeps the sidebar in the
+          normal document flow while making it stick to the viewport when the
+          user scrolls past its offset. This is the recommended modern approach
+          used by documentation sites like Tailwind CSS, React, and Next.js.
+        </p>
+
+        <h3 class="docs-h3">Key CSS Changes</h3>
+<pre class="docs-code"><code>/* Before (broken) */
+.docs-sidebar {
+  position: fixed;
+  top: 60px;
+  left: 0;
+  bottom: 0;
+  width: 260px;
+}
+
+/* After (fixed) */
+.docs-sidebar {
+  position: sticky;
+  top: 60px;
+  width: 260px;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  flex-shrink: 0;
+}</code></pre>
+      </section>
+
+      <section id="variables">
+        <h2 class="docs-h2">Variables</h2>
+        <p class="docs-p">
+          EaseMotion CSS uses CSS custom properties for theming. Below are some
+          example variables that demonstrate the sticky sidebar working alongside
+          the content area.
+        </p>
+        <p class="docs-p">
+          Scroll down through this long content to verify the sidebar stays in
+          place while you scroll.
+        </p>
+      </section>
+
+      <section id="dark-mode">
+        <h2 class="docs-h2">Dark Mode</h2>
+        <p class="docs-p">
+          The sidebar supports both light and dark themes via CSS custom properties.
+          The <code>position: sticky</code> approach works correctly in both modes
+          without requiring additional JavaScript.
+        </p>
+        <p class="docs-p">
+          The sidebar background, border, and text colors all adapt to the current
+          theme while maintaining its sticky behavior throughout the scroll.
+        </p>
+      </section>
+
+      <section id="utilities">
+        <h2 class="docs-h2">Utilities</h2>
+        <p class="docs-p">
+          EaseMotion CSS provides a wide range of utility classes for spacing,
+          typography, colors, and animations. The sticky sidebar ensures these
+          utilities are always accessible as you browse the documentation.
+        </p>
+        <p class="docs-p">
+          Utility classes follow the <code>ease-</code> naming convention and are
+          designed to be composable and tree-shakable for optimal bundle sizes.
+        </p>
+      </section>
+
+      <section id="animations">
+        <h2 class="docs-h2">Animations</h2>
+        <p class="docs-p">
+          The animation system supports entrance, exit, hover, and scroll-triggered
+          effects. Each animation is defined as a CSS keyframe and can be applied
+          via utility classes or the SCSS mixin system.
+        </p>
+        <p class="docs-p">
+          Common animations include fade-in, slide-up, zoom-in, and bounce effects.
+          All animations respect the <code>prefers-reduced-motion</code> media
+          query for accessibility.
+        </p>
+      </section>
+
+      <section id="buttons">
+        <h2 class="docs-h2">Buttons</h2>
+        <p class="docs-p">
+          Button components support multiple variants including primary, secondary,
+          outline, and ghost styles. Each variant includes hover, focus, and
+          active states with smooth transitions.
+        </p>
+        <p class="docs-p">
+          Buttons can be combined with animation utilities for entrance effects
+          and micro-interactions that enhance the user experience.
+        </p>
+      </section>
+
+      <section id="cards">
+        <h2 class="docs-h2">Cards</h2>
+        <p class="docs-p">
+          Card components provide a flexible container for grouping related content.
+          They support hover effects, scroll animations, and responsive layouts
+          that adapt to different screen sizes.
+        </p>
+        <p class="docs-p">
+          Cards can include headers, footers, images, and action buttons. The
+          sticky sidebar ensures you can always navigate between card examples
+          without losing your place.
+        </p>
+      </section>
+
+      <section id="forms">
+        <h2 class="docs-h2">Forms</h2>
+        <p class="docs-p">
+          Form components include input fields, textareas, select dropdowns, and
+          custom checkboxes/radios. Each form element supports validation states,
+          helper text, and consistent styling across browsers.
+        </p>
+        <p class="docs-p">
+          The form system integrates with the animation utilities for smooth
+          validation feedback and focus transitions.
+        </p>
+      </section>
+
+      <section id="performance-guide">
+        <h2 class="docs-h2">Performance Guide</h2>
+        <p class="docs-p">
+          EaseMotion CSS is designed for performance. All animations use
+          GPU-accelerated properties (transform, opacity) and avoid layout-thrashing
+          properties (width, height, top, left).
+        </p>
+        <p class="docs-p">
+          The tree-shaking engine removes unused keyframes and classes from the
+          final bundle, ensuring minimal CSS output for production builds.
+        </p>
+      </section>
+
+      <section id="benchmarks">
+        <h2 class="docs-h2">Benchmarks</h2>
+        <p class="docs-p">
+          Performance benchmarks demonstrate that EaseMotion CSS animations
+          maintain 60fps on modern browsers. The framework's lightweight footprint
+          ensures fast load times even on mobile networks.
+        </p>
+        <p class="docs-p">
+          Benchmark results are available in the <code>benchmarks/</code> directory
+          and can be run locally using the provided test scripts.
+        </p>
+      </section>
+
+      <section id="contribute">
+        <h2 class="docs-h2">How to Contribute</h2>
+        <p class="docs-p">
+          Contributions are welcome via the <code>submissions/</code> directory.
+          Each submission must be self-contained with a demo, CSS, and README.
+          The maintainer reviews and integrates submissions into the core framework.
+        </p>
+        <p class="docs-p">
+          See the CONTRIBUTING.md file for detailed guidelines on submission
+          tracks, naming conventions, and PR requirements.
+        </p>
+      </section>
+
+      <section id="naming">
+        <h2 class="docs-h2">Naming Rules</h2>
+        <p class="docs-p">
+          Contributors can use any class names in their submissions. The maintainer
+          standardizes all names to follow the <code>ease-kebab-case</code>
+          convention before integrating into the core framework.
+        </p>
+        <p class="docs-p">
+          This ensures consistent API design across the entire framework while
+          allowing contributors to focus on functionality rather than naming.
+        </p>
+      </section>
+
+      <div class="docs-footer">
+        <p>End of documentation. Scroll back up to verify the sticky sidebar behavior.</p>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    // Active link tracking on scroll
+    const sections = document.querySelectorAll('section[id]');
+    const navLinks = document.querySelectorAll('.sidebar-nav a');
+
+    function updateActiveLink() {
+      let current = '';
+      sections.forEach(section => {
+        const sectionTop = section.offsetTop - 120;
+        if (window.scrollY >= sectionTop) {
+          current = section.getAttribute('id');
+        }
+      });
+      navLinks.forEach(link => {
+        link.classList.remove('active');
+        if (link.getAttribute('href') === '#' + current) {
+          link.classList.add('active');
+        }
+      });
+    }
+
+    window.addEventListener('scroll', updateActiveLink, { passive: true });
+    updateActiveLink();
+  </script>
+
+</body>
+</html>

--- a/submissions/docs/sticky-sidebar-eranmol/style.css
+++ b/submissions/docs/sticky-sidebar-eranmol/style.css
@@ -1,0 +1,252 @@
+:root {
+  --bg-primary: #0f172a;
+  --bg-surface: rgba(30, 41, 59, 0.7);
+  --sidebar-bg: rgba(15, 23, 42, 0.95);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --color-primary: #6366f1;
+  --color-text: #f1f5f9;
+  --color-text-muted: #94a3b8;
+  --sidebar-w: 260px;
+  --header-h: 60px;
+  --font-sans: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'Cascadia Code', 'Fira Code', monospace;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  line-height: 1.7;
+}
+
+/* ── Header ─────────────────────────────────────── */
+.docs-header {
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  height: var(--header-h);
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.docs-header-inner {
+  max-width: 100%;
+  height: 100%;
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.docs-logo {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--color-text);
+  text-decoration: none;
+  letter-spacing: -0.03em;
+}
+
+.docs-header-tag {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 6px;
+  background: rgba(99, 102, 241, 0.2);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+/* ── Shell (flex layout) ────────────────────────── */
+.docs-shell {
+  display: flex;
+  min-height: calc(100vh - var(--header-h));
+}
+
+/* ── Sidebar (STICKY — the fix) ─────────────────── */
+.docs-sidebar {
+  position: sticky;
+  top: var(--header-h);
+  width: var(--sidebar-w);
+  height: calc(100vh - var(--header-h));
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 2rem 1rem;
+  border-right: 1px solid var(--border-color);
+  background: var(--sidebar-bg);
+  z-index: 100;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-color) transparent;
+}
+
+.docs-sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.docs-sidebar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 4px;
+}
+
+.sidebar-group {
+  margin-bottom: 1.5rem;
+}
+
+.sidebar-group-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(99, 102, 241, 0.8);
+  margin-bottom: 6px;
+  padding: 0 0.5rem;
+}
+
+.sidebar-nav {
+  list-style: none;
+}
+
+.sidebar-nav a {
+  display: block;
+  padding: 6px 10px;
+  font-size: 0.84rem;
+  color: var(--color-text-muted);
+  border-radius: 6px;
+  border-left: 2px solid transparent;
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+.sidebar-nav a:hover {
+  background: rgba(99, 102, 241, 0.08);
+  border-left-color: rgba(99, 102, 241, 0.4);
+  color: rgba(255, 255, 255, 0.9);
+  padding-left: 14px;
+}
+
+.sidebar-nav a.active {
+  background: linear-gradient(90deg, rgba(99, 102, 241, 0.15), rgba(99, 102, 241, 0.05));
+  border-left: 2px solid var(--color-primary);
+  color: #ffffff;
+  padding-left: 14px;
+}
+
+/* ── Main Content ───────────────────────────────── */
+.docs-content {
+  flex: 1;
+  padding: 3rem 4rem 4rem 3.5rem;
+  max-width: 820px;
+}
+
+.docs-h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  letter-spacing: -0.05em;
+  line-height: 1.1;
+  margin-bottom: 1.25rem;
+}
+
+.docs-h2 {
+  font-size: 1.5rem;
+  letter-spacing: -0.025em;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.docs-h3 {
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.75rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.docs-p {
+  font-size: 0.9625rem;
+  line-height: 1.8;
+  color: var(--color-text-muted);
+  margin-bottom: 1rem;
+}
+
+.docs-p code {
+  background: rgba(99, 102, 241, 0.12);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  color: #a5b4fc;
+}
+
+.docs-code {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+}
+
+.docs-code code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  color: #c4b5fd;
+  background: none;
+  padding: 0;
+}
+
+.docs-footer {
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border-color);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+/* ── Responsive ─────────────────────────────────── */
+@media (max-width: 900px) {
+  .docs-sidebar {
+    width: 220px;
+  }
+
+  .docs-content {
+    padding: 2rem 2rem 3rem 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-shell {
+    flex-direction: column;
+  }
+
+  .docs-sidebar {
+    position: relative;
+    top: 0;
+    width: 100%;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+    max-height: 200px;
+  }
+
+  .docs-content {
+    padding: 1.5rem 1rem 2rem 1rem;
+  }
+}
+
+/* ── Reduced Motion ─────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-nav a {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Demonstrates the fix for the documentation sidebar using `position: sticky` as requested in issue #47378.

## Type of Change

- [x] Documentation improvement

## Submission Checklist

- [x] All changes are inside `submissions/docs/sticky-sidebar-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — CSS with `position: sticky` sidebar fix
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**

Changes the documentation sidebar from `position: fixed` to `position: sticky`, keeping it visible during scroll while maintaining proper document flow.

**How does a developer use it?**

```css
.docs-sidebar {
  position: sticky;
  top: 60px;
  width: 260px;
  height: calc(100vh - 60px);
  overflow-y: auto;
  flex-shrink: 0;
}