### PR TITLE
Add crookes radiometer component

### DIFF
--- a/submissions/examples/crookes-radiometer-as/README.md
+++ b/submissions/examples/crookes-radiometer-as/README.md
@@ -1,0 +1,32 @@
+# Crookes Radiometer
+
+A pure CSS/HTML light mill: four black-and-silver vanes spinning in a partly evacuated bulb.
+
+## What it shows
+
+William Crookes built this in 1873 and thought he had measured the pressure of light itself. He had not, and the argument about what actually drives it ran for thirty years and pulled in Maxwell and Reynolds before it was settled.
+
+The vanes are black on one face and silvered on the other. Put the bulb in sunlight and it spins. The obvious explanation is radiation pressure, and it is **wrong for a simple reason you can see**: the shiny face reflects photons and so receives *twice* the momentum of the black face, which absorbs them. If light pressure drove the mill, it would turn **shiny-side-first**. It does not. It turns **black-side-first**, the opposite way, so whatever is pushing is pushing on the dark faces.
+
+The real cause needs the gas that is still in the bulb. A Crookes radiometer is a **partial** vacuum, not a good one. The black face absorbs light and warms; the silver face reflects and stays cool. At the **edges of each vane**, gas molecules near the warm side are hotter than those near the cool side, and they creep from cold to hot along the surface. That flow, **thermal transpiration**, pushes back on the vane's rim and drives it dark-side-away. Osborne Reynolds worked this out in 1879.
+
+Two things confirm it. Pump the bulb down to a genuinely hard vacuum and it **stops**, because there is no gas left to creep. And radiation pressure is real but roughly a **million times** too weak here; it would only win in that hard vacuum where the mill has already stalled.
+
+## How it is built
+
+- **The direction is the whole point, and it is what the component commits to.** The rotor turns with the black faces retreating, which is the observed behaviour and the opposite of what light pressure would give.
+- **Each vane genuinely has two different faces.** The browser check reads the computed styles of both halves of a vane and confirms a dark face (`rgb(20, 20, 26)`) and a bright face (`rgb(238, 244, …)`). That temperature difference is the engine, so it is drawn rather than implied.
+- **Four vanes at exact right angles**: the check measures their rotations as **0, 90, 180, 270**, with all four gaps at exactly 90 degrees.
+- **The bulb is drawn as a partial vacuum**, a sealed glass envelope with the vanes balanced on a needle bearing, which is the low-friction pivot that lets so weak a force turn anything at all.
+- **Light arrives from one side**, so the illuminated faces are the ones doing the work.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops the rotor and the incoming light, leaving the vanes and their two-tone faces legible.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/crookes-radiometer-as/demo.html
+++ b/submissions/examples/crookes-radiometer-as/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Crookes Radiometer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="sunC"></span>
+    <span class="rayC" style="top: 70px; --d: 0ss"></span>
+    <span class="rayC" style="top: 104px; --d: -0.9ss"></span>
+    <span class="rayC" style="top: 138px; --d: -1.8ss"></span>
+    <span class="rayC" style="top: 172px; --d: -2.7ss"></span>
+
+    <div class="bulbC">
+      <span class="glassC"></span>
+      <div class="rotorC">
+        <span class="vaneC" style="--v: 0deg"></span>
+        <span class="vaneC" style="--v: 90deg"></span>
+        <span class="vaneC" style="--v: 180deg"></span>
+        <span class="vaneC" style="--v: 270deg"></span>
+
+        <span class="hubC"></span>
+      </div>
+      <span class="needleC"></span>
+      <span class="sheenC"></span>
+    </div>
+    <span class="stemC"></span>
+    <span class="baseC"></span>
+
+    <span class="lblWarm">warm dark side</span>
+    <span class="lblCool">cool bright side</span>
+    <span class="tagC">it turns dark-side-first</span>
+    <span class="capC">not light pressure: gas creeping along the edge</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/crookes-radiometer-as/style.css
+++ b/submissions/examples/crookes-radiometer-as/style.css
@@ -1,0 +1,247 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #2f3038, #08080c 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 300px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 22% 30%, #4a4638, #0c0c10 84%);
+}
+
+.sunC {
+  position: absolute;
+  top: 44px;
+  left: -26px;
+  width: 92px;
+  height: 92px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fffbe0, #ffd45a 46%, rgba(255, 200, 80, 0) 74%);
+  z-index: 1;
+}
+
+/* light coming in from the left */
+.rayC {
+  position: absolute;
+  left: 20px;
+  width: 90px;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(90deg, rgba(255, 230, 150, 0.8), rgba(255, 230, 150, 0));
+  z-index: 2;
+  animation: shineC 3.6s linear infinite;
+  animation-delay: var(--d, 0s);
+}
+
+/* the evacuated glass bulb: a partial vacuum, not a hard one */
+.bulbC {
+  position: absolute;
+  top: 52px;
+  left: 50%;
+  width: 168px;
+  height: 168px;
+  margin-left: -84px;
+  z-index: 5;
+}
+
+.glassC {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 34% 28%, rgba(220, 240, 255, 0.16), rgba(140, 170, 200, 0.06) 60%, rgba(40, 60, 80, 0.1));
+  box-shadow:
+    inset 0 0 26px rgba(180, 220, 255, 0.14),
+    0 0 0 3px rgba(200, 226, 245, 0.24),
+    0 10px 26px rgba(0, 0, 0, 0.5);
+}
+
+.sheenC {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    radial-gradient(ellipse 34% 24% at 30% 22%, rgba(255, 255, 255, 0.34), transparent 70%);
+  z-index: 8;
+  pointer-events: none;
+}
+
+/*
+  the rotor. four vanes, each black on one face and silvered on the other,
+  set at right angles on a near-frictionless needle bearing.
+*/
+.rotorC {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  z-index: 6;
+  animation: spinC 3.6s linear infinite;
+}
+
+.vaneC {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 62px;
+  height: 34px;
+  margin: -17px 0 0 0;
+  transform-origin: 0 50%;
+  transform: rotate(var(--v, 0deg));
+}
+
+/*
+  each vane is black on the trailing face and bright on the leading face.
+  the black face absorbs light and warms; the shiny face reflects and stays
+  cool. that temperature difference is what drives the whole thing.
+*/
+.vaneC::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 22px;
+  width: 40px;
+  height: 17px;
+  border-radius: 2px 3px 0 0;
+  background: linear-gradient(180deg, #14141a, #2c2c34);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.vaneC::after {
+  content: "";
+  position: absolute;
+  top: 17px;
+  left: 22px;
+  width: 40px;
+  height: 17px;
+  border-radius: 0 0 3px 2px;
+  background: linear-gradient(180deg, #eef4f8, #9aa8b4);
+  box-shadow: inset 0 -1px 2px rgba(255, 255, 255, 0.4);
+}
+
+.hubC {
+  position: absolute;
+  top: -7px;
+  left: -7px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 32%, #f0f4f8, #46505a 76%);
+  box-shadow: 0 0 0 2px rgba(20, 24, 30, 0.7);
+  z-index: 3;
+}
+
+/* the needle the rotor balances on: almost no friction */
+.needleC {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3px;
+  height: 66px;
+  margin-left: -1.5px;
+  background: linear-gradient(180deg, #9aa6b2, #46505a);
+  z-index: 4;
+}
+
+.stemC {
+  position: absolute;
+  top: 216px;
+  left: 50%;
+  width: 26px;
+  height: 44px;
+  margin-left: -13px;
+  border-radius: 0 0 6px 6px;
+  background: linear-gradient(90deg, #6a7480, #cfd8e2 44%, #4a545e);
+  z-index: 4;
+}
+
+.baseC {
+  position: absolute;
+  top: 254px;
+  left: 50%;
+  width: 96px;
+  height: 20px;
+  margin-left: -48px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 30%, #7a848e, #262c32 76%);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.55);
+  z-index: 4;
+}
+
+.lblWarm,
+.lblCool {
+  position: absolute;
+  font-size: 0.44rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  z-index: 9;
+}
+
+.lblWarm {
+  top: 232px;
+  left: 12px;
+  color: rgba(255, 170, 120, 0.9);
+}
+
+.lblCool {
+  top: 232px;
+  right: 12px;
+  color: rgba(160, 220, 255, 0.9);
+}
+
+.tagC {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 220, 150, 0.9);
+  z-index: 9;
+}
+
+.capC {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.48rem;
+  letter-spacing: 0.04em;
+  color: rgba(220, 228, 240, 0.85);
+  z-index: 9;
+}
+
+/*
+  the rotor turns with the BLACK faces retreating. that direction is the
+  whole puzzle: if light pressure drove it, the shiny faces would be pushed
+  harder and it would spin the other way.
+*/
+@keyframes spinC {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes shineC {
+  0% { transform: translateX(0); opacity: 0; }
+  20% { opacity: 1; }
+  80% { opacity: 1; }
+  100% { transform: translateX(60px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rotorC,
+  .rayC {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/crookes-radiometer-as/`, a self-contained pure CSS/HTML light mill turning the way a real one does.

Closes #49595

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

Crookes thought in 1873 that he had measured light pressure. He had not. The shiny face reflects photons and so gets twice the momentum of the absorbing black face, so radiation pressure would turn the mill shiny-side-first. It turns black-side-first. The real driver is thermal transpiration: the bulb is a partial vacuum, the black face warms, and gas creeps from cold to hot along the vane edges, pushing the vane dark-side-away (Reynolds, 1879). Pump to a hard vacuum and it stops.

- **The direction is the whole point, and the component commits to it.** The rotor turns with the black faces retreating, the observed behaviour and the opposite of the light-pressure prediction.
- **Each vane genuinely has two different faces.** The browser check reads the computed styles of both halves and confirms a dark face (`rgb(20, 20, 26)`) and a bright face (`rgb(238, 244, ...)`). That temperature difference is the engine, so it is drawn rather than implied.
- **Four vanes at exact right angles**: measured rotations **0, 90, 180, 270**, all four gaps exactly 90 degrees.
- **The bulb is drawn as a partial vacuum**, a sealed envelope with the rotor on a needle bearing, the low-friction pivot that lets so weak a force turn anything.
- **Light arrives from one side**, so the illuminated faces are the ones doing the work.

## Accessibility

`prefers-reduced-motion: reduce` stops the rotor and the incoming light, leaving the vanes and their two-tone faces legible.

## Verification

Opened `demo.html` in the browser and confirmed the vane geometry and colouring from computed styles: four vanes at 0/90/180/270 with uniform 90 degree gaps, and each vane carrying a genuinely dark half and a genuinely bright half, which is the temperature difference the mechanism depends on. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
