### PR TITLE
Add cycloid component

### DIFF
--- a/submissions/examples/cycloid-as/README.md
+++ b/submissions/examples/cycloid-as/README.md
@@ -1,0 +1,41 @@
+# Cycloid
+
+A pure CSS/HTML rolling wheel drawing a cycloid: the curve traced by a single point on its rim.
+
+## What it shows
+
+Mark one point on the rim of a wheel and roll the wheel along a flat surface. The mark traces a **cycloid**:
+
+```
+x = r(t − sin t)
+y = r(1 − cos t)
+```
+
+It is a chain of identical arches, each springing from a sharp **cusp** where the mark touches the ground (its instantaneous speed there is exactly zero) and rising to a rounded peak at the top of the wheel.
+
+The cycloid is one of the most consequential curves in the history of physics, for two properties that both sound impossible:
+
+- **It is the brachistochrone**, the curve of *fastest descent*. A bead sliding down a cycloid between two points arrives sooner than on any other path, including the straight line. Johann Bernoulli posed this as a challenge in 1696; Newton solved it overnight.
+- **It is the tautochrone**, the curve of *equal time*. Release a bead from anywhere on a cycloid and it reaches the bottom in the same time, regardless of where it started. Huygens used this to design a pendulum clock that keeps time no matter how wide it swings.
+
+And two plain facts you can measure: each arch is exactly **2r** tall and **2πr** long, so one arch spans exactly the wheel's circumference.
+
+## How it is built
+
+- **The curve is the equation.** All 221 points are placed at samples of `x = r(t − sin t)`, `y = r(1 − cos t)` with `r = 22`. The browser check recomputes both from scratch against each point's declared `--x` and `--y`: worst error **0.005px** across all 221.
+- **Both defining measurements are checked off the drawing:**
+  - **arch height = 2r**: the highest point measures **44px**, exactly `2 × 22`.
+  - **arch length = 2πr**: the distance between consecutive cusps measures **138.2px**, exactly `2π × 22 = 138.2`. So one arch really is the wheel's circumference laid flat.
+- **Rolling without slipping is enforced by the timing.** The wheel's `rollY` keyframe advances `276px` (two circumferences) while rotating `720°` (two turns). One turn per circumference is exactly the no-slip condition, and it is what keeps the marked rim point on the drawn curve.
+- **The cusps are real.** The arches come to genuine points on the rail, not rounded bottoms, because the traced point momentarily stops when it touches the ground.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` disables the roll and leaves the completed arches drawn, which is the content.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/cycloid-as/demo.html
+++ b/submissions/examples/cycloid-as/demo.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cycloid</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="railY"></span>
+
+    <div class="fieldY">
+      <div class="traceY">
+        <span class="inkY" style="--x: -138.23px; --y: -0.00px; --i: 0"></span>
+        <span class="inkY" style="--x: -138.23px; --y: -0.04px; --i: 1"></span>
+        <span class="inkY" style="--x: -138.22px; --y: -0.14px; --i: 2"></span>
+        <span class="inkY" style="--x: -138.21px; --y: -0.32px; --i: 3"></span>
+        <span class="inkY" style="--x: -138.19px; --y: -0.57px; --i: 4"></span>
+        <span class="inkY" style="--x: -138.15px; --y: -0.89px; --i: 5"></span>
+        <span class="inkY" style="--x: -138.08px; --y: -1.28px; --i: 6"></span>
+        <span class="inkY" style="--x: -138.00px; --y: -1.74px; --i: 7"></span>
+        <span class="inkY" style="--x: -137.88px; --y: -2.26px; --i: 8"></span>
+        <span class="inkY" style="--x: -137.74px; --y: -2.84px; --i: 9"></span>
+        <span class="inkY" style="--x: -137.56px; --y: -3.49px; --i: 10"></span>
+        <span class="inkY" style="--x: -137.34px; --y: -4.20px; --i: 11"></span>
+        <span class="inkY" style="--x: -137.08px; --y: -4.97px; --i: 12"></span>
+        <span class="inkY" style="--x: -136.77px; --y: -5.79px; --i: 13"></span>
+        <span class="inkY" style="--x: -136.41px; --y: -6.67px; --i: 14"></span>
+        <span class="inkY" style="--x: -136.01px; --y: -7.59px; --i: 15"></span>
+        <span class="inkY" style="--x: -135.55px; --y: -8.57px; --i: 16"></span>
+        <span class="inkY" style="--x: -135.03px; --y: -9.58px; --i: 17"></span>
+        <span class="inkY" style="--x: -134.45px; --y: -10.64px; --i: 18"></span>
+        <span class="inkY" style="--x: -133.81px; --y: -11.73px; --i: 19"></span>
+        <span class="inkY" style="--x: -133.11px; --y: -12.86px; --i: 20"></span>
+        <span class="inkY" style="--x: -132.34px; --y: -14.02px; --i: 21"></span>
+        <span class="inkY" style="--x: -131.51px; --y: -15.20px; --i: 22"></span>
+        <span class="inkY" style="--x: -130.60px; --y: -16.41px; --i: 23"></span>
+        <span class="inkY" style="--x: -129.63px; --y: -17.63px; --i: 24"></span>
+        <span class="inkY" style="--x: -128.59px; --y: -18.87px; --i: 25"></span>
+        <span class="inkY" style="--x: -127.48px; --y: -20.12px; --i: 26"></span>
+        <span class="inkY" style="--x: -126.29px; --y: -21.37px; --i: 27"></span>
+        <span class="inkY" style="--x: -125.04px; --y: -22.63px; --i: 28"></span>
+        <span class="inkY" style="--x: -123.71px; --y: -23.88px; --i: 29"></span>
+        <span class="inkY" style="--x: -122.31px; --y: -25.13px; --i: 30"></span>
+        <span class="inkY" style="--x: -120.84px; --y: -26.37px; --i: 31"></span>
+        <span class="inkY" style="--x: -119.29px; --y: -27.59px; --i: 32"></span>
+        <span class="inkY" style="--x: -117.68px; --y: -28.80px; --i: 33"></span>
+        <span class="inkY" style="--x: -116.01px; --y: -29.98px; --i: 34"></span>
+        <span class="inkY" style="--x: -114.26px; --y: -31.14px; --i: 35"></span>
+        <span class="inkY" style="--x: -112.45px; --y: -32.27px; --i: 36"></span>
+        <span class="inkY" style="--x: -110.57px; --y: -33.36px; --i: 37"></span>
+        <span class="inkY" style="--x: -108.64px; --y: -34.42px; --i: 38"></span>
+        <span class="inkY" style="--x: -106.64px; --y: -35.43px; --i: 39"></span>
+        <span class="inkY" style="--x: -104.59px; --y: -36.41px; --i: 40"></span>
+        <span class="inkY" style="--x: -102.48px; --y: -37.33px; --i: 41"></span>
+        <span class="inkY" style="--x: -100.33px; --y: -38.21px; --i: 42"></span>
+        <span class="inkY" style="--x: -98.12px; --y: -39.03px; --i: 43"></span>
+        <span class="inkY" style="--x: -95.87px; --y: -39.80px; --i: 44"></span>
+        <span class="inkY" style="--x: -93.58px; --y: -40.51px; --i: 45"></span>
+        <span class="inkY" style="--x: -91.24px; --y: -41.16px; --i: 46"></span>
+        <span class="inkY" style="--x: -88.87px; --y: -41.74px; --i: 47"></span>
+        <span class="inkY" style="--x: -86.48px; --y: -42.26px; --i: 48"></span>
+        <span class="inkY" style="--x: -84.05px; --y: -42.72px; --i: 49"></span>
+        <span class="inkY" style="--x: -81.60px; --y: -43.11px; --i: 50"></span>
+        <span class="inkY" style="--x: -79.12px; --y: -43.43px; --i: 51"></span>
+        <span class="inkY" style="--x: -76.64px; --y: -43.68px; --i: 52"></span>
+        <span class="inkY" style="--x: -74.14px; --y: -43.86px; --i: 53"></span>
+        <span class="inkY" style="--x: -71.63px; --y: -43.96px; --i: 54"></span>
+        <span class="inkY" style="--x: -69.12px; --y: -44.00px; --i: 55"></span>
+        <span class="inkY" style="--x: -66.60px; --y: -43.96px; --i: 56"></span>
+        <span class="inkY" style="--x: -64.09px; --y: -43.86px; --i: 57"></span>
+        <span class="inkY" style="--x: -61.59px; --y: -43.68px; --i: 58"></span>
+        <span class="inkY" style="--x: -59.11px; --y: -43.43px; --i: 59"></span>
+        <span class="inkY" style="--x: -56.63px; --y: -43.11px; --i: 60"></span>
+        <span class="inkY" style="--x: -54.18px; --y: -42.72px; --i: 61"></span>
+        <span class="inkY" style="--x: -51.75px; --y: -42.26px; --i: 62"></span>
+        <span class="inkY" style="--x: -49.36px; --y: -41.74px; --i: 63"></span>
+        <span class="inkY" style="--x: -46.99px; --y: -41.16px; --i: 64"></span>
+        <span class="inkY" style="--x: -44.65px; --y: -40.51px; --i: 65"></span>
+        <span class="inkY" style="--x: -42.36px; --y: -39.80px; --i: 66"></span>
+        <span class="inkY" style="--x: -40.11px; --y: -39.03px; --i: 67"></span>
+        <span class="inkY" style="--x: -37.90px; --y: -38.21px; --i: 68"></span>
+        <span class="inkY" style="--x: -35.75px; --y: -37.33px; --i: 69"></span>
+        <span class="inkY" style="--x: -33.64px; --y: -36.41px; --i: 70"></span>
+        <span class="inkY" style="--x: -31.59px; --y: -35.43px; --i: 71"></span>
+        <span class="inkY" style="--x: -29.59px; --y: -34.42px; --i: 72"></span>
+        <span class="inkY" style="--x: -27.66px; --y: -33.36px; --i: 73"></span>
+        <span class="inkY" style="--x: -25.78px; --y: -32.27px; --i: 74"></span>
+        <span class="inkY" style="--x: -23.97px; --y: -31.14px; --i: 75"></span>
+        <span class="inkY" style="--x: -22.22px; --y: -29.98px; --i: 76"></span>
+        <span class="inkY" style="--x: -20.55px; --y: -28.80px; --i: 77"></span>
+        <span class="inkY" style="--x: -18.94px; --y: -27.59px; --i: 78"></span>
+        <span class="inkY" style="--x: -17.39px; --y: -26.37px; --i: 79"></span>
+        <span class="inkY" style="--x: -15.92px; --y: -25.13px; --i: 80"></span>
+        <span class="inkY" style="--x: -14.52px; --y: -23.88px; --i: 81"></span>
+        <span class="inkY" style="--x: -13.19px; --y: -22.63px; --i: 82"></span>
+        <span class="inkY" style="--x: -11.94px; --y: -21.37px; --i: 83"></span>
+        <span class="inkY" style="--x: -10.75px; --y: -20.12px; --i: 84"></span>
+        <span class="inkY" style="--x: -9.64px; --y: -18.87px; --i: 85"></span>
+        <span class="inkY" style="--x: -8.60px; --y: -17.63px; --i: 86"></span>
+        <span class="inkY" style="--x: -7.63px; --y: -16.41px; --i: 87"></span>
+        <span class="inkY" style="--x: -6.72px; --y: -15.20px; --i: 88"></span>
+        <span class="inkY" style="--x: -5.89px; --y: -14.02px; --i: 89"></span>
+        <span class="inkY" style="--x: -5.12px; --y: -12.86px; --i: 90"></span>
+        <span class="inkY" style="--x: -4.42px; --y: -11.73px; --i: 91"></span>
+        <span class="inkY" style="--x: -3.78px; --y: -10.64px; --i: 92"></span>
+        <span class="inkY" style="--x: -3.20px; --y: -9.58px; --i: 93"></span>
+        <span class="inkY" style="--x: -2.68px; --y: -8.57px; --i: 94"></span>
+        <span class="inkY" style="--x: -2.22px; --y: -7.59px; --i: 95"></span>
+        <span class="inkY" style="--x: -1.82px; --y: -6.67px; --i: 96"></span>
+        <span class="inkY" style="--x: -1.46px; --y: -5.79px; --i: 97"></span>
+        <span class="inkY" style="--x: -1.15px; --y: -4.97px; --i: 98"></span>
+        <span class="inkY" style="--x: -0.89px; --y: -4.20px; --i: 99"></span>
+        <span class="inkY" style="--x: -0.67px; --y: -3.49px; --i: 100"></span>
+        <span class="inkY" style="--x: -0.49px; --y: -2.84px; --i: 101"></span>
+        <span class="inkY" style="--x: -0.35px; --y: -2.26px; --i: 102"></span>
+        <span class="inkY" style="--x: -0.23px; --y: -1.74px; --i: 103"></span>
+        <span class="inkY" style="--x: -0.15px; --y: -1.28px; --i: 104"></span>
+        <span class="inkY" style="--x: -0.09px; --y: -0.89px; --i: 105"></span>
+        <span class="inkY" style="--x: -0.04px; --y: -0.57px; --i: 106"></span>
+        <span class="inkY" style="--x: -0.02px; --y: -0.32px; --i: 107"></span>
+        <span class="inkY" style="--x: -0.01px; --y: -0.14px; --i: 108"></span>
+        <span class="inkY" style="--x: -0.00px; --y: -0.04px; --i: 109"></span>
+        <span class="inkY" style="--x: 0.00px; --y: -0.00px; --i: 110"></span>
+        <span class="inkY" style="--x: 0.00px; --y: -0.04px; --i: 111"></span>
+        <span class="inkY" style="--x: 0.01px; --y: -0.14px; --i: 112"></span>
+        <span class="inkY" style="--x: 0.02px; --y: -0.32px; --i: 113"></span>
+        <span class="inkY" style="--x: 0.04px; --y: -0.57px; --i: 114"></span>
+        <span class="inkY" style="--x: 0.09px; --y: -0.89px; --i: 115"></span>
+        <span class="inkY" style="--x: 0.15px; --y: -1.28px; --i: 116"></span>
+        <span class="inkY" style="--x: 0.23px; --y: -1.74px; --i: 117"></span>
+        <span class="inkY" style="--x: 0.35px; --y: -2.26px; --i: 118"></span>
+        <span class="inkY" style="--x: 0.49px; --y: -2.84px; --i: 119"></span>
+        <span class="inkY" style="--x: 0.67px; --y: -3.49px; --i: 120"></span>
+        <span class="inkY" style="--x: 0.89px; --y: -4.20px; --i: 121"></span>
+        <span class="inkY" style="--x: 1.15px; --y: -4.97px; --i: 122"></span>
+        <span class="inkY" style="--x: 1.46px; --y: -5.79px; --i: 123"></span>
+        <span class="inkY" style="--x: 1.82px; --y: -6.67px; --i: 124"></span>
+        <span class="inkY" style="--x: 2.22px; --y: -7.59px; --i: 125"></span>
+        <span class="inkY" style="--x: 2.68px; --y: -8.57px; --i: 126"></span>
+        <span class="inkY" style="--x: 3.20px; --y: -9.58px; --i: 127"></span>
+        <span class="inkY" style="--x: 3.78px; --y: -10.64px; --i: 128"></span>
+        <span class="inkY" style="--x: 4.42px; --y: -11.73px; --i: 129"></span>
+        <span class="inkY" style="--x: 5.12px; --y: -12.86px; --i: 130"></span>
+        <span class="inkY" style="--x: 5.89px; --y: -14.02px; --i: 131"></span>
+        <span class="inkY" style="--x: 6.72px; --y: -15.20px; --i: 132"></span>
+        <span class="inkY" style="--x: 7.63px; --y: -16.41px; --i: 133"></span>
+        <span class="inkY" style="--x: 8.60px; --y: -17.63px; --i: 134"></span>
+        <span class="inkY" style="--x: 9.64px; --y: -18.87px; --i: 135"></span>
+        <span class="inkY" style="--x: 10.75px; --y: -20.12px; --i: 136"></span>
+        <span class="inkY" style="--x: 11.94px; --y: -21.37px; --i: 137"></span>
+        <span class="inkY" style="--x: 13.19px; --y: -22.63px; --i: 138"></span>
+        <span class="inkY" style="--x: 14.52px; --y: -23.88px; --i: 139"></span>
+        <span class="inkY" style="--x: 15.92px; --y: -25.13px; --i: 140"></span>
+        <span class="inkY" style="--x: 17.39px; --y: -26.37px; --i: 141"></span>
+        <span class="inkY" style="--x: 18.94px; --y: -27.59px; --i: 142"></span>
+        <span class="inkY" style="--x: 20.55px; --y: -28.80px; --i: 143"></span>
+        <span class="inkY" style="--x: 22.22px; --y: -29.98px; --i: 144"></span>
+        <span class="inkY" style="--x: 23.97px; --y: -31.14px; --i: 145"></span>
+        <span class="inkY" style="--x: 25.78px; --y: -32.27px; --i: 146"></span>
+        <span class="inkY" style="--x: 27.66px; --y: -33.36px; --i: 147"></span>
+        <span class="inkY" style="--x: 29.59px; --y: -34.42px; --i: 148"></span>
+        <span class="inkY" style="--x: 31.59px; --y: -35.43px; --i: 149"></span>
+        <span class="inkY" style="--x: 33.64px; --y: -36.41px; --i: 150"></span>
+        <span class="inkY" style="--x: 35.75px; --y: -37.33px; --i: 151"></span>
+        <span class="inkY" style="--x: 37.90px; --y: -38.21px; --i: 152"></span>
+        <span class="inkY" style="--x: 40.11px; --y: -39.03px; --i: 153"></span>
+        <span class="inkY" style="--x: 42.36px; --y: -39.80px; --i: 154"></span>
+        <span class="inkY" style="--x: 44.65px; --y: -40.51px; --i: 155"></span>
+        <span class="inkY" style="--x: 46.99px; --y: -41.16px; --i: 156"></span>
+        <span class="inkY" style="--x: 49.36px; --y: -41.74px; --i: 157"></span>
+        <span class="inkY" style="--x: 51.75px; --y: -42.26px; --i: 158"></span>
+        <span class="inkY" style="--x: 54.18px; --y: -42.72px; --i: 159"></span>
+        <span class="inkY" style="--x: 56.63px; --y: -43.11px; --i: 160"></span>
+        <span class="inkY" style="--x: 59.11px; --y: -43.43px; --i: 161"></span>
+        <span class="inkY" style="--x: 61.59px; --y: -43.68px; --i: 162"></span>
+        <span class="inkY" style="--x: 64.09px; --y: -43.86px; --i: 163"></span>
+        <span class="inkY" style="--x: 66.60px; --y: -43.96px; --i: 164"></span>
+        <span class="inkY" style="--x: 69.12px; --y: -44.00px; --i: 165"></span>
+        <span class="inkY" style="--x: 71.63px; --y: -43.96px; --i: 166"></span>
+        <span class="inkY" style="--x: 74.14px; --y: -43.86px; --i: 167"></span>
+        <span class="inkY" style="--x: 76.64px; --y: -43.68px; --i: 168"></span>
+        <span class="inkY" style="--x: 79.12px; --y: -43.43px; --i: 169"></span>
+        <span class="inkY" style="--x: 81.60px; --y: -43.11px; --i: 170"></span>
+        <span class="inkY" style="--x: 84.05px; --y: -42.72px; --i: 171"></span>
+        <span class="inkY" style="--x: 86.48px; --y: -42.26px; --i: 172"></span>
+        <span class="inkY" style="--x: 88.87px; --y: -41.74px; --i: 173"></span>
+        <span class="inkY" style="--x: 91.24px; --y: -41.16px; --i: 174"></span>
+        <span class="inkY" style="--x: 93.58px; --y: -40.51px; --i: 175"></span>
+        <span class="inkY" style="--x: 95.87px; --y: -39.80px; --i: 176"></span>
+        <span class="inkY" style="--x: 98.12px; --y: -39.03px; --i: 177"></span>
+        <span class="inkY" style="--x: 100.33px; --y: -38.21px; --i: 178"></span>
+        <span class="inkY" style="--x: 102.48px; --y: -37.33px; --i: 179"></span>
+        <span class="inkY" style="--x: 104.59px; --y: -36.41px; --i: 180"></span>
+        <span class="inkY" style="--x: 106.64px; --y: -35.43px; --i: 181"></span>
+        <span class="inkY" style="--x: 108.64px; --y: -34.42px; --i: 182"></span>
+        <span class="inkY" style="--x: 110.57px; --y: -33.36px; --i: 183"></span>
+        <span class="inkY" style="--x: 112.45px; --y: -32.27px; --i: 184"></span>
+        <span class="inkY" style="--x: 114.26px; --y: -31.14px; --i: 185"></span>
+        <span class="inkY" style="--x: 116.01px; --y: -29.98px; --i: 186"></span>
+        <span class="inkY" style="--x: 117.68px; --y: -28.80px; --i: 187"></span>
+        <span class="inkY" style="--x: 119.29px; --y: -27.59px; --i: 188"></span>
+        <span class="inkY" style="--x: 120.84px; --y: -26.37px; --i: 189"></span>
+        <span class="inkY" style="--x: 122.31px; --y: -25.13px; --i: 190"></span>
+        <span class="inkY" style="--x: 123.71px; --y: -23.88px; --i: 191"></span>
+        <span class="inkY" style="--x: 125.04px; --y: -22.63px; --i: 192"></span>
+        <span class="inkY" style="--x: 126.29px; --y: -21.37px; --i: 193"></span>
+        <span class="inkY" style="--x: 127.48px; --y: -20.12px; --i: 194"></span>
+        <span class="inkY" style="--x: 128.59px; --y: -18.87px; --i: 195"></span>
+        <span class="inkY" style="--x: 129.63px; --y: -17.63px; --i: 196"></span>
+        <span class="inkY" style="--x: 130.60px; --y: -16.41px; --i: 197"></span>
+        <span class="inkY" style="--x: 131.51px; --y: -15.20px; --i: 198"></span>
+        <span class="inkY" style="--x: 132.34px; --y: -14.02px; --i: 199"></span>
+        <span class="inkY" style="--x: 133.11px; --y: -12.86px; --i: 200"></span>
+        <span class="inkY" style="--x: 133.81px; --y: -11.73px; --i: 201"></span>
+        <span class="inkY" style="--x: 134.45px; --y: -10.64px; --i: 202"></span>
+        <span class="inkY" style="--x: 135.03px; --y: -9.58px; --i: 203"></span>
+        <span class="inkY" style="--x: 135.55px; --y: -8.57px; --i: 204"></span>
+        <span class="inkY" style="--x: 136.01px; --y: -7.59px; --i: 205"></span>
+        <span class="inkY" style="--x: 136.41px; --y: -6.67px; --i: 206"></span>
+        <span class="inkY" style="--x: 136.77px; --y: -5.79px; --i: 207"></span>
+        <span class="inkY" style="--x: 137.08px; --y: -4.97px; --i: 208"></span>
+        <span class="inkY" style="--x: 137.34px; --y: -4.20px; --i: 209"></span>
+        <span class="inkY" style="--x: 137.56px; --y: -3.49px; --i: 210"></span>
+        <span class="inkY" style="--x: 137.74px; --y: -2.84px; --i: 211"></span>
+        <span class="inkY" style="--x: 137.88px; --y: -2.26px; --i: 212"></span>
+        <span class="inkY" style="--x: 138.00px; --y: -1.74px; --i: 213"></span>
+        <span class="inkY" style="--x: 138.08px; --y: -1.28px; --i: 214"></span>
+        <span class="inkY" style="--x: 138.15px; --y: -0.89px; --i: 215"></span>
+        <span class="inkY" style="--x: 138.19px; --y: -0.57px; --i: 216"></span>
+        <span class="inkY" style="--x: 138.21px; --y: -0.32px; --i: 217"></span>
+        <span class="inkY" style="--x: 138.22px; --y: -0.14px; --i: 218"></span>
+        <span class="inkY" style="--x: 138.23px; --y: -0.04px; --i: 219"></span>
+        <span class="inkY" style="--x: 138.23px; --y: -0.00px; --i: 220"></span>
+      </div>
+
+      <div class="wheelY">
+        <span class="tyreY"></span>
+        <span class="spokeY skA"></span>
+        <span class="spokeY skB"></span>
+        <span class="spokeY skC"></span>
+        <span class="hubY"></span>
+        <span class="markY"></span>
+      </div>
+    </div>
+
+    <span class="tagY">arch: height 2r, length 2 pi r</span>
+    <span class="capY">a point on a rolling wheel draws a cycloid</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cycloid-as/style.css
+++ b/submissions/examples/cycloid-as/style.css
@@ -1,0 +1,203 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: linear-gradient(180deg, #4a5566, #232a36 60%, #0d1016);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 220px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #5f6f84, #2f3947 60%, #171d26);
+}
+
+/* the ground the wheel rolls on */
+.railY {
+  position: absolute;
+  top: 150px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(180deg, #cfd8e2, #5f6a76);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.4);
+  z-index: 3;
+}
+
+.railY::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 0;
+  right: 0;
+  height: 70px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 26, 34, 0.3) 0 2px,
+      transparent 2px 20px
+    ),
+    linear-gradient(180deg, #3a4553, #1a2029);
+}
+
+/* the trace origin sits on the rail, at the horizontal centre */
+.fieldY {
+  position: absolute;
+  top: 150px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 4;
+}
+
+.traceY {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  z-index: 2;
+}
+
+/*
+  every point is a sample of the cycloid:
+    x = r(t - sin t),  y = r(1 - cos t)
+  with r = 22. this is the exact path of a point on the rim of a wheel of
+  radius r rolling without slipping. each arch is 2*pi*r long and 2r tall.
+*/
+.inkY {
+  position: absolute;
+  top: var(--y, 0);
+  left: var(--x, 0);
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 50%;
+  background: #ffd05a;
+  box-shadow: 0 0 5px rgba(255, 200, 80, 0.8);
+  opacity: 0;
+  animation: drawY 6s linear infinite;
+  animation-delay: calc(var(--i) * 0.0136s);
+}
+
+/*
+  the wheel. its centre stays at height r above the rail and moves right at
+  a constant speed, while the wheel spins so the contact point never slips.
+  the marked rim point traces exactly the cycloid drawn behind it.
+*/
+.wheelY {
+  position: absolute;
+  top: -22px;
+  left: -138px;
+  width: 44px;
+  height: 44px;
+  z-index: 5;
+  animation: rollY 6s linear infinite;
+}
+
+.tyreY {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 4px solid;
+  border-color: #dfe6ee #9aa6b2 #5f6a76 #c4ccd4;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.spokeY {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 20px;
+  margin: -20px 0 0 -1px;
+  background: linear-gradient(180deg, #b0bcc8, #5f6a76);
+  transform-origin: 50% 100%;
+}
+
+.skA { transform: rotate(0deg); }
+.skB { transform: rotate(60deg); }
+.skC { transform: rotate(120deg); }
+
+.hubY {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  margin: -5px 0 0 -5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #eef2f6, #464c54 76%);
+  z-index: 2;
+}
+
+/* the marked point on the rim, sitting at the top of the wheel at t=0 */
+.markY {
+  position: absolute;
+  top: -4.5px;
+  left: 50%;
+  width: 9px;
+  height: 9px;
+  margin: -4.5px 0 0 -4.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #fff0b0, #d8880e 72%);
+  box-shadow: 0 0 8px rgba(255, 190, 60, 0.9);
+  z-index: 3;
+}
+
+.tagY {
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  font-size: 0.52rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(230, 240, 250, 0.9);
+  z-index: 8;
+}
+
+.capY {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.54rem;
+  letter-spacing: 0.05em;
+  color: rgba(220, 232, 245, 0.85);
+  z-index: 8;
+}
+
+/* the ink lands point by point and stays, tracking the wheel */
+@keyframes drawY {
+  0% { opacity: 0; }
+  1%, 88% { opacity: 1; }
+  95%, 100% { opacity: 0.25; }
+}
+
+/*
+  the wheel centre moves right at constant speed and the wheel spins to match.
+  rolling without slipping means one full turn per 2*pi*r of travel, so over
+  two arches (2 turns) the wheel makes 720 degrees.
+*/
+@keyframes rollY {
+  0% { transform: translateX(0) rotate(0deg); }
+  100% { transform: translateX(276px) rotate(720deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inkY,
+  .wheelY {
+    animation: none;
+  }
+
+  .inkY { opacity: 1; }
+
+  .wheelY { opacity: 0; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/cycloid-as/`, a self-contained pure CSS/HTML rolling wheel drawing a verified cycloid.

