### PR TITLE
feat: add seismic activity chart component (#48219)

### DIFF
--- a/submissions/examples/ease-seismic-activity-chart-rs/README.md
+++ b/submissions/examples/ease-seismic-activity-chart-rs/README.md
@@ -1,0 +1,42 @@
+# Seismic Activity Chart
+
+A pure CSS + SVG animated seismograph chart for visualizing earthquake activity, styled for monitoring dashboards.
+
+## Features
+
+- **SVG seismograph wave** — Smooth line chart with draw animation using `stroke-dasharray`/`stroke-dashoffset`
+- **Earthquake event markers** — Circles pop in at event positions with staggered delays
+- **Magnitude color coding** — Green (minor), yellow (moderate), orange (strong), red (major)
+- **Summary statistics** — Auto-counted breakdown by magnitude category
+- **Data table** — Chronological list with date, location, magnitude badge, and depth
+- **Time range controls** — Switch between 7, 14, and 30-day views
+- **Replay button** — Re-triggers the draw animation
+- **Dark/light mode** — Automatic via `prefers-color-scheme`
+- **Forced colors** — Respects `forced-colors: active`
+
+## Custom Properties
+
+| Property              | Default | Description                      |
+| --------------------- | ------- | -------------------------------- |
+| `--sac-draw-duration` | `2s`    | SVG line draw animation duration |
+| `--sac-line-width`    | `2`     | Seismograph stroke width         |
+| `--sac-rad`           | `12px`  | Card border radius               |
+
+## Usage
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css"
+/>
+<link rel="stylesheet" href="style.css" />
+
+<div class="sac-card">
+  <div class="sac-chart">
+    <svg class="sac-svg" viewBox="0 0 800 400">
+      <path class="sac-wave sac-wave-path" id="wave-path" d="" />
+    </svg>
+  </div>
+  <button class="sac-replay" onclick="replay()">Replay</button>
+</div>
+```

--- a/submissions/examples/ease-seismic-activity-chart-rs/demo.html
+++ b/submissions/examples/ease-seismic-activity-chart-rs/demo.html
@@ -1,0 +1,469 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Seismic Activity Chart — EaseMotion</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="wrapper">
+      <h1>
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M2 12h3l3-9 3 18 3-18 3 9h3" />
+        </svg>
+        Seismic Activity Chart
+      </h1>
+      <p class="desc">Real-time earthquake monitoring — Pacific Ring of Fire</p>
+
+      <div class="sac-card">
+        <div class="sac-header">
+          <h2>Seismograph — Last 7 Days</h2>
+          <span>Updated: <span id="sac-updated">Just now</span></span>
+        </div>
+
+        <div class="sac-chart">
+          <svg
+            class="sac-svg"
+            viewBox="0 0 800 400"
+            preserveAspectRatio="xMidYMid meet"
+            id="sac-svg"
+          >
+            <line class="sac-grid-line" x1="0" y1="80" x2="800" y2="80" />
+            <line class="sac-grid-line" x1="0" y1="160" x2="800" y2="160" />
+            <line class="sac-grid-line" x1="0" y1="240" x2="800" y2="240" />
+            <line class="sac-grid-line" x1="0" y1="320" x2="800" y2="320" />
+            <text class="sac-label-y" x="788" y="84">7.0</text>
+            <text class="sac-label-y" x="788" y="164">5.0</text>
+            <text class="sac-label-y" x="788" y="244">3.0</text>
+            <text class="sac-label-y" x="788" y="324">1.0</text>
+            <text class="sac-label-x" x="50" y="392">Mon</text>
+            <text class="sac-label-x" x="183" y="392">Tue</text>
+            <text class="sac-label-x" x="316" y="392">Wed</text>
+            <text class="sac-label-x" x="450" y="392">Thu</text>
+            <text class="sac-label-x" x="583" y="392">Fri</text>
+            <text class="sac-label-x" x="716" y="392">Sat</text>
+            <text class="sac-label-x" x="785" y="392">Sun</text>
+            <path class="sac-wave sac-wave-path" id="sac-wave-path" d="" />
+          </svg>
+        </div>
+
+        <div class="sac-legend">
+          <span class="sac-legend-item"
+            ><span
+              class="sac-legend-dot"
+              style="background: var(--sac-green)"
+            ></span
+            >Minor (≤3.9)</span
+          >
+          <span class="sac-legend-item"
+            ><span
+              class="sac-legend-dot"
+              style="background: var(--sac-yellow)"
+            ></span
+            >Moderate (4.0–4.9)</span
+          >
+          <span class="sac-legend-item"
+            ><span
+              class="sac-legend-dot"
+              style="background: var(--sac-orange)"
+            ></span
+            >Strong (5.0–5.9)</span
+          >
+          <span class="sac-legend-item"
+            ><span
+              class="sac-legend-dot"
+              style="background: var(--sac-red)"
+            ></span
+            >Major (6.0+)</span
+          >
+        </div>
+
+        <div class="sac-stats" id="sac-stats">
+          <div class="sac-stat">
+            <div class="sac-stat-value" id="sac-total">0</div>
+            <div class="sac-stat-label">Total Events</div>
+          </div>
+          <div class="sac-stat">
+            <div class="sac-stat-value green" id="sac-minor">0</div>
+            <div class="sac-stat-label">Minor</div>
+          </div>
+          <div class="sac-stat">
+            <div class="sac-stat-value yellow" id="sac-moderate">0</div>
+            <div class="sac-stat-label">Moderate</div>
+          </div>
+          <div class="sac-stat">
+            <div class="sac-stat-value orange" id="sac-strong">0</div>
+            <div class="sac-stat-label">Strong</div>
+          </div>
+          <div class="sac-stat">
+            <div class="sac-stat-value red" id="sac-major">0</div>
+            <div class="sac-stat-label">Major</div>
+          </div>
+        </div>
+
+        <button class="sac-replay" id="sac-replay" type="button">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="1 4 1 10 7 10" />
+            <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+          </svg>
+          Replay Animation
+        </button>
+      </div>
+
+      <div class="sac-card">
+        <div class="sac-header">
+          <h2>Recent Earthquake Events</h2>
+          <span>Source: USGS</span>
+        </div>
+        <table class="sac-table" id="sac-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Location</th>
+              <th>Magnitude</th>
+              <th>Depth</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+
+      <div class="sac-card">
+        <div class="sac-header">
+          <h2>Time Range</h2>
+          <span>Demo controls</span>
+        </div>
+        <div class="sac-controls">
+          <button type="button" class="active" data-days="7">7 Days</button>
+          <button type="button" data-days="14">14 Days</button>
+          <button type="button" data-days="30">30 Days</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const earthquakes = [
+        {
+          mag: 6.8,
+          date: "2026-07-14",
+          loc: "Kermadec Islands",
+          depth: "18 km",
+          cat: "major",
+        },
+        {
+          mag: 5.4,
+          date: "2026-07-14",
+          loc: "Vanuatu",
+          depth: "112 km",
+          cat: "strong",
+        },
+        {
+          mag: 4.7,
+          date: "2026-07-13",
+          loc: "Philippines",
+          depth: "35 km",
+          cat: "moderate",
+        },
+        {
+          mag: 3.2,
+          date: "2026-07-13",
+          loc: "California",
+          depth: "8 km",
+          cat: "minor",
+        },
+        {
+          mag: 5.1,
+          date: "2026-07-12",
+          loc: "Japan",
+          depth: "48 km",
+          cat: "strong",
+        },
+        {
+          mag: 6.2,
+          date: "2026-07-12",
+          loc: "Indonesia",
+          depth: "10 km",
+          cat: "major",
+        },
+        {
+          mag: 4.3,
+          date: "2026-07-11",
+          loc: "Mexico",
+          depth: "62 km",
+          cat: "moderate",
+        },
+        {
+          mag: 5.8,
+          date: "2026-07-11",
+          loc: "Papua New Guinea",
+          depth: "85 km",
+          cat: "strong",
+        },
+        {
+          mag: 3.8,
+          date: "2026-07-10",
+          loc: "Iceland",
+          depth: "5 km",
+          cat: "minor",
+        },
+        {
+          mag: 4.9,
+          date: "2026-07-10",
+          loc: "Taiwan",
+          depth: "24 km",
+          cat: "moderate",
+        },
+        {
+          mag: 7.1,
+          date: "2026-07-09",
+          loc: "Alaska Peninsula",
+          depth: "40 km",
+          cat: "major",
+        },
+        {
+          mag: 4.1,
+          date: "2026-07-09",
+          loc: "Greece",
+          depth: "12 km",
+          cat: "moderate",
+        },
+        {
+          mag: 3.5,
+          date: "2026-07-08",
+          loc: "New Zealand",
+          depth: "22 km",
+          cat: "minor",
+        },
+        {
+          mag: 6.4,
+          date: "2026-07-08",
+          loc: "Solomon Islands",
+          depth: "55 km",
+          cat: "major",
+        },
+        {
+          mag: 2.9,
+          date: "2026-07-07",
+          loc: "Nevada",
+          depth: "6 km",
+          cat: "minor",
+        },
+      ];
+
+      const catColors = {
+        minor: "#22c55e",
+        moderate: "#eab308",
+        strong: "#f97316",
+        major: "#ef4444",
+      };
+
+      function getDateRange(data) {
+        const times = data.map((q) => new Date(q.date).getTime());
+        return { t0: Math.min(...times), t1: Math.max(...times) };
+      }
+
+      function generateWavePath(quakeData, width, height) {
+        const pts = 80;
+        const pad = 40;
+        const usable = width - pad * 2;
+        const mid = height / 2 + 10;
+        const step = usable / (pts - 1);
+        if (!quakeData.length)
+          return `M ${pad} ${mid} L ${pad + usable} ${mid}`;
+        const { t0, t1 } = getDateRange(quakeData);
+        const range = t1 - t0 || 86400000;
+        let d = `M ${pad} ${mid}`;
+        for (let i = 1; i < pts; i++) {
+          let x = pad + i * step;
+          let t = t0 + range * (i / (pts - 1));
+          let noise =
+            Math.sin(i * 0.3) * 4 +
+            Math.cos(i * 0.7) * 3 +
+            Math.sin(i * 1.1) * 2;
+          let wave = 0;
+          for (let q of quakeData) {
+            let qt = new Date(q.date).getTime();
+            let dist = Math.abs(t - qt);
+            if (dist < 43200000) {
+              let factor = 1 - dist / 43200000;
+              let amp = q.mag * 6;
+              let spike =
+                amp * Math.pow(factor, 2) * Math.sin(factor * Math.PI);
+              wave += spike;
+            }
+          }
+          let y = mid - wave + noise;
+          y = Math.max(30, Math.min(height - 30, y));
+          d += ` L ${x} ${y}`;
+        }
+        return d;
+      }
+
+      function getMagnitudeClass(mag) {
+        if (mag >= 6) return "major";
+        if (mag >= 5) return "strong";
+        if (mag >= 4) return "moderate";
+        return "minor";
+      }
+
+      function renderChart(daysFilter) {
+        let filtered = earthquakes;
+        if (daysFilter) {
+          const cutoff = new Date();
+          cutoff.setDate(cutoff.getDate() - daysFilter);
+          filtered = earthquakes.filter((q) => new Date(q.date) >= cutoff);
+        }
+
+        const svg = document.getElementById("sac-svg");
+        const path = document.getElementById("sac-wave-path");
+        const w = 800,
+          h = 400;
+
+        const existing = svg.querySelectorAll(
+          ".sac-marker,.sac-pulse,.sac-mag-label"
+        );
+        existing.forEach((el) => el.remove());
+
+        const newPath = generateWavePath(filtered, w, h);
+        path.setAttribute("d", newPath);
+        path.style.animation = "none";
+        void path.offsetHeight;
+        path.style.animation = "";
+
+        const pad = 40;
+        const usable = w - pad * 2;
+        const { t0, t1 } = getDateRange(
+          filtered.length ? filtered : earthquakes
+        );
+        const range = t1 - t0 || 86400000;
+
+        for (let i = 0; i < filtered.length; i++) {
+          const q = filtered[i];
+          const qt = new Date(q.date).getTime();
+          const frac = (qt - t0) / range;
+          const x = pad + frac * usable;
+          const yScale = -q.mag * 9;
+          const y = 210 + yScale;
+
+          const marker = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "circle"
+          );
+          marker.setAttribute("cx", x);
+          marker.setAttribute("cy", y);
+          marker.setAttribute("r", "5");
+          marker.setAttribute("class", "sac-marker " + q.cat);
+          marker.style.animationDelay = 2.2 + i * 0.12 + "s";
+          svg.appendChild(marker);
+
+          const label = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "text"
+          );
+          label.setAttribute("x", x);
+          label.setAttribute("y", y - 12);
+          label.setAttribute("class", "sac-mag-label");
+          label.textContent = q.mag.toFixed(1);
+          label.style.animationDelay = 2.4 + i * 0.12 + "s";
+          svg.appendChild(label);
+        }
+
+        updateLabels(filtered);
+        updateStats(filtered);
+        updateTable(filtered);
+
+        document.getElementById("sac-updated").textContent = "Just now";
+      }
+
+      function updateLabels(data) {
+        if (!data.length) return;
+        const svg = document.getElementById("sac-svg");
+        const labels = svg.querySelectorAll(".sac-label-x");
+        const { t0, t1 } = getDateRange(data);
+        const range = t1 - t0 || 86400000;
+        for (let i = 0; i < labels.length; i++) {
+          const t = new Date(t0 + range * (i / (labels.length - 1)));
+          labels[i].textContent = t.toLocaleDateString("en", {
+            month: "short",
+            day: "numeric",
+          });
+        }
+      }
+
+      function updateStats(data) {
+        document.getElementById("sac-total").textContent = data.length;
+        document.getElementById("sac-minor").textContent = data.filter(
+          (q) => q.cat === "minor"
+        ).length;
+        document.getElementById("sac-moderate").textContent = data.filter(
+          (q) => q.cat === "moderate"
+        ).length;
+        document.getElementById("sac-strong").textContent = data.filter(
+          (q) => q.cat === "strong"
+        ).length;
+        document.getElementById("sac-major").textContent = data.filter(
+          (q) => q.cat === "major"
+        ).length;
+      }
+
+      function updateTable(data) {
+        const tbody = document.querySelector("#sac-table tbody");
+        tbody.innerHTML = "";
+        const sorted = [...data].sort(
+          (a, b) => new Date(b.date) - new Date(a.date)
+        );
+        for (let q of sorted) {
+          const tr = document.createElement("tr");
+          tr.innerHTML = `
+      <td>${q.date}</td>
+      <td class="sac-location">${q.loc}</td>
+      <td><span class="sac-mag-badge mag-${q.cat}">${q.mag.toFixed(1)}</span></td>
+      <td class="sac-location">${q.depth}</td>
+    `;
+          tbody.appendChild(tr);
+        }
+      }
+
+      document
+        .getElementById("sac-replay")
+        .addEventListener("click", () => renderChart(7));
+
+      document.querySelectorAll(".sac-controls button").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          document
+            .querySelectorAll(".sac-controls button")
+            .forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+          renderChart(parseInt(btn.dataset.days));
+        });
+      });
+
+      renderChart(7);
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-seismic-activity-chart-rs/style.css
+++ b/submissions/examples/ease-seismic-activity-chart-rs/style.css
@@ -1,0 +1,361 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+:root {
+  --sac-bg: #0a0e1a;
+  --sac-surface: #111827;
+  --sac-border: #1f2937;
+  --sac-text: #e5e7eb;
+  --sac-muted: #6b7280;
+  --sac-green: #22c55e;
+  --sac-yellow: #eab308;
+  --sac-orange: #f97316;
+  --sac-red: #ef4444;
+  --sac-purple: #a78bfa;
+  --sac-line-color: #60a5fa;
+  --sac-line-width: 2;
+  --sac-draw-duration: 2s;
+  --sac-wave-duration: 3s;
+  --sac-rad: 12px;
+}
+body {
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  background: var(--sac-bg);
+  color: var(--sac-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+}
+.wrapper {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+}
+h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+h1 svg {
+  color: var(--sac-orange);
+}
+.desc {
+  font-size: 0.875rem;
+  color: var(--sac-muted);
+  margin-bottom: 20px;
+}
+
+.sac-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.sac-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.sac-header span {
+  font-size: 0.75rem;
+  color: var(--sac-muted);
+}
+
+.sac-card {
+  background: var(--sac-surface);
+  border: 1px solid var(--sac-border);
+  border-radius: var(--sac-rad);
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.sac-chart {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 2/1;
+  overflow: hidden;
+  border-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(96, 165, 250, 0.03) 100%
+  );
+  margin-bottom: 8px;
+}
+.sac-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.sac-grid-line {
+  stroke: var(--sac-border);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+}
+.sac-label-x {
+  font-size: 9px;
+  fill: var(--sac-muted);
+  text-anchor: middle;
+}
+.sac-label-y {
+  font-size: 9px;
+  fill: var(--sac-muted);
+  text-anchor: end;
+}
+
+.sac-wave {
+  fill: none;
+  stroke: var(--sac-line-color);
+  stroke-width: var(--sac-line-width);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 6px rgba(96, 165, 250, 0.3));
+}
+.sac-wave-path {
+  stroke-dasharray: 2000;
+  stroke-dashoffset: 2000;
+  animation: sac-draw var(--sac-draw-duration) ease-out forwards;
+}
+@keyframes sac-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+.sac-pulse {
+  fill: var(--sac-line-color);
+  opacity: 0;
+  animation: sac-pulse-fade 0.6s ease-out forwards;
+}
+@keyframes sac-pulse-fade {
+  0% {
+    opacity: 1;
+    r: 3;
+  }
+  100% {
+    opacity: 0;
+    r: 6;
+  }
+}
+
+.sac-marker {
+  animation: sac-marker-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  opacity: 0;
+}
+@keyframes sac-marker-pop {
+  0% {
+    opacity: 0;
+    r: 0;
+  }
+  100% {
+    opacity: 1;
+    r: 5;
+  }
+}
+.sac-marker.minor {
+  fill: var(--sac-green);
+}
+.sac-marker.moderate {
+  fill: var(--sac-yellow);
+}
+.sac-marker.strong {
+  fill: var(--sac-orange);
+}
+.sac-marker.major {
+  fill: var(--sac-red);
+}
+
+.sac-mag-label {
+  font-size: 8px;
+  font-weight: 700;
+  text-anchor: middle;
+  dominant-baseline: central;
+  fill: #fff;
+  pointer-events: none;
+}
+
+.sac-legend {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.sac-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: var(--sac-muted);
+}
+.sac-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.sac-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+}
+.sac-stat {
+  text-align: center;
+}
+.sac-stat-value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+.sac-stat-label {
+  font-size: 0.6875rem;
+  color: var(--sac-muted);
+}
+.sac-stat-value.green {
+  color: var(--sac-green);
+}
+.sac-stat-value.yellow {
+  color: var(--sac-yellow);
+}
+.sac-stat-value.orange {
+  color: var(--sac-orange);
+}
+.sac-stat-value.red {
+  color: var(--sac-red);
+}
+
+.sac-replay {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 20px;
+  margin-top: 12px;
+  background: var(--sac-surface);
+  border: 1px solid var(--sac-border);
+  color: var(--sac-text);
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease;
+}
+.sac-replay:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--sac-line-color);
+}
+
+.sac-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 12px;
+  font-size: 0.75rem;
+}
+.sac-table th {
+  text-align: left;
+  padding: 6px 10px;
+  color: var(--sac-muted);
+  font-weight: 600;
+  border-bottom: 1px solid var(--sac-border);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.sac-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid rgba(31, 41, 55, 0.5);
+}
+.sac-table tr:last-child td {
+  border-bottom: none;
+}
+.sac-mag-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: #fff;
+}
+.mag-minor {
+  background: var(--sac-green);
+}
+.mag-moderate {
+  background: var(--sac-yellow);
+  color: #1a1a1a;
+}
+.mag-strong {
+  background: var(--sac-orange);
+}
+.mag-major {
+  background: var(--sac-red);
+}
+.sac-location {
+  color: var(--sac-muted);
+}
+
+.sac-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 12px;
+}
+.sac-controls button {
+  background: var(--sac-surface);
+  border: 1px solid var(--sac-border);
+  color: var(--sac-text);
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.sac-controls button:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.sac-controls button.active {
+  background: var(--sac-line-color);
+  color: #fff;
+  border-color: var(--sac-line-color);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --sac-bg: #f4f6f9;
+    --sac-surface: #fff;
+    --sac-border: #e2e8f0;
+    --sac-text: #1e293b;
+    --sac-muted: #64748b;
+  }
+}
+
+@media (forced-colors: active) {
+  .sac-card {
+    border: 2px solid CanvasText;
+  }
+  .sac-wave {
+    stroke: CanvasText;
+  }
+}


### PR DESCRIPTION
Adds a pure CSS + SVG animated seismograph chart component for visualizing earthquake activity to \submissions/examples/ease-seismic-activity-chart-rs/\.

## Features
- **SVG seismograph wave**: Smooth line chart with stroke-dasharray draw animation over \--sac-draw-duration\
- **Earthquake event markers**: Animated circles with staggered pop-in at magnitude positions
- **Magnitude color coding**: Green (minor ≤3.9), yellow (moderate 4.0–4.9), orange (strong 5.0–5.9), red (major 6.0+)
- **Summary stats section**: Auto-counted breakdown by category
- **Event data table**: Chronological list with date, location, magnitude badge, and depth
- **Time range controls**: Switch between 7, 14, and 30-day views
- **Replay button**: Re-triggers the SVG draw animation
- **Dark/light mode** via \prefers-color-scheme\, forced-colors support
- **No external dependencies**: Pure CSS + vanilla JS

## Files
- \style.css\: Seismic chart CSS (namespace \sac-\)
- \demo.html\: Interactive demo with 15 earthquake events, SVG chart, stats, and controls
- \README.md\: Documentation and custom properties table

Closes #48219