### PR TITLE
Add Swing-Hover popover component for dashboard layouts (swing-hover-…

### DIFF
--- a/submissions/examples/swing-hover-popover-hr18/README.md
+++ b/submissions/examples/swing-hover-popover-hr18/README.md
@@ -1,0 +1,95 @@
+# Swing-Hover Popover (`swing-hover-popover-hr18`)
+
+A pure-CSS animated popover with a "Swing-Hover" pendulum motion, styled for
+responsive dashboard layouts, built for issue
+[#46548](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46548).
+
+## What it does
+
+Hovering — or tabbing to, with a keyboard — a small info-icon trigger
+reveals an explanatory popover that swings in like it's rocking on the
+hinge of its own pointer arrow, then settles to rest. Both the
+**show/hide behavior and the swing animation are pure CSS**, driven by
+`:hover` and `:focus-within` plus `@keyframes ease-swing-hover-hr18` — no
+JavaScript is required for the core interaction at all. A few lines of
+optional script only add `Escape`-to-dismiss as a convenience.
+
+The demo applies it to three dashboard stat cards (Monthly Revenue, Active
+Users, Churn Rate), each with its own info popover explaining that metric.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap an info-icon trigger and a popover bubble in the component markup:
+
+```html
+<span class="swh-popover-wrap-hr18">
+  <button type="button" class="swh-info-trigger-hr18" aria-describedby="myTip">i</button>
+  <span class="ease-popover-swing-hr18" id="myTip" role="tooltip">
+    Total recognized revenue this billing cycle, before refunds and chargebacks.
+  </span>
+</span>
+```
+
+That's the entire component — no JavaScript wiring is needed per instance.
+Add as many as you like anywhere on a page.
+
+### Tuning the animation
+
+Every timing/amplitude value is a CSS custom property, overridable per
+instance or globally:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-swing-duration-hr18` | `700ms` | How long the pendulum motion takes to settle |
+| `--ease-swing-easing-hr18` | `ease-out` | The easing curve applied to the whole swing sequence |
+| `--ease-swing-amplitude-hr18` | `14deg` | How far the first, biggest swing rotates — later rocks scale off this |
+| `--ease-swing-delay-hr18` | `0ms` | Delay before the swing starts after hover/focus |
+
+```css
+.swh-popover-wrap-hr18.gentle {
+  --ease-swing-amplitude-hr18: 6deg;
+  --ease-swing-duration-hr18: 500ms;
+}
+```
+
+## Accessibility notes
+
+- The trigger is a native `<button>`, reachable and triggerable by keyboard
+  without any extra scripting.
+- The popover shows on `:focus-within` as well as `:hover`, so keyboard-only
+  users see exactly the same content sighted mouse users do — not just a
+  hover-only tooltip they can never reach.
+- The trigger and its popover are connected with `aria-describedby`, and the
+  popover carries `role="tooltip"`, so it's announced together with the
+  control it describes.
+- The popover contains only descriptive text — no interactive content —
+  matching the WAI-ARIA tooltip pattern's expectations, so nothing inside it
+  is ever unreachable.
+- `Escape` blurs the trigger (via the small optional script) to dismiss the
+  popover early without needing to tab away.
+- The swing animation respects `@media (prefers-reduced-motion: reduce)`
+  and settles to its final position instantly instead.
+
+## Responsiveness
+
+The three-card stat row collapses from three columns to one under a
+`680px` viewport width; the popover bubble uses a fixed comfortable width
+that fits within that layout at every size.
+
+## Why this fits EaseMotion CSS
+
+The entire interaction — visibility and animation both — runs on plain CSS
+selectors and a single `@keyframes` block, matching the issue's explicit
+ask for "zero JavaScript overhead," while still exposing every timing value
+as a tunable custom property and remaining genuinely keyboard accessible
+via `:focus-within`.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/swing-hover-popover-hr18/demo.html
+++ b/submissions/examples/swing-hover-popover-hr18/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Swing-Hover Popover — dashboard demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="swh-hr18">
+  <div class="swh-wrap-hr18">
+
+    <header class="swh-header-hr18">
+      <span class="swh-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Overview</h1>
+      <p>Hover or tab to any <strong>i</strong> icon below — its explanation
+        swings in like it's hanging from the tooltip's own arrow, then
+        settles. Built for dashboard-style stat cards.</p>
+    </header>
+
+    <section class="swh-stats-hr18">
+
+      <!-- Stat 1: Revenue -->
+      <article class="swh-stat-card-hr18">
+        <div class="swh-stat-head-hr18">
+          <span class="swh-stat-label-hr18">Monthly Revenue</span>
+          <span class="swh-popover-wrap-hr18">
+            <button type="button" class="swh-info-trigger-hr18" aria-describedby="swhTip1">i</button>
+            <span class="ease-popover-swing-hr18" id="swhTip1" role="tooltip">Total recognized revenue this billing cycle, before refunds and chargebacks.</span>
+          </span>
+        </div>
+        <p class="swh-stat-value-hr18">$48,210</p>
+        <p class="swh-stat-delta-hr18 positive">&#9650; 6.2% vs last month</p>
+      </article>
+
+      <!-- Stat 2: Active Users -->
+      <article class="swh-stat-card-hr18">
+        <div class="swh-stat-head-hr18">
+          <span class="swh-stat-label-hr18">Active Users</span>
+          <span class="swh-popover-wrap-hr18">
+            <button type="button" class="swh-info-trigger-hr18" aria-describedby="swhTip2">i</button>
+            <span class="ease-popover-swing-hr18" id="swhTip2" role="tooltip">Unique accounts with at least one session in the last 30 days.</span>
+          </span>
+        </div>
+        <p class="swh-stat-value-hr18">12,904</p>
+        <p class="swh-stat-delta-hr18 positive">&#9650; 3.8% vs last month</p>
+      </article>
+
+      <!-- Stat 3: Churn Rate -->
+      <article class="swh-stat-card-hr18">
+        <div class="swh-stat-head-hr18">
+          <span class="swh-stat-label-hr18">Churn Rate</span>
+          <span class="swh-popover-wrap-hr18">
+            <button type="button" class="swh-info-trigger-hr18" aria-describedby="swhTip3">i</button>
+            <span class="ease-popover-swing-hr18" id="swhTip3" role="tooltip">Share of subscribers who cancelled during the period, annualized.</span>
+          </span>
+        </div>
+        <p class="swh-stat-value-hr18">2.1%</p>
+        <p class="swh-stat-delta-hr18 negative">&#9660; 0.4% vs last month</p>
+      </article>
+
+    </section>
+
+    <div class="swh-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-swing-duration-hr18</code></td><td><code>700ms</code></td><td>How long the pendulum motion takes to settle.</td></tr>
+          <tr><td><code>--ease-swing-easing-hr18</code></td><td><code>ease-out</code></td><td>The easing curve applied to the whole swing sequence.</td></tr>
+          <tr><td><code>--ease-swing-amplitude-hr18</code></td><td><code>14deg</code></td><td>How far the first, biggest swing rotates — every later rock scales off this.</td></tr>
+          <tr><td><code>--ease-swing-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the swing starts after hover/focus.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="swh-footnote-hr18">submissions/examples/swing-hover-popover-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // The core show/hide and swing animation are pure CSS (:hover /
+  // :focus-within) — no JavaScript is required for them to work. This
+  // script only adds one convenience: pressing Escape while a popover is
+  // showing via keyboard focus blurs the trigger, which naturally hides
+  // the popover since it's no longer within a :focus-within wrapper.
+  document.addEventListener("keydown", function (e) {
+    if (e.key !== "Escape") return;
+    var active = document.activeElement;
+    if (active && active.classList.contains("swh-info-trigger-hr18")) {
+      active.blur();
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/swing-hover-popover-hr18/style.css
+++ b/submissions/examples/swing-hover-popover-hr18/style.css
@@ -1,0 +1,283 @@
+/* ==========================================================================
+   swing-hover-popover-hr18 — style.css
+   CSS Swing-Hover Popover for Responsive Dashboard layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.swh-hr18 {
+  --bg-hr18: #f4f6f9;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e3e7ee;
+  --text-hr18: #151a24;
+  --text-muted-hr18: #667085;
+  --accent-hr18: #2f6fed;
+  --accent-soft-hr18: #eaf1fe;
+  --positive-hr18: #1a9c6b;
+  --negative-hr18: #d1453a;
+  --radius-hr18: 14px;
+
+  /* Exposed animation parameters. */
+  --ease-swing-duration-hr18: 700ms;
+  --ease-swing-easing-hr18: ease-out;
+  --ease-swing-amplitude-hr18: 14deg;
+  --ease-swing-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4.5rem;
+  min-height: 100%;
+}
+
+.swh-hr18 * {
+  box-sizing: border-box;
+}
+
+.swh-hr18 h1,
+.swh-hr18 h2,
+.swh-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.swh-wrap-hr18 {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+/* ---- Header ------------------------------------------------------------------ */
+.swh-header-hr18 {
+  margin-bottom: 2.25rem;
+}
+
+.swh-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.swh-header-hr18 h1 {
+  font-size: clamp(1.6rem, 2.6vw, 2.2rem);
+}
+
+.swh-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 60ch;
+  font-size: 0.96rem;
+  line-height: 1.6;
+}
+
+/* ---- Dashboard stat row -------------------------------------------------------- */
+.swh-stats-hr18 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 680px) {
+  .swh-stats-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.swh-stat-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.3rem;
+  box-shadow: 0 1px 2px rgba(10, 15, 30, 0.03), 0 8px 20px rgba(10, 15, 30, 0.04);
+}
+
+.swh-stat-head-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.swh-stat-label-hr18 {
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+}
+
+.swh-stat-value-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.swh-stat-delta-hr18 {
+  font-size: 0.78rem;
+  font-weight: 600;
+  margin-top: 0.15rem;
+}
+
+.swh-stat-delta-hr18.positive {
+  color: var(--positive-hr18);
+}
+
+.swh-stat-delta-hr18.negative {
+  color: var(--negative-hr18);
+}
+
+/* ---- The reusable popover component ---------------------------------------------
+   Drop-in markup: a .swh-popover-wrap-hr18 containing an info-icon trigger
+   and a .ease-popover-swing-hr18 panel. Visibility and the swing animation
+   are both driven purely by :hover / :focus-within — no JavaScript is
+   required for the core interaction. A tiny optional script only adds
+   Escape-to-dismiss for convenience. */
+.swh-popover-wrap-hr18 {
+  position: relative;
+  display: inline-flex;
+}
+
+.swh-info-trigger-hr18 {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid var(--border-hr18);
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-family: var(--font-display-hr18);
+  cursor: default;
+  padding: 0;
+}
+
+.ease-popover-swing-hr18 {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform-origin: bottom center;
+  width: 210px;
+  background: var(--text-hr18);
+  color: #fff;
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  box-shadow: 0 16px 34px rgba(10, 15, 30, 0.22);
+  visibility: hidden;
+  opacity: 0;
+  z-index: 20;
+  transform: translateX(-50%) rotate(0deg);
+}
+
+.ease-popover-swing-hr18::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--text-hr18);
+}
+
+.swh-popover-wrap-hr18:hover .ease-popover-swing-hr18,
+.swh-popover-wrap-hr18:focus-within .ease-popover-swing-hr18 {
+  visibility: visible;
+  opacity: 1;
+  animation: ease-swing-hover-hr18 var(--ease-swing-duration-hr18) var(--ease-swing-easing-hr18) var(--ease-swing-delay-hr18) both;
+}
+
+/* The swing: a pendulum-style rocking motion anchored at the bottom of the
+   bubble (where its arrow points at the trigger), settling back to rest.
+   Amplitude is controlled by --ease-swing-amplitude-hr18. */
+@keyframes ease-swing-hover-hr18 {
+  0% {
+    transform: translateX(-50%) rotate(0deg);
+  }
+  20% {
+    transform: translateX(-50%) rotate(var(--ease-swing-amplitude-hr18));
+  }
+  40% {
+    transform: translateX(-50%) rotate(calc(var(--ease-swing-amplitude-hr18) * -0.65));
+  }
+  60% {
+    transform: translateX(-50%) rotate(calc(var(--ease-swing-amplitude-hr18) * 0.35));
+  }
+  80% {
+    transform: translateX(-50%) rotate(calc(var(--ease-swing-amplitude-hr18) * -0.15));
+  }
+  100% {
+    transform: translateX(-50%) rotate(0deg);
+  }
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.swh-tuning-hr18 {
+  margin-top: 3rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.swh-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.swh-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.swh-tuning-hr18 th,
+.swh-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.swh-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.swh-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+}
+
+.swh-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Focus & reduced motion ------------------------------------------------------- */
+.swh-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .swh-popover-wrap-hr18:hover .ease-popover-swing-hr18,
+  .swh-popover-wrap-hr18:focus-within .ease-popover-swing-hr18 {
+    animation: none;
+    transform: translateX(-50%) rotate(0deg);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Popover with a "Swing-Hover" pendulum motion,
styled for responsive dashboard layouts. Hovering — or tabbing to, with a
keyboard — a small info-icon trigger reveals an explanatory popover that
swings like it's rocking on the hinge of its own pointer arrow, then
settles. Both the show/hide behavior and the swing animation are pure CSS
(:hover / :focus-within + one @keyframes block) — no JavaScript is required
for the core interaction. Demo applies it to three dashboard stat cards
(Monthly Revenue, Active Users, Churn Rate).

Resolves #46548

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/swing-hover-popover-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS "swing" hover/focus popover for info tooltips, with
tunable timing/amplitude via custom properties.

**How does a developer use it?**
```html
<span class="swh-popover-wrap-hr18">
  <button type="button" class="swh-info-trigger-hr18" aria-describedby="myTip">i</button>
  <span class="ease-popover-swing-hr18" id="myTip" role="tooltip">
    Explanation text here.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**
The entire interaction runs on plain CSS selectors and one `@keyframes`
block, matching the issue's ask for zero JavaScript overhead, while
exposing every timing value as a tunable custom property and staying
keyboard accessible via `:focus-within`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
Show/hide and the swing animation need zero JS — the only script present
adds Escape-to-dismiss as a convenience by blurring the trigger. Tested
keyboard flow (Tab, focus reveal, Escape) in Chrome; haven't checked other
browsers yet.