### PR TITLE
Add reusable Copy Code button component (copy-code-btn-hr18)

### DIFF
--- a/submissions/examples/copy-code-btn-hr18/README.md
+++ b/submissions/examples/copy-code-btn-hr18/README.md
@@ -1,0 +1,82 @@
+# Copy Code Button (`copy-code-btn-hr18`)
+
+A reusable Copy Code button for documentation code blocks, built for issue
+[#48659](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/48659).
+
+## What it does
+
+Wraps any code block in a `.ease-code-block-hr18` container with a
+`.ease-copy-btn-hr18` button pinned to its top-right corner. Clicking it
+copies the block's text via the Clipboard API, swaps the icon from a
+clipboard to a checkmark, changes the label to "Copied!", and reverts back
+after ~1.8 seconds — no page reload, no per-block wiring required.
+
+The demo shows it applied to three realistic documentation examples: an
+`npm install` command, a CDN `<link>` tag, and a multi-line `import`
+snippet.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap any code block in the component markup:
+
+```html
+<div class="ease-code-block-hr18">
+  <pre><code>npm install easemotion-css</code></pre>
+  <button type="button" class="ease-copy-btn-hr18" aria-label="Copy code">
+    <svg class="ccb-icon-hr18 ccb-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="9" y="9" width="11" height="11" rx="2"></rect>
+      <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+    </svg>
+    <svg class="ccb-icon-hr18 ccb-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <polyline points="20 6 9 17 4 12"></polyline>
+    </svg>
+    <span class="ccb-label-hr18">Copy</span>
+  </button>
+</div>
+```
+
+Add as many `.ease-code-block-hr18` elements to a page as you like — the
+included script finds every instance automatically on load and wires up its
+button, so a new code block only needs the markup above, not extra
+JavaScript per instance.
+
+## Accessibility notes
+
+- The button always has a real `aria-label="Copy code"`, so it's announced
+  correctly by screen readers even though its visible label text changes.
+- A separate visually-hidden `role="status"` / `aria-live="polite"` region
+  announces "Code copied to clipboard." (or a failure message) on every
+  copy, independent of the button's own visual state change.
+- Copying uses the async Clipboard API first, with a hidden-`<textarea>` +
+  `document.execCommand('copy')` fallback for older or restricted browsers.
+- The success state isn't color-only: the icon swaps from a clipboard glyph
+  to a checkmark and the label text changes to "Copied!", so it reads
+  correctly without relying on the green background alone.
+- The button is a native `<button>`, so it's reachable and operable by
+  keyboard (`Tab` + `Enter`/`Space`) with no extra scripting.
+
+## Responsiveness
+
+Code blocks scroll horizontally on narrow viewports rather than wrapping
+awkwardly, and below `420px` the button collapses to icon-only (no "Copy" /
+"Copied!" text) so it doesn't crowd the corner of a narrow code block.
+
+## Why this fits EaseMotion CSS
+
+It's exactly the kind of small, high-frequency-use component the framework
+is meant to make trivial: pure CSS for the look, minimal vanilla JS for the
+behavior, and a class-based API (`ease-code-block-hr18` /
+`ease-copy-btn-hr18`) consistent with EaseMotion's existing naming
+conventions. It directly improves the documentation experience described in
+the issue, matching the one-click copy pattern used by Tailwind CSS,
+shadcn/ui, and similar modern docs sites.
+
+All classes and custom properties, and the folder itself, use a `-hr18`
+suffix to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/copy-code-btn-hr18/demo.html
+++ b/submissions/examples/copy-code-btn-hr18/demo.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Copy Code Button — component demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ccb-hr18">
+  <div class="ccb-wrap-hr18">
+
+    <header class="ccb-header-hr18">
+      <span class="ccb-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Copy Code button</h1>
+      <p>A drop-in copy button for documentation code blocks — installation
+        commands, CDN links, and import statements can all be copied with one
+        click instead of manual selection.</p>
+    </header>
+
+    <!-- Example 1: npm install -->
+    <section class="ccb-section-hr18">
+      <span class="ccb-section-label-hr18">Install via npm</span>
+      <div class="ease-code-block-hr18">
+        <pre><code>npm install easemotion-css</code></pre>
+        <button type="button" class="ease-copy-btn-hr18" aria-label="Copy code">
+          <svg class="ccb-icon-hr18 ccb-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="9" y="9" width="11" height="11" rx="2"></rect>
+            <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+          </svg>
+          <svg class="ccb-icon-hr18 ccb-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+          <span class="ccb-label-hr18">Copy</span>
+        </button>
+      </div>
+    </section>
+
+    <!-- Example 2: CDN link -->
+    <section class="ccb-section-hr18">
+      <span class="ccb-section-label-hr18">Or via CDN</span>
+      <div class="ease-code-block-hr18">
+        <pre><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/dist/easemotion.min.css"&gt;</code></pre>
+        <button type="button" class="ease-copy-btn-hr18" aria-label="Copy code">
+          <svg class="ccb-icon-hr18 ccb-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="9" y="9" width="11" height="11" rx="2"></rect>
+            <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+          </svg>
+          <svg class="ccb-icon-hr18 ccb-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+          <span class="ccb-label-hr18">Copy</span>
+        </button>
+      </div>
+    </section>
+
+    <!-- Example 3: import statement, multi-line -->
+    <section class="ccb-section-hr18">
+      <span class="ccb-section-label-hr18">Import in your entry file</span>
+      <div class="ease-code-block-hr18">
+        <pre><code>// app/layout.js
+import "easemotion-css/min";
+
+export default function RootLayout({ children }) {
+  return (
+    &lt;html lang="en"&gt;
+      &lt;body&gt;{children}&lt;/body&gt;
+    &lt;/html&gt;
+  );
+}</code></pre>
+        <button type="button" class="ease-copy-btn-hr18" aria-label="Copy code">
+          <svg class="ccb-icon-hr18 ccb-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="9" y="9" width="11" height="11" rx="2"></rect>
+            <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+          </svg>
+          <svg class="ccb-icon-hr18 ccb-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+          <span class="ccb-label-hr18">Copy</span>
+        </button>
+      </div>
+    </section>
+
+    <p class="ccb-note-hr18">Every <code>.ease-code-block-hr18</code> on the page
+      gets a working copy button automatically — the script below finds each
+      one and wires it up, so adding a new code block is just markup, no
+      extra JavaScript per instance.</p>
+
+    <p class="ccb-sr-only-hr18" id="ccbLiveRegion" role="status" aria-live="polite"></p>
+
+    <p class="ccb-footnote-hr18">submissions/examples/copy-code-btn-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var liveRegion = document.getElementById("ccbLiveRegion");
+
+  function announce(message) {
+    liveRegion.textContent = message;
+    window.setTimeout(function () {
+      liveRegion.textContent = "";
+    }, 2000);
+  }
+
+  function fallbackCopy(text) {
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    var ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } catch (err) {
+      ok = false;
+    }
+    document.body.removeChild(textarea);
+    return ok;
+  }
+
+  function handleCopyClick(btn, codeEl) {
+    var text = codeEl.textContent;
+
+    function onSuccess() {
+      btn.classList.add("is-copied-hr18");
+      var label = btn.querySelector(".ccb-label-hr18");
+      var originalLabel = label ? label.textContent : "";
+      if (label) label.textContent = "Copied!";
+      announce("Code copied to clipboard.");
+      window.setTimeout(function () {
+        btn.classList.remove("is-copied-hr18");
+        if (label) label.textContent = originalLabel;
+      }, 1800);
+    }
+
+    function onFailure() {
+      announce("Copy failed. Please select and copy manually.");
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(onSuccess, function () {
+        if (fallbackCopy(text)) {
+          onSuccess();
+        } else {
+          onFailure();
+        }
+      });
+    } else {
+      if (fallbackCopy(text)) {
+        onSuccess();
+      } else {
+        onFailure();
+      }
+    }
+  }
+
+  // Wire up every code block on the page automatically.
+  var blocks = document.querySelectorAll(".ease-code-block-hr18");
+  blocks.forEach(function (block) {
+    var btn = block.querySelector(".ease-copy-btn-hr18");
+    var codeEl = block.querySelector("code");
+    if (!btn || !codeEl) return;
+    btn.addEventListener("click", function () {
+      handleCopyClick(btn, codeEl);
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/copy-code-btn-hr18/style.css
+++ b/submissions/examples/copy-code-btn-hr18/style.css
@@ -1,0 +1,215 @@
+/* ==========================================================================
+   copy-code-btn-hr18 — style.css
+   Reusable Copy Code button for documentation code blocks
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.ccb-hr18 {
+  --bg-hr18: #fafafa;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e6e6ea;
+  --text-hr18: #17181c;
+  --text-muted-hr18: #6d7080;
+  --accent-hr18: #6a4cff;
+  --accent-soft-hr18: #efeaff;
+  --success-hr18: #1f9d5e;
+  --success-soft-hr18: #e7f8ee;
+  --code-bg-hr18: #1a1b23;
+  --code-text-hr18: #e9e9f2;
+  --code-border-hr18: #2b2d3a;
+  --radius-hr18: 12px;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4rem;
+  min-height: 100%;
+}
+
+.ccb-hr18 * {
+  box-sizing: border-box;
+}
+
+.ccb-hr18 h1,
+.ccb-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.ccb-hr18 code {
+  font-family: var(--font-mono-hr18);
+}
+
+.ccb-wrap-hr18 {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+/* ---- Header --------------------------------------------------------------- */
+.ccb-header-hr18 {
+  margin-bottom: 2.25rem;
+}
+
+.ccb-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.ccb-header-hr18 h1 {
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+}
+
+.ccb-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 60ch;
+  font-size: 0.96rem;
+  line-height: 1.6;
+}
+
+/* ---- Section ---------------------------------------------------------------- */
+.ccb-section-hr18 {
+  margin-top: 2rem;
+}
+
+.ccb-section-label-hr18 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted-hr18);
+  margin-bottom: 0.6rem;
+  display: block;
+}
+
+/* ---- The reusable component --------------------------------------------------
+   Drop this markup anywhere: a .ease-code-block-hr18 wrapping a <pre><code>,
+   with a .ease-copy-btn-hr18 inside it. The JS below finds every instance on
+   the page automatically — no per-block wiring required. */
+.ease-code-block-hr18 {
+  position: relative;
+  background: var(--code-bg-hr18);
+  border: 1px solid var(--code-border-hr18);
+  border-radius: var(--radius-hr18);
+  overflow: hidden;
+}
+
+.ease-code-block-hr18 pre {
+  margin: 0;
+  padding: 1.1rem 3.2rem 1.1rem 1.25rem;
+  overflow-x: auto;
+}
+
+.ease-code-block-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--code-text-hr18);
+  white-space: pre;
+}
+
+.ease-copy-btn-hr18 {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--code-text-hr18);
+  padding: 0.4rem 0.6rem;
+  border-radius: 8px;
+  font-family: var(--font-body-hr18);
+  font-size: 0.74rem;
+  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease, border-color 150ms ease;
+}
+
+.ease-copy-btn-hr18:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+.ease-copy-btn-hr18:active {
+  transform: scale(0.94);
+}
+
+.ease-copy-btn-hr18 .ccb-icon-hr18 {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.ease-copy-btn-hr18 .ccb-icon-check-hr18 {
+  display: none;
+}
+
+.ease-copy-btn-hr18.is-copied-hr18 {
+  background: var(--success-hr18);
+  border-color: var(--success-hr18);
+  color: #ffffff;
+}
+
+.ease-copy-btn-hr18.is-copied-hr18 .ccb-icon-copy-hr18 {
+  display: none;
+}
+
+.ease-copy-btn-hr18.is-copied-hr18 .ccb-icon-check-hr18 {
+  display: block;
+}
+
+.ease-copy-btn-hr18 .ccb-label-hr18 {
+  min-width: 3.4em;
+  text-align: left;
+}
+
+@media (max-width: 420px) {
+  .ease-copy-btn-hr18 .ccb-label-hr18 {
+    display: none;
+  }
+}
+
+/* ---- Live-region status, visually hidden but announced --------------------------- */
+.ccb-sr-only-hr18 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* ---- Focus visibility ------------------------------------------------------------- */
+.ccb-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+/* ---- Usage note box ------------------------------------------------------------------ */
+.ccb-note-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--accent-soft-hr18);
+  background: var(--accent-soft-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1rem 1.2rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: #3b2f9e;
+}
+
+.ccb-footnote-hr18 {
+  margin-top: 2rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}


