### PR TITLE
feat: add neon glow dashboard popover 

### DIFF
--- a/submissions/examples/neon-glow-dashboard-popover-cs/README.md
+++ b/submissions/examples/neon-glow-dashboard-popover-cs/README.md
@@ -1,0 +1,39 @@
+# Neon Glow Dashboard Popover
+
+A responsive, keyboard-accessible analytics popover with a neon glow, fade, scale, and slide interaction.
+
+The component uses semantic HTML and pure CSS, with no JavaScript required.
+
+## Features
+
+- Pure HTML and CSS
+- Semantic `<details>` and `<summary>` interaction
+- Keyboard-accessible trigger
+- Neon glow, fade, slide, and scale effects
+- Responsive dashboard layout
+- Configurable CSS custom properties
+- Visible focus styles
+- `prefers-reduced-motion` support
+
+## Usage
+
+Use the `neon-popover` component inside any dashboard or analytics interface:
+
+```html
+<details class="neon-popover">
+  <summary class="neon-popover__trigger">
+    View breakdown
+  </summary>
+
+  <div class="neon-popover__panel">
+    <!-- Popover content -->
+  </div>
+</details>
+```
+
+## What problem does it solve?
+
+Dashboards often need to display additional information related to a metric, control, or status.
+
+A full page or modal can be excessive for small amounts of information. This popover keeps the information close to the element that triggered it.
+

