### PR TITLE
feat: add prefers-reduced-motion support to all animations — fixes #47376

### DIFF
--- a/submissions/examples/reduced-motion-support-eranmol/README.md
+++ b/submissions/examples/reduced-motion-support-eranmol/README.md
@@ -1,0 +1,40 @@
+# prefers-reduced-motion Support — Issue #47376
+
+## What does it do?
+
+Adds a global `prefers-reduced-motion: reduce` media query that disables or simplifies all animations for users who have enabled the "Reduce Motion" accessibility setting in their operating system.
+
+## How is it used?
+
+Add this CSS block to your stylesheet:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+For components that rely on transforms for layout (not just decoration), add explicit overrides:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .scroll-box {
+    opacity: 1;
+    transform: none;
+  }
+}
+```
+
+## Why is it useful?
+
+- **Accessibility**: Respects WCAG 2.1 SCSS 2.3.3 (Animation from Interactions).
+- **Inclusive design**: Users with vestibular disorders or motion sensitivity get a usable experience.
+- **Legal compliance**: Many accessibility standards require reduced-motion support.
+- **Using `0.01ms`** instead of `none` ensures animations reach their final state instantly without breaking layout.

--- a/submissions/examples/reduced-motion-support-eranmol/demo.html
+++ b/submissions/examples/reduced-motion-support-eranmol/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>prefers-reduced-motion Support Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <header>
+      <h1>prefers-reduced-motion Support</h1>
+      <p class="subtitle">Issue #47376 — Accessibility enhancement for motion-sensitive users</p>
+      <p class="instruction">Enable "Reduce Motion" in your OS settings to see the effect:<br>
+        <strong>Windows:</strong> Settings → Accessibility → Visual effects → Animation effects<br>
+        <strong>macOS:</strong> System Preferences → Accessibility → Display → Reduce motion
+      </p>
+    </header>
+
+    <section class="card">
+      <h2>Animated Elements (with motion)</h2>
+      <div class="grid">
+        <div class="box pulse">Pulse</div>
+        <div class="box bounce">Bounce</div>
+        <div class="box spin">Spin</div>
+        <div class="box fade">Fade</div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Hover Interactions</h2>
+      <div class="grid">
+        <button class="btn hover-lift">Hover Lift</button>
+        <button class="btn hover-glow">Hover Glow</button>
+        <button class="btn hover-scale">Hover Scale</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Scroll-triggered Animation</h2>
+      <div class="scroll-box">
+        <p>This element animates when it enters the viewport.</p>
+      </div>
+    </section>
+
+    <section class="card code-card">
+      <h2>Implementation</h2>
+      <pre><code>/* Add to your CSS file */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}</code></pre>
+      <p class="note">Using <code>0.01ms</code> instead of <code>none</code> preserves the final state of animations while effectively disabling motion.</p>
+    </section>
+  </div>
+
+  <script>
+    // Simple scroll-triggered animation demo
+    const scrollBox = document.querySelector('.scroll-box');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+        }
+      });
+    }, { threshold: 0.5 });
+    observer.observe(scrollBox);
+  </script>
+</body>
+</html>

--- a/submissions/examples/reduced-motion-support-eranmol/style.css
+++ b/submissions/examples/reduced-motion-support-eranmol/style.css
@@ -1,0 +1,216 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  line-height: 1.6;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+header h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.instruction {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  text-align: left;
+}
+
+.card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  font-size: 1rem;
+  margin-bottom: 1rem;
+  color: #38bdf8;
+}
+
+.note {
+  font-size: 0.82rem;
+  color: #64748b;
+  margin-top: 0.75rem;
+}
+
+/* ── Grid ────────────────────────────────────────── */
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+/* ── Animated Boxes ──────────────────────────────── */
+
+.box {
+  width: 100px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.pulse {
+  background: #3b82f6;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.bounce {
+  background: #22c55e;
+  animation: bounce 1s ease-in-out infinite;
+}
+
+.spin {
+  background: #a855f7;
+  animation: spin 2s linear infinite;
+}
+
+.fade {
+  background: #f97316;
+  animation: fade 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.1); }
+}
+
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-15px); }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes fade {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}
+
+/* ── Buttons ─────────────────────────────────────── */
+
+.btn {
+  padding: 0.6em 1.4em;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 2px solid #334155;
+  border-radius: 8px;
+  background: #0f172a;
+  color: #e2e8f0;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.hover-lift:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.3);
+  background: #1e3a5f;
+}
+
+.hover-glow:hover {
+  box-shadow: 0 0 20px rgba(34, 197, 94, 0.5);
+  background: #14532d;
+}
+
+.hover-scale:hover {
+  transform: scale(1.08);
+  background: #581c87;
+}
+
+/* ── Scroll Box ──────────────────────────────────── */
+
+.scroll-box {
+  background: #0f172a;
+  border: 2px dashed #334155;
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.scroll-box.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ── Code Card ───────────────────────────────────── */
+
+.code-card pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.code-card code {
+  color: #4ade80;
+}
+
+/* ═══════════════════════════════════════════════════
+   REDUCED MOTION SUPPORT — Issue #47376
+   ═══════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .scroll-box {
+    opacity: 1;
+    transform: none;
+  }
+
+  .btn:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Type of Change
- [x] Enhancement (accessibility)

## Submission Checklist
- [x] Files only in `submissions/examples/reduced-motion-support-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
Adds a global `@media (prefers-reduced-motion: reduce)` rule that disables or simplifies all animations for users with the OS "Reduce Motion" setting enabled. Uses `0.01ms` instead of `none` to preserve final animation states. Includes demo with pulse, bounce, spin, fade animations, hover interactions, and scroll-triggered animation.

## Demo
Open `demo.html` — enable "Reduce Motion" in your OS accessibility settings to see all animations stop. Disable it to see them resume.

## Browser Testing
Tested on Chrome, Firefox, Safari (all support prefers-reduced-motion).

## Notes for Maintainer
The CSS block in `style.css` can be extracted and added to `core/animations.css` or a new `core/accessibility.css` file. The `0.01ms` pattern is recommended over `none` because it ensures animations reach their final state without breaking layout.