### PR TITLE
feat: add CSS zoom-in popover for creative portfolio layouts

### DIFF
--- a/submissions/examples/zoom-in-popover-portfolio-ak/README.md
+++ b/submissions/examples/zoom-in-popover-portfolio-ak/README.md
@@ -1,0 +1,24 @@
+# Zoom-In Portfolio Popover
+
+## What does this do?
+A pure CSS zoom-in animated popover styled for creative portfolio project cards, revealing project details on click.
+
+## How is it used?
+```html
+<div class="portfolio-card">
+  <img class="portfolio-thumb" src="thumbnail.jpg" alt="Project thumbnail">
+  <button class="portfolio-popover-trigger" id="portfolioBtn" aria-expanded="false" aria-describedby="portfolioBox">
+    View Details
+  </button>
+
+  <div class="portfolio-popover-box" id="portfolioBox" role="tooltip">
+    <h3>Project Name</h3>
+    <p>Project description.</p>
+    <span class="portfolio-tag">Category · Year</span>
+  </div>
+</div>
+```
+Toggle `is-open` on `.portfolio-popover-box` to trigger the centered zoom-in reveal. Customize via `--portfolio-scale-from`, `--portfolio-duration`, `--portfolio-easing`.
+
+## Why is it useful?
+It gives creative portfolio layouts a polished, centered case-study reveal pattern — CSS-only animation, minimal JS for state, keyboard accessible, and respects `prefers-reduced-motion`, matching EaseMotion's lightweight animation-first philosophy.

--- a/submissions/examples/zoom-in-popover-portfolio-ak/demo.html
+++ b/submissions/examples/zoom-in-popover-portfolio-ak/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zoom-In Portfolio Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="portfolio-card">
+    <img class="portfolio-thumb" src="https://picsum.photos/seed/portfolio1/400/300" alt="Project thumbnail">
+    <button class="portfolio-popover-trigger" id="portfolioBtn" aria-expanded="false" aria-describedby="portfolioBox">
+      View Details
+    </button>
+
+    <div class="portfolio-popover-box" id="portfolioBox" role="tooltip">
+      <h3>Project Nova</h3>
+      <p>A minimal brand identity project featuring custom typography and a zoom-reveal case study card.</p>
+      <span class="portfolio-tag">Branding · 2026</span>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('portfolioBtn');
+    const box = document.getElementById('portfolioBox');
+
+    btn.addEventListener('click', () => {
+      const isOpen = box.classList.toggle('is-open');
+      btn.setAttribute('aria-expanded', isOpen);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        box.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!box.contains(e.target) && !btn.contains(e.target)) {
+        box.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-popover-portfolio-ak/style.css
+++ b/submissions/examples/zoom-in-popover-portfolio-ak/style.css
@@ -1,0 +1,125 @@
+:root {
+  --portfolio-scale-from: 0.8;
+  --portfolio-duration: 260ms;
+  --portfolio-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --portfolio-bg: #ffffff;
+  --portfolio-fg: #1a1a1a;
+  --portfolio-accent: #ff5c5c;
+  --portfolio-radius: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: #f4f4f6;
+  color: #1a1a1a;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 40px 20px;
+}
+
+.portfolio-card {
+  position: relative;
+  width: 320px;
+  border-radius: var(--portfolio-radius);
+  overflow: visible;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.portfolio-thumb {
+  width: 100%;
+  display: block;
+  border-radius: var(--portfolio-radius) var(--portfolio-radius) 0 0;
+}
+
+.portfolio-popover-trigger {
+  display: block;
+  width: 100%;
+  background: var(--portfolio-accent);
+  color: #fff;
+  border: none;
+  padding: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 0 0 var(--portfolio-radius) var(--portfolio-radius);
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.portfolio-popover-trigger:hover {
+  background: #e64545;
+}
+
+.portfolio-popover-trigger:focus-visible {
+  outline: 2px solid var(--portfolio-accent);
+  outline-offset: 3px;
+}
+
+.portfolio-popover-box {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 260px;
+  padding: 20px;
+  background: var(--portfolio-bg);
+  color: var(--portfolio-fg);
+  border-radius: var(--portfolio-radius);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+
+  transform: translate(-50%, -50%) scale(var(--portfolio-scale-from));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--portfolio-duration) var(--portfolio-easing),
+    opacity var(--portfolio-duration) ease,
+    visibility 0s linear var(--portfolio-duration);
+}
+
+.portfolio-popover-box.is-open {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--portfolio-duration) var(--portfolio-easing),
+    opacity var(--portfolio-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.portfolio-popover-box h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.portfolio-popover-box p {
+  margin: 0 0 10px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: #4a4a4a;
+}
+
+.portfolio-tag {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--portfolio-accent);
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .portfolio-popover-box {
+    transition: opacity var(--portfolio-duration) ease, visibility 0s linear var(--portfolio-duration);
+  }
+  .portfolio-popover-box.is-open {
+    transition: opacity var(--portfolio-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION
Closes #46406
## Pull Request Description
Adds a pure CSS animated popover, styled for creative portfolio project cards, that reveals project details with a smooth zoom-in transition. Closes #46406.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-in-popover-portfolio-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only, centered zoom-in popover designed for creative portfolio project cards, revealing project details on click.

**How does a developer use it?**
```html
<div class="portfolio-card">
  <img class="portfolio-thumb" src="thumbnail.jpg" alt="Project thumbnail">
  <button class="portfolio-popover-trigger" id="portfolioBtn" aria-expanded="false" aria-describedby="portfolioBox">
    View Details
  </button>

  <div class="portfolio-popover-box" id="portfolioBox" role="tooltip">
    <h3>Project Name</h3>
    <p>Project description.</p>
    <span class="portfolio-tag">Category · Year</span>
  </div>
</div>
```
Toggling the `is-open` class on `.portfolio-popover-box` triggers the centered zoom-in reveal. Timing, easing, and scale are customizable via `--portfolio-scale-from`, `--portfolio-duration`, `--portfolio-easing`.

**Why does it fit EaseMotion CSS?**
It's a CSS-driven, animation-first reveal pattern tailored to portfolio/case-study cards, with minimal JS (state toggling only), keyboard accessibility (Escape to close), and `prefers-reduced-motion` support — aligned with EaseMotion's lightweight, human-readable motion philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a variant of the interactive-interface zoom-in popover (issue #46407) but restyled for portfolio card layouts — centered reveal, image thumbnail, and a category/year tag instead of a general-purpose tooltip. Class names are unprefixed as instructed; happy to have these renamed to `ease-*` on integration.