### PR TITLE
Add ease-scale-hover-popover-a11y component

### DIFF
--- a/submissions/examples/ease-scale-hover-popover-a11y/README.md
+++ b/submissions/examples/ease-scale-hover-popover-a11y/README.md
@@ -1,0 +1,30 @@
+# Accessible Scale-Hover Popover
+
+### 1. What does this do?
+An info-icon-triggered popover with a smooth scale-up transition, built for accessible web layouts. It uses `aria-describedby`, `aria-expanded`, `aria-label`, and `role="tooltip"` so the content is properly announced by screen readers, and respects `prefers-reduced-motion`.
+
+### 2. How is it used?
+\`\`\`html
+<span class="a11y-info-wrap">
+  <button
+    type="button"
+    class="a11y-info-btn"
+    aria-describedby="a11y-pop-1"
+    aria-expanded="false"
+    aria-label="Why we need this"
+  >i</button>
+  <span class="a11y-scalepop" role="tooltip" id="a11y-pop-1">
+    Explanation text goes here.
+  </span>
+</span>
+\`\`\`
+- The trigger is a real `<button>` (focusable and operable by keyboard by default) linked to the popover via `aria-describedby`.
+- A small inline script toggles `aria-expanded` on hover/focus/blur so assistive tech knows the popover's visibility state — the actual show/hide transition itself is pure CSS (`:hover` / `:focus-visible` + sibling selector).
+- Customize the motion with CSS custom properties on `.a11y-scalepop`:
+  - `--a11ypop-timing` — transition duration (default `0.3s`)
+  - `--a11ypop-easing` — transition easing function (default a slight overshoot cubic-bezier)
+  - `--a11ypop-scale` — final scale factor on reveal (default `1`)
+- Motion is disabled automatically under `prefers-reduced-motion: reduce`.
+
+### 3. Why is it useful?
+Contextual help icons (form field explanations, password requirements, etc.) are common in accessible web forms, but are often built with JS-heavy tooltip libraries. This component shows the same pattern achievable with a native button, proper ARIA wiring, and CSS-only motion — fitting EaseMotion's animation-first, zero-JS-overhead philosophy while staying genuinely accessible.

--- a/submissions/examples/ease-scale-hover-popover-a11y/demo.html
+++ b/submissions/examples/ease-scale-hover-popover-a11y/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Accessible Scale-Hover Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Accessible Scale-Hover Popover</h1>
+  <p>An info-icon-triggered popover with a smooth scale-up transition, built with explicit ARIA attributes for screen reader support.</p>
+
+  <div class="demo-row">
+
+    <div class="a11y-field">
+      <label class="a11y-label" for="field-email">
+        Email address
+        <span class="a11y-info-wrap">
+          <button
+            type="button"
+            class="a11y-info-btn"
+            aria-describedby="a11y-pop-1"
+            aria-expanded="false"
+            aria-label="Why we need this"
+          >i</button>
+          <span class="a11y-scalepop" role="tooltip" id="a11y-pop-1">
+            We use your email only for account recovery and critical security alerts. Never for marketing.
+          </span>
+        </span>
+      </label>
+      <input class="a11y-input" id="field-email" type="email" placeholder="you@example.com">
+    </div>
+
+    <div class="a11y-field">
+      <label class="a11y-label" for="field-pass">
+        Password
+        <span class="a11y-info-wrap">
+          <button
+            type="button"
+            class="a11y-info-btn"
+            aria-describedby="a11y-pop-2"
+            aria-expanded="false"
+            aria-label="Password requirements"
+          >i</button>
+          <span class="a11y-scalepop" role="tooltip" id="a11y-pop-2" style="--a11ypop-scale: 1.05; --a11ypop-timing: 0.45s;">
+            Minimum 10 characters, with at least one number and one symbol.
+          </span>
+        </span>
+      </label>
+      <input class="a11y-input" id="field-pass" type="password" placeholder="••••••••">
+    </div>
+
+  </div>
+
+  <script>
+    document.querySelectorAll('.a11y-info-btn').forEach(function (btn) {
+      var show = function () { btn.setAttribute('aria-expanded', 'true'); };
+      var hide = function () { btn.setAttribute('aria-expanded', 'false'); };
+      btn.addEventListener('focus', show);
+      btn.addEventListener('blur', hide);
+      btn.addEventListener('mouseenter', show);
+      btn.addEventListener('mouseleave', hide);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-scale-hover-popover-a11y/style.css
+++ b/submissions/examples/ease-scale-hover-popover-a11y/style.css
@@ -1,0 +1,127 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1115;
+  color: #f2f2f2;
+  padding: 40px;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 32px;
+  margin-top: 48px;
+}
+
+.a11y-field {
+  width: 260px;
+  text-align: left;
+}
+
+.a11y-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.a11y-info-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.a11y-info-btn {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1px solid #4a90d9;
+  background: transparent;
+  color: #4a90d9;
+  font-size: 12px;
+  font-style: italic;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.a11y-info-btn:hover,
+.a11y-info-btn:focus-visible {
+  background: #4a90d9;
+  color: #0f1115;
+}
+
+.a11y-info-btn:focus-visible {
+  outline: 2px solid #4a90d9;
+  outline-offset: 3px;
+}
+
+.a11y-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: #f2f2f2;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+}
+
+.a11y-input:focus-visible {
+  outline: 2px solid #4a90d9;
+  outline-offset: 2px;
+}
+
+.a11y-scalepop {
+  --a11ypop-timing: 0.3s;
+  --a11ypop-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --a11ypop-scale: 1;
+
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 20;
+  width: 220px;
+  text-align: left;
+  font-size: 12.5px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #f2f2f2;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 10px;
+  padding: 12px 14px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  pointer-events: none;
+  opacity: 0;
+  transform-origin: bottom left;
+  transform: translateX(-4px) scale(calc(var(--a11ypop-scale) * 0.85));
+  transition:
+    opacity var(--a11ypop-timing) var(--a11ypop-easing),
+    transform var(--a11ypop-timing) var(--a11ypop-easing);
+}
+
+.a11y-info-btn:hover + .a11y-scalepop,
+.a11y-info-btn:focus-visible + .a11y-scalepop {
+  opacity: 1;
+  transform: translateX(-4px) scale(var(--a11ypop-scale));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .a11y-scalepop {
+    transition-duration: 0.01ms;
+  }
+}
+
+@media (max-width: 480px) {
+  .a11y-scalepop {
+    width: 180px;
+  }
+}


### PR DESCRIPTION
Closes #46447

## Pull Request Description
Adds a new `scale-hover-popover-a11y` component — an info-icon-triggered popover with a smooth scale-up transition and full ARIA wiring, styled for accessible web layouts. Closes #46447.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-scale-hover-popover-a11y/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An info-icon-triggered popover with a smooth scale-up transition, built with `aria-describedby`, `aria-expanded`, `aria-label`, and `role="tooltip"` for screen reader support, and respecting `prefers-reduced-motion`.

**How does a developer use it?**
```html
<span class="a11y-info-wrap">
  <button
    type="button"
    class="a11y-info-btn"
    aria-describedby="a11y-pop-1"
    aria-expanded="false"
    aria-label="Why we need this"
  >i</button>
  <span class="a11y-scalepop" role="tooltip" id="a11y-pop-1">
    Explanation text goes here.
  </span>
</span>
```
The trigger is a real `<button>` linked to the popover via `aria-describedby`; a small inline script toggles `aria-expanded` on hover/focus/blur while the actual show/hide transition is pure CSS. Customize the motion with `--a11ypop-timing`, `--a11ypop-easing`, and `--a11ypop-scale`.

**Why does it fit EaseMotion CSS?**
Contextual help icons are common in accessible forms but are often built with JS-heavy tooltip libraries. This shows the same pattern with a native button, proper ARIA wiring, and CSS-only motion — fitting EaseMotion's animation-first, zero-JS-overhead philosophy while staying genuinely accessible (including `prefers-reduced-motion` support).

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Heads up: there are already a large number of scale-hover popover/tooltip submissions in `submissions/examples/` from other contributors (e.g. `scale-hover-popover`, `scale-hover-popover-ps`, `ease-scale-hover-tooltip`, and several more). This one differentiates itself by being icon/button-triggered with explicit ARIA attributes and `prefers-reduced-motion` support rather than a plain hover-card, but you may want to consider whether further scale-hover popover issues should stay open given how saturated this pattern already is in the repo.