### PR TITLE
Nav Issue Resolved

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -271,6 +271,7 @@ body {
   left: 0;
   bottom: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: var(--ease-space-8) var(--ease-space-5);
   border-right: 1px solid var(--border-color);
   background: var(--sidebar-bg);
@@ -1151,12 +1152,19 @@ body > .docs-shell {
   opacity: 0.35;
 }
 
-.docs-header,
 .docs-shell,
 .ease-scroll-progress {
   position: relative;
   z-index: 1;
 }
+
+/* NOTE: .docs-header intentionally excluded from the rule above.
+   It already sets position: fixed (see top of file) so it stays
+   pinned while scrolling; re-declaring position: relative here
+   silently overrode that (later rule, same specificity) and broke
+   both the sticky header and the sidebar's scroll alignment, which
+   depends on the header actually being fixed at top: 0. It already
+   has its own z-index (200), so it doesn't need this rule anyway. */
 
 .hero-orb {
   position: absolute;

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
+      rel ="stylesheet"
     />
 
     <!-- Link to external docs.css -->


### PR DESCRIPTION
## Pull Request Description
Fixes a CSS cascade bug in the docs site where the sticky header (and by extension the sticky sidebar) silently lost its `position: fixed` due to a later, same-specificity rule re-declaring `position: relative` on `.docs-header`. Resolves #47378.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ This PR modifies `docs/docs.css` directly rather than adding a new folder under `submissions/`, since it fixes a layout bug on the existing docs page rather than adding a new feature/example. See Notes for Maintainer below.

- [ ] All changes are inside `submissions/`
- [ ] Includes `demo.html`
- [ ] Includes `style.css`
- [ ] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
What does this add?
Restores the pinned/sticky header and fixes the sidebar's scroll alignment so it stays visible while scrolling, resolving #47378.

How does a developer use it?
No new class or markup — this is a CSS fix to the existing docs shell (`.docs-header`, `.docs-sidebar`). No usage changes required.

Why does it fit EaseMotion CSS?
It's a fix to the docs site's own navigation experience, which is what the linked issue asked for.

---

## Demo
- [ ] Demo added
> N/A — verify by opening `docs/index.html` locally and scrolling any long page (e.g. Components); the header and sidebar should stay pinned.

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This PR touches `docs/docs.css` rather than `submissions/`, since it fixes a cascade bug affecting the live docs page's sticky header/sidebar, not a new component. Root cause:

```css
.docs-header,
.docs-shell,
.ease-scroll-progress {
  position: relative;
  z-index: 1;
}
```

This later rule overrode the earlier `.docs-header { position: fixed; }` because of identical specificity and source order, which also threw off the sidebar's scroll alignment (it assumes a genuinely fixed 60px header). Fix: removed `.docs-header` from that shared selector (it already has its own `z-index: 200`, so it didn't need this rule), and added `overscroll-behavior: contain` to `.docs-sidebar` so scrolling the nav doesn't chain into the page.

If docs-infra fixes should go through a different path than `submissions/`, happy to restructure — let me know.