### PR TITLE
Add ease-scale-hover-popover-showcase component

### DIFF
--- a/submissions/examples/ease-scale-hover-popover-showcase/README.md
+++ b/submissions/examples/ease-scale-hover-popover-showcase/README.md
@@ -1,0 +1,23 @@
+# Scale-Hover Showcase Popover
+
+### 1. What does this do?
+A pure CSS popover revealed on hovering or focusing a customer logo, with a smooth scale-up transition, styled for SaaS "trusted by" / testimonial showcase sections. Hovering a logo reveals a short customer quote without navigating away.
+
+### 2. How is it used?
+\`\`\`html
+<div class="showcase-logo-wrap">
+  <div class="showcase-logo" tabindex="0">Northwind</div>
+  <div class="showcasepop">
+    <p class="showcasepop-quote">"Customer quote goes here."</p>
+    <p class="showcasepop-author">— Name, Title, Company</p>
+  </div>
+</div>
+\`\`\`
+- Wrap a `.showcase-logo` (with `tabindex="0"` for keyboard access) and a sibling `.showcasepop` in a `.showcase-logo-wrap`. The popover reveals on logo hover or focus.
+- Customize the motion with CSS custom properties on `.showcasepop`:
+  - `--showcasepop-timing` — transition duration (default `0.3s`)
+  - `--showcasepop-easing` — transition easing function (default a slight overshoot cubic-bezier)
+  - `--showcasepop-scale` — final scale factor on reveal (default `1`)
+
+### 3. Why is it useful?
+SaaS marketing pages commonly show a row of customer logos as social proof; surfacing a quote on hover adds credibility without cluttering the layout. The scale-up transition gives that reveal a tactile, purposeful feel rather than a flat fade, matching EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

--- a/submissions/examples/ease-scale-hover-popover-showcase/demo.html
+++ b/submissions/examples/ease-scale-hover-popover-showcase/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scale-Hover Showcase Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Scale-Hover Showcase Popover</h1>
+  <p>A pure CSS popover revealed on hovering a customer logo, with a smooth scale-up transition, styled for SaaS showcase/testimonial sections.</p>
+
+  <div class="demo-row">
+
+    <div class="showcase-logo-wrap">
+      <div class="showcase-logo" tabindex="0">Northwind</div>
+      <div class="showcasepop">
+        <p class="showcasepop-quote">"Cut our onboarding time by half within the first quarter."</p>
+        <p class="showcasepop-author">— Head of Ops, Northwind</p>
+      </div>
+    </div>
+
+    <div class="showcase-logo-wrap">
+      <div class="showcase-logo" tabindex="0">Fabrikam</div>
+      <div class="showcasepop" style="--showcasepop-scale: 1.06; --showcasepop-timing: 0.5s;">
+        <p class="showcasepop-quote">"The dashboard gave our whole team visibility we never had before."</p>
+        <p class="showcasepop-author">— VP Engineering, Fabrikam</p>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scale-hover-popover-showcase/style.css
+++ b/submissions/examples/ease-scale-hover-popover-showcase/style.css
@@ -1,0 +1,100 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1115;
+  color: #f2f2f2;
+  padding: 40px;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 40px;
+  margin-top: 48px;
+}
+
+.showcase-logo-wrap {
+  position: relative;
+}
+
+.showcase-logo {
+  width: 180px;
+  height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 16px;
+  color: #f2f2f2;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.showcase-logo:hover,
+.showcase-logo:focus-visible {
+  border-color: #f2b134;
+  transform: translateY(-3px);
+}
+
+.showcase-logo:focus-visible {
+  outline: 2px solid #f2b134;
+  outline-offset: 4px;
+}
+
+/* Scale-Hover popover: exposed custom properties for timing, easing, scale */
+.showcasepop {
+  --showcasepop-timing: 0.3s;
+  --showcasepop-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --showcasepop-scale: 1;
+
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  z-index: 20;
+  width: min(260px, 90vw);
+  text-align: left;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  padding: 16px 18px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  pointer-events: none;
+  opacity: 0;
+  transform-origin: top center;
+  transform: translateX(-50%) scale(calc(var(--showcasepop-scale) * 0.85));
+  transition:
+    opacity var(--showcasepop-timing) var(--showcasepop-easing),
+    transform var(--showcasepop-timing) var(--showcasepop-easing);
+}
+
+.showcase-logo:hover + .showcasepop,
+.showcase-logo:focus-visible + .showcasepop {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) scale(var(--showcasepop-scale));
+}
+
+.showcasepop-quote {
+  margin: 0 0 8px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  font-style: italic;
+}
+
+.showcasepop-author {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.6;
+}
+
+@media (max-width: 480px) {
+  .showcasepop {
+    width: min(220px, 85vw);
+    padding: 14px 16px;
+  }
+}


### PR DESCRIPTION
Closes #46441
## Pull Request Description
Adds a new `scale-hover-popover-showcase` component — a pure CSS popover revealed on hovering a customer logo, with a smooth scale-up transition, styled for SaaS showcase/testimonial sections. Closes #46441.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-scale-hover-popover-showcase/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS popover revealed on hovering or focusing a customer logo, with a smooth scale-up transition, styled for SaaS "trusted by" / testimonial showcase sections.

**How does a developer use it?**
```html
<div class="showcase-logo-wrap">
  <div class="showcase-logo" tabindex="0">Northwind</div>
  <div class="showcasepop">
    <p class="showcasepop-quote">"Customer quote goes here."</p>
    <p class="showcasepop-author">— Name, Title, Company</p>
  </div>
</div>
```
Wrap a `.showcase-logo` (with `tabindex="0"` for keyboard access) and a sibling `.showcasepop` in a `.showcase-logo-wrap`. The popover reveals on logo hover or focus. Customize the motion with `--showcasepop-timing`, `--showcasepop-easing`, and `--showcasepop-scale`.

**Why does it fit EaseMotion CSS?**
SaaS marketing pages commonly show a row of customer logos as social proof; surfacing a quote on hover adds credibility without cluttering the layout. The scale-up transition gives that reveal a tactile, purposeful feel rather than a flat fade, matching EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Heads up: this issue (#46441) is very close to #46448 ("Scale-Hover Popover for Creative Portfolio Layouts") — same interaction, different target audience in the title. I differentiated this one as a logo/testimonial hover-reveal rather than a portfolio thumbnail reveal, but at this point there are five+ scale-hover/skew-active popover issues (#46455, #46450, #46448, #46447, #46441) auto-assigned to me with near-identical descriptions, plus a dozen+ pre-existing scale-hover popover/tooltip submissions already in the repo from other contributors. Might be worth checking whether the issue generator is producing duplicates faster than they're useful.