### PR TITLE
Add ease-scale-hover-popover component

### DIFF
--- a/submissions/examples/ease-scale-hover-popover/README.md
+++ b/submissions/examples/ease-scale-hover-popover/README.md
@@ -1,0 +1,23 @@
+# Scale-Hover Popover
+
+### 1. What does this do?
+A pure CSS popover revealed on hover or keyboard focus with a smooth scale-up transition (growing from slightly smaller to full size), styled for creative portfolio layouts where thumbnails need quick context on hover.
+
+### 2. How is it used?
+\`\`\`html
+<figure class="portfolio-item" tabindex="0">
+  <div class="portfolio-thumb" style="background: url(...);"></div>
+  <div class="scalepop">
+    <h4 class="scalepop-title">Project Title</h4>
+    <p class="scalepop-body">Details go here.</p>
+  </div>
+</figure>
+\`\`\`
+- Wrap a `.portfolio-thumb` and a sibling `.scalepop` in a `.portfolio-item` (with `tabindex="0"` for keyboard access). The popover reveals on item hover or focus.
+- Customize the motion with CSS custom properties on `.scalepop`:
+  - `--scalepop-timing` — transition duration (default `0.3s`)
+  - `--scalepop-easing` — transition easing function (default a slight overshoot cubic-bezier)
+  - `--scalepop-scale` — final scale factor on reveal (default `1`)
+
+### 3. Why is it useful?
+Creative portfolios rely on thumbnail grids where hover reveals project context without navigating away. A scale-up transition feels more tactile and "alive" than a flat fade, fitting EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

--- a/submissions/examples/ease-scale-hover-popover/demo.html
+++ b/submissions/examples/ease-scale-hover-popover/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scale-Hover Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Scale-Hover Popover</h1>
+  <p>A pure CSS popover revealed on hover/focus with a smooth scale-up transition, styled for creative portfolio interfaces.</p>
+
+  <div class="demo-row">
+
+    <figure class="portfolio-item" tabindex="0">
+      <div class="portfolio-thumb" style="background: linear-gradient(135deg, #6a4c93, #1982c4);"></div>
+      <div class="scalepop">
+        <h4 class="scalepop-title">Brand Identity</h4>
+        <p class="scalepop-body">A full visual identity system for a boutique coffee roastery, including logo, packaging, and signage.</p>
+      </div>
+    </figure>
+
+    <figure class="portfolio-item" tabindex="0">
+      <div class="portfolio-thumb" style="background: linear-gradient(135deg, #f15bb5, #fee440);"></div>
+      <div class="scalepop" style="--scalepop-scale: 1.08; --scalepop-timing: 0.5s;">
+        <h4 class="scalepop-title">Editorial Layout</h4>
+        <p class="scalepop-body">A magazine spread exploring bold typography and asymmetric grid systems for an art quarterly.</p>
+      </div>
+    </figure>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scale-hover-popover/style.css
+++ b/submissions/examples/ease-scale-hover-popover/style.css
@@ -1,0 +1,95 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1115;
+  color: #f2f2f2;
+  padding: 40px;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 32px;
+  margin-top: 48px;
+}
+
+.portfolio-item {
+  position: relative;
+  margin: 0;
+  cursor: pointer;
+}
+
+.portfolio-thumb {
+  width: 220px;
+  height: 150px;
+  border-radius: 14px;
+  border: 1px solid #2a2f3a;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.portfolio-item:hover .portfolio-thumb,
+.portfolio-item:focus-visible .portfolio-thumb {
+  border-color: #f2f2f2;
+  transform: translateY(-3px);
+}
+
+.portfolio-item:focus-visible {
+  outline: 2px solid #4caf50;
+  outline-offset: 4px;
+  border-radius: 14px;
+}
+
+/* Scale-Hover popover: exposed custom properties for timing, easing, scale */
+.scalepop {
+  --scalepop-timing: 0.3s;
+  --scalepop-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --scalepop-scale: 1;
+
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  z-index: 20;
+  width: min(240px, 90vw);
+  text-align: left;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  padding: 16px 18px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  pointer-events: none;
+  opacity: 0;
+  transform-origin: top center;
+  transform: translateX(-50%) scale(calc(var(--scalepop-scale) * 0.85));
+  transition:
+    opacity var(--scalepop-timing) var(--scalepop-easing),
+    transform var(--scalepop-timing) var(--scalepop-easing);
+}
+
+.portfolio-item:hover .scalepop,
+.portfolio-item:focus-visible .scalepop {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) scale(var(--scalepop-scale));
+}
+
+.scalepop-title {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.scalepop-body {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.8;
+}
+
+@media (max-width: 480px) {
+  .scalepop {
+    width: min(200px, 85vw);
+    padding: 14px 16px;
+  }
+}


### PR DESCRIPTION
Closes #46448

## Pull Request Description
Adds a new `scale-hover-popover` component — a pure CSS popover revealed on hover/focus with a smooth scale-up transition, styled for creative portfolio layouts. Closes #46448.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-scale-hover-popover/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS popover revealed on hover or keyboard focus with a smooth scale-up transition, styled for creative portfolio thumbnail grids.

**How does a developer use it?**
```html
<figure class="portfolio-item" tabindex="0">
  <div class="portfolio-thumb" style="background: url(...);"></div>
  <div class="scalepop">
    <h4 class="scalepop-title">Project Title</h4>
    <p class="scalepop-body">Details go here.</p>
  </div>
</figure>
```
Wrap a `.portfolio-thumb` and a sibling `.scalepop` in a `.portfolio-item` (with `tabindex="0"` for keyboard access). The popover reveals on item hover or focus. Customize the motion with `--scalepop-timing`, `--scalepop-easing`, and `--scalepop-scale`.

**Why does it fit EaseMotion CSS?**
Creative portfolios rely on thumbnail grids where hover reveals project context without navigating away. A scale-up transition feels more tactile and "alive" than a flat fade, matching EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Used raw class names (`scalepop`, `scalepop-title`, `scalepop-body`, `portfolio-item`, `portfolio-thumb`) per the guide — happy to have these standardized to `ease-*` naming during integration.