### PR TITLE
Add Next.js App Router import placement pitfalls guide (ease-nextjs-i…

### DIFF
--- a/submissions/docs/ease-nextjs-import-pitfalls-hr18/README.md
+++ b/submissions/docs/ease-nextjs-import-pitfalls-hr18/README.md
@@ -1,0 +1,77 @@
+# Next.js App Router Import Placement Pitfalls (`ease-nextjs-import-pitfalls-hr18`)
+
+A documentation-style guide explaining how EaseMotion's stylesheet import
+location affects a Next.js App Router app, built for issue
+[#47640](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47640).
+
+## What it does
+
+The App Router keeps `app/layout.js` mounted across every navigation but
+remounts `app/page.js` on each route change — which means *where* you import
+`easemotion-css` actually matters, unlike in a plain single-page setup. This
+guide:
+
+- **Demonstrates the flash live** — two mock browser windows, one simulating
+  an import scoped to `page.js` (flashes unstyled content on every simulated
+  navigation) and one simulating an import in `layout.js` (never flashes,
+  since the layout never unmounts)
+- **Compares wrong vs correct placement** with real code for both
+  `app/page.js` and `app/layout.js`
+- **Explains FOUC's causes** (per-route imports, duplicate imports) and its
+  **prevention** (import once at the root, avoid pushing it into a nested
+  Client Component)
+- **Covers Server Component compatibility** — the import needs no
+  `"use client"` directive, since EaseMotion is plain CSS
+- **Provides copy-ready snippets** for both `layout.js` and `page.js`,
+  switchable by tab
+- **Gives a pitfall checklist** covering import order, global scope, and
+  duplicate imports
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN. (A Next.js project isn't
+required to view the guide — the App Router code is shown as illustrative
+snippets.)
+
+## Usage
+
+Open `demo.html`. Click **"Simulate navigation"** on the `page.js` window
+first to see the unstyled flash, then on the `layout.js` window to see the
+same simulated navigation with no flash. Read through the wrong-vs-correct
+comparison and the FOUC callouts, then use the **layout.js / page.js** tabs
+and **Copy snippet** button to grab the import you need.
+
+## Accessibility notes
+
+- The two demo windows are labeled with their import location in a visible
+  URL bar (`app/page.js imports styles` / `app/layout.js imports styles`),
+  not color alone, so the difference reads without relying on the flash
+  itself.
+- The copy button announces success or failure through an
+  `aria-live="polite"` status region.
+- Copying uses the async Clipboard API first, with a hidden-`<textarea>` +
+  `document.execCommand('copy')` fallback for older or restricted browsers.
+- The tabs use proper `role="tablist"` / `role="tab"` semantics with
+  `aria-selected` state, built on native `<button>` elements.
+- The demo's entrance animation respects
+  `@media (prefers-reduced-motion: reduce)`.
+
+## Responsiveness
+
+The FOUC-demo grid and the wrong-vs-correct comparison grid both collapse
+from two columns to one under a `720px` viewport width.
+
+## Why this fits EaseMotion CSS
+
+This closes a real, easy-to-hit setup mistake for one of the most common
+frameworks EaseMotion gets used in — the fix isn't a framework quirk to work
+around, it's just putting a plain CSS import in the file that actually
+matches how long it needs to stay applied. Built the same way as every other
+submission here: plain HTML/CSS/vanilla JS, no framework or build step
+required to read or run it.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/docs/`.

--- a/submissions/docs/ease-nextjs-import-pitfalls-hr18/demo.html
+++ b/submissions/docs/ease-nextjs-import-pitfalls-hr18/demo.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Next.js App Router Import Placement Pitfalls</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="nip-hr18">
+  <div class="nip-wrap-hr18">
+
+    <header class="nip-header-hr18">
+      <span class="nip-eyebrow-hr18">EaseMotion-css · submissions/docs</span>
+      <h1>Next.js App Router Import Placement Pitfalls</h1>
+      <p>EaseMotion is a single global stylesheet import, but <em>where</em> you
+        put that import in a Next.js App Router project changes what a visitor
+        actually sees. Import it in the wrong file and you can get a flash of
+        unstyled content (FOUC) every time someone navigates. This guide shows
+        why, and where the import actually belongs.</p>
+    </header>
+
+    <!-- Live FOUC demo -->
+    <section class="nip-section-hr18" aria-labelledby="nipDemoHeading">
+      <h2 id="nipDemoHeading">See the flash</h2>
+      <p class="nip-lede-hr18">Click "Simulate navigation" on each window to see
+        what a route change looks like depending on where the import lives.</p>
+
+      <div class="nip-demo-grid-hr18">
+
+        <div class="nip-demo-card-hr18">
+          <div class="nip-window-chrome-hr18">
+            <span class="nip-dot-hr18"></span><span class="nip-dot-hr18"></span><span class="nip-dot-hr18"></span>
+            <span class="nip-window-url-hr18">app/page.js imports styles</span>
+          </div>
+          <div class="nip-window-body-hr18 styled-hr18" id="nipWrongWindow">
+            <p class="nip-fake-title-hr18">Welcome back</p>
+            <span class="nip-fake-btn-hr18">Continue</span>
+          </div>
+          <div class="nip-demo-controls-hr18">
+            <p>Import scoped to the page — reloads (and briefly flashes) on every navigation.</p>
+            <button type="button" class="nip-replay-btn-hr18" id="nipWrongBtn">Simulate navigation</button>
+          </div>
+        </div>
+
+        <div class="nip-demo-card-hr18">
+          <div class="nip-window-chrome-hr18">
+            <span class="nip-dot-hr18"></span><span class="nip-dot-hr18"></span><span class="nip-dot-hr18"></span>
+            <span class="nip-window-url-hr18">app/layout.js imports styles</span>
+          </div>
+          <div class="nip-window-body-hr18 styled-hr18" id="nipCorrectWindow">
+            <p class="nip-fake-title-hr18">Welcome back</p>
+            <span class="nip-fake-btn-hr18">Continue</span>
+          </div>
+          <div class="nip-demo-controls-hr18">
+            <p>Import lives in the persistent root layout — already applied, no flash.</p>
+            <button type="button" class="nip-replay-btn-hr18" id="nipCorrectBtn">Simulate navigation</button>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Wrong vs correct -->
+    <section class="nip-section-hr18" aria-labelledby="nipPatternHeading">
+      <h2 id="nipPatternHeading">Wrong vs correct import placement</h2>
+      <p class="nip-lede-hr18">The App Router re-renders <code>page.js</code> on
+        every navigation to that route, but keeps a shared <code>layout.js</code>
+        mounted across all of them — which is exactly why import location
+        matters here in a way it didn't in the old Pages Router.</p>
+
+      <div class="nip-pattern-grid-hr18">
+        <article class="nip-pattern-card-hr18 wrong">
+          <div class="nip-pattern-head-hr18">&#10007; app/page.js</div>
+          <pre class="nip-pattern-code-hr18">// app/page.js
+import "easemotion-css/min";
+
+export default function Page() {
+  return (
+    &lt;main className="ease-fade-in"&gt;
+      &lt;h1&gt;Home&lt;/h1&gt;
+    &lt;/main&gt;
+  );
+}</pre>
+          <p class="nip-pattern-note-hr18">Works on the first load, but every
+            other route (<code>app/about/page.js</code>, etc.) needs its own
+            copy of this import — miss one and that page silently renders
+            unstyled. Even where it is imported, Next.js can reload the chunk
+            on navigation, producing a brief unstyled flash.</p>
+        </article>
+
+        <article class="nip-pattern-card-hr18 correct">
+          <div class="nip-pattern-head-hr18">&#10003; app/layout.js</div>
+          <pre class="nip-pattern-code-hr18">// app/layout.js
+import "easemotion-css/min";
+
+export default function RootLayout({ children }) {
+  return (
+    &lt;html lang="en"&gt;
+      &lt;body&gt;{children}&lt;/body&gt;
+    &lt;/html&gt;
+  );
+}</pre>
+          <p class="nip-pattern-note-hr18">Imported exactly once, in the file
+            that wraps every route. The stylesheet is applied before any page
+            renders and stays applied across client-side navigations, since
+            the root layout never unmounts.</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- FOUC explanation -->
+    <section class="nip-section-hr18" aria-labelledby="nipFoucHeading">
+      <h2 id="nipFoucHeading">Why the flash happens — and how to prevent it</h2>
+      <div class="nip-callout-grid-hr18">
+        <div class="nip-callout-hr18">
+          <h3>Cause: per-route imports</h3>
+          <p>A CSS import inside <code>page.js</code> is scoped to that route's
+            bundle. On navigation, React has to mount the new page (and its
+            styles) before they can apply — there's a real, if brief, unstyled
+            window.</p>
+        </div>
+        <div class="nip-callout-hr18">
+          <h3>Cause: duplicate imports</h3>
+          <p>Importing the same stylesheet in multiple page files doesn't
+            error, but it does nothing for consistency — each route still only
+            gets styled once its own bundle loads.</p>
+        </div>
+        <div class="nip-callout-hr18">
+          <h3>Prevention: import once, at the root</h3>
+          <p>Put the import in <code>app/layout.js</code> (or
+            <code>app/globals.css</code>'s own import chain). It loads with the
+            shell that wraps every page, so there's nothing left to flash.</p>
+        </div>
+        <div class="nip-callout-hr18">
+          <h3>Prevention: don't nest it in Client Components</h3>
+          <p>Keep the import in a Server Component layout. Pushing it into a
+            deeply nested <code>"use client"</code> component ties the
+            stylesheet to that component's hydration timing instead of the
+            initial HTML response.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Server component note -->
+    <section class="nip-section-hr18" aria-labelledby="nipServerHeading">
+      <h2 id="nipServerHeading">Server Component compatibility</h2>
+      <div class="nip-note-box-hr18">
+        <strong>EaseMotion's classes are plain CSS</strong>, so importing the
+        stylesheet needs no <code>"use client"</code> directive and works
+        fine inside a Server Component like the default <code>app/layout.js</code>.
+        You only need <code>"use client"</code> for a component if it also
+        uses React state, effects, or browser-only APIs — not just because it
+        happens to have EaseMotion classes on its markup.
+      </div>
+    </section>
+
+    <!-- Copy-ready snippets -->
+    <section class="nip-section-hr18" aria-labelledby="nipSnippetHeading">
+      <h2 id="nipSnippetHeading">Copy-ready imports</h2>
+      <p class="nip-lede-hr18">Pick the file you're editing.</p>
+
+      <div class="nip-tabs-hr18" role="tablist" aria-label="Snippet target file">
+        <button type="button" class="nip-tab-hr18" role="tab" aria-selected="true" id="nipTabLayout" data-target="nipCodeLayout">layout.js</button>
+        <button type="button" class="nip-tab-hr18" role="tab" aria-selected="false" id="nipTabPage" data-target="nipCodePage">page.js</button>
+      </div>
+
+      <div class="nip-snippet-card-hr18">
+        <div class="nip-snippet-head-hr18">
+          <button type="button" class="nip-copy-btn-hr18" id="nipCopyBtn">Copy snippet</button>
+        </div>
+        <pre class="nip-snippet-code-hr18" id="nipCodeLayout">// app/layout.js
+import "easemotion-css/min";
+
+export default function RootLayout({ children }) {
+  return (
+    &lt;html lang="en"&gt;
+      &lt;body&gt;{children}&lt;/body&gt;
+    &lt;/html&gt;
+  );
+}</pre>
+        <pre class="nip-snippet-code-hr18" id="nipCodePage" hidden>// app/page.js
+// No stylesheet import here — it already loads
+// once, globally, from app/layout.js.
+
+export default function Page() {
+  return (
+    &lt;main className="ease-fade-in"&gt;
+      &lt;h1&gt;Home&lt;/h1&gt;
+    &lt;/main&gt;
+  );
+}</pre>
+        <p class="nip-status-hr18" id="nipSnippetStatus" role="status" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <!-- Checklist -->
+    <section class="nip-section-hr18" aria-labelledby="nipChecklistHeading">
+      <h2 id="nipChecklistHeading">Pitfall checklist</h2>
+      <ul class="nip-checklist-hr18">
+        <li><strong>Import order</strong> — if you also have a custom <code>globals.css</code>, import EaseMotion before it so your own overrides win the cascade.</li>
+        <li><strong>Global scope</strong> — the import should appear exactly once, in <code>app/layout.js</code>, not repeated per route.</li>
+        <li><strong>Duplicate imports</strong> — search your <code>app/</code> tree for other <code>easemotion-css</code> imports before adding a new one; a second import doesn't break anything but is a sign the first one is in the wrong place.</li>
+        <li><strong>No unnecessary "use client"</strong> — importing the stylesheet doesn't require marking the file a Client Component.</li>
+      </ul>
+    </section>
+
+    <p class="nip-footnote-hr18">submissions/docs/ease-nextjs-import-pitfalls-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // ---- FOUC demo ----
+  var wrongWindow = document.getElementById("nipWrongWindow");
+  var wrongBtn = document.getElementById("nipWrongBtn");
+  var correctWindow = document.getElementById("nipCorrectWindow");
+  var correctBtn = document.getElementById("nipCorrectBtn");
+
+  wrongBtn.addEventListener("click", function () {
+    wrongWindow.classList.remove("styled-hr18");
+    wrongWindow.classList.add("unstyled-hr18");
+    window.setTimeout(function () {
+      wrongWindow.classList.remove("unstyled-hr18");
+      wrongWindow.classList.add("styled-hr18");
+    }, 550);
+  });
+
+  correctBtn.addEventListener("click", function () {
+    // Layout never unmounts, so styling never drops out — just a quick
+    // re-affirm animation on the content, no unstyled phase.
+    var title = correctWindow.querySelector(".nip-fake-title-hr18");
+    title.style.animation = "none";
+    void title.offsetWidth;
+    title.style.animation = "";
+  });
+
+  // ---- Tabs ----
+  var tabs = document.querySelectorAll(".nip-tab-hr18");
+  tabs.forEach(function (tab) {
+    tab.addEventListener("click", function () {
+      tabs.forEach(function (t) {
+        t.setAttribute("aria-selected", "false");
+        document.getElementById(t.getAttribute("data-target")).hidden = true;
+      });
+      tab.setAttribute("aria-selected", "true");
+      document.getElementById(tab.getAttribute("data-target")).hidden = false;
+    });
+  });
+
+  // ---- Copy ----
+  var copyBtn = document.getElementById("nipCopyBtn");
+  var status = document.getElementById("nipSnippetStatus");
+
+  function announce(message) {
+    status.textContent = message;
+    window.setTimeout(function () {
+      status.textContent = "";
+    }, 3000);
+  }
+
+  function fallbackCopy(text) {
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    try {
+      var ok = document.execCommand("copy");
+      announce(ok ? "Copied to clipboard." : "Copy failed \u2014 select and copy manually.");
+    } catch (err) {
+      announce("Copy failed \u2014 select and copy manually.");
+    }
+    document.body.removeChild(textarea);
+  }
+
+  copyBtn.addEventListener("click", function () {
+    var visible = document.querySelector(".nip-snippet-code-hr18:not([hidden])");
+    var text = visible.textContent;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () {
+        announce("Copied to clipboard.");
+      }, function () {
+        fallbackCopy(text);
+      });
+    } else {
+      fallbackCopy(text);
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/docs/ease-nextjs-import-pitfalls-hr18/style.css
+++ b/submissions/docs/ease-nextjs-import-pitfalls-hr18/style.css
@@ -1,0 +1,465 @@
+/* ==========================================================================
+   ease-nextjs-import-pitfalls-hr18 — style.css
+   Next.js App Router Import Placement Pitfalls guide
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.nip-hr18 {
+  --bg-hr18: #f4f5f8;
+  --panel-hr18: #ffffff;
+  --panel-raised-hr18: #f8f8fb;
+  --border-hr18: #e1e3ea;
+  --text-hr18: #1a1d24;
+  --text-muted-hr18: #676c78;
+  --accent-hr18: #4f46e5;
+  --accent-soft-hr18: #ecebfd;
+  --wrong-hr18: #cf3f30;
+  --wrong-bg-hr18: #fbeae7;
+  --correct-hr18: #1f8a4c;
+  --correct-bg-hr18: #e6f5ec;
+  --radius-hr18: 12px;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4rem;
+  min-height: 100%;
+}
+
+.nip-hr18 * {
+  box-sizing: border-box;
+}
+
+.nip-hr18 h1,
+.nip-hr18 h2,
+.nip-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.nip-hr18 code {
+  font-family: var(--font-mono-hr18);
+  background: var(--panel-raised-hr18);
+  border: 1px solid var(--border-hr18);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.88em;
+}
+
+.nip-wrap-hr18 {
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+/* ---- Header --------------------------------------------------------------- */
+.nip-header-hr18 {
+  margin-bottom: 2.5rem;
+}
+
+.nip-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.nip-header-hr18 h1 {
+  font-size: clamp(1.6rem, 2.8vw, 2.3rem);
+}
+
+.nip-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 64ch;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* ---- Section shell ---------------------------------------------------------- */
+.nip-section-hr18 {
+  margin-top: 3rem;
+}
+
+.nip-section-hr18 h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.4rem;
+}
+
+.nip-lede-hr18 {
+  color: var(--text-muted-hr18);
+  font-size: 0.92rem;
+  max-width: 64ch;
+  line-height: 1.6;
+  margin: 0 0 1.25rem;
+}
+
+/* ---- FOUC demo: mini browser windows ----------------------------------------- */
+.nip-demo-grid-hr18 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 720px) {
+  .nip-demo-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.nip-demo-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  overflow: hidden;
+}
+
+.nip-window-chrome-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 0.8rem;
+  background: var(--panel-raised-hr18);
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.nip-dot-hr18 {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--border-hr18);
+}
+
+.nip-window-url-hr18 {
+  margin-left: 0.5rem;
+  font-family: var(--font-mono-hr18);
+  font-size: 0.72rem;
+  color: var(--text-muted-hr18);
+}
+
+.nip-window-body-hr18 {
+  padding: 1.5rem 1.25rem;
+  min-height: 130px;
+}
+
+.nip-fake-title-hr18 {
+  font-family: var(--font-display-hr18);
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem;
+}
+
+.nip-fake-btn-hr18 {
+  display: inline-block;
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.82rem;
+  border-radius: 999px;
+}
+
+/* Unstyled flash state: plain browser defaults, no EaseMotion applied. */
+.nip-window-body-hr18.unstyled-hr18 .nip-fake-title-hr18 {
+  font-family: Georgia, "Times New Roman", serif;
+  color: #000;
+}
+
+.nip-window-body-hr18.unstyled-hr18 .nip-fake-btn-hr18 {
+  background: none;
+  border: 1px solid #767676;
+  color: #000;
+  border-radius: 2px;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+/* Styled state: EaseMotion applied. */
+.nip-window-body-hr18.styled-hr18 .nip-fake-title-hr18 {
+  color: var(--accent-hr18);
+  animation: nip-fade-in-hr18 400ms ease both;
+}
+
+.nip-window-body-hr18.styled-hr18 .nip-fake-btn-hr18 {
+  background: var(--accent-hr18);
+  color: #fff;
+  border: none;
+  transition: transform 180ms ease;
+}
+
+.nip-window-body-hr18.styled-hr18 .nip-fake-btn-hr18:hover {
+  transform: translateY(-2px);
+}
+
+@keyframes nip-fade-in-hr18 {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.nip-demo-controls-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-top: 1px solid var(--border-hr18);
+}
+
+.nip-demo-controls-hr18 p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-muted-hr18);
+}
+
+.nip-replay-btn-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.78rem;
+  font-weight: 600;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-raised-hr18);
+  color: var(--text-hr18);
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.nip-replay-btn-hr18:hover {
+  border-color: var(--accent-hr18);
+  color: var(--accent-hr18);
+}
+
+/* ---- Wrong vs correct code comparison ------------------------------------------ */
+.nip-pattern-grid-hr18 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 720px) {
+  .nip-pattern-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.nip-pattern-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  overflow: hidden;
+  background: var(--panel-hr18);
+}
+
+.nip-pattern-card-hr18.wrong {
+  border-color: rgba(207, 63, 48, 0.3);
+}
+
+.nip-pattern-card-hr18.correct {
+  border-color: rgba(31, 138, 76, 0.3);
+}
+
+.nip-pattern-head-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.nip-pattern-card-hr18.wrong .nip-pattern-head-hr18 {
+  background: var(--wrong-bg-hr18);
+  color: var(--wrong-hr18);
+}
+
+.nip-pattern-card-hr18.correct .nip-pattern-head-hr18 {
+  background: var(--correct-bg-hr18);
+  color: var(--correct-hr18);
+}
+
+.nip-pattern-code-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.78rem;
+  line-height: 1.65;
+  padding: 1rem;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--text-hr18);
+}
+
+.nip-pattern-note-hr18 {
+  border-top: 1px solid var(--border-hr18);
+  padding: 0.85rem 1rem;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- FOUC explanation panel -------------------------------------------------------- */
+.nip-callout-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.nip-callout-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 1.1rem 1.25rem;
+}
+
+.nip-callout-hr18 h3 {
+  font-size: 0.95rem;
+  margin-bottom: 0.4rem;
+}
+
+.nip-callout-hr18 p {
+  margin: 0;
+  color: var(--text-muted-hr18);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+/* ---- Server component note box ------------------------------------------------------- */
+.nip-note-box-hr18 {
+  border: 1px solid var(--accent-soft-hr18);
+  background: var(--accent-soft-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.1rem 1.25rem;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: #33308f;
+}
+
+.nip-note-box-hr18 strong {
+  color: var(--accent-hr18);
+}
+
+/* ---- Snippet tabs with copy ----------------------------------------------------------- */
+.nip-tabs-hr18 {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0;
+}
+
+.nip-tab-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.78rem;
+  background: var(--panel-raised-hr18);
+  border: 1px solid var(--border-hr18);
+  border-bottom: none;
+  color: var(--text-muted-hr18);
+  padding: 0.55rem 1rem;
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+}
+
+.nip-tab-hr18[aria-selected="true"] {
+  background: var(--panel-hr18);
+  color: var(--accent-hr18);
+  font-weight: 600;
+}
+
+.nip-snippet-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: 0 var(--radius-hr18) var(--radius-hr18) var(--radius-hr18);
+  background: var(--panel-hr18);
+  overflow: hidden;
+}
+
+.nip-snippet-head-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.nip-copy-btn-hr18 {
+  background: var(--accent-hr18);
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font-family: var(--font-body-hr18);
+  font-size: 0.76rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.nip-copy-btn-hr18:hover {
+  filter: brightness(1.08);
+}
+
+.nip-snippet-code-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.78rem;
+  line-height: 1.65;
+  padding: 1rem;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--text-hr18);
+}
+
+.nip-snippet-code-hr18[hidden] {
+  display: none;
+}
+
+.nip-status-hr18 {
+  padding: 0 1rem 0.85rem;
+  font-size: 0.76rem;
+  color: var(--correct-hr18);
+  min-height: 1.1em;
+}
+
+/* ---- Checklist ---------------------------------------------------------------------------- */
+.nip-checklist-hr18 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.nip-checklist-hr18 li {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 0.85rem 1rem;
+  font-size: 0.88rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.55;
+}
+
+.nip-checklist-hr18 strong {
+  color: var(--accent-hr18);
+  font-family: var(--font-mono-hr18);
+  margin-right: 0.5rem;
+}
+
+/* ---- Footnote ------------------------------------------------------------------------------ */
+.nip-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+.nip-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+/* ---- Reduced motion ---------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .nip-window-body-hr18.styled-hr18 .nip-fake-title-hr18 {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a documentation-style guide explaining how EaseMotion's stylesheet
import location affects a Next.js App Router app. Includes a live demo
comparing a `page.js`-scoped import (flashes unstyled content on simulated
navigation) against a `layout.js` import (no flash, since the layout never
unmounts), a wrong-vs-correct code comparison, FOUC cause/prevention
callouts, a Server Component compatibility note, copy-ready tabbed snippets
for both files, and a pitfall checklist.

Resolves #47640

Note for the maintainer: this issue has multiple assignees. The issue body
references a `-sp` suffixed folder name, which I'm assuming belongs to
@suman20041's own submission — mine is a separate, independently-built
implementation under a `-hr18` suffix so the two don't collide.

---

## Type of Change
- [x] 📝 Documentation improvement

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/ease-nextjs-import-pitfalls-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A static, interactive guide showing why EaseMotion's stylesheet import
belongs in `app/layout.js`, not `app/page.js`, in a Next.js App Router app.

**How does a developer use it?**
\`\`\`html
<!-- Open demo.html directly. Click "Simulate navigation" on each mock
     browser window to feel the difference, then copy the correct import
     from the layout.js tab. -->
\`\`\`

**Why does it fit EaseMotion CSS?**
Closes a real, easy-to-hit setup mistake in one of the most common
frameworks EaseMotion gets used in. Built the same way as every other
submission here: plain HTML/CSS/vanilla JS, no framework or build step
needed to read or run it.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
The FOUC simulation uses a plain class-swap timer rather than an actual
Next.js build, since the guide is meant to be readable without a Next.js
project set up. Tested in Chrome; haven't checked other browsers yet.