### PR TITLE
Add dracula ant component

### DIFF
--- a/submissions/examples/dracula-ant-as/README.md
+++ b/submissions/examples/dracula-ant-as/README.md
@@ -1,0 +1,31 @@
+# Dracula Ant
+
+A pure CSS/HTML *Mystrium camillae*, the animal that holds the record for the fastest movement of any living thing.
+
+## What it shows
+
+The dracula ant's mandible snap is the **fastest known animal movement**: the jaw tips reach about **90 metres per second** and the whole strike is over in a quarter of a millisecond, accelerating at around 100,000 g.
+
+The mechanism is the surprising part. Most fast-striking ants are **trap-jaw** ants: they hold the mandibles wide open, latched, and release them to swing shut. The dracula ant does something completely different. Its jaws are **already closed, pressed tip against tip**, and it **loads them by pushing them together** so hard they bend and store energy like a bow. Then one mandible **slides across the other and slips free**, releasing all that stored strain at once. It is a spring-loaded snap, exactly like snapping your fingers: the power does not come from the muscle's speed, it comes from the sudden release of a loaded surface.
+
+The muscle is slow. The spring is not. Separating the loading from the release is what lets a small animal exceed what any muscle could do directly.
+
+(The name is unrelated to the jaws. Adults cannot eat solid food, so they chew holes in their own larvae and drink the blood, non-lethally. Hence Dracula.)
+
+## How it is built
+
+- **Load slow, release in one frame.** The mandible keyframe holds near its resting angle from 0% to 60%, presses inward to 64%, and the whole 40-degree throw happens between 64% and 66% of the cycle. The browser check samples the mandible's live angle at 1000 points and confirms it spends **89.8% of the cycle within 8 degrees of rest**, with the entire strike landing at **66%**. That ratio is the animal: almost all waiting, then a snap.
+- **They press, they do not swing.** The two mandibles start pressed together, not open. The `.loadD` glow builds while they press and vanishes the instant they slip at 66%, so the stored-energy phase is visible.
+- **Mirrored jaw, its own keyframe.** The lower mandible carries `scaleY(-1)` and gets a separate keyframe that rebuilds it at every stop, so the snap cannot flip it.
+- **Everything fires on frame 66%**: the spark rays, the prey being snatched in, and the ant's recoil all key to the same instant, because in life they are simultaneous.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and holds the jaws loaded with the strain glow showing, so the mechanism reads without motion.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/dracula-ant-as/demo.html
+++ b/submissions/examples/dracula-ant-as/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dracula Ant</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="litterD"></span>
+    <span class="leafD"></span>
+
+    <span class="preyD"></span>
+
+    <div class="antD">
+      <span class="gasterD"></span>
+      <span class="petioleD"></span>
+      <span class="thoraxD"></span>
+        <span class="legD" style="--i: 0; --s: 1"></span>
+        <span class="legD" style="--i: 1; --s: 1"></span>
+        <span class="legD" style="--i: 2; --s: 1"></span>
+        <span class="legD" style="--i: 3; --s: -1"></span>
+        <span class="legD" style="--i: 4; --s: -1"></span>
+        <span class="legD" style="--i: 5; --s: -1"></span>
+
+      <span class="headD"></span>
+      <span class="eyeD"></span>
+      <span class="antennaD anL"></span>
+      <span class="antennaD anR"></span>
+      <div class="mandD mdL">
+        <span class="loadD"></span>
+      </div>
+      <div class="mandD mdR">
+        <span class="loadD"></span>
+      </div>
+      <div class="snapFx">
+        <span class="sparkD" style="--a: -40deg; --i: 0"></span>
+        <span class="sparkD" style="--a: -24deg; --i: 1"></span>
+        <span class="sparkD" style="--a: -8deg; --i: 2"></span>
+        <span class="sparkD" style="--a: 8deg; --i: 3"></span>
+        <span class="sparkD" style="--a: 24deg; --i: 4"></span>
+        <span class="sparkD" style="--a: 40deg; --i: 5"></span>
+
+      </div>
+    </div>
+
+    <span class="tagSpeed">tip speed: 90 m / s</span>
+    <span class="capD">the jaws load against each other, then one slips</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dracula-ant-as/style.css
+++ b/submissions/examples/dracula-ant-as/style.css
@@ -1,0 +1,360 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #3f3830, #080705 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 44% 36%, #6f6448, #16140d 88%);
+}
+
+.litterD {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 70px;
+  background:
+    radial-gradient(circle at 18% 44%, rgba(90, 66, 26, 0.4) 0 8px, transparent 13px),
+    radial-gradient(circle at 66% 64%, rgba(90, 66, 26, 0.34) 0 10px, transparent 15px),
+    radial-gradient(circle at 88% 38%, rgba(90, 66, 26, 0.3) 0 7px, transparent 12px),
+    linear-gradient(180deg, #43391f, #14110a);
+  z-index: 2;
+}
+
+.leafD {
+  position: absolute;
+  bottom: 48px;
+  left: -20px;
+  width: 150px;
+  height: 40px;
+  border-radius: 60% 20% 60% 20%;
+  background: linear-gradient(150deg, #5a6a34, #24300f);
+  z-index: 3;
+}
+
+/*
+  the prey. dracula ants hunt springtails and centipedes, which are fast,
+  so the ant needs a strike faster than a nervous system can react to.
+*/
+.preyD {
+  position: absolute;
+  bottom: 96px;
+  left: 34px;
+  width: 26px;
+  height: 12px;
+  border-radius: 50% 40% 40% 50%;
+  background: radial-gradient(circle at 40% 32%, #b0b8c0, #4a5058 78%);
+  z-index: 5;
+  animation: fleeD 3.6s cubic-bezier(0.2, 0.9, 0.3, 1) infinite;
+}
+
+.preyD::after {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: 2px;
+  right: 2px;
+  height: 5px;
+  background: repeating-linear-gradient(90deg, #3a4048 0 1px, transparent 1px 4px);
+}
+
+/* ---------------- the ant ---------------- */
+
+.antD {
+  position: absolute;
+  bottom: 74px;
+  left: 128px;
+  width: 150px;
+  height: 70px;
+  z-index: 6;
+  animation: braceD 3.6s ease-out infinite;
+}
+
+.gasterD {
+  position: absolute;
+  bottom: 6px;
+  left: 96px;
+  width: 52px;
+  height: 40px;
+  border-radius: 52% 48% 46% 54% / 58% 58% 42% 42%;
+  background: radial-gradient(circle at 40% 32%, #6a3a1a, #1e0f06 78%);
+  box-shadow: inset -5px -4px 12px rgba(12, 6, 2, 0.6);
+  z-index: 3;
+}
+
+.petioleD {
+  position: absolute;
+  bottom: 18px;
+  left: 84px;
+  width: 18px;
+  height: 14px;
+  border-radius: 40% 40% 30% 30%;
+  background: linear-gradient(180deg, #7a4622, #2a1608);
+  z-index: 2;
+}
+
+.thoraxD {
+  position: absolute;
+  bottom: 16px;
+  left: 48px;
+  width: 44px;
+  height: 26px;
+  border-radius: 44% 40% 40% 44%;
+  background: radial-gradient(circle at 42% 32%, #8a4e24, #2a1608 78%);
+  z-index: 4;
+}
+
+.legD {
+  position: absolute;
+  bottom: 18px;
+  left: calc(52px + var(--i) * 8px);
+  width: 2.4px;
+  height: 30px;
+  background: #1e1208;
+  transform-origin: 50% 0;
+  transform: rotate(calc(var(--s) * 30deg));
+  z-index: 2;
+}
+
+.legD::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 14px;
+  height: 2.4px;
+  background: #1e1208;
+  transform-origin: 0 50%;
+  transform: rotate(calc(var(--s) * 46deg));
+}
+
+.headD {
+  position: absolute;
+  bottom: 10px;
+  left: 16px;
+  width: 40px;
+  height: 38px;
+  border-radius: 46% 40% 40% 46% / 44% 44% 56% 56%;
+  background: radial-gradient(circle at 56% 34%, #9a5a2c, #2f1a0a 80%);
+  z-index: 5;
+}
+
+.eyeD {
+  position: absolute;
+  bottom: 34px;
+  left: 24px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #3a2a1a, #06040a 66%);
+  box-shadow: 0 0 0 1px rgba(20, 12, 4, 0.8);
+  z-index: 6;
+}
+
+.antennaD {
+  position: absolute;
+  width: 22px;
+  height: 2px;
+  border-radius: 1px;
+  background:
+    repeating-linear-gradient(90deg, #4a2c14 0 2px, transparent 2px 3.4px),
+    #2f1a0a;
+  transform-origin: 100% 50%;
+  transform: rotate(var(--an, 0deg));
+  z-index: 4;
+}
+
+.anL { --an: -30deg; bottom: 42px; left: 2px; }
+.anR { --an: 4deg; bottom: 32px; left: 0; }
+
+/*
+  the mandibles. they do NOT swing in from open like a trap-jaw ant.
+  they press together, tip to tip, and load by bending, then one slides
+  past the other and releases like a finger-snap. that is the mechanism.
+*/
+.mandD {
+  position: absolute;
+  bottom: 20px;
+  left: 12px;
+  width: 40px;
+  height: 8px;
+  transform-origin: 100% 50%;
+  z-index: 7;
+}
+
+.mandD::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 6px 3px 3px 6px;
+  background: linear-gradient(180deg, #d8a860, #6a3c14);
+  clip-path: polygon(0 0, 100% 30%, 100% 70%, 0 100%);
+}
+
+.mandD::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: -3px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50% 0 50% 50%;
+  background: #4a2a0e;
+}
+
+.mdL {
+  transform: rotate(-6deg);
+  animation: snapLD 3.6s cubic-bezier(0.9, 0, 1, 0.4) infinite;
+}
+
+.mdR {
+  transform: rotate(6deg) scaleY(-1);
+  animation: snapRD 3.6s cubic-bezier(0.9, 0, 1, 0.4) infinite;
+}
+
+/* the little pale bar showing the tips bending against each other under load */
+.loadD {
+  position: absolute;
+  top: 2px;
+  left: -6px;
+  width: 8px;
+  height: 4px;
+  border-radius: 2px;
+  background: radial-gradient(circle, rgba(255, 244, 200, 0.9), transparent 74%);
+  opacity: 0;
+  animation: loadD 3.6s ease-in infinite;
+}
+
+.snapFx {
+  position: absolute;
+  bottom: 24px;
+  left: -8px;
+  width: 0;
+  height: 0;
+  z-index: 8;
+}
+
+.sparkD {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 20px;
+  height: 1.6px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, rgba(255, 240, 190, 0.95), transparent);
+  transform-origin: 0 50%;
+  transform: rotate(var(--a, 0deg)) scaleX(0);
+  z-index: 8;
+  animation: sparkD 3.6s ease-out infinite;
+  animation-delay: calc(var(--i) * 0.002s);
+}
+
+.tagSpeed {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  font-size: 0.52rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 214, 140, 0.9);
+  z-index: 9;
+  opacity: 0;
+  animation: cueD 3.6s ease-out infinite;
+}
+
+.capD {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.05em;
+  color: rgba(250, 236, 200, 0.75);
+  z-index: 9;
+}
+
+/*
+  the strike is 1/1000th of a second in life. here it is a single keyframe
+  step: the jaws load slowly, hold, and release in about 1% of the cycle.
+*/
+@keyframes snapLD {
+  0%, 60% { transform: rotate(-6deg); }
+  64% { transform: rotate(-2deg); }
+  66% { transform: rotate(-40deg); }
+  76% { transform: rotate(-10deg); }
+  84%, 100% { transform: rotate(-6deg); }
+}
+
+@keyframes snapRD {
+  0%, 60% { transform: rotate(6deg) scaleY(-1); }
+  64% { transform: rotate(2deg) scaleY(-1); }
+  66% { transform: rotate(40deg) scaleY(-1); }
+  76% { transform: rotate(10deg) scaleY(-1); }
+  84%, 100% { transform: rotate(6deg) scaleY(-1); }
+}
+
+/* the load glow builds while the jaws press, and is gone the instant they slip */
+@keyframes loadD {
+  0%, 20% { opacity: 0; }
+  55% { opacity: 1; }
+  64% { opacity: 1; }
+  66% { opacity: 0; }
+  100% { opacity: 0; }
+}
+
+/* the spray of the strike: everything happens in one frame at 66% */
+@keyframes sparkD {
+  0%, 64% { transform: rotate(var(--a, 0deg)) scaleX(0); opacity: 0; }
+  66% { transform: rotate(var(--a, 0deg)) scaleX(1); opacity: 1; }
+  74%, 100% { transform: rotate(var(--a, 0deg)) scaleX(1.4); opacity: 0; }
+}
+
+/* the prey is snatched inward on the strike frame */
+@keyframes fleeD {
+  0%, 40% { transform: translateX(0); }
+  58% { transform: translateX(18px); }
+  66% { transform: translateX(74px); }
+  70%, 100% { transform: translateX(74px); opacity: 0; }
+}
+
+@keyframes braceD {
+  0%, 60% { transform: translateX(0); }
+  66% { transform: translateX(-5px); }
+  80%, 100% { transform: translateX(0); }
+}
+
+@keyframes cueD {
+  0%, 60% { opacity: 0; }
+  66%, 80% { opacity: 1; }
+  90%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mdL,
+  .mdR,
+  .loadD,
+  .sparkD,
+  .preyD,
+  .antD,
+  .tagSpeed {
+    animation: none;
+  }
+
+  .loadD { opacity: 1; }
+
+  .sparkD,
+  .tagSpeed { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/dracula-ant-as/`, a self-contained pure CSS/HTML dracula ant firing the fastest strike in the animal kingdom.

Closes #48887

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

The dracula ant does not swing its jaws shut like a trap-jaw ant. Its mandibles are already closed, pressed tip to tip, and it loads them by pushing them together until they bend and store energy, then one slides past the other and slips free. It is a finger-snap: the speed comes from the sudden release of a loaded surface, not from the muscle.

- **Load slow, release in one frame.** The mandible keyframe holds near its resting angle from 0% to 60%, presses inward to 64%, and the whole 40-degree throw happens between 64% and 66%. The browser check samples the mandible's live angle at 1000 points and confirms it spends **89.8% of the cycle within 8 degrees of rest**, with the strike landing at **66%**. That ratio is the animal: almost all waiting, then a snap.
- **They press, they do not swing.** The two mandibles start pressed together, not open. The load glow builds while they press and vanishes the instant they slip at 66%, so the stored-energy phase is visible.
- **Mirrored jaw, its own keyframe.** The lower mandible carries `scaleY(-1)` and gets a separate keyframe that rebuilds it at every stop, so the snap cannot flip it.
- **Everything fires on frame 66%**: the spark rays, the prey being snatched in, and the ant's recoil all key to the same instant, because in life they are simultaneous.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and holds the jaws loaded with the strain glow showing.

## Verification

Opened `demo.html` in the browser and measured the strike off the mandible's live animation timeline rather than eyeballing it: 1000 samples confirm it holds within 8 degrees of rest for 89.8% of the cycle and fires its whole arc at 66%, which is the load-and-snap signature. Confirmed the two mandibles share a duration and the mirrored one keeps its `scaleY(-1)`. Also caught and fixed an accidental 8-digit hex I introduced while brightening the scene. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
