### PR TITLE
feat: Add copy-to-clipboard button for code blocks in documentation (fixes #45910)

### DIFF
--- a/submissions/examples/45910-copy-to-clipboard-code-sb/README.md
+++ b/submissions/examples/45910-copy-to-clipboard-code-sb/README.md
@@ -1,0 +1,65 @@
+# Copy-to-Clipboard Code Blocks
+
+Documentation-style code blocks with one-click copy-to-clipboard functionality.
+
+## Files
+
+- `demo.html` - Demo page showing code blocks with copy functionality
+- `style.css` - Code block styles with copy button
+
+## Usage
+
+Open `demo.html` in a browser. Click the "Copy" button on any code block to copy its content to clipboard.
+
+## Features
+
+### Copy-to-Clipboard
+- One-click copy functionality
+- Visual feedback on copy success
+- Automatic button state reset
+- Accessible aria-label
+
+### Code Block Variants
+- Default dark theme
+- HTML syntax highlighting variant
+- JavaScript syntax highlighting variant
+- CSS syntax highlighting variant
+
+### Design System
+- Clean documentation aesthetic
+- Dark code blocks
+- Rounded corners
+- Smooth hover states
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `ease-code-block-sb` | Code block container |
+| `ease-copy-btn-sb` | Copy to clipboard button |
+| `ease-code-html-sb` | HTML code variant |
+| `ease-code-js-sb` | JavaScript code variant |
+| `ease-code-css-sb` | CSS code variant |
+
+## JavaScript Usage
+
+The copy functionality requires a small JavaScript snippet:
+
+```javascript
+document.querySelectorAll('.ease-copy-btn-sb').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    const text = btn.getAttribute('data-copy');
+    await navigator.clipboard.writeText(text);
+    btn.classList.add('copied');
+    // Reset after 2 seconds
+  });
+});
+```
+
+## Implementation
+
+1. Add `data-copy="your-code-here"` attribute with the code to copy
+2. Include the JavaScript snippet to handle clicks
+3. Add `aria-label="Copy to clipboard"` for accessibility
+
+Closes #45910

--- a/submissions/examples/45910-copy-to-clipboard-code-sb/demo.html
+++ b/submissions/examples/45910-copy-to-clipboard-code-sb/demo.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copy-to-Clipboard Code Blocks</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-label="Copy-to-clipboard code blocks demo">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1>Copy-to-Clipboard Code Blocks</h1>
+        <p>Documentation-style code blocks with copy-to-clipboard functionality.</p>
+        
+        <div class="documentation">
+          <h2>Getting Started</h2>
+          <p>Install the package using npm:</p>
+          
+          <div class="ease-code-block-sb">
+            <button class="ease-copy-btn-sb" data-copy="npm install easemotion-css" aria-label="Copy to clipboard">
+              <span class="copy-icon"></span>
+              <span class="copy-text">Copy</span>
+            </button>
+            <pre><code>npm install easemotion-css</code></pre>
+          </div>
+          
+          <p>Or using yarn:</p>
+          
+          <div class="ease-code-block-sb">
+            <button class="ease-copy-btn-sb" data-copy="yarn add easemotion-css" aria-label="Copy to clipboard">
+              <span class="copy-icon"></span>
+              <span class="copy-text">Copy</span>
+            </button>
+            <pre><code>yarn add easemotion-css</code></pre>
+          </div>
+          
+          <h2>Basic Usage</h2>
+          <p>Import and use the animation classes:</p>
+          
+          <div class="ease-code-block-sb ease-code-html-sb">
+            <button class="ease-copy-btn-sb" data-copy="&lt;div class='ease-fade-in'&gt;Content&lt;/div&gt;" aria-label="Copy to clipboard">
+              <span class="copy-icon"></span>
+              <span class="copy-text">Copy</span>
+            </button>
+            <pre><code>&lt;div class="ease-fade-in"&gt;
+  Content
+&lt;/div&gt;</code></pre>
+          </div>
+          
+          <div class="ease-code-block-sb ease-code-js-sb">
+            <button class="ease-copy-btn-sb" data-copy="import { init } from 'easemotion-css'; init();" aria-label="Copy to clipboard">
+              <span class="copy-icon"></span>
+              <span class="copy-text">Copy</span>
+            </button>
+            <pre><code>import { init } from 'easemotion-css';
+
+init();</code></pre>
+          </div>
+          
+          <h2>Configuration</h2>
+          <p>Customize animations with CSS custom properties:</p>
+          
+          <div class="ease-code-block-sb ease-code-css-sb">
+            <button class="ease-copy-btn-sb" data-copy=":root { --ease-duration: 500ms; --ease-easing: ease-out; }" aria-label="Copy to clipboard">
+              <span class="copy-icon"></span>
+              <span class="copy-text">Copy</span>
+            </button>
+            <pre><code>:root {
+  --ease-duration: 500ms;
+  --ease-easing: ease-out;
+}</code></pre>
+          </div>
+        </div>
+      </section>
+    </main>
+    
+    <script>
+      document.querySelectorAll('.ease-copy-btn-sb').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const text = btn.getAttribute('data-copy');
+          try {
+            await navigator.clipboard.writeText(text);
+            btn.classList.add('copied');
+            btn.querySelector('.copy-text').textContent = 'Copied!';
+            setTimeout(() => {
+              btn.classList.remove('copied');
+              btn.querySelector('.copy-text').textContent = 'Copy';
+            }, 2000);
+          } catch (err) {
+            console.error('Failed to copy:', err);
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/45910-copy-to-clipboard-code-sb/style.css
+++ b/submissions/examples/45910-copy-to-clipboard-code-sb/style.css
@@ -1,0 +1,188 @@
+/* ============================================================
+   EaseMotion CSS - Copy-to-Clipboard Code Blocks
+   Documentation-style code blocks with copy functionality
+   ============================================================ */
+
+/* ── Base Styles ───────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shell {
+  padding: 2rem;
+  max-width: 800px;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 20px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e2e8f0;
+}
+
+.eyebrow {
+  color: #6366f1;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+p {
+  color: #64748b;
+  margin-bottom: 1rem;
+  line-height: 1.6;
+}
+
+h2 {
+  font-size: 1.25rem;
+  color: #0f172a;
+  margin: 2rem 0 1rem;
+}
+
+h2:first-of-type {
+  margin-top: 0;
+}
+
+/* ── Documentation ─────────────────────────────────────────── */
+.documentation {
+  background: #f8fafc;
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+/* ── Code Block ────────────────────────────────────────────── */
+.ease-code-block-sb {
+  position: relative;
+  background: #1e1b4b;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+}
+
+.ease-code-block-sb pre {
+  margin: 0;
+  padding: 1.25rem;
+  overflow-x: auto;
+}
+
+.ease-code-block-sb code {
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', monospace;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #e2e8f0;
+  white-space: pre;
+}
+
+/* ── Copy Button ────────────────────────────────────────────── */
+.ease-copy-btn-sb {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: #94a3b8;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 10;
+}
+
+.ease-copy-btn-sb:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+.ease-copy-btn-sb.copied {
+  background: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #22c55e;
+}
+
+.copy-icon {
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z'/%3E%3C/svg%3E");
+}
+
+.ease-copy-btn-sb.copied .copy-icon {
+  background: #22c55e;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
+}
+
+.copy-text {
+  transition: all 0.2s ease;
+}
+
+/* ── Language Variants ───────────────────────────────────────── */
+.ease-code-html-sb {
+  background: linear-gradient(135deg, #1e1b4b 0%, #2d1b69 100%);
+}
+
+.ease-code-html-sb code {
+  color: #fb7185;
+}
+
+.ease-code-js-sb {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+}
+
+.ease-code-js-sb code {
+  color: #fbbf24;
+}
+
+.ease-code-css-sb {
+  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+}
+
+.ease-code-css-sb code {
+  color: #60a5fa;
+}
+
+/* ── Line Numbers (Optional Enhancement) ───────────────────── */
+.ease-code-block-sb.with-lines pre {
+  counter-reset: line;
+}
+
+.ease-code-block-sb.with-lines code:before {
+  counter-increment: line;
+  content: counter(line);
+  display: inline-block;
+  width: 2rem;
+  margin-right: 1rem;
+  text-align: right;
+  color: #475569;
+  border-right: 1px solid #334155;
+  padding-right: 1rem;
+}


### PR DESCRIPTION
## Summary
Add copy-to-clipboard functionality for documentation code blocks.

## Features
- One-click copy to clipboard
- Visual feedback on success
- Multiple code block variants
- Accessible implementation

## Changes
- Add ease-code-block-sb class for code containers
- Add ease-copy-btn-sb class for copy button
- Add language-specific code variants
- Include JavaScript for copy functionality

## Testing
- [x] Copy button works correctly
- [x] Visual feedback displays on copy
- [x] Code block renders correctly

## Files
- submissions/examples/45910-copy-to-clipboard-code-sb/demo.html
- submissions/examples/45910-copy-to-clipboard-code-sb/style.css
- submissions/examples/45910-copy-to-clipboard-code-sb/README.md

Closes #45910