### PR TITLE
feat: add CSS zoom-in popover for dashboard analytics layouts

### DIFF
--- a/submissions/examples/zoom-in-popover-dashboard-analytics-ak/README.md
+++ b/submissions/examples/zoom-in-popover-dashboard-analytics-ak/README.md
@@ -1,0 +1,31 @@
+# Zoom-In Dashboard Analytics Popover
+
+## What does this do?
+A pure CSS zoom-in animated popover styled for dashboard/analytics stat cards, revealing a metric breakdown from an info icon.
+
+## How is it used?
+```html
+<div class="stat-card">
+  <div class="stat-header">
+    <span class="stat-label">Monthly Revenue</span>
+    <button class="stat-popover-trigger" id="statBtn" aria-expanded="false" aria-describedby="statBox">
+      ⓘ
+    </button>
+  </div>
+  <div class="stat-value">$48,290</div>
+  <div class="stat-change">▲ 12.4% vs last month</div>
+
+  <div class="stat-popover-box" id="statBox" role="tooltip">
+    <h3>Revenue Breakdown</h3>
+    <ul class="stat-meta">
+      <li><span>Subscriptions</span><strong>$31,200</strong></li>
+      <li><span>One-time sales</span><strong>$17,090</strong></li>
+    </ul>
+    <p>Additional context text.</p>
+  </div>
+</div>
+```
+Toggle `is-open` on `.stat-popover-box` to trigger a zoom-in reveal anchored to the top-right corner of the card. Customize via `--stat-scale-from`, `--stat-duration`, `--stat-easing`.
+
+## Why is it useful?
+It provides a compact, unobtrusive way to surface extra metric context in analytics dashboards without cluttering the card itself — CSS-driven animation, minimal JS for state, keyboard accessible, and respects `prefers-reduced-motion`, matching EaseMotion's lightweight animation-first philosophy.

