### PR TITLE
Add CSS Fade-In Popover for Neumorphic Soft Layouts

### DIFF
--- a/submissions/examples/Add CSS Fade-In Popover for Neumorphic Soft Layouts 46375/README.md
+++ b/submissions/examples/Add CSS Fade-In Popover for Neumorphic Soft Layouts 46375/README.md
@@ -1,0 +1,55 @@
+# Fade-In Neumorphic Soft Popover
+
+A pure CSS, fully responsive, and accessible popover featuring a buttery-smooth "Fade-In" entrance animation triggered via focus or hover. This component is specifically designed to complement the extruded, clay-like **Neumorphic Soft** interface aesthetics utilizing the **EaseMotion** framework.
+
+## Features
+
+- **Neumorphic Aesthetics**: Heavily utilizes complex `box-shadow` techniques to create physical UI depth. Elements appear either extruded from the background (using light and dark drop shadows) or pressed into it (using inset shadows). The background color `#e0e5ec` serves as the canvas for this lighting effect.
+- **Pure CSS Focus Toggle**: The interaction relies entirely on native CSS pseudo-classes (`:focus-within` and `:hover`). Keyboard navigation is fully supported, allowing users to tab to the control buttons and instantly reveal the neumorphic popover panels. 
+- **Smooth Fade-In Animation**: Employs a custom `@keyframes` sequence (`ease-fade-in-popover`). The popover begins fully transparent and slightly shifted down (`translateY(5px)`), and smoothly fades in to full opacity while sliding into its resting place. This creates a very soft, subtle entrance that perfectly matches the "soft UI" aesthetic.
+- **Accessibility**: The native `<button type="button">` acts as the trigger, receiving focus naturally without JS event listeners, making it natively accessible to assistive technologies. A custom dashed focus outline ensures keyboard users know exactly where they are.
+- **Customizable**: Component variables are natively exposed on `.ease-popover-wrapper` allowing overriding of timing and neumorphic shadow variables. The `.center-align` modifier is provided to easily center the popover over a trigger (as seen in the Thermostat example).
+
+## Usage Structure
+
+```html
+<!-- Wrapper for the component -->
+<!-- Use 'center-align' modifier on the content if you want it centered -->
+<div class="ease-popover-wrapper">
+    
+    <!-- Native focusable button acts as the trigger -->
+    <!-- 'neu-btn' applies the extruded clay look -->
+    <button type="button" class="ease-popover-trigger neu-btn" aria-haspopup="dialog" aria-label="Settings">
+        <svg>...</svg>
+    </button>
+    
+    <!-- Popover Content (triggers when the button is focused or hovered) -->
+    <div class="ease-popover-content" role="dialog">
+        <div class="ease-popover-header">
+            <h4>Settings Title</h4>
+        </div>
+        <div class="ease-popover-body">
+            <!-- Neumorphic sliders and dials go here -->
+            <p>Soft UI Content</p>
+        </div>
+    </div>
+    
+</div>
+```
+
+## Customization Parameters
+
+The following CSS variables can be adjusted directly on the `.ease-popover-wrapper`:
+
+| Variable | Default Value | Description |
+| :--- | :--- | :--- |
+| `--popover-timing` | `300ms` | Total duration of the buttery smooth Fade-In animation. |
+| `--popover-bg` | `var(--neu-bg)` | The base background color (`#e0e5ec`) necessary for the shadows to look correct. |
+| `--popover-border` | `transparent` | Neumorphism doesn't use standard borders, it relies on light/shadow. |
+| `--popover-shadow` | `12px 12px 20px var(--neu-shadow-dark), -12px -12px 20px var(--neu-shadow-light)` | The heavy extruded dual-shadow that gives the popover its physical volume. |
+| `--popover-text` | `var(--neu-text-main)` | Soft, dark grey text for readable contrast. |
+| `--popover-radius` | `20px` | Large border radius for the friendly, soft aesthetic. |
+
+## Live Demo
+
+Open `demo.html` in your browser to view the popover integrated within a mock `Smart Home Control` dashboard. Use your mouse or the `Tab` key to interact with the Light Settings and Thermostat triggers to watch the soft fade-in animation and play with the neumorphic sliders!

