### PR TITLE
Add ease-sugar-level-monitor component

### DIFF
--- a/submissions/examples/ease-sugar-level-monitor-ij/README.md
+++ b/submissions/examples/ease-sugar-level-monitor-ij/README.md
@@ -1,0 +1,16 @@
+# ease-sugar-level-monitor
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(58, 74%, 64%) | Primary color |
+| --bg | hsl(58, 12%, 97%) | Background |
+| --duration | 0.75s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-sugar-level-monitor-ij/demo.html
+++ b/submissions/examples/ease-sugar-level-monitor-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-sugar-level-monitor</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>sugar-level-monitor</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-sugar-level-monitor-ij/style.css
+++ b/submissions/examples/ease-sugar-level-monitor-ij/style.css
@@ -1,0 +1,23 @@
+:root{--primary:hsl(58, 74%, 64%);--bg:hsl(58, 12%, 97%);--text:#1e293b;--duration:0.75s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes count-sugar-level-monitor {
+  0% { transform: translateY(-41px); opacity: 0; }
+  50% { transform: translateY(-10px); opacity: 0.83; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+@keyframes blink-sugar-level-monitor {
+  0%, 100% { opacity: 1; }
+  25% { opacity: 0.83; }
+  50% { opacity: 1; }
+  75% { opacity: 0.73; }
+}
+.anim-target.active { animation: count-sugar-level-monitor 0.75s ease-out, blink-sugar-level-monitor 1.2s ease-in-out infinite 0.2s; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(298, 74%, 64%)}


### PR DESCRIPTION
## Component: ease-sugar-level-monitor -- sugar level monitor -- data display with translateY count-up entrance and multi-step blinking indicator pulse

**Closes #49203**

### What this adds
A data display with value transition. The at-keyframes count-sugar-level-monitor slides the element in from below with opacity fade using custom easing. blink-sugar-level-monitor creates a four-stage blinking indicator to draw attention.

### Acceptance Criteria covered
- CSS at-keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-sugar-level-monitor-ij/demo.html
- submissions/examples/ease-sugar-level-monitor-ij/style.css
- submissions/examples/ease-sugar-level-monitor-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS at-keyframes transitions.
