### PR TITLE
Add peaucellier linkage component

### DIFF
--- a/submissions/examples/peaucellier-linkage-as/README.md
+++ b/submissions/examples/peaucellier-linkage-as/README.md
@@ -1,0 +1,35 @@
+# Peaucellier Linkage
+
+A pure CSS/HTML Peaucellier-Lipkin cell: seven rigid bars that turn rotary motion into a mathematically exact straight line.
+
+## What it shows
+
+For most of the 19th century, no one knew how to make a machine draw a straight line. This sounds absurd, but think about it: to make a straight edge you trace along a straight edge you already have, and to make the *first* one you have nothing. James Watt spent years on the problem for his steam engine and never solved it exactly; his famous linkage draws an approximate straight line that is really a very thin figure-eight. He said he was prouder of it than of anything else he invented.
+
+In 1864 a French army officer, Charles-Nicolas Peaucellier, solved it exactly with seven rigid bars and no slots or curves, purely from the geometry of **inversion**.
+
+The trick is a preserved product. Label the fixed pivot O, the driven point B, and the output point P. The linkage forces
+
+```
+|OB| · |OP| = a² − b²  =  constant
+```
+
+for all positions (`a` is the long arm, `b` the rhombus side). That is exactly a **geometric inversion** in a circle of radius √(a²−b²). Inversion has one magic property: it turns circles through the centre into straight lines. So if you drive B around a circle that passes through O, the output P is forced onto a perfectly straight line, with no approximation at all.
+
+## How it is built
+
+- **The whole linkage is solved, then baked.** For each of 121 crank angles, the five joint positions (O, A, B, C, P) are computed from the real inversion geometry, and each of the six bars gets keyframes for its position, length, and angle at that frame.
+- **The output is a genuine straight line, and it is measured.** The browser check drives the paused animation across 101 steps and tracks the pen's centre: its **x-coordinate varies by 0.016px** over the entire cycle while it sweeps **127px vertically**. It stays within **0.02px** of the drawn guide line. That is not an approximate straight line like Watt's; it is straight to within rounding.
+- **The bars are actually rigid, and that is checked too.** The same sweep measures each bar's length at every frame: all six vary by at most **0.016px**. A linkage whose "bars" stretched would be cheating; these do not.
+- **The identity is the mechanism.** `|OB|·|OP| = a²−b²` is what the whole thing enforces, and the straight line is its consequence, exactly as Peaucellier proved.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` pauses the linkage, leaving a static pose with the pen on its line and the reference guide showing.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/peaucellier-linkage-as/demo.html
+++ b/submissions/examples/peaucellier-linkage-as/demo.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Peaucellier Linkage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="gridP"></span>
+
+    <div class="fieldP">
+      <span class="dotP" style="left: 172.38px; top: 85.82px"></span>
+      <span class="dotP" style="left: 172.38px; top: 87.14px"></span>
+      <span class="dotP" style="left: 172.38px; top: 88.45px"></span>
+      <span class="dotP" style="left: 172.38px; top: 89.74px"></span>
+      <span class="dotP" style="left: 172.38px; top: 91.02px"></span>
+      <span class="dotP" style="left: 172.38px; top: 92.29px"></span>
+      <span class="dotP" style="left: 172.37px; top: 93.54px"></span>
+      <span class="dotP" style="left: 172.38px; top: 94.78px"></span>
+      <span class="dotP" style="left: 172.38px; top: 96.01px"></span>
+      <span class="dotP" style="left: 172.37px; top: 97.22px"></span>
+      <span class="dotP" style="left: 172.38px; top: 98.43px"></span>
+      <span class="dotP" style="left: 172.38px; top: 99.62px"></span>
+      <span class="dotP" style="left: 172.38px; top: 100.80px"></span>
+      <span class="dotP" style="left: 172.38px; top: 101.97px"></span>
+      <span class="dotP" style="left: 172.38px; top: 103.13px"></span>
+      <span class="dotP" style="left: 172.38px; top: 104.28px"></span>
+      <span class="dotP" style="left: 172.38px; top: 105.42px"></span>
+      <span class="dotP" style="left: 172.38px; top: 106.56px"></span>
+      <span class="dotP" style="left: 172.37px; top: 107.68px"></span>
+      <span class="dotP" style="left: 172.38px; top: 108.79px"></span>
+      <span class="dotP" style="left: 172.38px; top: 109.90px"></span>
+      <span class="dotP" style="left: 172.37px; top: 111.00px"></span>
+      <span class="dotP" style="left: 172.38px; top: 112.09px"></span>
+      <span class="dotP" style="left: 172.38px; top: 113.17px"></span>
+      <span class="dotP" style="left: 172.38px; top: 114.25px"></span>
+      <span class="dotP" style="left: 172.38px; top: 115.31px"></span>
+      <span class="dotP" style="left: 172.38px; top: 116.38px"></span>
+      <span class="dotP" style="left: 172.38px; top: 117.43px"></span>
+      <span class="dotP" style="left: 172.38px; top: 118.48px"></span>
+      <span class="dotP" style="left: 172.37px; top: 119.52px"></span>
+      <span class="dotP" style="left: 172.38px; top: 120.56px"></span>
+      <span class="dotP" style="left: 172.38px; top: 121.59px"></span>
+      <span class="dotP" style="left: 172.37px; top: 122.62px"></span>
+      <span class="dotP" style="left: 172.37px; top: 123.64px"></span>
+      <span class="dotP" style="left: 172.38px; top: 124.66px"></span>
+      <span class="dotP" style="left: 172.38px; top: 125.67px"></span>
+      <span class="dotP" style="left: 172.37px; top: 126.68px"></span>
+      <span class="dotP" style="left: 172.38px; top: 127.68px"></span>
+      <span class="dotP" style="left: 172.38px; top: 128.68px"></span>
+      <span class="dotP" style="left: 172.38px; top: 129.67px"></span>
+      <span class="dotP" style="left: 172.38px; top: 130.66px"></span>
+      <span class="dotP" style="left: 172.38px; top: 131.65px"></span>
+      <span class="dotP" style="left: 172.38px; top: 132.64px"></span>
+      <span class="dotP" style="left: 172.38px; top: 133.62px"></span>
+      <span class="dotP" style="left: 172.37px; top: 134.60px"></span>
+      <span class="dotP" style="left: 172.38px; top: 135.57px"></span>
+      <span class="dotP" style="left: 172.37px; top: 136.55px"></span>
+      <span class="dotP" style="left: 172.37px; top: 137.52px"></span>
+      <span class="dotP" style="left: 172.38px; top: 138.49px"></span>
+      <span class="dotP" style="left: 172.37px; top: 139.45px"></span>
+      <span class="dotP" style="left: 172.38px; top: 140.42px"></span>
+      <span class="dotP" style="left: 172.38px; top: 141.38px"></span>
+      <span class="dotP" style="left: 172.37px; top: 142.34px"></span>
+      <span class="dotP" style="left: 172.38px; top: 143.30px"></span>
+      <span class="dotP" style="left: 172.38px; top: 144.26px"></span>
+      <span class="dotP" style="left: 172.38px; top: 145.22px"></span>
+      <span class="dotP" style="left: 172.38px; top: 146.18px"></span>
+      <span class="dotP" style="left: 172.38px; top: 147.13px"></span>
+      <span class="dotP" style="left: 172.38px; top: 148.09px"></span>
+      <span class="dotP" style="left: 172.38px; top: 149.04px"></span>
+      <span class="dotP" style="left: 172.38px; top: 150.00px"></span>
+      <span class="dotP" style="left: 172.38px; top: 150.96px"></span>
+      <span class="dotP" style="left: 172.38px; top: 151.91px"></span>
+      <span class="dotP" style="left: 172.38px; top: 152.87px"></span>
+      <span class="dotP" style="left: 172.38px; top: 153.82px"></span>
+      <span class="dotP" style="left: 172.38px; top: 154.78px"></span>
+      <span class="dotP" style="left: 172.38px; top: 155.74px"></span>
+      <span class="dotP" style="left: 172.38px; top: 156.70px"></span>
+      <span class="dotP" style="left: 172.37px; top: 157.66px"></span>
+      <span class="dotP" style="left: 172.38px; top: 158.62px"></span>
+      <span class="dotP" style="left: 172.38px; top: 159.58px"></span>
+      <span class="dotP" style="left: 172.37px; top: 160.55px"></span>
+      <span class="dotP" style="left: 172.38px; top: 161.51px"></span>
+      <span class="dotP" style="left: 172.37px; top: 162.48px"></span>
+      <span class="dotP" style="left: 172.37px; top: 163.45px"></span>
+      <span class="dotP" style="left: 172.38px; top: 164.43px"></span>
+      <span class="dotP" style="left: 172.37px; top: 165.40px"></span>
+      <span class="dotP" style="left: 172.38px; top: 166.38px"></span>
+      <span class="dotP" style="left: 172.38px; top: 167.36px"></span>
+      <span class="dotP" style="left: 172.38px; top: 168.35px"></span>
+      <span class="dotP" style="left: 172.38px; top: 169.34px"></span>
+      <span class="dotP" style="left: 172.38px; top: 170.33px"></span>
+      <span class="dotP" style="left: 172.38px; top: 171.32px"></span>
+      <span class="dotP" style="left: 172.38px; top: 172.32px"></span>
+      <span class="dotP" style="left: 172.37px; top: 173.32px"></span>
+      <span class="dotP" style="left: 172.38px; top: 174.33px"></span>
+      <span class="dotP" style="left: 172.38px; top: 175.34px"></span>
+      <span class="dotP" style="left: 172.37px; top: 176.36px"></span>
+      <span class="dotP" style="left: 172.37px; top: 177.38px"></span>
+      <span class="dotP" style="left: 172.38px; top: 178.41px"></span>
+      <span class="dotP" style="left: 172.38px; top: 179.44px"></span>
+      <span class="dotP" style="left: 172.38px; top: 180.48px"></span>
+      <span class="dotP" style="left: 172.38px; top: 181.52px"></span>
+      <span class="dotP" style="left: 172.38px; top: 182.57px"></span>
+      <span class="dotP" style="left: 172.38px; top: 183.62px"></span>
+      <span class="dotP" style="left: 172.38px; top: 184.69px"></span>
+      <span class="dotP" style="left: 172.38px; top: 185.75px"></span>
+      <span class="dotP" style="left: 172.38px; top: 186.83px"></span>
+      <span class="dotP" style="left: 172.38px; top: 187.91px"></span>
+      <span class="dotP" style="left: 172.37px; top: 189.00px"></span>
+      <span class="dotP" style="left: 172.38px; top: 190.10px"></span>
+      <span class="dotP" style="left: 172.38px; top: 191.21px"></span>
+      <span class="dotP" style="left: 172.37px; top: 192.32px"></span>
+      <span class="dotP" style="left: 172.38px; top: 193.44px"></span>
+      <span class="dotP" style="left: 172.38px; top: 194.58px"></span>
+      <span class="dotP" style="left: 172.38px; top: 195.72px"></span>
+      <span class="dotP" style="left: 172.38px; top: 196.87px"></span>
+      <span class="dotP" style="left: 172.37px; top: 198.03px"></span>
+      <span class="dotP" style="left: 172.37px; top: 199.20px"></span>
+      <span class="dotP" style="left: 172.38px; top: 200.38px"></span>
+      <span class="dotP" style="left: 172.38px; top: 201.57px"></span>
+      <span class="dotP" style="left: 172.37px; top: 202.78px"></span>
+      <span class="dotP" style="left: 172.38px; top: 203.99px"></span>
+      <span class="dotP" style="left: 172.38px; top: 205.22px"></span>
+      <span class="dotP" style="left: 172.37px; top: 206.46px"></span>
+      <span class="dotP" style="left: 172.38px; top: 207.71px"></span>
+      <span class="dotP" style="left: 172.38px; top: 208.98px"></span>
+      <span class="dotP" style="left: 172.38px; top: 210.26px"></span>
+      <span class="dotP" style="left: 172.38px; top: 211.55px"></span>
+      <span class="dotP" style="left: 172.38px; top: 212.86px"></span>
+      <span class="dotP" style="left: 172.38px; top: 214.18px"></span>
+      <span class="guideP"></span>
+      <span class="barP barOA"></span>
+      <span class="barP barOC"></span>
+      <span class="barP barAB"></span>
+      <span class="barP barCB"></span>
+      <span class="barP barAP"></span>
+      <span class="barP barCP"></span>
+      <span class="jointP jA"></span>
+      <span class="jointP jB"></span>
+      <span class="jointP jC"></span>
+      <span class="pivotP"></span>
+      <span class="penP jP"></span>
+    </div>
+
+    <span class="tagP">rotary in, exact straight line out</span>
+    <span class="capP">Peaucellier 1864: the first true straight-line linkage</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/peaucellier-linkage-as/style.css
+++ b/submissions/examples/peaucellier-linkage-as/style.css
@@ -1,0 +1,1393 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #2a3038, #08090c 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 40% 34%, #3c4653, #0d1016 86%);
+}
+
+.gridP {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(90deg, rgba(150, 180, 210, 0.05) 0 1px, transparent 1px 24px),
+    repeating-linear-gradient(0deg, rgba(150, 180, 210, 0.05) 0 1px, transparent 1px 24px);
+  z-index: 1;
+}
+
+.fieldP {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+}
+
+.dotP {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 50%;
+  background: rgba(120, 230, 170, 0.7);
+  z-index: 3;
+}
+
+/*
+  the exact vertical line the output pen sweeps, drawn as a dashed reference.
+*/
+.guideP {
+  position: absolute;
+  left: 172.38px;
+  top: 82px;
+  width: 2px;
+  height: 136px;
+  margin-left: -1px;
+  background: repeating-linear-gradient(180deg, rgba(120, 230, 170, 0.5) 0 5px, transparent 5px 10px);
+  z-index: 3;
+}
+
+/*
+  the seven bars of a Peaucellier-Lipkin cell: two long arms from the fixed
+  pivot O, a four-bar rhombus, and a crank. the identity |OB| * |OP| = a^2 - b^2
+  is constant, so as the driver swings on a circle through O, the inverse point
+  P is forced onto a perfectly straight line.
+*/
+.barP {
+  position: absolute;
+  height: 5px;
+  margin-top: -2.5px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #cfd8e2, #5f6a76);
+  transform-origin: 0 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.barOA { animation: barOA 7s linear infinite; }
+.barOC { animation: barOC 7s linear infinite; }
+.barAB { animation: barAB 7s linear infinite; background: linear-gradient(180deg, #b0bcc8, #4f5a66); }
+.barCB { animation: barCB 7s linear infinite; background: linear-gradient(180deg, #b0bcc8, #4f5a66); }
+.barAP { animation: barAP 7s linear infinite; background: linear-gradient(180deg, #b0bcc8, #4f5a66); }
+.barCP { animation: barCP 7s linear infinite; background: linear-gradient(180deg, #b0bcc8, #4f5a66); }
+
+.jointP {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  margin: -5px 0 0 -5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #eef2f6, #46505a 76%);
+  box-shadow: 0 0 0 2px rgba(20, 24, 30, 0.7);
+  z-index: 6;
+}
+
+.jA { animation: jA 7s linear infinite; }
+.jB { animation: jB 7s linear infinite; }
+.jC { animation: jC 7s linear infinite; }
+
+.pivotP {
+  position: absolute;
+  left: 70px;
+  top: 150px;
+  width: 14px;
+  height: 14px;
+  margin: -7px 0 0 -7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #ffd48a, #a05c10 74%);
+  box-shadow: 0 0 0 3px rgba(30, 22, 8, 0.8);
+  z-index: 7;
+}
+
+.penP {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #eafff2, #14a86a 66%);
+  box-shadow: 0 0 10px rgba(90, 240, 170, 0.9);
+  z-index: 8;
+  animation: jP 7s linear infinite;
+}
+
+.tagP {
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  font-size: 0.52rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(150, 240, 200, 0.9);
+  z-index: 9;
+}
+
+.capP {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.04em;
+  color: rgba(200, 224, 236, 0.82);
+  z-index: 9;
+}
+
+@keyframes barOA {
+  0.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(10.82deg); }
+  0.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(11.42deg); }
+  1.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(12.02deg); }
+  2.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(12.62deg); }
+  3.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(13.21deg); }
+  4.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(13.80deg); }
+  5.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(14.39deg); }
+  5.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(14.98deg); }
+  6.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(15.56deg); }
+  7.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(16.14deg); }
+  8.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(16.71deg); }
+  9.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(17.29deg); }
+  10.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(17.86deg); }
+  10.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(18.43deg); }
+  11.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(19.00deg); }
+  12.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(19.56deg); }
+  13.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(20.13deg); }
+  14.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(20.69deg); }
+  15.000% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(21.25deg); }
+  15.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(21.81deg); }
+  16.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(22.37deg); }
+  17.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(22.93deg); }
+  18.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(23.48deg); }
+  19.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(24.04deg); }
+  20.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(24.59deg); }
+  20.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(25.14deg); }
+  21.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(25.69deg); }
+  22.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(26.24deg); }
+  23.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(26.79deg); }
+  24.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(27.34deg); }
+  25.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(27.88deg); }
+  25.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(28.43deg); }
+  26.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(28.97deg); }
+  27.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(29.52deg); }
+  28.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(30.06deg); }
+  29.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(30.60deg); }
+  30.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(31.15deg); }
+  30.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(31.69deg); }
+  31.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(32.23deg); }
+  32.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(32.77deg); }
+  33.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(33.31deg); }
+  34.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(33.85deg); }
+  35.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(34.39deg); }
+  35.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(34.93deg); }
+  36.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(35.47deg); }
+  37.500% { left: 70.00px; top: 150.00px; width: 138.01px; transform: rotate(36.01deg); }
+  38.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(36.54deg); }
+  39.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(37.08deg); }
+  40.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(37.62deg); }
+  40.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(38.16deg); }
+  41.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(38.69deg); }
+  42.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(39.23deg); }
+  43.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(39.76deg); }
+  44.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(40.30deg); }
+  45.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(40.84deg); }
+  45.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(41.37deg); }
+  46.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(41.91deg); }
+  47.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(42.44deg); }
+  48.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(42.98deg); }
+  49.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(43.51deg); }
+  50.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(44.05deg); }
+  50.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(44.58deg); }
+  51.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(45.12deg); }
+  52.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(45.65deg); }
+  53.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(46.19deg); }
+  54.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(46.72deg); }
+  55.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(47.25deg); }
+  55.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(47.79deg); }
+  56.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(48.32deg); }
+  57.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(48.85deg); }
+  58.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(49.39deg); }
+  59.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(49.92deg); }
+  60.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(50.45deg); }
+  60.833% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(50.99deg); }
+  61.667% { left: 70.00px; top: 150.00px; width: 138.01px; transform: rotate(51.52deg); }
+  62.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(52.05deg); }
+  63.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(52.58deg); }
+  64.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(53.11deg); }
+  65.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(53.64deg); }
+  65.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(54.17deg); }
+  66.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(54.70deg); }
+  67.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(55.23deg); }
+  68.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(55.76deg); }
+  69.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(56.29deg); }
+  70.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(56.82deg); }
+  70.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(57.34deg); }
+  71.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(57.87deg); }
+  72.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(58.39deg); }
+  73.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(58.92deg); }
+  74.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(59.45deg); }
+  75.000% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(59.97deg); }
+  75.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(60.49deg); }
+  76.667% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(61.01deg); }
+  77.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(61.54deg); }
+  78.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(62.06deg); }
+  79.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(62.58deg); }
+  80.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(63.09deg); }
+  80.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(63.61deg); }
+  81.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(64.12deg); }
+  82.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(64.64deg); }
+  83.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(65.15deg); }
+  84.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(65.66deg); }
+  85.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(66.17deg); }
+  85.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(66.68deg); }
+  86.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(67.19deg); }
+  87.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(67.69deg); }
+  88.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(68.20deg); }
+  89.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(68.70deg); }
+  90.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(69.20deg); }
+  90.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(69.69deg); }
+  91.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(70.19deg); }
+  92.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(70.68deg); }
+  93.333% { left: 70.00px; top: 150.00px; width: 138.01px; transform: rotate(71.17deg); }
+  94.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(71.66deg); }
+  95.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(72.15deg); }
+  95.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(72.62deg); }
+  96.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(73.10deg); }
+  97.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(73.58deg); }
+  98.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(74.06deg); }
+  99.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(74.53deg); }
+  100.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(74.99deg); }
+}
+
+@keyframes barOC {
+  0.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-74.99deg); }
+  0.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-74.53deg); }
+  1.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-74.06deg); }
+  2.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-73.58deg); }
+  3.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-73.10deg); }
+  4.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-72.62deg); }
+  5.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-72.15deg); }
+  5.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-71.66deg); }
+  6.667% { left: 70.00px; top: 150.00px; width: 138.01px; transform: rotate(-71.17deg); }
+  7.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-70.68deg); }
+  8.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-70.19deg); }
+  9.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-69.69deg); }
+  10.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-69.20deg); }
+  10.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-68.70deg); }
+  11.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-68.20deg); }
+  12.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-67.69deg); }
+  13.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-67.19deg); }
+  14.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-66.68deg); }
+  15.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-66.17deg); }
+  15.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-65.66deg); }
+  16.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-65.15deg); }
+  17.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-64.64deg); }
+  18.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-64.12deg); }
+  19.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-63.61deg); }
+  20.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-63.09deg); }
+  20.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-62.58deg); }
+  21.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-62.06deg); }
+  22.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-61.54deg); }
+  23.333% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(-61.01deg); }
+  24.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-60.49deg); }
+  25.000% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(-59.97deg); }
+  25.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-59.45deg); }
+  26.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-58.92deg); }
+  27.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-58.39deg); }
+  28.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-57.87deg); }
+  29.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-57.34deg); }
+  30.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-56.82deg); }
+  30.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-56.29deg); }
+  31.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-55.76deg); }
+  32.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-55.23deg); }
+  33.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-54.70deg); }
+  34.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-54.17deg); }
+  35.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-53.64deg); }
+  35.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-53.11deg); }
+  36.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-52.58deg); }
+  37.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-52.05deg); }
+  38.333% { left: 70.00px; top: 150.00px; width: 138.01px; transform: rotate(-51.52deg); }
+  39.167% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(-50.99deg); }
+  40.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-50.45deg); }
+  40.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-49.92deg); }
+  41.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-49.39deg); }
+  42.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-48.85deg); }
+  43.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-48.32deg); }
+  44.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-47.79deg); }
+  45.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-47.25deg); }
+  45.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-46.72deg); }
+  46.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-46.19deg); }
+  47.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-45.65deg); }
+  48.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-45.12deg); }
+  49.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-44.58deg); }
+  50.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-44.05deg); }
+  50.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-43.51deg); }
+  51.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-42.98deg); }
+  52.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-42.44deg); }
+  53.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-41.91deg); }
+  54.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-41.37deg); }
+  55.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-40.84deg); }
+  55.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-40.30deg); }
+  56.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-39.76deg); }
+  57.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-39.23deg); }
+  58.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-38.69deg); }
+  59.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-38.16deg); }
+  60.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-37.62deg); }
+  60.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-37.08deg); }
+  61.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-36.54deg); }
+  62.500% { left: 70.00px; top: 150.00px; width: 138.01px; transform: rotate(-36.01deg); }
+  63.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-35.47deg); }
+  64.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-34.93deg); }
+  65.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-34.39deg); }
+  65.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-33.85deg); }
+  66.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-33.31deg); }
+  67.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-32.77deg); }
+  68.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-32.23deg); }
+  69.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-31.69deg); }
+  70.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-31.15deg); }
+  70.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-30.60deg); }
+  71.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-30.06deg); }
+  72.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-29.52deg); }
+  73.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-28.97deg); }
+  74.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-28.43deg); }
+  75.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-27.88deg); }
+  75.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-27.34deg); }
+  76.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-26.79deg); }
+  77.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-26.24deg); }
+  78.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-25.69deg); }
+  79.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-25.14deg); }
+  80.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-24.59deg); }
+  80.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-24.04deg); }
+  81.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-23.48deg); }
+  82.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-22.93deg); }
+  83.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-22.37deg); }
+  84.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-21.81deg); }
+  85.000% { left: 70.00px; top: 150.00px; width: 137.99px; transform: rotate(-21.25deg); }
+  85.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-20.69deg); }
+  86.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-20.13deg); }
+  87.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-19.56deg); }
+  88.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-19.00deg); }
+  89.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-18.43deg); }
+  90.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-17.86deg); }
+  90.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-17.29deg); }
+  91.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-16.71deg); }
+  92.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-16.14deg); }
+  93.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-15.56deg); }
+  94.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-14.98deg); }
+  95.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-14.39deg); }
+  95.833% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-13.80deg); }
+  96.667% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-13.21deg); }
+  97.500% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-12.62deg); }
+  98.333% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-12.02deg); }
+  99.167% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-11.42deg); }
+  100.000% { left: 70.00px; top: 150.00px; width: 138.00px; transform: rotate(-10.82deg); }
+}
+
+@keyframes barAB {
+  0.000% { left: 205.55px; top: 175.90px; width: 96.00px; transform: rotate(-133.96deg); }
+  0.833% { left: 205.27px; top: 177.33px; width: 96.00px; transform: rotate(-133.06deg); }
+  1.667% { left: 204.97px; top: 178.74px; width: 95.99px; transform: rotate(-132.18deg); }
+  2.500% { left: 204.67px; top: 180.15px; width: 96.01px; transform: rotate(-131.30deg); }
+  3.333% { left: 204.35px; top: 181.54px; width: 96.00px; transform: rotate(-130.44deg); }
+  4.167% { left: 204.02px; top: 182.92px; width: 96.00px; transform: rotate(-129.58deg); }
+  5.000% { left: 203.67px; top: 184.30px; width: 96.01px; transform: rotate(-128.73deg); }
+  5.833% { left: 203.31px; top: 185.66px; width: 96.00px; transform: rotate(-127.88deg); }
+  6.667% { left: 202.94px; top: 187.01px; width: 95.99px; transform: rotate(-127.04deg); }
+  7.500% { left: 202.56px; top: 188.35px; width: 96.00px; transform: rotate(-126.22deg); }
+  8.333% { left: 202.17px; top: 189.68px; width: 95.99px; transform: rotate(-125.40deg); }
+  9.167% { left: 201.77px; top: 191.01px; width: 96.00px; transform: rotate(-124.58deg); }
+  10.000% { left: 201.35px; top: 192.32px; width: 96.00px; transform: rotate(-123.77deg); }
+  10.833% { left: 200.92px; top: 193.63px; width: 96.00px; transform: rotate(-122.97deg); }
+  11.667% { left: 200.48px; top: 194.92px; width: 95.99px; transform: rotate(-122.17deg); }
+  12.500% { left: 200.03px; top: 196.21px; width: 95.99px; transform: rotate(-121.38deg); }
+  13.333% { left: 199.57px; top: 197.49px; width: 96.00px; transform: rotate(-120.60deg); }
+  14.167% { left: 199.10px; top: 198.76px; width: 96.00px; transform: rotate(-119.83deg); }
+  15.000% { left: 198.61px; top: 200.02px; width: 95.99px; transform: rotate(-119.06deg); }
+  15.833% { left: 198.12px; top: 201.28px; width: 96.00px; transform: rotate(-118.29deg); }
+  16.667% { left: 197.61px; top: 202.52px; width: 95.99px; transform: rotate(-117.54deg); }
+  17.500% { left: 197.10px; top: 203.76px; width: 96.00px; transform: rotate(-116.79deg); }
+  18.333% { left: 196.57px; top: 204.99px; width: 96.00px; transform: rotate(-116.04deg); }
+  19.167% { left: 196.03px; top: 206.21px; width: 96.00px; transform: rotate(-115.30deg); }
+  20.000% { left: 195.49px; top: 207.42px; width: 96.00px; transform: rotate(-114.58deg); }
+  20.833% { left: 194.93px; top: 208.63px; width: 96.01px; transform: rotate(-113.85deg); }
+  21.667% { left: 194.36px; top: 209.83px; width: 96.01px; transform: rotate(-113.13deg); }
+  22.500% { left: 193.78px; top: 211.02px; width: 96.00px; transform: rotate(-112.41deg); }
+  23.333% { left: 193.19px; top: 212.20px; width: 96.00px; transform: rotate(-111.70deg); }
+  24.167% { left: 192.59px; top: 213.37px; width: 96.00px; transform: rotate(-111.00deg); }
+  25.000% { left: 191.98px; top: 214.54px; width: 96.00px; transform: rotate(-110.30deg); }
+  25.833% { left: 191.36px; top: 215.70px; width: 96.00px; transform: rotate(-109.61deg); }
+  26.667% { left: 190.73px; top: 216.85px; width: 96.00px; transform: rotate(-108.93deg); }
+  27.500% { left: 190.09px; top: 217.99px; width: 96.00px; transform: rotate(-108.25deg); }
+  28.333% { left: 189.44px; top: 219.13px; width: 96.00px; transform: rotate(-107.57deg); }
+  29.167% { left: 188.78px; top: 220.26px; width: 96.01px; transform: rotate(-106.90deg); }
+  30.000% { left: 188.11px; top: 221.38px; width: 96.00px; transform: rotate(-106.24deg); }
+  30.833% { left: 187.43px; top: 222.49px; width: 96.00px; transform: rotate(-105.58deg); }
+  31.667% { left: 186.74px; top: 223.60px; width: 96.00px; transform: rotate(-104.93deg); }
+  32.500% { left: 186.04px; top: 224.70px; width: 96.01px; transform: rotate(-104.28deg); }
+  33.333% { left: 185.33px; top: 225.79px; width: 96.01px; transform: rotate(-103.64deg); }
+  34.167% { left: 184.61px; top: 226.87px; width: 96.00px; transform: rotate(-103.00deg); }
+  35.000% { left: 183.88px; top: 227.95px; width: 96.01px; transform: rotate(-102.37deg); }
+  35.833% { left: 183.14px; top: 229.01px; width: 96.00px; transform: rotate(-101.74deg); }
+  36.667% { left: 182.39px; top: 230.07px; width: 95.99px; transform: rotate(-101.12deg); }
+  37.500% { left: 181.64px; top: 231.13px; width: 96.01px; transform: rotate(-100.51deg); }
+  38.333% { left: 180.87px; top: 232.17px; width: 96.00px; transform: rotate(-99.90deg); }
+  39.167% { left: 180.09px; top: 233.21px; width: 96.00px; transform: rotate(-99.29deg); }
+  40.000% { left: 179.31px; top: 234.24px; width: 96.00px; transform: rotate(-98.69deg); }
+  40.833% { left: 178.51px; top: 235.26px; width: 96.01px; transform: rotate(-98.10deg); }
+  41.667% { left: 177.71px; top: 236.27px; width: 96.00px; transform: rotate(-97.51deg); }
+  42.500% { left: 176.90px; top: 237.27px; width: 96.00px; transform: rotate(-96.93deg); }
+  43.333% { left: 176.08px; top: 238.27px; width: 96.00px; transform: rotate(-96.35deg); }
+  44.167% { left: 175.25px; top: 239.26px; width: 96.00px; transform: rotate(-95.78deg); }
+  45.000% { left: 174.41px; top: 240.24px; width: 96.00px; transform: rotate(-95.21deg); }
+  45.833% { left: 173.56px; top: 241.21px; width: 95.99px; transform: rotate(-94.64deg); }
+  46.667% { left: 172.70px; top: 242.18px; width: 96.00px; transform: rotate(-94.08deg); }
+  47.500% { left: 171.84px; top: 243.13px; width: 96.00px; transform: rotate(-93.54deg); }
+  48.333% { left: 170.96px; top: 244.08px; width: 96.00px; transform: rotate(-92.98deg); }
+  49.167% { left: 170.08px; top: 245.02px; width: 96.01px; transform: rotate(-92.44deg); }
+  50.000% { left: 169.19px; top: 245.95px; width: 96.00px; transform: rotate(-91.90deg); }
+  50.833% { left: 168.29px; top: 246.87px; width: 96.00px; transform: rotate(-91.37deg); }
+  51.667% { left: 167.38px; top: 247.78px; width: 96.00px; transform: rotate(-90.84deg); }
+  52.500% { left: 166.46px; top: 248.69px; width: 96.00px; transform: rotate(-90.32deg); }
+  53.333% { left: 165.54px; top: 249.58px; width: 96.00px; transform: rotate(-89.80deg); }
+  54.167% { left: 164.61px; top: 250.47px; width: 96.01px; transform: rotate(-89.30deg); }
+  55.000% { left: 163.67px; top: 251.34px; width: 96.00px; transform: rotate(-88.79deg); }
+  55.833% { left: 162.72px; top: 252.21px; width: 96.00px; transform: rotate(-88.29deg); }
+  56.667% { left: 161.76px; top: 253.07px; width: 96.00px; transform: rotate(-87.79deg); }
+  57.500% { left: 160.80px; top: 253.92px; width: 96.00px; transform: rotate(-87.30deg); }
+  58.333% { left: 159.83px; top: 254.76px; width: 96.00px; transform: rotate(-86.81deg); }
+  59.167% { left: 158.85px; top: 255.59px; width: 96.00px; transform: rotate(-86.33deg); }
+  60.000% { left: 157.87px; top: 256.41px; width: 96.00px; transform: rotate(-85.86deg); }
+  60.833% { left: 156.87px; top: 257.22px; width: 96.00px; transform: rotate(-85.39deg); }
+  61.667% { left: 155.88px; top: 258.03px; width: 96.01px; transform: rotate(-84.93deg); }
+  62.500% { left: 154.87px; top: 258.82px; width: 96.00px; transform: rotate(-84.46deg); }
+  63.333% { left: 153.86px; top: 259.60px; width: 96.00px; transform: rotate(-84.01deg); }
+  64.167% { left: 152.84px; top: 260.37px; width: 95.99px; transform: rotate(-83.56deg); }
+  65.000% { left: 151.81px; top: 261.13px; width: 95.99px; transform: rotate(-83.11deg); }
+  65.833% { left: 150.78px; top: 261.89px; width: 96.00px; transform: rotate(-82.68deg); }
+  66.667% { left: 149.74px; top: 262.63px; width: 96.00px; transform: rotate(-82.25deg); }
+  67.500% { left: 148.70px; top: 263.36px; width: 96.00px; transform: rotate(-81.82deg); }
+  68.333% { left: 147.65px; top: 264.08px; width: 96.00px; transform: rotate(-81.40deg); }
+  69.167% { left: 146.59px; top: 264.79px; width: 96.00px; transform: rotate(-80.98deg); }
+  70.000% { left: 145.53px; top: 265.49px; width: 96.00px; transform: rotate(-80.57deg); }
+  70.833% { left: 144.47px; top: 266.18px; width: 95.99px; transform: rotate(-80.16deg); }
+  71.667% { left: 143.40px; top: 266.86px; width: 96.00px; transform: rotate(-79.76deg); }
+  72.500% { left: 142.32px; top: 267.53px; width: 96.00px; transform: rotate(-79.37deg); }
+  73.333% { left: 141.24px; top: 268.19px; width: 96.00px; transform: rotate(-78.98deg); }
+  74.167% { left: 140.15px; top: 268.84px; width: 96.01px; transform: rotate(-78.59deg); }
+  75.000% { left: 139.06px; top: 269.47px; width: 95.99px; transform: rotate(-78.21deg); }
+  75.833% { left: 137.97px; top: 270.10px; width: 96.00px; transform: rotate(-77.84deg); }
+  76.667% { left: 136.87px; top: 270.71px; width: 95.99px; transform: rotate(-77.47deg); }
+  77.500% { left: 135.77px; top: 271.32px; width: 96.01px; transform: rotate(-77.11deg); }
+  78.333% { left: 134.67px; top: 271.91px; width: 96.00px; transform: rotate(-76.76deg); }
+  79.167% { left: 133.56px; top: 272.49px; width: 96.00px; transform: rotate(-76.41deg); }
+  80.000% { left: 132.45px; top: 273.06px; width: 96.00px; transform: rotate(-76.07deg); }
+  80.833% { left: 131.34px; top: 273.62px; width: 96.00px; transform: rotate(-75.73deg); }
+  81.667% { left: 130.23px; top: 274.16px; width: 96.00px; transform: rotate(-75.40deg); }
+  82.500% { left: 129.11px; top: 274.70px; width: 96.00px; transform: rotate(-75.08deg); }
+  83.333% { left: 127.99px; top: 275.22px; width: 96.00px; transform: rotate(-74.76deg); }
+  84.167% { left: 126.87px; top: 275.74px; width: 96.01px; transform: rotate(-74.44deg); }
+  85.000% { left: 125.75px; top: 276.24px; width: 96.01px; transform: rotate(-74.14deg); }
+  85.833% { left: 124.63px; top: 276.73px; width: 96.00px; transform: rotate(-73.84deg); }
+  86.667% { left: 123.50px; top: 277.21px; width: 96.00px; transform: rotate(-73.54deg); }
+  87.500% { left: 122.38px; top: 277.67px; width: 96.00px; transform: rotate(-73.25deg); }
+  88.333% { left: 121.26px; top: 278.13px; width: 96.01px; transform: rotate(-72.97deg); }
+  89.167% { left: 120.13px; top: 278.57px; width: 96.00px; transform: rotate(-72.70deg); }
+  90.000% { left: 119.01px; top: 279.00px; width: 96.00px; transform: rotate(-72.43deg); }
+  90.833% { left: 117.89px; top: 279.42px; width: 96.00px; transform: rotate(-72.17deg); }
+  91.667% { left: 116.77px; top: 279.83px; width: 96.00px; transform: rotate(-71.92deg); }
+  92.500% { left: 115.65px; top: 280.23px; width: 96.00px; transform: rotate(-71.67deg); }
+  93.333% { left: 114.54px; top: 280.62px; width: 96.01px; transform: rotate(-71.43deg); }
+  94.167% { left: 113.43px; top: 280.99px; width: 96.00px; transform: rotate(-71.20deg); }
+  95.000% { left: 112.31px; top: 281.35px; width: 96.00px; transform: rotate(-70.97deg); }
+  95.833% { left: 111.21px; top: 281.70px; width: 95.99px; transform: rotate(-70.76deg); }
+  96.667% { left: 110.11px; top: 282.04px; width: 96.00px; transform: rotate(-70.55deg); }
+  97.500% { left: 109.01px; top: 282.37px; width: 95.99px; transform: rotate(-70.34deg); }
+  98.333% { left: 107.91px; top: 282.69px; width: 96.00px; transform: rotate(-70.15deg); }
+  99.167% { left: 106.82px; top: 283.00px; width: 96.00px; transform: rotate(-69.96deg); }
+  100.000% { left: 105.74px; top: 283.29px; width: 96.00px; transform: rotate(-69.79deg); }
+}
+
+@keyframes barCB {
+  0.000% { left: 105.74px; top: 16.71px; width: 96.00px; transform: rotate(69.79deg); }
+  0.833% { left: 106.82px; top: 17.00px; width: 96.00px; transform: rotate(69.96deg); }
+  1.667% { left: 107.91px; top: 17.31px; width: 96.00px; transform: rotate(70.15deg); }
+  2.500% { left: 109.01px; top: 17.63px; width: 95.99px; transform: rotate(70.34deg); }
+  3.333% { left: 110.11px; top: 17.96px; width: 96.00px; transform: rotate(70.55deg); }
+  4.167% { left: 111.21px; top: 18.30px; width: 95.99px; transform: rotate(70.76deg); }
+  5.000% { left: 112.31px; top: 18.65px; width: 96.00px; transform: rotate(70.97deg); }
+  5.833% { left: 113.43px; top: 19.01px; width: 96.00px; transform: rotate(71.20deg); }
+  6.667% { left: 114.54px; top: 19.38px; width: 96.01px; transform: rotate(71.43deg); }
+  7.500% { left: 115.65px; top: 19.77px; width: 96.00px; transform: rotate(71.67deg); }
+  8.333% { left: 116.77px; top: 20.17px; width: 96.00px; transform: rotate(71.92deg); }
+  9.167% { left: 117.89px; top: 20.58px; width: 96.00px; transform: rotate(72.17deg); }
+  10.000% { left: 119.01px; top: 21.00px; width: 96.00px; transform: rotate(72.43deg); }
+  10.833% { left: 120.13px; top: 21.43px; width: 96.00px; transform: rotate(72.70deg); }
+  11.667% { left: 121.26px; top: 21.87px; width: 96.01px; transform: rotate(72.97deg); }
+  12.500% { left: 122.38px; top: 22.33px; width: 96.00px; transform: rotate(73.25deg); }
+  13.333% { left: 123.50px; top: 22.79px; width: 96.00px; transform: rotate(73.54deg); }
+  14.167% { left: 124.63px; top: 23.27px; width: 96.00px; transform: rotate(73.84deg); }
+  15.000% { left: 125.75px; top: 23.76px; width: 96.01px; transform: rotate(74.14deg); }
+  15.833% { left: 126.87px; top: 24.26px; width: 96.01px; transform: rotate(74.44deg); }
+  16.667% { left: 127.99px; top: 24.78px; width: 96.00px; transform: rotate(74.76deg); }
+  17.500% { left: 129.11px; top: 25.30px; width: 96.00px; transform: rotate(75.08deg); }
+  18.333% { left: 130.23px; top: 25.84px; width: 96.00px; transform: rotate(75.40deg); }
+  19.167% { left: 131.34px; top: 26.38px; width: 96.00px; transform: rotate(75.73deg); }
+  20.000% { left: 132.45px; top: 26.94px; width: 96.00px; transform: rotate(76.07deg); }
+  20.833% { left: 133.56px; top: 27.51px; width: 96.00px; transform: rotate(76.41deg); }
+  21.667% { left: 134.67px; top: 28.09px; width: 96.00px; transform: rotate(76.76deg); }
+  22.500% { left: 135.77px; top: 28.68px; width: 96.01px; transform: rotate(77.11deg); }
+  23.333% { left: 136.87px; top: 29.29px; width: 95.99px; transform: rotate(77.47deg); }
+  24.167% { left: 137.97px; top: 29.90px; width: 96.00px; transform: rotate(77.84deg); }
+  25.000% { left: 139.06px; top: 30.53px; width: 95.99px; transform: rotate(78.21deg); }
+  25.833% { left: 140.15px; top: 31.16px; width: 96.01px; transform: rotate(78.59deg); }
+  26.667% { left: 141.24px; top: 31.81px; width: 96.00px; transform: rotate(78.98deg); }
+  27.500% { left: 142.32px; top: 32.47px; width: 96.00px; transform: rotate(79.37deg); }
+  28.333% { left: 143.40px; top: 33.14px; width: 96.00px; transform: rotate(79.76deg); }
+  29.167% { left: 144.47px; top: 33.82px; width: 95.99px; transform: rotate(80.16deg); }
+  30.000% { left: 145.53px; top: 34.51px; width: 96.00px; transform: rotate(80.57deg); }
+  30.833% { left: 146.59px; top: 35.21px; width: 96.00px; transform: rotate(80.98deg); }
+  31.667% { left: 147.65px; top: 35.92px; width: 96.00px; transform: rotate(81.40deg); }
+  32.500% { left: 148.70px; top: 36.64px; width: 96.00px; transform: rotate(81.82deg); }
+  33.333% { left: 149.74px; top: 37.37px; width: 96.00px; transform: rotate(82.25deg); }
+  34.167% { left: 150.78px; top: 38.11px; width: 96.00px; transform: rotate(82.68deg); }
+  35.000% { left: 151.81px; top: 38.87px; width: 95.99px; transform: rotate(83.11deg); }
+  35.833% { left: 152.84px; top: 39.63px; width: 95.99px; transform: rotate(83.56deg); }
+  36.667% { left: 153.86px; top: 40.40px; width: 96.00px; transform: rotate(84.01deg); }
+  37.500% { left: 154.87px; top: 41.18px; width: 96.00px; transform: rotate(84.46deg); }
+  38.333% { left: 155.88px; top: 41.97px; width: 96.01px; transform: rotate(84.93deg); }
+  39.167% { left: 156.87px; top: 42.78px; width: 96.00px; transform: rotate(85.39deg); }
+  40.000% { left: 157.87px; top: 43.59px; width: 96.00px; transform: rotate(85.86deg); }
+  40.833% { left: 158.85px; top: 44.41px; width: 96.00px; transform: rotate(86.33deg); }
+  41.667% { left: 159.83px; top: 45.24px; width: 96.00px; transform: rotate(86.81deg); }
+  42.500% { left: 160.80px; top: 46.08px; width: 96.00px; transform: rotate(87.30deg); }
+  43.333% { left: 161.76px; top: 46.93px; width: 96.00px; transform: rotate(87.79deg); }
+  44.167% { left: 162.72px; top: 47.79px; width: 96.00px; transform: rotate(88.29deg); }
+  45.000% { left: 163.67px; top: 48.66px; width: 96.00px; transform: rotate(88.79deg); }
+  45.833% { left: 164.61px; top: 49.53px; width: 96.01px; transform: rotate(89.30deg); }
+  46.667% { left: 165.54px; top: 50.42px; width: 96.00px; transform: rotate(89.80deg); }
+  47.500% { left: 166.46px; top: 51.31px; width: 96.00px; transform: rotate(90.32deg); }
+  48.333% { left: 167.38px; top: 52.22px; width: 96.00px; transform: rotate(90.84deg); }
+  49.167% { left: 168.29px; top: 53.13px; width: 96.00px; transform: rotate(91.37deg); }
+  50.000% { left: 169.19px; top: 54.05px; width: 96.00px; transform: rotate(91.90deg); }
+  50.833% { left: 170.08px; top: 54.98px; width: 96.01px; transform: rotate(92.44deg); }
+  51.667% { left: 170.96px; top: 55.92px; width: 96.00px; transform: rotate(92.98deg); }
+  52.500% { left: 171.84px; top: 56.87px; width: 96.00px; transform: rotate(93.54deg); }
+  53.333% { left: 172.70px; top: 57.82px; width: 96.00px; transform: rotate(94.08deg); }
+  54.167% { left: 173.56px; top: 58.79px; width: 95.99px; transform: rotate(94.64deg); }
+  55.000% { left: 174.41px; top: 59.76px; width: 96.00px; transform: rotate(95.21deg); }
+  55.833% { left: 175.25px; top: 60.74px; width: 96.00px; transform: rotate(95.78deg); }
+  56.667% { left: 176.08px; top: 61.73px; width: 96.00px; transform: rotate(96.35deg); }
+  57.500% { left: 176.90px; top: 62.73px; width: 96.00px; transform: rotate(96.93deg); }
+  58.333% { left: 177.71px; top: 63.73px; width: 96.00px; transform: rotate(97.51deg); }
+  59.167% { left: 178.51px; top: 64.74px; width: 96.01px; transform: rotate(98.10deg); }
+  60.000% { left: 179.31px; top: 65.76px; width: 96.00px; transform: rotate(98.69deg); }
+  60.833% { left: 180.09px; top: 66.79px; width: 96.00px; transform: rotate(99.29deg); }
+  61.667% { left: 180.87px; top: 67.83px; width: 96.00px; transform: rotate(99.90deg); }
+  62.500% { left: 181.64px; top: 68.87px; width: 96.01px; transform: rotate(100.51deg); }
+  63.333% { left: 182.39px; top: 69.93px; width: 95.99px; transform: rotate(101.12deg); }
+  64.167% { left: 183.14px; top: 70.99px; width: 96.00px; transform: rotate(101.74deg); }
+  65.000% { left: 183.88px; top: 72.05px; width: 96.01px; transform: rotate(102.37deg); }
+  65.833% { left: 184.61px; top: 73.13px; width: 96.00px; transform: rotate(103.00deg); }
+  66.667% { left: 185.33px; top: 74.21px; width: 96.01px; transform: rotate(103.64deg); }
+  67.500% { left: 186.04px; top: 75.30px; width: 96.01px; transform: rotate(104.28deg); }
+  68.333% { left: 186.74px; top: 76.40px; width: 96.00px; transform: rotate(104.93deg); }
+  69.167% { left: 187.43px; top: 77.51px; width: 96.00px; transform: rotate(105.58deg); }
+  70.000% { left: 188.11px; top: 78.62px; width: 96.00px; transform: rotate(106.24deg); }
+  70.833% { left: 188.78px; top: 79.74px; width: 96.01px; transform: rotate(106.90deg); }
+  71.667% { left: 189.44px; top: 80.87px; width: 96.00px; transform: rotate(107.57deg); }
+  72.500% { left: 190.09px; top: 82.01px; width: 96.00px; transform: rotate(108.25deg); }
+  73.333% { left: 190.73px; top: 83.15px; width: 96.00px; transform: rotate(108.93deg); }
+  74.167% { left: 191.36px; top: 84.30px; width: 96.00px; transform: rotate(109.61deg); }
+  75.000% { left: 191.98px; top: 85.46px; width: 96.00px; transform: rotate(110.30deg); }
+  75.833% { left: 192.59px; top: 86.63px; width: 96.00px; transform: rotate(111.00deg); }
+  76.667% { left: 193.19px; top: 87.80px; width: 96.00px; transform: rotate(111.70deg); }
+  77.500% { left: 193.78px; top: 88.98px; width: 96.00px; transform: rotate(112.41deg); }
+  78.333% { left: 194.36px; top: 90.17px; width: 96.01px; transform: rotate(113.13deg); }
+  79.167% { left: 194.93px; top: 91.37px; width: 96.01px; transform: rotate(113.85deg); }
+  80.000% { left: 195.49px; top: 92.58px; width: 96.00px; transform: rotate(114.58deg); }
+  80.833% { left: 196.03px; top: 93.79px; width: 96.00px; transform: rotate(115.30deg); }
+  81.667% { left: 196.57px; top: 95.01px; width: 96.00px; transform: rotate(116.04deg); }
+  82.500% { left: 197.10px; top: 96.24px; width: 96.00px; transform: rotate(116.79deg); }
+  83.333% { left: 197.61px; top: 97.48px; width: 95.99px; transform: rotate(117.54deg); }
+  84.167% { left: 198.12px; top: 98.72px; width: 96.00px; transform: rotate(118.29deg); }
+  85.000% { left: 198.61px; top: 99.98px; width: 95.99px; transform: rotate(119.06deg); }
+  85.833% { left: 199.10px; top: 101.24px; width: 96.00px; transform: rotate(119.83deg); }
+  86.667% { left: 199.57px; top: 102.51px; width: 96.00px; transform: rotate(120.60deg); }
+  87.500% { left: 200.03px; top: 103.79px; width: 95.99px; transform: rotate(121.38deg); }
+  88.333% { left: 200.48px; top: 105.08px; width: 95.99px; transform: rotate(122.17deg); }
+  89.167% { left: 200.92px; top: 106.37px; width: 96.00px; transform: rotate(122.97deg); }
+  90.000% { left: 201.35px; top: 107.68px; width: 96.00px; transform: rotate(123.77deg); }
+  90.833% { left: 201.77px; top: 108.99px; width: 96.00px; transform: rotate(124.58deg); }
+  91.667% { left: 202.17px; top: 110.32px; width: 95.99px; transform: rotate(125.40deg); }
+  92.500% { left: 202.56px; top: 111.65px; width: 96.00px; transform: rotate(126.22deg); }
+  93.333% { left: 202.94px; top: 112.99px; width: 95.99px; transform: rotate(127.04deg); }
+  94.167% { left: 203.31px; top: 114.34px; width: 96.00px; transform: rotate(127.88deg); }
+  95.000% { left: 203.67px; top: 115.70px; width: 96.01px; transform: rotate(128.73deg); }
+  95.833% { left: 204.02px; top: 117.08px; width: 96.00px; transform: rotate(129.58deg); }
+  96.667% { left: 204.35px; top: 118.46px; width: 96.00px; transform: rotate(130.44deg); }
+  97.500% { left: 204.67px; top: 119.85px; width: 96.01px; transform: rotate(131.30deg); }
+  98.333% { left: 204.97px; top: 121.26px; width: 95.99px; transform: rotate(132.18deg); }
+  99.167% { left: 205.27px; top: 122.67px; width: 96.00px; transform: rotate(133.06deg); }
+  100.000% { left: 205.55px; top: 124.10px; width: 96.00px; transform: rotate(133.96deg); }
+}
+
+@keyframes barAP {
+  0.000% { left: 205.55px; top: 175.90px; width: 95.99px; transform: rotate(-110.22deg); }
+  0.833% { left: 205.27px; top: 177.33px; width: 96.00px; transform: rotate(-110.04deg); }
+  1.667% { left: 204.97px; top: 178.74px; width: 95.99px; transform: rotate(-109.85deg); }
+  2.500% { left: 204.67px; top: 180.15px; width: 96.00px; transform: rotate(-109.65deg); }
+  3.333% { left: 204.35px; top: 181.54px; width: 96.00px; transform: rotate(-109.45deg); }
+  4.167% { left: 204.02px; top: 182.92px; width: 95.99px; transform: rotate(-109.24deg); }
+  5.000% { left: 203.67px; top: 184.30px; width: 96.01px; transform: rotate(-109.03deg); }
+  5.833% { left: 203.31px; top: 185.66px; width: 96.00px; transform: rotate(-108.80deg); }
+  6.667% { left: 202.94px; top: 187.01px; width: 95.99px; transform: rotate(-108.56deg); }
+  7.500% { left: 202.56px; top: 188.35px; width: 96.00px; transform: rotate(-108.33deg); }
+  8.333% { left: 202.17px; top: 189.68px; width: 95.99px; transform: rotate(-108.08deg); }
+  9.167% { left: 201.77px; top: 191.01px; width: 96.00px; transform: rotate(-107.83deg); }
+  10.000% { left: 201.35px; top: 192.32px; width: 96.00px; transform: rotate(-107.56deg); }
+  10.833% { left: 200.92px; top: 193.63px; width: 96.00px; transform: rotate(-107.29deg); }
+  11.667% { left: 200.48px; top: 194.92px; width: 95.99px; transform: rotate(-107.02deg); }
+  12.500% { left: 200.03px; top: 196.21px; width: 96.00px; transform: rotate(-106.74deg); }
+  13.333% { left: 199.57px; top: 197.49px; width: 96.00px; transform: rotate(-106.45deg); }
+  14.167% { left: 199.10px; top: 198.76px; width: 95.99px; transform: rotate(-106.16deg); }
+  15.000% { left: 198.61px; top: 200.02px; width: 96.00px; transform: rotate(-105.86deg); }
+  15.833% { left: 198.12px; top: 201.28px; width: 96.00px; transform: rotate(-105.55deg); }
+  16.667% { left: 197.61px; top: 202.52px; width: 95.99px; transform: rotate(-105.24deg); }
+  17.500% { left: 197.10px; top: 203.76px; width: 96.00px; transform: rotate(-104.93deg); }
+  18.333% { left: 196.57px; top: 204.99px; width: 96.00px; transform: rotate(-104.60deg); }
+  19.167% { left: 196.03px; top: 206.21px; width: 96.00px; transform: rotate(-104.26deg); }
+  20.000% { left: 195.49px; top: 207.42px; width: 95.99px; transform: rotate(-103.93deg); }
+  20.833% { left: 194.93px; top: 208.63px; width: 96.01px; transform: rotate(-103.58deg); }
+  21.667% { left: 194.36px; top: 209.83px; width: 96.00px; transform: rotate(-103.24deg); }
+  22.500% { left: 193.78px; top: 211.02px; width: 96.01px; transform: rotate(-102.88deg); }
+  23.333% { left: 193.19px; top: 212.20px; width: 96.00px; transform: rotate(-102.52deg); }
+  24.167% { left: 192.59px; top: 213.37px; width: 96.00px; transform: rotate(-102.16deg); }
+  25.000% { left: 191.98px; top: 214.54px; width: 96.00px; transform: rotate(-101.78deg); }
+  25.833% { left: 191.36px; top: 215.70px; width: 96.00px; transform: rotate(-101.40deg); }
+  26.667% { left: 190.73px; top: 216.85px; width: 96.00px; transform: rotate(-101.03deg); }
+  27.500% { left: 190.09px; top: 217.99px; width: 96.00px; transform: rotate(-100.64deg); }
+  28.333% { left: 189.44px; top: 219.13px; width: 96.00px; transform: rotate(-100.24deg); }
+  29.167% { left: 188.78px; top: 220.26px; width: 96.00px; transform: rotate(-99.84deg); }
+  30.000% { left: 188.11px; top: 221.38px; width: 96.00px; transform: rotate(-99.44deg); }
+  30.833% { left: 187.43px; top: 222.49px; width: 96.00px; transform: rotate(-99.02deg); }
+  31.667% { left: 186.74px; top: 223.60px; width: 96.00px; transform: rotate(-98.60deg); }
+  32.500% { left: 186.04px; top: 224.70px; width: 96.01px; transform: rotate(-98.18deg); }
+  33.333% { left: 185.33px; top: 225.79px; width: 96.01px; transform: rotate(-97.75deg); }
+  34.167% { left: 184.61px; top: 226.87px; width: 96.00px; transform: rotate(-97.32deg); }
+  35.000% { left: 183.88px; top: 227.95px; width: 96.00px; transform: rotate(-96.88deg); }
+  35.833% { left: 183.14px; top: 229.01px; width: 95.99px; transform: rotate(-96.44deg); }
+  36.667% { left: 182.39px; top: 230.07px; width: 95.99px; transform: rotate(-95.99deg); }
+  37.500% { left: 181.64px; top: 231.13px; width: 96.01px; transform: rotate(-95.53deg); }
+  38.333% { left: 180.87px; top: 232.17px; width: 96.00px; transform: rotate(-95.08deg); }
+  39.167% { left: 180.09px; top: 233.21px; width: 96.00px; transform: rotate(-94.61deg); }
+  40.000% { left: 179.31px; top: 234.24px; width: 96.00px; transform: rotate(-94.14deg); }
+  40.833% { left: 178.51px; top: 235.26px; width: 96.01px; transform: rotate(-93.67deg); }
+  41.667% { left: 177.71px; top: 236.27px; width: 96.00px; transform: rotate(-93.18deg); }
+  42.500% { left: 176.90px; top: 237.27px; width: 96.00px; transform: rotate(-92.70deg); }
+  43.333% { left: 176.08px; top: 238.27px; width: 96.00px; transform: rotate(-92.21deg); }
+  44.167% { left: 175.25px; top: 239.26px; width: 96.00px; transform: rotate(-91.71deg); }
+  45.000% { left: 174.41px; top: 240.24px; width: 96.00px; transform: rotate(-91.21deg); }
+  45.833% { left: 173.56px; top: 241.21px; width: 96.00px; transform: rotate(-90.70deg); }
+  46.667% { left: 172.70px; top: 242.18px; width: 96.00px; transform: rotate(-90.19deg); }
+  47.500% { left: 171.84px; top: 243.13px; width: 96.00px; transform: rotate(-89.68deg); }
+  48.333% { left: 170.96px; top: 244.08px; width: 96.00px; transform: rotate(-89.15deg); }
+  49.167% { left: 170.08px; top: 245.02px; width: 96.01px; transform: rotate(-88.63deg); }
+  50.000% { left: 169.19px; top: 245.95px; width: 96.00px; transform: rotate(-88.10deg); }
+  50.833% { left: 168.29px; top: 246.87px; width: 96.00px; transform: rotate(-87.56deg); }
+  51.667% { left: 167.38px; top: 247.78px; width: 96.00px; transform: rotate(-87.01deg); }
+  52.500% { left: 166.46px; top: 248.69px; width: 96.00px; transform: rotate(-86.46deg); }
+  53.333% { left: 165.54px; top: 249.58px; width: 96.00px; transform: rotate(-85.91deg); }
+  54.167% { left: 164.61px; top: 250.47px; width: 96.00px; transform: rotate(-85.36deg); }
+  55.000% { left: 163.67px; top: 251.34px; width: 96.00px; transform: rotate(-84.79deg); }
+  55.833% { left: 162.72px; top: 252.21px; width: 96.00px; transform: rotate(-84.22deg); }
+  56.667% { left: 161.76px; top: 253.07px; width: 96.00px; transform: rotate(-83.65deg); }
+  57.500% { left: 160.80px; top: 253.92px; width: 96.00px; transform: rotate(-83.07deg); }
+  58.333% { left: 159.83px; top: 254.76px; width: 96.00px; transform: rotate(-82.49deg); }
+  59.167% { left: 158.85px; top: 255.59px; width: 96.00px; transform: rotate(-81.90deg); }
+  60.000% { left: 157.87px; top: 256.41px; width: 96.00px; transform: rotate(-81.31deg); }
+  60.833% { left: 156.87px; top: 257.22px; width: 96.00px; transform: rotate(-80.71deg); }
+  61.667% { left: 155.88px; top: 258.03px; width: 96.01px; transform: rotate(-80.11deg); }
+  62.500% { left: 154.87px; top: 258.82px; width: 96.00px; transform: rotate(-79.49deg); }
+  63.333% { left: 153.86px; top: 259.60px; width: 96.00px; transform: rotate(-78.88deg); }
+  64.167% { left: 152.84px; top: 260.37px; width: 96.00px; transform: rotate(-78.26deg); }
+  65.000% { left: 151.81px; top: 261.13px; width: 96.00px; transform: rotate(-77.63deg); }
+  65.833% { left: 150.78px; top: 261.89px; width: 96.00px; transform: rotate(-77.00deg); }
+  66.667% { left: 149.74px; top: 262.63px; width: 96.00px; transform: rotate(-76.36deg); }
+  67.500% { left: 148.70px; top: 263.36px; width: 96.00px; transform: rotate(-75.72deg); }
+  68.333% { left: 147.65px; top: 264.08px; width: 96.00px; transform: rotate(-75.07deg); }
+  69.167% { left: 146.59px; top: 264.79px; width: 96.00px; transform: rotate(-74.42deg); }
+  70.000% { left: 145.53px; top: 265.49px; width: 96.00px; transform: rotate(-73.76deg); }
+  70.833% { left: 144.47px; top: 266.18px; width: 96.00px; transform: rotate(-73.10deg); }
+  71.667% { left: 143.40px; top: 266.86px; width: 96.00px; transform: rotate(-72.43deg); }
+  72.500% { left: 142.32px; top: 267.53px; width: 95.99px; transform: rotate(-71.76deg); }
+  73.333% { left: 141.24px; top: 268.19px; width: 96.00px; transform: rotate(-71.08deg); }
+  74.167% { left: 140.15px; top: 268.84px; width: 96.00px; transform: rotate(-70.38deg); }
+  75.000% { left: 139.06px; top: 269.47px; width: 96.00px; transform: rotate(-69.69deg); }
+  75.833% { left: 137.97px; top: 270.10px; width: 96.00px; transform: rotate(-69.00deg); }
+  76.667% { left: 136.87px; top: 270.71px; width: 96.00px; transform: rotate(-68.29deg); }
+  77.500% { left: 135.77px; top: 271.32px; width: 96.00px; transform: rotate(-67.58deg); }
+  78.333% { left: 134.67px; top: 271.91px; width: 96.01px; transform: rotate(-66.87deg); }
+  79.167% { left: 133.56px; top: 272.49px; width: 96.00px; transform: rotate(-66.15deg); }
+  80.000% { left: 132.45px; top: 273.06px; width: 96.01px; transform: rotate(-65.42deg); }
+  80.833% { left: 131.34px; top: 273.62px; width: 96.00px; transform: rotate(-64.69deg); }
+  81.667% { left: 130.23px; top: 274.16px; width: 96.00px; transform: rotate(-63.96deg); }
+  82.500% { left: 129.11px; top: 274.70px; width: 96.00px; transform: rotate(-63.22deg); }
+  83.333% { left: 127.99px; top: 275.22px; width: 96.00px; transform: rotate(-62.46deg); }
+  84.167% { left: 126.87px; top: 275.74px; width: 96.00px; transform: rotate(-61.70deg); }
+  85.000% { left: 125.75px; top: 276.24px; width: 96.00px; transform: rotate(-60.95deg); }
+  85.833% { left: 124.63px; top: 276.73px; width: 96.01px; transform: rotate(-60.17deg); }
+  86.667% { left: 123.50px; top: 277.21px; width: 96.01px; transform: rotate(-59.39deg); }
+  87.500% { left: 122.38px; top: 277.67px; width: 96.00px; transform: rotate(-58.61deg); }
+  88.333% { left: 121.26px; top: 278.13px; width: 96.00px; transform: rotate(-57.83deg); }
+  89.167% { left: 120.13px; top: 278.57px; width: 96.00px; transform: rotate(-57.03deg); }
+  90.000% { left: 119.01px; top: 279.00px; width: 96.00px; transform: rotate(-56.23deg); }
+  90.833% { left: 117.89px; top: 279.42px; width: 96.00px; transform: rotate(-55.42deg); }
+  91.667% { left: 116.77px; top: 279.83px; width: 96.01px; transform: rotate(-54.60deg); }
+  92.500% { left: 115.65px; top: 280.23px; width: 96.00px; transform: rotate(-53.78deg); }
+  93.333% { left: 114.54px; top: 280.62px; width: 96.01px; transform: rotate(-52.95deg); }
+  94.167% { left: 113.43px; top: 280.99px; width: 96.00px; transform: rotate(-52.12deg); }
+  95.000% { left: 112.31px; top: 281.35px; width: 96.00px; transform: rotate(-51.27deg); }
+  95.833% { left: 111.21px; top: 281.70px; width: 96.00px; transform: rotate(-50.42deg); }
+  96.667% { left: 110.11px; top: 282.04px; width: 96.00px; transform: rotate(-49.56deg); }
+  97.500% { left: 109.01px; top: 282.37px; width: 96.00px; transform: rotate(-48.69deg); }
+  98.333% { left: 107.91px; top: 282.69px; width: 96.01px; transform: rotate(-47.82deg); }
+  99.167% { left: 106.82px; top: 283.00px; width: 96.01px; transform: rotate(-46.93deg); }
+  100.000% { left: 105.74px; top: 283.29px; width: 96.01px; transform: rotate(-46.04deg); }
+}
+
+@keyframes barCP {
+  0.000% { left: 105.74px; top: 16.71px; width: 96.01px; transform: rotate(46.04deg); }
+  0.833% { left: 106.82px; top: 17.00px; width: 96.01px; transform: rotate(46.93deg); }
+  1.667% { left: 107.91px; top: 17.31px; width: 96.01px; transform: rotate(47.82deg); }
+  2.500% { left: 109.01px; top: 17.63px; width: 96.00px; transform: rotate(48.69deg); }
+  3.333% { left: 110.11px; top: 17.96px; width: 96.00px; transform: rotate(49.56deg); }
+  4.167% { left: 111.21px; top: 18.30px; width: 96.00px; transform: rotate(50.42deg); }
+  5.000% { left: 112.31px; top: 18.65px; width: 96.00px; transform: rotate(51.27deg); }
+  5.833% { left: 113.43px; top: 19.01px; width: 96.00px; transform: rotate(52.12deg); }
+  6.667% { left: 114.54px; top: 19.38px; width: 96.01px; transform: rotate(52.95deg); }
+  7.500% { left: 115.65px; top: 19.77px; width: 96.00px; transform: rotate(53.78deg); }
+  8.333% { left: 116.77px; top: 20.17px; width: 96.01px; transform: rotate(54.60deg); }
+  9.167% { left: 117.89px; top: 20.58px; width: 96.00px; transform: rotate(55.42deg); }
+  10.000% { left: 119.01px; top: 21.00px; width: 96.00px; transform: rotate(56.23deg); }
+  10.833% { left: 120.13px; top: 21.43px; width: 96.00px; transform: rotate(57.03deg); }
+  11.667% { left: 121.26px; top: 21.87px; width: 96.00px; transform: rotate(57.83deg); }
+  12.500% { left: 122.38px; top: 22.33px; width: 96.00px; transform: rotate(58.61deg); }
+  13.333% { left: 123.50px; top: 22.79px; width: 96.01px; transform: rotate(59.39deg); }
+  14.167% { left: 124.63px; top: 23.27px; width: 96.01px; transform: rotate(60.17deg); }
+  15.000% { left: 125.75px; top: 23.76px; width: 96.00px; transform: rotate(60.95deg); }
+  15.833% { left: 126.87px; top: 24.26px; width: 96.00px; transform: rotate(61.70deg); }
+  16.667% { left: 127.99px; top: 24.78px; width: 96.00px; transform: rotate(62.46deg); }
+  17.500% { left: 129.11px; top: 25.30px; width: 96.00px; transform: rotate(63.22deg); }
+  18.333% { left: 130.23px; top: 25.84px; width: 96.00px; transform: rotate(63.96deg); }
+  19.167% { left: 131.34px; top: 26.38px; width: 96.00px; transform: rotate(64.69deg); }
+  20.000% { left: 132.45px; top: 26.94px; width: 96.01px; transform: rotate(65.42deg); }
+  20.833% { left: 133.56px; top: 27.51px; width: 96.00px; transform: rotate(66.15deg); }
+  21.667% { left: 134.67px; top: 28.09px; width: 96.01px; transform: rotate(66.87deg); }
+  22.500% { left: 135.77px; top: 28.68px; width: 96.00px; transform: rotate(67.58deg); }
+  23.333% { left: 136.87px; top: 29.29px; width: 96.00px; transform: rotate(68.29deg); }
+  24.167% { left: 137.97px; top: 29.90px; width: 96.00px; transform: rotate(69.00deg); }
+  25.000% { left: 139.06px; top: 30.53px; width: 96.00px; transform: rotate(69.69deg); }
+  25.833% { left: 140.15px; top: 31.16px; width: 96.00px; transform: rotate(70.38deg); }
+  26.667% { left: 141.24px; top: 31.81px; width: 96.00px; transform: rotate(71.08deg); }
+  27.500% { left: 142.32px; top: 32.47px; width: 95.99px; transform: rotate(71.76deg); }
+  28.333% { left: 143.40px; top: 33.14px; width: 96.00px; transform: rotate(72.43deg); }
+  29.167% { left: 144.47px; top: 33.82px; width: 96.00px; transform: rotate(73.10deg); }
+  30.000% { left: 145.53px; top: 34.51px; width: 96.00px; transform: rotate(73.76deg); }
+  30.833% { left: 146.59px; top: 35.21px; width: 96.00px; transform: rotate(74.42deg); }
+  31.667% { left: 147.65px; top: 35.92px; width: 96.00px; transform: rotate(75.07deg); }
+  32.500% { left: 148.70px; top: 36.64px; width: 96.00px; transform: rotate(75.72deg); }
+  33.333% { left: 149.74px; top: 37.37px; width: 96.00px; transform: rotate(76.36deg); }
+  34.167% { left: 150.78px; top: 38.11px; width: 96.00px; transform: rotate(77.00deg); }
+  35.000% { left: 151.81px; top: 38.87px; width: 96.00px; transform: rotate(77.63deg); }
+  35.833% { left: 152.84px; top: 39.63px; width: 96.00px; transform: rotate(78.26deg); }
+  36.667% { left: 153.86px; top: 40.40px; width: 96.00px; transform: rotate(78.88deg); }
+  37.500% { left: 154.87px; top: 41.18px; width: 96.00px; transform: rotate(79.49deg); }
+  38.333% { left: 155.88px; top: 41.97px; width: 96.01px; transform: rotate(80.11deg); }
+  39.167% { left: 156.87px; top: 42.78px; width: 96.00px; transform: rotate(80.71deg); }
+  40.000% { left: 157.87px; top: 43.59px; width: 96.00px; transform: rotate(81.31deg); }
+  40.833% { left: 158.85px; top: 44.41px; width: 96.00px; transform: rotate(81.90deg); }
+  41.667% { left: 159.83px; top: 45.24px; width: 96.00px; transform: rotate(82.49deg); }
+  42.500% { left: 160.80px; top: 46.08px; width: 96.00px; transform: rotate(83.07deg); }
+  43.333% { left: 161.76px; top: 46.93px; width: 96.00px; transform: rotate(83.65deg); }
+  44.167% { left: 162.72px; top: 47.79px; width: 96.00px; transform: rotate(84.22deg); }
+  45.000% { left: 163.67px; top: 48.66px; width: 96.00px; transform: rotate(84.79deg); }
+  45.833% { left: 164.61px; top: 49.53px; width: 96.00px; transform: rotate(85.36deg); }
+  46.667% { left: 165.54px; top: 50.42px; width: 96.00px; transform: rotate(85.91deg); }
+  47.500% { left: 166.46px; top: 51.31px; width: 96.00px; transform: rotate(86.46deg); }
+  48.333% { left: 167.38px; top: 52.22px; width: 96.00px; transform: rotate(87.01deg); }
+  49.167% { left: 168.29px; top: 53.13px; width: 96.00px; transform: rotate(87.56deg); }
+  50.000% { left: 169.19px; top: 54.05px; width: 96.00px; transform: rotate(88.10deg); }
+  50.833% { left: 170.08px; top: 54.98px; width: 96.01px; transform: rotate(88.63deg); }
+  51.667% { left: 170.96px; top: 55.92px; width: 96.00px; transform: rotate(89.15deg); }
+  52.500% { left: 171.84px; top: 56.87px; width: 96.00px; transform: rotate(89.68deg); }
+  53.333% { left: 172.70px; top: 57.82px; width: 96.00px; transform: rotate(90.19deg); }
+  54.167% { left: 173.56px; top: 58.79px; width: 96.00px; transform: rotate(90.70deg); }
+  55.000% { left: 174.41px; top: 59.76px; width: 96.00px; transform: rotate(91.21deg); }
+  55.833% { left: 175.25px; top: 60.74px; width: 96.00px; transform: rotate(91.71deg); }
+  56.667% { left: 176.08px; top: 61.73px; width: 96.00px; transform: rotate(92.21deg); }
+  57.500% { left: 176.90px; top: 62.73px; width: 96.00px; transform: rotate(92.70deg); }
+  58.333% { left: 177.71px; top: 63.73px; width: 96.00px; transform: rotate(93.18deg); }
+  59.167% { left: 178.51px; top: 64.74px; width: 96.01px; transform: rotate(93.67deg); }
+  60.000% { left: 179.31px; top: 65.76px; width: 96.00px; transform: rotate(94.14deg); }
+  60.833% { left: 180.09px; top: 66.79px; width: 96.00px; transform: rotate(94.61deg); }
+  61.667% { left: 180.87px; top: 67.83px; width: 96.00px; transform: rotate(95.08deg); }
+  62.500% { left: 181.64px; top: 68.87px; width: 96.01px; transform: rotate(95.53deg); }
+  63.333% { left: 182.39px; top: 69.93px; width: 95.99px; transform: rotate(95.99deg); }
+  64.167% { left: 183.14px; top: 70.99px; width: 95.99px; transform: rotate(96.44deg); }
+  65.000% { left: 183.88px; top: 72.05px; width: 96.00px; transform: rotate(96.88deg); }
+  65.833% { left: 184.61px; top: 73.13px; width: 96.00px; transform: rotate(97.32deg); }
+  66.667% { left: 185.33px; top: 74.21px; width: 96.01px; transform: rotate(97.75deg); }
+  67.500% { left: 186.04px; top: 75.30px; width: 96.01px; transform: rotate(98.18deg); }
+  68.333% { left: 186.74px; top: 76.40px; width: 96.00px; transform: rotate(98.60deg); }
+  69.167% { left: 187.43px; top: 77.51px; width: 96.00px; transform: rotate(99.02deg); }
+  70.000% { left: 188.11px; top: 78.62px; width: 96.00px; transform: rotate(99.44deg); }
+  70.833% { left: 188.78px; top: 79.74px; width: 96.00px; transform: rotate(99.84deg); }
+  71.667% { left: 189.44px; top: 80.87px; width: 96.00px; transform: rotate(100.24deg); }
+  72.500% { left: 190.09px; top: 82.01px; width: 96.00px; transform: rotate(100.64deg); }
+  73.333% { left: 190.73px; top: 83.15px; width: 96.00px; transform: rotate(101.03deg); }
+  74.167% { left: 191.36px; top: 84.30px; width: 96.00px; transform: rotate(101.40deg); }
+  75.000% { left: 191.98px; top: 85.46px; width: 96.00px; transform: rotate(101.78deg); }
+  75.833% { left: 192.59px; top: 86.63px; width: 96.00px; transform: rotate(102.15deg); }
+  76.667% { left: 193.19px; top: 87.80px; width: 96.00px; transform: rotate(102.52deg); }
+  77.500% { left: 193.78px; top: 88.98px; width: 96.01px; transform: rotate(102.88deg); }
+  78.333% { left: 194.36px; top: 90.17px; width: 96.00px; transform: rotate(103.24deg); }
+  79.167% { left: 194.93px; top: 91.37px; width: 96.01px; transform: rotate(103.58deg); }
+  80.000% { left: 195.49px; top: 92.58px; width: 95.99px; transform: rotate(103.93deg); }
+  80.833% { left: 196.03px; top: 93.79px; width: 96.00px; transform: rotate(104.26deg); }
+  81.667% { left: 196.57px; top: 95.01px; width: 96.00px; transform: rotate(104.60deg); }
+  82.500% { left: 197.10px; top: 96.24px; width: 96.00px; transform: rotate(104.93deg); }
+  83.333% { left: 197.61px; top: 97.48px; width: 95.99px; transform: rotate(105.24deg); }
+  84.167% { left: 198.12px; top: 98.72px; width: 96.00px; transform: rotate(105.55deg); }
+  85.000% { left: 198.61px; top: 99.98px; width: 96.00px; transform: rotate(105.86deg); }
+  85.833% { left: 199.10px; top: 101.24px; width: 95.99px; transform: rotate(106.16deg); }
+  86.667% { left: 199.57px; top: 102.51px; width: 96.00px; transform: rotate(106.45deg); }
+  87.500% { left: 200.03px; top: 103.79px; width: 96.00px; transform: rotate(106.74deg); }
+  88.333% { left: 200.48px; top: 105.08px; width: 95.99px; transform: rotate(107.02deg); }
+  89.167% { left: 200.92px; top: 106.37px; width: 96.00px; transform: rotate(107.30deg); }
+  90.000% { left: 201.35px; top: 107.68px; width: 96.00px; transform: rotate(107.57deg); }
+  90.833% { left: 201.77px; top: 108.99px; width: 96.00px; transform: rotate(107.83deg); }
+  91.667% { left: 202.17px; top: 110.32px; width: 95.99px; transform: rotate(108.08deg); }
+  92.500% { left: 202.56px; top: 111.65px; width: 96.00px; transform: rotate(108.33deg); }
+  93.333% { left: 202.94px; top: 112.99px; width: 95.99px; transform: rotate(108.56deg); }
+  94.167% { left: 203.31px; top: 114.34px; width: 96.00px; transform: rotate(108.80deg); }
+  95.000% { left: 203.67px; top: 115.70px; width: 96.01px; transform: rotate(109.03deg); }
+  95.833% { left: 204.02px; top: 117.08px; width: 95.99px; transform: rotate(109.24deg); }
+  96.667% { left: 204.35px; top: 118.46px; width: 96.00px; transform: rotate(109.45deg); }
+  97.500% { left: 204.67px; top: 119.85px; width: 96.00px; transform: rotate(109.65deg); }
+  98.333% { left: 204.97px; top: 121.26px; width: 95.99px; transform: rotate(109.85deg); }
+  99.167% { left: 205.27px; top: 122.67px; width: 96.00px; transform: rotate(110.04deg); }
+  100.000% { left: 205.55px; top: 124.10px; width: 95.99px; transform: rotate(110.22deg); }
+}
+
+@keyframes jA {
+  0.000% { left: 205.55px; top: 175.90px; }
+  0.833% { left: 205.27px; top: 177.33px; }
+  1.667% { left: 204.97px; top: 178.74px; }
+  2.500% { left: 204.67px; top: 180.15px; }
+  3.333% { left: 204.35px; top: 181.54px; }
+  4.167% { left: 204.02px; top: 182.92px; }
+  5.000% { left: 203.67px; top: 184.30px; }
+  5.833% { left: 203.31px; top: 185.66px; }
+  6.667% { left: 202.94px; top: 187.01px; }
+  7.500% { left: 202.56px; top: 188.35px; }
+  8.333% { left: 202.17px; top: 189.68px; }
+  9.167% { left: 201.77px; top: 191.01px; }
+  10.000% { left: 201.35px; top: 192.32px; }
+  10.833% { left: 200.92px; top: 193.63px; }
+  11.667% { left: 200.48px; top: 194.92px; }
+  12.500% { left: 200.03px; top: 196.21px; }
+  13.333% { left: 199.57px; top: 197.49px; }
+  14.167% { left: 199.10px; top: 198.76px; }
+  15.000% { left: 198.61px; top: 200.02px; }
+  15.833% { left: 198.12px; top: 201.28px; }
+  16.667% { left: 197.61px; top: 202.52px; }
+  17.500% { left: 197.10px; top: 203.76px; }
+  18.333% { left: 196.57px; top: 204.99px; }
+  19.167% { left: 196.03px; top: 206.21px; }
+  20.000% { left: 195.49px; top: 207.42px; }
+  20.833% { left: 194.93px; top: 208.63px; }
+  21.667% { left: 194.36px; top: 209.83px; }
+  22.500% { left: 193.78px; top: 211.02px; }
+  23.333% { left: 193.19px; top: 212.20px; }
+  24.167% { left: 192.59px; top: 213.37px; }
+  25.000% { left: 191.98px; top: 214.54px; }
+  25.833% { left: 191.36px; top: 215.70px; }
+  26.667% { left: 190.73px; top: 216.85px; }
+  27.500% { left: 190.09px; top: 217.99px; }
+  28.333% { left: 189.44px; top: 219.13px; }
+  29.167% { left: 188.78px; top: 220.26px; }
+  30.000% { left: 188.11px; top: 221.38px; }
+  30.833% { left: 187.43px; top: 222.49px; }
+  31.667% { left: 186.74px; top: 223.60px; }
+  32.500% { left: 186.04px; top: 224.70px; }
+  33.333% { left: 185.33px; top: 225.79px; }
+  34.167% { left: 184.61px; top: 226.87px; }
+  35.000% { left: 183.88px; top: 227.95px; }
+  35.833% { left: 183.14px; top: 229.01px; }
+  36.667% { left: 182.39px; top: 230.07px; }
+  37.500% { left: 181.64px; top: 231.13px; }
+  38.333% { left: 180.87px; top: 232.17px; }
+  39.167% { left: 180.09px; top: 233.21px; }
+  40.000% { left: 179.31px; top: 234.24px; }
+  40.833% { left: 178.51px; top: 235.26px; }
+  41.667% { left: 177.71px; top: 236.27px; }
+  42.500% { left: 176.90px; top: 237.27px; }
+  43.333% { left: 176.08px; top: 238.27px; }
+  44.167% { left: 175.25px; top: 239.26px; }
+  45.000% { left: 174.41px; top: 240.24px; }
+  45.833% { left: 173.56px; top: 241.21px; }
+  46.667% { left: 172.70px; top: 242.18px; }
+  47.500% { left: 171.84px; top: 243.13px; }
+  48.333% { left: 170.96px; top: 244.08px; }
+  49.167% { left: 170.08px; top: 245.02px; }
+  50.000% { left: 169.19px; top: 245.95px; }
+  50.833% { left: 168.29px; top: 246.87px; }
+  51.667% { left: 167.38px; top: 247.78px; }
+  52.500% { left: 166.46px; top: 248.69px; }
+  53.333% { left: 165.54px; top: 249.58px; }
+  54.167% { left: 164.61px; top: 250.47px; }
+  55.000% { left: 163.67px; top: 251.34px; }
+  55.833% { left: 162.72px; top: 252.21px; }
+  56.667% { left: 161.76px; top: 253.07px; }
+  57.500% { left: 160.80px; top: 253.92px; }
+  58.333% { left: 159.83px; top: 254.76px; }
+  59.167% { left: 158.85px; top: 255.59px; }
+  60.000% { left: 157.87px; top: 256.41px; }
+  60.833% { left: 156.87px; top: 257.22px; }
+  61.667% { left: 155.88px; top: 258.03px; }
+  62.500% { left: 154.87px; top: 258.82px; }
+  63.333% { left: 153.86px; top: 259.60px; }
+  64.167% { left: 152.84px; top: 260.37px; }
+  65.000% { left: 151.81px; top: 261.13px; }
+  65.833% { left: 150.78px; top: 261.89px; }
+  66.667% { left: 149.74px; top: 262.63px; }
+  67.500% { left: 148.70px; top: 263.36px; }
+  68.333% { left: 147.65px; top: 264.08px; }
+  69.167% { left: 146.59px; top: 264.79px; }
+  70.000% { left: 145.53px; top: 265.49px; }
+  70.833% { left: 144.47px; top: 266.18px; }
+  71.667% { left: 143.40px; top: 266.86px; }
+  72.500% { left: 142.32px; top: 267.53px; }
+  73.333% { left: 141.24px; top: 268.19px; }
+  74.167% { left: 140.15px; top: 268.84px; }
+  75.000% { left: 139.06px; top: 269.47px; }
+  75.833% { left: 137.97px; top: 270.10px; }
+  76.667% { left: 136.87px; top: 270.71px; }
+  77.500% { left: 135.77px; top: 271.32px; }
+  78.333% { left: 134.67px; top: 271.91px; }
+  79.167% { left: 133.56px; top: 272.49px; }
+  80.000% { left: 132.45px; top: 273.06px; }
+  80.833% { left: 131.34px; top: 273.62px; }
+  81.667% { left: 130.23px; top: 274.16px; }
+  82.500% { left: 129.11px; top: 274.70px; }
+  83.333% { left: 127.99px; top: 275.22px; }
+  84.167% { left: 126.87px; top: 275.74px; }
+  85.000% { left: 125.75px; top: 276.24px; }
+  85.833% { left: 124.63px; top: 276.73px; }
+  86.667% { left: 123.50px; top: 277.21px; }
+  87.500% { left: 122.38px; top: 277.67px; }
+  88.333% { left: 121.26px; top: 278.13px; }
+  89.167% { left: 120.13px; top: 278.57px; }
+  90.000% { left: 119.01px; top: 279.00px; }
+  90.833% { left: 117.89px; top: 279.42px; }
+  91.667% { left: 116.77px; top: 279.83px; }
+  92.500% { left: 115.65px; top: 280.23px; }
+  93.333% { left: 114.54px; top: 280.62px; }
+  94.167% { left: 113.43px; top: 280.99px; }
+  95.000% { left: 112.31px; top: 281.35px; }
+  95.833% { left: 111.21px; top: 281.70px; }
+  96.667% { left: 110.11px; top: 282.04px; }
+  97.500% { left: 109.01px; top: 282.37px; }
+  98.333% { left: 107.91px; top: 282.69px; }
+  99.167% { left: 106.82px; top: 283.00px; }
+  100.000% { left: 105.74px; top: 283.29px; }
+}
+
+@keyframes jB {
+  0.000% { left: 138.91px; top: 106.80px; }
+  0.833% { left: 139.72px; top: 107.19px; }
+  1.667% { left: 140.51px; top: 107.61px; }
+  2.500% { left: 141.30px; top: 108.03px; }
+  3.333% { left: 142.08px; top: 108.48px; }
+  4.167% { left: 142.85px; top: 108.93px; }
+  5.000% { left: 143.61px; top: 109.40px; }
+  5.833% { left: 144.36px; top: 109.89px; }
+  6.667% { left: 145.11px; top: 110.39px; }
+  7.500% { left: 145.84px; top: 110.90px; }
+  8.333% { left: 146.57px; top: 111.43px; }
+  9.167% { left: 147.28px; top: 111.97px; }
+  10.000% { left: 147.99px; top: 112.52px; }
+  10.833% { left: 148.68px; top: 113.09px; }
+  11.667% { left: 149.37px; top: 113.67px; }
+  12.500% { left: 150.04px; top: 114.26px; }
+  13.333% { left: 150.70px; top: 114.86px; }
+  14.167% { left: 151.35px; top: 115.48px; }
+  15.000% { left: 151.99px; top: 116.11px; }
+  15.833% { left: 152.62px; top: 116.75px; }
+  16.667% { left: 153.23px; top: 117.40px; }
+  17.500% { left: 153.83px; top: 118.06px; }
+  18.333% { left: 154.42px; top: 118.74px; }
+  19.167% { left: 155.00px; top: 119.42px; }
+  20.000% { left: 155.56px; top: 120.12px; }
+  20.833% { left: 156.11px; top: 120.82px; }
+  21.667% { left: 156.65px; top: 121.54px; }
+  22.500% { left: 157.18px; top: 122.27px; }
+  23.333% { left: 157.69px; top: 123.00px; }
+  24.167% { left: 158.19px; top: 123.75px; }
+  25.000% { left: 158.67px; top: 124.50px; }
+  25.833% { left: 159.14px; top: 125.27px; }
+  26.667% { left: 159.59px; top: 126.04px; }
+  27.500% { left: 160.03px; top: 126.82px; }
+  28.333% { left: 160.46px; top: 127.61px; }
+  29.167% { left: 160.87px; top: 128.40px; }
+  30.000% { left: 161.26px; top: 129.21px; }
+  30.833% { left: 161.64px; top: 130.02px; }
+  31.667% { left: 162.01px; top: 130.84px; }
+  32.500% { left: 162.36px; top: 131.66px; }
+  33.333% { left: 162.69px; top: 132.49px; }
+  34.167% { left: 163.01px; top: 133.33px; }
+  35.000% { left: 163.32px; top: 134.17px; }
+  35.833% { left: 163.60px; top: 135.02px; }
+  36.667% { left: 163.88px; top: 135.88px; }
+  37.500% { left: 164.13px; top: 136.73px; }
+  38.333% { left: 164.37px; top: 137.60px; }
+  39.167% { left: 164.59px; top: 138.47px; }
+  40.000% { left: 164.80px; top: 139.34px; }
+  40.833% { left: 164.99px; top: 140.21px; }
+  41.667% { left: 165.17px; top: 141.09px; }
+  42.500% { left: 165.32px; top: 141.97px; }
+  43.333% { left: 165.47px; top: 142.86px; }
+  44.167% { left: 165.59px; top: 143.75px; }
+  45.000% { left: 165.70px; top: 144.64px; }
+  45.833% { left: 165.79px; top: 145.53px; }
+  46.667% { left: 165.87px; top: 146.42px; }
+  47.500% { left: 165.92px; top: 147.31px; }
+  48.333% { left: 165.97px; top: 148.21px; }
+  49.167% { left: 165.99px; top: 149.10px; }
+  50.000% { left: 166.00px; top: 150.00px; }
+  50.833% { left: 165.99px; top: 150.90px; }
+  51.667% { left: 165.97px; top: 151.79px; }
+  52.500% { left: 165.92px; top: 152.69px; }
+  53.333% { left: 165.87px; top: 153.58px; }
+  54.167% { left: 165.79px; top: 154.47px; }
+  55.000% { left: 165.70px; top: 155.36px; }
+  55.833% { left: 165.59px; top: 156.25px; }
+  56.667% { left: 165.47px; top: 157.14px; }
+  57.500% { left: 165.32px; top: 158.03px; }
+  58.333% { left: 165.17px; top: 158.91px; }
+  59.167% { left: 164.99px; top: 159.79px; }
+  60.000% { left: 164.80px; top: 160.66px; }
+  60.833% { left: 164.59px; top: 161.53px; }
+  61.667% { left: 164.37px; top: 162.40px; }
+  62.500% { left: 164.13px; top: 163.27px; }
+  63.333% { left: 163.88px; top: 164.12px; }
+  64.167% { left: 163.60px; top: 164.98px; }
+  65.000% { left: 163.32px; top: 165.83px; }
+  65.833% { left: 163.01px; top: 166.67px; }
+  66.667% { left: 162.69px; top: 167.51px; }
+  67.500% { left: 162.36px; top: 168.34px; }
+  68.333% { left: 162.01px; top: 169.16px; }
+  69.167% { left: 161.64px; top: 169.98px; }
+  70.000% { left: 161.26px; top: 170.79px; }
+  70.833% { left: 160.87px; top: 171.60px; }
+  71.667% { left: 160.46px; top: 172.39px; }
+  72.500% { left: 160.03px; top: 173.18px; }
+  73.333% { left: 159.59px; top: 173.96px; }
+  74.167% { left: 159.14px; top: 174.73px; }
+  75.000% { left: 158.67px; top: 175.50px; }
+  75.833% { left: 158.19px; top: 176.25px; }
+  76.667% { left: 157.69px; top: 177.00px; }
+  77.500% { left: 157.18px; top: 177.73px; }
+  78.333% { left: 156.65px; top: 178.46px; }
+  79.167% { left: 156.11px; top: 179.18px; }
+  80.000% { left: 155.56px; top: 179.88px; }
+  80.833% { left: 155.00px; top: 180.58px; }
+  81.667% { left: 154.42px; top: 181.26px; }
+  82.500% { left: 153.83px; top: 181.94px; }
+  83.333% { left: 153.23px; top: 182.60px; }
+  84.167% { left: 152.62px; top: 183.25px; }
+  85.000% { left: 151.99px; top: 183.89px; }
+  85.833% { left: 151.35px; top: 184.52px; }
+  86.667% { left: 150.70px; top: 185.14px; }
+  87.500% { left: 150.04px; top: 185.74px; }
+  88.333% { left: 149.37px; top: 186.33px; }
+  89.167% { left: 148.68px; top: 186.91px; }
+  90.000% { left: 147.99px; top: 187.48px; }
+  90.833% { left: 147.28px; top: 188.03px; }
+  91.667% { left: 146.57px; top: 188.57px; }
+  92.500% { left: 145.84px; top: 189.10px; }
+  93.333% { left: 145.11px; top: 189.61px; }
+  94.167% { left: 144.36px; top: 190.11px; }
+  95.000% { left: 143.61px; top: 190.60px; }
+  95.833% { left: 142.85px; top: 191.07px; }
+  96.667% { left: 142.08px; top: 191.52px; }
+  97.500% { left: 141.30px; top: 191.97px; }
+  98.333% { left: 140.51px; top: 192.39px; }
+  99.167% { left: 139.72px; top: 192.81px; }
+  100.000% { left: 138.91px; top: 193.20px; }
+}
+
+@keyframes jC {
+  0.000% { left: 105.74px; top: 16.71px; }
+  0.833% { left: 106.82px; top: 17.00px; }
+  1.667% { left: 107.91px; top: 17.31px; }
+  2.500% { left: 109.01px; top: 17.63px; }
+  3.333% { left: 110.11px; top: 17.96px; }
+  4.167% { left: 111.21px; top: 18.30px; }
+  5.000% { left: 112.31px; top: 18.65px; }
+  5.833% { left: 113.43px; top: 19.01px; }
+  6.667% { left: 114.54px; top: 19.38px; }
+  7.500% { left: 115.65px; top: 19.77px; }
+  8.333% { left: 116.77px; top: 20.17px; }
+  9.167% { left: 117.89px; top: 20.58px; }
+  10.000% { left: 119.01px; top: 21.00px; }
+  10.833% { left: 120.13px; top: 21.43px; }
+  11.667% { left: 121.26px; top: 21.87px; }
+  12.500% { left: 122.38px; top: 22.33px; }
+  13.333% { left: 123.50px; top: 22.79px; }
+  14.167% { left: 124.63px; top: 23.27px; }
+  15.000% { left: 125.75px; top: 23.76px; }
+  15.833% { left: 126.87px; top: 24.26px; }
+  16.667% { left: 127.99px; top: 24.78px; }
+  17.500% { left: 129.11px; top: 25.30px; }
+  18.333% { left: 130.23px; top: 25.84px; }
+  19.167% { left: 131.34px; top: 26.38px; }
+  20.000% { left: 132.45px; top: 26.94px; }
+  20.833% { left: 133.56px; top: 27.51px; }
+  21.667% { left: 134.67px; top: 28.09px; }
+  22.500% { left: 135.77px; top: 28.68px; }
+  23.333% { left: 136.87px; top: 29.29px; }
+  24.167% { left: 137.97px; top: 29.90px; }
+  25.000% { left: 139.06px; top: 30.53px; }
+  25.833% { left: 140.15px; top: 31.16px; }
+  26.667% { left: 141.24px; top: 31.81px; }
+  27.500% { left: 142.32px; top: 32.47px; }
+  28.333% { left: 143.40px; top: 33.14px; }
+  29.167% { left: 144.47px; top: 33.82px; }
+  30.000% { left: 145.53px; top: 34.51px; }
+  30.833% { left: 146.59px; top: 35.21px; }
+  31.667% { left: 147.65px; top: 35.92px; }
+  32.500% { left: 148.70px; top: 36.64px; }
+  33.333% { left: 149.74px; top: 37.37px; }
+  34.167% { left: 150.78px; top: 38.11px; }
+  35.000% { left: 151.81px; top: 38.87px; }
+  35.833% { left: 152.84px; top: 39.63px; }
+  36.667% { left: 153.86px; top: 40.40px; }
+  37.500% { left: 154.87px; top: 41.18px; }
+  38.333% { left: 155.88px; top: 41.97px; }
+  39.167% { left: 156.87px; top: 42.78px; }
+  40.000% { left: 157.87px; top: 43.59px; }
+  40.833% { left: 158.85px; top: 44.41px; }
+  41.667% { left: 159.83px; top: 45.24px; }
+  42.500% { left: 160.80px; top: 46.08px; }
+  43.333% { left: 161.76px; top: 46.93px; }
+  44.167% { left: 162.72px; top: 47.79px; }
+  45.000% { left: 163.67px; top: 48.66px; }
+  45.833% { left: 164.61px; top: 49.53px; }
+  46.667% { left: 165.54px; top: 50.42px; }
+  47.500% { left: 166.46px; top: 51.31px; }
+  48.333% { left: 167.38px; top: 52.22px; }
+  49.167% { left: 168.29px; top: 53.13px; }
+  50.000% { left: 169.19px; top: 54.05px; }
+  50.833% { left: 170.08px; top: 54.98px; }
+  51.667% { left: 170.96px; top: 55.92px; }
+  52.500% { left: 171.84px; top: 56.87px; }
+  53.333% { left: 172.70px; top: 57.82px; }
+  54.167% { left: 173.56px; top: 58.79px; }
+  55.000% { left: 174.41px; top: 59.76px; }
+  55.833% { left: 175.25px; top: 60.74px; }
+  56.667% { left: 176.08px; top: 61.73px; }
+  57.500% { left: 176.90px; top: 62.73px; }
+  58.333% { left: 177.71px; top: 63.73px; }
+  59.167% { left: 178.51px; top: 64.74px; }
+  60.000% { left: 179.31px; top: 65.76px; }
+  60.833% { left: 180.09px; top: 66.79px; }
+  61.667% { left: 180.87px; top: 67.83px; }
+  62.500% { left: 181.64px; top: 68.87px; }
+  63.333% { left: 182.39px; top: 69.93px; }
+  64.167% { left: 183.14px; top: 70.99px; }
+  65.000% { left: 183.88px; top: 72.05px; }
+  65.833% { left: 184.61px; top: 73.13px; }
+  66.667% { left: 185.33px; top: 74.21px; }
+  67.500% { left: 186.04px; top: 75.30px; }
+  68.333% { left: 186.74px; top: 76.40px; }
+  69.167% { left: 187.43px; top: 77.51px; }
+  70.000% { left: 188.11px; top: 78.62px; }
+  70.833% { left: 188.78px; top: 79.74px; }
+  71.667% { left: 189.44px; top: 80.87px; }
+  72.500% { left: 190.09px; top: 82.01px; }
+  73.333% { left: 190.73px; top: 83.15px; }
+  74.167% { left: 191.36px; top: 84.30px; }
+  75.000% { left: 191.98px; top: 85.46px; }
+  75.833% { left: 192.59px; top: 86.63px; }
+  76.667% { left: 193.19px; top: 87.80px; }
+  77.500% { left: 193.78px; top: 88.98px; }
+  78.333% { left: 194.36px; top: 90.17px; }
+  79.167% { left: 194.93px; top: 91.37px; }
+  80.000% { left: 195.49px; top: 92.58px; }
+  80.833% { left: 196.03px; top: 93.79px; }
+  81.667% { left: 196.57px; top: 95.01px; }
+  82.500% { left: 197.10px; top: 96.24px; }
+  83.333% { left: 197.61px; top: 97.48px; }
+  84.167% { left: 198.12px; top: 98.72px; }
+  85.000% { left: 198.61px; top: 99.98px; }
+  85.833% { left: 199.10px; top: 101.24px; }
+  86.667% { left: 199.57px; top: 102.51px; }
+  87.500% { left: 200.03px; top: 103.79px; }
+  88.333% { left: 200.48px; top: 105.08px; }
+  89.167% { left: 200.92px; top: 106.37px; }
+  90.000% { left: 201.35px; top: 107.68px; }
+  90.833% { left: 201.77px; top: 108.99px; }
+  91.667% { left: 202.17px; top: 110.32px; }
+  92.500% { left: 202.56px; top: 111.65px; }
+  93.333% { left: 202.94px; top: 112.99px; }
+  94.167% { left: 203.31px; top: 114.34px; }
+  95.000% { left: 203.67px; top: 115.70px; }
+  95.833% { left: 204.02px; top: 117.08px; }
+  96.667% { left: 204.35px; top: 118.46px; }
+  97.500% { left: 204.67px; top: 119.85px; }
+  98.333% { left: 204.97px; top: 121.26px; }
+  99.167% { left: 205.27px; top: 122.67px; }
+  100.000% { left: 205.55px; top: 124.10px; }
+}
+
+@keyframes jP {
+  0.000% { left: 172.38px; top: 85.82px; }
+  0.833% { left: 172.38px; top: 87.14px; }
+  1.667% { left: 172.38px; top: 88.45px; }
+  2.500% { left: 172.38px; top: 89.74px; }
+  3.333% { left: 172.38px; top: 91.02px; }
+  4.167% { left: 172.38px; top: 92.29px; }
+  5.000% { left: 172.37px; top: 93.54px; }
+  5.833% { left: 172.38px; top: 94.78px; }
+  6.667% { left: 172.38px; top: 96.01px; }
+  7.500% { left: 172.37px; top: 97.22px; }
+  8.333% { left: 172.38px; top: 98.43px; }
+  9.167% { left: 172.38px; top: 99.62px; }
+  10.000% { left: 172.38px; top: 100.80px; }
+  10.833% { left: 172.38px; top: 101.97px; }
+  11.667% { left: 172.38px; top: 103.13px; }
+  12.500% { left: 172.38px; top: 104.28px; }
+  13.333% { left: 172.38px; top: 105.42px; }
+  14.167% { left: 172.38px; top: 106.56px; }
+  15.000% { left: 172.37px; top: 107.68px; }
+  15.833% { left: 172.38px; top: 108.79px; }
+  16.667% { left: 172.38px; top: 109.90px; }
+  17.500% { left: 172.37px; top: 111.00px; }
+  18.333% { left: 172.38px; top: 112.09px; }
+  19.167% { left: 172.38px; top: 113.17px; }
+  20.000% { left: 172.38px; top: 114.25px; }
+  20.833% { left: 172.38px; top: 115.31px; }
+  21.667% { left: 172.38px; top: 116.38px; }
+  22.500% { left: 172.38px; top: 117.43px; }
+  23.333% { left: 172.38px; top: 118.48px; }
+  24.167% { left: 172.37px; top: 119.52px; }
+  25.000% { left: 172.38px; top: 120.56px; }
+  25.833% { left: 172.38px; top: 121.59px; }
+  26.667% { left: 172.37px; top: 122.62px; }
+  27.500% { left: 172.37px; top: 123.64px; }
+  28.333% { left: 172.38px; top: 124.66px; }
+  29.167% { left: 172.38px; top: 125.67px; }
+  30.000% { left: 172.37px; top: 126.68px; }
+  30.833% { left: 172.38px; top: 127.68px; }
+  31.667% { left: 172.38px; top: 128.68px; }
+  32.500% { left: 172.38px; top: 129.67px; }
+  33.333% { left: 172.38px; top: 130.66px; }
+  34.167% { left: 172.38px; top: 131.65px; }
+  35.000% { left: 172.38px; top: 132.64px; }
+  35.833% { left: 172.38px; top: 133.62px; }
+  36.667% { left: 172.37px; top: 134.60px; }
+  37.500% { left: 172.38px; top: 135.57px; }
+  38.333% { left: 172.37px; top: 136.55px; }
+  39.167% { left: 172.37px; top: 137.52px; }
+  40.000% { left: 172.38px; top: 138.49px; }
+  40.833% { left: 172.37px; top: 139.45px; }
+  41.667% { left: 172.38px; top: 140.42px; }
+  42.500% { left: 172.38px; top: 141.38px; }
+  43.333% { left: 172.37px; top: 142.34px; }
+  44.167% { left: 172.38px; top: 143.30px; }
+  45.000% { left: 172.38px; top: 144.26px; }
+  45.833% { left: 172.38px; top: 145.22px; }
+  46.667% { left: 172.38px; top: 146.18px; }
+  47.500% { left: 172.38px; top: 147.13px; }
+  48.333% { left: 172.38px; top: 148.09px; }
+  49.167% { left: 172.38px; top: 149.04px; }
+  50.000% { left: 172.38px; top: 150.00px; }
+  50.833% { left: 172.38px; top: 150.96px; }
+  51.667% { left: 172.38px; top: 151.91px; }
+  52.500% { left: 172.38px; top: 152.87px; }
+  53.333% { left: 172.38px; top: 153.82px; }
+  54.167% { left: 172.38px; top: 154.78px; }
+  55.000% { left: 172.38px; top: 155.74px; }
+  55.833% { left: 172.38px; top: 156.70px; }
+  56.667% { left: 172.37px; top: 157.66px; }
+  57.500% { left: 172.38px; top: 158.62px; }
+  58.333% { left: 172.38px; top: 159.58px; }
+  59.167% { left: 172.37px; top: 160.55px; }
+  60.000% { left: 172.38px; top: 161.51px; }
+  60.833% { left: 172.37px; top: 162.48px; }
+  61.667% { left: 172.37px; top: 163.45px; }
+  62.500% { left: 172.38px; top: 164.43px; }
+  63.333% { left: 172.37px; top: 165.40px; }
+  64.167% { left: 172.38px; top: 166.38px; }
+  65.000% { left: 172.38px; top: 167.36px; }
+  65.833% { left: 172.38px; top: 168.35px; }
+  66.667% { left: 172.38px; top: 169.34px; }
+  67.500% { left: 172.38px; top: 170.33px; }
+  68.333% { left: 172.38px; top: 171.32px; }
+  69.167% { left: 172.38px; top: 172.32px; }
+  70.000% { left: 172.37px; top: 173.32px; }
+  70.833% { left: 172.38px; top: 174.33px; }
+  71.667% { left: 172.38px; top: 175.34px; }
+  72.500% { left: 172.37px; top: 176.36px; }
+  73.333% { left: 172.37px; top: 177.38px; }
+  74.167% { left: 172.38px; top: 178.41px; }
+  75.000% { left: 172.38px; top: 179.44px; }
+  75.833% { left: 172.38px; top: 180.48px; }
+  76.667% { left: 172.38px; top: 181.52px; }
+  77.500% { left: 172.38px; top: 182.57px; }
+  78.333% { left: 172.38px; top: 183.62px; }
+  79.167% { left: 172.38px; top: 184.69px; }
+  80.000% { left: 172.38px; top: 185.75px; }
+  80.833% { left: 172.38px; top: 186.83px; }
+  81.667% { left: 172.38px; top: 187.91px; }
+  82.500% { left: 172.37px; top: 189.00px; }
+  83.333% { left: 172.38px; top: 190.10px; }
+  84.167% { left: 172.38px; top: 191.21px; }
+  85.000% { left: 172.37px; top: 192.32px; }
+  85.833% { left: 172.38px; top: 193.44px; }
+  86.667% { left: 172.38px; top: 194.58px; }
+  87.500% { left: 172.38px; top: 195.72px; }
+  88.333% { left: 172.38px; top: 196.87px; }
+  89.167% { left: 172.37px; top: 198.03px; }
+  90.000% { left: 172.37px; top: 199.20px; }
+  90.833% { left: 172.38px; top: 200.38px; }
+  91.667% { left: 172.38px; top: 201.57px; }
+  92.500% { left: 172.37px; top: 202.78px; }
+  93.333% { left: 172.38px; top: 203.99px; }
+  94.167% { left: 172.38px; top: 205.22px; }
+  95.000% { left: 172.37px; top: 206.46px; }
+  95.833% { left: 172.38px; top: 207.71px; }
+  96.667% { left: 172.38px; top: 208.98px; }
+  97.500% { left: 172.38px; top: 210.26px; }
+  98.333% { left: 172.38px; top: 211.55px; }
+  99.167% { left: 172.38px; top: 212.86px; }
+  100.000% { left: 172.38px; top: 214.18px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .barP,
+  .jointP,
+  .penP {
+    animation-play-state: paused;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/peaucellier-linkage-as/`, a self-contained pure CSS/HTML Peaucellier-Lipkin cell that turns rotation into an exact straight line.

