### PR TITLE
Add ease-tachometer-gauge-dial component

### DIFF
--- a/submissions/examples/ease-tachometer-gauge-dial-ij/README.md
+++ b/submissions/examples/ease-tachometer-gauge-dial-ij/README.md
@@ -1,0 +1,16 @@
+# ease-tachometer-gauge-dial
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(229, 76%, 46%) | Primary color |
+| --bg | hsl(229, 12%, 97%) | Background |
+| --duration | 0.35s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-tachometer-gauge-dial-ij/demo.html
+++ b/submissions/examples/ease-tachometer-gauge-dial-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-tachometer-gauge-dial</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>tachometer-gauge-dial</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-tachometer-gauge-dial-ij/style.css
+++ b/submissions/examples/ease-tachometer-gauge-dial-ij/style.css
@@ -1,0 +1,23 @@
+:root{--primary:hsl(229, 76%, 46%);--bg:hsl(229, 12%, 97%);--text:#1e293b;--duration:0.35s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes spin-tachometer-gauge-dial {
+  0% { transform: rotate(0deg) scale(1); }
+  25% { transform: rotate(89.25deg) scale(1.3); border-radius: 50% 50% 50% 0; }
+  50% { transform: rotate(178.5deg) scale(1.65); border-radius: 50%; }
+  75% { transform: rotate(267.75deg) scale(1.3); border-radius: 0 50% 50% 50%; }
+  100% { transform: rotate(357deg) scale(1); border-radius: 8px; }
+}
+@keyframes pulse-tachometer-gauge-dial {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 hsl(229, 76%, 46%)80; }
+  50% { opacity: 0.97; box-shadow: 0 0 20px 8px hsl(229, 76%, 46%)40; }
+}
+.anim-target.active { animation: spin-tachometer-gauge-dial 0.35s ease-in-out infinite, pulse-tachometer-gauge-dial 2s ease-in-out infinite; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(109, 76%, 46%)}


### PR DESCRIPTION
## Component: ease-tachometer-gauge-dial -- tachometer gauge dial -- animation with multi-stop translate, scale, border-radius and background transitions driven by at-keyframes

**Closes #49272**

### What this adds
A loading indicator. CSS at-keyframes spin-tachometer-gauge-dial rotates the element through four stages while changing border-radius between square and circle. pulse-tachometer-gauge-dial varies opacity and box-shadow to create a breathing glow effect. Both keyframes loop infinitely to signal ongoing activity.

### Acceptance Criteria covered
- CSS at-keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-tachometer-gauge-dial-ij/demo.html
- submissions/examples/ease-tachometer-gauge-dial-ij/style.css
- submissions/examples/ease-tachometer-gauge-dial-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS at-keyframes transitions.
