### PR TITLE
Add double pendulum component

### DIFF
--- a/submissions/examples/double-pendulum-as/README.md
+++ b/submissions/examples/double-pendulum-as/README.md
@@ -1,0 +1,34 @@
+# Double Pendulum
+
+A pure CSS/HTML double pendulum, run twice from starting angles that differ by one thousandth of a radian.
+
+## What it shows
+
+Hang one pendulum off another and you get the standard teaching example of **deterministic chaos**.
+
+Nothing about it is random. The equations of motion are exact, derived from the Lagrangian, and given the starting state the entire future is fixed. Yet the motion is **unpredictable in practice**, because the system has *sensitive dependence on initial conditions*: two starts that differ by an amount too small to measure end up doing completely different things.
+
+That is what this component shows. Two double pendulums are released from identical positions except that the second arm of one starts **0.001 radians** further along, about a twentieth of a degree. For the first second or so they are indistinguishable. Then they separate, and within a few seconds they are in unrelated configurations, one swinging over the top while the other doubles back.
+
+This is why weather forecasts have a horizon. The atmosphere is deterministic too; the problem is that you cannot measure its current state precisely enough, and the error grows exponentially. Lorenz found this in 1961 when he restarted a simulation from a printout rounded to three decimals and got a totally different forecast.
+
+A single pendulum, by contrast, is completely predictable. Adding one joint is enough to destroy that.
+
+## How it is built
+
+- **The motion is simulated, not drawn.** Both pendulums are integrated from the real coupled equations of motion with **RK4** at a 2ms timestep, and the resulting 201 frames are baked into keyframes for the rods and bobs.
+- **The physics is checked by conservation of energy.** Total energy (kinetic plus potential) is computed at every step of the simulation and drifts by only **1.7 × 10⁻⁷ relative** across the whole 8-second run. A hand-animated pendulum would not conserve anything; this one does, which is the evidence that it is real dynamics.
+- **The chaos is measured in the browser, on the rendered elements.** Sweeping the paused animation across 201 steps and tracking the two tip positions: they start **0.07px** apart and grow to **127.4px**, an amplification of about **1800×**. The tiny difference is not smoothed away, it is magnified.
+- **The rods stay rigid, and that is checked too.** Both arms measure 62px at every frame, varying by **0.04px**. The bobs really are swinging on fixed-length rods rather than drifting.
+- **The second pendulum is drawn as a ghost**, so you can watch the two agree and then part company.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` pauses both pendulums mid-swing.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/double-pendulum-as/demo.html
+++ b/submissions/examples/double-pendulum-as/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Double Pendulum</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="gridD"></span>
+    <span class="rodD r1B"></span>
+    <span class="rodD r2B"></span>
+    <span class="bobD b1B"></span>
+    <span class="bobD tipB b2B"></span>
+    <span class="rodD rodA r1A"></span>
+    <span class="rodD rodA r2A"></span>
+    <span class="bobD bobA b1A"></span>
+    <span class="bobD bobA tipA b2A"></span>
+    <span class="pivotD"></span>
+    <span class="tagD">two starts, 0.001 rad apart</span>
+    <span class="capD">deterministic, and completely unpredictable</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/double-pendulum-as/style.css
+++ b/submissions/examples/double-pendulum-as/style.css
@@ -1,0 +1,1758 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #241c30, #06040a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 28%, #2a2140, #08060e 86%);
+}
+
+.gridD {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(90deg, rgba(180, 150, 240, 0.05) 0 1px, transparent 1px 24px),
+    repeating-linear-gradient(0deg, rgba(180, 150, 240, 0.05) 0 1px, transparent 1px 24px);
+  z-index: 1;
+}
+
+/*
+  two double pendulums released from initial angles that differ by one
+  thousandth of a radian. the equations are identical and fully deterministic,
+  integrated with RK4 from the real Lagrangian equations of motion.
+*/
+.rodD {
+  position: absolute;
+  width: 62.0px;
+  height: 3px;
+  margin-top: -1.5px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(190, 160, 250, 0.55), rgba(120, 100, 180, 0.35));
+  transform-origin: 0 50%;
+  z-index: 3;
+}
+
+.rodA {
+  background: linear-gradient(90deg, #e0d4ff, #8a74c8);
+  height: 4px;
+  margin-top: -2px;
+  z-index: 5;
+}
+
+.bobD {
+  position: absolute;
+  width: 13px;
+  height: 13px;
+  margin: -6.5px 0 0 -6.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, rgba(200, 180, 255, 0.5), rgba(90, 70, 140, 0.4) 76%);
+  z-index: 4;
+}
+
+.bobA {
+  background: radial-gradient(circle at 34% 32%, #f0e8ff, #6a4fb0 74%);
+  box-shadow: 0 0 8px rgba(180, 150, 255, 0.6);
+  z-index: 6;
+}
+
+.tipA {
+  background: radial-gradient(circle at 34% 30%, #fff0a0, #d88a10 70%);
+  box-shadow: 0 0 12px rgba(255, 200, 80, 0.9);
+}
+
+.tipB {
+  background: radial-gradient(circle at 34% 30%, rgba(120, 240, 220, 0.7), rgba(20, 140, 130, 0.5) 72%);
+  box-shadow: 0 0 8px rgba(80, 230, 210, 0.5);
+}
+
+.pivotD {
+  position: absolute;
+  left: 150px;
+  top: 96px;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #eef2f6, #46505a 76%);
+  box-shadow: 0 0 0 3px rgba(20, 16, 28, 0.8);
+  z-index: 8;
+}
+
+.tagD {
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(210, 190, 255, 0.9);
+  z-index: 9;
+}
+
+.capD {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.04em;
+  color: rgba(220, 205, 250, 0.85);
+  z-index: 9;
+}
+
+.r1A { animation: r1A 8s linear infinite; }
+.r2A { animation: r2A 8s linear infinite; }
+.b1A { animation: b1A 8s linear infinite; }
+.b2A { animation: b2A 8s linear infinite; }
+.r1B { animation: r1B 8s linear infinite; }
+.r2B { animation: r2B 8s linear infinite; }
+.b1B { animation: b1B 8s linear infinite; }
+.b2B { animation: b2B 8s linear infinite; }
+
+@keyframes r1A {
+  0.000% { left: 150.00px; top: 96.00px; transform: rotate(-30.00deg); }
+  0.500% { left: 150.00px; top: 96.00px; transform: rotate(-29.67deg); }
+  1.000% { left: 150.00px; top: 96.00px; transform: rotate(-28.66deg); }
+  1.500% { left: 150.00px; top: 96.00px; transform: rotate(-26.95deg); }
+  2.000% { left: 150.00px; top: 96.00px; transform: rotate(-24.51deg); }
+  2.500% { left: 150.00px; top: 96.00px; transform: rotate(-21.30deg); }
+  3.000% { left: 150.00px; top: 96.00px; transform: rotate(-17.25deg); }
+  3.500% { left: 150.00px; top: 96.00px; transform: rotate(-12.29deg); }
+  4.000% { left: 150.00px; top: 96.00px; transform: rotate(-6.34deg); }
+  4.500% { left: 150.00px; top: 96.00px; transform: rotate(0.73deg); }
+  5.000% { left: 150.00px; top: 96.00px; transform: rotate(9.07deg); }
+  5.500% { left: 150.00px; top: 96.00px; transform: rotate(18.83deg); }
+  6.000% { left: 150.00px; top: 96.00px; transform: rotate(30.06deg); }
+  6.500% { left: 150.00px; top: 96.00px; transform: rotate(42.28deg); }
+  7.000% { left: 150.00px; top: 96.00px; transform: rotate(54.61deg); }
+  7.500% { left: 150.00px; top: 96.00px; transform: rotate(66.42deg); }
+  8.000% { left: 150.00px; top: 96.00px; transform: rotate(77.47deg); }
+  8.500% { left: 150.00px; top: 96.00px; transform: rotate(87.61deg); }
+  9.000% { left: 150.00px; top: 96.00px; transform: rotate(96.58deg); }
+  9.500% { left: 150.00px; top: 96.00px; transform: rotate(104.01deg); }
+  10.000% { left: 150.00px; top: 96.00px; transform: rotate(109.49deg); }
+  10.500% { left: 150.00px; top: 96.00px; transform: rotate(112.66deg); }
+  11.000% { left: 150.00px; top: 96.00px; transform: rotate(113.47deg); }
+  11.500% { left: 150.00px; top: 96.00px; transform: rotate(112.96deg); }
+  12.000% { left: 150.00px; top: 96.00px; transform: rotate(113.10deg); }
+  12.500% { left: 150.00px; top: 96.00px; transform: rotate(114.92deg); }
+  13.000% { left: 150.00px; top: 96.00px; transform: rotate(118.34deg); }
+  13.500% { left: 150.00px; top: 96.00px; transform: rotate(122.96deg); }
+  14.000% { left: 150.00px; top: 96.00px; transform: rotate(128.39deg); }
+  14.500% { left: 150.00px; top: 96.00px; transform: rotate(134.27deg); }
+  15.000% { left: 150.00px; top: 96.00px; transform: rotate(140.27deg); }
+  15.500% { left: 150.00px; top: 96.00px; transform: rotate(146.15deg); }
+  16.000% { left: 150.00px; top: 96.00px; transform: rotate(151.72deg); }
+  16.500% { left: 150.00px; top: 96.00px; transform: rotate(156.83deg); }
+  17.000% { left: 150.00px; top: 96.00px; transform: rotate(161.36deg); }
+  17.500% { left: 150.00px; top: 96.00px; transform: rotate(165.23deg); }
+  18.000% { left: 150.00px; top: 96.00px; transform: rotate(168.37deg); }
+  18.500% { left: 150.00px; top: 96.00px; transform: rotate(170.73deg); }
+  19.000% { left: 150.00px; top: 96.00px; transform: rotate(172.27deg); }
+  19.500% { left: 150.00px; top: 96.00px; transform: rotate(172.97deg); }
+  20.000% { left: 150.00px; top: 96.00px; transform: rotate(172.81deg); }
+  20.500% { left: 150.00px; top: 96.00px; transform: rotate(171.80deg); }
+  21.000% { left: 150.00px; top: 96.00px; transform: rotate(169.94deg); }
+  21.500% { left: 150.00px; top: 96.00px; transform: rotate(167.26deg); }
+  22.000% { left: 150.00px; top: 96.00px; transform: rotate(163.80deg); }
+  22.500% { left: 150.00px; top: 96.00px; transform: rotate(159.57deg); }
+  23.000% { left: 150.00px; top: 96.00px; transform: rotate(154.64deg); }
+  23.500% { left: 150.00px; top: 96.00px; transform: rotate(149.07deg); }
+  24.000% { left: 150.00px; top: 96.00px; transform: rotate(142.93deg); }
+  24.500% { left: 150.00px; top: 96.00px; transform: rotate(136.35deg); }
+  25.000% { left: 150.00px; top: 96.00px; transform: rotate(129.50deg); }
+  25.500% { left: 150.00px; top: 96.00px; transform: rotate(122.63deg); }
+  26.000% { left: 150.00px; top: 96.00px; transform: rotate(116.05deg); }
+  26.500% { left: 150.00px; top: 96.00px; transform: rotate(110.18deg); }
+  27.000% { left: 150.00px; top: 96.00px; transform: rotate(105.46deg); }
+  27.500% { left: 150.00px; top: 96.00px; transform: rotate(102.40deg); }
+  28.000% { left: 150.00px; top: 96.00px; transform: rotate(101.54deg); }
+  28.500% { left: 150.00px; top: 96.00px; transform: rotate(103.27deg); }
+  29.000% { left: 150.00px; top: 96.00px; transform: rotate(106.52deg); }
+  29.500% { left: 150.00px; top: 96.00px; transform: rotate(108.17deg); }
+  30.000% { left: 150.00px; top: 96.00px; transform: rotate(106.81deg); }
+  30.500% { left: 150.00px; top: 96.00px; transform: rotate(102.70deg); }
+  31.000% { left: 150.00px; top: 96.00px; transform: rotate(96.39deg); }
+  31.500% { left: 150.00px; top: 96.00px; transform: rotate(88.43deg); }
+  32.000% { left: 150.00px; top: 96.00px; transform: rotate(79.34deg); }
+  32.500% { left: 150.00px; top: 96.00px; transform: rotate(69.53deg); }
+  33.000% { left: 150.00px; top: 96.00px; transform: rotate(59.29deg); }
+  33.500% { left: 150.00px; top: 96.00px; transform: rotate(48.74deg); }
+  34.000% { left: 150.00px; top: 96.00px; transform: rotate(37.87deg); }
+  34.500% { left: 150.00px; top: 96.00px; transform: rotate(26.72deg); }
+  35.000% { left: 150.00px; top: 96.00px; transform: rotate(15.65deg); }
+  35.500% { left: 150.00px; top: 96.00px; transform: rotate(5.46deg); }
+  36.000% { left: 150.00px; top: 96.00px; transform: rotate(-3.31deg); }
+  36.500% { left: 150.00px; top: 96.00px; transform: rotate(-10.67deg); }
+  37.000% { left: 150.00px; top: 96.00px; transform: rotate(-16.82deg); }
+  37.500% { left: 150.00px; top: 96.00px; transform: rotate(-21.94deg); }
+  38.000% { left: 150.00px; top: 96.00px; transform: rotate(-26.13deg); }
+  38.500% { left: 150.00px; top: 96.00px; transform: rotate(-29.47deg); }
+  39.000% { left: 150.00px; top: 96.00px; transform: rotate(-31.97deg); }
+  39.500% { left: 150.00px; top: 96.00px; transform: rotate(-33.64deg); }
+  40.000% { left: 150.00px; top: 96.00px; transform: rotate(-34.45deg); }
+  40.500% { left: 150.00px; top: 96.00px; transform: rotate(-34.34deg); }
+  41.000% { left: 150.00px; top: 96.00px; transform: rotate(-33.26deg); }
+  41.500% { left: 150.00px; top: 96.00px; transform: rotate(-31.14deg); }
+  42.000% { left: 150.00px; top: 96.00px; transform: rotate(-27.91deg); }
+  42.500% { left: 150.00px; top: 96.00px; transform: rotate(-23.53deg); }
+  43.000% { left: 150.00px; top: 96.00px; transform: rotate(-17.99deg); }
+  43.500% { left: 150.00px; top: 96.00px; transform: rotate(-11.31deg); }
+  44.000% { left: 150.00px; top: 96.00px; transform: rotate(-3.57deg); }
+  44.500% { left: 150.00px; top: 96.00px; transform: rotate(5.14deg); }
+  45.000% { left: 150.00px; top: 96.00px; transform: rotate(14.74deg); }
+  45.500% { left: 150.00px; top: 96.00px; transform: rotate(25.18deg); }
+  46.000% { left: 150.00px; top: 96.00px; transform: rotate(36.60deg); }
+  46.500% { left: 150.00px; top: 96.00px; transform: rotate(49.36deg); }
+  47.000% { left: 150.00px; top: 96.00px; transform: rotate(64.26deg); }
+  47.500% { left: 150.00px; top: 96.00px; transform: rotate(81.94deg); }
+  48.000% { left: 150.00px; top: 96.00px; transform: rotate(99.55deg); }
+  48.500% { left: 150.00px; top: 96.00px; transform: rotate(114.53deg); }
+  49.000% { left: 150.00px; top: 96.00px; transform: rotate(127.65deg); }
+  49.500% { left: 150.00px; top: 96.00px; transform: rotate(139.62deg); }
+  50.000% { left: 150.00px; top: 96.00px; transform: rotate(150.74deg); }
+  50.500% { left: 150.00px; top: 96.00px; transform: rotate(161.01deg); }
+  51.000% { left: 150.00px; top: 96.00px; transform: rotate(170.26deg); }
+  51.500% { left: 150.00px; top: 96.00px; transform: rotate(178.27deg); }
+  52.000% { left: 150.00px; top: 96.00px; transform: rotate(-175.19deg); }
+  52.500% { left: 150.00px; top: 96.00px; transform: rotate(-170.26deg); }
+  53.000% { left: 150.00px; top: 96.00px; transform: rotate(-166.99deg); }
+  53.500% { left: 150.00px; top: 96.00px; transform: rotate(-165.39deg); }
+  54.000% { left: 150.00px; top: 96.00px; transform: rotate(-165.42deg); }
+  54.500% { left: 150.00px; top: 96.00px; transform: rotate(-167.06deg); }
+  55.000% { left: 150.00px; top: 96.00px; transform: rotate(-170.36deg); }
+  55.500% { left: 150.00px; top: 96.00px; transform: rotate(-175.44deg); }
+  56.000% { left: 150.00px; top: 96.00px; transform: rotate(177.56deg); }
+  56.500% { left: 150.00px; top: 96.00px; transform: rotate(169.04deg); }
+  57.000% { left: 150.00px; top: 96.00px; transform: rotate(160.22deg); }
+  57.500% { left: 150.00px; top: 96.00px; transform: rotate(151.84deg); }
+  58.000% { left: 150.00px; top: 96.00px; transform: rotate(143.81deg); }
+  58.500% { left: 150.00px; top: 96.00px; transform: rotate(135.83deg); }
+  59.000% { left: 150.00px; top: 96.00px; transform: rotate(127.63deg); }
+  59.500% { left: 150.00px; top: 96.00px; transform: rotate(118.97deg); }
+  60.000% { left: 150.00px; top: 96.00px; transform: rotate(109.69deg); }
+  60.500% { left: 150.00px; top: 96.00px; transform: rotate(99.70deg); }
+  61.000% { left: 150.00px; top: 96.00px; transform: rotate(89.05deg); }
+  61.500% { left: 150.00px; top: 96.00px; transform: rotate(77.98deg); }
+  62.000% { left: 150.00px; top: 96.00px; transform: rotate(66.92deg); }
+  62.500% { left: 150.00px; top: 96.00px; transform: rotate(56.47deg); }
+  63.000% { left: 150.00px; top: 96.00px; transform: rotate(47.33deg); }
+  63.500% { left: 150.00px; top: 96.00px; transform: rotate(40.12deg); }
+  64.000% { left: 150.00px; top: 96.00px; transform: rotate(35.34deg); }
+  64.500% { left: 150.00px; top: 96.00px; transform: rotate(33.29deg); }
+  65.000% { left: 150.00px; top: 96.00px; transform: rotate(34.20deg); }
+  65.500% { left: 150.00px; top: 96.00px; transform: rotate(38.42deg); }
+  66.000% { left: 150.00px; top: 96.00px; transform: rotate(46.73deg); }
+  66.500% { left: 150.00px; top: 96.00px; transform: rotate(58.51deg); }
+  67.000% { left: 150.00px; top: 96.00px; transform: rotate(68.51deg); }
+  67.500% { left: 150.00px; top: 96.00px; transform: rotate(75.25deg); }
+  68.000% { left: 150.00px; top: 96.00px; transform: rotate(79.68deg); }
+  68.500% { left: 150.00px; top: 96.00px; transform: rotate(82.41deg); }
+  69.000% { left: 150.00px; top: 96.00px; transform: rotate(83.73deg); }
+  69.500% { left: 150.00px; top: 96.00px; transform: rotate(83.82deg); }
+  70.000% { left: 150.00px; top: 96.00px; transform: rotate(82.78deg); }
+  70.500% { left: 150.00px; top: 96.00px; transform: rotate(80.80deg); }
+  71.000% { left: 150.00px; top: 96.00px; transform: rotate(78.17deg); }
+  71.500% { left: 150.00px; top: 96.00px; transform: rotate(75.37deg); }
+  72.000% { left: 150.00px; top: 96.00px; transform: rotate(72.99deg); }
+  72.500% { left: 150.00px; top: 96.00px; transform: rotate(71.59deg); }
+  73.000% { left: 150.00px; top: 96.00px; transform: rotate(71.50deg); }
+  73.500% { left: 150.00px; top: 96.00px; transform: rotate(72.89deg); }
+  74.000% { left: 150.00px; top: 96.00px; transform: rotate(75.87deg); }
+  74.500% { left: 150.00px; top: 96.00px; transform: rotate(80.61deg); }
+  75.000% { left: 150.00px; top: 96.00px; transform: rotate(87.52deg); }
+  75.500% { left: 150.00px; top: 96.00px; transform: rotate(97.58deg); }
+  76.000% { left: 150.00px; top: 96.00px; transform: rotate(111.67deg); }
+  76.500% { left: 150.00px; top: 96.00px; transform: rotate(124.74deg); }
+  77.000% { left: 150.00px; top: 96.00px; transform: rotate(133.18deg); }
+  77.500% { left: 150.00px; top: 96.00px; transform: rotate(138.09deg); }
+  78.000% { left: 150.00px; top: 96.00px; transform: rotate(140.16deg); }
+  78.500% { left: 150.00px; top: 96.00px; transform: rotate(139.57deg); }
+  79.000% { left: 150.00px; top: 96.00px; transform: rotate(136.39deg); }
+  79.500% { left: 150.00px; top: 96.00px; transform: rotate(130.77deg); }
+  80.000% { left: 150.00px; top: 96.00px; transform: rotate(123.02deg); }
+  80.500% { left: 150.00px; top: 96.00px; transform: rotate(113.64deg); }
+  81.000% { left: 150.00px; top: 96.00px; transform: rotate(103.16deg); }
+  81.500% { left: 150.00px; top: 96.00px; transform: rotate(92.06deg); }
+  82.000% { left: 150.00px; top: 96.00px; transform: rotate(80.72deg); }
+  82.500% { left: 150.00px; top: 96.00px; transform: rotate(69.46deg); }
+  83.000% { left: 150.00px; top: 96.00px; transform: rotate(58.59deg); }
+  83.500% { left: 150.00px; top: 96.00px; transform: rotate(48.45deg); }
+  84.000% { left: 150.00px; top: 96.00px; transform: rotate(39.46deg); }
+  84.500% { left: 150.00px; top: 96.00px; transform: rotate(32.13deg); }
+  85.000% { left: 150.00px; top: 96.00px; transform: rotate(26.88deg); }
+  85.500% { left: 150.00px; top: 96.00px; transform: rotate(24.00deg); }
+  86.000% { left: 150.00px; top: 96.00px; transform: rotate(23.58deg); }
+  86.500% { left: 150.00px; top: 96.00px; transform: rotate(25.59deg); }
+  87.000% { left: 150.00px; top: 96.00px; transform: rotate(30.07deg); }
+  87.500% { left: 150.00px; top: 96.00px; transform: rotate(37.35deg); }
+  88.000% { left: 150.00px; top: 96.00px; transform: rotate(48.39deg); }
+  88.500% { left: 150.00px; top: 96.00px; transform: rotate(63.42deg); }
+  89.000% { left: 150.00px; top: 96.00px; transform: rotate(76.98deg); }
+  89.500% { left: 150.00px; top: 96.00px; transform: rotate(87.10deg); }
+  90.000% { left: 150.00px; top: 96.00px; transform: rotate(95.07deg); }
+  90.500% { left: 150.00px; top: 96.00px; transform: rotate(101.70deg); }
+  91.000% { left: 150.00px; top: 96.00px; transform: rotate(107.43deg); }
+  91.500% { left: 150.00px; top: 96.00px; transform: rotate(112.48deg); }
+  92.000% { left: 150.00px; top: 96.00px; transform: rotate(116.99deg); }
+  92.500% { left: 150.00px; top: 96.00px; transform: rotate(121.00deg); }
+  93.000% { left: 150.00px; top: 96.00px; transform: rotate(124.51deg); }
+  93.500% { left: 150.00px; top: 96.00px; transform: rotate(127.50deg); }
+  94.000% { left: 150.00px; top: 96.00px; transform: rotate(130.00deg); }
+  94.500% { left: 150.00px; top: 96.00px; transform: rotate(132.07deg); }
+  95.000% { left: 150.00px; top: 96.00px; transform: rotate(133.76deg); }
+  95.500% { left: 150.00px; top: 96.00px; transform: rotate(135.18deg); }
+  96.000% { left: 150.00px; top: 96.00px; transform: rotate(136.40deg); }
+  96.500% { left: 150.00px; top: 96.00px; transform: rotate(137.52deg); }
+  97.000% { left: 150.00px; top: 96.00px; transform: rotate(138.63deg); }
+  97.500% { left: 150.00px; top: 96.00px; transform: rotate(139.86deg); }
+  98.000% { left: 150.00px; top: 96.00px; transform: rotate(141.35deg); }
+  98.500% { left: 150.00px; top: 96.00px; transform: rotate(143.31deg); }
+  99.000% { left: 150.00px; top: 96.00px; transform: rotate(145.98deg); }
+  99.500% { left: 150.00px; top: 96.00px; transform: rotate(149.64deg); }
+  100.000% { left: 150.00px; top: 96.00px; transform: rotate(154.29deg); }
+}
+
+@keyframes r2A {
+  0.000% { left: 203.69px; top: 65.00px; transform: rotate(30.00deg); }
+  0.500% { left: 203.87px; top: 65.31px; transform: rotate(30.22deg); }
+  1.000% { left: 204.41px; top: 66.27px; transform: rotate(30.87deg); }
+  1.500% { left: 205.27px; top: 67.90px; transform: rotate(31.91deg); }
+  2.000% { left: 206.41px; top: 70.28px; transform: rotate(33.27deg); }
+  2.500% { left: 207.77px; top: 73.48px; transform: rotate(34.85deg); }
+  3.000% { left: 209.21px; top: 77.61px; transform: rotate(36.51deg); }
+  3.500% { left: 210.58px; top: 82.80px; transform: rotate(38.07deg); }
+  4.000% { left: 211.62px; top: 89.16px; transform: rotate(39.30deg); }
+  4.500% { left: 211.99px; top: 96.79px; transform: rotate(39.91deg); }
+  5.000% { left: 211.23px; top: 105.77px; transform: rotate(39.59deg); }
+  5.500% { left: 208.68px; top: 116.02px; transform: rotate(38.02deg); }
+  6.000% { left: 203.66px; top: 127.05px; transform: rotate(35.18deg); }
+  6.500% { left: 195.87px; top: 137.71px; transform: rotate(31.89deg); }
+  7.000% { left: 185.91px; top: 146.54px; transform: rotate(29.74deg); }
+  7.500% { left: 174.81px; top: 152.82px; transform: rotate(29.88deg); }
+  8.000% { left: 163.45px; top: 156.52px; transform: rotate(32.74deg); }
+  8.500% { left: 152.59px; top: 157.95px; transform: rotate(38.38deg); }
+  9.000% { left: 142.90px; top: 157.59px; transform: rotate(46.70deg); }
+  9.500% { left: 134.99px; top: 156.16px; transform: rotate(57.54deg); }
+  10.000% { left: 129.31px; top: 154.45px; transform: rotate(70.74deg); }
+  10.500% { left: 126.11px; top: 153.21px; transform: rotate(86.29deg); }
+  11.000% { left: 125.30px; top: 152.87px; transform: rotate(104.03deg); }
+  11.500% { left: 125.82px; top: 153.09px; transform: rotate(122.84deg); }
+  12.000% { left: 125.67px; top: 153.03px; transform: rotate(140.53deg); }
+  12.500% { left: 123.87px; top: 152.23px; transform: rotate(156.05deg); }
+  13.000% { left: 120.57px; top: 150.57px; transform: rotate(169.46deg); }
+  13.500% { left: 116.27px; top: 148.02px; transform: rotate(-179.02deg); }
+  14.000% { left: 111.49px; top: 144.59px; transform: rotate(-169.20deg); }
+  14.500% { left: 106.72px; top: 140.40px; transform: rotate(-160.98deg); }
+  15.000% { left: 102.32px; top: 135.63px; transform: rotate(-154.22deg); }
+  15.500% { left: 98.51px; top: 130.53px; transform: rotate(-148.79deg); }
+  16.000% { left: 95.40px; top: 125.37px; transform: rotate(-144.51deg); }
+  16.500% { left: 93.00px; top: 120.40px; transform: rotate(-141.21deg); }
+  17.000% { left: 91.25px; top: 115.82px; transform: rotate(-138.70deg); }
+  17.500% { left: 90.05px; top: 111.81px; transform: rotate(-136.80deg); }
+  18.000% { left: 89.27px; top: 108.50px; transform: rotate(-135.36deg); }
+  18.500% { left: 88.81px; top: 105.99px; transform: rotate(-134.24deg); }
+  19.000% { left: 88.56px; top: 104.34px; transform: rotate(-133.33deg); }
+  19.500% { left: 88.47px; top: 103.59px; transform: rotate(-132.56deg); }
+  20.000% { left: 88.49px; top: 103.76px; transform: rotate(-131.92deg); }
+  20.500% { left: 88.63px; top: 104.85px; transform: rotate(-131.39deg); }
+  21.000% { left: 88.95px; top: 106.83px; transform: rotate(-131.03deg); }
+  21.500% { left: 89.53px; top: 109.67px; transform: rotate(-130.92deg); }
+  22.000% { left: 90.46px; top: 113.30px; transform: rotate(-131.17deg); }
+  22.500% { left: 91.90px; top: 117.64px; transform: rotate(-131.93deg); }
+  23.000% { left: 93.97px; top: 122.55px; transform: rotate(-133.37deg); }
+  23.500% { left: 96.82px; top: 127.87px; transform: rotate(-135.69deg); }
+  24.000% { left: 100.53px; top: 133.38px; transform: rotate(-139.10deg); }
+  24.500% { left: 105.14px; top: 138.80px; transform: rotate(-143.78deg); }
+  25.000% { left: 110.57px; top: 143.84px; transform: rotate(-149.92deg); }
+  25.500% { left: 116.57px; top: 148.22px; transform: rotate(-157.66deg); }
+  26.000% { left: 122.77px; top: 151.70px; transform: rotate(-167.06deg); }
+  26.500% { left: 128.61px; top: 154.19px; transform: rotate(-178.17deg); }
+  27.000% { left: 133.47px; top: 155.76px; transform: rotate(168.98deg); }
+  27.500% { left: 136.69px; top: 156.55px; transform: rotate(154.23deg); }
+  28.000% { left: 137.59px; top: 156.75px; transform: rotate(137.23deg); }
+  28.500% { left: 135.77px; top: 156.34px; transform: rotate(117.48deg); }
+  29.000% { left: 132.37px; top: 155.44px; transform: rotate(95.87deg); }
+  29.500% { left: 130.66px; top: 154.91px; transform: rotate(75.70deg); }
+  30.000% { left: 132.07px; top: 155.35px; transform: rotate(58.28deg); }
+  30.500% { left: 136.37px; top: 156.48px; transform: rotate(43.31deg); }
+  31.000% { left: 143.10px; top: 157.61px; transform: rotate(30.55deg); }
+  31.500% { left: 151.70px; top: 157.98px; transform: rotate(20.08deg); }
+  32.000% { left: 161.47px; top: 156.93px; transform: rotate(12.06deg); }
+  32.500% { left: 171.68px; top: 154.09px; transform: rotate(6.65deg); }
+  33.000% { left: 181.66px; top: 149.30px; transform: rotate(3.88deg); }
+  33.500% { left: 190.89px; top: 142.60px; transform: rotate(3.74deg); }
+  34.000% { left: 198.94px; top: 134.06px; transform: rotate(6.11deg); }
+  34.500% { left: 205.38px; top: 123.88px; transform: rotate(10.72deg); }
+  35.000% { left: 209.70px; top: 112.72px; transform: rotate(16.72deg); }
+  35.500% { left: 211.72px; top: 101.90px; transform: rotate(22.68deg); }
+  36.000% { left: 211.90px; top: 92.42px; transform: rotate(27.68deg); }
+  36.500% { left: 210.93px; top: 84.52px; transform: rotate(31.71deg); }
+  37.000% { left: 209.35px; top: 78.06px; transform: rotate(35.08deg); }
+  37.500% { left: 207.51px; top: 72.83px; transform: rotate(38.11deg); }
+  38.000% { left: 205.66px; top: 68.69px; transform: rotate(41.05deg); }
+  38.500% { left: 203.98px; top: 65.50px; transform: rotate(44.12deg); }
+  39.000% { left: 202.59px; top: 63.17px; transform: rotate(47.45deg); }
+  39.500% { left: 201.62px; top: 61.65px; transform: rotate(51.15deg); }
+  40.000% { left: 201.13px; top: 60.93px; transform: rotate(55.32deg); }
+  40.500% { left: 201.19px; top: 61.03px; transform: rotate(59.98deg); }
+  41.000% { left: 201.84px; top: 62.00px; transform: rotate(65.16deg); }
+  41.500% { left: 203.07px; top: 63.94px; transform: rotate(70.83deg); }
+  42.000% { left: 204.79px; top: 66.98px; transform: rotate(76.89deg); }
+  42.500% { left: 206.84px; top: 71.25px; transform: rotate(83.20deg); }
+  43.000% { left: 208.97px; top: 76.85px; transform: rotate(89.53deg); }
+  43.500% { left: 210.80px; top: 83.84px; transform: rotate(95.58deg); }
+  44.000% { left: 211.88px; top: 92.14px; transform: rotate(100.99deg); }
+  44.500% { left: 211.75px; top: 101.56px; transform: rotate(105.31deg); }
+  45.000% { left: 209.96px; top: 111.77px; transform: rotate(108.11deg); }
+  45.500% { left: 206.11px; top: 122.38px; transform: rotate(108.93deg); }
+  46.000% { left: 199.78px; top: 132.96px; transform: rotate(107.28deg); }
+  46.500% { left: 190.38px; top: 143.04px; transform: rotate(102.53deg); }
+  47.000% { left: 176.93px; top: 151.85px; transform: rotate(93.70deg); }
+  47.500% { left: 158.69px; top: 157.39px; transform: rotate(80.33deg); }
+  48.000% { left: 139.72px; top: 157.14px; transform: rotate(67.33deg); }
+  48.500% { left: 124.26px; top: 152.40px; transform: rotate(59.15deg); }
+  49.000% { left: 112.13px; top: 145.09px; transform: rotate(55.27deg); }
+  49.500% { left: 102.77px; top: 136.17px; transform: rotate(54.85deg); }
+  50.000% { left: 95.91px; top: 126.30px; transform: rotate(57.34deg); }
+  50.500% { left: 91.37px; top: 116.18px; transform: rotate(62.26deg); }
+  51.000% { left: 88.89px; top: 106.49px; transform: rotate(69.10deg); }
+  51.500% { left: 88.03px; top: 97.87px; transform: rotate(77.30deg); }
+  52.000% { left: 88.22px; top: 90.80px; transform: rotate(86.34deg); }
+  52.500% { left: 88.89px; top: 85.51px; transform: rotate(95.79deg); }
+  53.000% { left: 89.59px; top: 82.04px; transform: rotate(105.33deg); }
+  53.500% { left: 90.00px; top: 80.36px; transform: rotate(114.82deg); }
+  54.000% { left: 90.00px; top: 80.39px; transform: rotate(124.25deg); }
+  54.500% { left: 89.57px; top: 82.12px; transform: rotate(133.73deg); }
+  55.000% { left: 88.88px; top: 85.62px; transform: rotate(143.53deg); }
+  55.500% { left: 88.20px; top: 91.07px; transform: rotate(154.07deg); }
+  56.000% { left: 88.06px; top: 98.64px; transform: rotate(165.75deg); }
+  56.500% { left: 89.13px; top: 107.78px; transform: rotate(178.23deg); }
+  57.000% { left: 91.66px; top: 116.98px; transform: rotate(-170.11deg); }
+  57.500% { left: 95.34px; top: 125.26px; transform: rotate(-160.32deg); }
+  58.000% { left: 99.96px; top: 132.61px; transform: rotate(-152.49deg); }
+  58.500% { left: 105.53px; top: 139.20px; transform: rotate(-146.47deg); }
+  59.000% { left: 112.15px; top: 145.10px; transform: rotate(-142.27deg); }
+  59.500% { left: 119.97px; top: 150.24px; transform: rotate(-140.02deg); }
+  60.000% { left: 129.11px; top: 154.37px; transform: rotate(-139.96deg); }
+  60.500% { left: 139.55px; top: 157.11px; transform: rotate(-142.35deg); }
+  61.000% { left: 151.03px; top: 157.99px; transform: rotate(-147.40deg); }
+  61.500% { left: 162.91px; top: 156.64px; transform: rotate(-155.17deg); }
+  62.000% { left: 174.31px; top: 153.04px; transform: rotate(-165.47deg); }
+  62.500% { left: 184.24px; top: 147.68px; transform: rotate(-177.88deg); }
+  63.000% { left: 192.02px; top: 141.58px; transform: rotate(168.17deg); }
+  63.500% { left: 197.41px; top: 135.95px; transform: rotate(153.30deg); }
+  64.000% { left: 200.58px; top: 131.86px; transform: rotate(137.98deg); }
+  64.500% { left: 201.82px; top: 130.03px; transform: rotate(122.35deg); }
+  65.000% { left: 201.28px; top: 130.85px; transform: rotate(106.14deg); }
+  65.500% { left: 198.57px; top: 134.53px; transform: rotate(88.49deg); }
+  66.000% { left: 192.50px; top: 141.14px; transform: rotate(67.71deg); }
+  66.500% { left: 182.39px; top: 148.87px; transform: rotate(43.66deg); }
+  67.000% { left: 172.71px; top: 153.69px; transform: rotate(22.30deg); }
+  67.500% { left: 165.78px; top: 155.96px; transform: rotate(4.86deg); }
+  68.000% { left: 161.10px; top: 157.00px; transform: rotate(-10.37deg); }
+  68.500% { left: 158.19px; top: 157.46px; transform: rotate(-24.46deg); }
+  69.000% { left: 156.77px; top: 157.63px; transform: rotate(-38.05deg); }
+  69.500% { left: 156.68px; top: 157.64px; transform: rotate(-51.58deg); }
+  70.000% { left: 157.79px; top: 157.51px; transform: rotate(-65.32deg); }
+  70.500% { left: 159.91px; top: 157.20px; transform: rotate(-79.47deg); }
+  71.000% { left: 162.71px; top: 156.68px; transform: rotate(-94.04deg); }
+  71.500% { left: 165.66px; top: 155.99px; transform: rotate(-108.81deg); }
+  72.000% { left: 168.13px; top: 155.29px; transform: rotate(-123.46deg); }
+  72.500% { left: 169.59px; top: 154.83px; transform: rotate(-137.70deg); }
+  73.000% { left: 169.68px; top: 154.79px; transform: rotate(-151.47deg); }
+  73.500% { left: 168.24px; top: 155.26px; transform: rotate(-164.95deg); }
+  74.000% { left: 165.13px; top: 156.12px; transform: rotate(-178.55deg); }
+  74.500% { left: 160.12px; top: 157.17px; transform: rotate(167.14deg); }
+  75.000% { left: 152.68px; top: 157.94px; transform: rotate(151.20deg); }
+  75.500% { left: 141.82px; top: 157.46px; transform: rotate(131.93deg); }
+  76.000% { left: 127.10px; top: 153.62px; transform: rotate(107.57deg); }
+  76.500% { left: 114.67px; top: 146.95px; transform: rotate(84.07deg); }
+  77.000% { left: 107.58px; top: 141.21px; transform: rotate(65.30deg); }
+  77.500% { left: 103.86px; top: 137.41px; transform: rotate(49.01deg); }
+  78.000% { left: 102.40px; top: 135.72px; transform: rotate(33.62deg); }
+  78.500% { left: 102.81px; top: 136.21px; transform: rotate(18.26deg); }
+  79.000% { left: 105.11px; top: 138.76px; transform: rotate(2.48deg); }
+  79.500% { left: 109.51px; top: 142.96px; transform: rotate(-13.83deg); }
+  80.000% { left: 116.21px; top: 147.99px; transform: rotate(-30.54deg); }
+  80.500% { left: 125.14px; top: 152.80px; transform: rotate(-47.37deg); }
+  81.000% { left: 135.89px; top: 156.37px; transform: rotate(-64.06deg); }
+  81.500% { left: 147.78px; top: 157.96px; transform: rotate(-80.51deg); }
+  82.000% { left: 160.00px; top: 157.19px; transform: rotate(-96.76deg); }
+  82.500% { left: 171.75px; top: 154.06px; transform: rotate(-112.94deg); }
+  83.000% { left: 182.32px; top: 148.91px; transform: rotate(-129.17deg); }
+  83.500% { left: 191.13px; top: 142.40px; transform: rotate(-145.50deg); }
+  84.000% { left: 197.87px; top: 135.41px; transform: rotate(-161.83deg); }
+  84.500% { left: 202.51px; top: 128.97px; transform: rotate(-177.90deg); }
+  85.000% { left: 205.30px; top: 124.03px; transform: rotate(166.58deg); }
+  85.500% { left: 206.64px; top: 121.22px; transform: rotate(151.80deg); }
+  86.000% { left: 206.82px; top: 120.80px; transform: rotate(137.68deg); }
+  86.500% { left: 205.92px; top: 122.78px; transform: rotate(123.85deg); }
+  87.000% { left: 203.66px; top: 127.06px; transform: rotate(109.66deg); }
+  87.500% { left: 199.29px; top: 133.62px; transform: rotate(94.02deg); }
+  88.000% { left: 191.17px; top: 142.35px; transform: rotate(75.05deg); }
+  88.500% { left: 177.74px; top: 151.45px; transform: rotate(51.74deg); }
+  89.000% { left: 163.96px; top: 156.41px; transform: rotate(30.92deg); }
+  89.500% { left: 153.14px; top: 157.92px; transform: rotate(14.91deg); }
+  90.000% { left: 144.52px; top: 157.76px; transform: rotate(1.81deg); }
+  90.500% { left: 137.42px; top: 156.71px; transform: rotate(-9.53deg); }
+  91.000% { left: 131.43px; top: 155.15px; transform: rotate(-19.67deg); }
+  91.500% { left: 126.29px; top: 153.29px; transform: rotate(-28.96deg); }
+  92.000% { left: 121.86px; top: 151.25px; transform: rotate(-37.63deg); }
+  92.500% { left: 118.07px; top: 149.15px; transform: rotate(-45.90deg); }
+  93.000% { left: 114.88px; top: 147.09px; transform: rotate(-53.97deg); }
+  93.500% { left: 112.25px; top: 145.19px; transform: rotate(-62.02deg); }
+  94.000% { left: 110.14px; top: 143.49px; transform: rotate(-70.16deg); }
+  94.500% { left: 108.46px; top: 142.03px; transform: rotate(-78.43deg); }
+  95.000% { left: 107.12px; top: 140.78px; transform: rotate(-86.87deg); }
+  95.500% { left: 106.02px; top: 139.70px; transform: rotate(-95.50deg); }
+  96.000% { left: 105.10px; top: 138.76px; transform: rotate(-104.36deg); }
+  96.500% { left: 104.28px; top: 137.87px; transform: rotate(-113.53deg); }
+  97.000% { left: 103.47px; top: 136.98px; transform: rotate(-123.07deg); }
+  97.500% { left: 102.61px; top: 135.97px; transform: rotate(-133.12deg); }
+  98.000% { left: 101.58px; top: 134.72px; transform: rotate(-143.83deg); }
+  98.500% { left: 100.29px; top: 133.05px; transform: rotate(-155.45deg); }
+  99.000% { left: 98.61px; top: 130.69px; transform: rotate(-168.31deg); }
+  99.500% { left: 96.50px; top: 127.33px; transform: rotate(177.12deg); }
+  100.000% { left: 94.14px; top: 122.90px; transform: rotate(160.69deg); }
+}
+
+@keyframes b1A {
+  0.000% { left: 203.69px; top: 65.00px; }
+  0.500% { left: 203.87px; top: 65.31px; }
+  1.000% { left: 204.41px; top: 66.27px; }
+  1.500% { left: 205.27px; top: 67.90px; }
+  2.000% { left: 206.41px; top: 70.28px; }
+  2.500% { left: 207.77px; top: 73.48px; }
+  3.000% { left: 209.21px; top: 77.61px; }
+  3.500% { left: 210.58px; top: 82.80px; }
+  4.000% { left: 211.62px; top: 89.16px; }
+  4.500% { left: 211.99px; top: 96.79px; }
+  5.000% { left: 211.23px; top: 105.77px; }
+  5.500% { left: 208.68px; top: 116.02px; }
+  6.000% { left: 203.66px; top: 127.05px; }
+  6.500% { left: 195.87px; top: 137.71px; }
+  7.000% { left: 185.91px; top: 146.54px; }
+  7.500% { left: 174.81px; top: 152.82px; }
+  8.000% { left: 163.45px; top: 156.52px; }
+  8.500% { left: 152.59px; top: 157.95px; }
+  9.000% { left: 142.90px; top: 157.59px; }
+  9.500% { left: 134.99px; top: 156.16px; }
+  10.000% { left: 129.31px; top: 154.45px; }
+  10.500% { left: 126.11px; top: 153.21px; }
+  11.000% { left: 125.30px; top: 152.87px; }
+  11.500% { left: 125.82px; top: 153.09px; }
+  12.000% { left: 125.67px; top: 153.03px; }
+  12.500% { left: 123.87px; top: 152.23px; }
+  13.000% { left: 120.57px; top: 150.57px; }
+  13.500% { left: 116.27px; top: 148.02px; }
+  14.000% { left: 111.49px; top: 144.59px; }
+  14.500% { left: 106.72px; top: 140.40px; }
+  15.000% { left: 102.32px; top: 135.63px; }
+  15.500% { left: 98.51px; top: 130.53px; }
+  16.000% { left: 95.40px; top: 125.37px; }
+  16.500% { left: 93.00px; top: 120.40px; }
+  17.000% { left: 91.25px; top: 115.82px; }
+  17.500% { left: 90.05px; top: 111.81px; }
+  18.000% { left: 89.27px; top: 108.50px; }
+  18.500% { left: 88.81px; top: 105.99px; }
+  19.000% { left: 88.56px; top: 104.34px; }
+  19.500% { left: 88.47px; top: 103.59px; }
+  20.000% { left: 88.49px; top: 103.76px; }
+  20.500% { left: 88.63px; top: 104.85px; }
+  21.000% { left: 88.95px; top: 106.83px; }
+  21.500% { left: 89.53px; top: 109.67px; }
+  22.000% { left: 90.46px; top: 113.30px; }
+  22.500% { left: 91.90px; top: 117.64px; }
+  23.000% { left: 93.97px; top: 122.55px; }
+  23.500% { left: 96.82px; top: 127.87px; }
+  24.000% { left: 100.53px; top: 133.38px; }
+  24.500% { left: 105.14px; top: 138.80px; }
+  25.000% { left: 110.57px; top: 143.84px; }
+  25.500% { left: 116.57px; top: 148.22px; }
+  26.000% { left: 122.77px; top: 151.70px; }
+  26.500% { left: 128.61px; top: 154.19px; }
+  27.000% { left: 133.47px; top: 155.76px; }
+  27.500% { left: 136.69px; top: 156.55px; }
+  28.000% { left: 137.59px; top: 156.75px; }
+  28.500% { left: 135.77px; top: 156.34px; }
+  29.000% { left: 132.37px; top: 155.44px; }
+  29.500% { left: 130.66px; top: 154.91px; }
+  30.000% { left: 132.07px; top: 155.35px; }
+  30.500% { left: 136.37px; top: 156.48px; }
+  31.000% { left: 143.10px; top: 157.61px; }
+  31.500% { left: 151.70px; top: 157.98px; }
+  32.000% { left: 161.47px; top: 156.93px; }
+  32.500% { left: 171.68px; top: 154.09px; }
+  33.000% { left: 181.66px; top: 149.30px; }
+  33.500% { left: 190.89px; top: 142.60px; }
+  34.000% { left: 198.94px; top: 134.06px; }
+  34.500% { left: 205.38px; top: 123.88px; }
+  35.000% { left: 209.70px; top: 112.72px; }
+  35.500% { left: 211.72px; top: 101.90px; }
+  36.000% { left: 211.90px; top: 92.42px; }
+  36.500% { left: 210.93px; top: 84.52px; }
+  37.000% { left: 209.35px; top: 78.06px; }
+  37.500% { left: 207.51px; top: 72.83px; }
+  38.000% { left: 205.66px; top: 68.69px; }
+  38.500% { left: 203.98px; top: 65.50px; }
+  39.000% { left: 202.59px; top: 63.17px; }
+  39.500% { left: 201.62px; top: 61.65px; }
+  40.000% { left: 201.13px; top: 60.93px; }
+  40.500% { left: 201.19px; top: 61.03px; }
+  41.000% { left: 201.84px; top: 62.00px; }
+  41.500% { left: 203.07px; top: 63.94px; }
+  42.000% { left: 204.79px; top: 66.98px; }
+  42.500% { left: 206.84px; top: 71.25px; }
+  43.000% { left: 208.97px; top: 76.85px; }
+  43.500% { left: 210.80px; top: 83.84px; }
+  44.000% { left: 211.88px; top: 92.14px; }
+  44.500% { left: 211.75px; top: 101.56px; }
+  45.000% { left: 209.96px; top: 111.77px; }
+  45.500% { left: 206.11px; top: 122.38px; }
+  46.000% { left: 199.78px; top: 132.96px; }
+  46.500% { left: 190.38px; top: 143.04px; }
+  47.000% { left: 176.93px; top: 151.85px; }
+  47.500% { left: 158.69px; top: 157.39px; }
+  48.000% { left: 139.72px; top: 157.14px; }
+  48.500% { left: 124.26px; top: 152.40px; }
+  49.000% { left: 112.13px; top: 145.09px; }
+  49.500% { left: 102.77px; top: 136.17px; }
+  50.000% { left: 95.91px; top: 126.30px; }
+  50.500% { left: 91.37px; top: 116.18px; }
+  51.000% { left: 88.89px; top: 106.49px; }
+  51.500% { left: 88.03px; top: 97.87px; }
+  52.000% { left: 88.22px; top: 90.80px; }
+  52.500% { left: 88.89px; top: 85.51px; }
+  53.000% { left: 89.59px; top: 82.04px; }
+  53.500% { left: 90.00px; top: 80.36px; }
+  54.000% { left: 90.00px; top: 80.39px; }
+  54.500% { left: 89.57px; top: 82.12px; }
+  55.000% { left: 88.88px; top: 85.62px; }
+  55.500% { left: 88.20px; top: 91.07px; }
+  56.000% { left: 88.06px; top: 98.64px; }
+  56.500% { left: 89.13px; top: 107.78px; }
+  57.000% { left: 91.66px; top: 116.98px; }
+  57.500% { left: 95.34px; top: 125.26px; }
+  58.000% { left: 99.96px; top: 132.61px; }
+  58.500% { left: 105.53px; top: 139.20px; }
+  59.000% { left: 112.15px; top: 145.10px; }
+  59.500% { left: 119.97px; top: 150.24px; }
+  60.000% { left: 129.11px; top: 154.37px; }
+  60.500% { left: 139.55px; top: 157.11px; }
+  61.000% { left: 151.03px; top: 157.99px; }
+  61.500% { left: 162.91px; top: 156.64px; }
+  62.000% { left: 174.31px; top: 153.04px; }
+  62.500% { left: 184.24px; top: 147.68px; }
+  63.000% { left: 192.02px; top: 141.58px; }
+  63.500% { left: 197.41px; top: 135.95px; }
+  64.000% { left: 200.58px; top: 131.86px; }
+  64.500% { left: 201.82px; top: 130.03px; }
+  65.000% { left: 201.28px; top: 130.85px; }
+  65.500% { left: 198.57px; top: 134.53px; }
+  66.000% { left: 192.50px; top: 141.14px; }
+  66.500% { left: 182.39px; top: 148.87px; }
+  67.000% { left: 172.71px; top: 153.69px; }
+  67.500% { left: 165.78px; top: 155.96px; }
+  68.000% { left: 161.10px; top: 157.00px; }
+  68.500% { left: 158.19px; top: 157.46px; }
+  69.000% { left: 156.77px; top: 157.63px; }
+  69.500% { left: 156.68px; top: 157.64px; }
+  70.000% { left: 157.79px; top: 157.51px; }
+  70.500% { left: 159.91px; top: 157.20px; }
+  71.000% { left: 162.71px; top: 156.68px; }
+  71.500% { left: 165.66px; top: 155.99px; }
+  72.000% { left: 168.13px; top: 155.29px; }
+  72.500% { left: 169.59px; top: 154.83px; }
+  73.000% { left: 169.68px; top: 154.79px; }
+  73.500% { left: 168.24px; top: 155.26px; }
+  74.000% { left: 165.13px; top: 156.12px; }
+  74.500% { left: 160.12px; top: 157.17px; }
+  75.000% { left: 152.68px; top: 157.94px; }
+  75.500% { left: 141.82px; top: 157.46px; }
+  76.000% { left: 127.10px; top: 153.62px; }
+  76.500% { left: 114.67px; top: 146.95px; }
+  77.000% { left: 107.58px; top: 141.21px; }
+  77.500% { left: 103.86px; top: 137.41px; }
+  78.000% { left: 102.40px; top: 135.72px; }
+  78.500% { left: 102.81px; top: 136.21px; }
+  79.000% { left: 105.11px; top: 138.76px; }
+  79.500% { left: 109.51px; top: 142.96px; }
+  80.000% { left: 116.21px; top: 147.99px; }
+  80.500% { left: 125.14px; top: 152.80px; }
+  81.000% { left: 135.89px; top: 156.37px; }
+  81.500% { left: 147.78px; top: 157.96px; }
+  82.000% { left: 160.00px; top: 157.19px; }
+  82.500% { left: 171.75px; top: 154.06px; }
+  83.000% { left: 182.32px; top: 148.91px; }
+  83.500% { left: 191.13px; top: 142.40px; }
+  84.000% { left: 197.87px; top: 135.41px; }
+  84.500% { left: 202.51px; top: 128.97px; }
+  85.000% { left: 205.30px; top: 124.03px; }
+  85.500% { left: 206.64px; top: 121.22px; }
+  86.000% { left: 206.82px; top: 120.80px; }
+  86.500% { left: 205.92px; top: 122.78px; }
+  87.000% { left: 203.66px; top: 127.06px; }
+  87.500% { left: 199.29px; top: 133.62px; }
+  88.000% { left: 191.17px; top: 142.35px; }
+  88.500% { left: 177.74px; top: 151.45px; }
+  89.000% { left: 163.96px; top: 156.41px; }
+  89.500% { left: 153.14px; top: 157.92px; }
+  90.000% { left: 144.52px; top: 157.76px; }
+  90.500% { left: 137.42px; top: 156.71px; }
+  91.000% { left: 131.43px; top: 155.15px; }
+  91.500% { left: 126.29px; top: 153.29px; }
+  92.000% { left: 121.86px; top: 151.25px; }
+  92.500% { left: 118.07px; top: 149.15px; }
+  93.000% { left: 114.88px; top: 147.09px; }
+  93.500% { left: 112.25px; top: 145.19px; }
+  94.000% { left: 110.14px; top: 143.49px; }
+  94.500% { left: 108.46px; top: 142.03px; }
+  95.000% { left: 107.12px; top: 140.78px; }
+  95.500% { left: 106.02px; top: 139.70px; }
+  96.000% { left: 105.10px; top: 138.76px; }
+  96.500% { left: 104.28px; top: 137.87px; }
+  97.000% { left: 103.47px; top: 136.98px; }
+  97.500% { left: 102.61px; top: 135.97px; }
+  98.000% { left: 101.58px; top: 134.72px; }
+  98.500% { left: 100.29px; top: 133.05px; }
+  99.000% { left: 98.61px; top: 130.69px; }
+  99.500% { left: 96.50px; top: 127.33px; }
+  100.000% { left: 94.14px; top: 122.90px; }
+}
+
+@keyframes b2A {
+  0.000% { left: 257.39px; top: 96.00px; }
+  0.500% { left: 257.45px; top: 96.52px; }
+  1.000% { left: 257.62px; top: 98.08px; }
+  1.500% { left: 257.90px; top: 100.68px; }
+  2.000% { left: 258.25px; top: 104.29px; }
+  2.500% { left: 258.64px; top: 108.91px; }
+  3.000% { left: 259.04px; top: 114.50px; }
+  3.500% { left: 259.39px; top: 121.03px; }
+  4.000% { left: 259.60px; top: 128.42px; }
+  4.500% { left: 259.55px; top: 136.57px; }
+  5.000% { left: 259.01px; top: 145.28px; }
+  5.500% { left: 257.53px; top: 154.20px; }
+  6.000% { left: 254.34px; top: 162.77px; }
+  6.500% { left: 248.51px; top: 170.47px; }
+  7.000% { left: 239.74px; top: 177.30px; }
+  7.500% { left: 228.57px; top: 183.71px; }
+  8.000% { left: 215.60px; top: 190.05px; }
+  8.500% { left: 201.19px; top: 196.44px; }
+  9.000% { left: 185.42px; top: 202.71px; }
+  9.500% { left: 168.27px; top: 208.47px; }
+  10.000% { left: 149.76px; top: 212.98px; }
+  10.500% { left: 130.13px; top: 215.08px; }
+  11.000% { left: 110.27px; top: 213.02px; }
+  11.500% { left: 92.20px; top: 205.18px; }
+  12.000% { left: 77.81px; top: 192.44px; }
+  12.500% { left: 67.21px; top: 177.39px; }
+  13.000% { left: 59.62px; top: 161.91px; }
+  13.500% { left: 54.27px; top: 146.96px; }
+  14.000% { left: 50.59px; top: 132.98px; }
+  14.500% { left: 48.11px; top: 120.19px; }
+  15.000% { left: 46.49px; top: 108.67px; }
+  15.500% { left: 45.48px; top: 98.40px; }
+  16.000% { left: 44.92px; top: 89.38px; }
+  16.500% { left: 44.68px; top: 81.56px; }
+  17.000% { left: 44.67px; top: 74.90px; }
+  17.500% { left: 44.85px; top: 69.37px; }
+  18.000% { left: 45.16px; top: 64.94px; }
+  18.500% { left: 45.56px; top: 61.57px; }
+  19.000% { left: 46.02px; top: 59.24px; }
+  19.500% { left: 46.53px; top: 57.93px; }
+  20.000% { left: 47.07px; top: 57.63px; }
+  20.500% { left: 47.64px; top: 58.33px; }
+  21.000% { left: 48.25px; top: 60.06px; }
+  21.500% { left: 48.92px; top: 62.82px; }
+  22.000% { left: 49.65px; top: 66.63px; }
+  22.500% { left: 50.47px; top: 71.51px; }
+  23.000% { left: 51.40px; top: 77.48px; }
+  23.500% { left: 52.45px; top: 84.56px; }
+  24.000% { left: 53.67px; top: 92.78px; }
+  24.500% { left: 55.12px; top: 102.17px; }
+  25.000% { left: 56.91px; top: 112.77px; }
+  25.500% { left: 59.23px; top: 124.65px; }
+  26.000% { left: 62.34px; top: 137.81px; }
+  26.500% { left: 66.64px; top: 152.21px; }
+  27.000% { left: 72.62px; top: 167.61px; }
+  27.500% { left: 80.85px; top: 183.51px; }
+  28.000% { left: 92.08px; top: 198.84px; }
+  28.500% { left: 107.16px; top: 211.35px; }
+  29.000% { left: 126.03px; top: 217.12px; }
+  29.500% { left: 145.98px; top: 214.99px; }
+  30.000% { left: 164.66px; top: 208.09px; }
+  30.500% { left: 181.49px; top: 199.01px; }
+  31.000% { left: 196.50px; top: 189.13px; }
+  31.500% { left: 209.93px; top: 179.26px; }
+  32.000% { left: 222.10px; top: 169.89px; }
+  32.500% { left: 233.27px; top: 161.26px; }
+  33.000% { left: 243.52px; top: 153.50px; }
+  33.500% { left: 252.76px; top: 146.64px; }
+  34.000% { left: 260.59px; top: 140.66px; }
+  34.500% { left: 266.30px; top: 135.40px; }
+  35.000% { left: 269.08px; top: 130.55px; }
+  35.500% { left: 268.93px; top: 125.80px; }
+  36.000% { left: 266.80px; top: 121.22px; }
+  36.500% { left: 263.67px; top: 117.11px; }
+  37.000% { left: 260.09px; top: 113.69px; }
+  37.500% { left: 256.29px; top: 111.10px; }
+  38.000% { left: 252.41px; top: 109.41px; }
+  38.500% { left: 248.49px; top: 108.66px; }
+  39.000% { left: 244.52px; top: 108.84px; }
+  39.500% { left: 240.50px; top: 109.94px; }
+  40.000% { left: 236.41px; top: 111.91px; }
+  40.500% { left: 232.21px; top: 114.71px; }
+  41.000% { left: 227.89px; top: 118.26px; }
+  41.500% { left: 223.43px; top: 122.50px; }
+  42.000% { left: 218.86px; top: 127.36px; }
+  42.500% { left: 214.19px; top: 132.81px; }
+  43.000% { left: 209.48px; top: 138.85px; }
+  43.500% { left: 204.76px; top: 145.55px; }
+  44.000% { left: 200.06px; top: 153.01px; }
+  44.500% { left: 195.38px; top: 161.36px; }
+  45.000% { left: 190.69px; top: 170.70px; }
+  45.500% { left: 186.00px; top: 181.03px; }
+  46.000% { left: 181.36px; top: 192.16px; }
+  46.500% { left: 176.93px; top: 203.57px; }
+  47.000% { left: 172.93px; top: 213.72px; }
+  47.500% { left: 169.11px; top: 218.51px; }
+  48.000% { left: 163.62px; top: 214.35px; }
+  48.500% { left: 156.05px; top: 205.63px; }
+  49.000% { left: 147.45px; top: 196.05px; }
+  49.500% { left: 138.46px; top: 186.86px; }
+  50.000% { left: 129.37px; top: 178.50px; }
+  50.500% { left: 120.23px; top: 171.05px; }
+  51.000% { left: 111.01px; top: 164.41px; }
+  51.500% { left: 101.66px; top: 158.36px; }
+  52.000% { left: 92.17px; top: 152.68px; }
+  52.500% { left: 82.64px; top: 147.19px; }
+  53.000% { left: 73.20px; top: 141.84px; }
+  53.500% { left: 63.98px; top: 136.63px; }
+  54.000% { left: 55.11px; top: 131.64px; }
+  54.500% { left: 46.72px; top: 126.92px; }
+  55.000% { left: 39.02px; top: 122.47px; }
+  55.500% { left: 32.44px; top: 118.18px; }
+  56.000% { left: 27.96px; top: 113.89px; }
+  56.500% { left: 27.16px; top: 109.70px; }
+  57.000% { left: 30.58px; top: 106.33px; }
+  57.500% { left: 36.96px; top: 104.38px; }
+  58.000% { left: 44.97px; top: 103.97px; }
+  58.500% { left: 53.84px; top: 104.95px; }
+  59.000% { left: 63.11px; top: 107.16px; }
+  59.500% { left: 72.46px; top: 110.41px; }
+  60.000% { left: 81.64px; top: 114.49px; }
+  60.500% { left: 90.47px; top: 119.24px; }
+  61.000% { left: 98.80px; top: 124.59px; }
+  61.500% { left: 106.65px; top: 130.60px; }
+  62.000% { left: 114.29px; top: 137.48px; }
+  62.500% { left: 122.29px; top: 145.40px; }
+  63.000% { left: 131.34px; top: 154.30px; }
+  63.500% { left: 142.02px; top: 163.81px; }
+  64.000% { left: 154.51px; top: 173.36px; }
+  64.500% { left: 168.65px; top: 182.41px; }
+  65.000% { left: 184.04px; top: 190.41px; }
+  65.500% { left: 200.21px; top: 196.51px; }
+  66.000% { left: 216.01px; top: 198.51px; }
+  66.500% { left: 227.24px; top: 191.67px; }
+  67.000% { left: 230.07px; top: 177.21px; }
+  67.500% { left: 227.56px; top: 161.21px; }
+  68.000% { left: 222.09px; top: 145.84px; }
+  68.500% { left: 214.63px; top: 131.79px; }
+  69.000% { left: 205.59px; top: 119.41px; }
+  69.500% { left: 195.21px; top: 109.07px; }
+  70.000% { left: 183.67px; top: 101.17px; }
+  70.500% { left: 171.23px; top: 96.25px; }
+  71.000% { left: 158.34px; top: 94.84px; }
+  71.500% { left: 145.67px; top: 97.30px; }
+  72.000% { left: 133.95px; top: 103.57px; }
+  72.500% { left: 123.73px; top: 113.10px; }
+  73.000% { left: 115.21px; top: 125.18px; }
+  73.500% { left: 108.36px; top: 139.16px; }
+  74.000% { left: 103.15px; top: 154.56px; }
+  74.500% { left: 99.67px; top: 170.97px; }
+  75.000% { left: 98.35px; top: 187.81px; }
+  75.500% { left: 100.39px; top: 203.58px; }
+  76.000% { left: 108.39px; top: 212.72px; }
+  76.500% { left: 121.08px; top: 208.62px; }
+  77.000% { left: 133.48px; top: 197.54px; }
+  77.500% { left: 144.52px; top: 184.21px; }
+  78.000% { left: 154.03px; top: 170.05px; }
+  78.500% { left: 161.69px; top: 155.63px; }
+  79.000% { left: 167.05px; top: 141.45px; }
+  79.500% { left: 169.72px; top: 128.13px; }
+  80.000% { left: 169.61px; top: 116.48px; }
+  80.500% { left: 167.14px; top: 107.19px; }
+  81.000% { left: 163.01px; top: 100.62px; }
+  81.500% { left: 158.00px; top: 96.81px; }
+  82.000% { left: 152.70px; top: 95.62px; }
+  82.500% { left: 147.59px; top: 96.96px; }
+  83.000% { left: 143.16px; top: 100.84px; }
+  83.500% { left: 140.03px; top: 107.28px; }
+  84.000% { left: 138.96px; top: 116.07px; }
+  84.500% { left: 140.55px; top: 126.70px; }
+  85.000% { left: 144.99px; top: 138.42px; }
+  85.500% { left: 151.99px; top: 150.51px; }
+  86.000% { left: 160.98px; top: 162.54px; }
+  86.500% { left: 171.39px; top: 174.27px; }
+  87.000% { left: 182.80px; top: 185.45px; }
+  87.500% { left: 194.94px; top: 195.46px; }
+  88.000% { left: 207.17px; top: 202.25px; }
+  88.500% { left: 216.13px; top: 200.13px; }
+  89.000% { left: 217.15px; top: 188.27px; }
+  89.500% { left: 213.05px; top: 173.88px; }
+  90.000% { left: 206.49px; top: 159.71px; }
+  90.500% { left: 198.57px; top: 146.45px; }
+  91.000% { left: 189.81px; top: 134.29px; }
+  91.500% { left: 180.54px; top: 123.27px; }
+  92.000% { left: 170.97px; top: 113.39px; }
+  92.500% { left: 161.22px; top: 104.62px; }
+  93.000% { left: 151.34px; top: 96.95px; }
+  93.500% { left: 141.34px; top: 90.43px; }
+  94.000% { left: 131.19px; top: 85.17px; }
+  94.500% { left: 120.90px; top: 81.29px; }
+  95.000% { left: 110.50px; top: 78.87px; }
+  95.500% { left: 100.08px; top: 77.99px; }
+  96.000% { left: 89.72px; top: 78.69px; }
+  96.500% { left: 79.53px; top: 81.03px; }
+  97.000% { left: 69.64px; top: 85.02px; }
+  97.500% { left: 60.23px; top: 90.72px; }
+  98.000% { left: 51.53px; top: 98.13px; }
+  98.500% { left: 43.89px; top: 107.28px; }
+  99.000% { left: 37.90px; top: 118.13px; }
+  99.500% { left: 34.58px; top: 130.44px; }
+  100.000% { left: 35.63px; top: 143.41px; }
+}
+
+@keyframes r1B {
+  0.000% { left: 150.00px; top: 96.00px; transform: rotate(-30.00deg); }
+  0.500% { left: 150.00px; top: 96.00px; transform: rotate(-29.67deg); }
+  1.000% { left: 150.00px; top: 96.00px; transform: rotate(-28.66deg); }
+  1.500% { left: 150.00px; top: 96.00px; transform: rotate(-26.95deg); }
+  2.000% { left: 150.00px; top: 96.00px; transform: rotate(-24.51deg); }
+  2.500% { left: 150.00px; top: 96.00px; transform: rotate(-21.30deg); }
+  3.000% { left: 150.00px; top: 96.00px; transform: rotate(-17.25deg); }
+  3.500% { left: 150.00px; top: 96.00px; transform: rotate(-12.30deg); }
+  4.000% { left: 150.00px; top: 96.00px; transform: rotate(-6.34deg); }
+  4.500% { left: 150.00px; top: 96.00px; transform: rotate(0.73deg); }
+  5.000% { left: 150.00px; top: 96.00px; transform: rotate(9.06deg); }
+  5.500% { left: 150.00px; top: 96.00px; transform: rotate(18.83deg); }
+  6.000% { left: 150.00px; top: 96.00px; transform: rotate(30.05deg); }
+  6.500% { left: 150.00px; top: 96.00px; transform: rotate(42.26deg); }
+  7.000% { left: 150.00px; top: 96.00px; transform: rotate(54.59deg); }
+  7.500% { left: 150.00px; top: 96.00px; transform: rotate(66.39deg); }
+  8.000% { left: 150.00px; top: 96.00px; transform: rotate(77.45deg); }
+  8.500% { left: 150.00px; top: 96.00px; transform: rotate(87.58deg); }
+  9.000% { left: 150.00px; top: 96.00px; transform: rotate(96.54deg); }
+  9.500% { left: 150.00px; top: 96.00px; transform: rotate(103.97deg); }
+  10.000% { left: 150.00px; top: 96.00px; transform: rotate(109.45deg); }
+  10.500% { left: 150.00px; top: 96.00px; transform: rotate(112.62deg); }
+  11.000% { left: 150.00px; top: 96.00px; transform: rotate(113.43deg); }
+  11.500% { left: 150.00px; top: 96.00px; transform: rotate(112.92deg); }
+  12.000% { left: 150.00px; top: 96.00px; transform: rotate(113.08deg); }
+  12.500% { left: 150.00px; top: 96.00px; transform: rotate(114.91deg); }
+  13.000% { left: 150.00px; top: 96.00px; transform: rotate(118.34deg); }
+  13.500% { left: 150.00px; top: 96.00px; transform: rotate(122.98deg); }
+  14.000% { left: 150.00px; top: 96.00px; transform: rotate(128.42deg); }
+  14.500% { left: 150.00px; top: 96.00px; transform: rotate(134.30deg); }
+  15.000% { left: 150.00px; top: 96.00px; transform: rotate(140.31deg); }
+  15.500% { left: 150.00px; top: 96.00px; transform: rotate(146.20deg); }
+  16.000% { left: 150.00px; top: 96.00px; transform: rotate(151.77deg); }
+  16.500% { left: 150.00px; top: 96.00px; transform: rotate(156.88deg); }
+  17.000% { left: 150.00px; top: 96.00px; transform: rotate(161.42deg); }
+  17.500% { left: 150.00px; top: 96.00px; transform: rotate(165.29deg); }
+  18.000% { left: 150.00px; top: 96.00px; transform: rotate(168.44deg); }
+  18.500% { left: 150.00px; top: 96.00px; transform: rotate(170.80deg); }
+  19.000% { left: 150.00px; top: 96.00px; transform: rotate(172.35deg); }
+  19.500% { left: 150.00px; top: 96.00px; transform: rotate(173.05deg); }
+  20.000% { left: 150.00px; top: 96.00px; transform: rotate(172.90deg); }
+  20.500% { left: 150.00px; top: 96.00px; transform: rotate(171.89deg); }
+  21.000% { left: 150.00px; top: 96.00px; transform: rotate(170.03deg); }
+  21.500% { left: 150.00px; top: 96.00px; transform: rotate(167.36deg); }
+  22.000% { left: 150.00px; top: 96.00px; transform: rotate(163.89deg); }
+  22.500% { left: 150.00px; top: 96.00px; transform: rotate(159.67deg); }
+  23.000% { left: 150.00px; top: 96.00px; transform: rotate(154.75deg); }
+  23.500% { left: 150.00px; top: 96.00px; transform: rotate(149.18deg); }
+  24.000% { left: 150.00px; top: 96.00px; transform: rotate(143.04deg); }
+  24.500% { left: 150.00px; top: 96.00px; transform: rotate(136.47deg); }
+  25.000% { left: 150.00px; top: 96.00px; transform: rotate(129.63deg); }
+  25.500% { left: 150.00px; top: 96.00px; transform: rotate(122.76deg); }
+  26.000% { left: 150.00px; top: 96.00px; transform: rotate(116.20deg); }
+  26.500% { left: 150.00px; top: 96.00px; transform: rotate(110.33deg); }
+  27.000% { left: 150.00px; top: 96.00px; transform: rotate(105.62deg); }
+  27.500% { left: 150.00px; top: 96.00px; transform: rotate(102.56deg); }
+  28.000% { left: 150.00px; top: 96.00px; transform: rotate(101.70deg); }
+  28.500% { left: 150.00px; top: 96.00px; transform: rotate(103.42deg); }
+  29.000% { left: 150.00px; top: 96.00px; transform: rotate(106.62deg); }
+  29.500% { left: 150.00px; top: 96.00px; transform: rotate(108.21deg); }
+  30.000% { left: 150.00px; top: 96.00px; transform: rotate(106.79deg); }
+  30.500% { left: 150.00px; top: 96.00px; transform: rotate(102.64deg); }
+  31.000% { left: 150.00px; top: 96.00px; transform: rotate(96.29deg); }
+  31.500% { left: 150.00px; top: 96.00px; transform: rotate(88.30deg); }
+  32.000% { left: 150.00px; top: 96.00px; transform: rotate(79.18deg); }
+  32.500% { left: 150.00px; top: 96.00px; transform: rotate(69.35deg); }
+  33.000% { left: 150.00px; top: 96.00px; transform: rotate(59.09deg); }
+  33.500% { left: 150.00px; top: 96.00px; transform: rotate(48.50deg); }
+  34.000% { left: 150.00px; top: 96.00px; transform: rotate(37.59deg); }
+  34.500% { left: 150.00px; top: 96.00px; transform: rotate(26.40deg); }
+  35.000% { left: 150.00px; top: 96.00px; transform: rotate(15.32deg); }
+  35.500% { left: 150.00px; top: 96.00px; transform: rotate(5.16deg); }
+  36.000% { left: 150.00px; top: 96.00px; transform: rotate(-3.56deg); }
+  36.500% { left: 150.00px; top: 96.00px; transform: rotate(-10.88deg); }
+  37.000% { left: 150.00px; top: 96.00px; transform: rotate(-17.01deg); }
+  37.500% { left: 150.00px; top: 96.00px; transform: rotate(-22.10deg); }
+  38.000% { left: 150.00px; top: 96.00px; transform: rotate(-26.28deg); }
+  38.500% { left: 150.00px; top: 96.00px; transform: rotate(-29.61deg); }
+  39.000% { left: 150.00px; top: 96.00px; transform: rotate(-32.11deg); }
+  39.500% { left: 150.00px; top: 96.00px; transform: rotate(-33.77deg); }
+  40.000% { left: 150.00px; top: 96.00px; transform: rotate(-34.58deg); }
+  40.500% { left: 150.00px; top: 96.00px; transform: rotate(-34.48deg); }
+  41.000% { left: 150.00px; top: 96.00px; transform: rotate(-33.42deg); }
+  41.500% { left: 150.00px; top: 96.00px; transform: rotate(-31.32deg); }
+  42.000% { left: 150.00px; top: 96.00px; transform: rotate(-28.12deg); }
+  42.500% { left: 150.00px; top: 96.00px; transform: rotate(-23.77deg); }
+  43.000% { left: 150.00px; top: 96.00px; transform: rotate(-18.27deg); }
+  43.500% { left: 150.00px; top: 96.00px; transform: rotate(-11.63deg); }
+  44.000% { left: 150.00px; top: 96.00px; transform: rotate(-3.92deg); }
+  44.500% { left: 150.00px; top: 96.00px; transform: rotate(4.75deg); }
+  45.000% { left: 150.00px; top: 96.00px; transform: rotate(14.31deg); }
+  45.500% { left: 150.00px; top: 96.00px; transform: rotate(24.73deg); }
+  46.000% { left: 150.00px; top: 96.00px; transform: rotate(36.11deg); }
+  46.500% { left: 150.00px; top: 96.00px; transform: rotate(48.84deg); }
+  47.000% { left: 150.00px; top: 96.00px; transform: rotate(63.68deg); }
+  47.500% { left: 150.00px; top: 96.00px; transform: rotate(81.32deg); }
+  48.000% { left: 150.00px; top: 96.00px; transform: rotate(98.96deg); }
+  48.500% { left: 150.00px; top: 96.00px; transform: rotate(113.99deg); }
+  49.000% { left: 150.00px; top: 96.00px; transform: rotate(127.14deg); }
+  49.500% { left: 150.00px; top: 96.00px; transform: rotate(139.14deg); }
+  50.000% { left: 150.00px; top: 96.00px; transform: rotate(150.28deg); }
+  50.500% { left: 150.00px; top: 96.00px; transform: rotate(160.57deg); }
+  51.000% { left: 150.00px; top: 96.00px; transform: rotate(169.84deg); }
+  51.500% { left: 150.00px; top: 96.00px; transform: rotate(177.86deg); }
+  52.000% { left: 150.00px; top: 96.00px; transform: rotate(-175.60deg); }
+  52.500% { left: 150.00px; top: 96.00px; transform: rotate(-170.67deg); }
+  53.000% { left: 150.00px; top: 96.00px; transform: rotate(-167.42deg); }
+  53.500% { left: 150.00px; top: 96.00px; transform: rotate(-165.85deg); }
+  54.000% { left: 150.00px; top: 96.00px; transform: rotate(-165.93deg); }
+  54.500% { left: 150.00px; top: 96.00px; transform: rotate(-167.64deg); }
+  55.000% { left: 150.00px; top: 96.00px; transform: rotate(-171.03deg); }
+  55.500% { left: 150.00px; top: 96.00px; transform: rotate(-176.25deg); }
+  56.000% { left: 150.00px; top: 96.00px; transform: rotate(176.61deg); }
+  56.500% { left: 150.00px; top: 96.00px; transform: rotate(168.02deg); }
+  57.000% { left: 150.00px; top: 96.00px; transform: rotate(159.27deg); }
+  57.500% { left: 150.00px; top: 96.00px; transform: rotate(150.99deg); }
+  58.000% { left: 150.00px; top: 96.00px; transform: rotate(143.04deg); }
+  58.500% { left: 150.00px; top: 96.00px; transform: rotate(135.13deg); }
+  59.000% { left: 150.00px; top: 96.00px; transform: rotate(126.96deg); }
+  59.500% { left: 150.00px; top: 96.00px; transform: rotate(118.33deg); }
+  60.000% { left: 150.00px; top: 96.00px; transform: rotate(109.05deg); }
+  60.500% { left: 150.00px; top: 96.00px; transform: rotate(99.04deg); }
+  61.000% { left: 150.00px; top: 96.00px; transform: rotate(88.35deg); }
+  61.500% { left: 150.00px; top: 96.00px; transform: rotate(77.22deg); }
+  62.000% { left: 150.00px; top: 96.00px; transform: rotate(66.07deg); }
+  62.500% { left: 150.00px; top: 96.00px; transform: rotate(55.52deg); }
+  63.000% { left: 150.00px; top: 96.00px; transform: rotate(46.23deg); }
+  63.500% { left: 150.00px; top: 96.00px; transform: rotate(38.86deg); }
+  64.000% { left: 150.00px; top: 96.00px; transform: rotate(33.89deg); }
+  64.500% { left: 150.00px; top: 96.00px; transform: rotate(31.62deg); }
+  65.000% { left: 150.00px; top: 96.00px; transform: rotate(32.26deg); }
+  65.500% { left: 150.00px; top: 96.00px; transform: rotate(36.12deg); }
+  66.000% { left: 150.00px; top: 96.00px; transform: rotate(43.89deg); }
+  66.500% { left: 150.00px; top: 96.00px; transform: rotate(55.57deg); }
+  67.000% { left: 150.00px; top: 96.00px; transform: rotate(66.31deg); }
+  67.500% { left: 150.00px; top: 96.00px; transform: rotate(73.74deg); }
+  68.000% { left: 150.00px; top: 96.00px; transform: rotate(78.76deg); }
+  68.500% { left: 150.00px; top: 96.00px; transform: rotate(82.07deg); }
+  69.000% { left: 150.00px; top: 96.00px; transform: rotate(84.01deg); }
+  69.500% { left: 150.00px; top: 96.00px; transform: rotate(84.75deg); }
+  70.000% { left: 150.00px; top: 96.00px; transform: rotate(84.41deg); }
+  70.500% { left: 150.00px; top: 96.00px; transform: rotate(83.15deg); }
+  71.000% { left: 150.00px; top: 96.00px; transform: rotate(81.24deg); }
+  71.500% { left: 150.00px; top: 96.00px; transform: rotate(79.10deg); }
+  72.000% { left: 150.00px; top: 96.00px; transform: rotate(77.30deg); }
+  72.500% { left: 150.00px; top: 96.00px; transform: rotate(76.34deg); }
+  73.000% { left: 150.00px; top: 96.00px; transform: rotate(76.55deg); }
+  73.500% { left: 150.00px; top: 96.00px; transform: rotate(78.09deg); }
+  74.000% { left: 150.00px; top: 96.00px; transform: rotate(81.07deg); }
+  74.500% { left: 150.00px; top: 96.00px; transform: rotate(85.67deg); }
+  75.000% { left: 150.00px; top: 96.00px; transform: rotate(92.28deg); }
+  75.500% { left: 150.00px; top: 96.00px; transform: rotate(101.82deg); }
+  76.000% { left: 150.00px; top: 96.00px; transform: rotate(115.26deg); }
+  76.500% { left: 150.00px; top: 96.00px; transform: rotate(128.31deg); }
+  77.000% { left: 150.00px; top: 96.00px; transform: rotate(136.79deg); }
+  77.500% { left: 150.00px; top: 96.00px; transform: rotate(141.61deg); }
+  78.000% { left: 150.00px; top: 96.00px; transform: rotate(143.47deg); }
+  78.500% { left: 150.00px; top: 96.00px; transform: rotate(142.59deg); }
+  79.000% { left: 150.00px; top: 96.00px; transform: rotate(139.06deg); }
+  79.500% { left: 150.00px; top: 96.00px; transform: rotate(133.01deg); }
+  80.000% { left: 150.00px; top: 96.00px; transform: rotate(124.81deg); }
+  80.500% { left: 150.00px; top: 96.00px; transform: rotate(114.95deg); }
+  81.000% { left: 150.00px; top: 96.00px; transform: rotate(103.98deg); }
+  81.500% { left: 150.00px; top: 96.00px; transform: rotate(92.42deg); }
+  82.000% { left: 150.00px; top: 96.00px; transform: rotate(80.67deg); }
+  82.500% { left: 150.00px; top: 96.00px; transform: rotate(69.03deg); }
+  83.000% { left: 150.00px; top: 96.00px; transform: rotate(57.74deg); }
+  83.500% { left: 150.00px; top: 96.00px; transform: rotate(46.97deg); }
+  84.000% { left: 150.00px; top: 96.00px; transform: rotate(36.84deg); }
+  84.500% { left: 150.00px; top: 96.00px; transform: rotate(27.43deg); }
+  85.000% { left: 150.00px; top: 96.00px; transform: rotate(18.77deg); }
+  85.500% { left: 150.00px; top: 96.00px; transform: rotate(10.92deg); }
+  86.000% { left: 150.00px; top: 96.00px; transform: rotate(3.91deg); }
+  86.500% { left: 150.00px; top: 96.00px; transform: rotate(-2.18deg); }
+  87.000% { left: 150.00px; top: 96.00px; transform: rotate(-7.22deg); }
+  87.500% { left: 150.00px; top: 96.00px; transform: rotate(-11.05deg); }
+  88.000% { left: 150.00px; top: 96.00px; transform: rotate(-13.50deg); }
+  88.500% { left: 150.00px; top: 96.00px; transform: rotate(-14.46deg); }
+  89.000% { left: 150.00px; top: 96.00px; transform: rotate(-13.89deg); }
+  89.500% { left: 150.00px; top: 96.00px; transform: rotate(-11.83deg); }
+  90.000% { left: 150.00px; top: 96.00px; transform: rotate(-8.36deg); }
+  90.500% { left: 150.00px; top: 96.00px; transform: rotate(-3.54deg); }
+  91.000% { left: 150.00px; top: 96.00px; transform: rotate(2.66deg); }
+  91.500% { left: 150.00px; top: 96.00px; transform: rotate(10.39deg); }
+  92.000% { left: 150.00px; top: 96.00px; transform: rotate(20.04deg); }
+  92.500% { left: 150.00px; top: 96.00px; transform: rotate(32.47deg); }
+  93.000% { left: 150.00px; top: 96.00px; transform: rotate(48.11deg); }
+  93.500% { left: 150.00px; top: 96.00px; transform: rotate(63.50deg); }
+  94.000% { left: 150.00px; top: 96.00px; transform: rotate(76.54deg); }
+  94.500% { left: 150.00px; top: 96.00px; transform: rotate(88.20deg); }
+  95.000% { left: 150.00px; top: 96.00px; transform: rotate(99.32deg); }
+  95.500% { left: 150.00px; top: 96.00px; transform: rotate(110.39deg); }
+  96.000% { left: 150.00px; top: 96.00px; transform: rotate(121.63deg); }
+  96.500% { left: 150.00px; top: 96.00px; transform: rotate(133.00deg); }
+  97.000% { left: 150.00px; top: 96.00px; transform: rotate(144.28deg); }
+  97.500% { left: 150.00px; top: 96.00px; transform: rotate(155.04deg); }
+  98.000% { left: 150.00px; top: 96.00px; transform: rotate(164.80deg); }
+  98.500% { left: 150.00px; top: 96.00px; transform: rotate(173.09deg); }
+  99.000% { left: 150.00px; top: 96.00px; transform: rotate(179.55deg); }
+  99.500% { left: 150.00px; top: 96.00px; transform: rotate(-176.03deg); }
+  100.000% { left: 150.00px; top: 96.00px; transform: rotate(-173.73deg); }
+}
+
+@keyframes r2B {
+  0.000% { left: 203.69px; top: 65.00px; transform: rotate(29.94deg); }
+  0.500% { left: 203.87px; top: 65.31px; transform: rotate(30.16deg); }
+  1.000% { left: 204.41px; top: 66.27px; transform: rotate(30.82deg); }
+  1.500% { left: 205.27px; top: 67.90px; transform: rotate(31.86deg); }
+  2.000% { left: 206.41px; top: 70.28px; transform: rotate(33.22deg); }
+  2.500% { left: 207.76px; top: 73.48px; transform: rotate(34.79deg); }
+  3.000% { left: 209.21px; top: 77.61px; transform: rotate(36.45deg); }
+  3.500% { left: 210.58px; top: 82.80px; transform: rotate(38.01deg); }
+  4.000% { left: 211.62px; top: 89.15px; transform: rotate(39.24deg); }
+  4.500% { left: 212.00px; top: 96.79px; transform: rotate(39.86deg); }
+  5.000% { left: 211.23px; top: 105.77px; transform: rotate(39.53deg); }
+  5.500% { left: 208.68px; top: 116.01px; transform: rotate(37.97deg); }
+  6.000% { left: 203.67px; top: 127.04px; transform: rotate(35.13deg); }
+  6.500% { left: 195.88px; top: 137.70px; transform: rotate(31.86deg); }
+  7.000% { left: 185.92px; top: 146.53px; transform: rotate(29.71deg); }
+  7.500% { left: 174.83px; top: 152.81px; transform: rotate(29.86deg); }
+  8.000% { left: 163.48px; top: 156.52px; transform: rotate(32.73deg); }
+  8.500% { left: 152.62px; top: 157.94px; transform: rotate(38.38deg); }
+  9.000% { left: 142.93px; top: 157.60px; transform: rotate(46.71deg); }
+  9.500% { left: 135.03px; top: 156.17px; transform: rotate(57.55deg); }
+  10.000% { left: 129.35px; top: 154.46px; transform: rotate(70.77deg); }
+  10.500% { left: 126.15px; top: 153.23px; transform: rotate(86.31deg); }
+  11.000% { left: 125.35px; top: 152.89px; transform: rotate(104.06deg); }
+  11.500% { left: 125.86px; top: 153.11px; transform: rotate(122.87deg); }
+  12.000% { left: 125.70px; top: 153.04px; transform: rotate(140.55deg); }
+  12.500% { left: 123.88px; top: 152.23px; transform: rotate(156.06deg); }
+  13.000% { left: 120.57px; top: 150.57px; transform: rotate(169.46deg); }
+  13.500% { left: 116.25px; top: 148.01px; transform: rotate(-179.03deg); }
+  14.000% { left: 111.47px; top: 144.58px; transform: rotate(-169.23deg); }
+  14.500% { left: 106.70px; top: 140.37px; transform: rotate(-161.01deg); }
+  15.000% { left: 102.29px; top: 135.60px; transform: rotate(-154.27deg); }
+  15.500% { left: 98.48px; top: 130.49px; transform: rotate(-148.85deg); }
+  16.000% { left: 95.37px; top: 125.32px; transform: rotate(-144.59deg); }
+  16.500% { left: 92.98px; top: 120.34px; transform: rotate(-141.30deg); }
+  17.000% { left: 91.23px; top: 115.76px; transform: rotate(-138.81deg); }
+  17.500% { left: 90.03px; top: 111.74px; transform: rotate(-136.93deg); }
+  18.000% { left: 89.26px; top: 108.43px; transform: rotate(-135.50deg); }
+  18.500% { left: 88.80px; top: 105.91px; transform: rotate(-134.38deg); }
+  19.000% { left: 88.55px; top: 104.25px; transform: rotate(-133.49deg); }
+  19.500% { left: 88.46px; top: 103.50px; transform: rotate(-132.73deg); }
+  20.000% { left: 88.48px; top: 103.67px; transform: rotate(-132.09deg); }
+  20.500% { left: 88.62px; top: 104.75px; transform: rotate(-131.57deg); }
+  21.000% { left: 88.94px; top: 106.73px; transform: rotate(-131.22deg); }
+  21.500% { left: 89.50px; top: 109.57px; transform: rotate(-131.11deg); }
+  22.000% { left: 90.43px; top: 113.20px; transform: rotate(-131.36deg); }
+  22.500% { left: 91.86px; top: 117.54px; transform: rotate(-132.12deg); }
+  23.000% { left: 93.93px; top: 122.45px; transform: rotate(-133.56deg); }
+  23.500% { left: 96.76px; top: 127.77px; transform: rotate(-135.88deg); }
+  24.000% { left: 100.46px; top: 133.28px; transform: rotate(-139.28deg); }
+  24.500% { left: 105.05px; top: 138.70px; transform: rotate(-143.96deg); }
+  25.000% { left: 110.46px; top: 143.75px; transform: rotate(-150.09deg); }
+  25.500% { left: 116.45px; top: 148.14px; transform: rotate(-157.81deg); }
+  26.000% { left: 122.63px; top: 151.63px; transform: rotate(-167.20deg); }
+  26.500% { left: 128.46px; top: 154.14px; transform: rotate(-178.29deg); }
+  27.000% { left: 133.31px; top: 155.71px; transform: rotate(168.86deg); }
+  27.500% { left: 136.52px; top: 156.52px; transform: rotate(154.12deg); }
+  28.000% { left: 137.42px; top: 156.71px; transform: rotate(137.12deg); }
+  28.500% { left: 135.61px; top: 156.31px; transform: rotate(117.36deg); }
+  29.000% { left: 132.27px; top: 155.41px; transform: rotate(95.79deg); }
+  29.500% { left: 130.63px; top: 154.89px; transform: rotate(75.67deg); }
+  30.000% { left: 132.09px; top: 155.36px; transform: rotate(58.31deg); }
+  30.500% { left: 136.44px; top: 156.50px; transform: rotate(43.37deg); }
+  31.000% { left: 143.21px; top: 157.63px; transform: rotate(30.66deg); }
+  31.500% { left: 151.84px; top: 157.97px; transform: rotate(20.25deg); }
+  32.000% { left: 161.64px; top: 156.90px; transform: rotate(12.30deg); }
+  32.500% { left: 171.86px; top: 154.02px; transform: rotate(6.95deg); }
+  33.000% { left: 181.85px; top: 149.19px; transform: rotate(4.26deg); }
+  33.500% { left: 191.08px; top: 142.43px; transform: rotate(4.20deg); }
+  34.000% { left: 199.13px; top: 133.82px; transform: rotate(6.65deg); }
+  34.500% { left: 205.53px; top: 123.57px; transform: rotate(11.32deg); }
+  35.000% { left: 209.80px; top: 112.38px; transform: rotate(17.31deg); }
+  35.500% { left: 211.75px; top: 101.58px; transform: rotate(23.20deg); }
+  36.000% { left: 211.88px; top: 92.15px; transform: rotate(28.10deg); }
+  36.500% { left: 210.89px; top: 84.30px; transform: rotate(32.03deg); }
+  37.000% { left: 209.29px; top: 77.87px; transform: rotate(35.31deg); }
+  37.500% { left: 207.44px; top: 72.67px; transform: rotate(38.27deg); }
+  38.000% { left: 205.59px; top: 68.55px; transform: rotate(41.15deg); }
+  38.500% { left: 203.90px; top: 65.37px; transform: rotate(44.15deg); }
+  39.000% { left: 202.52px; top: 63.05px; transform: rotate(47.42deg); }
+  39.500% { left: 201.54px; top: 61.53px; transform: rotate(51.07deg); }
+  40.000% { left: 201.05px; top: 60.81px; transform: rotate(55.18deg); }
+  40.500% { left: 201.11px; top: 60.90px; transform: rotate(59.79deg); }
+  41.000% { left: 201.75px; top: 61.85px; transform: rotate(64.92deg); }
+  41.500% { left: 202.97px; top: 63.77px; transform: rotate(70.54deg); }
+  42.000% { left: 204.68px; top: 66.78px; transform: rotate(76.55deg); }
+  42.500% { left: 206.74px; top: 71.01px; transform: rotate(82.82deg); }
+  43.000% { left: 208.88px; top: 76.57px; transform: rotate(89.12deg); }
+  43.500% { left: 210.73px; top: 83.51px; transform: rotate(95.16deg); }
+  44.000% { left: 211.85px; top: 91.76px; transform: rotate(100.55deg); }
+  44.500% { left: 211.79px; top: 101.14px; transform: rotate(104.88deg); }
+  45.000% { left: 210.08px; top: 111.33px; transform: rotate(107.70deg); }
+  45.500% { left: 206.31px; top: 121.94px; transform: rotate(108.56deg); }
+  46.000% { left: 200.09px; top: 132.54px; transform: rotate(106.98deg); }
+  46.500% { left: 190.81px; top: 142.67px; transform: rotate(102.31deg); }
+  47.000% { left: 177.49px; top: 151.57px; transform: rotate(93.58deg); }
+  47.500% { left: 159.36px; top: 157.29px; transform: rotate(80.31deg); }
+  48.000% { left: 140.35px; top: 157.24px; transform: rotate(67.28deg); }
+  48.500% { left: 124.79px; top: 152.64px; transform: rotate(59.04deg); }
+  49.000% { left: 112.57px; top: 145.42px; transform: rotate(55.13deg); }
+  49.500% { left: 103.11px; top: 136.56px; transform: rotate(54.69deg); }
+  50.000% { left: 96.15px; top: 126.73px; transform: rotate(57.17deg); }
+  50.500% { left: 91.53px; top: 116.62px; transform: rotate(62.10deg); }
+  51.000% { left: 88.97px; top: 106.93px; transform: rotate(68.96deg); }
+  51.500% { left: 88.04px; top: 98.32px; transform: rotate(77.20deg); }
+  52.000% { left: 88.18px; top: 91.24px; transform: rotate(86.29deg); }
+  52.500% { left: 88.82px; top: 85.95px; transform: rotate(95.80deg); }
+  53.000% { left: 89.49px; top: 82.50px; transform: rotate(105.41deg); }
+  53.500% { left: 89.88px; top: 80.85px; transform: rotate(114.98deg); }
+  54.000% { left: 89.86px; top: 80.93px; transform: rotate(124.50deg); }
+  54.500% { left: 89.44px; top: 82.73px; transform: rotate(134.10deg); }
+  55.000% { left: 88.76px; top: 86.34px; transform: rotate(144.07deg); }
+  55.500% { left: 88.13px; top: 91.94px; transform: rotate(154.83deg); }
+  56.000% { left: 88.11px; top: 99.67px; transform: rotate(166.76deg); }
+  56.500% { left: 89.35px; top: 108.87px; transform: rotate(179.37deg); }
+  57.000% { left: 92.01px; top: 117.95px; transform: rotate(-168.99deg); }
+  57.500% { left: 95.78px; top: 126.07px; transform: rotate(-159.29deg); }
+  58.000% { left: 100.46px; top: 133.28px; transform: rotate(-151.51deg); }
+  58.500% { left: 106.06px; top: 139.74px; transform: rotate(-145.53deg); }
+  59.000% { left: 112.72px; top: 145.54px; transform: rotate(-141.36deg); }
+  59.500% { left: 120.58px; top: 150.57px; transform: rotate(-139.13deg); }
+  60.000% { left: 129.76px; top: 154.60px; transform: rotate(-139.09deg); }
+  60.500% { left: 140.26px; top: 157.23px; transform: rotate(-141.50deg); }
+  61.000% { left: 151.78px; top: 157.97px; transform: rotate(-146.58deg); }
+  61.500% { left: 163.72px; top: 156.46px; transform: rotate(-154.37deg); }
+  62.000% { left: 175.14px; top: 152.67px; transform: rotate(-164.69deg); }
+  62.500% { left: 185.10px; top: 147.11px; transform: rotate(-177.12deg); }
+  63.000% { left: 192.89px; top: 140.77px; transform: rotate(168.93deg); }
+  63.500% { left: 198.28px; top: 134.90px; transform: rotate(154.08deg); }
+  64.000% { left: 201.47px; top: 130.57px; transform: rotate(138.81deg); }
+  64.500% { left: 202.79px; top: 128.51px; transform: rotate(123.31deg); }
+  65.000% { left: 202.43px; top: 129.10px; transform: rotate(107.34deg); }
+  65.500% { left: 200.08px; top: 132.55px; transform: rotate(90.14deg); }
+  66.000% { left: 194.68px; top: 138.99px; transform: rotate(70.14deg); }
+  66.500% { left: 185.05px; top: 147.14px; transform: rotate(46.44deg); }
+  67.000% { left: 174.91px; top: 152.78px; transform: rotate(24.51deg); }
+  67.500% { left: 167.36px; top: 155.52px; transform: rotate(6.73deg); }
+  68.000% { left: 162.08px; top: 156.81px; transform: rotate(-8.57deg); }
+  68.500% { left: 158.55px; top: 157.41px; transform: rotate(-22.57deg); }
+  69.000% { left: 156.47px; top: 157.66px; transform: rotate(-35.96deg); }
+  69.500% { left: 155.68px; top: 157.74px; transform: rotate(-49.17deg); }
+  70.000% { left: 156.04px; top: 157.71px; transform: rotate(-62.54deg); }
+  70.500% { left: 157.39px; top: 157.56px; transform: rotate(-76.25deg); }
+  71.000% { left: 159.45px; top: 157.28px; transform: rotate(-90.34deg); }
+  71.500% { left: 161.73px; top: 156.88px; transform: rotate(-104.65deg); }
+  72.000% { left: 163.63px; top: 156.48px; transform: rotate(-118.85deg); }
+  72.500% { left: 164.65px; top: 156.25px; transform: rotate(-132.69deg); }
+  73.000% { left: 164.43px; top: 156.30px; transform: rotate(-146.13deg); }
+  73.500% { left: 162.80px; top: 156.66px; transform: rotate(-159.35deg); }
+  74.000% { left: 159.63px; top: 157.25px; transform: rotate(-172.73deg); }
+  74.500% { left: 154.68px; top: 157.82px; transform: rotate(173.18deg); }
+  75.000% { left: 147.53px; top: 157.95px; transform: rotate(157.53deg); }
+  75.500% { left: 137.30px; top: 156.69px; transform: rotate(138.77deg); }
+  76.000% { left: 123.54px; top: 152.07px; transform: rotate(115.05deg); }
+  76.500% { left: 111.56px; top: 144.65px; transform: rotate(91.32deg); }
+  77.000% { left: 104.81px; top: 138.45px; transform: rotate(72.23deg); }
+  77.500% { left: 101.41px; top: 134.50px; transform: rotate(55.72deg); }
+  78.000% { left: 100.18px; top: 132.91px; transform: rotate(40.18deg); }
+  78.500% { left: 100.75px; top: 133.66px; transform: rotate(24.73deg); }
+  79.000% { left: 103.17px; top: 136.63px; transform: rotate(8.96deg); }
+  79.500% { left: 107.70px; top: 141.33px; transform: rotate(-7.21deg); }
+  80.000% { left: 114.61px; top: 146.91px; transform: rotate(-23.57deg); }
+  80.500% { left: 123.85px; top: 152.22px; transform: rotate(-39.77deg); }
+  81.000% { left: 135.02px; top: 156.16px; transform: rotate(-55.45deg); }
+  81.500% { left: 147.38px; top: 157.94px; transform: rotate(-70.39deg); }
+  82.000% { left: 160.06px; top: 157.18px; transform: rotate(-84.51deg); }
+  82.500% { left: 172.19px; top: 153.89px; transform: rotate(-97.82deg); }
+  83.000% { left: 183.09px; top: 148.43px; transform: rotate(-110.38deg); }
+  83.500% { left: 192.31px; top: 141.32px; transform: rotate(-122.30deg); }
+  84.000% { left: 199.62px; top: 133.18px; transform: rotate(-133.72deg); }
+  84.500% { left: 205.03px; top: 124.56px; transform: rotate(-144.78deg); }
+  85.000% { left: 208.70px; top: 115.95px; transform: rotate(-155.62deg); }
+  85.500% { left: 210.88px; top: 107.74px; transform: rotate(-166.37deg); }
+  86.000% { left: 211.86px; top: 100.23px; transform: rotate(-177.09deg); }
+  86.500% { left: 211.96px; top: 93.64px; transform: rotate(172.19deg); }
+  87.000% { left: 211.51px; top: 88.21px; transform: rotate(161.58deg); }
+  87.500% { left: 210.85px; top: 84.12px; transform: rotate(151.24deg); }
+  88.000% { left: 210.29px; top: 81.52px; transform: rotate(141.36deg); }
+  88.500% { left: 210.04px; top: 80.52px; transform: rotate(132.12deg); }
+  89.000% { left: 210.19px; top: 81.12px; transform: rotate(123.54deg); }
+  89.500% { left: 210.68px; top: 83.29px; transform: rotate(115.52deg); }
+  90.000% { left: 211.34px; top: 86.98px; transform: rotate(107.87deg); }
+  90.500% { left: 211.88px; top: 92.18px; transform: rotate(100.25deg); }
+  91.000% { left: 211.93px; top: 98.88px; transform: rotate(92.28deg); }
+  91.500% { left: 210.98px; top: 107.18px; transform: rotate(83.40deg); }
+  92.000% { left: 208.25px; top: 117.25px; transform: rotate(72.80deg); }
+  92.500% { left: 202.31px; top: 129.28px; transform: rotate(59.13deg); }
+  93.000% { left: 191.40px; top: 142.15px; transform: rotate(41.74deg); }
+  93.500% { left: 177.67px; top: 151.48px; transform: rotate(25.68deg); }
+  94.000% { left: 164.43px; top: 156.30px; transform: rotate(14.29deg); }
+  94.500% { left: 151.95px; top: 157.97px; transform: rotate(6.74deg); }
+  95.000% { left: 139.96px; top: 157.18px; transform: rotate(2.40deg); }
+  95.500% { left: 128.40px; top: 154.11px; transform: rotate(1.07deg); }
+  96.000% { left: 117.49px; top: 148.79px; transform: rotate(2.74deg); }
+  96.500% { left: 107.71px; top: 141.34px; transform: rotate(7.34deg); }
+  97.000% { left: 99.66px; top: 132.20px; transform: rotate(14.59deg); }
+  97.500% { left: 93.79px; top: 122.16px; transform: rotate(24.03deg); }
+  98.000% { left: 90.17px; top: 112.25px; transform: rotate(35.04deg); }
+  98.500% { left: 88.45px; top: 103.45px; transform: rotate(46.96deg); }
+  99.000% { left: 88.00px; top: 96.48px; transform: rotate(59.20deg); }
+  99.500% { left: 88.15px; top: 91.71px; transform: rotate(71.32deg); }
+  100.000% { left: 88.37px; top: 89.23px; transform: rotate(83.11deg); }
+}
+
+@keyframes b1B {
+  0.000% { left: 203.69px; top: 65.00px; }
+  0.500% { left: 203.87px; top: 65.31px; }
+  1.000% { left: 204.41px; top: 66.27px; }
+  1.500% { left: 205.27px; top: 67.90px; }
+  2.000% { left: 206.41px; top: 70.28px; }
+  2.500% { left: 207.76px; top: 73.48px; }
+  3.000% { left: 209.21px; top: 77.61px; }
+  3.500% { left: 210.58px; top: 82.80px; }
+  4.000% { left: 211.62px; top: 89.15px; }
+  4.500% { left: 212.00px; top: 96.79px; }
+  5.000% { left: 211.23px; top: 105.77px; }
+  5.500% { left: 208.68px; top: 116.01px; }
+  6.000% { left: 203.67px; top: 127.04px; }
+  6.500% { left: 195.88px; top: 137.70px; }
+  7.000% { left: 185.92px; top: 146.53px; }
+  7.500% { left: 174.83px; top: 152.81px; }
+  8.000% { left: 163.48px; top: 156.52px; }
+  8.500% { left: 152.62px; top: 157.94px; }
+  9.000% { left: 142.93px; top: 157.60px; }
+  9.500% { left: 135.03px; top: 156.17px; }
+  10.000% { left: 129.35px; top: 154.46px; }
+  10.500% { left: 126.15px; top: 153.23px; }
+  11.000% { left: 125.35px; top: 152.89px; }
+  11.500% { left: 125.86px; top: 153.11px; }
+  12.000% { left: 125.70px; top: 153.04px; }
+  12.500% { left: 123.88px; top: 152.23px; }
+  13.000% { left: 120.57px; top: 150.57px; }
+  13.500% { left: 116.25px; top: 148.01px; }
+  14.000% { left: 111.47px; top: 144.58px; }
+  14.500% { left: 106.70px; top: 140.37px; }
+  15.000% { left: 102.29px; top: 135.60px; }
+  15.500% { left: 98.48px; top: 130.49px; }
+  16.000% { left: 95.37px; top: 125.32px; }
+  16.500% { left: 92.98px; top: 120.34px; }
+  17.000% { left: 91.23px; top: 115.76px; }
+  17.500% { left: 90.03px; top: 111.74px; }
+  18.000% { left: 89.26px; top: 108.43px; }
+  18.500% { left: 88.80px; top: 105.91px; }
+  19.000% { left: 88.55px; top: 104.25px; }
+  19.500% { left: 88.46px; top: 103.50px; }
+  20.000% { left: 88.48px; top: 103.67px; }
+  20.500% { left: 88.62px; top: 104.75px; }
+  21.000% { left: 88.94px; top: 106.73px; }
+  21.500% { left: 89.50px; top: 109.57px; }
+  22.000% { left: 90.43px; top: 113.20px; }
+  22.500% { left: 91.86px; top: 117.54px; }
+  23.000% { left: 93.93px; top: 122.45px; }
+  23.500% { left: 96.76px; top: 127.77px; }
+  24.000% { left: 100.46px; top: 133.28px; }
+  24.500% { left: 105.05px; top: 138.70px; }
+  25.000% { left: 110.46px; top: 143.75px; }
+  25.500% { left: 116.45px; top: 148.14px; }
+  26.000% { left: 122.63px; top: 151.63px; }
+  26.500% { left: 128.46px; top: 154.14px; }
+  27.000% { left: 133.31px; top: 155.71px; }
+  27.500% { left: 136.52px; top: 156.52px; }
+  28.000% { left: 137.42px; top: 156.71px; }
+  28.500% { left: 135.61px; top: 156.31px; }
+  29.000% { left: 132.27px; top: 155.41px; }
+  29.500% { left: 130.63px; top: 154.89px; }
+  30.000% { left: 132.09px; top: 155.36px; }
+  30.500% { left: 136.44px; top: 156.50px; }
+  31.000% { left: 143.21px; top: 157.63px; }
+  31.500% { left: 151.84px; top: 157.97px; }
+  32.000% { left: 161.64px; top: 156.90px; }
+  32.500% { left: 171.86px; top: 154.02px; }
+  33.000% { left: 181.85px; top: 149.19px; }
+  33.500% { left: 191.08px; top: 142.43px; }
+  34.000% { left: 199.13px; top: 133.82px; }
+  34.500% { left: 205.53px; top: 123.57px; }
+  35.000% { left: 209.80px; top: 112.38px; }
+  35.500% { left: 211.75px; top: 101.58px; }
+  36.000% { left: 211.88px; top: 92.15px; }
+  36.500% { left: 210.89px; top: 84.30px; }
+  37.000% { left: 209.29px; top: 77.87px; }
+  37.500% { left: 207.44px; top: 72.67px; }
+  38.000% { left: 205.59px; top: 68.55px; }
+  38.500% { left: 203.90px; top: 65.37px; }
+  39.000% { left: 202.52px; top: 63.05px; }
+  39.500% { left: 201.54px; top: 61.53px; }
+  40.000% { left: 201.05px; top: 60.81px; }
+  40.500% { left: 201.11px; top: 60.90px; }
+  41.000% { left: 201.75px; top: 61.85px; }
+  41.500% { left: 202.97px; top: 63.77px; }
+  42.000% { left: 204.68px; top: 66.78px; }
+  42.500% { left: 206.74px; top: 71.01px; }
+  43.000% { left: 208.88px; top: 76.57px; }
+  43.500% { left: 210.73px; top: 83.51px; }
+  44.000% { left: 211.85px; top: 91.76px; }
+  44.500% { left: 211.79px; top: 101.14px; }
+  45.000% { left: 210.08px; top: 111.33px; }
+  45.500% { left: 206.31px; top: 121.94px; }
+  46.000% { left: 200.09px; top: 132.54px; }
+  46.500% { left: 190.81px; top: 142.67px; }
+  47.000% { left: 177.49px; top: 151.57px; }
+  47.500% { left: 159.36px; top: 157.29px; }
+  48.000% { left: 140.35px; top: 157.24px; }
+  48.500% { left: 124.79px; top: 152.64px; }
+  49.000% { left: 112.57px; top: 145.42px; }
+  49.500% { left: 103.11px; top: 136.56px; }
+  50.000% { left: 96.15px; top: 126.73px; }
+  50.500% { left: 91.53px; top: 116.62px; }
+  51.000% { left: 88.97px; top: 106.93px; }
+  51.500% { left: 88.04px; top: 98.32px; }
+  52.000% { left: 88.18px; top: 91.24px; }
+  52.500% { left: 88.82px; top: 85.95px; }
+  53.000% { left: 89.49px; top: 82.50px; }
+  53.500% { left: 89.88px; top: 80.85px; }
+  54.000% { left: 89.86px; top: 80.93px; }
+  54.500% { left: 89.44px; top: 82.73px; }
+  55.000% { left: 88.76px; top: 86.34px; }
+  55.500% { left: 88.13px; top: 91.94px; }
+  56.000% { left: 88.11px; top: 99.67px; }
+  56.500% { left: 89.35px; top: 108.87px; }
+  57.000% { left: 92.01px; top: 117.95px; }
+  57.500% { left: 95.78px; top: 126.07px; }
+  58.000% { left: 100.46px; top: 133.28px; }
+  58.500% { left: 106.06px; top: 139.74px; }
+  59.000% { left: 112.72px; top: 145.54px; }
+  59.500% { left: 120.58px; top: 150.57px; }
+  60.000% { left: 129.76px; top: 154.60px; }
+  60.500% { left: 140.26px; top: 157.23px; }
+  61.000% { left: 151.78px; top: 157.97px; }
+  61.500% { left: 163.72px; top: 156.46px; }
+  62.000% { left: 175.14px; top: 152.67px; }
+  62.500% { left: 185.10px; top: 147.11px; }
+  63.000% { left: 192.89px; top: 140.77px; }
+  63.500% { left: 198.28px; top: 134.90px; }
+  64.000% { left: 201.47px; top: 130.57px; }
+  64.500% { left: 202.79px; top: 128.51px; }
+  65.000% { left: 202.43px; top: 129.10px; }
+  65.500% { left: 200.08px; top: 132.55px; }
+  66.000% { left: 194.68px; top: 138.99px; }
+  66.500% { left: 185.05px; top: 147.14px; }
+  67.000% { left: 174.91px; top: 152.78px; }
+  67.500% { left: 167.36px; top: 155.52px; }
+  68.000% { left: 162.08px; top: 156.81px; }
+  68.500% { left: 158.55px; top: 157.41px; }
+  69.000% { left: 156.47px; top: 157.66px; }
+  69.500% { left: 155.68px; top: 157.74px; }
+  70.000% { left: 156.04px; top: 157.71px; }
+  70.500% { left: 157.39px; top: 157.56px; }
+  71.000% { left: 159.45px; top: 157.28px; }
+  71.500% { left: 161.73px; top: 156.88px; }
+  72.000% { left: 163.63px; top: 156.48px; }
+  72.500% { left: 164.65px; top: 156.25px; }
+  73.000% { left: 164.43px; top: 156.30px; }
+  73.500% { left: 162.80px; top: 156.66px; }
+  74.000% { left: 159.63px; top: 157.25px; }
+  74.500% { left: 154.68px; top: 157.82px; }
+  75.000% { left: 147.53px; top: 157.95px; }
+  75.500% { left: 137.30px; top: 156.69px; }
+  76.000% { left: 123.54px; top: 152.07px; }
+  76.500% { left: 111.56px; top: 144.65px; }
+  77.000% { left: 104.81px; top: 138.45px; }
+  77.500% { left: 101.41px; top: 134.50px; }
+  78.000% { left: 100.18px; top: 132.91px; }
+  78.500% { left: 100.75px; top: 133.66px; }
+  79.000% { left: 103.17px; top: 136.63px; }
+  79.500% { left: 107.70px; top: 141.33px; }
+  80.000% { left: 114.61px; top: 146.91px; }
+  80.500% { left: 123.85px; top: 152.22px; }
+  81.000% { left: 135.02px; top: 156.16px; }
+  81.500% { left: 147.38px; top: 157.94px; }
+  82.000% { left: 160.06px; top: 157.18px; }
+  82.500% { left: 172.19px; top: 153.89px; }
+  83.000% { left: 183.09px; top: 148.43px; }
+  83.500% { left: 192.31px; top: 141.32px; }
+  84.000% { left: 199.62px; top: 133.18px; }
+  84.500% { left: 205.03px; top: 124.56px; }
+  85.000% { left: 208.70px; top: 115.95px; }
+  85.500% { left: 210.88px; top: 107.74px; }
+  86.000% { left: 211.86px; top: 100.23px; }
+  86.500% { left: 211.96px; top: 93.64px; }
+  87.000% { left: 211.51px; top: 88.21px; }
+  87.500% { left: 210.85px; top: 84.12px; }
+  88.000% { left: 210.29px; top: 81.52px; }
+  88.500% { left: 210.04px; top: 80.52px; }
+  89.000% { left: 210.19px; top: 81.12px; }
+  89.500% { left: 210.68px; top: 83.29px; }
+  90.000% { left: 211.34px; top: 86.98px; }
+  90.500% { left: 211.88px; top: 92.18px; }
+  91.000% { left: 211.93px; top: 98.88px; }
+  91.500% { left: 210.98px; top: 107.18px; }
+  92.000% { left: 208.25px; top: 117.25px; }
+  92.500% { left: 202.31px; top: 129.28px; }
+  93.000% { left: 191.40px; top: 142.15px; }
+  93.500% { left: 177.67px; top: 151.48px; }
+  94.000% { left: 164.43px; top: 156.30px; }
+  94.500% { left: 151.95px; top: 157.97px; }
+  95.000% { left: 139.96px; top: 157.18px; }
+  95.500% { left: 128.40px; top: 154.11px; }
+  96.000% { left: 117.49px; top: 148.79px; }
+  96.500% { left: 107.71px; top: 141.34px; }
+  97.000% { left: 99.66px; top: 132.20px; }
+  97.500% { left: 93.79px; top: 122.16px; }
+  98.000% { left: 90.17px; top: 112.25px; }
+  98.500% { left: 88.45px; top: 103.45px; }
+  99.000% { left: 88.00px; top: 96.48px; }
+  99.500% { left: 88.15px; top: 91.71px; }
+  100.000% { left: 88.37px; top: 89.23px; }
+}
+
+@keyframes b2B {
+  0.000% { left: 257.42px; top: 95.95px; }
+  0.500% { left: 257.48px; top: 96.47px; }
+  1.000% { left: 257.65px; top: 98.03px; }
+  1.500% { left: 257.93px; top: 100.62px; }
+  2.000% { left: 258.28px; top: 104.24px; }
+  2.500% { left: 258.68px; top: 108.86px; }
+  3.000% { left: 259.08px; top: 114.45px; }
+  3.500% { left: 259.43px; top: 120.98px; }
+  4.000% { left: 259.64px; top: 128.37px; }
+  4.500% { left: 259.59px; top: 136.52px; }
+  5.000% { left: 259.04px; top: 145.23px; }
+  5.500% { left: 257.56px; top: 154.15px; }
+  6.000% { left: 254.37px; top: 162.72px; }
+  6.500% { left: 248.54px; top: 170.42px; }
+  7.000% { left: 239.77px; top: 177.26px; }
+  7.500% { left: 228.60px; top: 183.68px; }
+  8.000% { left: 215.63px; top: 190.04px; }
+  8.500% { left: 201.22px; top: 196.44px; }
+  9.000% { left: 185.45px; top: 202.72px; }
+  9.500% { left: 168.30px; top: 208.48px; }
+  10.000% { left: 149.77px; top: 213.00px; }
+  10.500% { left: 130.14px; top: 215.10px; }
+  11.000% { left: 110.29px; top: 213.03px; }
+  11.500% { left: 92.21px; top: 205.18px; }
+  12.000% { left: 77.82px; top: 192.43px; }
+  12.500% { left: 67.22px; top: 177.39px; }
+  13.000% { left: 59.62px; top: 161.91px; }
+  13.500% { left: 54.26px; top: 146.96px; }
+  14.000% { left: 50.57px; top: 132.99px; }
+  14.500% { left: 48.07px; top: 120.20px; }
+  15.000% { left: 46.44px; top: 108.68px; }
+  15.500% { left: 45.42px; top: 98.42px; }
+  16.000% { left: 44.84px; top: 89.40px; }
+  16.500% { left: 44.59px; top: 81.58px; }
+  17.000% { left: 44.58px; top: 74.92px; }
+  17.500% { left: 44.74px; top: 69.40px; }
+  18.000% { left: 45.04px; top: 64.97px; }
+  18.500% { left: 45.43px; top: 61.60px; }
+  19.000% { left: 45.89px; top: 59.27px; }
+  19.500% { left: 46.38px; top: 57.96px; }
+  20.000% { left: 46.91px; top: 57.66px; }
+  20.500% { left: 47.48px; top: 58.37px; }
+  21.000% { left: 48.08px; top: 60.09px; }
+  21.500% { left: 48.74px; top: 62.85px; }
+  22.000% { left: 49.46px; top: 66.67px; }
+  22.500% { left: 50.28px; top: 71.55px; }
+  23.000% { left: 51.20px; top: 77.52px; }
+  23.500% { left: 52.25px; top: 84.61px; }
+  24.000% { left: 53.47px; top: 92.83px; }
+  24.500% { left: 54.92px; top: 102.22px; }
+  25.000% { left: 56.72px; top: 112.84px; }
+  25.500% { left: 59.04px; top: 124.72px; }
+  26.000% { left: 62.17px; top: 137.89px; }
+  26.500% { left: 66.48px; top: 152.29px; }
+  27.000% { left: 72.48px; top: 167.69px; }
+  27.500% { left: 80.73px; top: 183.58px; }
+  28.000% { left: 91.99px; top: 198.90px; }
+  28.500% { left: 107.11px; top: 211.37px; }
+  29.000% { left: 126.01px; top: 217.09px; }
+  29.500% { left: 145.97px; top: 214.97px; }
+  30.000% { left: 164.66px; top: 208.11px; }
+  30.500% { left: 181.50px; top: 199.08px; }
+  31.000% { left: 196.54px; top: 189.25px; }
+  31.500% { left: 210.01px; top: 179.43px; }
+  32.000% { left: 222.21px; top: 170.11px; }
+  32.500% { left: 233.41px; top: 161.52px; }
+  33.000% { left: 243.68px; top: 153.80px; }
+  33.500% { left: 252.92px; top: 146.97px; }
+  34.000% { left: 260.71px; top: 141.00px; }
+  34.500% { left: 266.33px; top: 135.73px; }
+  35.000% { left: 268.99px; top: 130.83px; }
+  35.500% { left: 268.74px; top: 126.00px; }
+  36.000% { left: 266.57px; top: 121.35px; }
+  36.500% { left: 263.45px; top: 117.18px; }
+  37.000% { left: 259.88px; top: 113.71px; }
+  37.500% { left: 256.12px; top: 111.07px; }
+  38.000% { left: 252.28px; top: 109.34px; }
+  38.500% { left: 248.39px; top: 108.55px; }
+  39.000% { left: 244.47px; top: 108.70px; }
+  39.500% { left: 240.50px; top: 109.76px; }
+  40.000% { left: 236.45px; top: 111.71px; }
+  40.500% { left: 232.30px; top: 114.48px; }
+  41.000% { left: 228.03px; top: 118.01px; }
+  41.500% { left: 223.62px; top: 122.23px; }
+  42.000% { left: 219.10px; top: 127.08px; }
+  42.500% { left: 214.49px; top: 132.52px; }
+  43.000% { left: 209.82px; top: 138.56px; }
+  43.500% { left: 205.16px; top: 145.25px; }
+  44.000% { left: 200.50px; top: 152.71px; }
+  44.500% { left: 195.86px; top: 161.06px; }
+  45.000% { left: 191.22px; top: 170.39px; }
+  45.500% { left: 186.58px; top: 180.71px; }
+  46.000% { left: 181.98px; top: 191.84px; }
+  46.500% { left: 177.59px; top: 203.25px; }
+  47.000% { left: 173.61px; top: 213.45px; }
+  47.500% { left: 169.79px; top: 218.41px; }
+  48.000% { left: 164.30px; top: 214.43px; }
+  48.500% { left: 156.69px; top: 205.81px; }
+  49.000% { left: 148.02px; top: 196.29px; }
+  49.500% { left: 138.95px; top: 187.15px; }
+  50.000% { left: 129.77px; top: 178.83px; }
+  50.500% { left: 120.54px; top: 171.42px; }
+  51.000% { left: 111.23px; top: 164.80px; }
+  51.500% { left: 101.78px; top: 158.78px; }
+  52.000% { left: 92.19px; top: 153.11px; }
+  52.500% { left: 82.56px; top: 147.63px; }
+  53.000% { left: 73.01px; top: 142.27px; }
+  53.500% { left: 63.70px; top: 137.05px; }
+  54.000% { left: 54.74px; top: 132.02px; }
+  54.500% { left: 46.29px; top: 127.25px; }
+  55.000% { left: 38.55px; top: 122.72px; }
+  55.500% { left: 32.02px; top: 118.31px; }
+  56.000% { left: 27.76px; top: 113.87px; }
+  56.500% { left: 27.35px; top: 109.55px; }
+  57.000% { left: 31.16px; top: 106.11px; }
+  57.500% { left: 37.79px; top: 104.14px; }
+  58.000% { left: 45.97px; top: 103.70px; }
+  58.500% { left: 54.95px; top: 104.66px; }
+  59.000% { left: 64.29px; top: 106.82px; }
+  59.500% { left: 73.69px; top: 110.01px; }
+  60.000% { left: 82.91px; top: 114.00px; }
+  60.500% { left: 91.74px; top: 118.63px; }
+  61.000% { left: 100.03px; top: 123.82px; }
+  61.500% { left: 107.82px; top: 129.64px; }
+  62.000% { left: 115.34px; top: 136.30px; }
+  62.500% { left: 123.18px; top: 143.99px; }
+  63.000% { left: 132.04px; top: 152.68px; }
+  63.500% { left: 142.52px; top: 162.00px; }
+  64.000% { left: 154.81px; top: 171.40px; }
+  64.500% { left: 168.75px; top: 180.32px; }
+  65.000% { left: 183.95px; top: 188.28px; }
+  65.500% { left: 199.93px; top: 194.55px; }
+  66.000% { left: 215.74px; top: 197.30px; }
+  66.500% { left: 227.78px; top: 192.07px; }
+  67.000% { left: 231.32px; top: 178.49px; }
+  67.500% { left: 228.94px; top: 162.78px; }
+  68.000% { left: 223.39px; top: 147.57px; }
+  68.500% { left: 215.80px; top: 133.61px; }
+  69.000% { left: 206.66px; top: 121.26px; }
+  69.500% { left: 196.21px; top: 110.83px; }
+  70.000% { left: 184.63px; top: 102.69px; }
+  70.500% { left: 172.13px; top: 97.34px; }
+  71.000% { left: 159.08px; top: 95.28px; }
+  71.500% { left: 146.05px; top: 96.90px; }
+  72.000% { left: 133.72px; top: 102.18px; }
+  72.500% { left: 122.61px; top: 110.67px; }
+  73.000% { left: 112.95px; top: 121.74px; }
+  73.500% { left: 104.78px; top: 134.80px; }
+  74.000% { left: 98.12px; top: 149.41px; }
+  74.500% { left: 93.12px; top: 165.18px; }
+  75.000% { left: 90.23px; top: 181.64px; }
+  75.500% { left: 90.67px; top: 197.55px; }
+  76.000% { left: 97.29px; top: 208.24px; }
+  76.500% { left: 110.14px; top: 206.63px; }
+  77.000% { left: 123.74px; top: 197.49px; }
+  77.500% { left: 136.32px; top: 185.74px; }
+  78.000% { left: 147.55px; top: 172.91px; }
+  78.500% { left: 157.06px; top: 159.60px; }
+  79.000% { left: 164.41px; top: 146.29px; }
+  79.500% { left: 169.21px; top: 133.55px; }
+  80.000% { left: 171.43px; top: 122.11px; }
+  80.500% { left: 171.51px; top: 112.56px; }
+  81.000% { left: 170.18px; top: 105.10px; }
+  81.500% { left: 168.19px; top: 99.54px; }
+  82.000% { left: 165.98px; top: 95.46px; }
+  82.500% { left: 163.76px; top: 92.47px; }
+  83.000% { left: 161.50px; top: 90.31px; }
+  83.500% { left: 159.18px; top: 88.92px; }
+  84.000% { left: 156.77px; top: 88.37px; }
+  84.500% { left: 154.38px; top: 88.80px; }
+  85.000% { left: 152.23px; top: 90.36px; }
+  85.500% { left: 150.62px; top: 93.13px; }
+  86.000% { left: 149.94px; top: 97.08px; }
+  86.500% { left: 150.53px; top: 102.07px; }
+  87.000% { left: 152.69px; top: 107.80px; }
+  87.500% { left: 156.50px; top: 113.95px; }
+  88.000% { left: 161.86px; top: 120.24px; }
+  88.500% { left: 168.46px; top: 126.51px; }
+  89.000% { left: 175.93px; top: 132.80px; }
+  89.500% { left: 183.97px; top: 139.24px; }
+  90.000% { left: 192.32px; top: 145.99px; }
+  90.500% { left: 200.85px; top: 153.19px; }
+  91.000% { left: 209.47px; top: 160.83px; }
+  91.500% { left: 218.11px; top: 168.77px; }
+  92.000% { left: 226.58px; top: 176.47px; }
+  92.500% { left: 234.12px; top: 182.50px; }
+  93.000% { left: 237.66px; top: 183.43px; }
+  93.500% { left: 233.54px; top: 178.35px; }
+  94.000% { left: 224.52px; top: 171.60px; }
+  94.500% { left: 213.52px; top: 165.25px; }
+  95.000% { left: 201.90px; top: 159.77px; }
+  95.500% { left: 190.38px; top: 155.27px; }
+  96.000% { left: 179.42px; top: 151.76px; }
+  96.500% { left: 169.21px; top: 149.26px; }
+  97.000% { left: 159.67px; top: 147.82px; }
+  97.500% { left: 150.42px; top: 147.41px; }
+  98.000% { left: 140.93px; top: 147.85px; }
+  98.500% { left: 130.76px; top: 148.77px; }
+  99.000% { left: 119.75px; top: 149.74px; }
+  99.500% { left: 108.01px; top: 150.44px; }
+  100.000% { left: 95.81px; top: 150.78px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rodD, .bobD { animation-play-state: paused; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/double-pendulum-as/`, a self-contained pure CSS/HTML double pendulum run twice from near-identical starts, showing deterministic chaos.