--- a/submissions/examples/Add CSS Fade-In Popover for Neumorphic Soft Layouts 46375/demo.html
+++ b/submissions/examples/Add CSS Fade-In Popover for Neumorphic Soft Layouts 46375/demo.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Popover - Neumorphic Soft UI</title>
+    <!-- Import EaseMotion Core -->
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <!-- Component Styles -->
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="demo-layout">
+    <div class="demo-container">
+        
+        <header class="demo-header">
+            <h1 class="demo-title">Smart Home Control</h1>
+            <p class="demo-subtitle">Living Room Environment</p>
+        </header>
+        
+        <div class="neumorphic-grid">
+            
+            <!-- Control Item 1 -->
+            <div class="control-card">
+                <div class="control-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="5"></circle>
+                        <line x1="12" y1="1" x2="12" y2="3"></line>
+                        <line x1="12" y1="21" x2="12" y2="23"></line>
+                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                        <line x1="18.36" y1="19.36" x2="19.78" y2="20.78"></line>
+                        <line x1="1" y1="12" x2="3" y2="12"></line>
+                        <line x1="21" y1="12" x2="23" y2="12"></line>
+                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                    </svg>
+                </div>
+                <div class="control-info">
+                    <span class="control-name">Main Lights</span>
+                    <span class="control-status">75% Brightness</span>
+                </div>
+                
+                <!-- Fade-In Popover Component -->
+                <div class="ease-popover-wrapper">
+                    <!-- Native focusable button acts as trigger -->
+                    <button type="button" class="ease-popover-trigger neu-btn" aria-haspopup="dialog" aria-label="Light Settings">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="1"></circle>
+                            <circle cx="12" cy="5" r="1"></circle>
+                            <circle cx="12" cy="19" r="1"></circle>
+                        </svg>
+                    </button>
+                    
+                    <!-- Popover Content (triggers on focus or hover) -->
+                    <div class="ease-popover-content" role="dialog">
+                        <div class="ease-popover-header">
+                            <h4>Light Settings</h4>
+                        </div>
+                        <div class="ease-popover-body">
+                            <div class="neu-slider-container">
+                                <label>Brightness</label>
+                                <div class="neu-track">
+                                    <div class="neu-fill" style="width: 75%;"></div>
+                                </div>
+                            </div>
+                            <div class="neu-slider-container">
+                                <label>Warmth</label>
+                                <div class="neu-track">
+                                    <div class="neu-fill" style="width: 40%; background: linear-gradient(90deg, #ffeedd, #ffcc99);"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- End Popover Component -->
+                
+            </div>
+            
+            <!-- Control Item 2 -->
+            <div class="control-card">
+                <div class="control-icon active">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"></path>
+                    </svg>
+                </div>
+                <div class="control-info">
+                    <span class="control-name">Thermostat</span>
+                    <span class="control-status">72°F Auto</span>
+                </div>
+                
+                <div class="ease-popover-wrapper">
+                    <button type="button" class="ease-popover-trigger neu-btn" aria-haspopup="dialog" aria-label="Thermostat Settings">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="1"></circle>
+                            <circle cx="12" cy="5" r="1"></circle>
+                            <circle cx="12" cy="19" r="1"></circle>
+                        </svg>
+                    </button>
+                    
+                    <div class="ease-popover-content center-align" role="dialog">
+                        <div class="ease-popover-header">
+                            <h4>Climate Control</h4>
+                        </div>
+                        <div class="ease-popover-body">
+                            <div class="temp-dial">
+                                <span>72°</span>
+                            </div>
+                            <div class="neu-modes">
+                                <button class="neu-btn-small active">Auto</button>
+                                <button class="neu-btn-small">Cool</button>
+                                <button class="neu-btn-small">Heat</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/Add CSS Fade-In Popover for Neumorphic Soft Layouts 46375/style.css
+++ b/submissions/examples/Add CSS Fade-In Popover for Neumorphic Soft Layouts 46375/style.css
@@ -1,0 +1,374 @@
+/* ============================================================
+   Neumorphic Soft Fade-In Popover
+   ============================================================ */
+
+/* ── Demo Layout (for demo.html only) ──────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap');
+
+:root {
+  --neu-bg: #e0e5ec;
+  --neu-text-main: #4a5568;
+  --neu-text-muted: #a0aec0;
+  --neu-accent: #3182ce;
+  --neu-shadow-light: #ffffff;
+  --neu-shadow-dark: #a3b1c6;
+  --neu-radius: 20px;
+  --neu-font: 'Nunito', sans-serif;
+  
+  /* Standard Neumorphic Drop Shadow (Extruded) */
+  --neu-drop-shadow: 
+    9px 9px 16px var(--neu-shadow-dark), 
+    -9px -9px 16px var(--neu-shadow-light);
+    
+  /* Standard Neumorphic Inner Shadow (Pressed/Inset) */
+  --neu-inner-shadow: 
+    inset 6px 6px 10px var(--neu-shadow-dark), 
+    inset -6px -6px 10px var(--neu-shadow-light);
+}
+
+.demo-layout {
+  background-color: var(--neu-bg);
+  color: var(--neu-text-main);
+  font-family: var(--neu-font);
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 600px;
+  padding: var(--ease-space-6);
+}
+
+.demo-header {
+  margin-bottom: var(--ease-space-8);
+  text-align: center;
+}
+
+.demo-title {
+  font-size: var(--ease-text-2xl);
+  font-weight: 700;
+  margin: 0;
+  color: var(--neu-text-main);
+  letter-spacing: -0.01em;
+}
+
+.demo-subtitle {
+  font-size: var(--ease-text-base);
+  color: var(--neu-text-muted);
+  margin-top: var(--ease-space-2);
+}
+
+.neumorphic-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-6);
+}
+
+/* Neumorphic Control Card */
+.control-card {
+  background: var(--neu-bg);
+  border-radius: var(--neu-radius);
+  padding: var(--ease-space-4) var(--ease-space-6);
+  display: flex;
+  align-items: center;
+  gap: var(--ease-space-4);
+  box-shadow: var(--neu-drop-shadow);
+  transition: all 0.2s ease;
+}
+
+.control-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--neu-bg);
+  box-shadow: var(--neu-drop-shadow);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--neu-text-muted);
+}
+
+.control-icon.active {
+  color: var(--neu-accent);
+  box-shadow: var(--neu-inner-shadow);
+}
+
+.control-info {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.control-name {
+  font-weight: 700;
+  font-size: var(--ease-text-lg);
+  color: var(--neu-text-main);
+}
+
+.control-status {
+  font-size: var(--ease-text-sm);
+  color: var(--neu-text-muted);
+}
+
+/* Generic Neumorphic Button */
+.neu-btn {
+  background: var(--neu-bg);
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--neu-text-muted);
+  box-shadow: var(--neu-drop-shadow);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.neu-btn:hover {
+  color: var(--neu-accent);
+}
+
+.neu-btn:active {
+  box-shadow: var(--neu-inner-shadow);
+}
+
+
+/* ── Popover Component (Fade-In) ───────────────────────────── */
+
+.ease-popover-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  
+  /* Component Custom Properties (Neumorphic Tuned) */
+  --popover-timing: 300ms;
+  --popover-bg: var(--neu-bg);
+  --popover-border: transparent; /* No borders in Neumorphism */
+  /* We use the extruded shadow for the popover panel itself */
+  --popover-shadow: 12px 12px 20px var(--neu-shadow-dark), -12px -12px 20px var(--neu-shadow-light);
+  --popover-text: var(--neu-text-main);
+  --popover-radius: var(--neu-radius);
+}
+
+/* The Trigger Button is defined generally in .neu-btn above, 
+   but we add focus styles for accessibility */
+.ease-popover-trigger:focus-visible {
+  outline: 2px dashed var(--neu-text-muted);
+  outline-offset: 4px;
+}
+
+/* The Popover Content Dialog */
+.ease-popover-content {
+  position: absolute;
+  /* Positioned above the trigger */
+  bottom: calc(100% + var(--ease-space-4));
+  right: -10px; /* Align near the right edge */
+  
+  width: 260px;
+  background: var(--popover-bg);
+  border-radius: var(--popover-radius);
+  box-shadow: var(--popover-shadow);
+  padding: var(--ease-space-5);
+  
+  /* Initial hidden state */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  
+  color: var(--popover-text);
+  z-index: var(--ease-z-overlay);
+  
+  /* Subtle positional shift to accompany the fade (optional, but feels nicer) */
+  transform: translateY(5px);
+  
+  /* Transition for closing (Fade out) */
+  transition: 
+    opacity var(--ease-speed-fast) ease-out,
+    transform var(--ease-speed-fast) ease-out,
+    visibility var(--ease-speed-fast);
+}
+
+/* Centered Modifier */
+.ease-popover-content.center-align {
+  right: auto;
+  left: 50%;
+  transform: translateX(-50%) translateY(5px);
+}
+.ease-popover-wrapper:focus-within .ease-popover-content.center-align,
+.ease-popover-wrapper:hover .ease-popover-content.center-align {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Neumorphic Popover Arrow (Optional, usually omitted in soft UI, but added for clarity) */
+.ease-popover-content::after {
+  /* It's difficult to create a true neumorphic arrow with just borders,
+     so we use a rotated square to maintain the shadow */
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  right: 22px;
+  width: 16px;
+  height: 16px;
+  background: var(--popover-bg);
+  transform: rotate(45deg);
+  /* Only apply the dark shadow to the bottom-right of the rotated square */
+  box-shadow: 4px 4px 6px -2px var(--neu-shadow-dark);
+  z-index: -1;
+}
+
+.ease-popover-content.center-align::after {
+  right: auto;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+/* Focus/Hover Interaction */
+.ease-popover-wrapper:focus-within .ease-popover-content,
+.ease-popover-wrapper:hover .ease-popover-content {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  /* Bring it to resting position */
+  transform: translateY(0);
+  
+  /* Use animation for a smooth Fade-In */
+  animation: ease-fade-in-popover var(--popover-timing) ease-out both;
+}
+
+.ease-popover-wrapper:focus-within .ease-popover-content.center-align,
+.ease-popover-wrapper:hover .ease-popover-content.center-align {
+  animation: ease-fade-in-center-popover var(--popover-timing) ease-out both;
+}
+
+
+/* ── Keyframes for Fade-In Interaction ─────────────────────── */
+@keyframes ease-fade-in-popover {
+  0% { 
+    opacity: 0; 
+    transform: translateY(5px);
+  }
+  100% { 
+    opacity: 1; 
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-fade-in-center-popover {
+  0% { 
+    opacity: 0; 
+    transform: translateX(-50%) translateY(5px);
+  }
+  100% { 
+    opacity: 1; 
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+/* ── Content Styling (Neumorphic Forms) ────────────────────── */
+.ease-popover-header {
+  margin-bottom: var(--ease-space-4);
+  text-align: center;
+}
+
+.ease-popover-header h4 {
+  margin: 0;
+  font-size: var(--ease-text-base);
+  font-weight: 700;
+  color: var(--neu-text-main);
+}
+
+/* Slider */
+.neu-slider-container {
+  margin-bottom: var(--ease-space-4);
+}
+
+.neu-slider-container label {
+  display: block;
+  font-size: var(--ease-text-xs);
+  font-weight: 600;
+  color: var(--neu-text-muted);
+  margin-bottom: var(--ease-space-2);
+}
+
+.neu-track {
+  width: 100%;
+  height: 12px;
+  border-radius: 10px;
+  background: var(--neu-bg);
+  box-shadow: var(--neu-inner-shadow); /* Inset shadow for track */
+  overflow: hidden;
+}
+
+.neu-fill {
+  height: 100%;
+  background: var(--neu-accent);
+  border-radius: 10px;
+  /* Give the fill a slight extruded look */
+  box-shadow: 2px 0 5px rgba(0,0,0,0.1); 
+}
+
+/* Temperature Dial Mockup */
+.temp-dial {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: var(--neu-bg);
+  box-shadow: var(--neu-drop-shadow);
+  margin: 0 auto var(--ease-space-6) auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+/* Inner pressed circle */
+.temp-dial::after {
+  content: '';
+  position: absolute;
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+  background: var(--neu-bg);
+  box-shadow: var(--neu-inner-shadow);
+}
+
+.temp-dial span {
+  position: relative;
+  z-index: 10;
+  font-size: var(--ease-text-2xl);
+  font-weight: 700;
+  color: var(--neu-text-main);
+}
+
+/* Small Modes Buttons */
+.neu-modes {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--ease-space-2);
+}
+
+.neu-btn-small {
+  flex: 1;
+  background: var(--neu-bg);
+  border: none;
+  padding: var(--ease-space-2) 0;
+  border-radius: 12px;
+  font-family: var(--neu-font);
+  font-size: var(--ease-text-xs);
+  font-weight: 700;
+  color: var(--neu-text-muted);
+  box-shadow: var(--neu-drop-shadow);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.neu-btn-small.active {
+  color: var(--neu-accent);
+  box-shadow: var(--neu-inner-shadow);
+}


### PR DESCRIPTION
#46375

## Pull Request Description

<!-- Briefly describe what you're submitting and the problem it solves. -->
- Resolves #46375 
- created the  CSS Popover component: a buttery smooth Fade-In interaction, designed specifically to match the extruded, clay-like Neumorphic Soft UI aesthetic
---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---



## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
