### PR TITLE
feat: Add draw-border line tooltip for responsive dashboard layouts (fixes #46348)

### DIFF
--- a/submissions/examples/46348-draw-border-tooltip-dashboard-sb/README.md
+++ b/submissions/examples/46348-draw-border-tooltip-dashboard-sb/README.md
@@ -1,0 +1,60 @@
+# Draw-Border Line Tooltip - Responsive Dashboard Layouts
+
+A CSS tooltip component with animated border drawing effect designed for dashboard interfaces.
+
+## Files
+
+- `demo.html` - Demo page showing dashboard UI with tooltips
+- `style.css` - Tooltip styles and animations
+
+## Usage
+
+Open `demo.html` in a browser and hover over info buttons and action buttons to see the draw-border tooltip animation.
+
+## Features
+
+### Draw-Border Animation
+- Border draws from left to right on hover
+- Blue cyan glow effect
+- Bouncy scale entrance animation
+
+### Dashboard Components
+- Stat cards with metrics
+- Info buttons with tooltips
+- Chart section with action buttons
+- Primary and secondary action buttons
+
+### Design System
+- Dark theme dashboard aesthetic
+- Cyan accent color for highlights
+- Subtle glow effects
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `ease-draw-tooltip-sb` | Draw-border line tooltip |
+| `ease-info-btn-sb` | Info button with tooltip |
+| `ease-chart-btn-sb` | Chart action button |
+| `ease-primary-action-sb` | Primary action button |
+| `ease-secondary-action-sb` | Secondary action button |
+| `stat-card` | Dashboard stat card |
+
+## Usage
+
+Add `data-tooltip="Your text"` attribute to any element with `ease-draw-tooltip-sb` class:
+
+```html
+<button class="ease-draw-tooltip-sb" data-tooltip="Download chart">
+  Download
+</button>
+```
+
+## Animation Details
+
+The draw-border animation uses `clip-path` to create a left-to-right border reveal effect:
+- Animation duration: 0.6s
+- Easing: ease forwards
+- Effect: Border sweeps from left to right
+
+Closes #46348

--- a/submissions/examples/46348-draw-border-tooltip-dashboard-sb/demo.html
+++ b/submissions/examples/46348-draw-border-tooltip-dashboard-sb/demo.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Draw-Border Line Tooltip - Dashboard</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-label="Dashboard tooltip demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Draw-Border Line Tooltip</h1>
+        <p>Responsive Dashboard Layout variant with animated border drawing effect.</p>
+        
+        <div class="dashboard-grid">
+          <div class="stat-card">
+            <div class="stat-header">
+              <span class="stat-label">Total Revenue</span>
+              <button class="ease-info-btn-sb ease-draw-tooltip-sb" data-tooltip="Total revenue for the current period">
+                <span class="info-icon"></span>
+              </button>
+            </div>
+            <div class="stat-value">$45,231</div>
+            <div class="stat-change positive">+12.5%</div>
+          </div>
+          
+          <div class="stat-card">
+            <div class="stat-header">
+              <span class="stat-label">Active Users</span>
+              <button class="ease-info-btn-sb ease-draw-tooltip-sb" data-tooltip="Users who logged in within 24 hours">
+                <span class="info-icon"></span>
+              </button>
+            </div>
+            <div class="stat-value">2,847</div>
+            <div class="stat-change positive">+8.2%</div>
+          </div>
+          
+          <div class="stat-card">
+            <div class="stat-header">
+              <span class="stat-label">Conversion Rate</span>
+              <button class="ease-info-btn-sb ease-draw-tooltip-sb" data-tooltip="Percentage of visitors who completed a purchase">
+                <span class="info-icon"></span>
+              </button>
+            </div>
+            <div class="stat-value">3.24%</div>
+            <div class="stat-change negative">-2.1%</div>
+          </div>
+          
+          <div class="stat-card">
+            <div class="stat-header">
+              <span class="stat-label">Avg Order Value</span>
+              <button class="ease-info-btn-sb ease-draw-tooltip-sb" data-tooltip="Average revenue per order">
+                <span class="info-icon"></span>
+              </button>
+            </div>
+            <div class="stat-value">$89.50</div>
+            <div class="stat-change positive">+4.3%</div>
+          </div>
+        </div>
+        
+        <div class="chart-section">
+          <div class="chart-header">
+            <h3>Performance Overview</h3>
+            <div class="chart-actions">
+              <button class="ease-chart-btn-sb ease-draw-tooltip-sb" data-tooltip="Download chart as PNG">
+                <span class="download-icon"></span>
+              </button>
+              <button class="ease-chart-btn-sb ease-draw-tooltip-sb" data-tooltip="Expand chart view">
+                <span class="expand-icon"></span>
+              </button>
+              <button class="ease-chart-btn-sb ease-draw-tooltip-sb" data-tooltip="Chart settings">
+                <span class="settings-icon"></span>
+              </button>
+            </div>
+          </div>
+          <div class="chart-placeholder">
+            <span>Chart visualization area</span>
+          </div>
+        </div>
+        
+        <div class="action-buttons">
+          <button class="ease-primary-action-sb ease-draw-tooltip-sb" data-tooltip="Create new report">
+            <span class="plus-icon"></span>
+            New Report
+          </button>
+          <button class="ease-secondary-action-sb ease-draw-tooltip-sb" data-tooltip="Export all data">
+            <span class="export-icon"></span>
+            Export
+          </button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/46348-draw-border-tooltip-dashboard-sb/style.css
+++ b/submissions/examples/46348-draw-border-tooltip-dashboard-sb/style.css
@@ -1,0 +1,355 @@
+/* ============================================================
+   EaseMotion CSS - Draw-Border Line Tooltip
+   Responsive Dashboard Layouts Variant
+   ============================================================ */
+
+/* ── Base Styles ───────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shell {
+  padding: 2rem;
+  max-width: 900px;
+}
+
+.card {
+  background: #1e293b;
+  padding: 2rem;
+  border-radius: 16px;
+  border: 1px solid #334155;
+}
+
+.eyebrow {
+  color: #38bdf8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #f8fafc;
+}
+
+p {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+/* ── Dashboard Grid ────────────────────────────────────────── */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+/* ── Stat Card ─────────────────────────────────────────────── */
+.stat-card {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1.25rem;
+  transition: all 0.3s ease;
+}
+
+.stat-card:hover {
+  border-color: #38bdf8;
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.1);
+}
+
+.stat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.stat-label {
+  font-size: 0.8125rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #f8fafc;
+  margin-bottom: 0.5rem;
+}
+
+.stat-change {
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.stat-change.positive {
+  color: #22c55e;
+}
+
+.stat-change.negative {
+  color: #ef4444;
+}
+
+/* ── Draw-Border Tooltip ───────────────────────────────────── */
+.ease-draw-tooltip-sb {
+  position: relative;
+}
+
+.ease-draw-tooltip-sb::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.9);
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 100;
+  border: 2px solid #38bdf8;
+  box-shadow: 0 0 15px rgba(56, 189, 248, 0.2);
+}
+
+.ease-draw-tooltip-sb::after {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.9);
+  border: 8px solid transparent;
+  border-top-color: #38bdf8;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 100;
+}
+
+.ease-draw-tooltip-sb:hover::before,
+.ease-draw-tooltip-sb:hover::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+}
+
+.ease-draw-tooltip-sb:hover::before {
+  animation: ease-draw-border-sb 0.6s ease forwards;
+}
+
+@keyframes ease-draw-border-sb {
+  0% {
+    clip-path: inset(0 100% 0 0);
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+/* ── Info Button ────────────────────────────────────────────── */
+.ease-info-btn-sb {
+  width: 24px;
+  height: 24px;
+  background: transparent;
+  border: 1px solid #475569;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.ease-info-btn-sb:hover {
+  border-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.info-icon {
+  width: 12px;
+  height: 12px;
+  background: #64748b;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z'/%3E%3C/svg%3E");
+}
+
+.ease-info-btn-sb:hover .info-icon {
+  background: #38bdf8;
+}
+
+/* ── Chart Section ────────────────────────────────────────── */
+.chart-section {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.chart-header h3 {
+  font-size: 1rem;
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.chart-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ease-chart-btn-sb {
+  width: 36px;
+  height: 36px;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.ease-chart-btn-sb:hover {
+  border-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.download-icon,
+.expand-icon,
+.settings-icon {
+  width: 18px;
+  height: 18px;
+  background: #64748b;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+}
+
+.download-icon {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z'/%3E%3C/svg%3E");
+}
+
+.expand-icon {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M15 3l2.3 2.3-2.89 2.87 1.42 1.42L18.7 6.7 21 9V3h-6zM3 9l2.3-2.3 2.87 2.89 1.42-1.42L6.7 5.3 9 3H3v6zm6 12l-2.3-2.3 2.89-2.87-1.42-1.42L5.3 17.3 3 15v6h6zm12-6l-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87L15 21h6v-6z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M15 3l2.3 2.3-2.89 2.87 1.42 1.42L18.7 6.7 21 9V3h-6zM3 9l2.3-2.3 2.87 2.89 1.42-1.42L6.7 5.3 9 3H3v6zm6 12l-2.3-2.3 2.89-2.87-1.42-1.42L5.3 17.3 3 15v6h6zm12-6l-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87L15 21h6v-6z'/%3E%3C/svg%3E");
+}
+
+.settings-icon {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z'/%3E%3C/svg%3E");
+}
+
+.ease-chart-btn-sb:hover .download-icon,
+.ease-chart-btn-sb:hover .expand-icon,
+.ease-chart-btn-sb:hover .settings-icon {
+  background: #38bdf8;
+}
+
+.chart-placeholder {
+  height: 200px;
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #475569;
+  font-size: 0.875rem;
+}
+
+/* ── Action Buttons ────────────────────────────────────────── */
+.action-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.ease-primary-action-sb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1.5rem;
+  background: linear-gradient(135deg, #38bdf8 0%, #0ea5e9 100%);
+  border: none;
+  border-radius: 10px;
+  color: #0f172a;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.ease-primary-action-sb:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(56, 189, 248, 0.4);
+}
+
+.ease-secondary-action-sb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1.5rem;
+  background: transparent;
+  border: 1px solid #475569;
+  border-radius: 10px;
+  color: #e2e8f0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.ease-secondary-action-sb:hover {
+  border-color: #38bdf8;
+  color: #38bdf8;
+}
+
+.plus-icon,
+.export-icon {
+  width: 18px;
+  height: 18px;
+  background: currentColor;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+}
+
+.plus-icon {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z'/%3E%3C/svg%3E");
+}
+
+.export-icon {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 .67l2.59-2.58L17 11.5l-5 5-5-5 1.41-1.41L11 12.67V3h2v9.67z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 .67l2.59-2.58L17 11.5l-5 5-5-5 1.41-1.41L11 12.67V3h2v9.67z'/%3E%3C/svg%3E");
+}


### PR DESCRIPTION
## Summary
Add CSS draw-border line tooltip component designed for responsive dashboard layouts.

## Features
- Border draws from left to right on hover
- Cyan glow effect
- Dark theme dashboard aesthetic
- Stat cards and chart components

## Changes
- Add ease-draw-tooltip-sb class with clip-path animation
- Add dashboard-specific UI components
- Add icon styles using CSS masks

## Testing
- [x] Tooltip displays on hover
- [x] Border animation runs smoothly
- [x] Dashboard UI renders correctly

## Files
- submissions/examples/46348-draw-border-tooltip-dashboard-sb/demo.html
- submissions/examples/46348-draw-border-tooltip-dashboard-sb/style.css
- submissions/examples/46348-draw-border-tooltip-dashboard-sb/README.md

Closes #46348