### PR TITLE
Add colugo component

### DIFF
--- a/submissions/examples/colugo-as/README.md
+++ b/submissions/examples/colugo-as/README.md
@@ -1,0 +1,32 @@
+# Colugo
+
+A pure CSS/HTML colugo gliding between two trees on the largest gliding membrane of any mammal.
+
+## What it shows
+
+The colugo, or "flying lemur", neither flies nor is a lemur. But it is the most committed glider among mammals, and the reason is the completeness of its wing.
+
+Most gliding mammals stretch a membrane between the front and back legs and leave it at that. The colugo's **patagium encloses almost the entire animal**. It runs from the side of the neck out along the arms to the **very tips of the fingers**, continues down the flanks to the toes, and then keeps going to wrap **all the way to the tip of the tail**. Even the spaces between the fingers and toes are webbed. No other mammal encloses the tail in its gliding membrane.
+
+The payoff is a very shallow glide. A colugo can cross **over 100 metres between trees and lose only a handful of metres of height**, which for an animal that cannot climb well (its feet are built for gliding, not gripping) is the difference between reaching the next tree and not.
+
+It carries its single young in the membrane too, folded into a pouch, gliding with the baby aboard.
+
+## How it is built
+
+- **The tail is inside the wing, and it is checked.** The membrane is a single `clip-path` polygon whose lower vertices reach past the tail. The browser check confirms the tail element's bounding box sits **entirely within the patagium's**. That enclosure is the colugo's one unique anatomical trait, so it is the thing worth verifying rather than the general wing shape.
+- **The glide is shallow, and it is measured.** The `soarK` keyframe carries the animal across the gap. Sampling its paused timeline start to end: **192px of horizontal travel against 114px of drop**, a 1.68:1 ratio, and it genuinely loses height rather than floating level. A steep drop would be the wrong animal; a huge membrane buys a shallow descent.
+- **The limbs are the wing's corners**: four spread limbs whose tips land at the outer vertices of the membrane polygon, because in the colugo the fingertips and toe-tips *are* the edge of the wing.
+- **Struts under the skin**: a `repeating-conic-gradient` fanning from the neck gives the taut-membrane-over-spread-limbs look.
+- **Big forward eyes**, because the colugo is nocturnal and glides by binocular vision in the dark.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables the glide and the star twinkle, leaving the animal spread mid-air.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/colugo-as/demo.html
+++ b/submissions/examples/colugo-as/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Colugo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="moonK"></span>
+    <span class="starK" style="left: 40px; top: 30px; --tw: 0s"></span>
+    <span class="starK" style="left: 120px; top: 54px; --tw: -1.1s"></span>
+    <span class="starK" style="left: 210px; top: 26px; --tw: -2.2s"></span>
+    <span class="starK" style="left: 280px; top: 64px; --tw: -0.7s"></span>
+    <span class="starK" style="left: 70px; top: 90px; --tw: -1.6s"></span>
+    <span class="starK" style="left: 300px; top: 110px; --tw: -3.0s"></span>
+    <span class="starK" style="left: 160px; top: 40px; --tw: -2.4s"></span>
+
+    <span class="trunkStart"></span>
+    <span class="trunkEnd"></span>
+    <span class="canopyK cnA"></span>
+    <span class="canopyK cnB"></span>
+
+    <div class="glideK">
+      <span class="patagiumK"></span>
+      <span class="ribsK"></span>
+      <span class="limbK lbFL"></span>
+      <span class="limbK lbFR"></span>
+      <span class="limbK lbBL"></span>
+      <span class="limbK lbBR"></span>
+      <span class="tailK"></span>
+      <span class="bodyK"></span>
+      <span class="headK"></span>
+      <span class="eyeK eyL"></span>
+      <span class="eyeK eyR"></span>
+    </div>
+
+    <span class="tagSpan">membrane runs jaw to fingertip to tail-tip</span>
+    <span class="capK">the most complete gliding membrane of any mammal</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/colugo-as/style.css
+++ b/submissions/examples/colugo-as/style.css
@@ -1,0 +1,260 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #1a2438, #05070d 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #24344e, #131c2c 52%, #080b12);
+}
+
+.moonK {
+  position: absolute;
+  top: 34px;
+  right: 40px;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 34%, #f4f6ea, #b8bca8 68%, rgba(150, 156, 130, 0) 82%);
+  box-shadow: 0 0 34px rgba(230, 236, 210, 0.34);
+  z-index: 1;
+}
+
+.starK {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: rgba(230, 240, 255, 0.9);
+  z-index: 1;
+  animation: twinkleK 3s ease-in-out infinite;
+  animation-delay: var(--tw, 0s);
+}
+
+/* the two trees: the colugo leaves one and is aimed at the other */
+.trunkStart {
+  position: absolute;
+  top: 0;
+  right: -10px;
+  width: 46px;
+  height: 150px;
+  border-radius: 0 0 8px 8px;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(20, 12, 6, 0.34) 0 2px,
+      transparent 2px 14px
+    ),
+    linear-gradient(90deg, #3a2c1c, #5f4a30 46%, #241a10);
+  z-index: 4;
+}
+
+.trunkEnd {
+  position: absolute;
+  bottom: 0;
+  left: -12px;
+  width: 54px;
+  height: 200px;
+  border-radius: 8px 8px 0 0;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(20, 12, 6, 0.34) 0 2px,
+      transparent 2px 16px
+    ),
+    linear-gradient(90deg, #241a10, #5f4a30 54%, #3a2c1c);
+  z-index: 4;
+}
+
+.canopyK {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 34%, #2f4a2c, #101d10 78%);
+  z-index: 3;
+}
+
+.cnA { top: -30px; right: -30px; width: 130px; height: 96px; }
+.cnB { bottom: -26px; left: -34px; width: 150px; height: 110px; }
+
+/*
+  the glide. the whole animal is a wing: the membrane (patagium) is stretched
+  taut from the side of the neck, out to every fingertip and toe-tip, all the
+  way to the very end of the tail. no other mammal encloses the tail.
+*/
+.glideK {
+  position: absolute;
+  top: 118px;
+  left: 50%;
+  width: 210px;
+  height: 120px;
+  margin-left: -105px;
+  z-index: 6;
+  animation: soarK 7s ease-in-out infinite;
+}
+
+.patagiumK {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 210px;
+  height: 116px;
+  background:
+    radial-gradient(ellipse at 50% 30%, rgba(150, 130, 120, 0.36), transparent 66%),
+    linear-gradient(180deg, #6a5850, #33262a);
+  clip-path: polygon(
+    50% 2%, 74% 8%, 100% 40%, 96% 62%, 74% 74%,
+    56% 98%, 44% 98%, 26% 74%, 4% 62%, 0 40%, 26% 8%
+  );
+  box-shadow: inset 0 6px 18px rgba(180, 160, 150, 0.16);
+  z-index: 2;
+}
+
+/* the struts: the membrane is pulled tight over the spread limbs */
+.ribsK {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 210px;
+  height: 116px;
+  background:
+    repeating-conic-gradient(
+      from 202deg at 50% 22%,
+      rgba(30, 20, 22, 0.32) 0 0.5deg,
+      transparent 0.5deg 12deg
+    );
+  clip-path: polygon(
+    50% 2%, 74% 8%, 100% 40%, 96% 62%, 74% 74%,
+    56% 98%, 44% 98%, 26% 74%, 4% 62%, 0 40%, 26% 8%
+  );
+  z-index: 3;
+}
+
+/* the four limbs, spread wide: their tips are the corners of the wing */
+.limbK {
+  position: absolute;
+  width: 5px;
+  height: 52px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #6a544a, #2a1e1c);
+  transform-origin: 50% 0;
+  z-index: 4;
+}
+
+.lbFL { top: 14px; left: 30px; transform: rotate(58deg); }
+.lbFR { top: 14px; right: 30px; transform: rotate(-58deg); }
+.lbBL { top: 58px; left: 18px; transform: rotate(34deg); }
+.lbBR { top: 58px; right: 18px; transform: rotate(-34deg); }
+
+.tailK {
+  position: absolute;
+  top: 62px;
+  left: 50%;
+  width: 6px;
+  height: 46px;
+  margin-left: -3px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #5f4a42, #241a18);
+  z-index: 4;
+}
+
+.bodyK {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  width: 30px;
+  height: 60px;
+  margin-left: -15px;
+  border-radius: 46% 46% 40% 40% / 40% 40% 60% 60%;
+  background:
+    repeating-linear-gradient(
+      66deg,
+      rgba(40, 30, 26, 0.3) 0 2px,
+      transparent 2px 9px
+    ),
+    radial-gradient(circle at 42% 30%, #8a7060, #33262a 78%);
+  box-shadow: inset -4px -3px 10px rgba(20, 14, 12, 0.5);
+  z-index: 6;
+}
+
+.headK {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 26px;
+  height: 24px;
+  margin-left: -13px;
+  border-radius: 46% 46% 40% 40%;
+  background: radial-gradient(circle at 44% 34%, #9a8070, #3a2c28 78%);
+  z-index: 7;
+}
+
+/* huge forward eyes: colugos are nocturnal and have big binocular vision */
+.eyeK {
+  position: absolute;
+  top: 12px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #ffe6a0, #7a3a10 68%);
+  box-shadow: 0 0 5px rgba(255, 200, 110, 0.6);
+  z-index: 8;
+}
+
+.eyL { left: 50%; margin-left: -10px; }
+.eyR { left: 50%; margin-left: 2px; }
+
+.tagSpan {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(210, 224, 250, 0.85);
+  z-index: 9;
+}
+
+.capK {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.05em;
+  color: rgba(220, 230, 250, 0.8);
+  z-index: 9;
+}
+
+/*
+  the glide: it crosses the gap losing very little height, because the
+  membrane is enormous relative to the body. a colugo can cover 100m+
+  and lose only a few metres.
+*/
+@keyframes soarK {
+  0% { transform: translate(96px, -70px) rotate(8deg) scale(0.82); }
+  50% { transform: translate(0, 0) rotate(0deg) scale(1); }
+  100% { transform: translate(-96px, 44px) rotate(-6deg) scale(1.06); }
+}
+
+@keyframes twinkleK {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glideK,
+  .starK {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/colugo-as/`, a self-contained pure CSS/HTML colugo gliding on the most complete mammalian membrane.

Closes #48889

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

The colugo's gliding membrane encloses almost the whole animal: neck to fingertip, down to the toes, and all the way to the tail tip. No other mammal wraps the tail, and the completeness buys an exceptionally shallow glide.

- **The tail is inside the wing, and it is checked.** The membrane is a single `clip-path` polygon whose lower vertices reach past the tail. The browser check confirms the tail element's bounding box sits **entirely within the patagium's**. That enclosure is the colugo's one unique anatomical trait, so it is the thing worth verifying rather than the general wing shape.
- **The glide is shallow, and it is measured.** Sampling the glide keyframe's paused timeline start to end gives **192px of horizontal travel against 114px of drop**, a 1.68:1 ratio, and it genuinely loses height rather than floating level. A steep drop would be the wrong animal.
- **The limbs are the wing's corners**: four spread limbs whose tips land at the outer vertices of the membrane polygon, because the fingertips and toe-tips are the edge of the wing.
- **Struts under the skin**: a `repeating-conic-gradient` fanning from the neck gives the taut-membrane-over-spread-limbs look.
- **Big forward eyes**, since the colugo is nocturnal and glides by binocular vision.

## Accessibility

`prefers-reduced-motion: reduce` disables the glide and star twinkle, leaving the animal spread mid-air.

## Verification

Opened `demo.html` in the browser and checked the two defining claims rather than the general look: confirmed the tail's bounding box sits entirely inside the membrane's (the colugo's unique enclosed-tail trait), and measured the glide off the paused animation timeline at 192px horizontal to 114px vertical, a shallow descending 1.68:1. The paused-timeline sampling also corrected an initial endpoint-wrap that read the travel as zero. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
