### PR TITLE
Add ease-synth-waveform-generator component

### DIFF
--- a/submissions/examples/ease-synth-waveform-generator-ij/README.md
+++ b/submissions/examples/ease-synth-waveform-generator-ij/README.md
@@ -1,0 +1,16 @@
+# ease-synth-waveform-generator
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(4, 79%, 49%) | Primary color |
+| --bg | hsl(4, 12%, 97%) | Background |
+| --duration | 0.50s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-synth-waveform-generator-ij/demo.html
+++ b/submissions/examples/ease-synth-waveform-generator-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-synth-waveform-generator</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>synth-waveform-generator</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-synth-waveform-generator-ij/style.css
+++ b/submissions/examples/ease-synth-waveform-generator-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(4, 79%, 49%);--bg:hsl(4, 12%, 97%);--text:#1e293b;--duration:0.50s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes grow-synth-waveform-generator {
+  0% { transform: scaleY(0); opacity: 0; }
+  50% { transform: scaleY(1.25); opacity: 0.68; }
+  100% { transform: scaleY(1); opacity: 1; }
+}
+@keyframes fill-synth-waveform-generator {
+  0% { width: 0; background: hsl(4, 79%, 49%); }
+  50% { width: 62%; background: hsl(124, 79%, 49%); }
+  100% { width: 100%; background: hsl(244, 79%, 49%); }
+}
+.anim-target.active { animation: grow-synth-waveform-generator 0.50s ease-out forwards, fill-synth-waveform-generator 0.70s ease-out forwards 0.1s; transform-origin: bottom; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(244, 79%, 49%)}


### PR DESCRIPTION
## Component: ease-synth-waveform-generator -- synth waveform generator -- data visualization with scaleY growth from bottom and width-fill progression through custom colors

**Closes #49258**

### What this adds
A chart visualization. The at-keyframes grow-synth-waveform-generator animates scaleY from 0 to 1 with opacity fade. fill-synth-waveform-generator progresses width from 0 to 100 through three color stops derived from the component name, simulating data loading.

### Acceptance Criteria covered
- CSS at-keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-synth-waveform-generator-ij/demo.html
- submissions/examples/ease-synth-waveform-generator-ij/style.css
- submissions/examples/ease-synth-waveform-generator-ij/README.md

### How to review
Open demo.html directly in a browser. Click to trigger the grow and fill animation showing data progression.
