### PR TITLE
Add CSS Staggered Entrance Tooltip for Creative Portfolio Layouts

### DIFF
--- a/submissions/examples/Add CSS Staggered Entrance Tooltip for Creative Portfolio Layouts #46280/README.md
+++ b/submissions/examples/Add CSS Staggered Entrance Tooltip for Creative Portfolio Layouts #46280/README.md
@@ -1,0 +1,29 @@
+# CSS Staggered Entrance Tooltip (Creative Portfolio Aesthetics)
+
+This example demonstrates how to create a rich, purely CSS-animated Tooltip featuring a Staggered Entrance interaction transition. 
+
+## Features
+- **Pure CSS**: Fully functional interactivity and rich staggered animations without JavaScript.
+- **Staggered Entrance**: Leveraging child selectors and `transition-delay`, the internal elements of the tooltip (title, tags) cascade into view one after another, creating a sophisticated and premium feel.
+- **Modern CSS APIs**: Uses `allow-discrete` and `@starting-style` to gracefully animate the tooltip from `display: none` to `display: flex` upon hover or focus.
+- **Creative Portfolio Aesthetics**: Incorporates brutalist/creative design paradigms, including high-contrast dark modes, monospace tech tags, neon accents (`#ccff00`), and bold uppercase typography (`Space Grotesk`).
+- **Fully Customizable**: Timing, easing curves, stagger delays, and translation offsets are all exposed via well-documented CSS Custom Properties (Variables).
+
+## Custom Properties Configuration
+You can tweak the stagger delays and animation speeds via these exposed CSS custom properties:
+```css
+:root {
+  --tooltip-duration: 0.3s;
+  --tooltip-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --stagger-offset-y: 8px;
+  
+  --stagger-delay-1: 0.05s;
+  --stagger-delay-2: 0.1s;
+  --stagger-delay-3: 0.15s;
+  --stagger-delay-4: 0.2s;
+}
+```
+
+## Browser Support
+This demo uses modern CSS features. For the full experience, it relies on:
+- **CSS `@starting-style` & `allow-discrete`** (Supported in Chrome 117+, Edge 117+, Firefox 129+, Safari 17.4+)

