### PR TITLE
feat: add ease-ripple-effect-button component — fixes #48117

### DIFF
--- a/submissions/examples/ease-ripple-effect-button-eranmol/README.md
+++ b/submissions/examples/ease-ripple-effect-button-eranmol/README.md
@@ -1,0 +1,47 @@
+# ease-ripple-effect-button
+
+A material-style ripple animation button component for EaseMotion CSS.
+
+## What does it do?
+
+Adds a radial ripple effect that expands outward from the exact click point on any button, providing tactile visual feedback inspired by Material Design.
+
+## How is it used?
+
+Add the base class `ripple-btn` plus a variant class to any `<button>` element, then attach the small JS snippet to inject the `.ripple-wave` span on click:
+
+```html
+<button class="ripple-btn ripple-primary">Click me</button>
+
+<script>
+document.querySelectorAll('.ripple-btn').forEach(btn => {
+  btn.addEventListener('click', function (e) {
+    const rect = this.getBoundingClientRect();
+    const ripple = document.createElement('span');
+    ripple.className = 'ripple-wave';
+    ripple.style.left = (e.clientX - rect.left) + 'px';
+    ripple.style.top  = (e.clientY - rect.top)  + 'px';
+    this.appendChild(ripple);
+    ripple.addEventListener('animationend', () => ripple.remove());
+  });
+});
+</script>
+```
+
+### Available variants
+
+| Class | Description |
+|---|---|
+| `ripple-primary` | Solid blue |
+| `ripple-success` | Solid green |
+| `ripple-danger` | Solid red |
+| `ripple-dark` | Dark surface |
+| `ripple-outline-primary` | Outlined blue |
+| `ripple-outline-success` | Outlined green |
+| `ripple-outline-danger` | Outlined red |
+| `ripple-sm` | Small size |
+| `ripple-lg` | Large size |
+
+## Why is it useful?
+
+Ripple feedback gives users an immediate, physical sense that their input was registered — a proven UX pattern. This component is lightweight (zero dependencies, ~30 lines of CSS + JS), drops into any existing button markup, and respects `prefers-reduced-motion` by disabling the animation for users who request it.

