### PR TITLE
Add ease-telephone-dialer-pad component

### DIFF
--- a/submissions/examples/ease-telephone-dialer-pad-ij/README.md
+++ b/submissions/examples/ease-telephone-dialer-pad-ij/README.md
@@ -1,0 +1,16 @@
+# ease-telephone-dialer-pad
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(68, 75%, 45%) | Primary color |
+| --bg | hsl(68, 12%, 97%) | Background |
+| --duration | 0.30s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-telephone-dialer-pad-ij/demo.html
+++ b/submissions/examples/ease-telephone-dialer-pad-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-telephone-dialer-pad</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>telephone-dialer-pad</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-telephone-dialer-pad-ij/style.css
+++ b/submissions/examples/ease-telephone-dialer-pad-ij/style.css
@@ -1,0 +1,20 @@
+:root{--primary:hsl(68, 75%, 45%);--bg:hsl(68, 12%, 97%);--text:#1e293b;--duration:0.30s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes focus-telephone-dialer-pad {
+  0%, 100% { border-color: hsl(68, 75%, 45%); box-shadow: 0 0 0 2px hsl(68, 75%, 45%)30; }
+  50% { border-color: hsl(188, 75%, 45%); box-shadow: 0 0 0 5px hsl(188, 75%, 45%)30; }
+}
+@keyframes check-telephone-dialer-pad {
+  0% { clip-path: polygon(0 0, 0 0, 0 0); }
+  100% { clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); }
+}
+.anim-target.active { animation: focus-telephone-dialer-pad 0.30s ease-in-out, check-telephone-dialer-pad 0.4s ease-in-out; border: 2px solid; border-radius: 8px; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(308, 75%, 45%)}


### PR DESCRIPTION
## Component: ease-telephone-dialer-pad -- telephone dialer pad -- animation with multi-stop translate, scale, border-radius and background transitions driven by at-keyframes

**Closes #49324**

### What this adds
A form control with validation animation. The at-keyframes focus-telephone-dialer-pad cycles border-color and box-shadow through two hue-stops while check-telephone-dialer-pad uses clip-path for a progressive checkmark reveal animation.

### Acceptance Criteria covered
- CSS at-keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-telephone-dialer-pad-ij/demo.html
- submissions/examples/ease-telephone-dialer-pad-ij/style.css
- submissions/examples/ease-telephone-dialer-pad-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS at-keyframes transitions.
