### PR TITLE
docs: fix inconsistent CDN paths in installation guide — fixes #47282

### DIFF
--- a/submissions/docs/cdn-path-fix-eranmol/README.md
+++ b/submissions/docs/cdn-path-fix-eranmol/README.md
@@ -1,0 +1,16 @@
+# CDN Path Consistency Fix — Issue #47282
+
+## What does this do?
+
+Resolves the inconsistent CDN paths shown in `docs/index.html` (lines 324–338) where two different URL patterns (GitHub-based and npm-based) are presented as equivalent, potentially causing version confusion.
+
+## How is it used?
+
+Apply the two diffs documented in `demo.html` to `docs/index.html`:
+
+1. **Lines 324–326** — Change the "recommended" CDN URL from the GitHub-based path to the npm-based path (`cdn.jsdelivr.net/npm/easemotion-css@latest/easemotion.min.css`)
+2. **Lines 331–338** — Reorder alternatives: npm is recommended, GitHub Raw is an alternative, unpkg is an alternative. Remove the raw.githubusercontent.com link (redundant with the jsDelivr GitHub path).
+
+## Why is it useful?
+
+A single recommended CDN path eliminates confusion. Users won't accidentally mix GitHub-pinned and npm-latest versions in their projects. The npm path is the most reliable for production because it always resolves to the latest published package.

--- a/submissions/docs/cdn-path-fix-eranmol/demo.html
+++ b/submissions/docs/cdn-path-fix-eranmol/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CDN Path Consistency Fix — Issue #47282</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>CDN Path Consistency Fix</h1>
+      <p class="subtitle">Issue #47282 — Unify CDN paths in docs/index.html</p>
+    </header>
+
+    <section class="card">
+      <h2>Problem</h2>
+      <p><code>docs/index.html</code> (lines 324–338) shows two different CDN URL patterns for the same file:</p>
+      <table>
+        <thead>
+          <tr><th>Line</th><th>Current Path</th><th>Source</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>325</td>
+            <td><code>cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css</code></td>
+            <td class="old">GitHub-based</td>
+          </tr>
+          <tr>
+            <td>332</td>
+            <td><code>cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css</code></td>
+            <td class="old">npm-based</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="note">These may resolve to different versions. Users following the "recommended" path get the GitHub version; those copying the "alternative" get the npm version.</p>
+    </section>
+
+    <section class="card">
+      <h2>Fix</h2>
+      <p>Standardize on the <strong>npm-based</strong> jsDelivr path as the single recommended CDN URL. It always resolves to the latest published npm package version and is the most reliable for production use.</p>
+
+      <div class="diff-block">
+        <h3>Replace the "Option 1" code block (lines 324–326)</h3>
+        <pre><code>- &lt;!-- CDN via jsDelivr (GitHub) — recommended, works everywhere --&gt;
+- &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" /&gt;
++ &lt;!-- CDN via jsDelivr (npm) — recommended, works everywhere --&gt;
++ &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css@latest/easemotion.min.css" /&gt;</code></pre>
+      </div>
+
+      <div class="diff-block">
+        <h3>Update the alternatives section (lines 331–338)</h3>
+        <pre><code> &lt;!-- Alternative CDN providers --&gt;
+
++&lt;!-- GitHub Raw ( pinned to main ) --&gt;
++&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" /&gt;
++
+ &lt;!-- unpkg --&gt;
+ &lt;link rel="stylesheet" href="https://unpkg.com/easemotion-css@latest/easemotion.min.css" /&gt;
+
+-&lt;!-- GitHub Raw CDN --&gt;
+-&lt;link rel="stylesheet" href="https://raw.githubusercontent.com/SAPTARSHI-coder/EaseMotion-css/main/easemotion.min.css" /&gt;</code></pre>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Result</h2>
+      <p>After the fix, the docs will show a single recommended path (<code>npm</code>) with two clear alternatives (GitHub pinned, unpkg). No conflicting "recommended" labels.</p>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/docs/cdn-path-fix-eranmol/style.css
+++ b/submissions/docs/cdn-path-fix-eranmol/style.css
@@ -1,0 +1,119 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  line-height: 1.6;
+  padding: 2rem 1rem;
+}
+
+.container {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: 1.5rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.card h3 {
+  font-size: 0.95rem;
+  color: #94a3b8;
+  margin-bottom: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.card h3:first-child {
+  margin-top: 0;
+}
+
+.note {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-top: 0.75rem;
+}
+
+/* ── Table ───────────────────────────────────────── */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid #334155;
+}
+
+th {
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.old {
+  color: #f87171;
+}
+
+.new {
+  color: #4ade80;
+}
+
+code {
+  background: #0f172a;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* ── Diff Block ──────────────────────────────────── */
+
+.diff-block {
+  margin-bottom: 1rem;
+}
+
+.diff-block pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.diff-block code {
+  background: none;
+  padding: 0;
+}


### PR DESCRIPTION
## Type of Change
- [x] Documentation fix

## Submission Checklist
- [x] Files only in `submissions/docs/cdn-path-fix-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
Resolves the inconsistent CDN paths in `docs/index.html` (lines 324–338) where a GitHub-based jsDelivr URL and an npm-based jsDelivr URL are both shown, potentially causing version confusion. Standardizes on the npm path as recommended, with GitHub Raw and unpkg as alternatives.

## Demo
Open `demo.html` to see the before/after diffs and the corrected URL hierarchy.

## Browser Testing
N/A — documentation-only change.

## Notes for Maintainer
The actual fix requires two edits to `docs/index.html` (not included per contribution guidelines). The diffs are documented in `demo.html` for the maintainer to apply.