### PR TITLE
Add catenary component

### DIFF
--- a/submissions/examples/catenary-as/README.md
+++ b/submissions/examples/catenary-as/README.md
@@ -1,0 +1,29 @@
+# Catenary
+
+A pure CSS/HTML hanging chain, drawn on its true curve, `y = a·cosh(x/a)`, with the parabola it is not laid over it for comparison.
+
+## What it shows
+
+Hang a chain between two points and it settles into a specific curve. Galileo said it was a parabola. He was wrong, and it took most of a century and three of the best mathematicians alive (Johann Bernoulli, Leibniz, and Huygens, in 1691) to prove what it really is: the **hyperbolic cosine**, `y = a·cosh(x/a)`.
+
+The reason is that the chain hangs to minimise its potential energy, and a uniform chain has its weight spread evenly *along its own length*, not evenly across the horizontal span. That difference is exactly what separates the cosh from the parabola. A parabola is what you get if the load is spread evenly across the horizontal, which is why a **suspension bridge deck** really does hang on parabolas: the roadway, not the cable, carries the weight, and the roadway is horizontal.
+
+Flip a catenary upside down and it becomes the strongest shape for an unreinforced arch, because it carries its own weight in pure compression. Gaudí used hanging chains as analogue computers to design them, and the St. Louis Gateway Arch is a (weighted) inverted catenary.
+
+## How it is built
+
+- **Every link is on the cosh.** The 22 chain links are placed at `y = sag − (a·cosh(x/a) − a)` with `a = 68`. The browser check recomputes the hyperbolic cosine from scratch against each link's declared `--x` and `--y`: worst error **0.011px**, the rest being two-decimal coordinate rounding.
+- **The parabola is the honest comparison.** A dashed parabola is drawn through the **same two posts and the same lowest point** as the chain. The check confirms the endpoints coincide (gap **0px**) but the curves **diverge by up to 8.2px** in between. So the drawing proves the claim rather than asserting it: same ends, different curve.
+- **It hangs, it does not arch.** The check confirms the middle link sits **lower** than the end links (`y` 115 against 0). A first pass had the sign inverted and drew an arch, which is the inverted catenary, a different (if related) object.
+- **The links lie along the tangent**: each link is rotated by the local slope, `−atan(sinh(x/a))`, so the chain reads as links following the curve rather than beads scattered on it.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops the faint sway, leaving the chain hanging on its curve.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/catenary-as/demo.html
+++ b/submissions/examples/catenary-as/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Catenary</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="skyC"></span>
+    <span class="postC poL"></span>
+    <span class="postC poR"></span>
+
+    <div class="fieldC">
+      <div class="parabolaC">
+        <span class="parC" style="--x: -112.00px; --y: 0.00px"></span>
+        <span class="parC" style="--x: -108.50px; --y: 7.08px"></span>
+        <span class="parC" style="--x: -105.00px; --y: 13.93px"></span>
+        <span class="parC" style="--x: -101.50px; --y: 20.56px"></span>
+        <span class="parC" style="--x: -98.00px; --y: 26.97px"></span>
+        <span class="parC" style="--x: -94.50px; --y: 33.15px"></span>
+        <span class="parC" style="--x: -91.00px; --y: 39.10px"></span>
+        <span class="parC" style="--x: -87.50px; --y: 44.84px"></span>
+        <span class="parC" style="--x: -84.00px; --y: 50.34px"></span>
+        <span class="parC" style="--x: -80.50px; --y: 55.62px"></span>
+        <span class="parC" style="--x: -77.00px; --y: 60.68px"></span>
+        <span class="parC" style="--x: -73.50px; --y: 65.51px"></span>
+        <span class="parC" style="--x: -70.00px; --y: 70.12px"></span>
+        <span class="parC" style="--x: -66.50px; --y: 74.50px"></span>
+        <span class="parC" style="--x: -63.00px; --y: 78.66px"></span>
+        <span class="parC" style="--x: -59.50px; --y: 82.59px"></span>
+        <span class="parC" style="--x: -56.00px; --y: 86.30px"></span>
+        <span class="parC" style="--x: -52.50px; --y: 89.78px"></span>
+        <span class="parC" style="--x: -49.00px; --y: 93.04px"></span>
+        <span class="parC" style="--x: -45.50px; --y: 96.08px"></span>
+        <span class="parC" style="--x: -42.00px; --y: 98.89px"></span>
+        <span class="parC" style="--x: -38.50px; --y: 101.47px"></span>
+        <span class="parC" style="--x: -35.00px; --y: 103.83px"></span>
+        <span class="parC" style="--x: -31.50px; --y: 105.96px"></span>
+        <span class="parC" style="--x: -28.00px; --y: 107.87px"></span>
+        <span class="parC" style="--x: -24.50px; --y: 109.56px"></span>
+        <span class="parC" style="--x: -21.00px; --y: 111.02px"></span>
+        <span class="parC" style="--x: -17.50px; --y: 112.26px"></span>
+        <span class="parC" style="--x: -14.00px; --y: 113.27px"></span>
+        <span class="parC" style="--x: -10.50px; --y: 114.05px"></span>
+        <span class="parC" style="--x: -7.00px; --y: 114.62px"></span>
+        <span class="parC" style="--x: -3.50px; --y: 114.95px"></span>
+        <span class="parC" style="--x: 0.00px; --y: 115.07px"></span>
+        <span class="parC" style="--x: 3.50px; --y: 114.95px"></span>
+        <span class="parC" style="--x: 7.00px; --y: 114.62px"></span>
+        <span class="parC" style="--x: 10.50px; --y: 114.05px"></span>
+        <span class="parC" style="--x: 14.00px; --y: 113.27px"></span>
+        <span class="parC" style="--x: 17.50px; --y: 112.26px"></span>
+        <span class="parC" style="--x: 21.00px; --y: 111.02px"></span>
+        <span class="parC" style="--x: 24.50px; --y: 109.56px"></span>
+        <span class="parC" style="--x: 28.00px; --y: 107.87px"></span>
+        <span class="parC" style="--x: 31.50px; --y: 105.96px"></span>
+        <span class="parC" style="--x: 35.00px; --y: 103.83px"></span>
+        <span class="parC" style="--x: 38.50px; --y: 101.47px"></span>
+        <span class="parC" style="--x: 42.00px; --y: 98.89px"></span>
+        <span class="parC" style="--x: 45.50px; --y: 96.08px"></span>
+        <span class="parC" style="--x: 49.00px; --y: 93.04px"></span>
+        <span class="parC" style="--x: 52.50px; --y: 89.78px"></span>
+        <span class="parC" style="--x: 56.00px; --y: 86.30px"></span>
+        <span class="parC" style="--x: 59.50px; --y: 82.59px"></span>
+        <span class="parC" style="--x: 63.00px; --y: 78.66px"></span>
+        <span class="parC" style="--x: 66.50px; --y: 74.50px"></span>
+        <span class="parC" style="--x: 70.00px; --y: 70.12px"></span>
+        <span class="parC" style="--x: 73.50px; --y: 65.51px"></span>
+        <span class="parC" style="--x: 77.00px; --y: 60.68px"></span>
+        <span class="parC" style="--x: 80.50px; --y: 55.62px"></span>
+        <span class="parC" style="--x: 84.00px; --y: 50.34px"></span>
+        <span class="parC" style="--x: 87.50px; --y: 44.84px"></span>
+        <span class="parC" style="--x: 91.00px; --y: 39.10px"></span>
+        <span class="parC" style="--x: 94.50px; --y: 33.15px"></span>
+        <span class="parC" style="--x: 98.00px; --y: 26.97px"></span>
+        <span class="parC" style="--x: 101.50px; --y: 20.56px"></span>
+        <span class="parC" style="--x: 105.00px; --y: 13.93px"></span>
+        <span class="parC" style="--x: 108.50px; --y: 7.08px"></span>
+        <span class="parC" style="--x: 112.00px; --y: 0.00px"></span>
+      </div>
+      <div class="chainC">
+        <span class="linkC" style="--x: -112.00px; --y: 0.00px; --a: 68.19deg"></span>
+        <span class="linkC" style="--x: -101.33px; --y: 24.51px; --a: 64.60deg"></span>
+        <span class="linkC" style="--x: -90.67px; --y: 45.12px; --a: 60.47deg"></span>
+        <span class="linkC" style="--x: -80.00px; --y: 62.32px; --a: 55.72deg"></span>
+        <span class="linkC" style="--x: -69.33px; --y: 76.55px; --a: 50.33deg"></span>
+        <span class="linkC" style="--x: -58.67px; --y: 88.15px; --a: 44.24deg"></span>
+        <span class="linkC" style="--x: -48.00px; --y: 97.41px; --a: 37.45deg"></span>
+        <span class="linkC" style="--x: -37.33px; --y: 104.56px; --a: 29.99deg"></span>
+        <span class="linkC" style="--x: -26.67px; --y: 109.77px; --a: 21.91deg"></span>
+        <span class="linkC" style="--x: -16.00px; --y: 113.18px; --a: 13.36deg"></span>
+        <span class="linkC" style="--x: -5.33px; --y: 114.86px; --a: 4.49deg"></span>
+        <span class="linkC" style="--x: 5.33px; --y: 114.86px; --a: -4.49deg"></span>
+        <span class="linkC" style="--x: 16.00px; --y: 113.18px; --a: -13.36deg"></span>
+        <span class="linkC" style="--x: 26.67px; --y: 109.77px; --a: -21.91deg"></span>
+        <span class="linkC" style="--x: 37.33px; --y: 104.56px; --a: -29.99deg"></span>
+        <span class="linkC" style="--x: 48.00px; --y: 97.41px; --a: -37.45deg"></span>
+        <span class="linkC" style="--x: 58.67px; --y: 88.15px; --a: -44.24deg"></span>
+        <span class="linkC" style="--x: 69.33px; --y: 76.55px; --a: -50.33deg"></span>
+        <span class="linkC" style="--x: 80.00px; --y: 62.32px; --a: -55.72deg"></span>
+        <span class="linkC" style="--x: 90.67px; --y: 45.12px; --a: -60.47deg"></span>
+        <span class="linkC" style="--x: 101.33px; --y: 24.51px; --a: -64.60deg"></span>
+        <span class="linkC" style="--x: 112.00px; --y: 0.00px; --a: -68.19deg"></span>
+      </div>
+      <span class="pegC pgL"></span>
+      <span class="pegC pgR"></span>
+    </div>
+
+    <span class="lblCat">chain: y = a cosh(x/a)</span>
+    <span class="lblPar">parabola (dashed)</span>
+    <span class="capC">a hanging chain is not a parabola. it is a cosh.</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/catenary-as/style.css
+++ b/submissions/examples/catenary-as/style.css
@@ -1,0 +1,174 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #8fb0cc, #4a5f74 60%, #1a222c);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #aec8dc, #6f8ba4 56%, #3a4a5a);
+}
+
+.skyC {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 22% 20%, rgba(255, 255, 255, 0.3) 0 34px, transparent 54px),
+    radial-gradient(circle at 78% 30%, rgba(255, 255, 255, 0.2) 0 28px, transparent 46px);
+  z-index: 1;
+}
+
+/* the two posts the chain hangs from */
+.postC {
+  position: absolute;
+  top: 70px;
+  width: 12px;
+  height: 220px;
+  border-radius: 3px;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(20, 14, 6, 0.3) 0 2px,
+      transparent 2px 18px
+    ),
+    linear-gradient(90deg, #4a3720, #7a5f38 46%, #2f2413);
+  z-index: 3;
+}
+
+.poL { left: 42px; }
+.poR { right: 42px; }
+
+.fieldC {
+  position: absolute;
+  top: 84px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 5;
+}
+
+/*
+  the comparison parabola: y = sag * (x/half)^2, through the same two posts
+  and the same lowest point as the chain. it is drawn dashed so you can see
+  it is NOT the same curve.
+*/
+.parabolaC {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  z-index: 1;
+}
+
+.parC {
+  position: absolute;
+  top: var(--y, 0);
+  left: var(--x, 0);
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 50%;
+  background: rgba(220, 70, 60, 0.9);
+  z-index: 1;
+}
+
+/*
+  the chain. every link sits at y = a*cosh(x/a) - a with a = 68. this is the
+  shape a chain takes under its own weight, and Galileo got it wrong: he
+  thought it was a parabola. it took Bernoulli, Leibniz and Huygens to show
+  it is the hyperbolic cosine.
+*/
+.chainC {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  z-index: 3;
+}
+
+.linkC {
+  position: absolute;
+  top: var(--y, 0);
+  left: var(--x, 0);
+  width: 13px;
+  height: 9px;
+  margin: -4.5px 0 0 -6.5px;
+  border-radius: 50%;
+  border: 2.4px solid;
+  border-color: #e8eef4 #9aa6b2 #5f6a76 #c4ccd4;
+  background: radial-gradient(circle at 40% 34%, rgba(220, 228, 236, 0.4), transparent 72%);
+  transform: rotate(var(--a, 0deg));
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  z-index: 3;
+  animation: settleC 5s ease-in-out infinite;
+  animation-delay: calc(var(--x) * 0.006s);
+}
+
+.pegC {
+  position: absolute;
+  top: -6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f0f4f8, #46505a 76%);
+  box-shadow: 0 0 0 2px rgba(20, 16, 10, 0.7);
+  z-index: 5;
+}
+
+.pgL { left: -118px; }
+.pgR { left: 106px; }
+
+.lblCat,
+.lblPar {
+  position: absolute;
+  font-size: 0.5rem;
+  letter-spacing: 0.06em;
+  z-index: 8;
+}
+
+.lblCat {
+  top: 14px;
+  left: 16px;
+  color: rgba(240, 248, 255, 0.95);
+}
+
+.lblPar {
+  top: 30px;
+  left: 16px;
+  color: rgba(255, 150, 140, 0.95);
+}
+
+.capC {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.05em;
+  color: rgba(240, 248, 255, 0.85);
+  z-index: 8;
+}
+
+/* the chain barely stirs in the wind, keeping its cosh shape */
+@keyframes settleC {
+  0%, 100% { transform: rotate(var(--a, 0deg)) translateY(0); }
+  50% { transform: rotate(var(--a, 0deg)) translateY(1.5px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .linkC {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/catenary-as/`, a self-contained pure CSS/HTML hanging chain on its true cosh curve, with the parabola it is not overlaid for comparison.

Closes #49353

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A hanging chain is a hyperbolic cosine, not a parabola (Galileo's mistake, corrected by Bernoulli, Leibniz and Huygens in 1691). The difference comes from weight being spread evenly along the chain's length rather than across the horizontal span.

- **Every link is on the cosh.** The 22 chain links are placed at `y = sag - (a cosh(x/a) - a)` with `a = 68`. The browser check recomputes the hyperbolic cosine from scratch against each link's declared `--x` and `--y`: worst error **0.011px**, the rest being two-decimal coordinate rounding.
- **The parabola is the honest comparison.** A dashed parabola is drawn through the **same two posts and the same lowest point** as the chain. The check confirms the endpoints coincide (gap **0px**) but the curves **diverge by up to 8.2px** in between, so the drawing proves the claim rather than asserting it.
- **It hangs, it does not arch.** The check confirms the middle link sits lower than the ends (`y` 115 against 0). A first pass had the sign inverted and drew an arch, which is the inverted catenary, a different object; corrected and re-checked.
- **The links lie along the tangent**: each is rotated by the local slope `-atan(sinh(x/a))`, so the chain reads as links following the curve rather than beads scattered on it.

## Accessibility

`prefers-reduced-motion: reduce` stops the faint sway, leaving the chain hanging on its curve.

## Verification

Opened `demo.html` in the browser and checked the maths off the DOM: recomputed `a cosh(x/a)` against all 22 links (worst error 0.011px), confirmed the comparison parabola shares the chain's endpoints (0px gap) while diverging up to 8.2px in between, and confirmed the chain hangs (middle below the ends) after correcting an initial inverted-sign arch. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