Closes #49593

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

A double pendulum is deterministic but unpredictable: two starts differing by less than you can measure end up doing completely different things. Here the second pendulum starts 0.001 radians along from the first, about a twentieth of a degree.

- **The motion is simulated, not drawn.** Both pendulums are integrated from the real coupled equations of motion with **RK4** at a 2ms timestep, and the resulting 201 frames are baked into keyframes for the rods and bobs.
- **The physics is checked by conservation of energy.** Total energy (kinetic plus potential) is computed at every simulation step and drifts by only **1.7e-07 relative** across the whole 8-second run. A hand-animated pendulum would not conserve anything; this one does, which is the evidence it is real dynamics.
- **The chaos is measured in the browser, on the rendered elements.** Sweeping the paused animation across 201 steps and tracking the two tip positions: they start **0.07px** apart and grow to **127.4px**, an amplification of about **1800x**.
- **The rods stay rigid, and that is checked too.** Both arms measure 62px at every frame, varying by **0.04px**.
- **The second pendulum is drawn as a ghost**, so you can watch the two agree and then part company.

## Accessibility

`prefers-reduced-motion: reduce` pauses both pendulums mid-swing.

## Verification

Opened `demo.html` in the browser and checked both claims on the rendered output: swept the paused animation and measured the two tips diverging from 0.07px to 127.4px (about 1800x amplification from a 0.001 rad perturbation), and confirmed both rods hold 62px to within 0.04px so nothing drifts. The underlying simulation conserves total energy to 1.7e-07 relative over the run, which is what distinguishes a real integration from a drawn approximation. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