--- a/submissions/examples/Add CSS Staggered Entrance Tooltip for Creative Portfolio Layouts #46280/demo.html
+++ b/submissions/examples/Add CSS Staggered Entrance Tooltip for Creative Portfolio Layouts #46280/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Staggered Entrance Tooltip - Creative Portfolio</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="portfolio-layout">
+    <header class="portfolio-header">
+      <h1>SELECTED WORKS <span>'24</span></h1>
+      <p>Hover over the tech stack buttons to reveal project details.</p>
+    </header>
+
+    <div class="project-grid">
+      <!-- Project 1 -->
+      <div class="project-card">
+        <div class="project-image img-1"></div>
+        <div class="project-meta">
+          <h2>Neon Cyberpunk UI</h2>
+          
+          <div class="tooltip-container">
+            <button class="tooltip-trigger" aria-describedby="tooltip-1">
+              Tech Stack
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12h4l3-9 5 18 3-9h5"/></svg>
+            </button>
+            
+            <div id="tooltip-1" class="tooltip" role="tooltip">
+              <div class="stagger-item tooltip-title">Built with:</div>
+              <div class="stagger-item tag">WebGL</div>
+              <div class="stagger-item tag">Three.js</div>
+              <div class="stagger-item tag">GLSL Shaders</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Project 2 -->
+      <div class="project-card">
+        <div class="project-image img-2"></div>
+        <div class="project-meta">
+          <h2>Brutalist E-Commerce</h2>
+          
+          <div class="tooltip-container">
+            <button class="tooltip-trigger" aria-describedby="tooltip-2">
+              Tech Stack
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12h4l3-9 5 18 3-9h5"/></svg>
+            </button>
+            
+            <div id="tooltip-2" class="tooltip" role="tooltip">
+              <div class="stagger-item tooltip-title">Built with:</div>
+              <div class="stagger-item tag">Next.js 14</div>
+              <div class="stagger-item tag">Tailwind CSS</div>
+              <div class="stagger-item tag">Stripe API</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/Add CSS Staggered Entrance Tooltip for Creative Portfolio Layouts #46280/style.css
+++ b/submissions/examples/Add CSS Staggered Entrance Tooltip for Creative Portfolio Layouts #46280/style.css
@@ -1,0 +1,253 @@
+:root {
+  /* --- Tooltip Custom Properties --- */
+  --tooltip-duration: 0.3s;
+  --tooltip-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --stagger-offset-y: 8px;
+  
+  /* Staggered entrance delays */
+  --stagger-delay-1: 0.05s;
+  --stagger-delay-2: 0.1s;
+  --stagger-delay-3: 0.15s;
+  --stagger-delay-4: 0.2s;
+  
+  /* Creative Portfolio Theme */
+  --color-bg: #111111;
+  --color-text: #ffffff;
+  --color-text-muted: #888888;
+  --color-accent: #ccff00; /* Neon Yellow/Green */
+  --color-border: #333333;
+  --color-tooltip-bg: #1a1a1a;
+}
+
+/* Base styles */
+body {
+  margin: 0;
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  -webkit-font-smoothing: antialiased;
+}
+
+.portfolio-layout {
+  width: 100%;
+  max-width: 1000px;
+  padding: 4rem 2rem;
+  box-sizing: border-box;
+}
+
+.portfolio-header {
+  margin-bottom: 4rem;
+  text-align: center;
+}
+
+.portfolio-header h1 {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  margin: 0 0 1rem 0;
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+}
+
+.portfolio-header h1 span {
+  color: var(--color-accent);
+}
+
+.portfolio-header p {
+  color: var(--color-text-muted);
+  font-size: 1.1rem;
+}
+
+/* Project Grid */
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 3rem;
+}
+
+.project-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.project-image {
+  width: 100%;
+  aspect-ratio: 4/3;
+  background-color: #222;
+  background-image: linear-gradient(45deg, #111, #222);
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  transition: border-color 0.3s;
+}
+
+.project-image.img-2 {
+  background-image: linear-gradient(135deg, #222, #111);
+}
+
+.project-card:hover .project-image {
+  border-color: var(--color-accent);
+}
+
+.project-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.project-meta h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+}
+
+/* --- TOOLTIP CORE STYLES --- */
+.tooltip-container {
+  position: relative; /* Anchor for absolute positioning */
+  display: inline-block;
+}
+
+.tooltip-trigger {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: 8px 16px;
+  border-radius: 30px;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.3s;
+}
+
+.tooltip-trigger:hover, 
+.tooltip-trigger:focus-visible {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  outline: none;
+}
+
+.tooltip {
+  /* Positioning directly above the trigger */
+  position: absolute;
+  bottom: calc(100% + 12px);
+  right: 0;
+  
+  /* Styling */
+  background: var(--color-tooltip-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 16px;
+  width: max-content;
+  min-width: 140px;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.8);
+  pointer-events: none; /* Don't block clicks/hovers from trigger */
+  z-index: 10;
+  
+  /* Flex layout for staggered items */
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  
+  /* Hidden by default (using modern discrete transitions!) */
+  display: none;
+  opacity: 0;
+  transform: translateY(10px);
+  
+  /* Transition for tooltip container */
+  transition: opacity var(--tooltip-duration) var(--tooltip-easing),
+              transform var(--tooltip-duration) var(--tooltip-easing),
+              display var(--tooltip-duration) var(--tooltip-easing) allow-discrete;
+}
+
+/* Tooltip Arrow */
+.tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  right: 32px;
+  width: 10px;
+  height: 10px;
+  background: var(--color-tooltip-bg);
+  border-right: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  transform: rotate(45deg);
+}
+
+/* Show Tooltip on Hover/Focus of Trigger */
+.tooltip-trigger:hover + .tooltip,
+.tooltip-trigger:focus-visible + .tooltip {
+  display: flex;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Entry Animation Initial Styles (Container) */
+@starting-style {
+  .tooltip-trigger:hover + .tooltip,
+  .tooltip-trigger:focus-visible + .tooltip {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}
+
+/* --- STAGGERED ENTRANCE ITEMS --- */
+.stagger-item {
+  /* Initial/Exit state: pushed down and transparent */
+  opacity: 0;
+  transform: translateY(var(--stagger-offset-y));
+  /* Fast exit transition (no delay) */
+  transition: opacity 0.2s var(--tooltip-easing),
+              transform 0.2s var(--tooltip-easing);
+}
+
+/* Hover state: slow entry with delays */
+.tooltip-trigger:hover + .tooltip .stagger-item,
+.tooltip-trigger:focus-visible + .tooltip .stagger-item {
+  opacity: 1;
+  transform: translateY(0);
+  /* Slower entry transition */
+  transition: opacity 0.4s var(--tooltip-easing),
+              transform 0.4s var(--tooltip-easing);
+}
+
+/* Apply staggered delays on entry ONLY */
+.tooltip-trigger:hover + .tooltip .stagger-item:nth-child(1),
+.tooltip-trigger:focus-visible + .tooltip .stagger-item:nth-child(1) { transition-delay: var(--stagger-delay-1); }
+
+.tooltip-trigger:hover + .tooltip .stagger-item:nth-child(2),
+.tooltip-trigger:focus-visible + .tooltip .stagger-item:nth-child(2) { transition-delay: var(--stagger-delay-2); }
+
+.tooltip-trigger:hover + .tooltip .stagger-item:nth-child(3),
+.tooltip-trigger:focus-visible + .tooltip .stagger-item:nth-child(3) { transition-delay: var(--stagger-delay-3); }
+
+.tooltip-trigger:hover + .tooltip .stagger-item:nth-child(4),
+.tooltip-trigger:focus-visible + .tooltip .stagger-item:nth-child(4) { transition-delay: var(--stagger-delay-4); }
+
+/* Internal Item Styling */
+.tooltip-title {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 4px;
+}
+
+.tag {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  font-family: monospace;
+}


### PR DESCRIPTION
#46280

## Pull Request Description

<!-- Briefly describe what you're submitting and the problem it solves. -->
- Implements the Staggered Entrance transition. It uses native CSS transition-delay with nth-child selectors on the tooltip's inner items (.stagger-item). When the tooltip wrapper becomes visible on hover (smoothly transitioning via modern @starting-style and allow-discrete), the child tags cascade into view one after the other. It leverages brutalist portfolio aesthetics: bold monospace tags, high-contrast borders, and neon yellow accents.
- Resolves #46280 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---



## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
