### PR TITLE
feat: implement useViewTransition hook — fixes #48638

### DIFF
--- a/submissions/react/ease-view-transition-eranmol/README.md
+++ b/submissions/react/ease-view-transition-eranmol/README.md
@@ -1,0 +1,71 @@
+# useViewTransition
+
+A lightweight React hook that wraps the native View Transitions API (`document.startViewTransition`) to enable smooth page-to-page morphing without external routing animation libraries. Falls back gracefully when the browser lacks support.
+
+## Props / Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `duration` | number (ms) | `300` | Transition duration injected into CSS custom property `--vt-duration` |
+| `easing` | string | `'ease'` | CSS timing function injected into `--vt-easing` |
+| `onReady` | function | — | Callback fired after the transition pseudo-element is created |
+
+## Return Values
+
+| Value | Type | Description |
+|---|---|---|
+| `startTransition(updateFn)` | function | Wraps any state update in `document.startViewTransition`. Falls back to a plain `updateFn()` call if unsupported. |
+| `supported` | boolean | Whether the current browser supports `document.startViewTransition`. |
+
+## Usage Example
+
+```jsx
+import { useState } from 'react';
+import { useViewTransition } from './useViewTransition';
+import './style.css';
+
+const items = [
+  { id: 1, title: 'Apple',   detail: 'A crisp red apple' },
+  { id: 2, title: 'Banana',  detail: 'A ripe yellow banana' },
+  { id: 3, title: 'Cherry',  detail: 'A sweet dark cherry' },
+];
+
+function App() {
+  const [selected, setSelected] = useState(null);
+  const { startTransition } = useViewTransition({ duration: 300, easing: 'ease' });
+
+  const selectItem = (item) => {
+    startTransition(() => setSelected(item));
+  };
+
+  return (
+    <div>
+      {!selected ? (
+        <ul>
+          {items.map(item => (
+            <li key={item.id} onClick={() => selectItem(item)}
+                style={{ viewTransitionName: 'morph' }}>
+              {item.title}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div style={{ viewTransitionName: 'morph' }}
+             onClick={() => startTransition(() => setSelected(null))}>
+          <h2>{selected.title}</h2>
+          <p>{selected.detail}</p>
+          <button>← Back</button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## CSS Companion
+
+The accompanying `style.css` defines three named view-transition classes you can use via `style={{ viewTransitionName: 'morph' }}` (or `'slide'` or `'fade'`). Durations and easings are driven by the `--vt-duration` and `--vt-easing` CSS custom properties set automatically by the hook.
+
+## Why is it useful?
+
+Smoothly transitioning between views in React normally requires heavy routing-animation libraries. This hook taps into the browser-native View Transitions API, giving you a single function call to trigger a morph/crossfade between any two DOM states — zero dependencies, respects `prefers-reduced-motion`, and degrades gracefully on unsupported browsers.

--- a/submissions/react/ease-view-transition-eranmol/demo.html
+++ b/submissions/react/ease-view-transition-eranmol/demo.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>useViewTransition Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .app { max-width: 480px; width: 100%; }
+    h1 { font-size: 1.4rem; margin-bottom: 1rem; text-align: center; }
+    .list { list-style: none; display: flex; flex-direction: column; gap: .75rem; }
+    .list li {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      cursor: pointer;
+      transition: background .2s;
+    }
+    .list li:hover { background: #334155; }
+    .detail {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 8px;
+      padding: 1.5rem;
+      cursor: pointer;
+    }
+    .detail h2 { font-size: 1.3rem; margin-bottom: .5rem; }
+    .detail p  { color: #94a3b8; margin-bottom: 1rem; }
+    .detail button {
+      background: #38bdf8;
+      color: #0f172a;
+      border: none;
+      border-radius: 6px;
+      padding: .5rem 1rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .badge {
+      display: inline-block;
+      background: #38bdf8;
+      color: #0f172a;
+      font-size: .7rem;
+      font-weight: 700;
+      padding: .15em .5em;
+      border-radius: 4px;
+      margin-left: .5rem;
+      vertical-align: middle;
+    }
+    .unsupported {
+      background: #7f1d1d;
+      color: #fca5a5;
+      padding: 1rem;
+      border-radius: 8px;
+      text-align: center;
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="app" id="root"></div>
+
+  <script type="module">
+    // ── Inline hook (same logic as useViewTransition.jsx) ────────
+    function useViewTransition({ duration = 300, easing = 'ease', onReady } = {}) {
+      const supported = typeof document !== 'undefined'
+        && typeof document.startViewTransition === 'function';
+
+      const startTransition = (updateFn) => {
+        if (typeof updateFn !== 'function') return;
+        if (!supported) { updateFn(); return; }
+
+        const transition = document.startViewTransition(() => {
+          updateFn();
+          if (onReady) onReady();
+        });
+
+        transition.ready.then(() => {
+          document.documentElement.style.setProperty('--vt-duration', duration + 'ms');
+          document.documentElement.style.setProperty('--vt-easing', easing);
+        });
+      };
+
+      return { startTransition, supported };
+    }
+
+    // ── Data ─────────────────────────────────────────────────────
+    const items = [
+      { id: 1, title: 'Apple',  emoji: '🍎', detail: 'A crisp red apple — perfect for snacking or baking into pies.' },
+      { id: 2, title: 'Banana', emoji: '🍌', detail: 'A ripe yellow banana — nature\'s energy bar, rich in potassium.' },
+      { id: 3, title: 'Cherry', emoji: '🍒', detail: 'A sweet dark cherry — ideal for desserts or enjoying fresh.' },
+      { id: 4, title: 'Grape',  emoji: '🍇', detail: 'A juicy purple grape — great in fruit salads or as wine.' },
+    ];
+
+    // ── State ────────────────────────────────────────────────────
+    let selected = null;
+    const { startTransition, supported } = useViewTransition({ duration: 300 });
+
+    // ── Render ───────────────────────────────────────────────────
+    const root = document.getElementById('root');
+
+    function render() {
+      root.innerHTML = '';
+
+      if (!supported) {
+        const warn = document.createElement('div');
+        warn.className = 'unsupported';
+        warn.textContent = 'Your browser does not support View Transitions. The demo will run without the morph effect.';
+        root.appendChild(warn);
+      }
+
+      const h1 = document.createElement('h1');
+      h1.innerHTML = 'useViewTransition Demo <span class="badge">React Hook</span>';
+      root.appendChild(h1);
+
+      if (!selected) {
+        const ul = document.createElement('ul');
+        ul.className = 'list';
+        items.forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = item.emoji + '  ' + item.title;
+          li.style.viewTransitionName = 'morph';
+          li.addEventListener('click', () => {
+            startTransition(() => { selected = item; render(); });
+          });
+          ul.appendChild(li);
+        });
+        root.appendChild(ul);
+      } else {
+        const div = document.createElement('div');
+        div.className = 'detail';
+        div.style.viewTransitionName = 'morph';
+        div.innerHTML = `
+          <h2>${selected.emoji}  ${selected.title}</h2>
+          <p>${selected.detail}</p>
+          <button>← Back to list</button>
+        `;
+        div.querySelector('button').addEventListener('click', () => {
+          startTransition(() => { selected = null; render(); });
+        });
+        root.appendChild(div);
+      }
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/submissions/react/ease-view-transition-eranmol/style.css
+++ b/submissions/react/ease-view-transition-eranmol/style.css
@@ -1,0 +1,108 @@
+/* ── View Transition pseudo-elements ─────────────────── */
+
+:root {
+  --vt-duration: 300ms;
+  --vt-easing: ease;
+}
+
+/* Cross-fade the entire document by default */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: var(--vt-duration);
+  animation-timing-function: var(--vt-easing);
+}
+
+/* Named transition: "morph" — morph old → new via scale + fade */
+::view-transition-old(morph) {
+  animation: vt-morph-out var(--vt-duration) var(--vt-easing) forwards;
+}
+
+::view-transition-new(morph) {
+  animation: vt-morph-in var(--vt-duration) var(--vt-easing) forwards;
+}
+
+@keyframes vt-morph-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+}
+
+@keyframes vt-morph-in {
+  from {
+    opacity: 0;
+    transform: scale(1.08);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Named transition: "slide" — slide old out, slide new in */
+::view-transition-old(slide) {
+  animation: vt-slide-out var(--vt-duration) var(--vt-easing) forwards;
+}
+
+::view-transition-new(slide) {
+  animation: vt-slide-in var(--vt-duration) var(--vt-easing) forwards;
+}
+
+@keyframes vt-slide-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+}
+
+@keyframes vt-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Named transition: "fade" — pure crossfade */
+::view-transition-old(fade) {
+  animation: vt-fade-out var(--vt-duration) var(--vt-easing) forwards;
+}
+
+::view-transition-new(fade) {
+  animation: vt-fade-in var(--vt-duration) var(--vt-easing) forwards;
+}
+
+@keyframes vt-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+@keyframes vt-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root),
+  ::view-transition-old(morph),
+  ::view-transition-new(morph),
+  ::view-transition-old(slide),
+  ::view-transition-new(slide),
+  ::view-transition-old(fade),
+  ::view-transition-new(fade) {
+    animation-duration: 0ms !important;
+  }
+}

--- a/submissions/react/ease-view-transition-eranmol/useViewTransition.jsx
+++ b/submissions/react/ease-view-transition-eranmol/useViewTransition.jsx
@@ -1,0 +1,55 @@
+import { useCallback } from 'react';
+
+/**
+ * useViewTransition
+ *
+ * Wraps any state update in the native View Transitions API
+ * (document.startViewTransition) so the browser can morph between
+ * old and new DOM snapshots with a smooth crossfade / morph animation.
+ *
+ * Falls back to a plain state update when the browser lacks support.
+ *
+ * @param {object}   opts
+ * @param {number}   [opts.duration=300]  – CSS transition duration in ms applied via custom properties
+ * @param {string}   [opts.easing='ease'] – CSS timing function
+ * @param {Function} [opts.onReady]       – called after the transition pseudo-element is created
+ * @returns {{ startTransition: (cb: () => void) => void, supported: boolean }}
+ */
+export function useViewTransition({
+  duration = 300,
+  easing = 'ease',
+  onReady,
+} = {}) {
+  const supported =
+    typeof document !== 'undefined' &&
+    typeof document.startViewTransition === 'function';
+
+  const startTransition = useCallback(
+    (updateFn) => {
+      if (typeof updateFn !== 'function') return;
+
+      if (!supported) {
+        updateFn();
+        return;
+      }
+
+      const transition = document.startViewTransition(() => {
+        updateFn();
+        onReady?.();
+      });
+
+      transition.ready.then(() => {
+        // Expose duration / easing via CSS custom properties so the
+        // companion style.css can drive the ::view-transition pseudo-elements.
+        document.documentElement.style.setProperty(
+          '--vt-duration',
+          `${duration}ms`
+        );
+        document.documentElement.style.setProperty('--vt-easing', easing);
+      });
+    },
+    [supported, duration, easing, onReady]
+  );
+
+  return { startTransition, supported };
+}


### PR DESCRIPTION
## Type of Change
- [x] New feature (React component)

## Submission Checklist
- [x] Files only in `submissions/react/ease-view-transition-eranmol/`
- [x] `useViewTransition.jsx`, `style.css`, `README.md`, `demo.html` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
A lightweight React hook that wraps the native `document.startViewTransition()` API, enabling smooth page-to-page morphing between DOM states. Injects EaseMotion CSS timing variables (`--vt-duration`, `--vt-easing`) to drive `::view-transition-old/new` pseudo-elements. Falls back to plain state updates on unsupported browsers.

## Demo
Open `demo.html` in Chrome 111+ — click a fruit to see the list morph into a detail view; click "Back" to morph back.

## Browser Testing
Chrome 111+, Edge 111+ (View Transitions supported). Graceful fallback on Firefox/Safari.

## Notes for Maintainer
Three named transition variants are defined in `style.css`: `morph` (scale+fade), `slide` (horizontal slide), and `fade` (pure crossfade). Apply via `style={{ viewTransitionName: 'morph' }}` on any element.