### PR TITLE
Add keyboard accessibility audit + reference patterns (ease-a11y-keyb…

### DIFF
--- a/submissions/docs/ease-a11y-keyboard-audit-hr18/README.md
+++ b/submissions/docs/ease-a11y-keyboard-audit-hr18/README.md
@@ -1,0 +1,87 @@
+# Keyboard Accessibility Audit (`ease-a11y-keyboard-audit-hr18`)
+
+An audit of EaseMotion's documented interactive patterns against keyboard and
+screen-reader expectations, with a working accessible reference
+implementation of each, built for issue
+[#47369](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/47369).
+
+## A note on scope
+
+The issue asks to "verify every button, modal, dropdown, tooltip, accordion,
+etc." — which, taken literally, means editing the framework's actual
+components in `core/`/`components/`. The repository's own README currently
+states that **PRs modifying core files, workflows, configs, or shared
+framework code are temporarily restricted** while the project stabilizes,
+and that only self-contained submissions inside `submissions/` are being
+reviewed. So instead of touching restricted files, this submission audits
+the patterns as EaseMotion's own documentation demonstrates them, and
+provides corrected, accessible reference markup/CSS/JS for each — something
+the maintainer (or any contributor, once core access reopens) can use
+directly to patch the real components.
+
+## What it covers
+
+Five patterns, each with a **common-issues list** and a **live, working
+reference implementation**:
+
+- **Button** — native `<button>` usage and `:focus-visible` styling instead
+  of a clickable `<div>` with focus suppressed
+- **Modal / Dialog** — focus moves into the dialog on open, `Tab` is trapped
+  inside it, `Escape` closes it, and focus returns to the trigger afterward
+- **Dropdown menu** — opens via keyboard, `↓`/`↑` move between items,
+  `Escape` closes and returns focus to the trigger, `aria-expanded` stays in
+  sync
+- **Accordion** — real `<button>` headers with `aria-expanded` /
+  `aria-controls` wired to their panels
+- **Tooltip** — shows on `:focus-visible` as well as `:hover`, dismissible
+  with `Escape`, connected to its trigger via `aria-describedby`
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Open `demo.html` and try each pattern with the keyboard only — `Tab` through
+the page, open the dialog and try `Tab`/`Escape`, open the menu with `Enter`
+and navigate with arrow keys, toggle the accordion headers with `Enter` or
+`Space`, and tab to the tooltip trigger to see it appear without hovering.
+Each pattern's "common issues" list explains what typically breaks these
+interactions and why the reference fixes it.
+
+## Accessibility notes (this is the whole submission, but a few specifics)
+
+- `:focus-visible` is used everywhere instead of `outline: none`, so the
+  focus ring only shows for keyboard users and never for mouse clicks.
+- The modal implements a real focus trap (`Tab`/`Shift+Tab` wrap within it)
+  and restores focus to whatever triggered it on close — both frequently
+  missed in ad-hoc modal implementations.
+- The dropdown menu follows the WAI-ARIA APG menu-button pattern closely
+  enough for this scope: `aria-haspopup`, `aria-expanded`, `role="menu"` /
+  `role="menuitem"`, arrow-key navigation, and `Escape`-to-close-with-
+  focus-return.
+- No element anywhere uses a `tabindex` greater than `0` — natural DOM order
+  matches visual order throughout.
+- The tooltip is reachable and dismissible by keyboard alone, not just by
+  hovering with a mouse.
+
+## Responsiveness
+
+Each pattern's body collapses from a two-column (issues list + demo) layout
+to a single column under a `760px` viewport width.
+
+## Why this fits EaseMotion CSS
+
+It directly serves the issue's goal — verifying and fixing keyboard
+accessibility across the framework's interactive patterns — while
+respecting the repository's current restriction on `core/`/`components/`
+edits. The reference implementations are pure CSS plus minimal, framework-
+free JavaScript, consistent with EaseMotion's zero-dependency philosophy,
+and can be lifted directly into the real components once core contributions
+reopen.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/docs/`.

--- a/submissions/docs/ease-a11y-keyboard-audit-hr18/demo.html
+++ b/submissions/docs/ease-a11y-keyboard-audit-hr18/demo.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Keyboard Accessibility Audit — EaseMotion patterns</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="a11y-hr18">
+  <div class="a11y-wrap-hr18">
+
+    <header class="a11y-header-hr18">
+      <span class="a11y-eyebrow-hr18">EaseMotion-css · submissions/docs</span>
+      <h1>Keyboard Accessibility Audit</h1>
+      <p>An audit of the interactive patterns EaseMotion's documentation shows
+        — buttons, modals, dropdowns, accordions, tooltips — against keyboard
+        and screen-reader expectations, paired with a working, accessible
+        reference implementation of each.</p>
+      <div class="a11y-note-box-hr18">
+        This submission doesn't edit <code>core/</code> or <code>components/</code>
+        directly — per the repo's current contribution policy, those are
+        temporarily restricted to the maintainer while the framework
+        stabilizes. Instead, each pattern below is a corrected, drop-in
+        reference the maintainer (or any contributor) can use to patch the
+        real components.
+      </div>
+    </header>
+
+    <!-- Button -->
+    <section class="a11y-pattern-hr18" aria-labelledby="a11yButtonHeading">
+      <div class="a11y-pattern-head-hr18">
+        <h2 id="a11yButtonHeading">Button</h2>
+        <span class="a11y-pattern-tag-hr18">role: button (native)</span>
+      </div>
+      <div class="a11y-pattern-body-hr18">
+        <div>
+          <ul class="a11y-issues-hr18">
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> Interactive elements built from <code>&lt;div&gt;</code> or <code>&lt;span&gt;</code> aren't focusable or triggerable by keyboard at all.</li>
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> Custom focus styles removed with <code>outline: none</code> and never replaced.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Use a native <code>&lt;button&gt;</code> — it's focusable, triggerable by <kbd>Enter</kbd>/<kbd>Space</kbd>, and announced correctly by default.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Style focus with <code>:focus-visible</code> instead of removing it, so it only shows for keyboard users.</li>
+          </ul>
+        </div>
+        <div class="a11y-demo-hr18">
+          <p class="a11y-demo-hint-hr18">Tab to this button — the focus ring is visible and never suppressed.</p>
+          <button type="button" class="a11y-btn-hr18">Primary action</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Modal -->
+    <section class="a11y-pattern-hr18" aria-labelledby="a11yModalHeading">
+      <div class="a11y-pattern-head-hr18">
+        <h2 id="a11yModalHeading">Modal / Dialog</h2>
+        <span class="a11y-pattern-tag-hr18">role="dialog" aria-modal="true"</span>
+      </div>
+      <div class="a11y-pattern-body-hr18">
+        <div>
+          <ul class="a11y-issues-hr18">
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> Focus stays on the page behind the modal, so keyboard users can tab into content they can't see.</li>
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> <kbd>Escape</kbd> doesn't close it, and there's no way back to the trigger without a mouse.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Move focus into the dialog on open, trap <kbd>Tab</kbd> within it, and return focus to the trigger on close.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Listen for <kbd>Escape</kbd> globally while open, and label the dialog with <code>aria-labelledby</code>.</li>
+          </ul>
+        </div>
+        <div class="a11y-demo-hr18">
+          <p class="a11y-demo-hint-hr18">Open it, then try Tab (focus stays inside) and Escape (closes and returns focus here).</p>
+          <button type="button" class="a11y-btn-hr18" id="a11yModalOpenBtn" aria-haspopup="dialog">Open dialog</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Dropdown menu -->
+    <section class="a11y-pattern-hr18" aria-labelledby="a11yMenuHeading">
+      <div class="a11y-pattern-head-hr18">
+        <h2 id="a11yMenuHeading">Dropdown menu</h2>
+        <span class="a11y-pattern-tag-hr18">role="menu" / role="menuitem"</span>
+      </div>
+      <div class="a11y-pattern-body-hr18">
+        <div>
+          <ul class="a11y-issues-hr18">
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> Menu only opens on hover/click, so keyboard users can't reach the items at all.</li>
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> No <code>aria-expanded</code> on the trigger, so screen readers don't announce open/closed state.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> move between items, <kbd>Enter</kbd> selects, <kbd>Escape</kbd> closes and returns focus to the trigger.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Trigger gets <code>aria-haspopup="true"</code> and <code>aria-expanded</code> kept in sync with the menu's state.</li>
+          </ul>
+        </div>
+        <div class="a11y-demo-hr18">
+          <p class="a11y-demo-hint-hr18">Open with Enter/Space, navigate with arrow keys, close with Escape.</p>
+          <div class="a11y-menu-wrap-hr18">
+            <button type="button" class="a11y-btn-hr18" id="a11yMenuTrigger" aria-haspopup="true" aria-expanded="false">Options</button>
+            <div class="a11y-menu-hr18" id="a11yMenu" role="menu" aria-labelledby="a11yMenuTrigger">
+              <button type="button" class="a11y-menu-item-hr18" role="menuitem">Rename</button>
+              <button type="button" class="a11y-menu-item-hr18" role="menuitem">Duplicate</button>
+              <button type="button" class="a11y-menu-item-hr18" role="menuitem">Delete</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Accordion -->
+    <section class="a11y-pattern-hr18" aria-labelledby="a11yAccordionHeading">
+      <div class="a11y-pattern-head-hr18">
+        <h2 id="a11yAccordionHeading">Accordion</h2>
+        <span class="a11y-pattern-tag-hr18">aria-expanded / aria-controls</span>
+      </div>
+      <div class="a11y-pattern-body-hr18">
+        <div>
+          <ul class="a11y-issues-hr18">
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> Header built as a clickable <code>&lt;div&gt;</code>, so it's invisible to keyboard and screen reader users.</li>
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> No relationship exposed between the header and the panel it controls.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Each header is a real <code>&lt;button&gt;</code> with <code>aria-expanded</code> and <code>aria-controls</code> pointing at its panel.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> The panel carries a matching <code>id</code>, so the relationship is programmatic, not just visual.</li>
+          </ul>
+        </div>
+        <div class="a11y-demo-hr18">
+          <p class="a11y-demo-hint-hr18">Tab to a header, press Enter or Space to toggle it.</p>
+          <div class="a11y-accordion-hr18">
+            <div class="a11y-accordion-item-hr18">
+              <button type="button" class="a11y-accordion-trigger-hr18" aria-expanded="false" aria-controls="a11yPanel1" id="a11yHeader1">
+                <span>What is EaseMotion CSS?</span>
+                <svg class="a11y-accordion-chevron-hr18" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
+              </button>
+              <div class="a11y-accordion-panel-hr18" id="a11yPanel1" role="region" aria-labelledby="a11yHeader1" hidden>
+                A zero-dependency, animation-first CSS framework with readable utility classes.
+              </div>
+            </div>
+            <div class="a11y-accordion-item-hr18">
+              <button type="button" class="a11y-accordion-trigger-hr18" aria-expanded="false" aria-controls="a11yPanel2" id="a11yHeader2">
+                <span>Does it need JavaScript?</span>
+                <svg class="a11y-accordion-chevron-hr18" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
+              </button>
+              <div class="a11y-accordion-panel-hr18" id="a11yPanel2" role="region" aria-labelledby="a11yHeader2" hidden>
+                No — the animation classes are pure CSS. This accordion's toggle behavior is the only JS on this page that isn't just a demo helper.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tooltip -->
+    <section class="a11y-pattern-hr18" aria-labelledby="a11yTooltipHeading">
+      <div class="a11y-pattern-head-hr18">
+        <h2 id="a11yTooltipHeading">Tooltip</h2>
+        <span class="a11y-pattern-tag-hr18">aria-describedby</span>
+      </div>
+      <div class="a11y-pattern-body-hr18">
+        <div>
+          <ul class="a11y-issues-hr18">
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> Tooltip only shows on <code>:hover</code>, so it never appears for keyboard-only users tabbing through the page.</li>
+            <li><span class="a11y-badge-hr18 fail">Common issue</span> No text relationship to the trigger, so screen readers never announce it at all.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Show on <code>:focus-visible</code> as well as <code>:hover</code>, and let <kbd>Escape</kbd> dismiss it without moving focus away.</li>
+            <li><span class="a11y-badge-hr18 pass">Fix</span> Connect trigger and bubble with <code>aria-describedby</code> so the tooltip text is announced with the control.</li>
+          </ul>
+        </div>
+        <div class="a11y-demo-hr18">
+          <p class="a11y-demo-hint-hr18">Tab to the button — the tooltip appears; press Escape to dismiss it early.</p>
+          <span class="a11y-tooltip-wrap-hr18">
+            <button type="button" class="a11y-btn-hr18 a11y-tooltip-trigger-hr18" id="a11yTooltipTrigger" aria-describedby="a11yTooltipBubble">Save</button>
+            <span class="a11y-tooltip-bubble-hr18" id="a11yTooltipBubble" role="tooltip">Ctrl/Cmd + S</span>
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Summary -->
+    <section class="a11y-summary-hr18" aria-labelledby="a11ySummaryHeading">
+      <h2 id="a11ySummaryHeading">What every pattern above does</h2>
+      <div class="a11y-summary-grid-hr18">
+        <div class="a11y-summary-item-hr18"><span class="a11y-badge-hr18 pass">&#10003;</span> <strong>Focus visible</strong> — every interactive element uses <code>:focus-visible</code>, never suppressed.</div>
+        <div class="a11y-summary-item-hr18"><span class="a11y-badge-hr18 pass">&#10003;</span> <strong>Escape closes dialogs</strong> — modal, menu, and tooltip all dismiss on <kbd>Escape</kbd>.</div>
+        <div class="a11y-summary-item-hr18"><span class="a11y-badge-hr18 pass">&#10003;</span> <strong>Logical tab order</strong> — no <code>tabindex</code> greater than 0 anywhere; DOM order matches visual order.</div>
+        <div class="a11y-summary-item-hr18"><span class="a11y-badge-hr18 pass">&#10003;</span> <strong>ARIA roles/labels</strong> — dialog, menu, menuitem, and tooltip roles applied with matching labelling attributes.</div>
+      </div>
+    </section>
+
+    <p class="a11y-footnote-hr18">submissions/docs/ease-a11y-keyboard-audit-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<!-- Modal markup lives outside the flow so it can be positioned fixed -->
+<div class="a11y-modal-backdrop-hr18" id="a11yModalBackdrop">
+  <div class="a11y-modal-hr18" role="dialog" aria-modal="true" aria-labelledby="a11yModalTitle" id="a11yModal">
+    <h3 id="a11yModalTitle">Delete this item?</h3>
+    <p>This is a reference dialog: focus is trapped inside it, Escape closes
+      it, and focus returns to the "Open dialog" button afterward.</p>
+    <div class="a11y-modal-actions-hr18">
+      <button type="button" class="a11y-btn-ghost-hr18" id="a11yModalCancelBtn">Cancel</button>
+      <button type="button" class="a11y-btn-hr18" id="a11yModalConfirmBtn">Confirm</button>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  /* ---------- Modal: focus trap + Escape + return focus ---------- */
+  var modalOpenBtn = document.getElementById("a11yModalOpenBtn");
+  var modalBackdrop = document.getElementById("a11yModalBackdrop");
+  var modal = document.getElementById("a11yModal");
+  var modalCancelBtn = document.getElementById("a11yModalCancelBtn");
+  var modalConfirmBtn = document.getElementById("a11yModalConfirmBtn");
+  var lastFocusedBeforeModal = null;
+
+  function getFocusable(container) {
+    return Array.prototype.slice.call(
+      container.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    ).filter(function (el) { return !el.disabled; });
+  }
+
+  function openModal() {
+    lastFocusedBeforeModal = document.activeElement;
+    modalBackdrop.classList.add("is-open-hr18");
+    var focusables = getFocusable(modal);
+    if (focusables.length) focusables[0].focus();
+    document.addEventListener("keydown", onModalKeydown, true);
+  }
+
+  function closeModal() {
+    modalBackdrop.classList.remove("is-open-hr18");
+    document.removeEventListener("keydown", onModalKeydown, true);
+    if (lastFocusedBeforeModal) lastFocusedBeforeModal.focus();
+  }
+
+  function onModalKeydown(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeModal();
+      return;
+    }
+    if (e.key === "Tab") {
+      var focusables = getFocusable(modal);
+      if (!focusables.length) return;
+      var first = focusables[0];
+      var last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  modalOpenBtn.addEventListener("click", openModal);
+  modalCancelBtn.addEventListener("click", closeModal);
+  modalConfirmBtn.addEventListener("click", closeModal);
+  modalBackdrop.addEventListener("click", function (e) {
+    if (e.target === modalBackdrop) closeModal();
+  });
+
+  /* ---------- Dropdown menu: arrow keys + Escape + return focus ---------- */
+  var menuTrigger = document.getElementById("a11yMenuTrigger");
+  var menu = document.getElementById("a11yMenu");
+  var menuItems = Array.prototype.slice.call(menu.querySelectorAll(".a11y-menu-item-hr18"));
+
+  function openMenu(focusFirst) {
+    menu.classList.add("is-open-hr18");
+    menuTrigger.setAttribute("aria-expanded", "true");
+    if (focusFirst) menuItems[0].focus();
+    document.addEventListener("click", onDocClickCloseMenu);
+  }
+
+  function closeMenu(returnFocus) {
+    menu.classList.remove("is-open-hr18");
+    menuTrigger.setAttribute("aria-expanded", "false");
+    document.removeEventListener("click", onDocClickCloseMenu);
+    if (returnFocus) menuTrigger.focus();
+  }
+
+  function onDocClickCloseMenu(e) {
+    if (!menu.contains(e.target) && e.target !== menuTrigger) {
+      closeMenu(false);
+    }
+  }
+
+  menuTrigger.addEventListener("click", function () {
+    if (menu.classList.contains("is-open-hr18")) {
+      closeMenu(false);
+    } else {
+      openMenu(false);
+    }
+  });
+
+  menuTrigger.addEventListener("keydown", function (e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      openMenu(true);
+    }
+  });
+
+  menu.addEventListener("keydown", function (e) {
+    var currentIndex = menuItems.indexOf(document.activeElement);
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      var next = menuItems[(currentIndex + 1) % menuItems.length];
+      next.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      var prev = menuItems[(currentIndex - 1 + menuItems.length) % menuItems.length];
+      prev.focus();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      closeMenu(true);
+    } else if (e.key === "Tab") {
+      closeMenu(false);
+    }
+  });
+
+  menuItems.forEach(function (item) {
+    item.addEventListener("click", function () {
+      closeMenu(true);
+    });
+  });
+
+  /* ---------- Accordion: native button toggle ---------- */
+  var accordionTriggers = document.querySelectorAll(".a11y-accordion-trigger-hr18");
+  accordionTriggers.forEach(function (trigger) {
+    trigger.addEventListener("click", function () {
+      var expanded = trigger.getAttribute("aria-expanded") === "true";
+      var panel = document.getElementById(trigger.getAttribute("aria-controls"));
+      trigger.setAttribute("aria-expanded", String(!expanded));
+      if (panel) panel.hidden = expanded;
+    });
+  });
+
+  /* ---------- Tooltip: Escape dismisses without losing focus ---------- */
+  var tooltipTrigger = document.getElementById("a11yTooltipTrigger");
+  var tooltipBubble = document.getElementById("a11yTooltipBubble");
+
+  tooltipTrigger.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") {
+      tooltipBubble.style.opacity = "0";
+      window.setTimeout(function () {
+        tooltipBubble.style.opacity = "";
+      }, 400);
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/docs/ease-a11y-keyboard-audit-hr18/style.css
+++ b/submissions/docs/ease-a11y-keyboard-audit-hr18/style.css
@@ -1,0 +1,439 @@
+/* ==========================================================================
+   ease-a11y-keyboard-audit-hr18 — style.css
+   Keyboard-accessibility audit + accessible reference patterns
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.a11y-hr18 {
+  --bg-hr18: #f6f7f9;
+  --panel-hr18: #ffffff;
+  --panel-raised-hr18: #f0f1f5;
+  --border-hr18: #e1e4ea;
+  --text-hr18: #14171f;
+  --text-muted-hr18: #62687a;
+  --accent-hr18: #1d4ed8;
+  --accent-soft-hr18: #e8edfc;
+  --pass-hr18: #15803d;
+  --pass-bg-hr18: #e7f5ec;
+  --fail-hr18: #b91c1c;
+  --fail-bg-hr18: #fbeaea;
+  --radius-hr18: 12px;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4rem;
+  min-height: 100%;
+}
+
+.a11y-hr18 * {
+  box-sizing: border-box;
+}
+
+.a11y-hr18 h1,
+.a11y-hr18 h2,
+.a11y-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.a11y-hr18 code {
+  font-family: var(--font-mono-hr18);
+  background: var(--panel-raised-hr18);
+  border: 1px solid var(--border-hr18);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.86em;
+}
+
+.a11y-wrap-hr18 {
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+/* ---- Visible focus styles, the whole point of the issue --------------------- */
+.a11y-hr18 :focus-visible {
+  outline: 3px solid var(--accent-hr18);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ---- Header -------------------------------------------------------------------- */
+.a11y-header-hr18 {
+  margin-bottom: 2.5rem;
+}
+
+.a11y-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.a11y-header-hr18 h1 {
+  font-size: clamp(1.6rem, 2.8vw, 2.3rem);
+}
+
+.a11y-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 66ch;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.a11y-note-box-hr18 {
+  margin-top: 1.25rem;
+  border: 1px solid var(--accent-soft-hr18);
+  background: var(--accent-soft-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1rem 1.2rem;
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: #1e3a8a;
+}
+
+/* ---- Pattern section shell ------------------------------------------------------- */
+.a11y-pattern-hr18 {
+  margin-top: 2.75rem;
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  overflow: hidden;
+}
+
+.a11y-pattern-head-hr18 {
+  padding: 1.1rem 1.4rem;
+  border-bottom: 1px solid var(--border-hr18);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.a11y-pattern-head-hr18 h2 {
+  font-size: 1.05rem;
+}
+
+.a11y-pattern-tag-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.72rem;
+  color: var(--text-muted-hr18);
+}
+
+.a11y-pattern-body-hr18 {
+  padding: 1.4rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 760px) {
+  .a11y-pattern-body-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---- Issue list --------------------------------------------------------------------- */
+.a11y-issues-hr18 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.a11y-issues-hr18 li {
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--text-muted-hr18);
+  display: flex;
+  gap: 0.55rem;
+}
+
+.a11y-badge-hr18 {
+  flex-shrink: 0;
+  font-family: var(--font-mono-hr18);
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.12rem 0.4rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+  height: fit-content;
+}
+
+.a11y-badge-hr18.fail {
+  color: var(--fail-hr18);
+  background: var(--fail-bg-hr18);
+}
+
+.a11y-badge-hr18.pass {
+  color: var(--pass-hr18);
+  background: var(--pass-bg-hr18);
+}
+
+/* ---- Live demo area ------------------------------------------------------------------- */
+.a11y-demo-hr18 {
+  border: 1px dashed var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-raised-hr18);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.a11y-demo-hint-hr18 {
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+  margin: 0;
+}
+
+/* ---- Button pattern -------------------------------------------------------------------- */
+.a11y-btn-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.88rem;
+  font-weight: 600;
+  background: var(--accent-hr18);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.a11y-btn-hr18:hover {
+  filter: brightness(1.08);
+}
+
+/* ---- Modal pattern ---------------------------------------------------------------------- */
+.a11y-modal-backdrop-hr18 {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 17, 26, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 50;
+}
+
+.a11y-modal-backdrop-hr18.is-open-hr18 {
+  display: flex;
+}
+
+.a11y-modal-hr18 {
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.5rem;
+  max-width: 360px;
+  width: 100%;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+}
+
+.a11y-modal-hr18 h3 {
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+.a11y-modal-hr18 p {
+  font-size: 0.86rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.55;
+  margin: 0 0 1.2rem;
+}
+
+.a11y-modal-actions-hr18 {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: flex-end;
+}
+
+.a11y-btn-ghost-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: transparent;
+  color: var(--text-hr18);
+  border: 1px solid var(--border-hr18);
+  padding: 0.55rem 1.05rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+/* ---- Dropdown menu pattern ---------------------------------------------------------------- */
+.a11y-menu-wrap-hr18 {
+  position: relative;
+}
+
+.a11y-menu-hr18 {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 180px;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 10px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+  padding: 0.4rem;
+  display: none;
+  z-index: 10;
+}
+
+.a11y-menu-hr18.is-open-hr18 {
+  display: block;
+}
+
+.a11y-menu-item-hr18 {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  font-family: var(--font-body-hr18);
+  font-size: 0.85rem;
+  color: var(--text-hr18);
+  padding: 0.5rem 0.7rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.a11y-menu-item-hr18:hover,
+.a11y-menu-item-hr18.is-active-hr18 {
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+}
+
+/* ---- Accordion pattern ---------------------------------------------------------------------- */
+.a11y-accordion-hr18 {
+  width: 100%;
+  border: 1px solid var(--border-hr18);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.a11y-accordion-item-hr18 + .a11y-accordion-item-hr18 {
+  border-top: 1px solid var(--border-hr18);
+}
+
+.a11y-accordion-trigger-hr18 {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  background: var(--panel-hr18);
+  border: none;
+  font-family: var(--font-body-hr18);
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--text-hr18);
+  padding: 0.75rem 0.9rem;
+  cursor: pointer;
+}
+
+.a11y-accordion-chevron-hr18 {
+  transition: transform 180ms ease;
+  flex-shrink: 0;
+}
+
+.a11y-accordion-trigger-hr18[aria-expanded="true"] .a11y-accordion-chevron-hr18 {
+  transform: rotate(180deg);
+}
+
+.a11y-accordion-panel-hr18 {
+  padding: 0 0.9rem 0.85rem;
+  font-size: 0.83rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.55;
+}
+
+.a11y-accordion-panel-hr18[hidden] {
+  display: none;
+}
+
+/* ---- Tooltip pattern ---------------------------------------------------------------------- */
+.a11y-tooltip-wrap-hr18 {
+  position: relative;
+  display: inline-block;
+}
+
+.a11y-tooltip-bubble-hr18 {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text-hr18);
+  color: #fff;
+  font-size: 0.76rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 6px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.a11y-tooltip-trigger-hr18:hover + .a11y-tooltip-bubble-hr18,
+.a11y-tooltip-trigger-hr18:focus-visible + .a11y-tooltip-bubble-hr18,
+.a11y-tooltip-bubble-hr18.is-visible-hr18 {
+  opacity: 1;
+}
+
+/* ---- Compliance summary ---------------------------------------------------------------------- */
+.a11y-summary-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 1.4rem;
+}
+
+.a11y-summary-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.a11y-summary-item-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem;
+  font-size: 0.83rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.a11y-summary-item-hr18 strong {
+  color: var(--text-hr18);
+}
+
+/* ---- Footnote --------------------------------------------------------------------------------- */
+.a11y-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Reduced motion ---------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .a11y-accordion-chevron-hr18,
+  .a11y-tooltip-bubble-hr18 {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a keyboard-accessibility audit of EaseMotion's documented interactive
patterns (button, modal, dropdown menu, accordion, tooltip), each paired
with a working, accessible reference implementation: visible focus styles
throughout, a real focus-trapped modal with Escape-to-close and
focus-return, a keyboard-operable dropdown menu (arrow keys + Escape), an
accordion built from real buttons with aria-expanded/aria-controls, and a
tooltip that appears on focus (not just hover) and dismisses on Escape.

Resolves #47369

Note for the maintainer: this issue asks to verify/fix keyboard
accessibility across the framework's actual components, which would
normally mean editing `core/`/`components/`. Since the repo's README
currently states core-file PRs are temporarily restricted while the
framework stabilizes, this submission audits the patterns as documented and
provides corrected reference implementations under `submissions/docs/`
instead — intended as something you (or a future core contributor) can lift
directly into the real components once core access reopens. Happy to adjust
the approach if you'd rather this be handled differently.

---

## Type of Change
- [x] 📝 Documentation improvement

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/ease-a11y-keyboard-audit-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A keyboard-accessibility audit with five corrected, accessible reference
patterns contributors and the maintainer can reuse.

**How does a developer use it?**
```html
<!-- Open demo.html and try each pattern with keyboard only:
     Tab, Shift+Tab, Enter, Space, Escape, and arrow keys. -->
```

**Why does it fit EaseMotion CSS?**
Directly serves the issue's goal while respecting the repo's current
restriction on core-file edits. Pure CSS plus minimal, dependency-free JS,
consistent with EaseMotion's zero-dependency philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
Tested each pattern with keyboard-only navigation in Chrome (Tab order,
Escape behavior, arrow-key menu navigation, focus trap/return in the
modal). Haven't checked other browsers or a real screen reader yet — happy
to do a screen-reader pass if that's wanted before merge.