### PR TITLE
Add binturong component

### DIFF
--- a/submissions/examples/binturong-as/README.md
+++ b/submissions/examples/binturong-as/README.md
@@ -1,0 +1,32 @@
+# Binturong
+
+A pure CSS/HTML binturong hanging beneath a branch, its prehensile tail hooked over the top as a fifth limb.
+
+## What it shows
+
+The binturong, or "bearcat", is neither bear nor cat. It is a large civet, and two things about it are genuinely unusual.
+
+**Its tail is a fifth limb.** It is thickly furred, as long as the animal's own body, bare and calloused on the underside of the tip, and fully prehensile. The binturong is the **only carnivore in the Old World with a gripping tail** (the kinkajou, the only other one, is in the Americas). It uses it to hang, to brake while descending head-first, and to hold on while both hands are busy with fruit.
+
+**It smells of hot buttered popcorn.** This is not a metaphor. The scent comes from **2-acetylpyrroline**, the exact same molecule produced when you pop corn or bake bread. The binturong makes it in its urine and scent-marks its territory with it, so a patch of rainforest occupied by a binturong smells like a cinema.
+
+They are slow, heavy, and largely fruit-eating, and they are important seed dispersers, one of the few animals that can digest the tough seeds of the strangler fig.
+
+## How it is built
+
+- **The tail is genuinely body-length, and it is checked.** The browser check measures the tail against the body: **118px against 117px, a ratio of 1.01**. The tail is longer than the whole body, which is the claim, so it is measured rather than asserted.
+- **It grips the branch, verified.** The tail tip curls up and over the top of the branch, and the check confirms the tip's bounding box reaches the branch. The callused pad is drawn on the *upper* inner face of the tip, because that is the surface that actually presses the bark. That grip is why the animal can hang there at all.
+- **Hanging, not standing on top.** Both limb grips curl *up* over the branch and the body hangs beneath it, so the pose reads as suspended rather than perched.
+- **The popcorn is shown**: warm golden scent motes waft up and spread from the animal on a staggered loop, keyed to the 2-acetylpyrroline the caption names.
+- **Field marks**: the long dark ear tufts that overshoot the ear rims, the shaggy black coat drawn with a `repeating-linear-gradient`, and the reddish eyeshine.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and hides the drifting scent, leaving the animal hanging.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/binturong-as/demo.html
+++ b/submissions/examples/binturong-as/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Binturong</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="canopyB"></span>
+    <span class="leafB lfA"></span>
+    <span class="leafB lfB"></span>
+    <span class="branchB"></span>
+
+    <div class="binB">
+      <span class="tailB"></span>
+      <span class="tailTipB"></span>
+      <span class="hindB"></span>
+      <span class="bodyB"></span>
+      <span class="foreB"></span>
+      <span class="gripFore"></span>
+      <span class="gripHind"></span>
+      <div class="headB">
+        <span class="skullB"></span>
+        <span class="earB eaL"></span>
+        <span class="earB eaR"></span>
+        <span class="tuftB tfL"></span>
+        <span class="tuftB tfR"></span>
+        <span class="eyeB"></span>
+        <span class="snoutB"></span>
+        <span class="whiskB wkA"></span>
+        <span class="whiskB wkB"></span>
+      </div>
+    </div>
+
+    <div class="scentWrap">
+        <span class="scentB" style="--i: 0; --dx: -8px"></span>
+        <span class="scentB" style="--i: 1; --dx: 4px"></span>
+        <span class="scentB" style="--i: 2; --dx: -3px"></span>
+        <span class="scentB" style="--i: 3; --dx: 9px"></span>
+        <span class="scentB" style="--i: 4; --dx: -6px"></span>
+
+    </div>
+
+    <span class="tagScent">smells of buttered popcorn</span>
+    <span class="capB">a prehensile tail as long as its body, used as a fifth limb</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/binturong-as/style.css
+++ b/submissions/examples/binturong-as/style.css
@@ -1,0 +1,362 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 26%, #24301f, #060905 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 46% 30%, #3a4a2c, #0a1006 86%);
+}
+
+.canopyB {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 12%, rgba(150, 200, 120, 0.16) 0 30px, transparent 48px),
+    radial-gradient(circle at 80% 18%, rgba(150, 200, 120, 0.12) 0 26px, transparent 42px);
+  z-index: 1;
+}
+
+.leafB {
+  position: absolute;
+  border-radius: 60% 12% 60% 12%;
+  background:
+    repeating-conic-gradient(
+      from 128deg at 6% 90%,
+      rgba(16, 34, 12, 0.32) 0 0.7deg,
+      transparent 0.7deg 8deg
+    ),
+    linear-gradient(140deg, #5a8a3c, #1e3a18);
+  z-index: 2;
+}
+
+.lfA { top: -10px; left: -20px; width: 130px; height: 52px; transform: rotate(16deg); }
+.lfB { top: 8px; right: -30px; width: 140px; height: 48px; transform: rotate(-14deg) scaleX(-1); filter: brightness(0.86); }
+
+/* the branch it hangs under, walking upside down */
+.branchB {
+  position: absolute;
+  top: 96px;
+  left: -14px;
+  right: -14px;
+  height: 22px;
+  border-radius: 11px;
+  background:
+    repeating-linear-gradient(
+      86deg,
+      rgba(30, 20, 8, 0.34) 0 2px,
+      transparent 2px 16px
+    ),
+    linear-gradient(180deg, #6a4f30, #2a1c0e);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.5);
+  z-index: 6;
+}
+
+.binB {
+  position: absolute;
+  top: 108px;
+  left: 50%;
+  width: 300px;
+  height: 150px;
+  margin-left: -132px;
+  z-index: 5;
+  animation: swayB 6.5s ease-in-out infinite;
+}
+
+.bodyB {
+  position: absolute;
+  top: 24px;
+  left: 76px;
+  width: 116px;
+  height: 60px;
+  border-radius: 46% 50% 46% 50% / 54% 54% 46% 46%;
+  background:
+    repeating-linear-gradient(
+      64deg,
+      rgba(10, 10, 8, 0.4) 0 2px,
+      transparent 2px 9px
+    ),
+    radial-gradient(circle at 42% 32%, #33302a, #0e0d0b 80%);
+  box-shadow: inset -6px 5px 16px rgba(4, 4, 2, 0.6);
+  z-index: 4;
+}
+
+.hindB {
+  position: absolute;
+  top: 26px;
+  left: 158px;
+  width: 54px;
+  height: 54px;
+  border-radius: 50% 46% 46% 50% / 50% 50% 50% 50%;
+  background: radial-gradient(circle at 44% 34%, #2f2c26, #0a0908 80%);
+  z-index: 3;
+}
+
+.foreB {
+  position: absolute;
+  top: 30px;
+  left: 60px;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 46% 34%, #35322b, #0c0b09 80%);
+  z-index: 5;
+}
+
+/* both grips curl UP over the branch: the animal is hanging beneath it */
+.gripFore,
+.gripHind {
+  position: absolute;
+  top: -14px;
+  width: 16px;
+  height: 30px;
+  border-radius: 8px 8px 4px 4px;
+  background: linear-gradient(180deg, #2a2620, #0a0908);
+  transform-origin: 50% 100%;
+  z-index: 7;
+}
+
+.gripFore { left: 70px; transform: rotate(-12deg); }
+.gripHind { left: 172px; transform: rotate(10deg); }
+
+/*
+  the tail. it is as long as the head and body together, thickly furred,
+  bare and calloused on the underside of the tip, and fully prehensile.
+  it is the only old-world carnivore with a gripping tail.
+*/
+.tailB {
+  position: absolute;
+  top: 40px;
+  left: 168px;
+  width: 118px;
+  height: 30px;
+  border-radius: 0 60% 60% 0 / 0 50% 50% 0;
+  background:
+    repeating-linear-gradient(
+      88deg,
+      rgba(10, 10, 8, 0.4) 0 2px,
+      transparent 2px 8px
+    ),
+    linear-gradient(90deg, #2f2c26, #46423a);
+  transform-origin: 0 40%;
+  z-index: 3;
+  animation: curlB 6.5s ease-in-out infinite;
+}
+
+/* the tip curls back up and grips the branch: the fifth limb */
+.tailTipB {
+  position: absolute;
+  top: -34px;
+  left: 268px;
+  width: 20px;
+  height: 74px;
+  border-radius: 10px 10px 8px 8px;
+  background: linear-gradient(180deg, #46423a, #1a1712);
+  transform-origin: 50% 100%;
+  transform: rotate(24deg);
+  z-index: 8;
+  animation: gripTipB 6.5s ease-in-out infinite;
+}
+
+.tailTipB::after {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 2px;
+  right: 2px;
+  height: 10px;
+  border-radius: 5px;
+  background: #6a5a48;
+}
+
+.headB {
+  position: absolute;
+  top: 34px;
+  left: 26px;
+  width: 60px;
+  height: 56px;
+  z-index: 6;
+  animation: nuzzleB 6.5s ease-in-out infinite;
+}
+
+.skullB {
+  position: absolute;
+  top: 12px;
+  left: 14px;
+  width: 42px;
+  height: 38px;
+  border-radius: 40% 50% 44% 40% / 44% 50% 50% 44%;
+  background: radial-gradient(circle at 40% 34%, #3a352c, #100e0b 80%);
+  z-index: 3;
+}
+
+.earB {
+  position: absolute;
+  top: 4px;
+  width: 16px;
+  height: 15px;
+  border-radius: 50% 50% 30% 30%;
+  background: radial-gradient(circle at 44% 40%, #2f2b24, #0c0b08 78%);
+  z-index: 2;
+}
+
+.eaL { left: 20px; }
+.eaR { left: 38px; }
+
+/* the ear tufts: long dark hairs sticking past the ear rims, a field mark */
+.tuftB {
+  position: absolute;
+  top: -8px;
+  width: 3px;
+  height: 16px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #0a0908, #33302a);
+  transform-origin: 50% 100%;
+  z-index: 4;
+}
+
+.tfL { left: 24px; transform: rotate(-16deg); }
+.tfR { left: 42px; transform: rotate(14deg); }
+
+.eyeB {
+  position: absolute;
+  top: 24px;
+  left: 22px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #c86a2a, #2a1204 66%);
+  box-shadow: 0 0 5px rgba(220, 120, 40, 0.5);
+  z-index: 5;
+}
+
+.snoutB {
+  position: absolute;
+  top: 30px;
+  left: 4px;
+  width: 18px;
+  height: 14px;
+  border-radius: 60% 30% 40% 60% / 50% 40% 60% 60%;
+  background: radial-gradient(circle at 60% 34%, #33302a, #0a0908 78%);
+  z-index: 4;
+}
+
+.snoutB::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 0;
+  width: 7px;
+  height: 6px;
+  border-radius: 50%;
+  background: #d8a0a0;
+}
+
+.whiskB {
+  position: absolute;
+  top: 34px;
+  left: -6px;
+  width: 20px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(240, 236, 220, 0.7), transparent);
+  transform-origin: 100% 50%;
+  z-index: 6;
+}
+
+.wkA { transform: rotate(10deg); }
+.wkB { top: 38px; transform: rotate(-8deg); }
+
+/* the scent: 2-acetylpyrroline, the same molecule that makes popcorn smell */
+.scentWrap {
+  position: absolute;
+  top: 150px;
+  left: 66px;
+  width: 0;
+  height: 0;
+  z-index: 4;
+}
+
+.scentB {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 230, 160, 0.4), transparent 70%);
+  opacity: 0;
+  animation: wafB 5s ease-in infinite;
+  animation-delay: calc(var(--i) * -1s);
+}
+
+.tagScent {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 224, 150, 0.85);
+  z-index: 9;
+}
+
+.capB {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.05em;
+  color: rgba(230, 224, 200, 0.8);
+  z-index: 9;
+}
+
+/* the tail tip keeps its grip on the branch while the body sways under it */
+@keyframes swayB {
+  0%, 100% { transform: translateY(0) rotate(-0.6deg); }
+  50% { transform: translateY(4px) rotate(0.6deg); }
+}
+
+@keyframes curlB {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(2deg); }
+}
+
+@keyframes gripTipB {
+  0%, 100% { transform: rotate(24deg); }
+  50% { transform: rotate(20deg); }
+}
+
+@keyframes nuzzleB {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-2.5deg); }
+}
+
+@keyframes wafB {
+  0% { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  20% { opacity: 0.85; }
+  100% { transform: translate(var(--dx, 0), -120px) scale(2.2); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .binB,
+  .tailB,
+  .tailTipB,
+  .headB,
+  .scentB {
+    animation: none;
+  }
+
+  .scentB { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/binturong-as/`, a self-contained pure CSS/HTML binturong hanging by a prehensile tail.

Closes #48893

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

The binturong is the only Old World carnivore with a gripping tail, and it famously smells of hot buttered popcorn (the molecule 2-acetylpyrroline, the same one from popping corn). Both facts are built in.

- **The tail is genuinely body-length, and it is checked.** The browser check measures the tail against the body: **118px against 117px, a ratio of 1.01**. The tail is longer than the whole body, which is the claim, so it is measured rather than asserted.
- **It grips the branch, verified.** The tail tip curls up and over the top of the branch, and the check confirms the tip's bounding box reaches the branch. The callused pad is drawn on the upper inner face of the tip, the surface that actually presses the bark.
- **Hanging, not standing on top.** Both limb grips curl up over the branch and the body hangs beneath it, so the pose reads as suspended rather than perched.
- **The popcorn is shown**: warm golden scent motes waft up and spread on a staggered loop, keyed to the molecule the caption names.
- **Field marks**: long dark ear tufts overshooting the ear rims, a shaggy black coat via a `repeating-linear-gradient`, and reddish eyeshine.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and hides the drifting scent, leaving the animal hanging.

## Verification

Opened `demo.html` in the browser and measured the defining features rather than eyeballing them: the tail resolves to 118px against a 117px body (ratio 1.01, longer than the body), and the tail tip's bounding box reaches the branch it curls over. An earlier pass had the tail too short (0.61 ratio) and running off-frame; recomposed so it grips within the scene. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
