### PR TITLE
docs: sync CONTRIBUTING.md with docs site — fixes #47443

### DIFF
--- a/submissions/docs/contributing-sync-eranmol/README.md
+++ b/submissions/docs/contributing-sync-eranmol/README.md
@@ -1,0 +1,25 @@
+# CONTRIBUTING.md Sync Fix — Issue #47443
+
+## What does this do?
+
+Documents and resolves two discrepancies between `CONTRIBUTING.md` and the live docs site that mislead new contributors.
+
+## Discrepancies
+
+| Rule | CONTRIBUTING.md (old) | Docs site (correct) |
+|---|---|---|
+| Inactivity unassign period | 5 days | **24 hours (1 day)** |
+| Suffix naming convention | Not mentioned | **Required** (e.g. `ease-hover-sap`) |
+
+## How is it used?
+
+Apply the two diffs documented in `demo.html` to `CONTRIBUTING.md`:
+
+1. **Line ~233** — change "5 days" to "24 hours (1 day)"
+2. **After line ~126** — add the suffix naming examples and rationale
+
+No new files are needed; this is a text-only fix to an existing markdown file.
+
+## Why is it useful?
+
+Contributors read `CONTRIBUTING.md` first as instructed. Outdated rules cause confusion, wasted assignments, and folder naming conflicts that the bot then rejects. Syncing the two sources eliminates this friction.

--- a/submissions/docs/contributing-sync-eranmol/demo.html
+++ b/submissions/docs/contributing-sync-eranmol/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CONTRIBUTING.md Sync Fix — Issue #47443</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>CONTRIBUTING.md Sync Fix</h1>
+      <p class="subtitle">Issue #47443 — Align CONTRIBUTING.md with the live docs site</p>
+    </header>
+
+    <section class="card">
+      <h2>Discrepancies Found</h2>
+      <table>
+        <thead>
+          <tr><th>Rule</th><th>CONTRIBUTING.md (old)</th><th>Docs site / Fixed</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Inactivity period</td>
+            <td class="old">5 days</td>
+            <td class="new">24 hours (1 day)</td>
+          </tr>
+          <tr>
+            <td>Suffix naming convention</td>
+            <td class="old">Not mentioned</td>
+            <td class="new">Required (e.g. <code>ease-hover-sap</code>)</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>Required Changes to CONTRIBUTING.md</h2>
+
+      <div class="diff-block">
+        <h3>1. Inactivity Period (line ~233)</h3>
+        <pre><code>- If an assigned issue has **no progress for 5 days**, the maintainer will unassign it and open it for others.
++ If an assigned issue has **no progress for 24 hours (1 day)**, the maintainer will unassign it and open it for others.</code></pre>
+      </div>
+
+      <div class="diff-block">
+        <h3>2. Add Suffix Naming Rule (after line ~126)</h3>
+        <pre><code> To avoid naming conflicts and overlapping components, contributors must append a short unique identifier or abbreviation to their feature/component/mixin name.
+
++ **Example:**
++
++ - `ease-hover-sap`
++ - `ease-tabs-ak`
++ - `ease-card-pr`
++
++ This ensures:
++
++ - Unambiguous component naming,
++ - Preservation of every contributor's work,
++ - Conflict-free merges,
++ - Easier maintenance and review workflow,
++ - Support for parallel implementations of similar ideas.</code></pre>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Verification</h2>
+      <p>After applying these changes, both CONTRIBUTING.md and the live docs site (<code>https://saptarshi-coder.github.io/EaseMotion-css/index.html#how-to-contribute</code>) should state identical contributor rules.</p>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/docs/contributing-sync-eranmol/style.css
+++ b/submissions/docs/contributing-sync-eranmol/style.css
@@ -1,0 +1,113 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  line-height: 1.6;
+  padding: 2rem 1rem;
+}
+
+.container {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: 1.5rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.card h3 {
+  font-size: 0.95rem;
+  color: #94a3b8;
+  margin-bottom: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.card h3:first-child {
+  margin-top: 0;
+}
+
+/* ── Table ───────────────────────────────────────── */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid #334155;
+}
+
+th {
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.old {
+  color: #f87171;
+}
+
+.new {
+  color: #4ade80;
+}
+
+code {
+  background: #0f172a;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* ── Diff Block ──────────────────────────────────── */
+
+.diff-block {
+  margin-bottom: 1rem;
+}
+
+.diff-block pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.diff-block code {
+  background: none;
+  padding: 0;
+}


### PR DESCRIPTION
## Type of Change
- [x] Documentation fix

## Submission Checklist
- [x] Files only in `submissions/docs/contributing-sync-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
Documents and resolves two discrepancies between `CONTRIBUTING.md` and the live docs site:
1. Inactivity unassign period: was "5 days", should be "24 hours (1 day)"
2. Suffix naming convention: was not mentioned, now required (e.g. `ease-hover-sap`)

## Demo
Open `demo.html` to see the exact diffs required and a side-by-side comparison table.

## Browser Testing
N/A — documentation-only change.

## Notes for Maintainer
The actual fix requires two text edits to `CONTRIBUTING.md` (not included in this submission per contribution guidelines). The diffs are documented in `demo.html` for the maintainer to apply directly.