### PR TITLE
Add print media query optimization to ease-modal (fixes #48285)

### DIFF
--- a/components/modals.css
+++ b/components/modals.css
@@ -224,3 +224,32 @@
     }
   }
 }
+
+  /* ── Print Styles ──────────────────────────────────────────────────────── */
+  @media print {
+    .ease-modal-overlay {
+      position: static;
+      background: transparent;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+    }
+
+    .ease-modal {
+      position: static;
+      box-shadow: none;
+      max-width: 100%;
+      max-height: none;
+    }
+
+    .ease-modal-close {
+      display: none;
+    }
+
+    .ease-modal-footer {
+      background: transparent;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add print media query optimization for the ease-modal component to ensure proper rendering when printed.

## Changes
- Hide modal overlay background in print mode
- Remove box shadows and decorative backgrounds
- Hide close button in print mode
- Make modal full width in print mode

## Testing
- [ ] Modal renders correctly on screen
- [ ] Modal renders cleanly when printed

Fixes #48285