--- a/submissions/examples/neon-glow-dashboard-popover-cs/demo.html
+++ b/submissions/examples/neon-glow-dashboard-popover-cs/demo.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <meta
+      name="description"
+      content="A responsive, keyboard-accessible neon glow analytics popover built with pure HTML and CSS."
+    />
+
+    <title>Neon Glow Dashboard Popover</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+
+  <body>
+    <main class="demo">
+      <section
+        class="analytics-card"
+        aria-labelledby="analytics-title"
+      >
+        <header class="analytics-card__header">
+          <div>
+            <p class="analytics-card__eyebrow">Performance overview</p>
+            <h1 id="analytics-title">Dashboard Analytics</h1>
+          </div>
+
+          <span class="analytics-card__status">
+            <span class="analytics-card__status-dot" aria-hidden="true"></span>
+            Live
+          </span>
+        </header>
+
+        <div class="analytics-card__metric">
+          <div>
+            <p class="analytics-card__label">Total revenue</p>
+            <p class="analytics-card__value">$48,320</p>
+          </div>
+
+          <span class="analytics-card__change">
+            <span aria-hidden="true">↑</span>
+            12.8%
+          </span>
+        </div>
+
+        <div
+          class="analytics-card__chart"
+          role="img"
+          aria-label="Revenue increased steadily over the last seven days."
+        >
+          <span style="--bar-height: 35%"></span>
+          <span style="--bar-height: 50%"></span>
+          <span style="--bar-height: 42%"></span>
+          <span style="--bar-height: 66%"></span>
+          <span style="--bar-height: 58%"></span>
+          <span style="--bar-height: 78%"></span>
+          <span style="--bar-height: 92%"></span>
+        </div>
+
+        <dl class="analytics-card__summary">
+          <div>
+            <dt>Visitors</dt>
+            <dd>18.4K</dd>
+          </div>
+
+          <div>
+            <dt>Conversions</dt>
+            <dd>1,284</dd>
+          </div>
+
+          <div>
+            <dt>Conversion rate</dt>
+            <dd>6.9%</dd>
+          </div>
+        </dl>
+
+        <details class="neon-popover">
+          <summary class="neon-popover__trigger">
+            <span>View revenue breakdown</span>
+
+            <svg
+              class="neon-popover__chevron"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                d="m7 10 5 5 5-5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </summary>
+
+          <div class="neon-popover__panel">
+            <div class="neon-popover__heading">
+              <div>
+                <p class="neon-popover__eyebrow">Revenue sources</p>
+                <h2>Channel breakdown</h2>
+              </div>
+
+              <span class="neon-popover__period">Last 30 days</span>
+            </div>
+
+            <ul class="channel-list">
+              <li class="channel-list__item">
+                <div class="channel-list__details">
+                  <span
+                    class="channel-list__indicator"
+                    aria-hidden="true"
+                  ></span>
+
+                  <div>
+                    <span class="channel-list__name">Organic search</span>
+                    <span class="channel-list__amount">$20,294</span>
+                  </div>
+
+                  <strong>42%</strong>
+                </div>
+
+                <div
+                  class="channel-list__track"
+                  role="progressbar"
+                  aria-label="Organic search revenue"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow="42"
+                >
+                  <span style="--progress: 42%"></span>
+                </div>
+              </li>
+
+              <li class="channel-list__item">
+                <div class="channel-list__details">
+                  <span
+                    class="channel-list__indicator"
+                    aria-hidden="true"
+                  ></span>
+
+                  <div>
+                    <span class="channel-list__name">Paid campaigns</span>
+                    <span class="channel-list__amount">$14,979</span>
+                  </div>
+
+                  <strong>31%</strong>
+                </div>
+
+                <div
+                  class="channel-list__track"
+                  role="progressbar"
+                  aria-label="Paid campaigns revenue"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow="31"
+                >
+                  <span style="--progress: 31%"></span>
+                </div>
+              </li>
+
+              <li class="channel-list__item">
+                <div class="channel-list__details">
+                  <span
+                    class="channel-list__indicator"
+                    aria-hidden="true"
+                  ></span>
+
+                  <div>
+                    <span class="channel-list__name">Referrals</span>
+                    <span class="channel-list__amount">$13,047</span>
+                  </div>
+
+                  <strong>27%</strong>
+                </div>
+
+                <div
+                  class="channel-list__track"
+                  role="progressbar"
+                  aria-label="Referral revenue"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow="27"
+                >
+                  <span style="--progress: 27%"></span>
+                </div>
+              </li>
+            </ul>
+
+            <p class="neon-popover__insight">
+              <span aria-hidden="true">↗</span>
+              Organic search generated the highest revenue this month.
+            </p>
+          </div>
+        </details>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/neon-glow-dashboard-popover-cs/style.css
+++ b/submissions/examples/neon-glow-dashboard-popover-cs/style.css
@@ -1,0 +1,581 @@
+:root {
+  color-scheme: dark;
+
+  --page-background: #050816;
+  --surface: #0b1022;
+  --surface-raised: #101831;
+  --surface-border: rgba(148, 163, 184, 0.16);
+
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+
+  --accent: #22d3ee;
+  --accent-secondary: #8b5cf6;
+  --positive: #34d399;
+
+  --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  overflow-x: hidden;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: var(--text-primary);
+  background:
+    radial-gradient(
+      circle at 20% 15%,
+      rgba(34, 211, 238, 0.12),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(139, 92, 246, 0.13),
+      transparent 30rem
+    ),
+    var(--page-background);
+}
+
+button,
+summary {
+  font: inherit;
+}
+
+.demo {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 3rem 1.25rem;
+}
+
+.analytics-card {
+  position: relative;
+  width: min(100%, 34rem);
+  padding: clamp(1.25rem, 4vw, 2rem);
+  border: 1px solid var(--surface-border);
+  border-radius: 1.5rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.035),
+      transparent 42%
+    ),
+    rgba(11, 16, 34, 0.94);
+  box-shadow:
+    0 2rem 5rem rgba(0, 0, 0, 0.42),
+    inset 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(18px);
+}
+
+.analytics-card::before {
+  position: absolute;
+  z-index: -1;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    rgba(34, 211, 238, 0.18),
+    transparent 35%,
+    rgba(139, 92, 246, 0.16)
+  );
+  content: "";
+  filter: blur(1.2rem);
+  opacity: 0.75;
+}
+
+.analytics-card__header,
+.analytics-card__metric,
+.analytics-card__summary,
+.neon-popover__heading,
+.channel-list__details {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.analytics-card__header {
+  gap: 1rem;
+}
+
+.analytics-card__eyebrow,
+.neon-popover__eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.analytics-card h1 {
+  margin: 0;
+  font-size: clamp(1.35rem, 4vw, 1.8rem);
+  letter-spacing: -0.035em;
+}
+
+.analytics-card__status {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid rgba(52, 211, 153, 0.22);
+  border-radius: 999px;
+  color: #a7f3d0;
+  background: rgba(52, 211, 153, 0.08);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.analytics-card__status-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--positive);
+  box-shadow: 0 0 0.7rem rgba(52, 211, 153, 0.9);
+  animation: ease-status-pulse 2s var(--ease-smooth) infinite;
+}
+
+.analytics-card__metric {
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.analytics-card__label {
+  margin: 0 0 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.analytics-card__value {
+  margin: 0;
+  font-size: clamp(2.15rem, 8vw, 3.2rem);
+  font-weight: 750;
+  letter-spacing: -0.065em;
+}
+
+.analytics-card__change {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 0.65rem;
+  color: #a7f3d0;
+  background: rgba(52, 211, 153, 0.09);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.analytics-card__chart {
+  display: flex;
+  height: 8rem;
+  align-items: end;
+  gap: clamp(0.45rem, 2vw, 0.75rem);
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 1rem;
+  background:
+    linear-gradient(rgba(148, 163, 184, 0.055) 1px, transparent 1px),
+    var(--surface-raised);
+  background-size: 100% 25%;
+}
+
+.analytics-card__chart span {
+  flex: 1;
+  height: var(--bar-height);
+  min-width: 0.7rem;
+  border-radius: 0.35rem 0.35rem 0.15rem 0.15rem;
+  background: linear-gradient(
+    to top,
+    rgba(139, 92, 246, 0.72),
+    var(--accent)
+  );
+  box-shadow: 0 0 1rem rgba(34, 211, 238, 0.18);
+  transform-origin: bottom;
+  animation: ease-chart-rise 700ms var(--ease-standard) both;
+}
+
+.analytics-card__chart span:nth-child(2) {
+  animation-delay: 60ms;
+}
+
+.analytics-card__chart span:nth-child(3) {
+  animation-delay: 120ms;
+}
+
+.analytics-card__chart span:nth-child(4) {
+  animation-delay: 180ms;
+}
+
+.analytics-card__chart span:nth-child(5) {
+  animation-delay: 240ms;
+}
+
+.analytics-card__chart span:nth-child(6) {
+  animation-delay: 300ms;
+}
+
+.analytics-card__chart span:nth-child(7) {
+  animation-delay: 360ms;
+}
+
+.analytics-card__summary {
+  gap: 0.75rem;
+  margin: 1.25rem 0 0;
+}
+
+.analytics-card__summary div {
+  flex: 1;
+  min-width: 0;
+}
+
+.analytics-card__summary dt {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.analytics-card__summary dd {
+  margin: 0.3rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+/* Reusable neon popover API */
+.neon-popover {
+  --popover-duration: 320ms;
+  --popover-easing: var(--ease-standard);
+  --popover-start-scale: 0.94;
+  --popover-offset: 0.75rem;
+  --popover-glow-size: 1.7rem;
+  --popover-glow-opacity: 0.42;
+  --popover-accent: var(--accent);
+
+  position: relative;
+  margin-top: 1.5rem;
+}
+
+.neon-popover__trigger {
+  display: flex;
+  width: 100%;
+  min-height: 3rem;
+  cursor: pointer;
+  list-style: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(34, 211, 238, 0.24);
+  border-radius: 0.85rem;
+  color: #cffafe;
+  background: rgba(34, 211, 238, 0.055);
+  font-size: 0.88rem;
+  font-weight: 700;
+  transition:
+    border-color var(--popover-duration) var(--popover-easing),
+    background-color var(--popover-duration) var(--popover-easing),
+    box-shadow var(--popover-duration) var(--popover-easing),
+    transform var(--popover-duration) var(--popover-easing);
+}
+
+.neon-popover__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.neon-popover__trigger:hover {
+  border-color: rgba(34, 211, 238, 0.55);
+  background: rgba(34, 211, 238, 0.1);
+  box-shadow: 0 0 1.25rem rgba(34, 211, 238, 0.12);
+  transform: translateY(-2px);
+}
+
+.neon-popover__trigger:focus-visible {
+  outline: 3px solid rgba(34, 211, 238, 0.55);
+  outline-offset: 4px;
+}
+
+.neon-popover__chevron {
+  width: 1.15rem;
+  flex: 0 0 auto;
+  transition: transform var(--popover-duration) var(--popover-easing);
+}
+
+.neon-popover[open] .neon-popover__trigger {
+  border-color: rgba(34, 211, 238, 0.58);
+  box-shadow:
+    0 0 var(--popover-glow-size)
+      rgba(34, 211, 238, var(--popover-glow-opacity)),
+    inset 0 0 1rem rgba(34, 211, 238, 0.05);
+}
+
+.neon-popover[open] .neon-popover__chevron {
+  transform: rotate(180deg);
+}
+
+.neon-popover__panel {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(25rem, calc(100vw - 3rem));
+  padding: 1.15rem;
+  overflow: hidden;
+  border: 1px solid rgba(34, 211, 238, 0.46);
+  border-radius: 1rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(34, 211, 238, 0.075),
+      transparent 38%
+    ),
+    rgba(8, 13, 29, 0.98);
+  box-shadow:
+    0 1.25rem 3.5rem rgba(0, 0, 0, 0.55),
+    0 0 var(--popover-glow-size)
+      rgba(34, 211, 238, var(--popover-glow-opacity)),
+    inset 0 1px rgba(255, 255, 255, 0.06);
+  transform-origin: top right;
+  animation: ease-neon-popover-enter var(--popover-duration)
+    var(--popover-easing) both;
+  backdrop-filter: blur(18px);
+}
+
+.neon-popover__panel::before {
+  position: absolute;
+  top: 0;
+  left: -35%;
+  width: 35%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--popover-accent),
+    transparent
+  );
+  content: "";
+  filter: drop-shadow(0 0 0.5rem var(--popover-accent));
+  animation: ease-neon-scan 2.4s var(--ease-smooth) infinite;
+}
+
+.neon-popover__heading {
+  gap: 0.75rem;
+}
+
+.neon-popover__heading h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.neon-popover__period {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+}
+
+.channel-list {
+  display: grid;
+  gap: 1rem;
+  margin: 1.2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.channel-list__details {
+  gap: 0.65rem;
+}
+
+.channel-list__details > div {
+  display: grid;
+  flex: 1;
+  gap: 0.15rem;
+}
+
+.channel-list__indicator {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--popover-accent);
+  box-shadow: 0 0 0.7rem rgba(34, 211, 238, 0.8);
+}
+
+.channel-list__item:nth-child(2) .channel-list__indicator {
+  background: var(--accent-secondary);
+  box-shadow: 0 0 0.7rem rgba(139, 92, 246, 0.8);
+}
+
+.channel-list__item:nth-child(3) .channel-list__indicator {
+  background: var(--positive);
+  box-shadow: 0 0 0.7rem rgba(52, 211, 153, 0.75);
+}
+
+.channel-list__name {
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.channel-list__amount {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.channel-list__details strong {
+  font-size: 0.82rem;
+}
+
+.channel-list__track {
+  height: 0.35rem;
+  margin-top: 0.45rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.channel-list__track span {
+  display: block;
+  width: var(--progress);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--accent-secondary),
+    var(--popover-accent)
+  );
+  box-shadow: 0 0 0.75rem rgba(34, 211, 238, 0.35);
+  transform-origin: left;
+  animation: ease-progress-grow 650ms var(--ease-standard) both;
+}
+
+.neon-popover__insight {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  margin: 1.15rem 0 0;
+  padding: 0.75rem;
+  border: 1px solid rgba(52, 211, 153, 0.15);
+  border-radius: 0.7rem;
+  color: #a7f3d0;
+  background: rgba(52, 211, 153, 0.06);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+@keyframes ease-neon-popover-enter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--popover-offset))
+      scale(var(--popover-start-scale));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ease-neon-scan {
+  0% {
+    left: -35%;
+  }
+
+  55%,
+  100% {
+    left: 115%;
+  }
+}
+
+@keyframes ease-status-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(52, 211, 153, 0.35),
+      0 0 0.7rem rgba(52, 211, 153, 0.85);
+  }
+
+  50% {
+    box-shadow:
+      0 0 0 0.4rem rgba(52, 211, 153, 0),
+      0 0 1rem rgba(52, 211, 153, 1);
+  }
+}
+
+@keyframes ease-chart-rise {
+  from {
+    opacity: 0;
+    transform: scaleY(0.08);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes ease-progress-grow {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 34rem) {
+  .demo {
+    align-items: start;
+    padding: 1.25rem 0.85rem;
+  }
+
+  .analytics-card {
+    border-radius: 1.15rem;
+  }
+
+  .analytics-card__header {
+    align-items: flex-start;
+  }
+
+  .analytics-card__summary {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .analytics-card__summary div:last-child {
+    grid-column: 1 / -1;
+  }
+
+  .neon-popover__panel {
+    position: relative;
+    top: auto;
+    right: auto;
+    width: 100%;
+    margin-top: 0.75rem;
+    transform-origin: top center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS neon-glow popover example for dashboard analytics layouts.

Closes #46480

## Features

- CSS-only implementation with no JavaScript
- Semantic `<details>` and `<summary>` interaction
- Smooth fade, slide, scale, and neon-glow transitions
- Responsive behavior for desktop and mobile layouts
- Keyboard-accessible trigger and visible focus state
- CSS custom properties for timing, easing, scale, offset, glow size, and glow intensity

## Purpose

This example demonstrates how developers can add a modern contextual popover to analytics dashboards while keeping the interaction lightweight, accessible, customizable, and JavaScript-free.