### PR TITLE
Add ease-team-speedometer component

### DIFF
--- a/submissions/examples/ease-team-speedometer-ij/README.md
+++ b/submissions/examples/ease-team-speedometer-ij/README.md
@@ -1,0 +1,16 @@
+# ease-team-speedometer
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(329, 71%, 61%) | Primary color |
+| --bg | hsl(329, 12%, 97%) | Background |
+| --duration | 0.60s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-team-speedometer-ij/demo.html
+++ b/submissions/examples/ease-team-speedometer-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-team-speedometer</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>team-speedometer</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-team-speedometer-ij/style.css
+++ b/submissions/examples/ease-team-speedometer-ij/style.css
@@ -1,0 +1,23 @@
+:root{--primary:hsl(329, 71%, 61%);--bg:hsl(329, 12%, 97%);--text:#1e293b;--duration:0.60s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes spin-team-speedometer {
+  0% { transform: rotate(0deg) scale(1); }
+  25% { transform: rotate(68deg) scale(1.3); border-radius: 50% 50% 50% 0; }
+  50% { transform: rotate(136deg) scale(1.45); border-radius: 50%; }
+  75% { transform: rotate(204deg) scale(1.3); border-radius: 0 50% 50% 50%; }
+  100% { transform: rotate(272deg) scale(1); border-radius: 8px; }
+}
+@keyframes pulse-team-speedometer {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 hsl(329, 71%, 61%)80; }
+  50% { opacity: 0.62; box-shadow: 0 0 20px 8px hsl(329, 71%, 61%)40; }
+}
+.anim-target.active { animation: spin-team-speedometer 0.60s ease-in-out infinite, pulse-team-speedometer 2s ease-in-out infinite; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(209, 71%, 61%)}


### PR DESCRIPTION
## Component: ease-team-speedometer -- team speedometer -- data display with translateY count-up entrance and multi-step blinking indicator pulse

**Closes #49315**

### What this adds
A loading indicator. CSS at-keyframes spin-team-speedometer rotates the element through four stages while changing border-radius between square and circle. pulse-team-speedometer varies opacity and box-shadow to create a breathing glow effect. Both keyframes loop infinitely to signal ongoing activity.

### Acceptance Criteria covered
- CSS at-keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-team-speedometer-ij/demo.html
- submissions/examples/ease-team-speedometer-ij/style.css
- submissions/examples/ease-team-speedometer-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS at-keyframes transitions.
