### PR TITLE
Add saiga component

### DIFF
--- a/submissions/examples/saiga-as/README.md
+++ b/submissions/examples/saiga-as/README.md
@@ -1,0 +1,33 @@
+# Saiga
+
+A pure CSS/HTML saiga antelope on the Central Asian steppe, with the extraordinary nose that defines it.
+
+## What it shows
+
+The saiga looks like an antelope that has been fitted with the wrong nose, and the nose is the whole story.
+
+It is a soft, inflatable, downward-pointing **proboscis**, oversized out of all proportion to the head, with the nostrils opening downward rather than forward. It is a piece of environmental engineering for one of the harshest ranges any large mammal occupies, and it does two opposite jobs across the year:
+
+- **In summer**, the herds raise enormous dust clouds crossing the dry steppe. The nose is a **filter**: the convoluted internal passages trap airborne dust before it reaches the lungs.
+- **In winter**, the same steppe drops to **−40°C**. Now the nose is a **heat exchanger**: it warms and humidifies each freezing breath before it hits the lungs, and reclaims heat and moisture on the way back out.
+
+The saiga is also a survivor and a warning. It lived alongside mammoths, and in 2015 a bacterial outbreak killed roughly **200,000 of them, more than half the world population, in a few weeks**. It has recovered since, which is rare enough to be worth noting.
+
+## How it is built
+
+- **The nose is genuinely oversized, and it is checked.** The browser check measures the proboscis against the skull: **35px tall against a 34px skull, a ratio of 1.03**. The nose is as tall as the entire rest of the head. On any normal antelope this would be absurd, which is exactly the point, so the drawing had to commit to it rather than hint at it.
+- **It points down, verified.** The check confirms the nose's bounding box extends **below the eye line**. A forward-pointing muzzle would be the wrong animal; the saiga's nostrils open downward.
+- **The filter is shown working**: dust motes drift in on the wind and **vanish at the nostrils**, on a loop, because trapping dust before the lungs is the nose's summer job.
+- **The nostrils flare on the intake**: a `scaleX` keyframe on each nostril, offset slightly so they are not in lockstep.
+- **Ringed amber horns**: the male's translucent, ridged horns via a `repeating-linear-gradient` over an amber base.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and hides the drifting dust, leaving the animal standing.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/saiga-as/demo.html
+++ b/submissions/examples/saiga-as/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Saiga</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="skyS"></span>
+    <span class="sunS"></span>
+    <span class="steppeS"></span>
+    <span class="grassS gsA"></span>
+    <span class="grassS gsB"></span>
+
+    <div class="dustS">
+        <span class="moteS" style="--i: 0; --y: -2px"></span>
+        <span class="moteS" style="--i: 1; --y: 2px"></span>
+        <span class="moteS" style="--i: 2; --y: -4px"></span>
+        <span class="moteS" style="--i: 3; --y: 4px"></span>
+        <span class="moteS" style="--i: 4; --y: 0px"></span>
+        <span class="moteS" style="--i: 5; --y: -3px"></span>
+
+    </div>
+
+    <div class="saigaS">
+      <span class="rumpS"></span>
+      <span class="bodyS"></span>
+      <span class="legS lgBB"></span>
+      <span class="legS lgBF"></span>
+      <span class="legS lgFB"></span>
+      <span class="legS lgFF"></span>
+      <span class="tailS"></span>
+      <span class="neckS"></span>
+      <div class="headS">
+        <span class="skullS"></span>
+        <span class="hornS hnB"></span>
+        <span class="hornS hnF"></span>
+        <span class="earS"></span>
+        <span class="eyeS"></span>
+        <div class="noseS">
+          <span class="proboscisS"></span>
+          <span class="nostrilS nsL"></span>
+          <span class="nostrilS nsR"></span>
+        </div>
+      </div>
+    </div>
+
+    <span class="tagNose">nose warms, humidifies, filters</span>
+    <span class="capS">a trunk-like nose for a continent of dust and frost</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/saiga-as/style.css
+++ b/submissions/examples/saiga-as/style.css
@@ -1,0 +1,358 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #d8c088, #a8895e 58%, #4f4030);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #ecd6a2, #cdae78 46%, #9a7e56 64%, #6a5640);
+}
+
+.skyS {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 72% 20%, rgba(255, 248, 214, 0.6), transparent 52%);
+  z-index: 1;
+}
+
+.sunS {
+  position: absolute;
+  top: 34px;
+  right: 44px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe0, #ffd868 56%, rgba(255, 210, 100, 0) 78%);
+  z-index: 2;
+}
+
+.steppeS {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 110px;
+  background:
+    radial-gradient(circle at 16% 40%, rgba(90, 70, 40, 0.3) 0 4px, transparent 8px),
+    radial-gradient(circle at 74% 62%, rgba(90, 70, 40, 0.26) 0 5px, transparent 9px),
+    linear-gradient(180deg, #b89464, #6a5236);
+  z-index: 3;
+}
+
+.grassS {
+  position: absolute;
+  bottom: 96px;
+  height: 20px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      #8a7a3a 0 1px,
+      transparent 1px 5px
+    );
+  mask-image: linear-gradient(180deg, transparent, #000 60%);
+  z-index: 4;
+}
+
+.gsA { left: 20px; width: 90px; }
+.gsB { right: 30px; width: 110px; }
+
+/* dust drifting in the wind: what the nose has to deal with */
+.dustS {
+  position: absolute;
+  bottom: 150px;
+  left: 34px;
+  width: 0;
+  height: 0;
+  z-index: 8;
+}
+
+.moteS {
+  position: absolute;
+  top: var(--y, 0);
+  left: 0;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(210, 190, 150, 0.7);
+  opacity: 0;
+  animation: driftS 4.5s linear infinite;
+  animation-delay: calc(var(--i) * -0.75s);
+}
+
+.saigaS {
+  position: absolute;
+  bottom: 62px;
+  left: 50%;
+  width: 220px;
+  height: 150px;
+  margin-left: -118px;
+  z-index: 6;
+  animation: breatheS 4.5s ease-in-out infinite;
+}
+
+.bodyS {
+  position: absolute;
+  bottom: 40px;
+  left: 60px;
+  width: 116px;
+  height: 56px;
+  border-radius: 44% 52% 44% 52% / 58% 58% 42% 42%;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(120, 96, 60, 0.2) 0 3px,
+      transparent 3px 13px
+    ),
+    radial-gradient(circle at 42% 32%, #e2cfa4, #9a7e54 78%);
+  box-shadow: inset -6px -5px 16px rgba(80, 60, 30, 0.4);
+  z-index: 4;
+}
+
+.rumpS {
+  position: absolute;
+  bottom: 42px;
+  left: 150px;
+  width: 52px;
+  height: 50px;
+  border-radius: 46% 50% 44% 40% / 56% 56% 44% 44%;
+  background: radial-gradient(circle at 40% 32%, #dcc89c, #8a6f4a 78%);
+  z-index: 3;
+}
+
+.legS {
+  position: absolute;
+  bottom: -6px;
+  width: 7px;
+  height: 50px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #c8b184, #5f4a2c);
+  transform-origin: 50% 0;
+  z-index: 3;
+}
+
+.legS::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -1px;
+  width: 9px;
+  height: 6px;
+  border-radius: 2px;
+  background: #2f2414;
+}
+
+.lgFF { left: 74px; z-index: 5; }
+.lgFB { left: 92px; filter: brightness(0.78); }
+.lgBF { left: 150px; z-index: 5; }
+.lgBB { left: 168px; filter: brightness(0.78); }
+
+.tailS {
+  position: absolute;
+  bottom: 60px;
+  left: 196px;
+  width: 12px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #9a7e54, #5f4a2c);
+  z-index: 3;
+}
+
+.neckS {
+  position: absolute;
+  bottom: 74px;
+  left: 44px;
+  width: 34px;
+  height: 40px;
+  border-radius: 40% 30% 30% 44%;
+  background: linear-gradient(200deg, #e2cfa4, #8a6f4a);
+  transform-origin: 50% 100%;
+  transform: rotate(-16deg);
+  z-index: 5;
+}
+
+.headS {
+  position: absolute;
+  bottom: 96px;
+  left: 6px;
+  width: 60px;
+  height: 54px;
+  z-index: 6;
+  animation: grazeS 4.5s ease-in-out infinite;
+}
+
+.skullS {
+  position: absolute;
+  bottom: 10px;
+  left: 26px;
+  width: 34px;
+  height: 34px;
+  border-radius: 46% 40% 36% 46% / 44% 44% 56% 56%;
+  background: radial-gradient(circle at 56% 34%, #e6d3a8, #8a6f4a 80%);
+  z-index: 4;
+}
+
+/* the ringed, translucent-amber horns of the male */
+.hornS {
+  position: absolute;
+  bottom: 40px;
+  width: 6px;
+  height: 40px;
+  border-radius: 3px 3px 2px 2px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(90, 60, 20, 0.5) 0 2px,
+      transparent 2px 5px
+    ),
+    linear-gradient(180deg, #e8d49a, #a07a3a);
+  transform-origin: 50% 100%;
+  z-index: 3;
+}
+
+.hnF { left: 44px; transform: rotate(6deg); }
+.hnB { left: 40px; transform: rotate(2deg); filter: brightness(0.82); z-index: 2; }
+
+.earS {
+  position: absolute;
+  bottom: 38px;
+  left: 52px;
+  width: 12px;
+  height: 9px;
+  border-radius: 50% 50% 40% 40%;
+  background: linear-gradient(180deg, #c8ac78, #6a5230);
+  transform: rotate(30deg);
+  z-index: 3;
+}
+
+.eyeS {
+  position: absolute;
+  bottom: 34px;
+  left: 40px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #4a3418, #0a0604 66%);
+  box-shadow: 0 0 0 1px rgba(30, 20, 8, 0.7);
+  z-index: 6;
+}
+
+/*
+  the nose. it is the whole point of the animal: an oversized, downward-
+  pointing, trunk-like proboscis. in summer it filters dust out of the air;
+  in the -40C winter it warms and humidifies each breath before the lungs.
+*/
+.noseS {
+  position: absolute;
+  bottom: 2px;
+  left: 0;
+  width: 34px;
+  height: 34px;
+  z-index: 7;
+  animation: snuffS 2.4s ease-in-out infinite;
+}
+
+.proboscisS {
+  position: absolute;
+  bottom: 0;
+  left: 6px;
+  width: 26px;
+  height: 34px;
+  border-radius: 46% 46% 50% 60% / 30% 30% 70% 70%;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(90, 60, 30, 0.24) 0 1px,
+      transparent 1px 5px
+    ),
+    radial-gradient(circle at 40% 26%, #d8bd8c, #6a4f2e 82%);
+  box-shadow: inset -3px -2px 8px rgba(60, 40, 16, 0.5);
+}
+
+.nostrilS {
+  position: absolute;
+  bottom: 2px;
+  width: 6px;
+  height: 8px;
+  border-radius: 50% 50% 50% 50% / 40% 40% 60% 60%;
+  background: radial-gradient(ellipse at 50% 30%, #2a1c0e, #0a0604 76%);
+  z-index: 2;
+  animation: flareS 2.4s ease-in-out infinite;
+}
+
+.nsL { left: 8px; }
+.nsR { left: 18px; animation-delay: -0.2s; }
+
+.tagNose {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(80, 56, 24, 0.85);
+  z-index: 9;
+}
+
+.capS {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.05em;
+  color: rgba(70, 52, 26, 0.85);
+  z-index: 9;
+}
+
+/* the nose flexes as the animal breathes; the nostrils flare on the intake */
+@keyframes snuffS {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  50% { transform: translateY(1px) scaleY(1.06); }
+}
+
+@keyframes flareS {
+  0%, 100% { transform: scaleX(1); }
+  50% { transform: scaleX(1.35); }
+}
+
+@keyframes grazeS {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-3deg); }
+}
+
+@keyframes breatheS {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2px); }
+}
+
+/* the dust is pulled toward the nose and vanishes at it: filtered out */
+@keyframes driftS {
+  0% { transform: translate(0, 0); opacity: 0; }
+  20% { opacity: 0.8; }
+  82% { opacity: 0.8; }
+  92% { transform: translate(-30px, 6px); opacity: 0; }
+  100% { transform: translate(-30px, 6px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .saigaS,
+  .headS,
+  .noseS,
+  .nostrilS,
+  .moteS {
+    animation: none;
+  }
+
+  .moteS { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/saiga-as/`, a self-contained pure CSS/HTML saiga antelope defined by its oversized filtering nose.

Closes #48891

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

The saiga's nose is a soft downward-pointing proboscis, oversized relative to the head, that filters summer dust and warms winter air. That nose is the animal, so the component commits to it and checks it.

- **The nose is genuinely oversized, and it is checked.** The browser check measures the proboscis against the skull: **35px tall against a 34px skull, a ratio of 1.03**. The nose is as tall as the entire rest of the head, which on a normal antelope would be absurd and is exactly the point.
- **It points down, verified.** The check confirms the nose's bounding box extends **below the eye line**. A forward-pointing muzzle would be the wrong animal.
- **The filter is shown working**: dust motes drift in on the wind and **vanish at the nostrils**, on a loop, because trapping dust before the lungs is the nose's summer job.
- **The nostrils flare on the intake**: a `scaleX` keyframe on each nostril, offset slightly so they are not in lockstep.
- **Ringed amber horns**: the male's translucent ridged horns via a `repeating-linear-gradient` over an amber base.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and hides the drifting dust, leaving the animal standing.

## Verification

Opened `demo.html` in the browser and checked the defining feature rather than the general shape: measured the proboscis at 35px against a 34px skull (ratio 1.03, so it really is as tall as the head) and confirmed its bounding box hangs below the eye line, matching the saiga's downward-pointing nose. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
