### PR TITLE
feat: add ease-real-time-clock component

### DIFF
--- a/submissions/examples/ease-real-time-clock/README.md
+++ b/submissions/examples/ease-real-time-clock/README.md
@@ -1,0 +1,21 @@
+# Real-Time Clock
+
+### 1. What does this do?
+A live-updating digital clock display with a blinking colon separator and a subtle fade/flash transition whenever a digit changes, supporting both 24-hour and 12-hour (AM/PM) formats.
+
+### 2. How is it used?
+\`\`\`html
+<div class="real-time-clock" data-format="24">
+  <span class="rtc-segment" data-unit="hours">00</span>
+  <span class="rtc-colon">:</span>
+  <span class="rtc-segment" data-unit="minutes">00</span>
+  <span class="rtc-colon">:</span>
+  <span class="rtc-segment" data-unit="seconds">00</span>
+</div>
+\`\`\`
+- Set \`data-format="12"\` on the container to switch to 12-hour format and include a \`<span class="rtc-meridiem" data-unit="meridiem">\` element to display AM/PM.
+- Add the \`is-compact\` class for a smaller footprint (e.g. in a navbar or widget).
+- A small inline script reads the current time each second and updates only the segments whose value changed, applying a brief \`rtc-flash\` transition class.
+
+### 3. Why is it useful?
+Clocks are a common UI element (dashboards, headers, kiosks) and this component adds motion-driven feedback — a blinking separator and a soft flash on digit change — instead of a static, jarring re-render, fitting EaseMotion's animation-first philosophy while staying framework-free and self-contained.

--- a/submissions/examples/ease-real-time-clock/demo.html
+++ b/submissions/examples/ease-real-time-clock/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Real-Time Clock Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Real-Time Clock</h1>
+  <p>A live-updating digital clock with a pulsing colon separator and smooth digit fade on change.</p>
+
+  <div class="demo-row">
+
+    <div class="real-time-clock" data-format="24">
+      <span class="rtc-segment" data-unit="hours">00</span>
+      <span class="rtc-colon">:</span>
+      <span class="rtc-segment" data-unit="minutes">00</span>
+      <span class="rtc-colon">:</span>
+      <span class="rtc-segment" data-unit="seconds">00</span>
+    </div>
+
+    <div class="real-time-clock is-compact" data-format="12">
+      <span class="rtc-segment" data-unit="hours">00</span>
+      <span class="rtc-colon">:</span>
+      <span class="rtc-segment" data-unit="minutes">00</span>
+      <span class="rtc-meridiem" data-unit="meridiem">AM</span>
+    </div>
+
+  </div>
+
+  <script>
+    function pad(n) {
+      return String(n).padStart(2, '0');
+    }
+
+    function updateClock(clockEl) {
+      const now = new Date();
+      const format = clockEl.dataset.format;
+      let hours = now.getHours();
+      let meridiem = null;
+
+      if (format === '12') {
+        meridiem = hours >= 12 ? 'PM' : 'AM';
+        hours = hours % 12 || 12;
+      }
+
+      const values = {
+        hours: pad(hours),
+        minutes: pad(now.getMinutes()),
+        seconds: pad(now.getSeconds()),
+        meridiem: meridiem
+      };
+
+      clockEl.querySelectorAll('[data-unit]').forEach(el => {
+        const unit = el.dataset.unit;
+        const newValue = values[unit];
+        if (newValue !== null && el.textContent !== newValue) {
+          el.classList.add('rtc-flash');
+          el.textContent = newValue;
+          setTimeout(() => el.classList.remove('rtc-flash'), 300);
+        }
+      });
+    }
+
+    document.querySelectorAll('.real-time-clock').forEach(clockEl => {
+      updateClock(clockEl);
+      setInterval(() => updateClock(clockEl), 1000);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-real-time-clock/style.css
+++ b/submissions/examples/ease-real-time-clock/style.css
@@ -1,0 +1,64 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1115;
+  color: #f2f2f2;
+  padding: 40px;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+  margin-top: 40px;
+  flex-wrap: wrap;
+}
+
+.real-time-clock {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  font-family: 'Courier New', monospace;
+  font-size: 42px;
+  font-weight: 600;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  padding: 18px 28px;
+  letter-spacing: 2px;
+}
+
+.real-time-clock.is-compact {
+  font-size: 32px;
+  padding: 14px 22px;
+}
+
+.rtc-segment {
+  display: inline-block;
+  min-width: 1.1ch;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.rtc-segment.rtc-flash {
+  opacity: 0.3;
+  transform: translateY(-2px);
+}
+
+.rtc-colon {
+  animation: rtc-blink 1s steps(1) infinite;
+  opacity: 0.8;
+  padding: 0 2px;
+}
+
+@keyframes rtc-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0.25; }
+}
+
+.rtc-meridiem {
+  font-size: 14px;
+  margin-left: 8px;
+  align-self: center;
+  opacity: 0.6;
+  letter-spacing: 1px;
+}


### PR DESCRIPTION
Closes #48008
## Pull Request Description
Adds a new `real-time-clock` component — a live-updating digital clock with a blinking colon separator and a subtle flash transition on digit changes. Supports both 24-hour and 12-hour (AM/PM) formats. Closes #48008.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-real-time-clock/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A live-updating digital clock display with a blinking colon separator and a soft flash transition whenever a digit changes, in either 24-hour or 12-hour format.

**How does a developer use it?**
```html
<div class="real-time-clock" data-format="24">
  <span class="rtc-segment" data-unit="hours">00</span>
  <span class="rtc-colon">:</span>
  <span class="rtc-segment" data-unit="minutes">00</span>
  <span class="rtc-colon">:</span>
  <span class="rtc-segment" data-unit="seconds">00</span>
</div>
```
Set `data-format="12"` on the container and add a `<span class="rtc-meridiem" data-unit="meridiem">` element to switch to 12-hour AM/PM format. Add `is-compact` for a smaller footprint. A small inline script reads the current time each second and applies a brief flash transition (`rtc-flash`) only to segments whose value changed.

**Why does it fit EaseMotion CSS?**
It replaces a jarring static re-render with motion-driven feedback — a blinking separator and a soft flash on digit change — matching EaseMotion's animation-first, purposeful-motion philosophy, while staying dependency-free and self-contained.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Used raw class names (`real-time-clock`, `rtc-segment`, `rtc-colon`, `rtc-meridiem`, `is-compact`) per the guide — happy to have these standardized to `ease-*` naming during integration. This one includes a small inline `<script>` in the demo to drive the live time updates and flash transitions; let me know if you'd prefer the timing logic handled differently (e.g. via the engine) during integration.