Closes #49424

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

Peaucellier's 1864 linkage was the first machine to draw a mathematically exact straight line, using seven rigid bars and the geometry of inversion. Label the fixed pivot O, driven point B, output P: the mechanism holds `|OB| * |OP| = a^2 - b^2` constant, which is an inversion in a circle of radius sqrt(a^2 - b^2), and inversion turns a circle through the centre into a straight line.

- **The whole linkage is solved, then baked.** For each of 121 crank angles the five joint positions (O, A, B, C, P) are computed from the real inversion geometry, and each of the six bars gets keyframes for its position, length and angle.
- **The output is a genuine straight line, and it is measured.** The browser check drives the paused animation across 101 steps and tracks the pen's centre: its **x-coordinate varies by 0.016px** over the entire cycle while it sweeps **127px vertically**, staying within **0.02px** of the drawn guide. That is straight to within rounding, not an approximation like Watt's figure-eight.
- **The bars are actually rigid, and that is checked too.** The same sweep measures each bar's length at every frame: all six vary by at most **0.016px**. A linkage whose bars stretched would be cheating; these do not.
- **A dashed guide line** marks the exact straight path the pen follows.

## Accessibility

`prefers-reduced-motion: reduce` pauses the linkage, leaving a static pose with the pen on its line.

## Verification

Opened `demo.html` in the browser and measured the two things that make it a real straight-line linkage rather than a drawing of one: swept the paused animation and found the pen's x constant to 0.016px across the full cycle (with 127px of vertical travel), and confirmed all six bars hold constant length to 0.016px, so nothing stretches. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
