### PR TITLE
Add ease-skew-active-popover-saas component

### DIFF
--- a/submissions/examples/ease-skew-active-popover-saas/README.md
+++ b/submissions/examples/ease-skew-active-popover-saas/README.md
@@ -1,0 +1,27 @@
+# Skew-Active SaaS Card Popover
+
+### 1. What does this do?
+A pure CSS popover anchored to a feature/pricing card, revealed on hover or keyboard focus with a smooth skew-to-straight and scale transition. Built for modern SaaS marketing interfaces (feature grids, pricing cards) where a static tooltip feels too abrupt.
+
+### 2. How is it used?
+\`\`\`html
+<div class="saas-card-wrap">
+  <div class="saas-card" tabindex="0">
+    <h3 class="saas-card-title">Analytics Suite</h3>
+    <p class="saas-card-hint">Hover or focus for details</p>
+  </div>
+  <div class="skewpop-saas">
+    <h4 class="skewpop-saas-title">Analytics Suite</h4>
+    <p class="skewpop-saas-body">Details go here.</p>
+  </div>
+</div>
+\`\`\`
+- Wrap a `.saas-card` (with `tabindex="0"` for keyboard access) and a sibling `.skewpop-saas` in a `.saas-card-wrap`. The popover reveals on card hover or keyboard focus via `:focus-visible + .skewpop-saas`.
+- Customize the motion with CSS custom properties on `.skewpop-saas`:
+  - `--skewpop-timing` — transition duration (default `0.35s`)
+  - `--skewpop-easing` — transition easing function (default a slight overshoot cubic-bezier)
+  - `--skewpop-scale` — entry scale factor (default `1`)
+  - `--skewpop-angle` — starting skew angle (default `8deg`)
+
+### 3. Why is it useful?
+Feature and pricing cards are core to SaaS marketing pages, and hover-revealed detail panels are a common pattern for keeping the main layout scannable. The skew-active transition gives that reveal a distinctive, purposeful motion instead of a flat fade, fitting EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

--- a/submissions/examples/ease-skew-active-popover-saas/demo.html
+++ b/submissions/examples/ease-skew-active-popover-saas/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skew-Active SaaS Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Skew-Active SaaS Card Popover</h1>
+  <p>A pure CSS popover anchored to a feature card, revealed on hover/focus with a smooth skew-active transition. Styled for modern SaaS interfaces.</p>
+
+  <div class="demo-row">
+
+    <div class="saas-card-wrap">
+      <div class="saas-card" tabindex="0">
+        <h3 class="saas-card-title">Analytics Suite</h3>
+        <p class="saas-card-hint">Hover or focus for details</p>
+      </div>
+      <div class="skewpop-saas">
+        <h4 class="skewpop-saas-title">Analytics Suite</h4>
+        <p class="skewpop-saas-body">Track usage, conversion, and retention across every workspace in real time, with exportable reports.</p>
+      </div>
+    </div>
+
+    <div class="saas-card-wrap">
+      <div class="saas-card" tabindex="0">
+        <h3 class="saas-card-title">Team Workspaces</h3>
+        <p class="saas-card-hint">Hover or focus for details</p>
+      </div>
+      <div class="skewpop-saas" style="--skewpop-scale: 1.06; --skewpop-timing: 0.5s;">
+        <h4 class="skewpop-saas-title">Team Workspaces</h4>
+        <p class="skewpop-saas-body">Isolated environments per team, with granular role-based permissions and shared billing.</p>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-skew-active-popover-saas/style.css
+++ b/submissions/examples/ease-skew-active-popover-saas/style.css
@@ -1,0 +1,108 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1115;
+  color: #f2f2f2;
+  padding: 40px;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 32px;
+  margin-top: 48px;
+}
+
+.saas-card-wrap {
+  position: relative;
+}
+
+.saas-card {
+  width: 220px;
+  text-align: left;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 14px;
+  padding: 20px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.saas-card:hover,
+.saas-card:focus-visible {
+  border-color: #4caf50;
+  transform: translateY(-3px);
+}
+
+.saas-card:focus-visible {
+  outline: 2px solid #4caf50;
+  outline-offset: 2px;
+}
+
+.saas-card-title {
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.saas-card-hint {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.55;
+}
+
+/* Skew-Active popover: exposed custom properties for timing, easing, scale */
+.skewpop-saas {
+  --skewpop-timing: 0.35s;
+  --skewpop-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --skewpop-scale: 1;
+  --skewpop-angle: 8deg;
+
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  z-index: 20;
+  width: min(260px, 90vw);
+  text-align: left;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  padding: 16px 18px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  pointer-events: none;
+  opacity: 0;
+  transform-origin: top left;
+  transform: skew(var(--skewpop-angle)) scale(var(--skewpop-scale));
+  transition:
+    opacity var(--skewpop-timing) var(--skewpop-easing),
+    transform var(--skewpop-timing) var(--skewpop-easing);
+}
+
+.saas-card-wrap:hover .skewpop-saas,
+.saas-card:focus-visible + .skewpop-saas {
+  opacity: 1;
+  pointer-events: auto;
+  transform: skew(0deg) scale(var(--skewpop-scale));
+}
+
+.skewpop-saas-title {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.skewpop-saas-body {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.8;
+}
+
+@media (max-width: 480px) {
+  .skewpop-saas {
+    width: min(220px, 85vw);
+    padding: 14px 16px;
+  }
+}


### PR DESCRIPTION
Closes #46450

## Pull Request Description
Adds a new `skew-active-popover-saas` component — a pure CSS card-hover popover with a smooth skew-to-straight and scale transition, styled for modern SaaS feature/pricing cards. Closes #46450.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-skew-active-popover-saas/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS popover anchored to a feature/pricing card, revealed on hover or keyboard focus with a smooth skew-to-straight and scale transition, styled for modern SaaS marketing interfaces.

**How does a developer use it?**
```html
<div class="saas-card-wrap">
  <div class="saas-card" tabindex="0">
    <h3 class="saas-card-title">Analytics Suite</h3>
    <p class="saas-card-hint">Hover or focus for details</p>
  </div>
  <div class="skewpop-saas">
    <h4 class="skewpop-saas-title">Analytics Suite</h4>
    <p class="skewpop-saas-body">Details go here.</p>
  </div>
</div>
```
Wrap a `.saas-card` (with `tabindex="0"` for keyboard access) and a sibling `.skewpop-saas` in a `.saas-card-wrap`. The popover reveals on card hover or keyboard focus. Customize the motion via `--skewpop-timing`, `--skewpop-easing`, `--skewpop-scale`, and `--skewpop-angle`.

**Why does it fit EaseMotion CSS?**
Feature and pricing cards are core to SaaS marketing pages, and hover-revealed detail panels are a common way to keep the main layout scannable. The skew-active transition gives that reveal a distinctive, purposeful motion instead of a flat fade, matching EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Heads up: this issue (#46450) reads as a near-duplicate of #46455 ("Add CSS Skew-Active Popover for SaaS Showcase Layouts"), which I also submitted a PR for. To keep them distinct, this one uses a hover/focus-revealed card popover rather than a click-triggered button popover. Happy to close one of these if they were meant to be the same issue — let me know which you'd prefer to keep.