--- a/submissions/examples/zoom-in-popover-dashboard-analytics-ak/demo.html
+++ b/submissions/examples/zoom-in-popover-dashboard-analytics-ak/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zoom-In Dashboard Analytics Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="stat-card">
+    <div class="stat-header">
+      <span class="stat-label">Monthly Revenue</span>
+      <button class="stat-popover-trigger" id="statBtn" aria-expanded="false" aria-describedby="statBox">
+        ⓘ
+      </button>
+    </div>
+    <div class="stat-value">$48,290</div>
+    <div class="stat-change">▲ 12.4% vs last month</div>
+
+    <div class="stat-popover-box" id="statBox" role="tooltip">
+      <h3>Revenue Breakdown</h3>
+      <ul class="stat-meta">
+        <li><span>Subscriptions</span><strong>$31,200</strong></li>
+        <li><span>One-time sales</span><strong>$17,090</strong></li>
+      </ul>
+      <p>Calculated across all active regions, updated hourly.</p>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('statBtn');
+    const box = document.getElementById('statBox');
+
+    btn.addEventListener('click', () => {
+      const isOpen = box.classList.toggle('is-open');
+      btn.setAttribute('aria-expanded', isOpen);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        box.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!box.contains(e.target) && !btn.contains(e.target)) {
+        box.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-popover-dashboard-analytics-ak/style.css
+++ b/submissions/examples/zoom-in-popover-dashboard-analytics-ak/style.css
@@ -1,0 +1,160 @@
+:root {
+  --stat-scale-from: 0.88;
+  --stat-duration: 200ms;
+  --stat-easing: cubic-bezier(0.2, 0.9, 0.4, 1);
+  --stat-bg: #16181d;
+  --stat-fg: #eceef1;
+  --stat-accent: #5b8cff;
+  --stat-positive: #3ddc97;
+  --stat-border: #262932;
+  --stat-radius: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: #0a0b0d;
+  color: #eceef1;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 40px 20px;
+}
+
+.stat-card {
+  position: relative;
+  width: 260px;
+  background: var(--stat-bg);
+  border: 1px solid var(--stat-border);
+  border-radius: var(--stat-radius);
+  padding: 18px 20px;
+}
+
+.stat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.stat-label {
+  font-size: 12.5px;
+  color: #9a9ea8;
+  font-weight: 500;
+}
+
+.stat-popover-trigger {
+  background: transparent;
+  border: 1px solid var(--stat-border);
+  color: #9a9ea8;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.stat-popover-trigger:hover {
+  border-color: var(--stat-accent);
+  color: var(--stat-accent);
+}
+
+.stat-popover-trigger:focus-visible {
+  outline: 2px solid var(--stat-accent);
+  outline-offset: 2px;
+}
+
+.stat-value {
+  font-size: 26px;
+  font-weight: 700;
+}
+
+.stat-change {
+  font-size: 12.5px;
+  color: var(--stat-positive);
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+.stat-popover-box {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  transform: translate(0, -100%) scale(var(--stat-scale-from));
+  transform-origin: bottom right;
+  width: 240px;
+  padding: 16px;
+  background: var(--stat-bg);
+  color: var(--stat-fg);
+  border: 1px solid var(--stat-border);
+  border-radius: var(--stat-radius);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.5);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--stat-duration) var(--stat-easing),
+    opacity var(--stat-duration) ease,
+    visibility 0s linear var(--stat-duration);
+}
+
+.stat-popover-box.is-open {
+  transform: translate(0, -100%) scale(1);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--stat-duration) var(--stat-easing),
+    opacity var(--stat-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.stat-popover-box h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.stat-meta {
+  list-style: none;
+  margin: 0 0 10px;
+  padding: 0;
+}
+
+.stat-meta li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12.5px;
+  color: #c4c7cd;
+  margin-bottom: 6px;
+}
+
+.stat-meta strong {
+  color: var(--stat-fg);
+}
+
+.stat-popover-box p {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: #7e828c;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-popover-box {
+    transition: opacity var(--stat-duration) ease, visibility 0s linear var(--stat-duration);
+  }
+  .stat-popover-box.is-open {
+    transition: opacity var(--stat-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION
Closes #46395
## Pull Request Description
Adds a pure CSS animated popover styled for dashboard/analytics stat cards, revealing a metric breakdown from an info icon with a smooth zoom-in transition. 

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-in-popover-dashboard-analytics-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only popover, triggered from an info icon on a stat card, that zooms in from the top-right corner to reveal a metric breakdown.

**How does a developer use it?**
```html
<div class="stat-card">
  <div class="stat-header">
    <span class="stat-label">Monthly Revenue</span>
    <button class="stat-popover-trigger" id="statBtn" aria-expanded="false" aria-describedby="statBox">
      ⓘ
    </button>
  </div>
  <div class="stat-value">$48,290</div>
  <div class="stat-change">▲ 12.4% vs last month</div>

  <div class="stat-popover-box" id="statBox" role="tooltip">
    <h3>Revenue Breakdown</h3>
    <ul class="stat-meta">
      <li><span>Subscriptions</span><strong>$31,200</strong></li>
      <li><span>One-time sales</span><strong>$17,090</strong></li>
    </ul>
    <p>Additional context text.</p>
  </div>
</div>
```
Toggling the `is-open` class on `.stat-popover-box` triggers a zoom-in reveal anchored to the top-right corner of the card. Timing, easing, and scale are customizable via `--stat-scale-from`, `--stat-duration`, `--stat-easing`.

**Why does it fit EaseMotion CSS?**
It offers a compact, unobtrusive way to surface extra metric context in analytics dashboards without cluttering the card — CSS-driven animation with minimal JS (state toggling only), keyboard accessibility (Escape to close), and `prefers-reduced-motion` support, matching EaseMotion's lightweight, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Fifth variant in the zoom-in popover series (following #46407, #46406, #46401, #46397 — all merged). This one uses a corner-anchored info-icon trigger rather than a labeled button, fitting the compact footprint typical of dashboard stat cards. Class names are unprefixed as instructed; happy to have them renamed to `ease-*` on integration.