### PR TITLE
Add sifaka component

### DIFF
--- a/submissions/examples/sifaka-as/README.md
+++ b/submissions/examples/sifaka-as/README.md
@@ -1,0 +1,33 @@
+# Sifaka
+
+A pure CSS/HTML Verreaux's sifaka crossing open ground the only way it can: upright, feet together, bounding sideways.
+
+## What it shows
+
+A sifaka is a lemur built entirely for the vertical. Its legs are far longer than its arms, and its whole body is engineered to cling to a trunk and then launch to the next one, sometimes ten metres away, steering in mid-air and landing feet-first.
+
+That specialisation has a cost. On the ground it **cannot walk on all fours** the way most primates do, because its arms are simply too short to reach. So when it has to cross a gap between trees, it does the thing it has become famous for: it stands **fully upright**, holds its **feet together**, throws its **arms out for balance**, and **bounds sideways** in a series of two-footed hops. Tourists call it the "dancing sifaka", and it is one of the strangest gaits in the animal kingdom, a direct consequence of a body that was never meant to touch the floor.
+
+The name is onomatopoeic. It comes from the *shif-auk* alarm call the animal makes.
+
+## How it is built
+
+- **The gait is verified against all three of its defining features.** The browser check measures the bound off its paused timeline and confirms:
+  - **Sideways**: 120px of horizontal travel across the ground.
+  - **A real airborne phase**: the body rises 54px off the ground at mid-hop, so it genuinely leaps rather than shuffling.
+  - **Feet together**: the two feet stay 14px apart, a single launch unit rather than a stride.
+- **Legs longer than arms, checked.** The measured leg is 41px against a 29px arm. That ratio is *why* the animal cannot walk, so it is built in and confirmed rather than implied.
+- **Upright and leaning.** The body holds vertical and leans into the direction of travel on each bound, righting itself on landing, which is the posture that makes it look like dancing.
+- **The launch is a spring**: the legs coil with `scaleY(0.7)` and extend to `scaleY(1.1)` at the push-off, and the dust kicks up on the landing frame.
+- **Field marks of Verreaux's sifaka**: white body, a bare **black face** under a **white fur cap**, and the long thickly-furred tail. Spiny "octopus trees" of the Madagascar spiny forest stand behind.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables every keyframe and hides the dust, leaving the sifaka standing upright.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/sifaka-as/demo.html
+++ b/submissions/examples/sifaka-as/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sifaka</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="skyF"></span>
+    <span class="sunF"></span>
+    <span class="spinyF spA"></span>
+    <span class="spinyF spB"></span>
+    <span class="groundF"></span>
+      <span class="dustF" style="--i: 0; --dx: -6px"></span>
+      <span class="dustF" style="--i: 1; --dx: 4px"></span>
+      <span class="dustF" style="--i: 2; --dx: -10px"></span>
+      <span class="dustF" style="--i: 3; --dx: 8px"></span>
+
+    <div class="hopF">
+      <div class="sifakaF">
+        <span class="tailF"></span>
+        <span class="legF lgB"></span>
+        <span class="legF lgF"></span>
+        <span class="torsoF"></span>
+        <span class="armF arB"></span>
+        <span class="armF arF"></span>
+        <span class="chestF"></span>
+        <div class="headF">
+          <span class="faceF"></span>
+          <span class="maskF"></span>
+          <span class="eyeF eyL"></span>
+          <span class="eyeF eyR"></span>
+          <span class="crownF"></span>
+        </div>
+      </div>
+    </div>
+
+    <span class="tagGait">upright, feet together, sideways</span>
+    <span class="capF">it cannot walk. on the ground it dances.</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/sifaka-as/style.css
+++ b/submissions/examples/sifaka-as/style.css
@@ -1,0 +1,356 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #e8b878, #b0805a 58%, #4f3c30);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f2d29a, #d8a874 44%, #a8805a 66%, #6f5642);
+}
+
+.skyF {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 24% 20%, rgba(255, 250, 220, 0.6), transparent 52%);
+  z-index: 1;
+}
+
+.sunF {
+  position: absolute;
+  top: 34px;
+  left: 44px;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe4, #ffd86a 56%, rgba(255, 210, 100, 0) 78%);
+  z-index: 1;
+}
+
+/* Madagascar spiny forest: octopus trees in the background */
+.spinyF {
+  position: absolute;
+  bottom: 96px;
+  width: 10px;
+  border-radius: 5px 5px 0 0;
+  background: linear-gradient(90deg, #3f5a3a, #26401f);
+  z-index: 2;
+}
+
+.spinyF::before,
+.spinyF::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  width: 8px;
+  height: 60px;
+  border-radius: 5px 5px 0 0;
+  background: linear-gradient(90deg, #3f5a3a, #26401f);
+}
+
+.spinyF::before { left: -9px; transform: rotate(14deg); transform-origin: 50% 100%; }
+.spinyF::after { right: -9px; transform: rotate(-14deg); transform-origin: 50% 100%; }
+
+.spA { right: 60px; height: 84px; }
+.spB { right: 100px; height: 108px; filter: brightness(0.86); }
+
+.groundF {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 100px;
+  background:
+    radial-gradient(circle at 18% 42%, rgba(90, 66, 40, 0.34) 0 5px, transparent 9px),
+    radial-gradient(circle at 72% 64%, rgba(90, 66, 40, 0.3) 0 6px, transparent 10px),
+    linear-gradient(180deg, #c49868, #6a4f34);
+  z-index: 3;
+}
+
+/* the dust each landing kicks up */
+.dustF {
+  position: absolute;
+  bottom: 92px;
+  left: 120px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(200, 170, 130, 0.7), transparent 70%);
+  opacity: 0;
+  z-index: 5;
+  animation: kickF 1.4s ease-out infinite;
+  animation-delay: calc(var(--i) * 0.05s);
+}
+
+/*
+  the bound. the sifaka cannot walk on all fours: its legs are far longer
+  than its arms, built for leaping between trunks. on the ground it holds
+  its body UPRIGHT, keeps its feet together, and springs SIDEWAYS in a hop.
+*/
+.hopF {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  width: 80px;
+  height: 120px;
+  margin-left: -40px;
+  z-index: 6;
+  animation: boundF 1.4s cubic-bezier(0.3, 0, 0.5, 1) infinite;
+}
+
+.sifakaF {
+  position: absolute;
+  inset: 0;
+  transform-origin: 50% 100%;
+  animation: leanF 1.4s ease-in-out infinite;
+}
+
+.torsoF {
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  width: 34px;
+  height: 52px;
+  margin-left: -17px;
+  border-radius: 44% 44% 40% 40% / 50% 50% 50% 50%;
+  background:
+    repeating-linear-gradient(
+      66deg,
+      rgba(120, 96, 60, 0.16) 0 3px,
+      transparent 3px 11px
+    ),
+    radial-gradient(circle at 42% 30%, #f4ecd8, #b09a76 82%);
+  box-shadow: inset -4px -3px 12px rgba(90, 70, 40, 0.3);
+  z-index: 4;
+}
+
+.chestF {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 22px;
+  height: 30px;
+  margin-left: -11px;
+  border-radius: 50% 50% 44% 44%;
+  background: linear-gradient(180deg, #fff8ec, #d8c8ac);
+  z-index: 5;
+}
+
+/* the long legs, held together, the launch spring */
+.legF {
+  position: absolute;
+  bottom: 0;
+  width: 12px;
+  height: 40px;
+  border-radius: 6px 6px 4px 4px;
+  background: linear-gradient(180deg, #4a2c14, #21120a);
+  transform-origin: 50% 0;
+  z-index: 3;
+  animation: springF 1.4s cubic-bezier(0.3, 0, 0.5, 1) infinite;
+}
+
+.legF::after {
+  content: "";
+  position: absolute;
+  bottom: -3px;
+  left: -3px;
+  width: 20px;
+  height: 6px;
+  border-radius: 3px;
+  background: #1a0e06;
+}
+
+.lgF { left: 50%; margin-left: -13px; z-index: 4; }
+.lgB { left: 50%; margin-left: 1px; filter: brightness(0.82); }
+
+/* the short arms, flung up for balance on each bound */
+.armF {
+  position: absolute;
+  bottom: 62px;
+  width: 8px;
+  height: 30px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #33301f, #16130a);
+  transform-origin: 50% 0;
+  z-index: 6;
+  animation: flailF 1.4s ease-in-out infinite;
+}
+
+.arF { left: 50%; margin-left: -22px; }
+.arB { left: 50%; margin-left: 14px; filter: brightness(0.82); animation-delay: -0.04s; }
+
+.tailF {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  width: 12px;
+  height: 60px;
+  margin-left: 12px;
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(120, 96, 60, 0.18) 0 3px,
+      transparent 3px 10px
+    ),
+    linear-gradient(180deg, #efe6d0, #b8a480);
+  transform-origin: 50% 0;
+  z-index: 2;
+  animation: tailFwave 1.4s ease-in-out infinite;
+}
+
+.headF {
+  position: absolute;
+  bottom: 74px;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin-left: -17px;
+  z-index: 7;
+  animation: bobF 1.4s ease-in-out infinite;
+}
+
+.faceF {
+  position: absolute;
+  bottom: 0;
+  left: 3px;
+  width: 28px;
+  height: 30px;
+  border-radius: 50% 50% 46% 46%;
+  background: radial-gradient(circle at 44% 34%, #f4ecd8, #b8a884 82%);
+  z-index: 3;
+}
+
+/* the black bare face and muzzle of the Verreaux's sifaka */
+.maskF {
+  position: absolute;
+  bottom: 2px;
+  left: 7px;
+  width: 20px;
+  height: 22px;
+  border-radius: 50% 50% 46% 46%;
+  background: radial-gradient(circle at 46% 40%, #2a2620, #060504 78%);
+  z-index: 4;
+}
+
+.eyeF {
+  position: absolute;
+  bottom: 15px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #f0c85a, #4a2a04 66%);
+  box-shadow: 0 0 4px rgba(240, 180, 60, 0.6);
+  z-index: 6;
+}
+
+.eyL { left: 9px; }
+.eyR { left: 18px; }
+
+/* the white fur cap over the black face */
+.crownF {
+  position: absolute;
+  bottom: 22px;
+  left: 2px;
+  width: 30px;
+  height: 14px;
+  border-radius: 50% 50% 30% 30%;
+  background: linear-gradient(180deg, #fff8ec, #d8c8ac);
+  z-index: 5;
+}
+
+.tagGait {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(80, 56, 24, 0.85);
+  z-index: 9;
+}
+
+.capF {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.05em;
+  color: rgba(70, 52, 26, 0.85);
+  z-index: 9;
+}
+
+/*
+  the bound: a big sideways leap with a real airborne phase, then a landing.
+  the arms fly up, the legs coil and extend, and it travels left across
+  the ground. this is the "dancing sifaka" gait.
+*/
+@keyframes boundF {
+  0% { transform: translate(60px, 0); }
+  30% { transform: translate(30px, -46px); }
+  50% { transform: translate(0, -54px); }
+  70% { transform: translate(-30px, -40px); }
+  92% { transform: translate(-60px, 0); }
+  100% { transform: translate(-60px, 0); }
+}
+
+/* the body leans into the direction of travel and rights itself on landing */
+@keyframes leanF {
+  0%, 100% { transform: rotate(-8deg); }
+  50% { transform: rotate(6deg); }
+}
+
+@keyframes springF {
+  0% { transform: scaleY(0.7); }
+  16% { transform: scaleY(1.1); }
+  50% { transform: scaleY(1); }
+  86% { transform: scaleY(0.7); }
+  100% { transform: scaleY(0.7); }
+}
+
+@keyframes flailF {
+  0%, 100% { transform: rotate(28deg); }
+  40% { transform: rotate(-40deg); }
+  60% { transform: rotate(-46deg); }
+}
+
+@keyframes tailFwave {
+  0%, 100% { transform: rotate(-16deg); }
+  50% { transform: rotate(12deg); }
+}
+
+@keyframes bobF {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-2px); }
+}
+
+@keyframes kickF {
+  0%, 78% { opacity: 0; transform: translate(0, 0) scale(0.4); }
+  84% { opacity: 0.8; transform: translate(0, 0) scale(1); }
+  100% { opacity: 0; transform: translate(var(--dx, 0), 8px) scale(1.6); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hopF,
+  .sifakaF,
+  .legF,
+  .armF,
+  .tailF,
+  .headF,
+  .dustF {
+    animation: none;
+  }
+
+  .dustF { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/sifaka-as/`, a self-contained pure CSS/HTML Verreaux's sifaka doing its upright sideways ground-bound.

Closes #48895

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A sifaka's legs are far longer than its arms, so on the ground it cannot walk on all fours. To cross open ground it stands upright, keeps its feet together, and bounds sideways: the "dancing sifaka" gait.

- **The gait is verified against all three of its defining features.** The browser check measures the bound off its paused animation timeline and confirms: **sideways** (120px of horizontal travel), **a real airborne phase** (the body rises 54px off the ground at mid-hop, so it genuinely leaps), and **feet together** (the two feet stay 14px apart, one launch unit rather than a stride).
- **Legs longer than arms, checked.** The measured leg is 41px against a 29px arm. That ratio is *why* the animal cannot walk, so it is built in and confirmed rather than implied.
- **Upright and leaning.** The body holds vertical and leans into the direction of travel on each bound, righting on landing, which is the posture that reads as dancing.
- **The launch is a spring**: the legs coil with `scaleY(0.7)` and extend to `scaleY(1.1)` at push-off, and dust kicks up on the landing frame.
- **Field marks of Verreaux's sifaka**: white body, bare black face under a white fur cap, long furred tail, and spiny "octopus trees" behind.

## Accessibility

`prefers-reduced-motion: reduce` disables every keyframe and hides the dust, leaving the sifaka standing upright.

## Verification

Opened `demo.html` in the browser and measured the gait off the paused timeline rather than eyeballing it: 120px sideways travel, 54px airborne rise at mid-hop, feet 14px apart, and legs (41px) confirmed longer than arms (29px), which is the anatomical reason for the gait. Also caught and fixed a malformed hex colour in the eye before linting. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
