### PR TITLE
Add ease-scale-hover-popover-dashboard component

### DIFF
--- a/submissions/examples/ease-scale-hover-popover-dashboard/README.md
+++ b/submissions/examples/ease-scale-hover-popover-dashboard/README.md
@@ -1,0 +1,27 @@
+# Scale-Hover Dashboard Popover
+
+### 1. What does this do?
+A pure CSS popover revealed on hovering or focusing a KPI tile, with a smooth scale-up transition, styled for analytics dashboard layouts. Hovering a metric tile reveals a quick trend breakdown without leaving the dashboard.
+
+### 2. How is it used?
+\`\`\`html
+<div class="kpi-tile-wrap">
+  <div class="kpi-tile" tabindex="0">
+    <span class="kpi-label">Active Users</span>
+    <span class="kpi-value">12,480</span>
+  </div>
+  <div class="kpipop">
+    <p class="kpipop-row"><span>vs. last week</span><span class="kpipop-up">+8.2%</span></p>
+    <p class="kpipop-row"><span>vs. last month</span><span class="kpipop-up">+21.5%</span></p>
+  </div>
+</div>
+\`\`\`
+- Wrap a `.kpi-tile` (with `tabindex="0"` for keyboard access) and a sibling `.kpipop` in a `.kpi-tile-wrap`. The popover reveals on tile hover or focus.
+- Use `.kpipop-up` / `.kpipop-down` on trend values for green/red styling.
+- Customize the motion with CSS custom properties on `.kpipop`:
+  - `--kpipop-timing` — transition duration (default `0.3s`)
+  - `--kpipop-easing` — transition easing function (default a slight overshoot cubic-bezier)
+  - `--kpipop-scale` — final scale factor on reveal (default `1`)
+
+### 3. Why is it useful?
+Analytics dashboards pack many metrics into a small space; hover-revealed detail breakdowns let users drill into a trend without navigating to a separate view. The scale-up transition gives that reveal a tactile, purposeful feel rather than a flat fade, matching EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

--- a/submissions/examples/ease-scale-hover-popover-dashboard/demo.html
+++ b/submissions/examples/ease-scale-hover-popover-dashboard/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scale-Hover Dashboard Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1>Scale-Hover Dashboard Popover</h1>
+  <p>A pure CSS popover revealed on hovering a KPI tile, with a smooth scale-up transition, styled for analytics dashboard layouts.</p>
+
+  <div class="demo-row">
+
+    <div class="kpi-tile-wrap">
+      <div class="kpi-tile" tabindex="0">
+        <span class="kpi-label">Active Users</span>
+        <span class="kpi-value">12,480</span>
+      </div>
+      <div class="kpipop">
+        <p class="kpipop-row"><span>vs. last week</span><span class="kpipop-up">+8.2%</span></p>
+        <p class="kpipop-row"><span>vs. last month</span><span class="kpipop-up">+21.5%</span></p>
+      </div>
+    </div>
+
+    <div class="kpi-tile-wrap">
+      <div class="kpi-tile" tabindex="0">
+        <span class="kpi-label">Churn Rate</span>
+        <span class="kpi-value">2.1%</span>
+      </div>
+      <div class="kpipop" style="--kpipop-scale: 1.06; --kpipop-timing: 0.5s;">
+        <p class="kpipop-row"><span>vs. last week</span><span class="kpipop-down">-0.4%</span></p>
+        <p class="kpipop-row"><span>vs. last month</span><span class="kpipop-down">-1.1%</span></p>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-scale-hover-popover-dashboard/style.css
+++ b/submissions/examples/ease-scale-hover-popover-dashboard/style.css
@@ -1,0 +1,115 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f1115;
+  color: #f2f2f2;
+  padding: 40px;
+  text-align: center;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 32px;
+  margin-top: 48px;
+}
+
+.kpi-tile-wrap {
+  position: relative;
+}
+
+.kpi-tile {
+  width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  padding: 16px 18px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.kpi-tile:hover,
+.kpi-tile:focus-visible {
+  border-color: #4a90d9;
+  transform: translateY(-3px);
+}
+
+.kpi-tile:focus-visible {
+  outline: 2px solid #4a90d9;
+  outline-offset: 4px;
+}
+
+.kpi-label {
+  font-size: 12px;
+  opacity: 0.6;
+}
+
+.kpi-value {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+/* Scale-Hover popover: exposed custom properties for timing, easing, scale */
+.kpipop {
+  --kpipop-timing: 0.3s;
+  --kpipop-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --kpipop-scale: 1;
+
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  z-index: 20;
+  width: 200px;
+  background: #1a1d24;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  padding: 14px 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  pointer-events: none;
+  opacity: 0;
+  transform-origin: top left;
+  transform: scale(calc(var(--kpipop-scale) * 0.85));
+  transition:
+    opacity var(--kpipop-timing) var(--kpipop-easing),
+    transform var(--kpipop-timing) var(--kpipop-easing);
+}
+
+.kpi-tile:hover + .kpipop,
+.kpi-tile:focus-visible + .kpipop {
+  opacity: 1;
+  pointer-events: auto;
+  transform: scale(var(--kpipop-scale));
+}
+
+.kpipop-row {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 0 8px;
+  font-size: 12.5px;
+}
+
+.kpipop-row:last-child {
+  margin-bottom: 0;
+}
+
+.kpipop-up {
+  color: #4caf50;
+  font-weight: 600;
+}
+
+.kpipop-down {
+  color: #e05656;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .kpipop {
+    width: 170px;
+    padding: 12px 14px;
+  }
+}


### PR DESCRIPTION
Closes #46437

## Pull Request Description
Adds a new `scale-hover-popover-dashboard` component — a pure CSS popover revealed on hovering a KPI tile, with a smooth scale-up transition, styled for analytics dashboard layouts. 
---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-scale-hover-popover-dashboard/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS popover revealed on hovering or focusing a KPI tile, with a smooth scale-up transition, styled for analytics dashboard layouts.

**How does a developer use it?**
```html
<div class="kpi-tile-wrap">
  <div class="kpi-tile" tabindex="0">
    <span class="kpi-label">Active Users</span>
    <span class="kpi-value">12,480</span>
  </div>
  <div class="kpipop">
    <p class="kpipop-row"><span>vs. last week</span><span class="kpipop-up">+8.2%</span></p>
    <p class="kpipop-row"><span>vs. last month</span><span class="kpipop-up">+21.5%</span></p>
  </div>
</div>
```
Wrap a `.kpi-tile` (with `tabindex="0"` for keyboard access) and a sibling `.kpipop` in a `.kpi-tile-wrap`. The popover reveals on tile hover or focus. Customize the motion with `--kpipop-timing`, `--kpipop-easing`, and `--kpipop-scale`.

**Why does it fit EaseMotion CSS?**
Analytics dashboards pack many metrics into a small space; hover-revealed detail breakdowns let users drill into a trend without navigating to a separate view. The scale-up transition gives that reveal a tactile, purposeful feel rather than a flat fade, matching EaseMotion's animation-first philosophy — fully CSS-driven, keyboard accessible via `:focus-visible`, and zero JS.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Flagging directly: this is the sixth "Scale-Hover / Skew-Active Popover" issue auto-assigned to me in a row (#46455, #46450, #46448, #46447, #46441, #46437), all opened by the same account 2 days ago with near-identical descriptions (only the target-layout name changes), on top of a dozen+ pre-existing scale-hover popover/tooltip submissions already in the repo from other contributors. I've submitted a PR for each with a genuinely distinct trigger pattern, but I'd appreciate confirmation these are intentional separate issues rather than duplicates from an issue-generation tool, before I take on any more from this batch.