### PR TITLE
Add ease-split-pane-layout component

### DIFF
--- a/submissions/examples/ease-split-pane-layout-ij/README.md
+++ b/submissions/examples/ease-split-pane-layout-ij/README.md
@@ -1,0 +1,16 @@
+# ease-split-pane-layout
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(116, 72%, 62%) | Primary color |
+| --bg | hsl(116, 12%, 97%) | Background |
+| --duration | 0.65s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-split-pane-layout-ij/demo.html
+++ b/submissions/examples/ease-split-pane-layout-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-split-pane-layout</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>split-pane-layout</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-split-pane-layout-ij/style.css
+++ b/submissions/examples/ease-split-pane-layout-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(116, 72%, 62%);--bg:hsl(116, 12%, 97%);--text:#1e293b;--duration:0.65s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes rise-split-pane-layout {
+  0% { transform: translateY(37px) scale(0.95); opacity: 0; }
+  60% { transform: translateY(-5px) scale(1.02); }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+@keyframes borderpulse-split-pane-layout {
+  0%, 100% { border-color: hsl(116, 72%, 62%); box-shadow: inset 0 0 0 0 hsl(116, 72%, 62%)20; }
+  33% { border-color: hsl(236, 72%, 62%); }
+  66% { border-color: hsl(356, 72%, 62%); box-shadow: inset 0 0 10px 2px hsl(356, 72%, 62%)20; }
+}
+.anim-target.active { animation: rise-split-pane-layout 0.65s ease-out forwards, borderpulse-split-pane-layout 2s ease-in-out infinite; border: 2px solid; border-radius: 12px; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(356, 72%, 62%)}


### PR DESCRIPTION
## Component: ease-split-pane-layout -- split pane layout -- layout element with rise translateY entrance and cycling border color progression

**Closes #49088**

### What this adds
A layout card with entrance animation. The at-keyframes rise-split-pane-layout lifts the element from below with slight overshoot while borderpulse-split-pane-layout transitions the border-color through three hue-shifted stops and adds an inner glow.

### Acceptance Criteria covered
- CSS at-keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-split-pane-layout-ij/demo.html
- submissions/examples/ease-split-pane-layout-ij/style.css
- submissions/examples/ease-split-pane-layout-ij/README.md

### How to review
Open demo.html directly in a browser. Click to see the rise entrance and border color cycling animation.
