### PR TITLE
feat: add CSS Spring Physics Tooltip for Cyberpunk Neon Layouts #46290

### DIFF
--- a/submissions/examples/css-spring-physics-tooltip-cyberpunk/README.md
+++ b/submissions/examples/css-spring-physics-tooltip-cyberpunk/README.md
@@ -1,0 +1,8 @@
+# CSS Spring Physics Tooltip — Cyberpunk Neon Layouts
+
+A striking, dark-themed responsive tooltip module combining aggressive spring momentum kinetics and vivid neon interface highlights.
+
+## Specifications
+- **Mechanical Physics**: Employs an extreme double-overshoot ease transition matrix (`cubic-bezier(0.68, -0.6, 0.34, 1.55)`) to achieve sharp kinetic snap-back and elastic recoil properties.
+- **Declarative Operations**: Exposes core tracking parameters (spring timings, vertical separation limits, and target transformations) explicitly inside global custom properties.
+- **Hardware Layering**: Confines element recoil transformations entirely to GPU compositor paths (`transform: translateY() scale()`) to bypass heavy layout paint updates.

--- a/submissions/examples/css-spring-physics-tooltip-cyberpunk/demo.html
+++ b/submissions/examples/css-spring-physics-tooltip-cyberpunk/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Spring Physics Tooltip - Cyberpunk Neon</title>
+    <link rel="stylesheet" href="../../../../core/easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="cyber-viewport">
+        <div class="terminal-card">
+            <div class="terminal-header">
+                <span class="matrix-label">NET_SECURITY_GRID</span>
+                <span class="status-indicator-syncing">ONLINE</span>
+            </div>
+            
+            <div class="tooltip-context-area">
+                <div class="tooltip-wrapper">
+                    <button class="tooltip-trigger-btn" aria-haspopup="true" aria-expanded="false">
+                        <span class="btn-glow-text">QUERY_PROXY_LOG</span>
+                        <svg class="terminal-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+                            <line x1="8" y1="21" x2="16" y2="21"/>
+                            <line x1="12" y1="17" x2="12" y2="21"/>
+                        </svg>
+                    </button>
+                    
+                    <div class="spring-neon-tooltip" role="tooltip">
+                        <div class="tooltip-inner-mesh">
+                            <div class="tooltip-header">
+                                <span class="badge-neon">SEC_TRACE</span>
+                                <p class="node-title">Encrypted Payload Route</p>
+                            </div>
+                            <div class="tooltip-body">
+                                <p class="node-desc">Incoming data packet channels routing directly across isolated proxy nodes. Zero leaks or structural integrity errors observed.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-spring-physics-tooltip-cyberpunk/style.css
+++ b/submissions/examples/css-spring-physics-tooltip-cyberpunk/style.css
@@ -1,0 +1,182 @@
+:root {
+    --tooltip-spring-timing: 0.65s;
+    --tooltip-spring-easing: cubic-bezier(0.68, -0.6, 0.34, 1.55);
+    --tooltip-spring-scale-initial: scale(0.5);
+    --tooltip-spring-scale-target: scale(1);
+    --tooltip-spring-offset: translateY(18px);
+    --tooltip-vertical-offset: 14px;
+    --neon-cyan: #00f2fe;
+    --neon-magenta: #f355da;
+    --terminal-dark: #07070a;
+}
+
+body {
+    background: #020204;
+    color: #f8fafc;
+    font-family: monospace;
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.cyber-viewport {
+    width: 100%;
+    max-width: 420px;
+}
+
+.terminal-card {
+    background: var(--terminal-dark);
+    border: 1px solid #1e1b4b;
+    border-radius: 4px;
+    padding: 36px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    box-shadow: 0 30px 60px -15px rgba(0, 0, 0, 0.9);
+    position: relative;
+}
+
+.terminal-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+}
+
+.terminal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #12121a;
+    padding-bottom: 16px;
+}
+
+.matrix-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    color: #64748b;
+}
+
+.status-indicator-syncing {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--neon-cyan);
+    text-shadow: 0 0 8px rgba(0, 242, 254, 0.5);
+}
+
+.tooltip-context-area {
+    position: relative;
+    display: flex;
+    justify-content: center;
+}
+
+.tooltip-wrapper {
+    position: relative;
+}
+
+.tooltip-trigger-btn {
+    background: transparent;
+    border: 1px solid var(--neon-magenta);
+    border-radius: 0;
+    padding: 14px 24px;
+    color: #ffffff;
+    cursor: pointer;
+    font-family: monospace;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 0 10px rgba(243, 85, 218, 0.15);
+    transition: background 0.2s, box-shadow 0.2s, transform 0.1s;
+}
+
+.tooltip-trigger-btn:hover {
+    background: rgba(243, 85, 218, 0.05);
+    box-shadow: 0 0 15px rgba(243, 85, 218, 0.35);
+}
+
+.tooltip-trigger-btn:active {
+    transform: scale(0.98);
+}
+
+.terminal-icon {
+    width: 18px;
+    height: 18px;
+    color: var(--neon-cyan);
+    filter: drop-shadow(0 0 4px var(--neon-cyan));
+}
+
+.spring-neon-tooltip {
+    position: absolute;
+    bottom: calc(100% + var(--tooltip-vertical-offset));
+    left: 50%;
+    transform: translateX(-50%) var(--tooltip-spring-offset) var(--tooltip-spring-scale-initial);
+    transform-origin: bottom center;
+    width: 290px;
+    opacity: 0;
+    pointer-events: none;
+    z-index: 50;
+    transition: transform var(--tooltip-spring-timing) var(--tooltip-spring-easing), 
+                opacity var(--tooltip-spring-timing) ease;
+}
+
+.tooltip-inner-mesh {
+    background: #09090f;
+    border: 1px solid var(--neon-cyan);
+    padding: 18px;
+    box-shadow: 0 20px 40px -15px rgba(0, 0, 0, 0.8), 0 0 20px rgba(0, 242, 254, 0.15);
+    position: relative;
+}
+
+.tooltip-inner-mesh::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: var(--neon-cyan) transparent transparent transparent;
+}
+
+.badge-neon {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    background: rgba(0, 242, 254, 0.1);
+    color: var(--neon-cyan);
+    padding: 2px 6px;
+    border: 1px solid rgba(0, 242, 254, 0.3);
+}
+
+.node-title {
+    margin: 8px 0 4px 0;
+    font-size: 15px;
+    font-weight: 700;
+    color: #ffffff;
+    text-transform: uppercase;
+}
+
+.node-desc {
+    margin: 0;
+    font-size: 12px;
+    color: #94a3b8;
+    line-height: 1.5;
+}
+
+.tooltip-wrapper:hover .spring-neon-tooltip,
+.tooltip-trigger-btn:focus + .spring-neon-tooltip {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(-50%) translateY(0) var(--tooltip-spring-scale-target);
+}


