### PR TITLE
feat: Add print media query optimization for ease-loader (fixes #48281)

### DIFF
--- a/submissions/examples/48281-print-media-loader-sb/README.md
+++ b/submissions/examples/48281-print-media-loader-sb/README.md
@@ -1,0 +1,22 @@
+# Print-Optimized Loader Component
+
+A collection of animated loader/spinner components with print media query optimization. All loaders are hidden when printing to save ink.
+
+## Files
+
+- `demo.html` - Loader demos with print optimization
+- `style.css` - Loader styling with @media print rules
+
+## Usage
+
+Open `demo.html` in a browser to see the animated loaders. Use Ctrl+P (Cmd+P on Mac) to see loaders hidden in print mode.
+
+## What This Does
+
+Adds print media query optimization to loader components, hiding all loader variants (spin, pulse, ping, dots) when printing to save ink and prevent unnecessary elements from appearing on paper.
+
+## Why Useful
+
+Loader animations are purely decorative and serve no purpose on printed pages. Hiding them saves ink and produces cleaner printed output.
+
+Closes #48281

--- a/submissions/examples/48281-print-media-loader-sb/demo.html
+++ b/submissions/examples/48281-print-media-loader-sb/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Print-Optimized Loader Component</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-label="Print-optimized loader demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Print-Optimized Loaders</h1>
+        <p>Demonstrates various loader/spinner components with print optimization.
+           These are hidden when printing to save ink.</p>
+        
+        <div class="loader-row">
+          <div class="ease-loader ease-loader-spin" aria-label="Loading"></div>
+          <span>Spinner</span>
+        </div>
+        
+        <div class="loader-row">
+          <div class="ease-loader ease-loader-pulse" aria-label="Loading"></div>
+          <span>Pulse</span>
+        </div>
+        
+        <div class="loader-row">
+          <div class="ease-loader ease-loader-ping" aria-label="Loading"></div>
+          <span>Ping</span>
+        </div>
+        
+        <div class="loader-row">
+          <div class="ease-loader-dots" aria-label="Loading">
+            <div class="ease-loader-dot"></div>
+            <div class="ease-loader-dot"></div>
+            <div class="ease-loader-dot"></div>
+          </div>
+          <span>Dots</span>
+        </div>
+        
+        <p class="print-hint">Press Ctrl+P (Cmd+P) to see loaders hidden in print mode.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/48281-print-media-loader-sb/style.css
+++ b/submissions/examples/48281-print-media-loader-sb/style.css
@@ -1,0 +1,179 @@
+/* ============================================================
+   Print-Optimized Loader Component
+   Includes print media query optimization for clean printing
+   ============================================================ */
+
+/* ── Base Styles ───────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shell {
+  padding: 2rem;
+  max-width: 600px;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.eyebrow {
+  color: #6c63ff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  color: #666;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.print-hint {
+  margin-top: 2rem;
+  padding: 1rem;
+  background: #f3f4f6;
+  border-radius: 8px;
+  font-size: 0.875rem;
+}
+
+/* ── Loader Row Layout ─────────────────────────────────────── */
+.loader-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.loader-row:last-of-type {
+  border-bottom: none;
+}
+
+.loader-row span {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+/* ── Loader Base ──────────────────────────────────────────── */
+.ease-loader {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+}
+
+/* ── Loader Spin Variant ──────────────────────────────────── */
+.ease-loader-spin {
+  border: 3px solid #e5e7eb;
+  border-top-color: #6c63ff;
+  animation: ease-kf-rotate 0.8s linear infinite;
+}
+
+@keyframes ease-kf-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── Loader Pulse Variant ──────────────────────────────────── */
+.ease-loader-pulse {
+  background-color: #6c63ff;
+  animation: ease-kf-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes ease-kf-pulse {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(0.8);
+  }
+}
+
+/* ── Loader Ping Variant ──────────────────────────────────── */
+.ease-loader-ping {
+  background-color: rgba(108, 99, 255, 0.5);
+  animation: ease-kf-ping 1s ease-out infinite;
+}
+
+@keyframes ease-kf-ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+/* ── Loader Dots ───────────────────────────────────────────── */
+.ease-loader-dots {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 12px;
+}
+
+.ease-loader-dot {
+  width: 8px;
+  height: 8px;
+  background-color: #6c63ff;
+  border-radius: 9999px;
+  animation: ease-kf-bounce 1s infinite alternate;
+}
+
+.ease-loader-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.ease-loader-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes ease-kf-bounce {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-6px);
+  }
+}
+
+/* ── Print Styles ──────────────────────────────────────────── */
+@media print {
+  .ease-loader,
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dots,
+  .ease-loader-dot {
+    display: none !important;
+  }
+  
+  .print-hint {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
Add print media query optimization for loader/spinner components to hide them when printing.

## Changes
- Add media print styles for all loader variants (spin, pulse, ping, dots)
- Hide all loaders in print mode to save ink

## Testing
- [x] Loaders animate correctly on screen
- [x] Loaders are hidden when printing

## Files
- submissions/examples/48281-print-media-loader-sb/demo.html
- submissions/examples/48281-print-media-loader-sb/style.css
- submissions/examples/48281-print-media-loader-sb/README.md

Closes #48281