### PR DESCRIPTION
## Pull Request Description
Adds a reusable Copy Code button for documentation code blocks. Wraps a code
block in a `.ease-code-block-hr18` container with an `.ease-copy-btn-hr18`
button pinned to its top-right corner; clicking it copies the block's text
via the Clipboard API, swaps a clipboard icon for a checkmark, and reverts
after ~1.8s. The demo shows it applied to three realistic examples: an npm
install command, a CDN link, and a multi-line import snippet.

Resolves #48659

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/copy-code-btn-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable copy-to-clipboard button component for code blocks, with a
copied/checkmark success state.

**How does a developer use it?**
```html
<div class="ease-code-block-hr18">
  <pre><code>npm install easemotion-css</code></pre>
  <button type="button" class="ease-copy-btn-hr18" aria-label="Copy code">
    <!-- clipboard + checkmark SVG icons, see README -->
    <span class="ccb-label-hr18">Copy</span>
  </button>
</div>
```

**Why does it fit EaseMotion CSS?**
It's the exact kind of small, high-frequency component EaseMotion is meant
to make trivial — pure CSS for the look, minimal vanilla JS for behavior,
and a class-based API consistent with the framework's existing naming.
Matches the copy-button pattern from Tailwind CSS, shadcn/ui, and similar
docs sites, as referenced in the issue.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
The script auto-discovers every `.ease-code-block-hr18` on the page, so a
new code block only needs the markup — no per-instance JS wiring. Tested in
Chrome; haven't checked other browsers yet.