### PR TITLE
Add Copy Class Name button for animation demo cards (copy-class-name-…

### DIFF
--- a/submissions/examples/copy-class-name-btn-hr18/README.md
+++ b/submissions/examples/copy-class-name-btn-hr18/README.md
@@ -1,0 +1,87 @@
+# Copy Class Name Button (`copy-class-name-btn-hr18`)
+
+A small copy button for the class names shown in EaseMotion's animation demo
+cards, built for issue
+[#48321](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/48321).
+
+## A note on scope and overlap
+
+This issue targets the "Motion Library" demo cards on EaseMotion's own
+[interactive demo page](https://saptarshi-coder.github.io/EaseMotion-css/demo.html)
+— content that lives outside `submissions/`, so this can't literally patch
+those cards in place. Instead, this submission reproduces that card pattern
+(replayable glyph + class-name label) as a self-contained reference so the
+copy-button behavior can be lifted directly into the real gallery.
+
+It's also a close cousin of **`copy-code-btn-hr18`**, submitted separately
+for issue #48659 — that component copies a whole multi-line code block; this
+one is deliberately scoped down to copying a single short class-name string
+and shows the exact **"Class name copied!"** success message the issue
+specifies, rather than reusing the other component's generic "Copied!"
+label. If the maintainer would rather these be consolidated into one
+component, that's an easy follow-up — flagged in the PR notes.
+
+## What it does
+
+Each demo card shows a small animation-replay glyph, the animation's class
+name, and a copy icon button right next to it. Clicking the copy button
+copies that exact class name (e.g. `ease-fade-in`) to the clipboard, swaps
+the icon to a checkmark briefly, and shows a "Class name copied!" message
+under the card.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap a class-name `<code>` element and a copy button in the component
+markup:
+
+```html
+<span class="ccn-tag-hr18">
+  <code>ease-fade-in</code>
+  <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-fade-in" aria-label="Copy class name">
+    <svg class="ccn-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>
+    <svg class="ccn-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+  </button>
+</span>
+<span class="ccn-toast-hr18">Class name copied!</span>
+```
+
+The included script finds every `.ease-copy-class-btn-hr18` on the page
+automatically and reads the string to copy from its `data-class-name`
+attribute — no per-button JavaScript wiring required. The demo applies this
+to six real EaseMotion class names (`ease-fade-in`, `ease-slide-up`,
+`ease-hover-grow`, `ease-bounce`, `ease-rotate`, `ease-pulse`).
+
+## Accessibility notes
+
+- The button always has a real `aria-label="Copy class name"`, so it reads
+  correctly for screen readers regardless of its icon state.
+- Each card's "Class name copied!" message is a plain text node that
+  becomes visible on copy — paired with the icon swap, so the outcome isn't
+  communicated by color or icon alone.
+- Copying uses the async Clipboard API first, with a hidden-`<textarea>` +
+  `document.execCommand('copy')` fallback for older or restricted browsers,
+  and a distinct "Copy failed" message if both attempts fail.
+- The button is a native `<button>`, reachable and operable by keyboard
+  (`Tab` + `Enter`/`Space`) without extra scripting.
+
+## Responsiveness
+
+The card grid runs three columns wide, dropping to two under `720px` and a
+single column under `460px`.
+
+## Why this fits EaseMotion CSS
+
+It directly implements what the issue describes — including matching its
+exact "Class name copied!" wording — as a small, dependency-free,
+reusable pattern consistent with EaseMotion's existing class-based
+component style. Built the same way as every other submission here: plain
+HTML/CSS/vanilla JS, no framework or build step required to read or run it.
+
+All classes and the folder itself use a `-hr18` suffix to avoid colliding
+with any other contributor's submission under `submissions/examples/`.

--- a/submissions/examples/copy-class-name-btn-hr18/demo.html
+++ b/submissions/examples/copy-class-name-btn-hr18/demo.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Copy Class Name Button — demo cards</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ccn-hr18">
+  <div class="ccn-wrap-hr18">
+
+    <header class="ccn-header-hr18">
+      <span class="ccn-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Copy Class Name button</h1>
+      <p>A small copy icon next to each class name in the animation gallery
+        — click it to copy that exact class straight to your clipboard,
+        instead of manually selecting the text.</p>
+      <div class="ccn-note-box-hr18">
+        This mirrors the "Motion Library" card pattern from EaseMotion's own
+        demo gallery (click a glyph to replay its animation, class name
+        shown underneath). Since the real gallery lives outside
+        <code>submissions/</code>, this is a self-contained, reusable
+        version of just the copy-button pattern the issue asks for. It's a
+        close cousin of the <code>copy-code-btn-hr18</code> component
+        submitted for issue #48659 — that one copies a whole code block,
+        this one copies a single class name with the exact "Class name
+        copied!" message the issue specifies.
+      </div>
+    </header>
+
+    <section class="ccn-grid-hr18">
+
+      <article class="ccn-card-hr18">
+        <button type="button" class="ccn-glyph-btn-hr18" data-anim="ccn-anim-fade-hr18" aria-label="Replay ease-fade-in animation">F</button>
+        <span class="ccn-tag-hr18">
+          <code>ease-fade-in</code>
+          <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-fade-in" aria-label="Copy class name">
+            <svg class="ccn-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>
+            <svg class="ccn-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          </button>
+        </span>
+        <span class="ccn-toast-hr18">Class name copied!</span>
+      </article>
+
+      <article class="ccn-card-hr18">
+        <button type="button" class="ccn-glyph-btn-hr18" data-anim="ccn-anim-slide-hr18" aria-label="Replay ease-slide-up animation">&#8593;</button>
+        <span class="ccn-tag-hr18">
+          <code>ease-slide-up</code>
+          <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-slide-up" aria-label="Copy class name">
+            <svg class="ccn-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>
+            <svg class="ccn-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          </button>
+        </span>
+        <span class="ccn-toast-hr18">Class name copied!</span>
+      </article>
+
+      <article class="ccn-card-hr18">
+        <button type="button" class="ccn-glyph-btn-hr18" data-anim="ccn-anim-grow-hr18" aria-label="Replay ease-hover-grow animation">&#8596;</button>
+        <span class="ccn-tag-hr18">
+          <code>ease-hover-grow</code>
+          <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-hover-grow" aria-label="Copy class name">
+            <svg class="ccn-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>
+            <svg class="ccn-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          </button>
+        </span>
+        <span class="ccn-toast-hr18">Class name copied!</span>
+      </article>
+
+      <article class="ccn-card-hr18">
+        <button type="button" class="ccn-glyph-btn-hr18" data-anim="ccn-anim-bounce-hr18" aria-label="Replay ease-bounce animation">&#8597;</button>
+        <span class="ccn-tag-hr18">
+          <code>ease-bounce</code>
+          <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-bounce" aria-label="Copy class name">
+            <svg class="ccn-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>
+            <svg class="ccn-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          </button>
+        </span>
+        <span class="ccn-toast-hr18">Class name copied!</span>
+      </article>
+
+      <article class="ccn-card-hr18">
+        <button type="button" class="ccn-glyph-btn-hr18" data-anim="ccn-anim-rotate-hr18" aria-label="Replay ease-rotate animation">&#10227;</button>
+        <span class="ccn-tag-hr18">
+          <code>ease-rotate</code>
+          <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-rotate" aria-label="Copy class name">
+            <svg class="ccn-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>
+            <svg class="ccn-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          </button>
+        </span>
+        <span class="ccn-toast-hr18">Class name copied!</span>
+      </article>
+
+      <article class="ccn-card-hr18">
+        <button type="button" class="ccn-glyph-btn-hr18" data-anim="ccn-anim-pulse-hr18" aria-label="Replay ease-pulse animation">&#9678;</button>
+        <span class="ccn-tag-hr18">
+          <code>ease-pulse</code>
+          <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-pulse" aria-label="Copy class name">
+            <svg class="ccn-icon-copy-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>
+            <svg class="ccn-icon-check-hr18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          </button>
+        </span>
+        <span class="ccn-toast-hr18">Class name copied!</span>
+      </article>
+
+    </section>
+
+    <p class="ccn-footnote-hr18">submissions/examples/copy-class-name-btn-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // ---- Glyph replay (demo-only, not part of the reusable component) ----
+  document.querySelectorAll(".ccn-glyph-btn-hr18").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var animClass = btn.getAttribute("data-anim");
+      btn.classList.remove(animClass);
+      void btn.offsetWidth;
+      btn.classList.add(animClass);
+    });
+  });
+
+  // ---- Copy Class Name: the actual reusable component ----
+  function fallbackCopy(text) {
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    var ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } catch (err) {
+      ok = false;
+    }
+    document.body.removeChild(textarea);
+    return ok;
+  }
+
+  document.querySelectorAll(".ease-copy-class-btn-hr18").forEach(function (btn) {
+    var className = btn.getAttribute("data-class-name");
+    var card = btn.closest(".ccn-card-hr18");
+    var toast = card ? card.querySelector(".ccn-toast-hr18") : null;
+
+    function onSuccess() {
+      btn.classList.add("is-copied-hr18");
+      if (toast) {
+        toast.classList.add("is-visible-hr18");
+      }
+      window.setTimeout(function () {
+        btn.classList.remove("is-copied-hr18");
+        if (toast) toast.classList.remove("is-visible-hr18");
+      }, 1800);
+    }
+
+    function onFailure() {
+      if (toast) {
+        toast.textContent = "Copy failed \u2014 select manually.";
+        toast.classList.add("is-visible-hr18");
+        window.setTimeout(function () {
+          toast.classList.remove("is-visible-hr18");
+          toast.textContent = "Class name copied!";
+        }, 2200);
+      }
+    }
+
+    btn.addEventListener("click", function () {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(className).then(onSuccess, function () {
+          if (fallbackCopy(className)) onSuccess(); else onFailure();
+        });
+      } else {
+        if (fallbackCopy(className)) onSuccess(); else onFailure();
+      }
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/copy-class-name-btn-hr18/style.css
+++ b/submissions/examples/copy-class-name-btn-hr18/style.css
@@ -1,0 +1,259 @@
+/* ==========================================================================
+   copy-class-name-btn-hr18 — style.css
+   Copy Class Name button for animation demo cards
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.ccn-hr18 {
+  --bg-hr18: #101126;
+  --panel-hr18: #17182f;
+  --panel-raised-hr18: #1d1f3b;
+  --border-hr18: #2c2e52;
+  --text-hr18: #eceafc;
+  --text-muted-hr18: #9a97c2;
+  --accent-hr18: #8b5cf6;
+  --accent-2-hr18: #22d3c8;
+  --success-hr18: #2ee6a6;
+  --success-soft-hr18: #123329;
+  --radius-hr18: 14px;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background:
+    radial-gradient(circle at 20% 0%, rgba(139, 92, 246, 0.14), transparent 45%),
+    radial-gradient(circle at 90% 20%, rgba(34, 211, 200, 0.1), transparent 40%),
+    var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4rem;
+  min-height: 100%;
+}
+
+.ccn-hr18 * {
+  box-sizing: border-box;
+}
+
+.ccn-hr18 h1,
+.ccn-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.ccn-wrap-hr18 {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+/* ---- Header ------------------------------------------------------------------ */
+.ccn-header-hr18 {
+  margin-bottom: 2.25rem;
+}
+
+.ccn-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-2-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.ccn-header-hr18 h1 {
+  font-size: clamp(1.6rem, 2.6vw, 2.2rem);
+}
+
+.ccn-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 62ch;
+  font-size: 0.96rem;
+  line-height: 1.6;
+}
+
+.ccn-note-box-hr18 {
+  margin-top: 1.25rem;
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  background: rgba(139, 92, 246, 0.08);
+  border-radius: var(--radius-hr18);
+  padding: 1rem 1.2rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: #d6cdfd;
+}
+
+.ccn-note-box-hr18 code {
+  font-family: var(--font-mono-hr18);
+}
+
+/* ---- Motion library grid ------------------------------------------------------- */
+.ccn-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 720px) {
+  .ccn-grid-hr18 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 460px) {
+  .ccn-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---- Demo card + replayable glyph ------------------------------------------------ */
+.ccn-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.ccn-glyph-btn-hr18 {
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-raised-hr18);
+  color: var(--accent-2-hr18);
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.ccn-glyph-btn-hr18:hover {
+  border-color: var(--accent-hr18);
+}
+
+/* ---- The reusable component: class-name label + copy button ------------------------
+   Drop-in markup: a .ccn-tag-hr18 wrapping the <code> class name and a
+   .ease-copy-class-btn-hr18 button. The script below finds every instance
+   automatically — no per-card wiring needed. */
+.ccn-tag-hr18 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--panel-raised-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 999px;
+  padding: 0.3rem 0.4rem 0.3rem 0.7rem;
+}
+
+.ccn-tag-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.76rem;
+  color: var(--text-hr18);
+}
+
+.ease-copy-class-btn-hr18 {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted-hr18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.ease-copy-class-btn-hr18:hover {
+  transform: scale(1.15);
+  background: rgba(139, 92, 246, 0.18);
+  color: var(--accent-hr18);
+}
+
+.ease-copy-class-btn-hr18:active {
+  transform: scale(0.95);
+}
+
+.ease-copy-class-btn-hr18 svg {
+  width: 13px;
+  height: 13px;
+}
+
+.ease-copy-class-btn-hr18 .ccn-icon-check-hr18 {
+  display: none;
+}
+
+.ease-copy-class-btn-hr18.is-copied-hr18 {
+  color: var(--success-hr18);
+  background: var(--success-soft-hr18);
+}
+
+.ease-copy-class-btn-hr18.is-copied-hr18 .ccn-icon-copy-hr18 {
+  display: none;
+}
+
+.ease-copy-class-btn-hr18.is-copied-hr18 .ccn-icon-check-hr18 {
+  display: block;
+}
+
+/* ---- Toast-style success message, per card ----------------------------------------- */
+.ccn-toast-hr18 {
+  font-size: 0.72rem;
+  color: var(--success-hr18);
+  min-height: 1.1em;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.ccn-toast-hr18.is-visible-hr18 {
+  opacity: 1;
+}
+
+/* ---- Demo animation classes, used only to replay the glyph preview ----------------- */
+.ccn-anim-fade-hr18 { animation: ccnFade-hr18 500ms ease both; }
+.ccn-anim-slide-hr18 { animation: ccnSlide-hr18 500ms ease both; }
+.ccn-anim-grow-hr18 { animation: ccnGrow-hr18 450ms ease both; }
+.ccn-anim-bounce-hr18 { animation: ccnBounce-hr18 600ms ease both; }
+.ccn-anim-rotate-hr18 { animation: ccnRotate-hr18 550ms ease both; }
+.ccn-anim-pulse-hr18 { animation: ccnPulse-hr18 500ms ease both; }
+
+@keyframes ccnFade-hr18 { from { opacity: 0.15; } to { opacity: 1; } }
+@keyframes ccnSlide-hr18 { from { transform: translateY(10px); opacity: 0.2; } to { transform: translateY(0); opacity: 1; } }
+@keyframes ccnGrow-hr18 { 0% { transform: scale(0.85); } 60% { transform: scale(1.12); } 100% { transform: scale(1); } }
+@keyframes ccnBounce-hr18 { 0%, 100% { transform: translateY(0); } 40% { transform: translateY(-8px); } 70% { transform: translateY(0); } }
+@keyframes ccnRotate-hr18 { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes ccnPulse-hr18 { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.08); opacity: 0.75; } }
+
+.ccn-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.ccn-hr18 :focus-visible {
+  outline: 2px solid var(--accent-2-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ccn-anim-fade-hr18,
+  .ccn-anim-slide-hr18,
+  .ccn-anim-grow-hr18,
+  .ccn-anim-bounce-hr18,
+  .ccn-anim-rotate-hr18,
+  .ccn-anim-pulse-hr18 {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a small "Copy Class Name" button for the class names shown in
EaseMotion's animation demo cards. Reproduces the Motion Library card
pattern (replayable glyph + class-name label) from the framework's own
demo gallery as a self-contained reference, with a copy icon next to each
class name that copies it to the clipboard and shows the "Class name
copied!" message specified in the issue.

Resolves #48321

Note for the maintainer: this is a close cousin of `copy-code-btn-hr18`
(submitted for #48659) — that component copies a whole code block, this
one is deliberately scoped to a single short class-name string with the
exact success message this issue asks for, rather than reusing the other
component's generic wording. Happy to consolidate the two into one
component if you'd prefer that over two similar submissions — flagging it
now rather than assuming. This issue also has 5 assignees; if someone
else's implementation is further along, no concern from my side about this
one not being picked.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/copy-class-name-btn-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A copy-to-clipboard button scoped to single class-name strings, with the
issue's specified "Class name copied!" success message.

**How does a developer use it?**
```html
<span class="ccn-tag-hr18">
  <code>ease-fade-in</code>
  <button type="button" class="ease-copy-class-btn-hr18" data-class-name="ease-fade-in" aria-label="Copy class name">
    <!-- copy + checkmark SVG icons, see README -->
  </button>
</span>
<span class="ccn-toast-hr18">Class name copied!</span>
```

**Why does it fit EaseMotion CSS?**
Implements exactly what the issue describes, including its exact wording,
as a small dependency-free reusable pattern matching EaseMotion's existing
class-based component style.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes and the folder itself use a `-hr18` suffix. The script
auto-discovers every `.ease-copy-class-btn-hr18` and reads its
`data-class-name` attribute, so adding a new card only needs markup.
Tested in Chrome; haven't checked other browsers yet.