### PR TITLE
feat: add creative blur-entrance popover component #46477

### DIFF
--- a/submissions/examples/blur-entrance-popover-ps/README.md
+++ b/submissions/examples/blur-entrance-popover-ps/README.md
@@ -1,0 +1,14 @@
+# Creative Blur-Entrance Popover (#46477)
+
+An elegant architectural-themed dialogue layout popover that smoothly resolves element visibility by transforming blurred pixel matrices back into pristine grid focus metrics.
+
+### How to use
+Anchor the structural modal block inside your main view templates:
+
+```html
+<div id="manifesto-popover" class="popover-viewport-backdrop">
+    <a href="#" class="popover-outside-dismiss"></a>
+    <article class="blur-entrance-card">
+        <!-- Content components -->
+    </article>
+</div>

--- a/submissions/examples/blur-entrance-popover-ps/demo.html
+++ b/submissions/examples/blur-entrance-popover-ps/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Creative Blur-Entrance Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="portfolio-dark-theme">
+    <main class="portfolio-grid-layout">
+        <!-- Minimalist Exhibition Header -->
+        <header class="portfolio-hero">
+            <span class="meta-label">Exhibition Vol. IV</span>
+            <h1 class="project-heading">Tactile Brutalism</h1>
+            <p class="project-subtext">A structural retrospective of monolithic raw architectural casting forms.</p>
+            
+            <!-- Target-linked button to reveal the blur entrance modal -->
+            <a href="#manifesto-popover" class="editorial-trigger-btn">Read Manifesto</a>
+        </header>
+    </main>
+
+    <!-- Pure CSS Blur Entrance Popover Element -->
+    <div id="manifesto-popover" class="popover-viewport-backdrop">
+        <!-- Anchor click area to automatically dismiss target status -->
+        <a href="#" class="popover-outside-dismiss" aria-label="Close dialog overlay"></a>
+        
+        <article class="blur-entrance-card">
+            <a href="#" class="editorial-close-btn" aria-label="Close dialogue grid">&times;</a>
+            
+            <header class="card-title-block">
+                <h3>Core Principles</h3>
+                <span class="index-num">01 // BOLD</span>
+            </header>
+
+            <div class="card-narrative">
+                <p>
+                    This interaction technique uses high-performance transition filters to smoothly interpolate focus clarity, shifting from an un-rasterized mist layer directly into crisp structural layouts.
+                </p>
+                <blockquote class="manifesto-quote">
+                    "Raw concrete reveals structural honesty under dynamic light."
+                </blockquote>
+            </div>
+
+            <footer class="card-footer-specs">
+                <span>Format: Hardcover</span>
+                <span>Pages: 312</span>
+            </footer>
+        </article>
+    </div>
+</body>
+</html>

--- a/submissions/examples/blur-entrance-popover-ps/style.css
+++ b/submissions/examples/blur-entrance-popover-ps/style.css
@@ -1,0 +1,196 @@
+/* CSS Document - Creative Blur-Entrance Popover (#46477) */
+
+:root {
+    --bg-editorial: #080808;
+    --card-surface: #121212;
+    --border-editorial: #222222;
+    --accent-red: #da373d;
+    --text-dim: #7f7f7f;
+    
+    /* Configurable Popover Custom Parameters */
+    --ease-blur-start: 24px;
+    --ease-scale-start: 1.12;
+    --ease-duration: 0.55s;
+    --ease-bezier-curve: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+body.portfolio-dark-theme {
+    background-color: var(--bg-editorial);
+    color: #ffffff;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.portfolio-grid-layout {
+    width: 90%;
+    max-width: 520px;
+    padding: 24px;
+    box-sizing: border-box;
+}
+
+.portfolio-hero {
+    border-left: 2px solid var(--border-editorial);
+    padding-left: 28px;
+}
+
+.meta-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    color: var(--accent-red);
+}
+
+.project-heading {
+    font-size: 2.6rem;
+    font-weight: 800;
+    letter-spacing: -1px;
+    margin: 12px 0;
+}
+
+.project-subtext {
+    font-size: 0.9rem;
+    color: var(--text-dim);
+    line-height: 1.6;
+    margin: 0 0 28px 0;
+}
+
+.editorial-trigger-btn {
+    color: #ffffff;
+    text-decoration: none;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border-bottom: 2px solid #ffffff;
+    padding-bottom: 4px;
+    transition: color 0.25s ease, border-color 0.25s ease;
+}
+
+.editorial-trigger-btn:hover {
+    color: var(--text-dim);
+    border-color: var(--border-editorial);
+}
+
+/* --- THE BLUR-ENTRANCE POPOVER LOGIC --- */
+
+.popover-viewport-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(4, 4, 4, 0.7);
+    opacity: 0;
+    pointer-events: none;
+    z-index: 500;
+    display: grid;
+    place-items: center;
+    transition: opacity var(--ease-duration) ease;
+}
+
+.popover-outside-dismiss {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    cursor: default;
+}
+
+/* Blur-Entrance Card Container */
+.blur-entrance-card {
+    background-color: var(--card-surface);
+    border: 1px solid var(--border-editorial);
+    padding: 40px;
+    width: 88%;
+    max-width: 420px;
+    position: relative;
+    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.7);
+    box-sizing: border-box;
+    
+    /* Configured start parameters for mist element reveal */
+    filter: blur(var(--ease-blur-start));
+    transform: scale(var(--ease-scale-start));
+    
+    /* Dual property tracking on accelerated channels */
+    transition: transform var(--ease-duration) var(--ease-bezier-curve),
+                filter var(--ease-duration) var(--ease-bezier-curve);
+}
+
+.editorial-close-btn {
+    position: absolute;
+    top: 20px;
+    right: 24px;
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 1.6rem;
+    line-height: 1;
+    transition: color 0.2s ease;
+}
+
+.editorial-close-btn:hover {
+    color: #ffffff;
+}
+
+.card-title-block {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    border-bottom: 1px solid var(--border-editorial);
+    padding-bottom: 16px;
+    margin-bottom: 24px;
+}
+
+.card-title-block h3 {
+    margin: 0;
+    font-size: 1.3rem;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+}
+
+.index-num {
+    font-size: 0.7rem;
+    font-family: monospace;
+    color: var(--text-dim);
+}
+
+.card-narrative p {
+    font-size: 0.88rem;
+    line-height: 1.6;
+    color: #d1d5db;
+    margin: 0 0 20px 0;
+}
+
+.manifesto-quote {
+    margin: 0;
+    padding-left: 16px;
+    border-left: 2px solid var(--accent-red);
+    font-style: italic;
+    font-size: 0.85rem;
+    color: var(--text-dim);
+}
+
+.card-footer-specs {
+    margin-top: 32px;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: var(--text-dim);
+    font-family: monospace;
+}
+
+/* INTERACTIVE TARGET ACTIVATION STATES */
+
+.popover-viewport-backdrop:target {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* Clears filter blur matrix and scales component smoothly into focus */
+.popover-viewport-backdrop:target .blur-entrance-card {
+    filter: blur(0px);
+    transform: scale(1);
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the `blur-entrance-popover` interaction layout. Built specifically for high-end creative portfolio systems, editorial design grids, and typography-focused digital products, it utilizes standard CSS `:target` mechanics to lift an element from an un-rasterized blur state directly into crisp focus.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw, non-templated CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An editorial blur-entrance canvas overlay component utilizing customizable CSS key filters and target pseudo-classes.

**How does a developer use it?**

```html
<div id="manifesto-popover" class="popover-viewport-backdrop">
  <article class="blur-entrance-card">...</article>
</div>