### PR TITLE
Add ease-tally-counter-app component

### DIFF
--- a/submissions/examples/ease-tally-counter-app-ij/README.md
+++ b/submissions/examples/ease-tally-counter-app-ij/README.md
@@ -1,0 +1,16 @@
+# ease-tally-counter-app
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(79, 72%, 62%) | Primary color |
+| --bg | hsl(79, 12%, 97%) | Background |
+| --duration | 0.65s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-tally-counter-app-ij/demo.html
+++ b/submissions/examples/ease-tally-counter-app-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-tally-counter-app</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>tally-counter-app</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-tally-counter-app-ij/style.css
+++ b/submissions/examples/ease-tally-counter-app-ij/style.css
@@ -1,0 +1,23 @@
+:root{--primary:hsl(79, 72%, 62%);--bg:hsl(79, 12%, 97%);--text:#1e293b;--duration:0.65s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes count-tally-counter-app {
+  0% { transform: translateY(37px); opacity: 0; }
+  50% { transform: translateY(9px); opacity: 0.69; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+@keyframes blink-tally-counter-app {
+  0%, 100% { opacity: 1; }
+  25% { opacity: 0.69; }
+  50% { opacity: 1; }
+  75% { opacity: 0.59; }
+}
+.anim-target.active { animation: count-tally-counter-app 0.65s ease-out, blink-tally-counter-app 1.2s ease-in-out infinite 0.2s; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(319, 72%, 62%)}


### PR DESCRIPTION
## Component: ease-tally-counter-app -- tally counter app -- data display with translateY count-up entrance and multi-step blinking indicator pulse

**Closes #49283**

### What this adds
A data display with value transition. The at-keyframes count-tally-counter-app slides the element in from below with opacity fade using custom easing. blink-tally-counter-app creates a four-stage blinking indicator to draw attention.

### Acceptance Criteria covered
- CSS at-keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-tally-counter-app-ij/demo.html
- submissions/examples/ease-tally-counter-app-ij/style.css
- submissions/examples/ease-tally-counter-app-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS at-keyframes transitions.