--- a/submissions/examples/ease-ripple-effect-button-eranmol/demo.html
+++ b/submissions/examples/ease-ripple-effect-button-eranmol/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-ripple-effect-button Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1>ease-ripple-effect-button</h1>
+    <p class="subtitle">Click any button to see the ripple animation expand from the click point</p>
+
+    <section class="button-group">
+      <h2>Solid Variants</h2>
+      <div class="row">
+        <button class="ripple-btn ripple-primary">Primary</button>
+        <button class="ripple-btn ripple-success">Success</button>
+        <button class="ripple-btn ripple-danger">Danger</button>
+        <button class="ripple-btn ripple-dark">Dark</button>
+      </div>
+    </section>
+
+    <section class="button-group">
+      <h2>Outline Variants</h2>
+      <div class="row">
+        <button class="ripple-btn ripple-outline-primary">Primary</button>
+        <button class="ripple-btn ripple-outline-success">Success</button>
+        <button class="ripple-btn ripple-outline-danger">Danger</button>
+      </div>
+    </section>
+
+    <section class="button-group">
+      <h2>Sizes</h2>
+      <div class="row">
+        <button class="ripple-btn ripple-primary ripple-sm">Small</button>
+        <button class="ripple-btn ripple-primary">Medium</button>
+        <button class="ripple-btn ripple-primary ripple-lg">Large</button>
+      </div>
+    </section>
+
+    <section class="button-group">
+      <h2>With Icon</h2>
+      <div class="row">
+        <button class="ripple-btn ripple-primary">
+          <span class="btn-icon">&#9654;</span> Play
+        </button>
+        <button class="ripple-btn ripple-success">
+          <span class="btn-icon">&#10003;</span> Confirm
+        </button>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    document.querySelectorAll('.ripple-btn').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        const rect = this.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+
+        const ripple = document.createElement('span');
+        ripple.className = 'ripple-wave';
+        ripple.style.left = x + 'px';
+        ripple.style.top = y + 'px';
+        this.appendChild(ripple);
+
+        ripple.addEventListener('animationend', () => ripple.remove());
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-ripple-effect-button-eranmol/style.css
+++ b/submissions/examples/ease-ripple-effect-button-eranmol/style.css
@@ -1,0 +1,200 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.demo-container {
+  max-width: 640px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.6rem;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  font-size: 0.9rem;
+}
+
+.button-group {
+  margin-bottom: 1.5rem;
+}
+
+.button-group h2 {
+  font-size: 0.85rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+/* ── Base Button ─────────────────────────────────── */
+
+.ripple-btn {
+  position: relative;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.6em 1.4em;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+  outline: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.ripple-btn:focus-visible {
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.4);
+}
+
+/* ── Solid Variants ──────────────────────────────── */
+
+.ripple-primary {
+  background: #3b82f6;
+  color: #fff;
+}
+.ripple-primary:hover { background: #2563eb; }
+.ripple-primary:active { background: #1d4ed8; }
+
+.ripple-success {
+  background: #22c55e;
+  color: #fff;
+}
+.ripple-success:hover { background: #16a34a; }
+.ripple-success:active { background: #15803d; }
+
+.ripple-danger {
+  background: #ef4444;
+  color: #fff;
+}
+.ripple-danger:hover { background: #dc2626; }
+.ripple-danger:active { background: #b91c1c; }
+
+.ripple-dark {
+  background: #1e293b;
+  color: #e2e8f0;
+  border-color: #334155;
+}
+.ripple-dark:hover { background: #334155; }
+.ripple-dark:active { background: #475569; }
+
+/* ── Outline Variants ────────────────────────────── */
+
+.ripple-outline-primary {
+  background: transparent;
+  color: #3b82f6;
+  border-color: #3b82f6;
+}
+.ripple-outline-primary:hover {
+  background: rgba(59, 130, 246, 0.1);
+}
+.ripple-outline-primary:active {
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.ripple-outline-success {
+  background: transparent;
+  color: #22c55e;
+  border-color: #22c55e;
+}
+.ripple-outline-success:hover {
+  background: rgba(34, 197, 94, 0.1);
+}
+.ripple-outline-success:active {
+  background: rgba(34, 197, 94, 0.2);
+}
+
+.ripple-outline-danger {
+  background: transparent;
+  color: #ef4444;
+  border-color: #ef4444;
+}
+.ripple-outline-danger:hover {
+  background: rgba(239, 68, 68, 0.1);
+}
+.ripple-outline-danger:active {
+  background: rgba(239, 68, 68, 0.2);
+}
+
+/* ── Sizes ───────────────────────────────────────── */
+
+.ripple-sm {
+  padding: 0.4em 1em;
+  font-size: 0.8rem;
+}
+
+.ripple-lg {
+  padding: 0.8em 2em;
+  font-size: 1.1rem;
+}
+
+/* ── Icon ────────────────────────────────────────── */
+
+.btn-icon {
+  font-size: 0.9em;
+}
+
+/* ── Ripple Wave Animation ───────────────────────── */
+
+.ripple-wave {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+  width: 0;
+  height: 0;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  animation: ripple-expand 0.55s ease-out forwards;
+}
+
+@keyframes ripple-expand {
+  0% {
+    width: 0;
+    height: 0;
+    opacity: 0.55;
+  }
+  100% {
+    width: 400px;
+    height: 400px;
+    opacity: 0;
+  }
+}
+
+/* ── Reduced Motion ──────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple-wave {
+    animation-duration: 0ms;
+  }
+  .ripple-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Type of Change
- [x] New component

## Submission Checklist
- [x] Files only in `submissions/examples/ease-ripple-effect-button-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
A material-style ripple animation button. Clicking any button spawns a radial wave that expands outward from the exact click point, providing tactile visual feedback. Includes solid, outline, and size variants; respects `prefers-reduced-motion`.

## Demo
Open `demo.html` in a browser — click any button to see the ripple expand from your click position.

## Browser Testing
Tested on Chrome, Firefox, Safari.

## Notes for Maintainer
Ripple wave is injected via a small JS snippet on click. The CSS animation auto-removes the span after it finishes. All variants and the reduced-motion guard are defined in `style.css`.