### PR TITLE
feat: add micro shake popover for interactive interface layouts (#46520)

### DIFF
--- a/submissions/examples/micro-shake-popover-interactive-rs/README.md
+++ b/submissions/examples/micro-shake-popover-interactive-rs/README.md
@@ -1,0 +1,56 @@
+# Micro Shake Popover — Interactive Interface
+
+A pure CSS animated popover with a subtle **micro shake** interaction, styled for creative interactive interfaces.
+
+## Features
+
+- **8 interactive-themed cards** — Gesture Controls, Media Player, Voice Commands, Drag & Drop, Navigation Shortcuts, Favorites, Undo History, Snap Layouts
+- **Micro shake animation** — Subtle vibration/buzz effect on open, unique to this component
+- **Gradient accent bar** — Each card has a colored top accent (purple/pink/green/amber)
+- **4 position variants** — Bottom, Top, Right, Left (switchable via radio buttons)
+- **Dark/light mode** — Automatic via `prefers-color-scheme`
+- **Reduced motion** — Respects `prefers-reduced-motion: reduce`
+- **Forced colors** — Respects `forced-colors: active`
+- **Keyboard accessible** — Tab navigation, Space/Enter to toggle
+- **No JavaScript dependency** — Checkbox hack for toggle behavior
+
+## Custom Properties
+
+| Variable                    | Default                          | Description                     |
+| --------------------------- | -------------------------------- | ------------------------------- |
+| `--popover-duration`        | `0.3s`                           | Open/close transition duration  |
+| `--popover-ease`            | `cubic-bezier(0.34,1.56,0.64,1)` | Transition easing (spring-like) |
+| `--popover-shake-intensity` | `3px`                            | Shake displacement in pixels    |
+| `--popover-max-width`       | `300px`                          | Maximum popover width           |
+| `--popover-gap`             | `10px`                           | Gap between trigger and popover |
+
+## Usage
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css"
+/>
+<link rel="stylesheet" href="style.css" />
+
+<div class="int-card card-accent-purple">
+  <div class="shake-popover-sh">
+    <input type="checkbox" id="my-popover" class="shake-popover-toggle-sh" />
+    <label for="my-popover" class="shake-popover-trigger-sh">Open</label>
+    <div class="shake-popover-content-sh" data-position="bottom" role="dialog">
+      <div class="popover-header">
+        <h4>Title</h4>
+        <button type="button" class="popover-close">×</button>
+      </div>
+      <div class="sh-row">
+        <span class="sh-label">Item</span>
+        <span class="sh-value">Value</span>
+      </div>
+      <div class="popover-footer">
+        <span class="popover-footer-label">Info</span>
+        <button type="button" class="popover-btn">Action</button>
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/submissions/examples/micro-shake-popover-interactive-rs/demo.html
+++ b/submissions/examples/micro-shake-popover-interactive-rs/demo.html
@@ -1,0 +1,932 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Micro Shake Popover — Interactive Interface</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M12 2L2 7l10 5 10-5-10-5z" />
+            <path d="M2 17l10 5 10-5" />
+            <path d="M2 12l10 5 10-5" />
+          </svg>
+          Micro Shake Popover
+        </h1>
+        <p>Subtle shake interaction for creative interactive interfaces</p>
+      </div>
+
+      <div class="sec-header">
+        <h2>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M12 2a10 10 0 0 1 10 10c0 2.2-.7 4.3-2 5.9l-1 1-2-2.9" />
+            <path d="M7 21l3-4" />
+            <path d="M14 21l-3-4" />
+          </svg>
+          Interaction Controls
+        </h2>
+        <span class="pill">Micro Shake • 0.5s</span>
+      </div>
+
+      <div class="grid">
+        <div class="int-card card-accent-purple">
+          <div class="card-icon icon-purple">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"
+              />
+              <line x1="4" y1="22" x2="4" y2="15" />
+            </svg>
+          </div>
+          <div class="card-label">Gesture Controls</div>
+          <div class="card-value">Swipe</div>
+          <div class="card-sub">Swipe gestures enabled system-wide</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-gesture"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-gesture" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              Gesture Map
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Gesture map"
+            >
+              <div class="popover-header">
+                <h4>Gesture Map</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="
+                    document.getElementById('sh-gesture').checked = false
+                  "
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label"
+                  ><span class="sh-gesture">→</span>Swipe Right</span
+                ><span class="sh-value">Next Page</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label"
+                  ><span class="sh-gesture">←</span>Swipe Left</span
+                ><span class="sh-value">Previous</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label"
+                  ><span class="sh-gesture">↑</span>Swipe Up</span
+                ><span class="sh-value">Refresh</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label"
+                  ><span class="sh-gesture">↓</span>Swipe Down</span
+                ><span class="sh-value">Details</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label"
+                  ><span class="sh-gesture">✕</span>Pinch</span
+                ><span class="sh-value">Zoom Out</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">6 gestures active</span>
+                <button type="button" class="popover-btn">Customize</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="int-card card-accent-pink">
+          <div class="card-icon icon-pink">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <polygon points="10 8 16 12 10 16 10 8" />
+            </svg>
+          </div>
+          <div class="card-label">Media Player</div>
+          <div class="card-value">Now Playing</div>
+          <div class="card-sub">"Midnight Waves" · 3:42 / 4:15</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-media"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-media" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              Playlist
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Playlist"
+            >
+              <div class="popover-header">
+                <h4>Up Next</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="document.getElementById('sh-media').checked = false"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label"
+                  ><span class="sh-dot" style="background: var(--accent)"></span
+                  >Midnight Waves</span
+                ><span class="sh-value pink">Playing</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Neon Rain</span
+                ><span class="sh-value">3:58</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Crystal Cave</span
+                ><span class="sh-value">4:32</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Shadow Dance</span
+                ><span class="sh-value">3:15</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">12 tracks · 48 min</span>
+                <button type="button" class="popover-btn-outline">
+                  Shuffle
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="int-card card-accent-green">
+          <div class="card-icon icon-green">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+              <line x1="12" y1="19" x2="12" y2="23" />
+              <line x1="8" y1="23" x2="16" y2="23" />
+            </svg>
+          </div>
+          <div class="card-label">Voice Commands</div>
+          <div class="card-value">Listening</div>
+          <div class="card-sub">"Hey Interface" · 3 commands detected</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-voice"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-voice" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              Commands
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Voice commands"
+            >
+              <div class="popover-header">
+                <h4>Voice Commands</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="document.getElementById('sh-voice').checked = false"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">"Open dashboard"</span
+                ><span class="sh-value green">Active</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">"Play music"</span
+                ><span class="sh-value green">Active</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">"Dark mode"</span
+                ><span class="sh-value green">Active</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">"Take screenshot"</span
+                ><span class="sh-value amber">Disabled</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">3 of 4 enabled</span>
+                <button type="button" class="popover-btn">Manage</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="int-card card-accent-amber">
+          <div class="card-icon icon-amber">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+            </svg>
+          </div>
+          <div class="card-label">Drag & Drop</div>
+          <div class="card-value">Enabled</div>
+          <div class="card-sub">3 active zones · auto-snap on</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-dnd"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-dnd" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              Drop Zones
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Drag and drop zones"
+            >
+              <div class="popover-header">
+                <h4>Drop Zones</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="document.getElementById('sh-dnd').checked = false"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">📁 Upload Area</span
+                ><span class="sh-value green">Active</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">📊 Chart Panel</span
+                ><span class="sh-value green">Active</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">📋 Sidebar</span
+                ><span class="sh-value green">Active</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Snap threshold</span
+                ><span class="sh-value">30px</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">Auto-snap enabled</span>
+                <button type="button" class="popover-btn-outline">
+                  Configure
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="sec-header">
+        <h2>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="4" />
+            <path d="M3 12h18" />
+            <path d="M12 3v18" />
+          </svg>
+          Keyboard Shortcuts
+        </h2>
+        <span class="pill">Context-aware</span>
+      </div>
+
+      <div class="grid">
+        <div class="int-card card-accent-purple">
+          <div class="card-icon icon-purple">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+              <path
+                d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"
+              />
+            </svg>
+          </div>
+          <div class="card-label">Navigation</div>
+          <div class="card-value">Ctrl+K</div>
+          <div class="card-sub">Quick command palette</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-nav"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-nav" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              Shortcuts
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Navigation shortcuts"
+            >
+              <div class="popover-header">
+                <h4>Navigation</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="document.getElementById('sh-nav').checked = false"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Command Palette</span
+                ><span class="sh-key">Ctrl+K</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Search</span
+                ><span class="sh-key">Ctrl+Shift+F</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Go to File</span
+                ><span class="sh-key">Ctrl+P</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Toggle Sidebar</span
+                ><span class="sh-key">Ctrl+B</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">12 shortcuts</span>
+                <button type="button" class="popover-btn">Edit</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="int-card card-accent-pink">
+          <div class="card-icon icon-pink">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polygon
+                points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+              />
+            </svg>
+          </div>
+          <div class="card-label">Favorites</div>
+          <div class="card-value">Ctrl+D</div>
+          <div class="card-sub">Bookmark current item</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-fav"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-fav" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              Bookmarks
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Favorites"
+            >
+              <div class="popover-header">
+                <h4>Bookmarks</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="document.getElementById('sh-fav').checked = false"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">⭐ Dashboard</span
+                ><span class="sh-value">Page</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">⭐ Settings</span
+                ><span class="sh-value">Page</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">⭐ Profile</span
+                ><span class="sh-value">Page</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">⭐ Reports</span
+                ><span class="sh-value">Section</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">4 bookmarks</span>
+                <button type="button" class="popover-btn-outline">
+                  Manage
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="int-card card-accent-green">
+          <div class="card-icon icon-green">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M23 4v6h-6" />
+              <path d="M1 20v-6h6" />
+              <path
+                d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"
+              />
+            </svg>
+          </div>
+          <div class="card-label">Undo / Redo</div>
+          <div class="card-value">Ctrl+Z</div>
+          <div class="card-sub">15-step history</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-undo"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-undo" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              History
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="History"
+            >
+              <div class="popover-header">
+                <h4>Action History</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="document.getElementById('sh-undo').checked = false"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Renamed file</span
+                ><span class="sh-value">2 min ago</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Deleted section</span
+                ><span class="sh-value">5 min ago</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Moved item</span
+                ><span class="sh-value">12 min ago</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Changed theme</span
+                ><span class="sh-value">18 min ago</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">15 actions stored</span>
+                <button type="button" class="popover-btn">Clear</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="int-card card-accent-amber">
+          <div class="card-icon icon-amber">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="3" y="3" width="7" height="7" />
+              <rect x="14" y="3" width="7" height="7" />
+              <rect x="3" y="14" width="7" height="7" />
+              <rect x="14" y="14" width="7" height="7" />
+            </svg>
+          </div>
+          <div class="card-label">Snap Layouts</div>
+          <div class="card-value">Win+→</div>
+          <div class="card-sub">Snap to grid position</div>
+          <div class="shake-popover-sh">
+            <input
+              type="checkbox"
+              id="sh-snap"
+              class="shake-popover-toggle-sh"
+            />
+            <label for="sh-snap" class="shake-popover-trigger-sh">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 20V10" />
+                <path d="M18 20V4" />
+                <path d="M6 20v-4" />
+              </svg>
+              Layouts
+            </label>
+            <div
+              class="shake-popover-content-sh"
+              data-position="bottom"
+              role="dialog"
+              aria-label="Snap layouts"
+            >
+              <div class="popover-header">
+                <h4>Snap Layouts</h4>
+                <button
+                  type="button"
+                  class="popover-close"
+                  onclick="document.getElementById('sh-snap').checked = false"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Left Half</span
+                ><span class="sh-key">Win+←</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Right Half</span
+                ><span class="sh-key">Win+→</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Top Half</span
+                ><span class="sh-key">Win+↑</span>
+              </div>
+              <div class="sh-row">
+                <span class="sh-label">Bottom Half</span
+                ><span class="sh-key">Win+↓</span>
+              </div>
+              <div class="popover-footer">
+                <span class="popover-footer-label">4 snap positions</span>
+                <button type="button" class="popover-btn-outline">
+                  Customize
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="sec-header">
+        <h2>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M8 14s1.5 2 4 2 4-2 4-2" />
+            <line x1="9" y1="9" x2="9.01" y2="9" />
+            <line x1="15" y1="9" x2="15.01" y2="9" />
+          </svg>
+          Position & Custom Properties
+        </h2>
+        <span class="pill">Demo Controls</span>
+      </div>
+
+      <div
+        style="
+          display: flex;
+          flex-wrap: wrap;
+          gap: 10px;
+          margin-bottom: 28px;
+          padding: 16px;
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: var(--radius);
+          box-shadow: var(--shadow);
+        "
+      >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.8125rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="sh-pos"
+            value="bottom"
+            checked
+            onchange="
+              document
+                .querySelectorAll('.shake-popover-content-sh')
+                .forEach((el) => (el.dataset.position = 'bottom'))
+            "
+          />
+          Bottom</label
+        >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.8125rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="sh-pos"
+            value="top"
+            onchange="
+              document
+                .querySelectorAll('.shake-popover-content-sh')
+                .forEach((el) => (el.dataset.position = 'top'))
+            "
+          />
+          Top</label
+        >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.8125rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="sh-pos"
+            value="right"
+            onchange="
+              document
+                .querySelectorAll('.shake-popover-content-sh')
+                .forEach((el) => (el.dataset.position = 'right'))
+            "
+          />
+          Right</label
+        >
+        <label
+          style="
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            font-size: 0.8125rem;
+            font-weight: 500;
+          "
+          ><input
+            type="radio"
+            name="sh-pos"
+            value="left"
+            onchange="
+              document
+                .querySelectorAll('.shake-popover-content-sh')
+                .forEach((el) => (el.dataset.position = 'left'))
+            "
+          />
+          Left</label
+        >
+      </div>
+
+      <div
+        style="
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+          gap: 8px;
+          margin-bottom: 32px;
+        "
+      >
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-duration</strong><br />
+          <span style="color: var(--muted)">0.3s</span>
+        </div>
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-ease</strong><br />
+          <span style="color: var(--muted)">cubic-bezier(.34,1.56,.64,1)</span>
+        </div>
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-shake-intensity</strong><br />
+          <span style="color: var(--muted)">3px</span>
+        </div>
+        <div
+          style="
+            padding: 12px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 0.75rem;
+          "
+        >
+          <strong>--popover-max-width</strong><br />
+          <span style="color: var(--muted)">300px</span>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/micro-shake-popover-interactive-rs/style.css
+++ b/submissions/examples/micro-shake-popover-interactive-rs/style.css
@@ -1,0 +1,511 @@
+:root {
+  --bg: #f0eeff;
+  --surface: #fff;
+  --border: #ddd6fe;
+  --text: #1e1b4b;
+  --muted: #7c7baa;
+  --primary: #7c3aed;
+  --primary-light: #a78bfa;
+  --primary-dark: #6d28d9;
+  --accent: #ec4899;
+  --accent-light: #fbcfe8;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --shadow: 0 2px 8px rgba(124, 58, 237, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
+  --shadow-lg:
+    0 12px 28px rgba(124, 58, 237, 0.12), 0 4px 12px rgba(0, 0, 0, 0.06);
+  --radius: 14px;
+  --popover-duration: 0.3s;
+  --popover-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --popover-shake-intensity: 3px;
+  --popover-max-width: 300px;
+  --popover-gap: 10px;
+}
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 24px;
+}
+.container {
+  max-width: 960px;
+  width: 100%;
+}
+.header {
+  text-align: center;
+  margin-bottom: 28px;
+}
+.header h1 {
+  font-size: 1.625rem;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.header p {
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+.sec-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid var(--border);
+}
+.sec-header h2 {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.sec-header .pill {
+  font-size: 0.6875rem;
+  color: var(--muted);
+  background: var(--bg);
+  padding: 3px 10px;
+  border-radius: 9999px;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 28px;
+}
+.int-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+.int-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  border-radius: var(--radius) var(--radius) 0 0;
+}
+.int-card:hover {
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-2px);
+}
+.card-accent-purple::before {
+  background: var(--primary);
+}
+.card-accent-pink::before {
+  background: var(--accent);
+}
+.card-accent-green::before {
+  background: var(--success);
+}
+.card-accent-amber::before {
+  background: var(--warning);
+}
+.card-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+  font-size: 1.125rem;
+}
+.icon-purple {
+  background: rgba(124, 58, 237, 0.1);
+  color: var(--primary);
+}
+.icon-pink {
+  background: rgba(236, 72, 153, 0.1);
+  color: var(--accent);
+}
+.icon-green {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--success);
+}
+.icon-amber {
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--warning);
+}
+.card-label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 2px;
+}
+.card-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1.2;
+  margin-bottom: 2px;
+}
+.card-sub {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.shake-popover-sh {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+.shake-popover-toggle-sh {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+.shake-popover-trigger-sh {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 16px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+  user-select: none;
+  margin-top: 12px;
+}
+.shake-popover-trigger-sh:hover {
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.2);
+  transform: scale(1.02);
+}
+.shake-popover-trigger-sh svg {
+  width: 13px;
+  height: 13px;
+}
+
+.shake-popover-content-sh {
+  position: absolute;
+  z-index: 100;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  padding: 14px;
+  min-width: 240px;
+  max-width: var(--popover-max-width);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px) scale(0.95);
+  transition:
+    opacity var(--popover-duration) var(--popover-ease),
+    visibility var(--popover-duration) var(--popover-ease),
+    transform var(--popover-duration) var(--popover-ease);
+  text-align: left;
+  pointer-events: none;
+}
+.shake-popover-content-sh[data-position="bottom"] {
+  top: calc(100% + var(--popover-gap));
+  left: 50%;
+  transform: translateX(-50%) translateY(8px) scale(0.95);
+}
+.shake-popover-content-sh[data-position="top"] {
+  bottom: calc(100% + var(--popover-gap));
+  left: 50%;
+  transform: translateX(-50%) translateY(-8px) scale(0.95);
+}
+.shake-popover-content-sh[data-position="right"] {
+  left: calc(100% + var(--popover-gap));
+  top: 50%;
+  transform: translateY(-50%) translateX(8px) scale(0.95);
+}
+.shake-popover-content-sh[data-position="left"] {
+  right: calc(100% + var(--popover-gap));
+  top: 50%;
+  transform: translateY(-50%) translateX(-8px) scale(0.95);
+}
+.shake-popover-toggle-sh:checked ~ .shake-popover-content-sh {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.shake-popover-content-sh::before {
+  content: "";
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  transform: rotate(45deg);
+  z-index: -1;
+}
+.shake-popover-content-sh[data-position="bottom"]::before {
+  top: -6px;
+  left: 50%;
+  margin-left: -5px;
+  border-right: none;
+  border-bottom: none;
+}
+.shake-popover-content-sh[data-position="top"]::before {
+  bottom: -6px;
+  left: 50%;
+  margin-left: -5px;
+  border-left: none;
+  border-top: none;
+}
+.shake-popover-content-sh[data-position="right"]::before {
+  left: -6px;
+  top: 50%;
+  margin-top: -5px;
+  border-left: none;
+  border-bottom: none;
+}
+.shake-popover-content-sh[data-position="left"]::before {
+  right: -6px;
+  top: 50%;
+  margin-top: -5px;
+  border-right: none;
+  border-top: none;
+}
+
+@keyframes sh-shake {
+  0%,
+  100% {
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+  10% {
+    transform: translateX(calc(-50% + var(--popover-shake-intensity) * -1));
+  }
+  20% {
+    transform: translateX(calc(-50% + var(--popover-shake-intensity)));
+  }
+  30% {
+    transform: translateX(calc(-50% + var(--popover-shake-intensity) * -0.6));
+  }
+  40% {
+    transform: translateX(calc(-50% + var(--popover-shake-intensity) * 0.6));
+  }
+  50% {
+    transform: translateX(calc(-50% + var(--popover-shake-intensity) * -0.3));
+  }
+  60% {
+    transform: translateX(calc(-50% + var(--popover-shake-intensity) * 0.3));
+  }
+  70%,
+  100% {
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+.shake-popover-toggle-sh:checked ~ .shake-popover-content-sh {
+  animation: sh-shake 0.5s ease-in-out;
+}
+.shake-popover-toggle-sh:checked ~ .shake-popover-trigger-sh {
+  animation: sh-shake 0.45s ease-in-out;
+}
+
+.popover-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.popover-header h4 {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--text);
+}
+.popover-close {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1.125rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition:
+    color 0.2s ease,
+    background 0.2s ease;
+}
+.popover-close:hover {
+  color: var(--text);
+  background: var(--bg);
+}
+
+.sh-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 5px 0;
+  font-size: 0.8125rem;
+}
+.sh-row:not(:last-child) {
+  border-bottom: 1px solid var(--border);
+}
+.sh-label {
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.sh-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.sh-value {
+  font-weight: 600;
+  color: var(--text);
+}
+.sh-value.green {
+  color: var(--success);
+}
+.sh-value.amber {
+  color: var(--warning);
+}
+.sh-value.pink {
+  color: var(--accent);
+}
+.sh-value.purple {
+  color: var(--primary);
+}
+.sh-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 4px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  color: var(--muted);
+  font-family: inherit;
+}
+.sh-gesture {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  background: var(--bg);
+  color: var(--muted);
+}
+
+.popover-footer {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.popover-footer-label {
+  font-size: 0.6875rem;
+  color: var(--muted);
+}
+.popover-btn {
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  border: none;
+  padding: 5px 12px;
+  border-radius: 6px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease;
+}
+.popover-btn:hover {
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.2);
+}
+.popover-btn-outline {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 12px;
+  border-radius: 6px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.popover-btn-outline:hover {
+  background: var(--bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shake-popover-toggle-sh:checked ~ .shake-popover-content-sh,
+  .shake-popover-toggle-sh:checked ~ .shake-popover-trigger-sh {
+    animation: none;
+  }
+  .shake-popover-content-sh {
+    transition: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f0a1a;
+    --surface: #1c1428;
+    --border: #2d2040;
+    --text: #e8e0f0;
+    --muted: #9a8ab0;
+    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media (forced-colors: active) {
+  .shake-popover-content-sh {
+    border: 2px solid CanvasText;
+  }
+  .shake-popover-content-sh::before {
+    border: 2px solid CanvasText;
+    background: Canvas;
+  }
+  .shake-popover-trigger-sh {
+    border: 1px solid CanvasText;
+  }
+}


### PR DESCRIPTION
Adds a pure CSS micro shake popover component styled for creative interactive interfaces to \submissions/examples/micro-shake-popover-interactive-rs/\.

## Features
- **8 interactive-themed cards**: 2 sections — Interaction Controls (Gesture Controls, Media Player, Voice Commands, Drag & Drop) and Keyboard Shortcuts (Navigation, Favorites, Undo History, Snap Layouts)
- **Micro shake animation**: Subtle vibration/buzz effect on open using \--popover-shake-intensity\
- **Gradient accent bars**: Each card features a colored top accent stripe (purple/pink/green/amber)
- **Rich interactive content**: Gesture symbols, keyboard shortcut badges, status indicators
- **Position switcher**: Radio controls for Bottom/Top/Right/Left
- **Dark/light mode**, **reduced motion**, **forced colors** support
- **Keyboard accessible**: Tab navigation, Space/Enter toggle, close button
- **5 customizable CSS properties**
- **No JavaScript dependency**: Checkbox hack for toggle behavior

## Files
- \style.css\: Interactive-themed micro shake popover CSS
- \demo.html\: Creative demo with 8 interactive cards and position controls
- \README.md\: Documentation and usage guide

Closes #46520