### PR TITLE
Add pantograph component

### DIFF
--- a/submissions/examples/pantograph-as/README.md
+++ b/submissions/examples/pantograph-as/README.md
@@ -1,0 +1,35 @@
+# Pantograph
+
+A pure CSS/HTML pantograph: four rigid bars that copy a traced shape at exactly twice the size.
+
+## What it shows
+
+A pantograph is a parallelogram of rigid bars with one corner pinned down. Move a pointer (the tracer) around a shape, and a pen at another corner draws the same shape scaled up, with no measuring and no error. It was patented by Christoph Scheiner in 1603 and was the standard way to enlarge or reduce drawings for three centuries; engravers, cartographers and forgers all relied on it, and the same linkage still steadies overhead power lines and camera rigs.
+
+The reason it works is a fixed geometric fact about parallelograms. In a parallelogram, the two diagonals bisect each other. So if the pivot sits at one corner O and the pen at the opposite corner P, the crossing point of the diagonals, T, is exactly the midpoint of the diagonal O–P. That means three things are true no matter how the linkage flexes:
+
+- **O, T, and P are always collinear**,
+- **|OP| = 2·|OT| exactly**, so the pen is always twice as far from the pivot as the tracer,
+- therefore the pen traces a copy of the tracer's path, at **exactly 2×**, right way up.
+
+Move the pivot to a different point along the bars and you get 3×, 5×, one-half, any ratio you like. This one is fixed at 2×.
+
+## How it is built
+
+- **The linkage is genuinely rigid, and it is solved.** For each of 121 tracer positions along a template triangle, the bar angles are found by two-bar inverse kinematics so that all four sides stay at their true lengths. Then each bar is keyframed for position, length and angle.
+- **Every claim is measured on the live DOM.** Driving the paused animation across 101 steps:
+  - **the four bars keep constant length**: every side varies by **0px**. Nothing stretches.
+  - **pivot, tracer and pen stay collinear**: worst deviation from the line is **0.01px**.
+  - **the ratio is exactly 2**: `|OP| / |OT|` holds at **2.0000** (worst deviation 0.0003) all the way round.
+- **The copy is shown against the original.** The tracer follows a small blue template triangle; the pen follows an orange triangle that is the same shape at 2× and positioned exactly where the geometry sends it. You can see the enlargement happen.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` pauses the linkage on a static pose with both triangles and the bars in place.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/pantograph-as/demo.html
+++ b/submissions/examples/pantograph-as/demo.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pantograph</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="gridN"></span>
+    <div class="fieldN">
+      <span class="tmplDot" style="left: 150.00px; top: 118.00px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 121.20px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 124.40px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 127.60px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 130.80px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 134.00px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 137.20px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 140.40px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 143.60px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 146.80px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 150.00px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 153.20px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 156.40px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 159.60px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 162.80px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 166.00px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 169.20px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 172.40px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 175.60px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 178.80px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 182.00px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 182.00px"></span>
+      <span class="tmplDot" style="left: 151.30px; top: 180.40px"></span>
+      <span class="tmplDot" style="left: 152.60px; top: 178.80px"></span>
+      <span class="tmplDot" style="left: 153.90px; top: 177.20px"></span>
+      <span class="tmplDot" style="left: 155.20px; top: 175.60px"></span>
+      <span class="tmplDot" style="left: 156.50px; top: 174.00px"></span>
+      <span class="tmplDot" style="left: 157.80px; top: 172.40px"></span>
+      <span class="tmplDot" style="left: 159.10px; top: 170.80px"></span>
+      <span class="tmplDot" style="left: 160.40px; top: 169.20px"></span>
+      <span class="tmplDot" style="left: 161.70px; top: 167.60px"></span>
+      <span class="tmplDot" style="left: 163.00px; top: 166.00px"></span>
+      <span class="tmplDot" style="left: 164.30px; top: 164.40px"></span>
+      <span class="tmplDot" style="left: 165.60px; top: 162.80px"></span>
+      <span class="tmplDot" style="left: 166.90px; top: 161.20px"></span>
+      <span class="tmplDot" style="left: 168.20px; top: 159.60px"></span>
+      <span class="tmplDot" style="left: 169.50px; top: 158.00px"></span>
+      <span class="tmplDot" style="left: 170.80px; top: 156.40px"></span>
+      <span class="tmplDot" style="left: 172.10px; top: 154.80px"></span>
+      <span class="tmplDot" style="left: 173.40px; top: 153.20px"></span>
+      <span class="tmplDot" style="left: 174.70px; top: 151.60px"></span>
+      <span class="tmplDot" style="left: 176.00px; top: 150.00px"></span>
+      <span class="tmplDot" style="left: 176.00px; top: 150.00px"></span>
+      <span class="tmplDot" style="left: 174.70px; top: 148.40px"></span>
+      <span class="tmplDot" style="left: 173.40px; top: 146.80px"></span>
+      <span class="tmplDot" style="left: 172.10px; top: 145.20px"></span>
+      <span class="tmplDot" style="left: 170.80px; top: 143.60px"></span>
+      <span class="tmplDot" style="left: 169.50px; top: 142.00px"></span>
+      <span class="tmplDot" style="left: 168.20px; top: 140.40px"></span>
+      <span class="tmplDot" style="left: 166.90px; top: 138.80px"></span>
+      <span class="tmplDot" style="left: 165.60px; top: 137.20px"></span>
+      <span class="tmplDot" style="left: 164.30px; top: 135.60px"></span>
+      <span class="tmplDot" style="left: 163.00px; top: 134.00px"></span>
+      <span class="tmplDot" style="left: 161.70px; top: 132.40px"></span>
+      <span class="tmplDot" style="left: 160.40px; top: 130.80px"></span>
+      <span class="tmplDot" style="left: 159.10px; top: 129.20px"></span>
+      <span class="tmplDot" style="left: 157.80px; top: 127.60px"></span>
+      <span class="tmplDot" style="left: 156.50px; top: 126.00px"></span>
+      <span class="tmplDot" style="left: 155.20px; top: 124.40px"></span>
+      <span class="tmplDot" style="left: 153.90px; top: 122.80px"></span>
+      <span class="tmplDot" style="left: 152.60px; top: 121.20px"></span>
+      <span class="tmplDot" style="left: 151.30px; top: 119.60px"></span>
+      <span class="tmplDot" style="left: 150.00px; top: 118.00px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 86.00px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 92.40px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 98.80px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 105.20px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 111.60px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 118.00px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 124.40px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 130.80px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 137.20px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 143.60px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 150.00px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 156.40px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 162.80px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 169.20px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 175.60px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 182.00px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 188.40px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 194.80px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 201.20px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 207.60px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 214.00px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 214.00px"></span>
+      <span class="copyDot" style="left: 214.60px; top: 210.80px"></span>
+      <span class="copyDot" style="left: 217.20px; top: 207.60px"></span>
+      <span class="copyDot" style="left: 219.80px; top: 204.40px"></span>
+      <span class="copyDot" style="left: 222.40px; top: 201.20px"></span>
+      <span class="copyDot" style="left: 225.00px; top: 198.00px"></span>
+      <span class="copyDot" style="left: 227.60px; top: 194.80px"></span>
+      <span class="copyDot" style="left: 230.20px; top: 191.60px"></span>
+      <span class="copyDot" style="left: 232.80px; top: 188.40px"></span>
+      <span class="copyDot" style="left: 235.40px; top: 185.20px"></span>
+      <span class="copyDot" style="left: 238.00px; top: 182.00px"></span>
+      <span class="copyDot" style="left: 240.60px; top: 178.80px"></span>
+      <span class="copyDot" style="left: 243.20px; top: 175.60px"></span>
+      <span class="copyDot" style="left: 245.80px; top: 172.40px"></span>
+      <span class="copyDot" style="left: 248.40px; top: 169.20px"></span>
+      <span class="copyDot" style="left: 251.00px; top: 166.00px"></span>
+      <span class="copyDot" style="left: 253.60px; top: 162.80px"></span>
+      <span class="copyDot" style="left: 256.20px; top: 159.60px"></span>
+      <span class="copyDot" style="left: 258.80px; top: 156.40px"></span>
+      <span class="copyDot" style="left: 261.40px; top: 153.20px"></span>
+      <span class="copyDot" style="left: 264.00px; top: 150.00px"></span>
+      <span class="copyDot" style="left: 264.00px; top: 150.00px"></span>
+      <span class="copyDot" style="left: 261.40px; top: 146.80px"></span>
+      <span class="copyDot" style="left: 258.80px; top: 143.60px"></span>
+      <span class="copyDot" style="left: 256.20px; top: 140.40px"></span>
+      <span class="copyDot" style="left: 253.60px; top: 137.20px"></span>
+      <span class="copyDot" style="left: 251.00px; top: 134.00px"></span>
+      <span class="copyDot" style="left: 248.40px; top: 130.80px"></span>
+      <span class="copyDot" style="left: 245.80px; top: 127.60px"></span>
+      <span class="copyDot" style="left: 243.20px; top: 124.40px"></span>
+      <span class="copyDot" style="left: 240.60px; top: 121.20px"></span>
+      <span class="copyDot" style="left: 238.00px; top: 118.00px"></span>
+      <span class="copyDot" style="left: 235.40px; top: 114.80px"></span>
+      <span class="copyDot" style="left: 232.80px; top: 111.60px"></span>
+      <span class="copyDot" style="left: 230.20px; top: 108.40px"></span>
+      <span class="copyDot" style="left: 227.60px; top: 105.20px"></span>
+      <span class="copyDot" style="left: 225.00px; top: 102.00px"></span>
+      <span class="copyDot" style="left: 222.40px; top: 98.80px"></span>
+      <span class="copyDot" style="left: 219.80px; top: 95.60px"></span>
+      <span class="copyDot" style="left: 217.20px; top: 92.40px"></span>
+      <span class="copyDot" style="left: 214.60px; top: 89.20px"></span>
+      <span class="copyDot" style="left: 212.00px; top: 86.00px"></span>
+      <span class="barN barOA"></span>
+      <span class="barN barAP"></span>
+      <span class="barN barPB"></span>
+      <span class="barN barBO"></span>
+      <span class="jointN jA"></span>
+      <span class="jointN jB"></span>
+      <span class="pivotN"></span>
+      <span class="tracerN jT"></span>
+      <span class="penN jP"></span>
+    </div>
+    <span class="tagN">pen copies tracer at exactly 2x</span>
+    <span class="capN">rigid bars, collinear pivot-tracer-pen, fixed ratio</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/pantograph-as/style.css
+++ b/submissions/examples/pantograph-as/style.css
@@ -1,0 +1,1147 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #2f2a22, #080705 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 44% 36%, #4a4232, #12100a 86%);
+}
+
+.gridN {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(90deg, rgba(210, 180, 120, 0.05) 0 1px, transparent 1px 24px),
+    repeating-linear-gradient(0deg, rgba(210, 180, 120, 0.05) 0 1px, transparent 1px 24px);
+  z-index: 1;
+}
+
+.fieldN { position: absolute; inset: 0; z-index: 2; }
+
+.tmplDot {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 50%;
+  background: rgba(120, 200, 255, 0.6);
+  z-index: 3;
+}
+
+.copyDot {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 50%;
+  background: rgba(255, 190, 90, 0.55);
+  z-index: 3;
+}
+
+/*
+  the four rigid bars of a parallelogram pantograph. the pivot O, the tracer T
+  (at the parallelogram diagonal midpoint) and the pen P (opposite vertex) are
+  always collinear, and |OP| = 2|OT| exactly, so the pen draws a copy of what
+  the tracer follows, at twice the size.
+*/
+.barN {
+  position: absolute;
+  height: 5px;
+  margin-top: -2.5px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #e8d4a0, #7a6238);
+  transform-origin: 0 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  z-index: 4;
+}
+
+.barOA { animation: barOA 7s linear infinite; }
+.barAP { animation: barAP 7s linear infinite; }
+.barPB { animation: barPB 7s linear infinite; }
+.barBO { animation: barBO 7s linear infinite; }
+
+.jointN {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  margin: -5px 0 0 -5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f4ecd0, #5f5230 76%);
+  box-shadow: 0 0 0 2px rgba(30, 24, 12, 0.7);
+  z-index: 6;
+}
+
+.jA { animation: jA 7s linear infinite; }
+.jB { animation: jB 7s linear infinite; }
+
+.pivotN {
+  position: absolute;
+  left: 88.0px;
+  top: 150.0px;
+  width: 14px;
+  height: 14px;
+  margin: -7px 0 0 -7px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #d8d8d8, #4a4a4a 74%);
+  box-shadow: 0 0 0 3px rgba(20, 20, 20, 0.8);
+  z-index: 7;
+}
+
+.tracerN {
+  position: absolute;
+  width: 11px;
+  height: 11px;
+  margin: -5.5px 0 0 -5.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #d8f0ff, #1a78c8 66%);
+  box-shadow: 0 0 8px rgba(90, 190, 255, 0.9);
+  z-index: 8;
+  animation: jT 7s linear infinite;
+}
+
+.penN {
+  position: absolute;
+  width: 13px;
+  height: 13px;
+  margin: -6.5px 0 0 -6.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #fff0c0, #d8880e 66%);
+  box-shadow: 0 0 10px rgba(255, 190, 60, 0.9);
+  z-index: 8;
+  animation: jP 7s linear infinite;
+}
+
+.tagN {
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  font-size: 0.52rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 214, 140, 0.9);
+  z-index: 9;
+}
+
+.capN {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.04em;
+  color: rgba(235, 224, 200, 0.82);
+  z-index: 9;
+}
+
+@keyframes barOA {
+  0.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(20.57deg); }
+  0.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(22.28deg); }
+  1.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(23.99deg); }
+  2.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(25.70deg); }
+  3.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(27.40deg); }
+  4.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(29.10deg); }
+  5.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(30.80deg); }
+  5.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.49deg); }
+  6.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(34.18deg); }
+  7.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(35.86deg); }
+  8.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(37.53deg); }
+  9.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(39.19deg); }
+  10.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(40.84deg); }
+  10.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(42.47deg); }
+  11.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(44.09deg); }
+  12.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(45.70deg); }
+  13.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(47.29deg); }
+  14.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(48.85deg); }
+  15.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(50.39deg); }
+  15.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(51.91deg); }
+  16.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(53.41deg); }
+  17.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(54.87deg); }
+  18.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(56.30deg); }
+  19.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(57.70deg); }
+  20.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(59.07deg); }
+  20.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(60.40deg); }
+  21.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(61.70deg); }
+  22.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(62.95deg); }
+  23.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(64.17deg); }
+  24.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(65.34deg); }
+  25.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(66.47deg); }
+  25.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(67.55deg); }
+  26.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(68.59deg); }
+  27.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(69.58deg); }
+  28.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(70.53deg); }
+  29.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(71.42deg); }
+  30.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(72.27deg); }
+  30.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(73.07deg); }
+  31.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(73.82deg); }
+  32.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(74.52deg); }
+  33.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(75.16deg); }
+  34.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(74.18deg); }
+  35.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(73.18deg); }
+  35.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(72.18deg); }
+  36.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(71.18deg); }
+  37.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(70.17deg); }
+  38.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(69.15deg); }
+  39.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(68.13deg); }
+  40.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(67.11deg); }
+  40.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(66.08deg); }
+  41.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(65.05deg); }
+  42.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(64.01deg); }
+  43.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(62.97deg); }
+  44.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(61.93deg); }
+  45.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(60.88deg); }
+  45.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(59.83deg); }
+  46.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(58.78deg); }
+  47.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(57.72deg); }
+  48.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(56.66deg); }
+  49.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(55.60deg); }
+  50.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(54.53deg); }
+  50.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(53.46deg); }
+  51.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(52.39deg); }
+  52.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(51.31deg); }
+  53.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(50.23deg); }
+  54.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(49.15deg); }
+  55.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(48.06deg); }
+  55.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(46.97deg); }
+  56.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(45.87deg); }
+  57.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(44.77deg); }
+  58.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(43.66deg); }
+  59.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(42.55deg); }
+  60.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(41.43deg); }
+  60.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(40.31deg); }
+  61.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(39.17deg); }
+  62.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(38.03deg); }
+  63.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(36.89deg); }
+  64.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(35.73deg); }
+  65.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(34.57deg); }
+  65.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(33.39deg); }
+  66.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.20deg); }
+  67.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.34deg); }
+  68.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.45deg); }
+  69.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.54deg); }
+  70.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.60deg); }
+  70.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.63deg); }
+  71.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.64deg); }
+  72.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.63deg); }
+  73.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.59deg); }
+  74.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.53deg); }
+  75.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.45deg); }
+  75.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.34deg); }
+  76.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.22deg); }
+  77.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(32.07deg); }
+  78.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(31.90deg); }
+  79.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(31.71deg); }
+  80.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(31.50deg); }
+  80.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(31.27deg); }
+  81.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(31.02deg); }
+  82.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(30.74deg); }
+  83.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(30.45deg); }
+  84.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(30.14deg); }
+  85.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(29.80deg); }
+  85.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(29.45deg); }
+  86.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(29.07deg); }
+  87.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(28.68deg); }
+  88.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(28.27deg); }
+  89.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(27.84deg); }
+  90.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(27.39deg); }
+  90.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(26.92deg); }
+  91.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(26.43deg); }
+  92.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(25.93deg); }
+  93.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(25.40deg); }
+  94.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(24.86deg); }
+  95.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(24.30deg); }
+  95.833% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(23.72deg); }
+  96.667% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(23.12deg); }
+  97.500% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(22.51deg); }
+  98.333% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(21.88deg); }
+  99.167% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(21.23deg); }
+  100.000% { left: 88.00px; top: 150.00px; width: 104.00px; transform: rotate(20.57deg); }
+}
+
+@keyframes barAP {
+  0.000% { left: 185.37px; top: 186.53px; width: 104.00px; transform: rotate(-75.16deg); }
+  0.833% { left: 184.24px; top: 189.43px; width: 104.00px; transform: rotate(-74.52deg); }
+  1.667% { left: 183.02px; top: 192.28px; width: 104.00px; transform: rotate(-73.82deg); }
+  2.500% { left: 181.72px; top: 195.09px; width: 104.00px; transform: rotate(-73.07deg); }
+  3.333% { left: 180.33px; top: 197.86px; width: 104.00px; transform: rotate(-72.27deg); }
+  4.167% { left: 178.87px; top: 200.58px; width: 104.00px; transform: rotate(-71.42deg); }
+  5.000% { left: 177.33px; top: 203.25px; width: 104.00px; transform: rotate(-70.53deg); }
+  5.833% { left: 175.72px; top: 205.87px; width: 104.00px; transform: rotate(-69.58deg); }
+  6.667% { left: 174.04px; top: 208.42px; width: 104.00px; transform: rotate(-68.59deg); }
+  7.500% { left: 172.29px; top: 210.92px; width: 104.00px; transform: rotate(-67.55deg); }
+  8.333% { left: 170.48px; top: 213.35px; width: 104.00px; transform: rotate(-66.47deg); }
+  9.167% { left: 168.61px; top: 215.71px; width: 104.00px; transform: rotate(-65.34deg); }
+  10.000% { left: 166.68px; top: 218.01px; width: 104.00px; transform: rotate(-64.17deg); }
+  10.833% { left: 164.71px; top: 220.23px; width: 104.00px; transform: rotate(-62.95deg); }
+  11.667% { left: 162.69px; top: 222.37px; width: 104.00px; transform: rotate(-61.70deg); }
+  12.500% { left: 160.64px; top: 224.43px; width: 104.00px; transform: rotate(-60.40deg); }
+  13.333% { left: 158.55px; top: 226.41px; width: 104.00px; transform: rotate(-59.07deg); }
+  14.167% { left: 156.43px; top: 228.31px; width: 104.00px; transform: rotate(-57.70deg); }
+  15.000% { left: 154.30px; top: 230.13px; width: 104.00px; transform: rotate(-56.30deg); }
+  15.833% { left: 152.15px; top: 231.86px; width: 104.00px; transform: rotate(-54.87deg); }
+  16.667% { left: 150.00px; top: 233.50px; width: 104.00px; transform: rotate(-53.41deg); }
+  17.500% { left: 147.85px; top: 235.06px; width: 104.00px; transform: rotate(-51.91deg); }
+  18.333% { left: 145.70px; top: 236.53px; width: 104.00px; transform: rotate(-50.39deg); }
+  19.167% { left: 143.57px; top: 237.91px; width: 104.00px; transform: rotate(-48.85deg); }
+  20.000% { left: 141.45px; top: 239.21px; width: 104.00px; transform: rotate(-47.29deg); }
+  20.833% { left: 139.36px; top: 240.43px; width: 104.00px; transform: rotate(-45.70deg); }
+  21.667% { left: 137.31px; top: 241.57px; width: 104.00px; transform: rotate(-44.09deg); }
+  22.500% { left: 135.29px; top: 242.63px; width: 104.00px; transform: rotate(-42.47deg); }
+  23.333% { left: 133.32px; top: 243.61px; width: 104.00px; transform: rotate(-40.84deg); }
+  24.167% { left: 131.39px; top: 244.51px; width: 104.00px; transform: rotate(-39.19deg); }
+  25.000% { left: 129.52px; top: 245.35px; width: 104.00px; transform: rotate(-37.53deg); }
+  25.833% { left: 127.71px; top: 246.12px; width: 104.00px; transform: rotate(-35.86deg); }
+  26.667% { left: 125.96px; top: 246.82px; width: 104.00px; transform: rotate(-34.18deg); }
+  27.500% { left: 124.28px; top: 247.47px; width: 104.00px; transform: rotate(-32.49deg); }
+  28.333% { left: 122.67px; top: 248.05px; width: 104.00px; transform: rotate(-30.80deg); }
+  29.167% { left: 121.13px; top: 248.58px; width: 104.00px; transform: rotate(-29.10deg); }
+  30.000% { left: 119.67px; top: 249.06px; width: 104.00px; transform: rotate(-27.40deg); }
+  30.833% { left: 118.28px; top: 249.49px; width: 104.00px; transform: rotate(-25.70deg); }
+  31.667% { left: 116.98px; top: 249.88px; width: 104.00px; transform: rotate(-23.99deg); }
+  32.500% { left: 115.76px; top: 250.23px; width: 104.00px; transform: rotate(-22.28deg); }
+  33.333% { left: 114.63px; top: 250.53px; width: 104.00px; transform: rotate(-20.57deg); }
+  34.167% { left: 116.36px; top: 250.06px; width: 104.00px; transform: rotate(-21.23deg); }
+  35.000% { left: 118.09px; top: 249.55px; width: 104.00px; transform: rotate(-21.88deg); }
+  35.833% { left: 119.82px; top: 249.01px; width: 104.00px; transform: rotate(-22.51deg); }
+  36.667% { left: 121.55px; top: 248.44px; width: 104.00px; transform: rotate(-23.12deg); }
+  37.500% { left: 123.28px; top: 247.83px; width: 104.00px; transform: rotate(-23.72deg); }
+  38.333% { left: 125.01px; top: 247.19px; width: 104.00px; transform: rotate(-24.30deg); }
+  39.167% { left: 126.73px; top: 246.52px; width: 104.00px; transform: rotate(-24.86deg); }
+  40.000% { left: 128.45px; top: 245.81px; width: 104.00px; transform: rotate(-25.40deg); }
+  40.833% { left: 130.17px; top: 245.07px; width: 104.00px; transform: rotate(-25.93deg); }
+  41.667% { left: 131.87px; top: 244.29px; width: 104.00px; transform: rotate(-26.43deg); }
+  42.500% { left: 133.57px; top: 243.49px; width: 104.00px; transform: rotate(-26.92deg); }
+  43.333% { left: 135.26px; top: 242.64px; width: 104.00px; transform: rotate(-27.39deg); }
+  44.167% { left: 136.94px; top: 241.77px; width: 104.00px; transform: rotate(-27.84deg); }
+  45.000% { left: 138.60px; top: 240.86px; width: 104.00px; transform: rotate(-28.27deg); }
+  45.833% { left: 140.26px; top: 239.92px; width: 104.00px; transform: rotate(-28.68deg); }
+  46.667% { left: 141.91px; top: 238.94px; width: 104.00px; transform: rotate(-29.07deg); }
+  47.500% { left: 143.54px; top: 237.93px; width: 104.00px; transform: rotate(-29.45deg); }
+  48.333% { left: 145.15px; top: 236.89px; width: 104.00px; transform: rotate(-29.80deg); }
+  49.167% { left: 146.76px; top: 235.81px; width: 104.00px; transform: rotate(-30.14deg); }
+  50.000% { left: 148.34px; top: 234.70px; width: 104.00px; transform: rotate(-30.45deg); }
+  50.833% { left: 149.91px; top: 233.56px; width: 104.00px; transform: rotate(-30.74deg); }
+  51.667% { left: 151.47px; top: 232.39px; width: 104.00px; transform: rotate(-31.02deg); }
+  52.500% { left: 153.01px; top: 231.18px; width: 104.00px; transform: rotate(-31.27deg); }
+  53.333% { left: 154.53px; top: 229.94px; width: 104.00px; transform: rotate(-31.50deg); }
+  54.167% { left: 156.03px; top: 228.67px; width: 104.00px; transform: rotate(-31.71deg); }
+  55.000% { left: 157.51px; top: 227.36px; width: 104.00px; transform: rotate(-31.90deg); }
+  55.833% { left: 158.97px; top: 226.02px; width: 104.00px; transform: rotate(-32.07deg); }
+  56.667% { left: 160.41px; top: 224.65px; width: 104.00px; transform: rotate(-32.22deg); }
+  57.500% { left: 161.84px; top: 223.24px; width: 104.00px; transform: rotate(-32.34deg); }
+  58.333% { left: 163.24px; top: 221.80px; width: 104.00px; transform: rotate(-32.45deg); }
+  59.167% { left: 164.62px; top: 220.33px; width: 104.00px; transform: rotate(-32.53deg); }
+  60.000% { left: 165.98px; top: 218.82px; width: 104.00px; transform: rotate(-32.59deg); }
+  60.833% { left: 167.31px; top: 217.27px; width: 104.00px; transform: rotate(-32.63deg); }
+  61.667% { left: 168.62px; top: 215.69px; width: 104.00px; transform: rotate(-32.64deg); }
+  62.500% { left: 169.91px; top: 214.08px; width: 104.00px; transform: rotate(-32.63deg); }
+  63.333% { left: 171.18px; top: 212.43px; width: 104.00px; transform: rotate(-32.60deg); }
+  64.167% { left: 172.42px; top: 210.74px; width: 104.00px; transform: rotate(-32.54deg); }
+  65.000% { left: 173.64px; top: 209.01px; width: 104.00px; transform: rotate(-32.45deg); }
+  65.833% { left: 174.83px; top: 207.24px; width: 104.00px; transform: rotate(-32.34deg); }
+  66.667% { left: 176.00px; top: 205.43px; width: 104.00px; transform: rotate(-32.20deg); }
+  67.500% { left: 175.87px; top: 205.64px; width: 104.00px; transform: rotate(-33.39deg); }
+  68.333% { left: 175.76px; top: 205.81px; width: 104.00px; transform: rotate(-34.57deg); }
+  69.167% { left: 175.68px; top: 205.94px; width: 104.00px; transform: rotate(-35.73deg); }
+  70.000% { left: 175.62px; top: 206.03px; width: 104.00px; transform: rotate(-36.89deg); }
+  70.833% { left: 175.59px; top: 206.08px; width: 104.00px; transform: rotate(-38.03deg); }
+  71.667% { left: 175.58px; top: 206.09px; width: 104.00px; transform: rotate(-39.17deg); }
+  72.500% { left: 175.59px; top: 206.07px; width: 104.00px; transform: rotate(-40.31deg); }
+  73.333% { left: 175.62px; top: 206.02px; width: 104.00px; transform: rotate(-41.43deg); }
+  74.167% { left: 175.68px; top: 205.93px; width: 104.00px; transform: rotate(-42.55deg); }
+  75.000% { left: 175.76px; top: 205.80px; width: 104.00px; transform: rotate(-43.66deg); }
+  75.833% { left: 175.86px; top: 205.64px; width: 104.00px; transform: rotate(-44.77deg); }
+  76.667% { left: 175.99px; top: 205.45px; width: 104.00px; transform: rotate(-45.87deg); }
+  77.500% { left: 176.13px; top: 205.22px; width: 104.00px; transform: rotate(-46.97deg); }
+  78.333% { left: 176.29px; top: 204.96px; width: 104.00px; transform: rotate(-48.06deg); }
+  79.167% { left: 176.47px; top: 204.67px; width: 104.00px; transform: rotate(-49.15deg); }
+  80.000% { left: 176.67px; top: 204.34px; width: 104.00px; transform: rotate(-50.23deg); }
+  80.833% { left: 176.89px; top: 203.98px; width: 104.00px; transform: rotate(-51.31deg); }
+  81.667% { left: 177.13px; top: 203.59px; width: 104.00px; transform: rotate(-52.39deg); }
+  82.500% { left: 177.39px; top: 203.16px; width: 104.00px; transform: rotate(-53.46deg); }
+  83.333% { left: 177.66px; top: 202.70px; width: 104.00px; transform: rotate(-54.53deg); }
+  84.167% { left: 177.94px; top: 202.21px; width: 104.00px; transform: rotate(-55.60deg); }
+  85.000% { left: 178.25px; top: 201.69px; width: 104.00px; transform: rotate(-56.66deg); }
+  85.833% { left: 178.56px; top: 201.13px; width: 104.00px; transform: rotate(-57.72deg); }
+  86.667% { left: 178.89px; top: 200.54px; width: 104.00px; transform: rotate(-58.78deg); }
+  87.500% { left: 179.24px; top: 199.92px; width: 104.00px; transform: rotate(-59.83deg); }
+  88.333% { left: 179.60px; top: 199.26px; width: 104.00px; transform: rotate(-60.88deg); }
+  89.167% { left: 179.96px; top: 198.57px; width: 104.00px; transform: rotate(-61.93deg); }
+  90.000% { left: 180.34px; top: 197.84px; width: 104.00px; transform: rotate(-62.97deg); }
+  90.833% { left: 180.73px; top: 197.09px; width: 104.00px; transform: rotate(-64.01deg); }
+  91.667% { left: 181.13px; top: 196.29px; width: 104.00px; transform: rotate(-65.05deg); }
+  92.500% { left: 181.53px; top: 195.47px; width: 104.00px; transform: rotate(-66.08deg); }
+  93.333% { left: 181.95px; top: 194.61px; width: 104.00px; transform: rotate(-67.11deg); }
+  94.167% { left: 182.37px; top: 193.72px; width: 104.00px; transform: rotate(-68.13deg); }
+  95.000% { left: 182.79px; top: 192.79px; width: 104.00px; transform: rotate(-69.15deg); }
+  95.833% { left: 183.22px; top: 191.83px; width: 104.00px; transform: rotate(-70.17deg); }
+  96.667% { left: 183.65px; top: 190.84px; width: 104.00px; transform: rotate(-71.18deg); }
+  97.500% { left: 184.08px; top: 189.81px; width: 104.00px; transform: rotate(-72.18deg); }
+  98.333% { left: 184.51px; top: 188.75px; width: 104.00px; transform: rotate(-73.18deg); }
+  99.167% { left: 184.94px; top: 187.66px; width: 104.00px; transform: rotate(-74.18deg); }
+  100.000% { left: 185.37px; top: 186.53px; width: 104.00px; transform: rotate(-75.16deg); }
+}
+
+@keyframes barPB {
+  0.000% { left: 212.00px; top: 86.00px; width: 104.00px; transform: rotate(-159.43deg); }
+  0.833% { left: 212.00px; top: 89.20px; width: 104.00px; transform: rotate(-157.72deg); }
+  1.667% { left: 212.00px; top: 92.40px; width: 104.00px; transform: rotate(-156.01deg); }
+  2.500% { left: 212.00px; top: 95.60px; width: 104.00px; transform: rotate(-154.30deg); }
+  3.333% { left: 212.00px; top: 98.80px; width: 104.00px; transform: rotate(-152.60deg); }
+  4.167% { left: 212.00px; top: 102.00px; width: 104.00px; transform: rotate(-150.90deg); }
+  5.000% { left: 212.00px; top: 105.20px; width: 104.00px; transform: rotate(-149.20deg); }
+  5.833% { left: 212.00px; top: 108.40px; width: 104.00px; transform: rotate(-147.51deg); }
+  6.667% { left: 212.00px; top: 111.60px; width: 104.00px; transform: rotate(-145.82deg); }
+  7.500% { left: 212.00px; top: 114.80px; width: 104.00px; transform: rotate(-144.14deg); }
+  8.333% { left: 212.00px; top: 118.00px; width: 104.00px; transform: rotate(-142.47deg); }
+  9.167% { left: 212.00px; top: 121.20px; width: 104.00px; transform: rotate(-140.81deg); }
+  10.000% { left: 212.00px; top: 124.40px; width: 104.00px; transform: rotate(-139.16deg); }
+  10.833% { left: 212.00px; top: 127.60px; width: 104.00px; transform: rotate(-137.53deg); }
+  11.667% { left: 212.00px; top: 130.80px; width: 104.00px; transform: rotate(-135.91deg); }
+  12.500% { left: 212.00px; top: 134.00px; width: 104.00px; transform: rotate(-134.30deg); }
+  13.333% { left: 212.00px; top: 137.20px; width: 104.00px; transform: rotate(-132.71deg); }
+  14.167% { left: 212.00px; top: 140.40px; width: 104.00px; transform: rotate(-131.15deg); }
+  15.000% { left: 212.00px; top: 143.60px; width: 104.00px; transform: rotate(-129.61deg); }
+  15.833% { left: 212.00px; top: 146.80px; width: 104.00px; transform: rotate(-128.09deg); }
+  16.667% { left: 212.00px; top: 150.00px; width: 104.00px; transform: rotate(-126.59deg); }
+  17.500% { left: 212.00px; top: 153.20px; width: 104.00px; transform: rotate(-125.13deg); }
+  18.333% { left: 212.00px; top: 156.40px; width: 104.00px; transform: rotate(-123.70deg); }
+  19.167% { left: 212.00px; top: 159.60px; width: 104.00px; transform: rotate(-122.30deg); }
+  20.000% { left: 212.00px; top: 162.80px; width: 104.00px; transform: rotate(-120.93deg); }
+  20.833% { left: 212.00px; top: 166.00px; width: 104.00px; transform: rotate(-119.60deg); }
+  21.667% { left: 212.00px; top: 169.20px; width: 104.00px; transform: rotate(-118.30deg); }
+  22.500% { left: 212.00px; top: 172.40px; width: 104.00px; transform: rotate(-117.05deg); }
+  23.333% { left: 212.00px; top: 175.60px; width: 104.00px; transform: rotate(-115.83deg); }
+  24.167% { left: 212.00px; top: 178.80px; width: 104.00px; transform: rotate(-114.66deg); }
+  25.000% { left: 212.00px; top: 182.00px; width: 104.00px; transform: rotate(-113.53deg); }
+  25.833% { left: 212.00px; top: 185.20px; width: 104.00px; transform: rotate(-112.45deg); }
+  26.667% { left: 212.00px; top: 188.40px; width: 104.00px; transform: rotate(-111.41deg); }
+  27.500% { left: 212.00px; top: 191.60px; width: 104.00px; transform: rotate(-110.42deg); }
+  28.333% { left: 212.00px; top: 194.80px; width: 104.00px; transform: rotate(-109.47deg); }
+  29.167% { left: 212.00px; top: 198.00px; width: 104.00px; transform: rotate(-108.58deg); }
+  30.000% { left: 212.00px; top: 201.20px; width: 104.00px; transform: rotate(-107.73deg); }
+  30.833% { left: 212.00px; top: 204.40px; width: 104.00px; transform: rotate(-106.93deg); }
+  31.667% { left: 212.00px; top: 207.60px; width: 104.00px; transform: rotate(-106.18deg); }
+  32.500% { left: 212.00px; top: 210.80px; width: 104.00px; transform: rotate(-105.48deg); }
+  33.333% { left: 212.00px; top: 214.00px; width: 104.00px; transform: rotate(-104.84deg); }
+  34.167% { left: 213.30px; top: 212.40px; width: 104.00px; transform: rotate(-105.82deg); }
+  35.000% { left: 214.60px; top: 210.80px; width: 104.00px; transform: rotate(-106.82deg); }
+  35.833% { left: 215.90px; top: 209.20px; width: 104.00px; transform: rotate(-107.82deg); }
+  36.667% { left: 217.20px; top: 207.60px; width: 104.00px; transform: rotate(-108.82deg); }
+  37.500% { left: 218.50px; top: 206.00px; width: 104.00px; transform: rotate(-109.83deg); }
+  38.333% { left: 219.80px; top: 204.40px; width: 104.00px; transform: rotate(-110.85deg); }
+  39.167% { left: 221.10px; top: 202.80px; width: 104.00px; transform: rotate(-111.87deg); }
+  40.000% { left: 222.40px; top: 201.20px; width: 104.00px; transform: rotate(-112.89deg); }
+  40.833% { left: 223.70px; top: 199.60px; width: 104.00px; transform: rotate(-113.92deg); }
+  41.667% { left: 225.00px; top: 198.00px; width: 104.00px; transform: rotate(-114.95deg); }
+  42.500% { left: 226.30px; top: 196.40px; width: 104.00px; transform: rotate(-115.99deg); }
+  43.333% { left: 227.60px; top: 194.80px; width: 104.00px; transform: rotate(-117.03deg); }
+  44.167% { left: 228.90px; top: 193.20px; width: 104.00px; transform: rotate(-118.07deg); }
+  45.000% { left: 230.20px; top: 191.60px; width: 104.00px; transform: rotate(-119.12deg); }
+  45.833% { left: 231.50px; top: 190.00px; width: 104.00px; transform: rotate(-120.17deg); }
+  46.667% { left: 232.80px; top: 188.40px; width: 104.00px; transform: rotate(-121.22deg); }
+  47.500% { left: 234.10px; top: 186.80px; width: 104.00px; transform: rotate(-122.28deg); }
+  48.333% { left: 235.40px; top: 185.20px; width: 104.00px; transform: rotate(-123.34deg); }
+  49.167% { left: 236.70px; top: 183.60px; width: 104.00px; transform: rotate(-124.40deg); }
+  50.000% { left: 238.00px; top: 182.00px; width: 104.00px; transform: rotate(-125.47deg); }
+  50.833% { left: 239.30px; top: 180.40px; width: 104.00px; transform: rotate(-126.54deg); }
+  51.667% { left: 240.60px; top: 178.80px; width: 104.00px; transform: rotate(-127.61deg); }
+  52.500% { left: 241.90px; top: 177.20px; width: 104.00px; transform: rotate(-128.69deg); }
+  53.333% { left: 243.20px; top: 175.60px; width: 104.00px; transform: rotate(-129.77deg); }
+  54.167% { left: 244.50px; top: 174.00px; width: 104.00px; transform: rotate(-130.85deg); }
+  55.000% { left: 245.80px; top: 172.40px; width: 104.00px; transform: rotate(-131.94deg); }
+  55.833% { left: 247.10px; top: 170.80px; width: 104.00px; transform: rotate(-133.03deg); }
+  56.667% { left: 248.40px; top: 169.20px; width: 104.00px; transform: rotate(-134.13deg); }
+  57.500% { left: 249.70px; top: 167.60px; width: 104.00px; transform: rotate(-135.23deg); }
+  58.333% { left: 251.00px; top: 166.00px; width: 104.00px; transform: rotate(-136.34deg); }
+  59.167% { left: 252.30px; top: 164.40px; width: 104.00px; transform: rotate(-137.45deg); }
+  60.000% { left: 253.60px; top: 162.80px; width: 104.00px; transform: rotate(-138.57deg); }
+  60.833% { left: 254.90px; top: 161.20px; width: 104.00px; transform: rotate(-139.69deg); }
+  61.667% { left: 256.20px; top: 159.60px; width: 104.00px; transform: rotate(-140.83deg); }
+  62.500% { left: 257.50px; top: 158.00px; width: 104.00px; transform: rotate(-141.97deg); }
+  63.333% { left: 258.80px; top: 156.40px; width: 104.00px; transform: rotate(-143.11deg); }
+  64.167% { left: 260.10px; top: 154.80px; width: 104.00px; transform: rotate(-144.27deg); }
+  65.000% { left: 261.40px; top: 153.20px; width: 104.00px; transform: rotate(-145.43deg); }
+  65.833% { left: 262.70px; top: 151.60px; width: 104.00px; transform: rotate(-146.61deg); }
+  66.667% { left: 264.00px; top: 150.00px; width: 104.00px; transform: rotate(-147.80deg); }
+  67.500% { left: 262.70px; top: 148.40px; width: 104.00px; transform: rotate(-147.66deg); }
+  68.333% { left: 261.40px; top: 146.80px; width: 104.00px; transform: rotate(-147.55deg); }
+  69.167% { left: 260.10px; top: 145.20px; width: 104.00px; transform: rotate(-147.46deg); }
+  70.000% { left: 258.80px; top: 143.60px; width: 104.00px; transform: rotate(-147.40deg); }
+  70.833% { left: 257.50px; top: 142.00px; width: 104.00px; transform: rotate(-147.37deg); }
+  71.667% { left: 256.20px; top: 140.40px; width: 104.00px; transform: rotate(-147.36deg); }
+  72.500% { left: 254.90px; top: 138.80px; width: 104.00px; transform: rotate(-147.37deg); }
+  73.333% { left: 253.60px; top: 137.20px; width: 104.00px; transform: rotate(-147.41deg); }
+  74.167% { left: 252.30px; top: 135.60px; width: 104.00px; transform: rotate(-147.47deg); }
+  75.000% { left: 251.00px; top: 134.00px; width: 104.00px; transform: rotate(-147.55deg); }
+  75.833% { left: 249.70px; top: 132.40px; width: 104.00px; transform: rotate(-147.66deg); }
+  76.667% { left: 248.40px; top: 130.80px; width: 104.00px; transform: rotate(-147.78deg); }
+  77.500% { left: 247.10px; top: 129.20px; width: 104.00px; transform: rotate(-147.93deg); }
+  78.333% { left: 245.80px; top: 127.60px; width: 104.00px; transform: rotate(-148.10deg); }
+  79.167% { left: 244.50px; top: 126.00px; width: 104.00px; transform: rotate(-148.29deg); }
+  80.000% { left: 243.20px; top: 124.40px; width: 104.00px; transform: rotate(-148.50deg); }
+  80.833% { left: 241.90px; top: 122.80px; width: 104.00px; transform: rotate(-148.73deg); }
+  81.667% { left: 240.60px; top: 121.20px; width: 104.00px; transform: rotate(-148.98deg); }
+  82.500% { left: 239.30px; top: 119.60px; width: 104.00px; transform: rotate(-149.26deg); }
+  83.333% { left: 238.00px; top: 118.00px; width: 104.00px; transform: rotate(-149.55deg); }
+  84.167% { left: 236.70px; top: 116.40px; width: 104.00px; transform: rotate(-149.86deg); }
+  85.000% { left: 235.40px; top: 114.80px; width: 104.00px; transform: rotate(-150.20deg); }
+  85.833% { left: 234.10px; top: 113.20px; width: 104.00px; transform: rotate(-150.55deg); }
+  86.667% { left: 232.80px; top: 111.60px; width: 104.00px; transform: rotate(-150.93deg); }
+  87.500% { left: 231.50px; top: 110.00px; width: 104.00px; transform: rotate(-151.32deg); }
+  88.333% { left: 230.20px; top: 108.40px; width: 104.00px; transform: rotate(-151.73deg); }
+  89.167% { left: 228.90px; top: 106.80px; width: 104.00px; transform: rotate(-152.16deg); }
+  90.000% { left: 227.60px; top: 105.20px; width: 104.00px; transform: rotate(-152.61deg); }
+  90.833% { left: 226.30px; top: 103.60px; width: 104.00px; transform: rotate(-153.08deg); }
+  91.667% { left: 225.00px; top: 102.00px; width: 104.00px; transform: rotate(-153.57deg); }
+  92.500% { left: 223.70px; top: 100.40px; width: 104.00px; transform: rotate(-154.07deg); }
+  93.333% { left: 222.40px; top: 98.80px; width: 104.00px; transform: rotate(-154.60deg); }
+  94.167% { left: 221.10px; top: 97.20px; width: 104.00px; transform: rotate(-155.14deg); }
+  95.000% { left: 219.80px; top: 95.60px; width: 104.00px; transform: rotate(-155.70deg); }
+  95.833% { left: 218.50px; top: 94.00px; width: 104.00px; transform: rotate(-156.28deg); }
+  96.667% { left: 217.20px; top: 92.40px; width: 104.00px; transform: rotate(-156.88deg); }
+  97.500% { left: 215.90px; top: 90.80px; width: 104.00px; transform: rotate(-157.49deg); }
+  98.333% { left: 214.60px; top: 89.20px; width: 104.00px; transform: rotate(-158.12deg); }
+  99.167% { left: 213.30px; top: 87.60px; width: 104.00px; transform: rotate(-158.77deg); }
+  100.000% { left: 212.00px; top: 86.00px; width: 104.00px; transform: rotate(-159.43deg); }
+}
+
+@keyframes barBO {
+  0.000% { left: 114.63px; top: 49.47px; width: 104.00px; transform: rotate(104.84deg); }
+  0.833% { left: 115.76px; top: 49.77px; width: 104.00px; transform: rotate(105.48deg); }
+  1.667% { left: 116.98px; top: 50.12px; width: 104.00px; transform: rotate(106.18deg); }
+  2.500% { left: 118.28px; top: 50.51px; width: 104.00px; transform: rotate(106.93deg); }
+  3.333% { left: 119.67px; top: 50.94px; width: 104.00px; transform: rotate(107.73deg); }
+  4.167% { left: 121.13px; top: 51.42px; width: 104.00px; transform: rotate(108.58deg); }
+  5.000% { left: 122.67px; top: 51.95px; width: 104.00px; transform: rotate(109.47deg); }
+  5.833% { left: 124.28px; top: 52.53px; width: 104.00px; transform: rotate(110.42deg); }
+  6.667% { left: 125.96px; top: 53.18px; width: 104.00px; transform: rotate(111.41deg); }
+  7.500% { left: 127.71px; top: 53.88px; width: 104.00px; transform: rotate(112.45deg); }
+  8.333% { left: 129.52px; top: 54.65px; width: 104.00px; transform: rotate(113.53deg); }
+  9.167% { left: 131.39px; top: 55.49px; width: 104.00px; transform: rotate(114.66deg); }
+  10.000% { left: 133.32px; top: 56.39px; width: 104.00px; transform: rotate(115.83deg); }
+  10.833% { left: 135.29px; top: 57.37px; width: 104.00px; transform: rotate(117.05deg); }
+  11.667% { left: 137.31px; top: 58.43px; width: 104.00px; transform: rotate(118.30deg); }
+  12.500% { left: 139.36px; top: 59.57px; width: 104.00px; transform: rotate(119.60deg); }
+  13.333% { left: 141.45px; top: 60.79px; width: 104.00px; transform: rotate(120.93deg); }
+  14.167% { left: 143.57px; top: 62.09px; width: 104.00px; transform: rotate(122.30deg); }
+  15.000% { left: 145.70px; top: 63.47px; width: 104.00px; transform: rotate(123.70deg); }
+  15.833% { left: 147.85px; top: 64.94px; width: 104.00px; transform: rotate(125.13deg); }
+  16.667% { left: 150.00px; top: 66.50px; width: 104.00px; transform: rotate(126.59deg); }
+  17.500% { left: 152.15px; top: 68.14px; width: 104.00px; transform: rotate(128.09deg); }
+  18.333% { left: 154.30px; top: 69.87px; width: 104.00px; transform: rotate(129.61deg); }
+  19.167% { left: 156.43px; top: 71.69px; width: 104.00px; transform: rotate(131.15deg); }
+  20.000% { left: 158.55px; top: 73.59px; width: 104.00px; transform: rotate(132.71deg); }
+  20.833% { left: 160.64px; top: 75.57px; width: 104.00px; transform: rotate(134.30deg); }
+  21.667% { left: 162.69px; top: 77.63px; width: 104.00px; transform: rotate(135.91deg); }
+  22.500% { left: 164.71px; top: 79.77px; width: 104.00px; transform: rotate(137.53deg); }
+  23.333% { left: 166.68px; top: 81.99px; width: 104.00px; transform: rotate(139.16deg); }
+  24.167% { left: 168.61px; top: 84.29px; width: 104.00px; transform: rotate(140.81deg); }
+  25.000% { left: 170.48px; top: 86.65px; width: 104.00px; transform: rotate(142.47deg); }
+  25.833% { left: 172.29px; top: 89.08px; width: 104.00px; transform: rotate(144.14deg); }
+  26.667% { left: 174.04px; top: 91.58px; width: 104.00px; transform: rotate(145.82deg); }
+  27.500% { left: 175.72px; top: 94.13px; width: 104.00px; transform: rotate(147.51deg); }
+  28.333% { left: 177.33px; top: 96.75px; width: 104.00px; transform: rotate(149.20deg); }
+  29.167% { left: 178.87px; top: 99.42px; width: 104.00px; transform: rotate(150.90deg); }
+  30.000% { left: 180.33px; top: 102.14px; width: 104.00px; transform: rotate(152.60deg); }
+  30.833% { left: 181.72px; top: 104.91px; width: 104.00px; transform: rotate(154.30deg); }
+  31.667% { left: 183.02px; top: 107.72px; width: 104.00px; transform: rotate(156.01deg); }
+  32.500% { left: 184.24px; top: 110.57px; width: 104.00px; transform: rotate(157.72deg); }
+  33.333% { left: 185.37px; top: 113.47px; width: 104.00px; transform: rotate(159.43deg); }
+  34.167% { left: 184.94px; top: 112.34px; width: 104.00px; transform: rotate(158.77deg); }
+  35.000% { left: 184.51px; top: 111.25px; width: 104.00px; transform: rotate(158.12deg); }
+  35.833% { left: 184.08px; top: 110.19px; width: 104.00px; transform: rotate(157.49deg); }
+  36.667% { left: 183.65px; top: 109.16px; width: 104.00px; transform: rotate(156.88deg); }
+  37.500% { left: 183.22px; top: 108.17px; width: 104.00px; transform: rotate(156.28deg); }
+  38.333% { left: 182.79px; top: 107.21px; width: 104.00px; transform: rotate(155.70deg); }
+  39.167% { left: 182.37px; top: 106.28px; width: 104.00px; transform: rotate(155.14deg); }
+  40.000% { left: 181.95px; top: 105.39px; width: 104.00px; transform: rotate(154.60deg); }
+  40.833% { left: 181.53px; top: 104.53px; width: 104.00px; transform: rotate(154.07deg); }
+  41.667% { left: 181.13px; top: 103.71px; width: 104.00px; transform: rotate(153.57deg); }
+  42.500% { left: 180.73px; top: 102.91px; width: 104.00px; transform: rotate(153.08deg); }
+  43.333% { left: 180.34px; top: 102.16px; width: 104.00px; transform: rotate(152.61deg); }
+  44.167% { left: 179.96px; top: 101.43px; width: 104.00px; transform: rotate(152.16deg); }
+  45.000% { left: 179.60px; top: 100.74px; width: 104.00px; transform: rotate(151.73deg); }
+  45.833% { left: 179.24px; top: 100.08px; width: 104.00px; transform: rotate(151.32deg); }
+  46.667% { left: 178.89px; top: 99.46px; width: 104.00px; transform: rotate(150.93deg); }
+  47.500% { left: 178.56px; top: 98.87px; width: 104.00px; transform: rotate(150.55deg); }
+  48.333% { left: 178.25px; top: 98.31px; width: 104.00px; transform: rotate(150.20deg); }
+  49.167% { left: 177.94px; top: 97.79px; width: 104.00px; transform: rotate(149.86deg); }
+  50.000% { left: 177.66px; top: 97.30px; width: 104.00px; transform: rotate(149.55deg); }
+  50.833% { left: 177.39px; top: 96.84px; width: 104.00px; transform: rotate(149.26deg); }
+  51.667% { left: 177.13px; top: 96.41px; width: 104.00px; transform: rotate(148.98deg); }
+  52.500% { left: 176.89px; top: 96.02px; width: 104.00px; transform: rotate(148.73deg); }
+  53.333% { left: 176.67px; top: 95.66px; width: 104.00px; transform: rotate(148.50deg); }
+  54.167% { left: 176.47px; top: 95.33px; width: 104.00px; transform: rotate(148.29deg); }
+  55.000% { left: 176.29px; top: 95.04px; width: 104.00px; transform: rotate(148.10deg); }
+  55.833% { left: 176.13px; top: 94.78px; width: 104.00px; transform: rotate(147.93deg); }
+  56.667% { left: 175.99px; top: 94.55px; width: 104.00px; transform: rotate(147.78deg); }
+  57.500% { left: 175.86px; top: 94.36px; width: 104.00px; transform: rotate(147.66deg); }
+  58.333% { left: 175.76px; top: 94.20px; width: 104.00px; transform: rotate(147.55deg); }
+  59.167% { left: 175.68px; top: 94.07px; width: 104.00px; transform: rotate(147.47deg); }
+  60.000% { left: 175.62px; top: 93.98px; width: 104.00px; transform: rotate(147.41deg); }
+  60.833% { left: 175.59px; top: 93.93px; width: 104.00px; transform: rotate(147.37deg); }
+  61.667% { left: 175.58px; top: 93.91px; width: 104.00px; transform: rotate(147.36deg); }
+  62.500% { left: 175.59px; top: 93.92px; width: 104.00px; transform: rotate(147.37deg); }
+  63.333% { left: 175.62px; top: 93.97px; width: 104.00px; transform: rotate(147.40deg); }
+  64.167% { left: 175.68px; top: 94.06px; width: 104.00px; transform: rotate(147.46deg); }
+  65.000% { left: 175.76px; top: 94.19px; width: 104.00px; transform: rotate(147.55deg); }
+  65.833% { left: 175.87px; top: 94.36px; width: 104.00px; transform: rotate(147.66deg); }
+  66.667% { left: 176.00px; top: 94.57px; width: 104.00px; transform: rotate(147.80deg); }
+  67.500% { left: 174.83px; top: 92.76px; width: 104.00px; transform: rotate(146.61deg); }
+  68.333% { left: 173.64px; top: 90.99px; width: 104.00px; transform: rotate(145.43deg); }
+  69.167% { left: 172.42px; top: 89.26px; width: 104.00px; transform: rotate(144.27deg); }
+  70.000% { left: 171.18px; top: 87.57px; width: 104.00px; transform: rotate(143.11deg); }
+  70.833% { left: 169.91px; top: 85.92px; width: 104.00px; transform: rotate(141.97deg); }
+  71.667% { left: 168.62px; top: 84.31px; width: 104.00px; transform: rotate(140.83deg); }
+  72.500% { left: 167.31px; top: 82.73px; width: 104.00px; transform: rotate(139.69deg); }
+  73.333% { left: 165.98px; top: 81.18px; width: 104.00px; transform: rotate(138.57deg); }
+  74.167% { left: 164.62px; top: 79.67px; width: 104.00px; transform: rotate(137.45deg); }
+  75.000% { left: 163.24px; top: 78.20px; width: 104.00px; transform: rotate(136.34deg); }
+  75.833% { left: 161.84px; top: 76.76px; width: 104.00px; transform: rotate(135.23deg); }
+  76.667% { left: 160.41px; top: 75.35px; width: 104.00px; transform: rotate(134.13deg); }
+  77.500% { left: 158.97px; top: 73.98px; width: 104.00px; transform: rotate(133.03deg); }
+  78.333% { left: 157.51px; top: 72.64px; width: 104.00px; transform: rotate(131.94deg); }
+  79.167% { left: 156.03px; top: 71.33px; width: 104.00px; transform: rotate(130.85deg); }
+  80.000% { left: 154.53px; top: 70.06px; width: 104.00px; transform: rotate(129.77deg); }
+  80.833% { left: 153.01px; top: 68.82px; width: 104.00px; transform: rotate(128.69deg); }
+  81.667% { left: 151.47px; top: 67.61px; width: 104.00px; transform: rotate(127.61deg); }
+  82.500% { left: 149.91px; top: 66.44px; width: 104.00px; transform: rotate(126.54deg); }
+  83.333% { left: 148.34px; top: 65.30px; width: 104.00px; transform: rotate(125.47deg); }
+  84.167% { left: 146.76px; top: 64.19px; width: 104.00px; transform: rotate(124.40deg); }
+  85.000% { left: 145.15px; top: 63.11px; width: 104.00px; transform: rotate(123.34deg); }
+  85.833% { left: 143.54px; top: 62.07px; width: 104.00px; transform: rotate(122.28deg); }
+  86.667% { left: 141.91px; top: 61.06px; width: 104.00px; transform: rotate(121.22deg); }
+  87.500% { left: 140.26px; top: 60.08px; width: 104.00px; transform: rotate(120.17deg); }
+  88.333% { left: 138.60px; top: 59.14px; width: 104.00px; transform: rotate(119.12deg); }
+  89.167% { left: 136.94px; top: 58.23px; width: 104.00px; transform: rotate(118.07deg); }
+  90.000% { left: 135.26px; top: 57.36px; width: 104.00px; transform: rotate(117.03deg); }
+  90.833% { left: 133.57px; top: 56.51px; width: 104.00px; transform: rotate(115.99deg); }
+  91.667% { left: 131.87px; top: 55.71px; width: 104.00px; transform: rotate(114.95deg); }
+  92.500% { left: 130.17px; top: 54.93px; width: 104.00px; transform: rotate(113.92deg); }
+  93.333% { left: 128.45px; top: 54.19px; width: 104.00px; transform: rotate(112.89deg); }
+  94.167% { left: 126.73px; top: 53.48px; width: 104.00px; transform: rotate(111.87deg); }
+  95.000% { left: 125.01px; top: 52.81px; width: 104.00px; transform: rotate(110.85deg); }
+  95.833% { left: 123.28px; top: 52.17px; width: 104.00px; transform: rotate(109.83deg); }
+  96.667% { left: 121.55px; top: 51.56px; width: 104.00px; transform: rotate(108.82deg); }
+  97.500% { left: 119.82px; top: 50.99px; width: 104.00px; transform: rotate(107.82deg); }
+  98.333% { left: 118.09px; top: 50.45px; width: 104.00px; transform: rotate(106.82deg); }
+  99.167% { left: 116.36px; top: 49.94px; width: 104.00px; transform: rotate(105.82deg); }
+  100.000% { left: 114.63px; top: 49.47px; width: 104.00px; transform: rotate(104.84deg); }
+}
+
+@keyframes jA {
+  0.000% { left: 185.37px; top: 186.53px; }
+  0.833% { left: 184.24px; top: 189.43px; }
+  1.667% { left: 183.02px; top: 192.28px; }
+  2.500% { left: 181.72px; top: 195.09px; }
+  3.333% { left: 180.33px; top: 197.86px; }
+  4.167% { left: 178.87px; top: 200.58px; }
+  5.000% { left: 177.33px; top: 203.25px; }
+  5.833% { left: 175.72px; top: 205.87px; }
+  6.667% { left: 174.04px; top: 208.42px; }
+  7.500% { left: 172.29px; top: 210.92px; }
+  8.333% { left: 170.48px; top: 213.35px; }
+  9.167% { left: 168.61px; top: 215.71px; }
+  10.000% { left: 166.68px; top: 218.01px; }
+  10.833% { left: 164.71px; top: 220.23px; }
+  11.667% { left: 162.69px; top: 222.37px; }
+  12.500% { left: 160.64px; top: 224.43px; }
+  13.333% { left: 158.55px; top: 226.41px; }
+  14.167% { left: 156.43px; top: 228.31px; }
+  15.000% { left: 154.30px; top: 230.13px; }
+  15.833% { left: 152.15px; top: 231.86px; }
+  16.667% { left: 150.00px; top: 233.50px; }
+  17.500% { left: 147.85px; top: 235.06px; }
+  18.333% { left: 145.70px; top: 236.53px; }
+  19.167% { left: 143.57px; top: 237.91px; }
+  20.000% { left: 141.45px; top: 239.21px; }
+  20.833% { left: 139.36px; top: 240.43px; }
+  21.667% { left: 137.31px; top: 241.57px; }
+  22.500% { left: 135.29px; top: 242.63px; }
+  23.333% { left: 133.32px; top: 243.61px; }
+  24.167% { left: 131.39px; top: 244.51px; }
+  25.000% { left: 129.52px; top: 245.35px; }
+  25.833% { left: 127.71px; top: 246.12px; }
+  26.667% { left: 125.96px; top: 246.82px; }
+  27.500% { left: 124.28px; top: 247.47px; }
+  28.333% { left: 122.67px; top: 248.05px; }
+  29.167% { left: 121.13px; top: 248.58px; }
+  30.000% { left: 119.67px; top: 249.06px; }
+  30.833% { left: 118.28px; top: 249.49px; }
+  31.667% { left: 116.98px; top: 249.88px; }
+  32.500% { left: 115.76px; top: 250.23px; }
+  33.333% { left: 114.63px; top: 250.53px; }
+  34.167% { left: 116.36px; top: 250.06px; }
+  35.000% { left: 118.09px; top: 249.55px; }
+  35.833% { left: 119.82px; top: 249.01px; }
+  36.667% { left: 121.55px; top: 248.44px; }
+  37.500% { left: 123.28px; top: 247.83px; }
+  38.333% { left: 125.01px; top: 247.19px; }
+  39.167% { left: 126.73px; top: 246.52px; }
+  40.000% { left: 128.45px; top: 245.81px; }
+  40.833% { left: 130.17px; top: 245.07px; }
+  41.667% { left: 131.87px; top: 244.29px; }
+  42.500% { left: 133.57px; top: 243.49px; }
+  43.333% { left: 135.26px; top: 242.64px; }
+  44.167% { left: 136.94px; top: 241.77px; }
+  45.000% { left: 138.60px; top: 240.86px; }
+  45.833% { left: 140.26px; top: 239.92px; }
+  46.667% { left: 141.91px; top: 238.94px; }
+  47.500% { left: 143.54px; top: 237.93px; }
+  48.333% { left: 145.15px; top: 236.89px; }
+  49.167% { left: 146.76px; top: 235.81px; }
+  50.000% { left: 148.34px; top: 234.70px; }
+  50.833% { left: 149.91px; top: 233.56px; }
+  51.667% { left: 151.47px; top: 232.39px; }
+  52.500% { left: 153.01px; top: 231.18px; }
+  53.333% { left: 154.53px; top: 229.94px; }
+  54.167% { left: 156.03px; top: 228.67px; }
+  55.000% { left: 157.51px; top: 227.36px; }
+  55.833% { left: 158.97px; top: 226.02px; }
+  56.667% { left: 160.41px; top: 224.65px; }
+  57.500% { left: 161.84px; top: 223.24px; }
+  58.333% { left: 163.24px; top: 221.80px; }
+  59.167% { left: 164.62px; top: 220.33px; }
+  60.000% { left: 165.98px; top: 218.82px; }
+  60.833% { left: 167.31px; top: 217.27px; }
+  61.667% { left: 168.62px; top: 215.69px; }
+  62.500% { left: 169.91px; top: 214.08px; }
+  63.333% { left: 171.18px; top: 212.43px; }
+  64.167% { left: 172.42px; top: 210.74px; }
+  65.000% { left: 173.64px; top: 209.01px; }
+  65.833% { left: 174.83px; top: 207.24px; }
+  66.667% { left: 176.00px; top: 205.43px; }
+  67.500% { left: 175.87px; top: 205.64px; }
+  68.333% { left: 175.76px; top: 205.81px; }
+  69.167% { left: 175.68px; top: 205.94px; }
+  70.000% { left: 175.62px; top: 206.03px; }
+  70.833% { left: 175.59px; top: 206.08px; }
+  71.667% { left: 175.58px; top: 206.09px; }
+  72.500% { left: 175.59px; top: 206.07px; }
+  73.333% { left: 175.62px; top: 206.02px; }
+  74.167% { left: 175.68px; top: 205.93px; }
+  75.000% { left: 175.76px; top: 205.80px; }
+  75.833% { left: 175.86px; top: 205.64px; }
+  76.667% { left: 175.99px; top: 205.45px; }
+  77.500% { left: 176.13px; top: 205.22px; }
+  78.333% { left: 176.29px; top: 204.96px; }
+  79.167% { left: 176.47px; top: 204.67px; }
+  80.000% { left: 176.67px; top: 204.34px; }
+  80.833% { left: 176.89px; top: 203.98px; }
+  81.667% { left: 177.13px; top: 203.59px; }
+  82.500% { left: 177.39px; top: 203.16px; }
+  83.333% { left: 177.66px; top: 202.70px; }
+  84.167% { left: 177.94px; top: 202.21px; }
+  85.000% { left: 178.25px; top: 201.69px; }
+  85.833% { left: 178.56px; top: 201.13px; }
+  86.667% { left: 178.89px; top: 200.54px; }
+  87.500% { left: 179.24px; top: 199.92px; }
+  88.333% { left: 179.60px; top: 199.26px; }
+  89.167% { left: 179.96px; top: 198.57px; }
+  90.000% { left: 180.34px; top: 197.84px; }
+  90.833% { left: 180.73px; top: 197.09px; }
+  91.667% { left: 181.13px; top: 196.29px; }
+  92.500% { left: 181.53px; top: 195.47px; }
+  93.333% { left: 181.95px; top: 194.61px; }
+  94.167% { left: 182.37px; top: 193.72px; }
+  95.000% { left: 182.79px; top: 192.79px; }
+  95.833% { left: 183.22px; top: 191.83px; }
+  96.667% { left: 183.65px; top: 190.84px; }
+  97.500% { left: 184.08px; top: 189.81px; }
+  98.333% { left: 184.51px; top: 188.75px; }
+  99.167% { left: 184.94px; top: 187.66px; }
+  100.000% { left: 185.37px; top: 186.53px; }
+}
+
+@keyframes jB {
+  0.000% { left: 114.63px; top: 49.47px; }
+  0.833% { left: 115.76px; top: 49.77px; }
+  1.667% { left: 116.98px; top: 50.12px; }
+  2.500% { left: 118.28px; top: 50.51px; }
+  3.333% { left: 119.67px; top: 50.94px; }
+  4.167% { left: 121.13px; top: 51.42px; }
+  5.000% { left: 122.67px; top: 51.95px; }
+  5.833% { left: 124.28px; top: 52.53px; }
+  6.667% { left: 125.96px; top: 53.18px; }
+  7.500% { left: 127.71px; top: 53.88px; }
+  8.333% { left: 129.52px; top: 54.65px; }
+  9.167% { left: 131.39px; top: 55.49px; }
+  10.000% { left: 133.32px; top: 56.39px; }
+  10.833% { left: 135.29px; top: 57.37px; }
+  11.667% { left: 137.31px; top: 58.43px; }
+  12.500% { left: 139.36px; top: 59.57px; }
+  13.333% { left: 141.45px; top: 60.79px; }
+  14.167% { left: 143.57px; top: 62.09px; }
+  15.000% { left: 145.70px; top: 63.47px; }
+  15.833% { left: 147.85px; top: 64.94px; }
+  16.667% { left: 150.00px; top: 66.50px; }
+  17.500% { left: 152.15px; top: 68.14px; }
+  18.333% { left: 154.30px; top: 69.87px; }
+  19.167% { left: 156.43px; top: 71.69px; }
+  20.000% { left: 158.55px; top: 73.59px; }
+  20.833% { left: 160.64px; top: 75.57px; }
+  21.667% { left: 162.69px; top: 77.63px; }
+  22.500% { left: 164.71px; top: 79.77px; }
+  23.333% { left: 166.68px; top: 81.99px; }
+  24.167% { left: 168.61px; top: 84.29px; }
+  25.000% { left: 170.48px; top: 86.65px; }
+  25.833% { left: 172.29px; top: 89.08px; }
+  26.667% { left: 174.04px; top: 91.58px; }
+  27.500% { left: 175.72px; top: 94.13px; }
+  28.333% { left: 177.33px; top: 96.75px; }
+  29.167% { left: 178.87px; top: 99.42px; }
+  30.000% { left: 180.33px; top: 102.14px; }
+  30.833% { left: 181.72px; top: 104.91px; }
+  31.667% { left: 183.02px; top: 107.72px; }
+  32.500% { left: 184.24px; top: 110.57px; }
+  33.333% { left: 185.37px; top: 113.47px; }
+  34.167% { left: 184.94px; top: 112.34px; }
+  35.000% { left: 184.51px; top: 111.25px; }
+  35.833% { left: 184.08px; top: 110.19px; }
+  36.667% { left: 183.65px; top: 109.16px; }
+  37.500% { left: 183.22px; top: 108.17px; }
+  38.333% { left: 182.79px; top: 107.21px; }
+  39.167% { left: 182.37px; top: 106.28px; }
+  40.000% { left: 181.95px; top: 105.39px; }
+  40.833% { left: 181.53px; top: 104.53px; }
+  41.667% { left: 181.13px; top: 103.71px; }
+  42.500% { left: 180.73px; top: 102.91px; }
+  43.333% { left: 180.34px; top: 102.16px; }
+  44.167% { left: 179.96px; top: 101.43px; }
+  45.000% { left: 179.60px; top: 100.74px; }
+  45.833% { left: 179.24px; top: 100.08px; }
+  46.667% { left: 178.89px; top: 99.46px; }
+  47.500% { left: 178.56px; top: 98.87px; }
+  48.333% { left: 178.25px; top: 98.31px; }
+  49.167% { left: 177.94px; top: 97.79px; }
+  50.000% { left: 177.66px; top: 97.30px; }
+  50.833% { left: 177.39px; top: 96.84px; }
+  51.667% { left: 177.13px; top: 96.41px; }
+  52.500% { left: 176.89px; top: 96.02px; }
+  53.333% { left: 176.67px; top: 95.66px; }
+  54.167% { left: 176.47px; top: 95.33px; }
+  55.000% { left: 176.29px; top: 95.04px; }
+  55.833% { left: 176.13px; top: 94.78px; }
+  56.667% { left: 175.99px; top: 94.55px; }
+  57.500% { left: 175.86px; top: 94.36px; }
+  58.333% { left: 175.76px; top: 94.20px; }
+  59.167% { left: 175.68px; top: 94.07px; }
+  60.000% { left: 175.62px; top: 93.98px; }
+  60.833% { left: 175.59px; top: 93.93px; }
+  61.667% { left: 175.58px; top: 93.91px; }
+  62.500% { left: 175.59px; top: 93.92px; }
+  63.333% { left: 175.62px; top: 93.97px; }
+  64.167% { left: 175.68px; top: 94.06px; }
+  65.000% { left: 175.76px; top: 94.19px; }
+  65.833% { left: 175.87px; top: 94.36px; }
+  66.667% { left: 176.00px; top: 94.57px; }
+  67.500% { left: 174.83px; top: 92.76px; }
+  68.333% { left: 173.64px; top: 90.99px; }
+  69.167% { left: 172.42px; top: 89.26px; }
+  70.000% { left: 171.18px; top: 87.57px; }
+  70.833% { left: 169.91px; top: 85.92px; }
+  71.667% { left: 168.62px; top: 84.31px; }
+  72.500% { left: 167.31px; top: 82.73px; }
+  73.333% { left: 165.98px; top: 81.18px; }
+  74.167% { left: 164.62px; top: 79.67px; }
+  75.000% { left: 163.24px; top: 78.20px; }
+  75.833% { left: 161.84px; top: 76.76px; }
+  76.667% { left: 160.41px; top: 75.35px; }
+  77.500% { left: 158.97px; top: 73.98px; }
+  78.333% { left: 157.51px; top: 72.64px; }
+  79.167% { left: 156.03px; top: 71.33px; }
+  80.000% { left: 154.53px; top: 70.06px; }
+  80.833% { left: 153.01px; top: 68.82px; }
+  81.667% { left: 151.47px; top: 67.61px; }
+  82.500% { left: 149.91px; top: 66.44px; }
+  83.333% { left: 148.34px; top: 65.30px; }
+  84.167% { left: 146.76px; top: 64.19px; }
+  85.000% { left: 145.15px; top: 63.11px; }
+  85.833% { left: 143.54px; top: 62.07px; }
+  86.667% { left: 141.91px; top: 61.06px; }
+  87.500% { left: 140.26px; top: 60.08px; }
+  88.333% { left: 138.60px; top: 59.14px; }
+  89.167% { left: 136.94px; top: 58.23px; }
+  90.000% { left: 135.26px; top: 57.36px; }
+  90.833% { left: 133.57px; top: 56.51px; }
+  91.667% { left: 131.87px; top: 55.71px; }
+  92.500% { left: 130.17px; top: 54.93px; }
+  93.333% { left: 128.45px; top: 54.19px; }
+  94.167% { left: 126.73px; top: 53.48px; }
+  95.000% { left: 125.01px; top: 52.81px; }
+  95.833% { left: 123.28px; top: 52.17px; }
+  96.667% { left: 121.55px; top: 51.56px; }
+  97.500% { left: 119.82px; top: 50.99px; }
+  98.333% { left: 118.09px; top: 50.45px; }
+  99.167% { left: 116.36px; top: 49.94px; }
+  100.000% { left: 114.63px; top: 49.47px; }
+}
+
+@keyframes jT {
+  0.000% { left: 150.00px; top: 118.00px; }
+  0.833% { left: 150.00px; top: 119.60px; }
+  1.667% { left: 150.00px; top: 121.20px; }
+  2.500% { left: 150.00px; top: 122.80px; }
+  3.333% { left: 150.00px; top: 124.40px; }
+  4.167% { left: 150.00px; top: 126.00px; }
+  5.000% { left: 150.00px; top: 127.60px; }
+  5.833% { left: 150.00px; top: 129.20px; }
+  6.667% { left: 150.00px; top: 130.80px; }
+  7.500% { left: 150.00px; top: 132.40px; }
+  8.333% { left: 150.00px; top: 134.00px; }
+  9.167% { left: 150.00px; top: 135.60px; }
+  10.000% { left: 150.00px; top: 137.20px; }
+  10.833% { left: 150.00px; top: 138.80px; }
+  11.667% { left: 150.00px; top: 140.40px; }
+  12.500% { left: 150.00px; top: 142.00px; }
+  13.333% { left: 150.00px; top: 143.60px; }
+  14.167% { left: 150.00px; top: 145.20px; }
+  15.000% { left: 150.00px; top: 146.80px; }
+  15.833% { left: 150.00px; top: 148.40px; }
+  16.667% { left: 150.00px; top: 150.00px; }
+  17.500% { left: 150.00px; top: 151.60px; }
+  18.333% { left: 150.00px; top: 153.20px; }
+  19.167% { left: 150.00px; top: 154.80px; }
+  20.000% { left: 150.00px; top: 156.40px; }
+  20.833% { left: 150.00px; top: 158.00px; }
+  21.667% { left: 150.00px; top: 159.60px; }
+  22.500% { left: 150.00px; top: 161.20px; }
+  23.333% { left: 150.00px; top: 162.80px; }
+  24.167% { left: 150.00px; top: 164.40px; }
+  25.000% { left: 150.00px; top: 166.00px; }
+  25.833% { left: 150.00px; top: 167.60px; }
+  26.667% { left: 150.00px; top: 169.20px; }
+  27.500% { left: 150.00px; top: 170.80px; }
+  28.333% { left: 150.00px; top: 172.40px; }
+  29.167% { left: 150.00px; top: 174.00px; }
+  30.000% { left: 150.00px; top: 175.60px; }
+  30.833% { left: 150.00px; top: 177.20px; }
+  31.667% { left: 150.00px; top: 178.80px; }
+  32.500% { left: 150.00px; top: 180.40px; }
+  33.333% { left: 150.00px; top: 182.00px; }
+  34.167% { left: 150.65px; top: 181.20px; }
+  35.000% { left: 151.30px; top: 180.40px; }
+  35.833% { left: 151.95px; top: 179.60px; }
+  36.667% { left: 152.60px; top: 178.80px; }
+  37.500% { left: 153.25px; top: 178.00px; }
+  38.333% { left: 153.90px; top: 177.20px; }
+  39.167% { left: 154.55px; top: 176.40px; }
+  40.000% { left: 155.20px; top: 175.60px; }
+  40.833% { left: 155.85px; top: 174.80px; }
+  41.667% { left: 156.50px; top: 174.00px; }
+  42.500% { left: 157.15px; top: 173.20px; }
+  43.333% { left: 157.80px; top: 172.40px; }
+  44.167% { left: 158.45px; top: 171.60px; }
+  45.000% { left: 159.10px; top: 170.80px; }
+  45.833% { left: 159.75px; top: 170.00px; }
+  46.667% { left: 160.40px; top: 169.20px; }
+  47.500% { left: 161.05px; top: 168.40px; }
+  48.333% { left: 161.70px; top: 167.60px; }
+  49.167% { left: 162.35px; top: 166.80px; }
+  50.000% { left: 163.00px; top: 166.00px; }
+  50.833% { left: 163.65px; top: 165.20px; }
+  51.667% { left: 164.30px; top: 164.40px; }
+  52.500% { left: 164.95px; top: 163.60px; }
+  53.333% { left: 165.60px; top: 162.80px; }
+  54.167% { left: 166.25px; top: 162.00px; }
+  55.000% { left: 166.90px; top: 161.20px; }
+  55.833% { left: 167.55px; top: 160.40px; }
+  56.667% { left: 168.20px; top: 159.60px; }
+  57.500% { left: 168.85px; top: 158.80px; }
+  58.333% { left: 169.50px; top: 158.00px; }
+  59.167% { left: 170.15px; top: 157.20px; }
+  60.000% { left: 170.80px; top: 156.40px; }
+  60.833% { left: 171.45px; top: 155.60px; }
+  61.667% { left: 172.10px; top: 154.80px; }
+  62.500% { left: 172.75px; top: 154.00px; }
+  63.333% { left: 173.40px; top: 153.20px; }
+  64.167% { left: 174.05px; top: 152.40px; }
+  65.000% { left: 174.70px; top: 151.60px; }
+  65.833% { left: 175.35px; top: 150.80px; }
+  66.667% { left: 176.00px; top: 150.00px; }
+  67.500% { left: 175.35px; top: 149.20px; }
+  68.333% { left: 174.70px; top: 148.40px; }
+  69.167% { left: 174.05px; top: 147.60px; }
+  70.000% { left: 173.40px; top: 146.80px; }
+  70.833% { left: 172.75px; top: 146.00px; }
+  71.667% { left: 172.10px; top: 145.20px; }
+  72.500% { left: 171.45px; top: 144.40px; }
+  73.333% { left: 170.80px; top: 143.60px; }
+  74.167% { left: 170.15px; top: 142.80px; }
+  75.000% { left: 169.50px; top: 142.00px; }
+  75.833% { left: 168.85px; top: 141.20px; }
+  76.667% { left: 168.20px; top: 140.40px; }
+  77.500% { left: 167.55px; top: 139.60px; }
+  78.333% { left: 166.90px; top: 138.80px; }
+  79.167% { left: 166.25px; top: 138.00px; }
+  80.000% { left: 165.60px; top: 137.20px; }
+  80.833% { left: 164.95px; top: 136.40px; }
+  81.667% { left: 164.30px; top: 135.60px; }
+  82.500% { left: 163.65px; top: 134.80px; }
+  83.333% { left: 163.00px; top: 134.00px; }
+  84.167% { left: 162.35px; top: 133.20px; }
+  85.000% { left: 161.70px; top: 132.40px; }
+  85.833% { left: 161.05px; top: 131.60px; }
+  86.667% { left: 160.40px; top: 130.80px; }
+  87.500% { left: 159.75px; top: 130.00px; }
+  88.333% { left: 159.10px; top: 129.20px; }
+  89.167% { left: 158.45px; top: 128.40px; }
+  90.000% { left: 157.80px; top: 127.60px; }
+  90.833% { left: 157.15px; top: 126.80px; }
+  91.667% { left: 156.50px; top: 126.00px; }
+  92.500% { left: 155.85px; top: 125.20px; }
+  93.333% { left: 155.20px; top: 124.40px; }
+  94.167% { left: 154.55px; top: 123.60px; }
+  95.000% { left: 153.90px; top: 122.80px; }
+  95.833% { left: 153.25px; top: 122.00px; }
+  96.667% { left: 152.60px; top: 121.20px; }
+  97.500% { left: 151.95px; top: 120.40px; }
+  98.333% { left: 151.30px; top: 119.60px; }
+  99.167% { left: 150.65px; top: 118.80px; }
+  100.000% { left: 150.00px; top: 118.00px; }
+}
+
+@keyframes jP {
+  0.000% { left: 212.00px; top: 86.00px; }
+  0.833% { left: 212.00px; top: 89.20px; }
+  1.667% { left: 212.00px; top: 92.40px; }
+  2.500% { left: 212.00px; top: 95.60px; }
+  3.333% { left: 212.00px; top: 98.80px; }
+  4.167% { left: 212.00px; top: 102.00px; }
+  5.000% { left: 212.00px; top: 105.20px; }
+  5.833% { left: 212.00px; top: 108.40px; }
+  6.667% { left: 212.00px; top: 111.60px; }
+  7.500% { left: 212.00px; top: 114.80px; }
+  8.333% { left: 212.00px; top: 118.00px; }
+  9.167% { left: 212.00px; top: 121.20px; }
+  10.000% { left: 212.00px; top: 124.40px; }
+  10.833% { left: 212.00px; top: 127.60px; }
+  11.667% { left: 212.00px; top: 130.80px; }
+  12.500% { left: 212.00px; top: 134.00px; }
+  13.333% { left: 212.00px; top: 137.20px; }
+  14.167% { left: 212.00px; top: 140.40px; }
+  15.000% { left: 212.00px; top: 143.60px; }
+  15.833% { left: 212.00px; top: 146.80px; }
+  16.667% { left: 212.00px; top: 150.00px; }
+  17.500% { left: 212.00px; top: 153.20px; }
+  18.333% { left: 212.00px; top: 156.40px; }
+  19.167% { left: 212.00px; top: 159.60px; }
+  20.000% { left: 212.00px; top: 162.80px; }
+  20.833% { left: 212.00px; top: 166.00px; }
+  21.667% { left: 212.00px; top: 169.20px; }
+  22.500% { left: 212.00px; top: 172.40px; }
+  23.333% { left: 212.00px; top: 175.60px; }
+  24.167% { left: 212.00px; top: 178.80px; }
+  25.000% { left: 212.00px; top: 182.00px; }
+  25.833% { left: 212.00px; top: 185.20px; }
+  26.667% { left: 212.00px; top: 188.40px; }
+  27.500% { left: 212.00px; top: 191.60px; }
+  28.333% { left: 212.00px; top: 194.80px; }
+  29.167% { left: 212.00px; top: 198.00px; }
+  30.000% { left: 212.00px; top: 201.20px; }
+  30.833% { left: 212.00px; top: 204.40px; }
+  31.667% { left: 212.00px; top: 207.60px; }
+  32.500% { left: 212.00px; top: 210.80px; }
+  33.333% { left: 212.00px; top: 214.00px; }
+  34.167% { left: 213.30px; top: 212.40px; }
+  35.000% { left: 214.60px; top: 210.80px; }
+  35.833% { left: 215.90px; top: 209.20px; }
+  36.667% { left: 217.20px; top: 207.60px; }
+  37.500% { left: 218.50px; top: 206.00px; }
+  38.333% { left: 219.80px; top: 204.40px; }
+  39.167% { left: 221.10px; top: 202.80px; }
+  40.000% { left: 222.40px; top: 201.20px; }
+  40.833% { left: 223.70px; top: 199.60px; }
+  41.667% { left: 225.00px; top: 198.00px; }
+  42.500% { left: 226.30px; top: 196.40px; }
+  43.333% { left: 227.60px; top: 194.80px; }
+  44.167% { left: 228.90px; top: 193.20px; }
+  45.000% { left: 230.20px; top: 191.60px; }
+  45.833% { left: 231.50px; top: 190.00px; }
+  46.667% { left: 232.80px; top: 188.40px; }
+  47.500% { left: 234.10px; top: 186.80px; }
+  48.333% { left: 235.40px; top: 185.20px; }
+  49.167% { left: 236.70px; top: 183.60px; }
+  50.000% { left: 238.00px; top: 182.00px; }
+  50.833% { left: 239.30px; top: 180.40px; }
+  51.667% { left: 240.60px; top: 178.80px; }
+  52.500% { left: 241.90px; top: 177.20px; }
+  53.333% { left: 243.20px; top: 175.60px; }
+  54.167% { left: 244.50px; top: 174.00px; }
+  55.000% { left: 245.80px; top: 172.40px; }
+  55.833% { left: 247.10px; top: 170.80px; }
+  56.667% { left: 248.40px; top: 169.20px; }
+  57.500% { left: 249.70px; top: 167.60px; }
+  58.333% { left: 251.00px; top: 166.00px; }
+  59.167% { left: 252.30px; top: 164.40px; }
+  60.000% { left: 253.60px; top: 162.80px; }
+  60.833% { left: 254.90px; top: 161.20px; }
+  61.667% { left: 256.20px; top: 159.60px; }
+  62.500% { left: 257.50px; top: 158.00px; }
+  63.333% { left: 258.80px; top: 156.40px; }
+  64.167% { left: 260.10px; top: 154.80px; }
+  65.000% { left: 261.40px; top: 153.20px; }
+  65.833% { left: 262.70px; top: 151.60px; }
+  66.667% { left: 264.00px; top: 150.00px; }
+  67.500% { left: 262.70px; top: 148.40px; }
+  68.333% { left: 261.40px; top: 146.80px; }
+  69.167% { left: 260.10px; top: 145.20px; }
+  70.000% { left: 258.80px; top: 143.60px; }
+  70.833% { left: 257.50px; top: 142.00px; }
+  71.667% { left: 256.20px; top: 140.40px; }
+  72.500% { left: 254.90px; top: 138.80px; }
+  73.333% { left: 253.60px; top: 137.20px; }
+  74.167% { left: 252.30px; top: 135.60px; }
+  75.000% { left: 251.00px; top: 134.00px; }
+  75.833% { left: 249.70px; top: 132.40px; }
+  76.667% { left: 248.40px; top: 130.80px; }
+  77.500% { left: 247.10px; top: 129.20px; }
+  78.333% { left: 245.80px; top: 127.60px; }
+  79.167% { left: 244.50px; top: 126.00px; }
+  80.000% { left: 243.20px; top: 124.40px; }
+  80.833% { left: 241.90px; top: 122.80px; }
+  81.667% { left: 240.60px; top: 121.20px; }
+  82.500% { left: 239.30px; top: 119.60px; }
+  83.333% { left: 238.00px; top: 118.00px; }
+  84.167% { left: 236.70px; top: 116.40px; }
+  85.000% { left: 235.40px; top: 114.80px; }
+  85.833% { left: 234.10px; top: 113.20px; }
+  86.667% { left: 232.80px; top: 111.60px; }
+  87.500% { left: 231.50px; top: 110.00px; }
+  88.333% { left: 230.20px; top: 108.40px; }
+  89.167% { left: 228.90px; top: 106.80px; }
+  90.000% { left: 227.60px; top: 105.20px; }
+  90.833% { left: 226.30px; top: 103.60px; }
+  91.667% { left: 225.00px; top: 102.00px; }
+  92.500% { left: 223.70px; top: 100.40px; }
+  93.333% { left: 222.40px; top: 98.80px; }
+  94.167% { left: 221.10px; top: 97.20px; }
+  95.000% { left: 219.80px; top: 95.60px; }
+  95.833% { left: 218.50px; top: 94.00px; }
+  96.667% { left: 217.20px; top: 92.40px; }
+  97.500% { left: 215.90px; top: 90.80px; }
+  98.333% { left: 214.60px; top: 89.20px; }
+  99.167% { left: 213.30px; top: 87.60px; }
+  100.000% { left: 212.00px; top: 86.00px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .barN,
+  .jointN,
+  .tracerN,
+  .penN {
+    animation-play-state: paused;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/pantograph-as/`, a self-contained pure CSS/HTML pantograph copying a shape at exactly 2x.

