### PR TITLE
fix: theme toggle moon icon visibility in light mode — fixes #47290

### DIFF
--- a/submissions/docs/theme-toggle-fix-eranmol/README.md
+++ b/submissions/docs/theme-toggle-fix-eranmol/README.md
@@ -1,0 +1,29 @@
+# Theme Toggle Visibility Fix — Issue #47290
+
+## What does it do?
+
+Fixes the low visibility of the moon icon in the theme toggle button when the site is in light mode. The icon now uses theme-aware colors so it remains clearly visible in both dark and light modes.
+
+## How is it used?
+
+Add the following CSS rules to `docs/docs.css` after the existing `.theme-toggle-btn .moon-icon` block (around line 252):
+
+```css
+/* Light mode: dark icon for visibility on light background */
+[data-theme="light"] .theme-toggle-btn .moon-icon {
+  color: #1e293b;
+}
+
+/* Dark mode: light icon for visibility on dark background */
+[data-theme="dark"] .theme-toggle-btn .moon-icon {
+  color: #e2e8f0;
+}
+```
+
+Also update the SVG icons in the HTML to use `stroke="currentColor"` so they inherit the button's color.
+
+## Why is it useful?
+
+- **Accessibility**: Users can clearly see the theme toggle in both modes.
+- **Consistency**: The icon now matches the other navigation elements.
+- **UX**: Users won't miss the theme toggle when browsing in light mode.

--- a/submissions/docs/theme-toggle-fix-eranmol/demo.html
+++ b/submissions/docs/theme-toggle-fix-eranmol/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Theme Toggle Fix — Issue #47290</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="navbar">
+    <span class="logo">EaseMotion</span>
+    <div class="nav-links">
+      <a href="#">Buttons</a>
+      <a href="#">Cards</a>
+      <a href="#">Docs</a>
+    </div>
+    <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+      <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5"></circle>
+        <line x1="12" y1="1" x2="12" y2="3"></line>
+        <line x1="12" y1="21" x2="12" y2="23"></line>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+        <line x1="1" y1="12" x2="3" y2="12"></line>
+        <line x1="21" y1="12" x2="23" y2="12"></line>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+      </svg>
+      <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      </svg>
+    </button>
+  </nav>
+
+  <main class="content">
+    <h1>Theme Toggle Icon Fix</h1>
+    <p class="subtitle">Issue #47290 — Moon icon visibility in light mode</p>
+
+    <section class="card">
+      <h2>Problem</h2>
+      <p>In light mode, the moon icon (theme toggle) remains dark, making it hard to see against the light navigation bar background.</p>
+    </section>
+
+    <section class="card">
+      <h2>Fix Applied</h2>
+      <p>Click the toggle button above to switch themes. The icon now adapts to the active theme:</p>
+      <ul>
+        <li><strong>Dark mode:</strong> Sun icon visible (white/light)</li>
+        <li><strong>Light mode:</strong> Moon icon visible (dark)</li>
+      </ul>
+    </section>
+
+    <section class="card code-card">
+      <h2>CSS Change</h2>
+      <pre><code>/* Add to docs.css after line 252 */
+
+[data-theme="light"] .theme-toggle-btn .moon-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  color: #1e293b;  /* dark color for light mode visibility */
+}
+
+[data-theme="dark"] .theme-toggle-btn .moon-icon {
+  color: #e2e8f0;  /* light color for dark mode */
+}</code></pre>
+    </section>
+  </main>
+
+  <script>
+    const toggle = document.getElementById('theme-toggle');
+    const html = document.documentElement;
+
+    toggle.addEventListener('click', () => {
+      const current = html.getAttribute('data-theme');
+      const next = current === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', next);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/theme-toggle-fix-eranmol/style.css
+++ b/submissions/docs/theme-toggle-fix-eranmol/style.css
@@ -1,0 +1,187 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --border: #334155;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #38bdf8;
+}
+
+[data-theme="light"] {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --border: #e2e8f0;
+  --text: #1e293b;
+  --text-muted: #64748b;
+  --accent: #3b82f6;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+/* ── Navbar ──────────────────────────────────────── */
+
+.navbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--accent);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  flex: 1;
+}
+
+.nav-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.nav-links a:hover {
+  color: var(--text);
+}
+
+/* ── Theme Toggle Button ─────────────────────────── */
+
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  position: relative;
+  overflow: hidden;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.theme-toggle-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--accent);
+}
+
+[data-theme="light"] .theme-toggle-btn:hover {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.theme-toggle-btn svg {
+  position: absolute;
+  transition:
+    transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.3s;
+}
+
+/* ── Icon States ─────────────────────────────────── */
+
+/* Dark mode (default): sun visible, moon hidden */
+.theme-toggle-btn .sun-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  color: #e2e8f0;
+}
+
+.theme-toggle-btn .moon-icon {
+  opacity: 0;
+  transform: rotate(90deg) scale(0);
+  color: #e2e8f0;
+}
+
+/* Light mode: sun hidden, moon visible */
+[data-theme="light"] .theme-toggle-btn .sun-icon {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0);
+  color: #1e293b;
+}
+
+[data-theme="light"] .theme-toggle-btn .moon-icon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  color: #1e293b;
+}
+
+/* ── Content ─────────────────────────────────────── */
+
+.content {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.card h2 {
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+  color: var(--accent);
+}
+
+.card ul {
+  padding-left: 1.25rem;
+  color: var(--text-muted);
+}
+
+.card li {
+  margin-bottom: 0.35rem;
+}
+
+.code-card pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.code-card code {
+  color: #4ade80;
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (UI/UX)

## Submission Checklist
- [x] Files only in `submissions/docs/theme-toggle-fix-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
Fixes the low visibility of the moon icon in the theme toggle button when the site is in light mode. Adds theme-aware color rules so the icon is clearly visible in both dark mode (light icon on dark background) and light mode (dark icon on light background). Includes an interactive demo with working theme toggle.

## Demo
Open `demo.html` — click the toggle button in the navbar to switch between dark and light modes. The icon is now clearly visible in both.

## Browser Testing
Tested on Chrome, Firefox, Safari.

## Notes for Maintainer
The actual fix requires adding CSS rules to `docs/docs.css` after line 252 (not included per contribution guidelines). The exact diff is documented in `demo.html` and `README.md`.