### PR TITLE
feat: add accessible horizontal roll tooltip example

### DIFF
--- a/submissions/examples/46265-accessible-horizontal-roll-tooltip-vk/README.md
+++ b/submissions/examples/46265-accessible-horizontal-roll-tooltip-vk/README.md
@@ -1,0 +1,62 @@
+# Accessible Horizontal Roll Tooltip
+
+A pure CSS tooltip component featuring a smooth horizontal roll-inspired reveal animation using `clip-path`, designed for responsive and accessible web interfaces without JavaScript.
+
+## Features
+
+- Pure CSS implementation
+- Smooth horizontal roll-inspired reveal animation
+- Responsive design for desktop and mobile devices
+- Keyboard accessible using `:focus-within` and `:focus-visible`
+- Customizable through CSS custom properties
+- Supports `prefers-reduced-motion`
+- No JavaScript required
+
+## Usage
+
+```html
+<div class="tooltip-wrapper">
+    <button
+        class="tooltip-button"
+        aria-describedby="roll-tooltip">
+        Hover Me
+    </button>
+
+    <span
+        id="roll-tooltip"
+        role="tooltip"
+        class="tooltip">
+        Smooth Horizontal Roll Animation
+    </span>
+</div>
+```
+
+## Customization
+
+The component exposes standard CSS custom properties for easy customization.
+
+```css
+:root{
+    --tooltip-bg:#1f2937;
+    --tooltip-color:#ffffff;
+
+    --button-bg:#2563eb;
+    --button-hover:#1d4ed8;
+
+    --duration:0.7s;
+    --easing:cubic-bezier(0.22,1,0.36,1);
+
+    --tooltip-radius:10px;
+    --tooltip-padding:10px 16px;
+}
+```
+
+## Accessibility
+
+- Supports keyboard navigation using `:focus-visible` and `:focus-within`
+- Uses semantic HTML with `role="tooltip"` and `aria-describedby`
+- Respects the user's `prefers-reduced-motion` setting
+
+## Why is it useful?
+
+This component provides a modern tooltip interaction with a smooth horizontal roll-inspired reveal while maintaining accessibility, responsiveness, and zero JavaScript overhead. It can be easily integrated into dashboards, portfolios, landing pages, forms, and modern UI designs.

--- a/submissions/examples/46265-accessible-horizontal-roll-tooltip-vk/demo.html
+++ b/submissions/examples/46265-accessible-horizontal-roll-tooltip-vk/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessible Horizontal Roll Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<main class="page-container">
+
+    <h1>Accessible Horizontal Roll Tooltip</h1>
+
+    <p class="subtitle">
+        Hover or focus on the button to reveal the tooltip.
+    </p>
+
+    <div class="tooltip-wrapper">
+
+        <button
+            class="tooltip-button"
+            aria-describedby="roll-tooltip">
+
+            Hover Me
+
+        </button>
+
+        <span
+            id="roll-tooltip"
+            role="tooltip"
+            class="tooltip">
+
+            Smooth Horizontal Roll Animation
+
+        </span>
+
+    </div>
+
+</main>
+
+</body>
+</html>

