### PR TITLE
feat: Add print media query optimization for ease-tooltip (fixes #48226)

### DIFF
--- a/submissions/examples/48226-print-media-tooltip-sb/README.md
+++ b/submissions/examples/48226-print-media-tooltip-sb/README.md
@@ -1,0 +1,22 @@
+# Print-Optimized Tooltip Component
+
+Tooltip components with print media query optimization. Tooltips are hidden when printing.
+
+## Files
+
+- `demo.html` - Tooltip demos with print optimization
+- `style.css` - Tooltip styling with @media print rules
+
+## Usage
+
+Open `demo.html` in a browser and hover over buttons to see tooltips. Use Ctrl+P (Cmd+P on Mac) to see tooltips hidden in print mode.
+
+## What This Does
+
+Adds print media query optimization to tooltip components, hiding all tooltip text when printing. Tooltips are purely informational overlays that don't need to appear on printed pages.
+
+## Why Useful
+
+Tooltips are hover-triggered overlays that serve no purpose when printed. Hiding them produces cleaner output and saves ink.
+
+Closes #48226

--- a/submissions/examples/48226-print-media-tooltip-sb/demo.html
+++ b/submissions/examples/48226-print-media-tooltip-sb/demo.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Print-Optimized Tooltip Component</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-label="Print-optimized tooltip demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Print-Optimized Tooltips</h1>
+        <p>Demonstrates tooltip components with print media query optimization.</p>
+        
+        <div class="tooltip-row">
+          <div class="ease-tooltip ease-tooltip-top">
+            <button class="ease-btn ease-btn-primary">Top Tooltip</button>
+            <span class="ease-tooltip-text">This is a top tooltip</span>
+          </div>
+          
+          <div class="ease-tooltip ease-tooltip-bottom">
+            <button class="ease-btn ease-btn-secondary">Bottom Tooltip</button>
+            <span class="ease-tooltip-text">This is a bottom tooltip</span>
+          </div>
+        </div>
+        
+        <div class="tooltip-row">
+          <div class="ease-tooltip ease-tooltip-left">
+            <button class="ease-btn ease-btn-outline">Left Tooltip</button>
+            <span class="ease-tooltip-text">This is a left tooltip</span>
+          </div>
+          
+          <div class="ease-tooltip ease-tooltip-right">
+            <button class="ease-btn ease-btn-ghost">Right Tooltip</button>
+            <span class="ease-tooltip-text">This is a right tooltip</span>
+          </div>
+        </div>
+        
+        <p class="print-hint">Press Ctrl+P (Cmd+P) to see tooltips hidden in print mode.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/48226-print-media-tooltip-sb/style.css
+++ b/submissions/examples/48226-print-media-tooltip-sb/style.css
@@ -1,0 +1,169 @@
+/* ============================================================
+   Print-Optimized Tooltip Component
+   Includes print media query optimization for clean printing
+   ============================================================ */
+
+/* ── Base Styles ───────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shell {
+  padding: 2rem;
+  max-width: 600px;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.eyebrow {
+  color: #6c63ff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  color: #666;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.print-hint {
+  margin-top: 2rem;
+  padding: 1rem;
+  background: #f3f4f6;
+  border-radius: 8px;
+  font-size: 0.875rem;
+}
+
+/* ── Tooltip Row ─────────────────────────────────────────── */
+.tooltip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin-bottom: 2rem;
+  justify-content: center;
+}
+
+/* ── Tooltip Base ─────────────────────────────────────────── */
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-tooltip .ease-tooltip-text {
+  visibility: hidden;
+  position: absolute;
+  background: #1f2937;
+  color: white;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.ease-tooltip:hover .ease-tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* ── Tooltip Positions ────────────────────────────────────── */
+.ease-tooltip-top .ease-tooltip-text {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 8px;
+}
+
+.ease-tooltip-bottom .ease-tooltip-text {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 8px;
+}
+
+.ease-tooltip-left .ease-tooltip-text {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-right: 8px;
+}
+
+.ease-tooltip-right .ease-tooltip-text {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 8px;
+}
+
+/* ── Button Styles ───────────────────────────────────────── */
+.ease-btn {
+  display: inline-block;
+  padding: 0.625rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+}
+
+.ease-btn-primary {
+  background: #6c63ff;
+  color: white;
+}
+
+.ease-btn-secondary {
+  background: #e5e7eb;
+  color: #333;
+}
+
+.ease-btn-outline {
+  background: transparent;
+  border: 2px solid #6c63ff;
+  color: #6c63ff;
+}
+
+.ease-btn-ghost {
+  background: transparent;
+  color: #6c63ff;
+}
+
+/* ── Print Styles ─────────────────────────────────────────── */
+@media print {
+  .ease-tooltip .ease-tooltip-text {
+    display: none !important;
+  }
+  
+  .print-hint {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
Add print media query optimization for tooltip components.

## Changes
- Hide tooltip text when printing

## Testing
- [x] Tooltips display correctly on hover
- [x] Tooltips are hidden when printing

## Files
- submissions/examples/48226-print-media-tooltip-sb/demo.html
- submissions/examples/48226-print-media-tooltip-sb/style.css
- submissions/examples/48226-print-media-tooltip-sb/README.md

Closes #48226