### PR TITLE
Add Tada-Click popover component for SaaS showcase layouts (tada-popo…

### DIFF
--- a/submissions/examples/tada-popover-hr18/README.md
+++ b/submissions/examples/tada-popover-hr18/README.md
@@ -1,0 +1,98 @@
+# Tada-Click Popover (`tada-popover-hr18`)
+
+A pure-CSS animated popover with a "Tada-Click" entrance, styled for SaaS
+showcase / product-page layouts, built for issue
+[#46557](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46557).
+
+## What it does
+
+Clicking a trigger button reveals a popover panel that pops in with a
+playful "tada" wobble — scales up past its resting size, rocks slightly
+left and right, then settles. The **animation itself is 100% CSS**
+(`@keyframes ease-tada-click-hr18`, driven entirely by custom properties);
+a small amount of vanilla JavaScript only handles the click-to-toggle
+state, `Escape`-to-close, click-outside-to-close, and keeping
+`aria-expanded` in sync — there's no animation logic in JavaScript at all.
+
+The demo shows it applied three times in a typical SaaS feature-showcase
+layout (Analytics / Automation / Integrations cards), each with its own
+independent popover.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap a trigger button and a popover panel in the component markup:
+
+```html
+<div class="tdp-popover-wrap-hr18" data-open="false">
+  <button type="button" class="tdp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">
+    Learn more
+  </button>
+  <div class="ease-popover-hr18" role="dialog" aria-label="Feature details" hidden>
+    <button type="button" class="tdp-popover-close-hr18" aria-label="Close">&times;</button>
+    <p class="tdp-popover-title-hr18">Analytics</p>
+    <p class="tdp-popover-hr18-body">Real-time dashboards for every metric that matters.</p>
+    <a href="#" class="tdp-popover-link-hr18">View docs &rarr;</a>
+  </div>
+</div>
+```
+
+The included script finds every `.tdp-popover-wrap-hr18` on the page
+automatically and wires it up — a new popover only needs the markup above,
+no extra JavaScript per instance. Opening one popover closes any other
+that's currently open.
+
+### Tuning the animation
+
+Every timing/scale value is a CSS custom property, overridable per instance
+or globally:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-tada-duration-hr18` | `550ms` | How long the pop-in + wobble takes |
+| `--ease-tada-easing-hr18` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | The overshoot curve that gives the "tada" its bounce |
+| `--ease-tada-scale-hr18` | `1.08` | Peak scale during the wobble — lower for a subtler pop |
+| `--ease-tada-delay-hr18` | `0ms` | Delay before the animation starts |
+
+```css
+.tdp-popover-wrap-hr18.subtle {
+  --ease-tada-scale-hr18: 1.02;
+  --ease-tada-duration-hr18: 350ms;
+}
+```
+
+## Accessibility notes
+
+- The trigger is a native `<button>` with `aria-haspopup="dialog"` and
+  `aria-expanded` kept in sync with the popover's open state.
+- `Escape` closes the popover and returns focus to its trigger.
+- Clicking outside the open popover closes it.
+- The panel itself has `role="dialog"` and an `aria-label` describing its
+  content, plus a visible, keyboard-reachable close button.
+- Fully keyboard operable: `Tab` to the trigger, `Enter`/`Space` to open,
+  `Tab` to reach the close button or link inside, `Escape` to dismiss.
+- The wobble animation respects `@media (prefers-reduced-motion: reduce)`
+  and settles instantly to its final state instead.
+
+## Responsiveness
+
+The three-card feature row collapses from three columns to one under a
+`680px` viewport width; the popover panel itself uses a fixed comfortable
+width that fits within that layout at every size.
+
+## Why this fits EaseMotion CSS
+
+It's a self-contained, reusable interaction pattern with a distinct named
+animation (`ease-tada-click`) exposed entirely through custom properties —
+matching the issue's ask for zero JavaScript animation overhead and
+tunable timing/easing/scale — while still being genuinely keyboard
+accessible from the start, not bolted on afterward.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/tada-popover-hr18/demo.html
+++ b/submissions/examples/tada-popover-hr18/demo.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Tada-Click Popover — SaaS showcase demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="tdp-hr18">
+  <div class="tdp-wrap-hr18">
+
+    <header class="tdp-header-hr18">
+      <span class="tdp-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Meet the platform</h1>
+      <p>Click any feature below — the popover pops in with a playful
+        "tada" wobble, styled for a modern SaaS product page.</p>
+    </header>
+
+    <section class="tdp-features-hr18">
+
+      <!-- Feature 1: Analytics -->
+      <article class="tdp-feature-card-hr18">
+        <div class="tdp-feature-icon-hr18" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"></path><path d="M18 17V9"></path><path d="M13 17V5"></path><path d="M8 17v-3"></path></svg>
+        </div>
+        <h3>Analytics</h3>
+        <p>Real-time dashboards for every metric that matters.</p>
+        <div class="tdp-popover-wrap-hr18" data-open="false">
+          <button type="button" class="tdp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Learn more</button>
+          <div class="ease-popover-hr18" role="dialog" aria-label="Analytics feature details" hidden>
+            <button type="button" class="tdp-popover-close-hr18" aria-label="Close">&times;</button>
+            <p class="tdp-popover-title-hr18">Analytics</p>
+            <p class="tdp-popover-hr18-body">Track conversion, retention, and revenue in one live dashboard — no SQL required.</p>
+            <a href="#" class="tdp-popover-link-hr18">View docs &rarr;</a>
+          </div>
+        </div>
+      </article>
+
+      <!-- Feature 2: Automation -->
+      <article class="tdp-feature-card-hr18">
+        <div class="tdp-feature-icon-hr18" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4"></path><path d="M12 18v4"></path><path d="m4.93 4.93 2.83 2.83"></path><path d="m16.24 16.24 2.83 2.83"></path><path d="M2 12h4"></path><path d="M18 12h4"></path></svg>
+        </div>
+        <h3>Automation</h3>
+        <p>Trigger workflows the moment your data changes.</p>
+        <div class="tdp-popover-wrap-hr18" data-open="false">
+          <button type="button" class="tdp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Learn more</button>
+          <div class="ease-popover-hr18" role="dialog" aria-label="Automation feature details" hidden>
+            <button type="button" class="tdp-popover-close-hr18" aria-label="Close">&times;</button>
+            <p class="tdp-popover-title-hr18">Automation</p>
+            <p class="tdp-popover-hr18-body">Build if-this-then-that rules across your stack — no code, no cron jobs.</p>
+            <a href="#" class="tdp-popover-link-hr18">View docs &rarr;</a>
+          </div>
+        </div>
+      </article>
+
+      <!-- Feature 3: Integrations -->
+      <article class="tdp-feature-card-hr18">
+        <div class="tdp-feature-icon-hr18" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M12 2v4"></path><path d="M12 18v4"></path><path d="m4.93 19.07 2.83-2.83"></path><path d="m16.24 7.76 2.83-2.83"></path></svg>
+        </div>
+        <h3>Integrations</h3>
+        <p>Connect the tools your team already uses.</p>
+        <div class="tdp-popover-wrap-hr18" data-open="false">
+          <button type="button" class="tdp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Learn more</button>
+          <div class="ease-popover-hr18" role="dialog" aria-label="Integrations feature details" hidden>
+            <button type="button" class="tdp-popover-close-hr18" aria-label="Close">&times;</button>
+            <p class="tdp-popover-title-hr18">Integrations</p>
+            <p class="tdp-popover-hr18-body">80+ prebuilt connectors, plus a webhook for everything else.</p>
+            <a href="#" class="tdp-popover-link-hr18">View docs &rarr;</a>
+          </div>
+        </div>
+      </article>
+
+    </section>
+
+    <div class="tdp-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-tada-duration-hr18</code></td><td><code>550ms</code></td><td>How long the pop-in + wobble takes.</td></tr>
+          <tr><td><code>--ease-tada-easing-hr18</code></td><td><code>cubic-bezier(0.34, 1.56, 0.64, 1)</code></td><td>The overshoot curve that gives the "tada" its bounce.</td></tr>
+          <tr><td><code>--ease-tada-scale-hr18</code></td><td><code>1.08</code></td><td>Peak scale during the wobble — turn down for a subtler pop.</td></tr>
+          <tr><td><code>--ease-tada-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the animation starts.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="tdp-footnote-hr18">submissions/examples/tada-popover-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var wraps = document.querySelectorAll(".tdp-popover-wrap-hr18");
+
+  wraps.forEach(function (wrap) {
+    var trigger = wrap.querySelector(".tdp-trigger-hr18");
+    var panel = wrap.querySelector(".ease-popover-hr18");
+    var closeBtn = wrap.querySelector(".tdp-popover-close-hr18");
+
+    function open() {
+      // Close any other open popover first.
+      wraps.forEach(function (other) {
+        if (other !== wrap) closeWrap(other);
+      });
+      wrap.setAttribute("data-open", "true");
+      trigger.setAttribute("aria-expanded", "true");
+      panel.hidden = false;
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("keydown", onKeydown);
+    }
+
+    function close(returnFocus) {
+      wrap.setAttribute("data-open", "false");
+      trigger.setAttribute("aria-expanded", "false");
+      panel.hidden = true;
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKeydown);
+      if (returnFocus) trigger.focus();
+    }
+
+    function onDocClick(e) {
+      if (!wrap.contains(e.target)) close(false);
+    }
+
+    function onKeydown(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close(true);
+      }
+    }
+
+    trigger.addEventListener("click", function () {
+      var isOpen = wrap.getAttribute("data-open") === "true";
+      if (isOpen) {
+        close(false);
+      } else {
+        open();
+      }
+    });
+
+    closeBtn.addEventListener("click", function () {
+      close(true);
+    });
+
+    // Exposed so the "close any other open popover" loop above can call it.
+    wrap.__tdpCloseHr18 = close;
+  });
+
+  function closeWrap(wrap) {
+    if (wrap.__tdpCloseHr18) wrap.__tdpCloseHr18(false);
+  }
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/tada-popover-hr18/style.css
+++ b/submissions/examples/tada-popover-hr18/style.css
@@ -1,0 +1,327 @@
+/* ==========================================================================
+   tada-popover-hr18 — style.css
+   CSS Tada-Click Popover for SaaS Showcase layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.tdp-hr18 {
+  --bg-hr18: #ffffff;
+  --panel-hr18: #ffffff;
+  --page-wash-hr18: #f7f6fd;
+  --border-hr18: #e7e5f2;
+  --text-hr18: #10121a;
+  --text-muted-hr18: #5b6072;
+  --accent-1-hr18: #6d28d9;
+  --accent-2-hr18: #2563eb;
+  --accent-soft-hr18: #f2eefe;
+  --radius-hr18: 16px;
+
+  /* Exposed animation parameters — override any of these per-instance. */
+  --ease-tada-duration-hr18: 550ms;
+  --ease-tada-easing-hr18: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-tada-scale-hr18: 1.08;
+  --ease-tada-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background:
+    radial-gradient(circle at 85% -10%, rgba(109, 40, 217, 0.08), transparent 45%),
+    var(--page-wash-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3.5rem 1.5rem 5rem;
+  min-height: 100%;
+}
+
+.tdp-hr18 * {
+  box-sizing: border-box;
+}
+
+.tdp-hr18 h1,
+.tdp-hr18 h2,
+.tdp-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.tdp-wrap-hr18 {
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+/* ---- Header --------------------------------------------------------------- */
+.tdp-header-hr18 {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.tdp-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  background: linear-gradient(90deg, var(--accent-1-hr18), var(--accent-2-hr18));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.tdp-header-hr18 h1 {
+  font-size: clamp(1.7rem, 3.2vw, 2.4rem);
+}
+
+.tdp-header-hr18 p {
+  margin: 0.9rem auto 0;
+  color: var(--text-muted-hr18);
+  max-width: 52ch;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* ---- Feature showcase row --------------------------------------------------- */
+.tdp-features-hr18 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+@media (max-width: 680px) {
+  .tdp-features-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.tdp-feature-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.5rem 1.25rem;
+  text-align: center;
+  box-shadow: 0 1px 2px rgba(20, 10, 50, 0.03), 0 12px 28px rgba(20, 10, 50, 0.05);
+}
+
+.tdp-feature-icon-hr18 {
+  width: 44px;
+  height: 44px;
+  margin: 0 auto 0.9rem;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--accent-1-hr18), var(--accent-2-hr18));
+  color: #fff;
+}
+
+.tdp-feature-card-hr18 h3 {
+  font-size: 0.98rem;
+  margin-bottom: 0.4rem;
+}
+
+.tdp-feature-card-hr18 p {
+  margin: 0 0 1rem;
+  font-size: 0.83rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.5;
+}
+
+/* ---- The reusable popover component ------------------------------------------
+   Drop-in markup: a .tdp-popover-wrap-hr18 containing a trigger button and a
+   .ease-popover-hr18 panel. Toggling the wrapper's data-open attribute (via
+   the small script below) reveals the panel and plays the tada-click
+   entrance animation — the animation itself is 100% CSS, driven entirely by
+   the custom properties declared above. */
+.tdp-popover-wrap-hr18 {
+  position: relative;
+  display: inline-block;
+}
+
+.tdp-trigger-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--accent-1-hr18);
+  background: var(--accent-soft-hr18);
+  border: 1px solid transparent;
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.tdp-trigger-hr18:hover {
+  border-color: var(--accent-1-hr18);
+}
+
+.tdp-trigger-hr18[aria-expanded="true"] {
+  background: linear-gradient(90deg, var(--accent-1-hr18), var(--accent-2-hr18));
+  color: #fff;
+}
+
+.ease-popover-hr18 {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 240px;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 14px;
+  padding: 1.1rem 1.15rem;
+  box-shadow: 0 20px 45px rgba(20, 10, 50, 0.16);
+  text-align: left;
+  z-index: 20;
+  display: none;
+}
+
+.ease-popover-hr18::before {
+  content: "";
+  position: absolute;
+  top: -7px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: var(--panel-hr18);
+  border-left: 1px solid var(--border-hr18);
+  border-top: 1px solid var(--border-hr18);
+}
+
+.tdp-popover-wrap-hr18[data-open="true"] .ease-popover-hr18 {
+  display: block;
+  animation: ease-tada-click-hr18 var(--ease-tada-duration-hr18) var(--ease-tada-easing-hr18) var(--ease-tada-delay-hr18) both;
+  transform-origin: top center;
+}
+
+/* The "tada" entrance: pop in, wobble, settle. Amplitude is controlled by
+   --ease-tada-scale-hr18 so an instance can be tuned without touching the
+   keyframes. */
+@keyframes ease-tada-click-hr18 {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) scale(0.4) rotate(-8deg);
+  }
+  50% {
+    opacity: 1;
+    transform: translateX(-50%) scale(var(--ease-tada-scale-hr18)) rotate(3deg);
+  }
+  65% {
+    transform: translateX(-50%) scale(0.96) rotate(-2deg);
+  }
+  80% {
+    transform: translateX(-50%) scale(1.03) rotate(1deg);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) scale(1) rotate(0deg);
+  }
+}
+
+.tdp-popover-title-hr18 {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.tdp-popover-hr18-body {
+  font-size: 0.82rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.55;
+  margin: 0 0 0.7rem;
+}
+
+.tdp-popover-link-hr18 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent-1-hr18);
+  text-decoration: none;
+}
+
+.tdp-popover-link-hr18:hover {
+  text-decoration: underline;
+}
+
+.tdp-popover-close-hr18 {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted-hr18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tdp-popover-close-hr18:hover {
+  background: var(--accent-soft-hr18);
+  color: var(--accent-1-hr18);
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.tdp-tuning-hr18 {
+  margin-top: 3rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.tdp-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.tdp-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.tdp-tuning-hr18 th,
+.tdp-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.tdp-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.tdp-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+}
+
+.tdp-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+  text-align: center;
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.tdp-hr18 :focus-visible {
+  outline: 2px solid var(--accent-1-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tdp-popover-wrap-hr18[data-open="true"] .ease-popover-hr18 {
+    animation: none;
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Popover with a "Tada-Click" entrance — clicking a
trigger reveals a panel that pops in with a playful wobble (scale-up,
rock left/right, settle), styled for SaaS showcase/product-page layouts.
The animation itself is 100% CSS, driven by exposed custom properties for
duration, easing, peak scale, and delay; a small vanilla-JS layer only
handles click-toggle, Escape-to-close, click-outside-to-close, and
aria-expanded sync. Demo shows it applied across a 3-card feature showcase.

Resolves #46557

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/tada-popover-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS "tada" pop-in animation for click-triggered popovers,
with tunable timing/scale via custom properties.

**How does a developer use it?**
```html
<div class="tdp-popover-wrap-hr18" data-open="false">
  <button type="button" class="tdp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Learn more</button>
  <div class="ease-popover-hr18" role="dialog" aria-label="Feature details" hidden>
    <!-- popover content -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
A self-contained interaction with a distinct named animation
(`ease-tada-click`) exposed entirely through custom properties, per the
issue's ask for zero JS animation overhead and tunable timing/easing/scale
— while being genuinely keyboard accessible from the start.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
The toggle script auto-discovers every `.tdp-popover-wrap-hr18` on the
page and closes any other open popover when a new one opens. Tested
keyboard flow (Tab/Enter/Escape) and click-outside-to-close in Chrome;
haven't checked other browsers yet.