### PR TITLE
Fix: Navbar text color unreadable under manual [data-theme="dark"] toggle

### DIFF
--- a/components/navbar.css
+++ b/components/navbar.css
@@ -127,4 +127,10 @@
       color: var(--ease-color-neutral-100, #f1f5f9);
     }
   }
+
+  [data-theme="dark"] .ease-navbar-glass {
+    background: var(--ease-glass-bg, rgba(15, 23, 42, 0.3));
+    border-color: var(--ease-glass-border, rgba(255, 255, 255, 0.08));
+    color: var(--ease-color-neutral-100, #f1f5f9);
+  }
 }

--- a/components/navbar.css
+++ b/components/navbar.css
@@ -127,10 +127,4 @@
       color: var(--ease-color-neutral-100, #f1f5f9);
     }
   }
-
-  [data-theme="dark"] .ease-navbar-glass {
-    background: var(--ease-glass-bg, rgba(15, 23, 42, 0.3));
-    border-color: var(--ease-glass-border, rgba(255, 255, 255, 0.08));
-    color: var(--ease-color-neutral-100, #f1f5f9);
-  }
 }

--- a/submissions/docs/fix-navbar-datatheme-baishnvi/README.md
+++ b/submissions/docs/fix-navbar-datatheme-baishnvi/README.md
@@ -1,0 +1,25 @@
+@'
+
+# Fix: Navbar text color unreadable under manual [data-theme=dark]
+
+Fixes #48570
+
+## Problem
+
+The glass navbar component only responded to system-level dark mode via
+@media (prefers-color-scheme: dark). When a site manually toggled dark
+mode using [data-theme="dark"] on the root/body element, the navbar
+text stayed dark and became unreadable against a dark background.
+
+## Fix
+
+Added a [data-theme="dark"] .ease-navbar-glass selector alongside the
+existing media query, applying the same dark-mode colors so the navbar
+adapts correctly to both system and manual theme toggles.
+
+## How to test
+
+1. Open demo.html in a browser
+2. Click "Dark Mode ON" - navbar text should turn light and readable
+3. Click "Dark Mode OFF" - navbar returns to light mode styling
+   '@ | Out-File -FilePath submissions\docs\fix-navbar-datatheme-baishnvi\README.md -Encoding utf8

--- a/submissions/docs/fix-navbar-datatheme-baishnvi/demo.html
+++ b/submissions/docs/fix-navbar-datatheme-baishnvi/demo.html
@@ -1,0 +1,21 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="style.css">
+<style>body{margin:0;padding:2rem;background:#333;font-family:sans-serif;}</style>
+</head>
+<body>
+<h3 style="color:#fff">Click to toggle manual dark theme</h3>
+<nav class="ease-navbar-glass">
+  <div>Logo</div>
+  <div>
+    <a class="ease-navbar-item" href="javascript:void(0)">Home</a>
+    <a class="ease-navbar-item" href="javascript:void(0)">About</a>
+    <a class="ease-navbar-item" href="javascript:void(0)">Contact</a>
+  </div>
+</nav>
+<button onclick="document.documentElement.setAttribute('data-theme','dark')">Dark Mode ON</button>
+<button onclick="document.documentElement.removeAttribute('data-theme')">Dark Mode OFF</button>
+</body>
+</html>

--- a/submissions/docs/fix-navbar-datatheme-baishnvi/style.css
+++ b/submissions/docs/fix-navbar-datatheme-baishnvi/style.css
@@ -1,0 +1,38 @@
+﻿.ease-navbar-glass {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  min-height: 4rem;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 1.5rem;
+  color: #0f172a;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.ease-navbar-glass .ease-navbar-item {
+  text-decoration: none;
+  color: #64748b;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-navbar-glass {
+    background: rgba(15, 23, 42, 0.3);
+    border-color: rgba(255, 255, 255, 0.08);
+    color: #f1f5f9;
+  }
+}
+
+[data-theme="dark"] .ease-navbar-glass {
+  background: rgba(15, 23, 42, 0.3);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: #f1f5f9;
+}


### PR DESCRIPTION
Fixes #48570

## Problem
The glass navbar component only responds to system-level dark mode via
`@media (prefers-color-scheme: dark)`. When a site manually toggles dark
mode using `[data-theme="dark"]` on the root/body element, the navbar
text stays dark and becomes unreadable against a dark background.

## Fix
Added a `[data-theme="dark"] .ease-navbar-glass` selector alongside the
existing media query, applying the same dark-mode colors so the navbar
adapts correctly to both system and manual theme toggles.

## How to test
1. Open `demo.html` in this submission folder
2. In the browser console, run:
   `document.documentElement.setAttribute('data-theme', 'dark')`
3. Navbar text and background should switch to the dark theme colors
4. To revert: `document.documentElement.removeAttribute('data-theme')`


## Screenshots

**Before (bug):** Navbar text remains dark and unreadable when `[data-theme="dark"]` is set manually.
<img width="1366" height="768" alt="Screenshot (393)" src="https://github.com/user-attachments/assets/41a5876e-d21e-4408-8e20-230c150851af" />

**After (fix):** Navbar text switches to a light, readable color when the manual dark theme is applied.

<img width="1366" height="768" alt="Screenshot (394)" src="https://github.com/user-attachments/assets/82463bab-6d2f-43ba-a7bf-40f000b4aab9" />