### PR DESCRIPTION
## Pull Request Description
This PR introduces an energetic, high-contrast terminal asset ("CSS Spring Physics Tooltip") implementing dual-overshoot spring simulations, elastic recoil timelines, and custom configuration properties styled to match Cyberpunk and Neon Dashboard layouts, closing issue #46290.
<!-- Briefly describe what you're submitting and the problem it solves. -->

---

## Type of Change

- [X] ✨ New animation / hover effect
- [X] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [X] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [X] Includes `demo.html` — self-contained, opens in browser with no server
- [X] Includes `style.css` — raw CSS for the proposed feature
- [X] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [X] **No changes to `core/`**
- [X] **No changes to `components/`**
- [X] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A vibrant cyberpunk system monitor tooltip that snaps into the viewport with a rapid "spring-back" kinetic recoil. By structuring an aggressive cubic curve (`cubic-bezier(0.68, -0.6, 0.34, 1.55)`) combined with explicit initial scaling and translation offsets (`translateY(18px) scale(0.5)`), the dialog box achieves elastic tension entirely via pure, semantic CSS loops.
<!-- One-sentence description -->

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
<div class="tooltip-wrapper">
    <button class="tooltip-trigger-btn">...</button>
    <div class="spring-neon-tooltip">
        <div class="tooltip-inner-mesh">
            <!-- Cyber security trace details and node cluster logs -->
        </div>
    </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It perfectly aligns with the library's performance standards by keeping all intensive layout bouncing, scale transformations, and focus glows isolated on GPU hardware compositor paths (transform: translateY() scale()), protecting primary document execution lanes from heavy paint invalidation cycles.
<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [X] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari *(optional but appreciated)*

---

## Notes for Maintainer
closes #46290 
<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