Closes #49429

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A pantograph is a parallelogram linkage: with the pivot at corner O and pen at opposite corner P, the diagonal midpoint T is collinear with them and |OP| = 2|OT|, so the pen copies the tracer at exactly 2x. The property comes from the parallelogram diagonals bisecting each other.

- **The linkage is genuinely rigid, and it is solved.** For each of 121 tracer positions along a template triangle, the bar angles are found by two-bar inverse kinematics so all four sides stay at their true lengths, then each bar is keyframed for position, length and angle.
- **Every claim is measured on the live DOM.** Driving the paused animation across 101 steps: the four bars keep constant length (every side varies by **0px**), pivot/tracer/pen stay collinear (worst deviation **0.01px**), and the ratio `|OP|/|OT|` holds at **2.0000** (worst deviation 0.0003) all the way round.
- **The copy is shown against the original.** The tracer follows a small blue template triangle; the pen follows an orange triangle that is the same shape at 2x, positioned exactly where the geometry sends it.

## Accessibility

`prefers-reduced-motion: reduce` pauses the linkage on a static pose with both triangles and the bars in place.

## Verification

Opened `demo.html` in the browser and measured the three properties that make it a real pantograph rather than a drawing of one, on the live animated linkage: all four bar lengths constant to 0px, pivot-tracer-pen collinear to 0.01px, and the pen-to-tracer distance ratio exactly 2 (deviation 0.0003) across the whole cycle. The bar angles were solved by inverse kinematics so the sides do not stretch. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