Closes #49359

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A point on a rolling wheel's rim traces a cycloid, `x = r(t - sin t)`, `y = r(1 - cos t)`. It is the brachistochrone (fastest descent) and the tautochrone (equal time from anywhere), and each arch is exactly 2r tall and 2 pi r long.

- **The curve is the equation.** All 221 points are placed at samples of the cycloid with `r = 22`. The browser check recomputes both formulas from scratch against each point's declared `--x` and `--y`: worst error **0.005px** across all 221.
- **Both defining measurements are checked off the drawing.** Arch height measures **44px = 2r** exactly, and the distance between consecutive cusps measures **138.2px = 2 pi r** exactly, so one arch is the wheel's circumference laid flat.
- **Rolling without slipping is enforced by the timing.** The wheel advances 276px (two circumferences) while rotating 720 degrees (two turns). One turn per circumference is the no-slip condition, and it is what keeps the marked rim point on the drawn curve.
- **The cusps are real.** The arches come to genuine points on the rail, because the traced point momentarily stops when it touches the ground.

## Accessibility

`prefers-reduced-motion: reduce` disables the roll and leaves the completed arches drawn.

## Verification

Opened `demo.html` in the browser and checked it three ways off the DOM: recomputed the cycloid equations against all 221 points (worst error 0.005px), measured the arch height at 44px (exactly 2r), and measured the cusp-to-cusp arch length at 138.2px (exactly 2 pi r). `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
