### PR TITLE
test(engine): add unit tests for fade out keyframes parsing (#49477)

### DIFF
--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -213,3 +213,67 @@ describe('optimizer — pruneClasses()', () => {
     expect(result).not.toContain('.ease-slide-up');
   });
 });
+
+// ── Fade Out Keyframes (Issue #49477) ────────────────────────────
+
+describe('Fade Out keyframes', () => {
+  it('successfully parses valid Fade Out keyframes', () => {
+    const ast = parse('fade-out 400ms ease-in-out delay-100ms repeat-2');
+    expect(ast).not.toBeNull();
+    expect(ast.animation).toBe('fade-out');
+    expect(ast.duration).toBe(400);
+    expect(ast.easing).toBe('cubic-bezier(0.4, 0, 0.2, 1)');
+    expect(ast.delay).toBe(100);
+    expect(ast.iterations).toBe(2);
+  });
+
+  it('generates AST matching expected structure', () => {
+    const ast = parse('fade-out');
+    expect(ast).toEqual({
+      animation: 'fade-out',
+      duration: 300,
+      easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+      delay: 0,
+      iterations: 1,
+      fill: 'both',
+      direction: 'normal'
+    });
+  });
+
+  it('generates compiler output successfully', () => {
+    const ast = parse('fade-out 500ms');
+    const cls = className(ast);
+    const css = compile(ast, cls);
+    expect(css).toContain(`.${cls}`);
+    expect(css).toContain('ease-kf-fade-out');
+    expect(css).toContain('500ms');
+    expect(css).not.toContain('ease-kf-fade-in');
+  });
+
+  it('rejects malformed keyframe syntax / invalid input', () => {
+    // The parser ignores unknown tokens and gracefully handles missing/duplicate values
+    // Empty strings or purely malformed input should return null
+    expect(parse('')).toBeNull();
+    expect(parse('   ')).toBeNull();
+    expect(parse(null)).toBeNull();
+    
+    // An animation string without a valid animation name should be rejected
+    expect(parse('500ms ease-out')).toBeNull();
+  });
+
+  it('handles missing closing braces gracefully (ignored tokens)', () => {
+    const ast = parse('fade-out 500ms { missing closing braces');
+    // The parser ignores '{', 'missing', 'closing', 'braces'
+    expect(ast).not.toBeNull();
+    expect(ast.animation).toBe('fade-out');
+    expect(ast.duration).toBe(500);
+  });
+
+  it('validates duplicate percentage handling by using last token', () => {
+    // Our string token parser handles duplicates by keeping the last recognized token
+    const ast = parse('fade-out 200ms 400ms delay-100ms delay-200ms');
+    expect(ast.duration).toBe(400);
+    expect(ast.delay).toBe(200);
+  });
+});
+


### PR DESCRIPTION
# Summary
Closes #49477. This PR adds comprehensive unit test coverage for the `fade-out` animation within the EaseMotion animation engine's parser.

---

# Root Cause
The `fade-out` animation syntax lacked explicit unit tests verifying that it generated the correct AST and compiled to the correct `ease-kf-*` CSS class, leading to a gap in test coverage that could mask regressions during parser modifications.

---

# Solution
Expanded `tests/engine.test.js` to include a dedicated suite for the `fade-out` animation string parsing and compiling pipeline.
*   Verified standard AST generation.
*   Verified proper compilation of the `ease-kf-fade-out` class.
*   Added assertions verifying the parser handles invalid/malformed input gracefully (returning `null` or ignoring unrecognized trailing strings).
*   Added assertions confirming how duplicate properties in the animation string are resolved.

---

# Files Changed
*   `tests/engine.test.js`: Added 6 new unit tests targeting `fade-out` parsing, compilation, and error handling.

---

# Testing
*   Successfully ran `npm test`.
*   All tests (67/67) pass.
*   No existing parser functionality was broken (0 regressions).

---

# Impact
*   **Breaking changes**: No
*   **Performance impact**: None
*   **Security impact**: None
*   **Compatibility**: Increases robustness for future engine updates.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