--- a/submissions/examples/46265-accessible-horizontal-roll-tooltip-vk/style.css
+++ b/submissions/examples/46265-accessible-horizontal-roll-tooltip-vk/style.css
@@ -1,0 +1,177 @@
+:root {
+    --tooltip-bg: #1f2937;
+    --tooltip-color: #ffffff;
+
+    --button-bg: #2563eb;
+    --button-hover: #1d4ed8;
+
+    --duration: 0.7s;
+    --easing: cubic-bezier(0.22, 1, 0.36, 1);
+
+    --tooltip-radius: 10px;
+    --tooltip-padding: 10px 16px;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: #f4f6f9;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.page-container {
+    text-align: center;
+}
+
+h1 {
+    color: #222;
+    margin-bottom: .7rem;
+}
+
+.subtitle {
+    color: #666;
+    margin-bottom: 2.8rem;
+}
+
+.tooltip-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.tooltip-button {
+    border: none;
+    cursor: pointer;
+
+    padding: 0.9rem 1.8rem;
+
+    background: var(--button-bg);
+    color: white;
+
+    border-radius: 8px;
+
+    font-size: 1rem;
+    font-weight: 600;
+
+    transition:
+        background .3s ease,
+        transform .3s ease;
+}
+
+.tooltip-button:hover,
+.tooltip-button:focus-visible {
+    background: var(--button-hover);
+    transform: translateY(-2px);
+    outline: none;
+}
+
+.tooltip-button:focus-visible {
+    outline: 3px solid rgba(37, 99, 235, .35);
+    outline-offset: 4px;
+}
+
+/* ---- The tooltip itself ----
+   Instead of a 3D tilt, this "unrolls" from the left edge using
+   clip-path. The left bound of the clip region is pulled slightly
+   negative (-10px) at all times so the arrow (::before, which sits
+   at left:-7px, outside the tooltip's own box) isn't clipped away.
+   Only the right bound animates, from 100% (fully hidden) to 0%
+   (fully revealed). This avoids squishing the text, which is what
+   happens if you try to "roll" via scaleX instead. */
+
+.tooltip {
+    position: absolute;
+
+    top: 50%;
+    left: calc(100% + 16px);
+
+    background: rgba(31, 41, 55, .95);
+    color: white;
+
+    padding: var(--tooltip-padding);
+    border-radius: var(--tooltip-radius);
+
+    white-space: nowrap;
+
+    box-shadow:
+        0 20px 40px rgba(0, 0, 0, .18),
+        0 8px 18px rgba(0, 0, 0, .12);
+
+    backdrop-filter: blur(8px);
+
+    pointer-events: none;
+    opacity: 0;
+
+    transform: translateY(-50%);
+    clip-path: inset(0 100% 0 -10px round var(--tooltip-radius));
+
+    transition:
+        clip-path var(--duration) var(--easing),
+        opacity calc(var(--duration) * .5) ease;
+}
+
+.tooltip::before {
+    content: "";
+    position: absolute;
+
+    left: -7px;
+    top: 50%;
+
+    width: 14px;
+    height: 14px;
+
+    background: rgba(31, 41, 55, .95);
+
+    transform: translateY(-50%) rotate(45deg);
+}
+
+.tooltip-wrapper:hover .tooltip,
+.tooltip-wrapper:focus-within .tooltip {
+    opacity: 1;
+    clip-path: inset(0 0 0 -10px round var(--tooltip-radius));
+}
+
+@media (max-width: 768px) {
+    /* On small screens the tooltip drops below the button and
+       unrolls downward instead of sideways, so the clip axis flips
+       from left/right to top/bottom, and the arrow moves to the
+       top edge, centered horizontally. */
+
+    .tooltip {
+        left: 50%;
+        top: calc(100% + 16px);
+
+        transform: translateX(-50%);
+        clip-path: inset(0 0 100% 0 round var(--tooltip-radius));
+    }
+
+    .tooltip::before {
+        top: -7px;
+        left: 50%;
+        transform: translateX(-50%) rotate(45deg);
+    }
+
+    .tooltip-wrapper:hover .tooltip,
+    .tooltip-wrapper:focus-within .tooltip {
+        clip-path: inset(0 0 0 0 round var(--tooltip-radius));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS accessible horizontal roll tooltip example featuring a smooth horizontal roll-inspired reveal animation using `clip-path`. The component is fully responsive, keyboard accessible, customizable through CSS custom properties, and requires no JavaScript.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

This contribution introduces a pure CSS horizontal roll tooltip with a smooth left-to-right reveal animation. The component is lightweight, responsive, accessible, and easy to customize.

### Features

- Pure CSS implementation
- Smooth horizontal roll-inspired reveal animation
- Responsive layout
- Keyboard accessibility using `:focus-visible` and `:focus-within`
- Customizable through CSS custom properties
- Supports `prefers-reduced-motion`
- No JavaScript required

### Why does it fit EaseMotion CSS?

The component provides a modern, reusable tooltip animation that enhances user interaction while maintaining accessibility and responsiveness without adding JavaScript.

---

## Demo

- [x] Added `demo.html`
- [x] Added `style.css`
- [x] Added `README.md`

---

## Browser Testing

- [x] Microsoft Edge

---

## Notes for Maintainers

Implemented the horizontal roll-inspired reveal using `clip-path` to preserve text readability while creating a smooth horizontal reveal animation. Animation timing and easing can be customized using CSS custom properties.

### Closes #46265