### PR TITLE
feat: add CSS zoom-in popover for minimalist tech layouts

### DIFF
--- a/submissions/examples/zoom-in-popover-minimal-tech-ak/README.md
+++ b/submissions/examples/zoom-in-popover-minimal-tech-ak/README.md
@@ -1,0 +1,23 @@
+# Zoom-In Minimal Tech Popover
+
+## What does this do?
+A pure CSS zoom-in animated popover styled for minimalist tech interfaces, using a compact scale-from-corner transition.
+
+## How is it used?
+```html
+<div class="tech-popover-wrap">
+  <button class="tech-popover-trigger" id="techBtn" aria-expanded="false" aria-describedby="techBox">
+    Learn more
+  </button>
+
+  <div class="tech-popover-box" id="techBox" role="tooltip">
+    <span class="tech-popover-label">Feature</span>
+    <h3>Title</h3>
+    <p>Description text.</p>
+  </div>
+</div>
+```
+Toggle `is-open` on `.tech-popover-box` to trigger the zoom-in from the top-left corner. Customize via `--tech-scale-from`, `--tech-duration`, `--tech-easing`.
+
+## Why is it useful?
+It provides a snappy, low-visual-noise popover suited to dark, minimalist tech UIs — dark background, monospace-friendly accent color, fast timing, CSS-only animation with minimal JS for state, keyboard support, and `prefers-reduced-motion` handling, in line with EaseMotion's lightweight philosophy.

--- a/submissions/examples/zoom-in-popover-minimal-tech-ak/demo.html
+++ b/submissions/examples/zoom-in-popover-minimal-tech-ak/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zoom-In Minimal Tech Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="tech-popover-wrap">
+    <button class="tech-popover-trigger" id="techBtn" aria-expanded="false" aria-describedby="techBox">
+      Learn more
+    </button>
+
+    <div class="tech-popover-box" id="techBox" role="tooltip">
+      <span class="tech-popover-label">Feature</span>
+      <h3>API-First Sync</h3>
+      <p>Real-time data sync across devices with a minimal, distraction-free interface.</p>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('techBtn');
+    const box = document.getElementById('techBox');
+
+    btn.addEventListener('click', () => {
+      const isOpen = box.classList.toggle('is-open');
+      btn.setAttribute('aria-expanded', isOpen);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        box.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!box.contains(e.target) && !btn.contains(e.target)) {
+        box.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-popover-minimal-tech-ak/style.css
+++ b/submissions/examples/zoom-in-popover-minimal-tech-ak/style.css
@@ -1,0 +1,120 @@
+:root {
+  --tech-scale-from: 0.9;
+  --tech-duration: 180ms;
+  --tech-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tech-bg: #101114;
+  --tech-fg: #e8e8ea;
+  --tech-accent: #00d4b0;
+  --tech-border: #26272c;
+  --tech-radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, sans-serif;
+  background: #050506;
+  color: #e8e8ea;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.tech-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.tech-popover-trigger {
+  background: transparent;
+  color: var(--tech-accent);
+  border: 1px solid var(--tech-accent);
+  padding: 10px 20px;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-radius: var(--tech-radius);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.tech-popover-trigger:hover {
+  background: var(--tech-accent);
+  color: #050506;
+}
+
+.tech-popover-trigger:focus-visible {
+  outline: 2px solid var(--tech-accent);
+  outline-offset: 3px;
+}
+
+.tech-popover-box {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  width: 240px;
+  padding: 16px;
+  background: var(--tech-bg);
+  color: var(--tech-fg);
+  border: 1px solid var(--tech-border);
+  border-radius: var(--tech-radius);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+
+  transform: scale(var(--tech-scale-from));
+  transform-origin: top left;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--tech-duration) var(--tech-easing),
+    opacity var(--tech-duration) ease,
+    visibility 0s linear var(--tech-duration);
+}
+
+.tech-popover-box.is-open {
+  transform: scale(1);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--tech-duration) var(--tech-easing),
+    opacity var(--tech-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.tech-popover-label {
+  display: inline-block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tech-accent);
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.tech-popover-box h3 {
+  margin: 0 0 6px;
+  font-size: 14.5px;
+  font-weight: 600;
+}
+
+.tech-popover-box p {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: #9a9aa2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tech-popover-box {
+    transition: opacity var(--tech-duration) ease, visibility 0s linear var(--tech-duration);
+  }
+  .tech-popover-box.is-open {
+    transition: opacity var(--tech-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION
Closes #46401
## Pull Request Description
Adds a pure CSS animated popover styled for minimalist tech interfaces, using a compact zoom-in-from-corner transition. 

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-in-popover-minimal-tech-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only popover with a fast, compact zoom-in transition, styled with a dark palette to match minimalist tech interfaces.

**How does a developer use it?**
```html
<div class="tech-popover-wrap">
  <button class="tech-popover-trigger" id="techBtn" aria-expanded="false" aria-describedby="techBox">
    Learn more
  </button>

  <div class="tech-popover-box" id="techBox" role="tooltip">
    <span class="tech-popover-label">Feature</span>
    <h3>Title</h3>
    <p>Description text.</p>
  </div>
</div>
```
Toggling the `is-open` class on `.tech-popover-box` triggers a scale-from-top-left-corner zoom-in. Timing, easing, and scale are customizable via `--tech-scale-from`, `--tech-duration`, `--tech-easing`.

**Why does it fit EaseMotion CSS?**
It offers a snappy, low-noise popover suited to dark, minimalist tech UIs — CSS-driven animation with minimal JS (state toggling only), keyboard accessibility (Escape to close), and `prefers-reduced-motion` support, matching EaseMotion's lightweight, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is the third variant in the zoom-in popover series (alongside #46407 and #46406), tailored for minimalist tech layouts — dark background, monospace-friendly accent color, and a faster/tighter timing curve than the other two. Class names are unprefixed as instructed; happy to have them renamed to `ease-*` on integration.