### PR TITLE
feat: add ease-recycle-progress-indicator component

### DIFF
--- a/submissions/examples/ease-recycle-progress-indicator/README.md
+++ b/submissions/examples/ease-recycle-progress-indicator/README.md
@@ -1,0 +1,23 @@
+# Recycle Progress Indicator
+
+### 1. What does this do?
+A circular (ring-style) progress indicator themed around recycling, showing completion percentage with a smooth animated fill and a distinct "complete" state.
+
+### 2. How is it used?
+\`\`\`html
+<div class="recycle-progress" style="--progress: 65;">
+  <svg viewBox="0 0 120 120">
+    <circle class="track" cx="60" cy="60" r="52"></circle>
+    <circle class="fill" cx="60" cy="60" r="52"></circle>
+  </svg>
+  <div class="recycle-label">
+    <span class="recycle-icon">♻️</span>
+    <span class="recycle-percent">65%</span>
+  </div>
+</div>
+\`\`\`
+- Set the \`--progress\` CSS custom property (0–100) inline to control fill amount.
+- Add the \`is-complete\` class when progress reaches 100% to switch to a darker "done" fill color and can be paired with a checkmark icon instead of the recycle icon.
+
+### 3. Why is it useful?
+It gives EaseMotion CSS a lightweight, dependency-free way to visualize progress toward a goal (e.g., recycling/sorting tasks, sustainability trackers, onboarding checklists) with a smooth animated transition rather than an abrupt jump — fitting EaseMotion's philosophy of motion-driven, purposeful UI feedback.

--- a/submissions/examples/ease-recycle-progress-indicator/demo.html
+++ b/submissions/examples/ease-recycle-progress-indicator/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Recycle Progress Indicator Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Recycle Progress Indicator</h1>
+  <p>A circular progress ring themed around recycling — fills up as a task (e.g. waste sorted, items recycled) nears completion.</p>
+
+  <div class="demo-row">
+
+    <!-- 30% -->
+    <div class="recycle-progress" style="--progress: 30;">
+      <svg viewBox="0 0 120 120">
+        <circle class="track" cx="60" cy="60" r="52"></circle>
+        <circle class="fill" cx="60" cy="60" r="52"></circle>
+      </svg>
+      <div class="recycle-label">
+        <span class="recycle-icon">♻️</span>
+        <span class="recycle-percent">30%</span>
+      </div>
+    </div>
+
+    <!-- 65% -->
+    <div class="recycle-progress" style="--progress: 65;">
+      <svg viewBox="0 0 120 120">
+        <circle class="track" cx="60" cy="60" r="52"></circle>
+        <circle class="fill" cx="60" cy="60" r="52"></circle>
+      </svg>
+      <div class="recycle-label">
+        <span class="recycle-icon">♻️</span>
+        <span class="recycle-percent">65%</span>
+      </div>
+    </div>
+
+    <!-- 100% (complete state) -->
+    <div class="recycle-progress is-complete" style="--progress: 100;">
+      <svg viewBox="0 0 120 120">
+        <circle class="track" cx="60" cy="60" r="52"></circle>
+        <circle class="fill" cx="60" cy="60" r="52"></circle>
+      </svg>
+      <div class="recycle-label">
+        <span class="recycle-icon">✅</span>
+        <span class="recycle-percent">100%</span>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-recycle-progress-indicator/style.css
+++ b/submissions/examples/ease-recycle-progress-indicator/style.css
@@ -1,0 +1,72 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1115;
+  color: #f2f2f2;
+  padding: 40px;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+  margin-top: 40px;
+  flex-wrap: wrap;
+}
+
+.recycle-progress {
+  --progress: 0;
+  --size: 140px;
+  --track-color: #23262f;
+  --fill-color: #4caf50;
+  --circumference: 326.7; /* 2 * PI * r(52) */
+
+  position: relative;
+  width: var(--size);
+  height: var(--size);
+}
+
+.recycle-progress svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.recycle-progress .track {
+  fill: none;
+  stroke: var(--track-color);
+  stroke-width: 10;
+}
+
+.recycle-progress .fill {
+  fill: none;
+  stroke: var(--fill-color);
+  stroke-width: 10;
+  stroke-linecap: round;
+  stroke-dasharray: var(--circumference);
+  stroke-dashoffset: calc(var(--circumference) - (var(--progress) / 100) * var(--circumference));
+  transition: stroke-dashoffset 0.8s ease, stroke 0.4s ease;
+}
+
+.recycle-progress.is-complete .fill {
+  stroke: #2e7d32;
+}
+
+.recycle-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.recycle-icon {
+  font-size: 22px;
+}
+
+.recycle-percent {
+  font-size: 18px;
+  font-weight: 600;
+}


### PR DESCRIPTION
Closes #48022
## Pull Request Description
Adds a new `recycle-progress-indicator` component — a circular (ring-style) progress indicator themed around recycling, with an animated fill and a distinct "complete" state. Closes #48022.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-recycle-progress-indicator/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A circular progress ring that fills up (with a smooth animated transition) to show completion percentage, e.g. for recycling/sorting tasks or sustainability trackers.

**How does a developer use it?**
```html
<div class="recycle-progress" style="--progress: 65;">
  <svg viewBox="0 0 120 120">
    <circle class="track" cx="60" cy="60" r="52"></circle>
    <circle class="fill" cx="60" cy="60" r="52"></circle>
  </svg>
  <div class="recycle-label">
    <span class="recycle-icon">♻️</span>
    <span class="recycle-percent">65%</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's motion-first — the ring fill animates smoothly via `stroke-dashoffset` transitions rather than jumping abruptly, matching EaseMotion's philosophy of purposeful, readable animation. It's also fully self-contained (no JS required) and easy to reuse with a single CSS variable (`--progress`) controlling state.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Used raw class names (`recycle-progress`, `track`, `fill`, `recycle-label`, etc.) per the guide — happy to have these standardized to `ease-*` naming during integration. The `is-complete` modifier class switches to a darker green fill + checkmark icon at 100%; let me know if you'd prefer that handled differently (e.g. via a data attribute instead of a class).