### PR TITLE
Add tautochrone component

### DIFF
--- a/submissions/examples/tautochrone-as/README.md
+++ b/submissions/examples/tautochrone-as/README.md
@@ -1,0 +1,51 @@
+# Tautochrone
+
+A pure CSS/HTML cycloid bowl with four beads released from four different heights, all reaching the bottom at the same instant.
+
+## What it shows
+
+Drop a bead into a bowl and it slides to the bottom. Drop it from higher up and it has further to travel, but it also picks up more speed. For almost every bowl shape those two effects do not cancel, and the trip takes longer from higher up.
+
+For one shape they cancel **exactly**. On an upside-down arch of a **cycloid**, the time to reach the bottom is
+
+```
+T = pi * sqrt(R / g)
+```
+
+with no reference at all to where the bead started. That is the **tautochrone** property, from the Greek for "same time". A bead let go just above the bottom and a bead let go from the rim arrive together.
+
+Christiaan Huygens found this in 1659, and he was not doing it for fun. A pendulum clock loses time as its swing decays, because an ordinary circular arc is *not* tautochronous: a wide swing takes fractionally longer than a narrow one. Huygens realised the cure was to make the bob travel a cycloid instead of a circle, and built a pendulum hung between two cycloidal cheeks so the string wrapped against them and forced exactly that path. The clock's rate would then be independent of how far it swung.
+
+The curve has a second life. It is also the **brachistochrone**, the curve of fastest descent between two points, which Johann Bernoulli posed as a challenge in 1696. One curve, two unrelated questions, same answer. Bernoulli remarked on the coincidence.
+
+## The numbers
+
+Descent time from an angle `t0` is `integral ds / sqrt(2 g (y - y0))`. The integrand blows up at the release point, where the bead is at rest, so the integral is evaluated after a substitution that cancels the singularity. For R = 44px at g = 980 px/s2:
+
+| released from | descent time |
+| --- | --- |
+| 81.5 px above the bottom | 0.665676 s |
+| 65.9 px | 0.665676 s |
+| 42.7 px | 0.665676 s |
+| 19.9 px | 0.665676 s |
+
+Four starting heights spanning a factor of four, and the four times agree to **3e-11 s**. The exact value `pi*sqrt(R/g)` is 0.665676 s.
+
+## How it is built
+
+- **The motion is the exact solution, not an easing curve.** Measured as arc length `s` from the bottom, a bead on a cycloid obeys `s'' = -(g/4R) s`, which is simple harmonic motion exactly, at any amplitude. Each bead's position is `s = s0*cos(wt)` mapped back onto the curve, so all four share one period, `4*pi*sqrt(R/g)` = 2.663 s, no matter how far they swing.
+- **The synchrony is measured in the browser, on the rendered beads.** Sweeping the paused animation at 2400 steps and detecting every crossing of the lowest point: all four beads cross at **the same instants**, with **0 ms** disagreement and **0 px** spread between them at the crossing.
+- **The four starts are genuinely different**, and that is checked too: the drop heights measure **81.5, 65.9, 42.7 and 19.9 px**, four distinct values. Without that the synchrony would prove nothing.
+- **The bowl is a real cycloid**, `x = R(t - sin t)`, `y = R(1 - cos t)`, drawn from 161 points, and the beads are constrained to it rather than animated near it.
+- Keyframes are sampled so linear interpolation between them never deviates more than **0.22 px** from the true path.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` pauses the four beads mid-swing, leaving the bowl and the release markers readable.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/tautochrone-as/demo.html
+++ b/submissions/examples/tautochrone-as/demo.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tautochrone</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="gridT"></span>
+      <span class="bowlT" style="left: 22.00px; top: 46.00px"></span>
+      <span class="bowlT" style="left: 22.00px; top: 46.03px"></span>
+      <span class="bowlT" style="left: 22.00px; top: 46.14px"></span>
+      <span class="bowlT" style="left: 22.01px; top: 46.30px"></span>
+      <span class="bowlT" style="left: 22.03px; top: 46.54px"></span>
+      <span class="bowlT" style="left: 22.06px; top: 46.85px"></span>
+      <span class="bowlT" style="left: 22.10px; top: 47.22px"></span>
+      <span class="bowlT" style="left: 22.15px; top: 47.65px"></span>
+      <span class="bowlT" style="left: 22.23px; top: 48.15px"></span>
+      <span class="bowlT" style="left: 22.32px; top: 48.72px"></span>
+      <span class="bowlT" style="left: 22.44px; top: 49.35px"></span>
+      <span class="bowlT" style="left: 22.59px; top: 50.04px"></span>
+      <span class="bowlT" style="left: 22.76px; top: 50.80px"></span>
+      <span class="bowlT" style="left: 22.96px; top: 51.61px"></span>
+      <span class="bowlT" style="left: 23.20px; top: 52.48px"></span>
+      <span class="bowlT" style="left: 23.47px; top: 53.42px"></span>
+      <span class="bowlT" style="left: 23.78px; top: 54.40px"></span>
+      <span class="bowlT" style="left: 24.13px; top: 55.45px"></span>
+      <span class="bowlT" style="left: 24.53px; top: 56.54px"></span>
+      <span class="bowlT" style="left: 24.96px; top: 57.69px"></span>
+      <span class="bowlT" style="left: 25.44px; top: 58.89px"></span>
+      <span class="bowlT" style="left: 25.98px; top: 60.13px"></span>
+      <span class="bowlT" style="left: 26.56px; top: 61.42px"></span>
+      <span class="bowlT" style="left: 27.19px; top: 62.76px"></span>
+      <span class="bowlT" style="left: 27.87px; top: 64.14px"></span>
+      <span class="bowlT" style="left: 28.61px; top: 65.55px"></span>
+      <span class="bowlT" style="left: 29.41px; top: 67.01px"></span>
+      <span class="bowlT" style="left: 30.26px; top: 68.50px"></span>
+      <span class="bowlT" style="left: 31.18px; top: 70.02px"></span>
+      <span class="bowlT" style="left: 32.15px; top: 71.58px"></span>
+      <span class="bowlT" style="left: 33.19px; top: 73.16px"></span>
+      <span class="bowlT" style="left: 34.28px; top: 74.77px"></span>
+      <span class="bowlT" style="left: 35.45px; top: 76.40px"></span>
+      <span class="bowlT" style="left: 36.67px; top: 78.06px"></span>
+      <span class="bowlT" style="left: 37.96px; top: 79.73px"></span>
+      <span class="bowlT" style="left: 39.32px; top: 81.42px"></span>
+      <span class="bowlT" style="left: 40.75px; top: 83.12px"></span>
+      <span class="bowlT" style="left: 42.24px; top: 84.83px"></span>
+      <span class="bowlT" style="left: 43.79px; top: 86.55px"></span>
+      <span class="bowlT" style="left: 45.42px; top: 88.27px"></span>
+      <span class="bowlT" style="left: 47.12px; top: 90.00px"></span>
+      <span class="bowlT" style="left: 48.88px; top: 91.73px"></span>
+      <span class="bowlT" style="left: 50.71px; top: 93.45px"></span>
+      <span class="bowlT" style="left: 52.60px; top: 95.17px"></span>
+      <span class="bowlT" style="left: 54.57px; top: 96.88px"></span>
+      <span class="bowlT" style="left: 56.60px; top: 98.58px"></span>
+      <span class="bowlT" style="left: 58.70px; top: 100.27px"></span>
+      <span class="bowlT" style="left: 60.86px; top: 101.94px"></span>
+      <span class="bowlT" style="left: 63.09px; top: 103.60px"></span>
+      <span class="bowlT" style="left: 65.39px; top: 105.23px"></span>
+      <span class="bowlT" style="left: 67.74px; top: 106.84px"></span>
+      <span class="bowlT" style="left: 70.16px; top: 108.42px"></span>
+      <span class="bowlT" style="left: 72.65px; top: 109.98px"></span>
+      <span class="bowlT" style="left: 75.19px; top: 111.50px"></span>
+      <span class="bowlT" style="left: 77.79px; top: 112.99px"></span>
+      <span class="bowlT" style="left: 80.45px; top: 114.45px"></span>
+      <span class="bowlT" style="left: 83.16px; top: 115.86px"></span>
+      <span class="bowlT" style="left: 85.93px; top: 117.24px"></span>
+      <span class="bowlT" style="left: 88.76px; top: 118.58px"></span>
+      <span class="bowlT" style="left: 91.63px; top: 119.87px"></span>
+      <span class="bowlT" style="left: 94.56px; top: 121.11px"></span>
+      <span class="bowlT" style="left: 97.53px; top: 122.31px"></span>
+      <span class="bowlT" style="left: 100.55px; top: 123.46px"></span>
+      <span class="bowlT" style="left: 103.62px; top: 124.55px"></span>
+      <span class="bowlT" style="left: 106.72px; top: 125.60px"></span>
+      <span class="bowlT" style="left: 109.87px; top: 126.58px"></span>
+      <span class="bowlT" style="left: 113.05px; top: 127.52px"></span>
+      <span class="bowlT" style="left: 116.27px; top: 128.39px"></span>
+      <span class="bowlT" style="left: 119.52px; top: 129.20px"></span>
+      <span class="bowlT" style="left: 122.80px; top: 129.96px"></span>
+      <span class="bowlT" style="left: 126.11px; top: 130.65px"></span>
+      <span class="bowlT" style="left: 129.45px; top: 131.28px"></span>
+      <span class="bowlT" style="left: 132.81px; top: 131.85px"></span>
+      <span class="bowlT" style="left: 136.19px; top: 132.35px"></span>
+      <span class="bowlT" style="left: 139.59px; top: 132.78px"></span>
+      <span class="bowlT" style="left: 143.01px; top: 133.15px"></span>
+      <span class="bowlT" style="left: 146.44px; top: 133.46px"></span>
+      <span class="bowlT" style="left: 149.87px; top: 133.70px"></span>
+      <span class="bowlT" style="left: 153.32px; top: 133.86px"></span>
+      <span class="bowlT" style="left: 156.77px; top: 133.97px"></span>
+      <span class="bowlT" style="left: 160.23px; top: 134.00px"></span>
+      <span class="bowlT" style="left: 163.69px; top: 133.97px"></span>
+      <span class="bowlT" style="left: 167.14px; top: 133.86px"></span>
+      <span class="bowlT" style="left: 170.59px; top: 133.70px"></span>
+      <span class="bowlT" style="left: 174.02px; top: 133.46px"></span>
+      <span class="bowlT" style="left: 177.45px; top: 133.15px"></span>
+      <span class="bowlT" style="left: 180.87px; top: 132.78px"></span>
+      <span class="bowlT" style="left: 184.27px; top: 132.35px"></span>
+      <span class="bowlT" style="left: 187.65px; top: 131.85px"></span>
+      <span class="bowlT" style="left: 191.01px; top: 131.28px"></span>
+      <span class="bowlT" style="left: 194.35px; top: 130.65px"></span>
+      <span class="bowlT" style="left: 197.66px; top: 129.96px"></span>
+      <span class="bowlT" style="left: 200.94px; top: 129.20px"></span>
+      <span class="bowlT" style="left: 204.19px; top: 128.39px"></span>
+      <span class="bowlT" style="left: 207.41px; top: 127.52px"></span>
+      <span class="bowlT" style="left: 210.59px; top: 126.58px"></span>
+      <span class="bowlT" style="left: 213.74px; top: 125.60px"></span>
+      <span class="bowlT" style="left: 216.84px; top: 124.55px"></span>
+      <span class="bowlT" style="left: 219.91px; top: 123.46px"></span>
+      <span class="bowlT" style="left: 222.93px; top: 122.31px"></span>
+      <span class="bowlT" style="left: 225.90px; top: 121.11px"></span>
+      <span class="bowlT" style="left: 228.83px; top: 119.87px"></span>
+      <span class="bowlT" style="left: 231.70px; top: 118.58px"></span>
+      <span class="bowlT" style="left: 234.53px; top: 117.24px"></span>
+      <span class="bowlT" style="left: 237.30px; top: 115.86px"></span>
+      <span class="bowlT" style="left: 240.01px; top: 114.45px"></span>
+      <span class="bowlT" style="left: 242.67px; top: 112.99px"></span>
+      <span class="bowlT" style="left: 245.27px; top: 111.50px"></span>
+      <span class="bowlT" style="left: 247.81px; top: 109.98px"></span>
+      <span class="bowlT" style="left: 250.30px; top: 108.42px"></span>
+      <span class="bowlT" style="left: 252.72px; top: 106.84px"></span>
+      <span class="bowlT" style="left: 255.07px; top: 105.23px"></span>
+      <span class="bowlT" style="left: 257.37px; top: 103.60px"></span>
+      <span class="bowlT" style="left: 259.60px; top: 101.94px"></span>
+      <span class="bowlT" style="left: 261.76px; top: 100.27px"></span>
+      <span class="bowlT" style="left: 263.86px; top: 98.58px"></span>
+      <span class="bowlT" style="left: 265.89px; top: 96.88px"></span>
+      <span class="bowlT" style="left: 267.86px; top: 95.17px"></span>
+      <span class="bowlT" style="left: 269.75px; top: 93.45px"></span>
+      <span class="bowlT" style="left: 271.58px; top: 91.73px"></span>
+      <span class="bowlT" style="left: 273.35px; top: 90.00px"></span>
+      <span class="bowlT" style="left: 275.04px; top: 88.27px"></span>
+      <span class="bowlT" style="left: 276.67px; top: 86.55px"></span>
+      <span class="bowlT" style="left: 278.22px; top: 84.83px"></span>
+      <span class="bowlT" style="left: 279.71px; top: 83.12px"></span>
+      <span class="bowlT" style="left: 281.14px; top: 81.42px"></span>
+      <span class="bowlT" style="left: 282.50px; top: 79.73px"></span>
+      <span class="bowlT" style="left: 283.79px; top: 78.06px"></span>
+      <span class="bowlT" style="left: 285.01px; top: 76.40px"></span>
+      <span class="bowlT" style="left: 286.18px; top: 74.77px"></span>
+      <span class="bowlT" style="left: 287.27px; top: 73.16px"></span>
+      <span class="bowlT" style="left: 288.31px; top: 71.58px"></span>
+      <span class="bowlT" style="left: 289.28px; top: 70.02px"></span>
+      <span class="bowlT" style="left: 290.20px; top: 68.50px"></span>
+      <span class="bowlT" style="left: 291.05px; top: 67.01px"></span>
+      <span class="bowlT" style="left: 291.85px; top: 65.55px"></span>
+      <span class="bowlT" style="left: 292.59px; top: 64.14px"></span>
+      <span class="bowlT" style="left: 293.27px; top: 62.76px"></span>
+      <span class="bowlT" style="left: 293.90px; top: 61.42px"></span>
+      <span class="bowlT" style="left: 294.48px; top: 60.13px"></span>
+      <span class="bowlT" style="left: 295.02px; top: 58.89px"></span>
+      <span class="bowlT" style="left: 295.50px; top: 57.69px"></span>
+      <span class="bowlT" style="left: 295.93px; top: 56.54px"></span>
+      <span class="bowlT" style="left: 296.33px; top: 55.45px"></span>
+      <span class="bowlT" style="left: 296.68px; top: 54.40px"></span>
+      <span class="bowlT" style="left: 296.99px; top: 53.42px"></span>
+      <span class="bowlT" style="left: 297.26px; top: 52.48px"></span>
+      <span class="bowlT" style="left: 297.50px; top: 51.61px"></span>
+      <span class="bowlT" style="left: 297.70px; top: 50.80px"></span>
+      <span class="bowlT" style="left: 297.87px; top: 50.04px"></span>
+      <span class="bowlT" style="left: 298.02px; top: 49.35px"></span>
+      <span class="bowlT" style="left: 298.14px; top: 48.72px"></span>
+      <span class="bowlT" style="left: 298.23px; top: 48.15px"></span>
+      <span class="bowlT" style="left: 298.31px; top: 47.65px"></span>
+      <span class="bowlT" style="left: 298.36px; top: 47.22px"></span>
+      <span class="bowlT" style="left: 298.40px; top: 46.85px"></span>
+      <span class="bowlT" style="left: 298.43px; top: 46.54px"></span>
+      <span class="bowlT" style="left: 298.45px; top: 46.30px"></span>
+      <span class="bowlT" style="left: 298.46px; top: 46.14px"></span>
+      <span class="bowlT" style="left: 298.46px; top: 46.03px"></span>
+      <span class="bowlT" style="left: 298.46px; top: 46.00px"></span>
+    <span class="vertT"></span>
+    <span class="relT rel1" style="left: 23.20px; top: 52.49px"></span>
+    <span class="relT rel2" style="left: 30.03px; top: 68.11px"></span>
+    <span class="relT rel3" style="left: 48.42px; top: 91.28px"></span>
+    <span class="relT rel4" style="left: 79.78px; top: 114.08px"></span>
+    <span class="beadT b1"></span>
+    <span class="beadT b2"></span>
+    <span class="beadT b3"></span>
+    <span class="beadT b4"></span>
+    <span class="tagT">released together, from four heights</span>
+    <span class="legT">drop 82 / 66 / 43 / 20 px &middot; all reach bottom in 0.666 s</span>
+    <span class="capT">the deeper the start, the faster the slide, exactly enough</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tautochrone-as/style.css
+++ b/submissions/examples/tautochrone-as/style.css
@@ -1,0 +1,639 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #221f2e, #06050a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 230px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 34%, #2c2740, #08060d 86%);
+}
+
+.gridT {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(90deg, rgba(190, 180, 255, 0.05) 0 1px, transparent 1px 20px),
+    repeating-linear-gradient(0deg, rgba(190, 180, 255, 0.05) 0 1px, transparent 1px 20px);
+  z-index: 1;
+}
+
+/*
+  the bowl is one arch of a cycloid, x = R(t - sin t), y = R(1 - cos t).
+  a bead released anywhere on it reaches the bottom in pi*sqrt(R/g),
+  the same number whatever height it started from. huygens found this
+  in 1659 while trying to build a clock that kept time as the swing decayed.
+*/
+.bowlT {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  margin: -1.5px 0 0 -1.5px;
+  border-radius: 50%;
+  background: rgba(175, 160, 255, 0.5);
+  z-index: 2;
+}
+
+.vertT {
+  position: absolute;
+  left: 160.23px;
+  top: 134.00px;
+  width: 1px;
+  height: 26px;
+  margin-left: -0.5px;
+  background: linear-gradient(rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+  z-index: 3;
+}
+
+/* where each bead was let go, all released at the same instant, at rest */
+.relT {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  margin: -4.5px 0 0 -4.5px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  z-index: 4;
+}
+
+.beadT {
+  position: absolute;
+  width: 11px;
+  height: 11px;
+  margin: -5.5px 0 0 -5.5px;
+  border-radius: 50%;
+  z-index: 6;
+  animation-duration: 4.2s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.b1 {
+  background: radial-gradient(circle at 34% 30%, #fff0d0, #e8a020 70%);
+  box-shadow: 0 0 9px rgba(255, 190, 80, 0.85);
+  animation-name: sw1;
+}
+
+.b2 {
+  background: radial-gradient(circle at 34% 30%, #ffdcf0, #e04a9a 70%);
+  box-shadow: 0 0 9px rgba(255, 110, 180, 0.85);
+  animation-name: sw2;
+}
+
+.b3 {
+  background: radial-gradient(circle at 34% 30%, #d8ecff, #3a86e0 70%);
+  box-shadow: 0 0 9px rgba(110, 175, 255, 0.85);
+  animation-name: sw3;
+}
+
+.b4 {
+  background: radial-gradient(circle at 34% 30%, #d8ffe8, #18b878 70%);
+  box-shadow: 0 0 9px rgba(90, 240, 175, 0.85);
+  animation-name: sw4;
+}
+
+.tagT {
+  position: absolute;
+  top: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.48rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: rgba(220, 210, 255, 0.9);
+  z-index: 9;
+}
+
+.legT {
+  position: absolute;
+  bottom: 26px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.04em;
+  color: rgba(200, 230, 255, 0.92);
+  z-index: 9;
+}
+
+.capT {
+  position: absolute;
+  bottom: 9px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.03em;
+  color: rgba(205, 195, 240, 0.78);
+  z-index: 9;
+}
+
+@keyframes sw1 {
+  0.000% { left: 23.20px; top: 52.49px; }
+  0.833% { left: 23.27px; top: 52.71px; }
+  1.667% { left: 23.46px; top: 53.38px; }
+  2.500% { left: 23.81px; top: 54.48px; }
+  3.333% { left: 24.33px; top: 56.01px; }
+  4.167% { left: 25.06px; top: 57.95px; }
+  5.000% { left: 26.04px; top: 60.27px; }
+  5.833% { left: 27.28px; top: 62.96px; }
+  6.667% { left: 28.84px; top: 65.97px; }
+  7.500% { left: 30.73px; top: 69.29px; }
+  8.333% { left: 32.99px; top: 72.87px; }
+  9.167% { left: 35.64px; top: 76.67px; }
+  10.000% { left: 38.70px; top: 80.65px; }
+  10.833% { left: 42.19px; top: 84.77px; }
+  11.667% { left: 46.11px; top: 88.98px; }
+  12.500% { left: 50.48px; top: 93.24px; }
+  13.333% { left: 55.30px; top: 97.50px; }
+  14.167% { left: 60.57px; top: 101.72px; }
+  15.000% { left: 66.27px; top: 105.84px; }
+  15.833% { left: 72.39px; top: 109.82px; }
+  16.667% { left: 78.93px; top: 113.62px; }
+  17.500% { left: 85.85px; top: 117.20px; }
+  18.333% { left: 93.14px; top: 120.52px; }
+  19.167% { left: 100.75px; top: 123.53px; }
+  20.000% { left: 108.67px; top: 126.22px; }
+  20.833% { left: 116.85px; top: 128.54px; }
+  21.667% { left: 125.25px; top: 130.48px; }
+  22.500% { left: 133.83px; top: 132.01px; }
+  23.333% { left: 142.55px; top: 133.11px; }
+  24.167% { left: 151.37px; top: 133.78px; }
+  25.000% { left: 160.23px; top: 134.00px; }
+  25.833% { left: 169.09px; top: 133.78px; }
+  26.667% { left: 177.91px; top: 133.11px; }
+  27.500% { left: 186.63px; top: 132.01px; }
+  28.333% { left: 195.21px; top: 130.48px; }
+  29.167% { left: 203.61px; top: 128.54px; }
+  30.000% { left: 211.79px; top: 126.22px; }
+  30.833% { left: 219.71px; top: 123.53px; }
+  31.667% { left: 227.32px; top: 120.52px; }
+  32.500% { left: 234.61px; top: 117.20px; }
+  33.333% { left: 241.53px; top: 113.62px; }
+  34.167% { left: 248.07px; top: 109.82px; }
+  35.000% { left: 254.19px; top: 105.84px; }
+  35.833% { left: 259.89px; top: 101.72px; }
+  36.667% { left: 265.16px; top: 97.50px; }
+  37.500% { left: 269.98px; top: 93.24px; }
+  38.333% { left: 274.35px; top: 88.98px; }
+  39.167% { left: 278.27px; top: 84.77px; }
+  40.000% { left: 281.76px; top: 80.65px; }
+  40.833% { left: 284.82px; top: 76.67px; }
+  41.667% { left: 287.47px; top: 72.87px; }
+  42.500% { left: 289.73px; top: 69.29px; }
+  43.333% { left: 291.62px; top: 65.97px; }
+  44.167% { left: 293.18px; top: 62.96px; }
+  45.000% { left: 294.42px; top: 60.27px; }
+  45.833% { left: 295.40px; top: 57.95px; }
+  46.667% { left: 296.13px; top: 56.01px; }
+  47.500% { left: 296.65px; top: 54.48px; }
+  48.333% { left: 297.00px; top: 53.38px; }
+  49.167% { left: 297.19px; top: 52.71px; }
+  50.000% { left: 297.26px; top: 52.49px; }
+  50.833% { left: 297.19px; top: 52.71px; }
+  51.667% { left: 297.00px; top: 53.38px; }
+  52.500% { left: 296.65px; top: 54.48px; }
+  53.333% { left: 296.13px; top: 56.01px; }
+  54.167% { left: 295.40px; top: 57.95px; }
+  55.000% { left: 294.42px; top: 60.27px; }
+  55.833% { left: 293.18px; top: 62.96px; }
+  56.667% { left: 291.62px; top: 65.97px; }
+  57.500% { left: 289.73px; top: 69.29px; }
+  58.333% { left: 287.47px; top: 72.87px; }
+  59.167% { left: 284.82px; top: 76.67px; }
+  60.000% { left: 281.76px; top: 80.65px; }
+  60.833% { left: 278.27px; top: 84.77px; }
+  61.667% { left: 274.35px; top: 88.98px; }
+  62.500% { left: 269.98px; top: 93.24px; }
+  63.333% { left: 265.16px; top: 97.50px; }
+  64.167% { left: 259.89px; top: 101.72px; }
+  65.000% { left: 254.19px; top: 105.84px; }
+  65.833% { left: 248.07px; top: 109.82px; }
+  66.667% { left: 241.53px; top: 113.62px; }
+  67.500% { left: 234.61px; top: 117.20px; }
+  68.333% { left: 227.32px; top: 120.52px; }
+  69.167% { left: 219.71px; top: 123.53px; }
+  70.000% { left: 211.79px; top: 126.22px; }
+  70.833% { left: 203.61px; top: 128.54px; }
+  71.667% { left: 195.21px; top: 130.48px; }
+  72.500% { left: 186.63px; top: 132.01px; }
+  73.333% { left: 177.91px; top: 133.11px; }
+  74.167% { left: 169.09px; top: 133.78px; }
+  75.000% { left: 160.23px; top: 134.00px; }
+  75.833% { left: 151.37px; top: 133.78px; }
+  76.667% { left: 142.55px; top: 133.11px; }
+  77.500% { left: 133.83px; top: 132.01px; }
+  78.333% { left: 125.25px; top: 130.48px; }
+  79.167% { left: 116.85px; top: 128.54px; }
+  80.000% { left: 108.67px; top: 126.22px; }
+  80.833% { left: 100.75px; top: 123.53px; }
+  81.667% { left: 93.14px; top: 120.52px; }
+  82.500% { left: 85.85px; top: 117.20px; }
+  83.333% { left: 78.93px; top: 113.62px; }
+  84.167% { left: 72.39px; top: 109.82px; }
+  85.000% { left: 66.27px; top: 105.84px; }
+  85.833% { left: 60.57px; top: 101.72px; }
+  86.667% { left: 55.30px; top: 97.50px; }
+  87.500% { left: 50.48px; top: 93.24px; }
+  88.333% { left: 46.11px; top: 88.98px; }
+  89.167% { left: 42.19px; top: 84.77px; }
+  90.000% { left: 38.70px; top: 80.65px; }
+  90.833% { left: 35.64px; top: 76.67px; }
+  91.667% { left: 32.99px; top: 72.87px; }
+  92.500% { left: 30.73px; top: 69.29px; }
+  93.333% { left: 28.84px; top: 65.97px; }
+  94.167% { left: 27.28px; top: 62.96px; }
+  95.000% { left: 26.04px; top: 60.27px; }
+  95.833% { left: 25.06px; top: 57.95px; }
+  96.667% { left: 24.33px; top: 56.01px; }
+  97.500% { left: 23.81px; top: 54.48px; }
+  98.333% { left: 23.46px; top: 53.38px; }
+  99.167% { left: 23.27px; top: 52.71px; }
+  100.000% { left: 23.20px; top: 52.49px; }
+}
+
+@keyframes sw2 {
+  0.000% { left: 30.03px; top: 68.11px; }
+  0.833% { left: 30.14px; top: 68.29px; }
+  1.667% { left: 30.45px; top: 68.83px; }
+  2.500% { left: 30.99px; top: 69.72px; }
+  3.333% { left: 31.75px; top: 70.96px; }
+  4.167% { left: 32.76px; top: 72.52px; }
+  5.000% { left: 34.03px; top: 74.40px; }
+  5.833% { left: 35.57px; top: 76.57px; }
+  6.667% { left: 37.40px; top: 79.01px; }
+  7.500% { left: 39.54px; top: 81.69px; }
+  8.333% { left: 42.02px; top: 84.58px; }
+  9.167% { left: 44.83px; top: 87.65px; }
+  10.000% { left: 48.00px; top: 90.87px; }
+  10.833% { left: 51.53px; top: 94.20px; }
+  11.667% { left: 55.43px; top: 97.61px; }
+  12.500% { left: 59.70px; top: 101.05px; }
+  13.333% { left: 64.35px; top: 104.50px; }
+  14.167% { left: 69.36px; top: 107.90px; }
+  15.000% { left: 74.74px; top: 111.23px; }
+  15.833% { left: 80.47px; top: 114.45px; }
+  16.667% { left: 86.53px; top: 117.53px; }
+  17.500% { left: 92.91px; top: 120.42px; }
+  18.333% { left: 99.59px; top: 123.10px; }
+  19.167% { left: 106.54px; top: 125.54px; }
+  20.000% { left: 113.73px; top: 127.71px; }
+  20.833% { left: 121.14px; top: 129.59px; }
+  21.667% { left: 128.74px; top: 131.15px; }
+  22.500% { left: 136.48px; top: 132.39px; }
+  23.333% { left: 144.33px; top: 133.28px; }
+  24.167% { left: 152.26px; top: 133.82px; }
+  25.000% { left: 160.23px; top: 134.00px; }
+  25.833% { left: 168.20px; top: 133.82px; }
+  26.667% { left: 176.13px; top: 133.28px; }
+  27.500% { left: 183.98px; top: 132.39px; }
+  28.333% { left: 191.72px; top: 131.15px; }
+  29.167% { left: 199.32px; top: 129.59px; }
+  30.000% { left: 206.73px; top: 127.71px; }
+  30.833% { left: 213.92px; top: 125.54px; }
+  31.667% { left: 220.87px; top: 123.10px; }
+  32.500% { left: 227.55px; top: 120.42px; }
+  33.333% { left: 233.93px; top: 117.53px; }
+  34.167% { left: 239.99px; top: 114.45px; }
+  35.000% { left: 245.72px; top: 111.23px; }
+  35.833% { left: 251.10px; top: 107.90px; }
+  36.667% { left: 256.11px; top: 104.50px; }
+  37.500% { left: 260.76px; top: 101.05px; }
+  38.333% { left: 265.03px; top: 97.61px; }
+  39.167% { left: 268.93px; top: 94.20px; }
+  40.000% { left: 272.46px; top: 90.87px; }
+  40.833% { left: 275.63px; top: 87.65px; }
+  41.667% { left: 278.44px; top: 84.58px; }
+  42.500% { left: 280.92px; top: 81.69px; }
+  43.333% { left: 283.06px; top: 79.01px; }
+  44.167% { left: 284.89px; top: 76.57px; }
+  45.000% { left: 286.43px; top: 74.40px; }
+  45.833% { left: 287.70px; top: 72.52px; }
+  46.667% { left: 288.71px; top: 70.96px; }
+  47.500% { left: 289.47px; top: 69.72px; }
+  48.333% { left: 290.01px; top: 68.83px; }
+  49.167% { left: 290.32px; top: 68.29px; }
+  50.000% { left: 290.43px; top: 68.11px; }
+  50.833% { left: 290.32px; top: 68.29px; }
+  51.667% { left: 290.01px; top: 68.83px; }
+  52.500% { left: 289.47px; top: 69.72px; }
+  53.333% { left: 288.71px; top: 70.96px; }
+  54.167% { left: 287.70px; top: 72.52px; }
+  55.000% { left: 286.43px; top: 74.40px; }
+  55.833% { left: 284.89px; top: 76.57px; }
+  56.667% { left: 283.06px; top: 79.01px; }
+  57.500% { left: 280.92px; top: 81.69px; }
+  58.333% { left: 278.44px; top: 84.58px; }
+  59.167% { left: 275.63px; top: 87.65px; }
+  60.000% { left: 272.46px; top: 90.87px; }
+  60.833% { left: 268.93px; top: 94.20px; }
+  61.667% { left: 265.03px; top: 97.61px; }
+  62.500% { left: 260.76px; top: 101.05px; }
+  63.333% { left: 256.11px; top: 104.50px; }
+  64.167% { left: 251.10px; top: 107.90px; }
+  65.000% { left: 245.72px; top: 111.23px; }
+  65.833% { left: 239.99px; top: 114.45px; }
+  66.667% { left: 233.93px; top: 117.53px; }
+  67.500% { left: 227.55px; top: 120.42px; }
+  68.333% { left: 220.87px; top: 123.10px; }
+  69.167% { left: 213.92px; top: 125.54px; }
+  70.000% { left: 206.73px; top: 127.71px; }
+  70.833% { left: 199.32px; top: 129.59px; }
+  71.667% { left: 191.72px; top: 131.15px; }
+  72.500% { left: 183.98px; top: 132.39px; }
+  73.333% { left: 176.13px; top: 133.28px; }
+  74.167% { left: 168.20px; top: 133.82px; }
+  75.000% { left: 160.23px; top: 134.00px; }
+  75.833% { left: 152.26px; top: 133.82px; }
+  76.667% { left: 144.33px; top: 133.28px; }
+  77.500% { left: 136.48px; top: 132.39px; }
+  78.333% { left: 128.74px; top: 131.15px; }
+  79.167% { left: 121.14px; top: 129.59px; }
+  80.000% { left: 113.73px; top: 127.71px; }
+  80.833% { left: 106.54px; top: 125.54px; }
+  81.667% { left: 99.59px; top: 123.10px; }
+  82.500% { left: 92.91px; top: 120.42px; }
+  83.333% { left: 86.53px; top: 117.53px; }
+  84.167% { left: 80.47px; top: 114.45px; }
+  85.000% { left: 74.74px; top: 111.23px; }
+  85.833% { left: 69.36px; top: 107.90px; }
+  86.667% { left: 64.35px; top: 104.50px; }
+  87.500% { left: 59.70px; top: 101.05px; }
+  88.333% { left: 55.43px; top: 97.61px; }
+  89.167% { left: 51.53px; top: 94.20px; }
+  90.000% { left: 48.00px; top: 90.87px; }
+  90.833% { left: 44.83px; top: 87.65px; }
+  91.667% { left: 42.02px; top: 84.58px; }
+  92.500% { left: 39.54px; top: 81.69px; }
+  93.333% { left: 37.40px; top: 79.01px; }
+  94.167% { left: 35.57px; top: 76.57px; }
+  95.000% { left: 34.03px; top: 74.40px; }
+  95.833% { left: 32.76px; top: 72.52px; }
+  96.667% { left: 31.75px; top: 70.96px; }
+  97.500% { left: 30.99px; top: 69.72px; }
+  98.333% { left: 30.45px; top: 68.83px; }
+  99.167% { left: 30.14px; top: 68.29px; }
+  100.000% { left: 30.03px; top: 68.11px; }
+}
+
+@keyframes sw3 {
+  0.000% { left: 48.42px; top: 91.28px; }
+  0.833% { left: 48.54px; top: 91.40px; }
+  1.667% { left: 48.90px; top: 91.75px; }
+  2.500% { left: 49.51px; top: 92.33px; }
+  3.333% { left: 50.36px; top: 93.13px; }
+  4.167% { left: 51.46px; top: 94.15px; }
+  5.000% { left: 52.82px; top: 95.36px; }
+  5.833% { left: 54.44px; top: 96.77px; }
+  6.667% { left: 56.32px; top: 98.35px; }
+  7.500% { left: 58.47px; top: 100.09px; }
+  8.333% { left: 60.89px; top: 101.96px; }
+  9.167% { left: 63.59px; top: 103.96px; }
+  10.000% { left: 66.56px; top: 106.04px; }
+  10.833% { left: 69.82px; top: 108.20px; }
+  11.667% { left: 73.36px; top: 110.41px; }
+  12.500% { left: 77.17px; top: 112.64px; }
+  13.333% { left: 81.26px; top: 114.87px; }
+  14.167% { left: 85.61px; top: 117.08px; }
+  15.000% { left: 90.22px; top: 119.24px; }
+  15.833% { left: 95.09px; top: 121.33px; }
+  16.667% { left: 100.18px; top: 123.32px; }
+  17.500% { left: 105.50px; top: 125.20px; }
+  18.333% { left: 111.03px; top: 126.93px; }
+  19.167% { left: 116.75px; top: 128.51px; }
+  20.000% { left: 122.63px; top: 129.92px; }
+  20.833% { left: 128.67px; top: 131.14px; }
+  21.667% { left: 134.83px; top: 132.15px; }
+  22.500% { left: 141.09px; top: 132.95px; }
+  23.333% { left: 147.42px; top: 133.53px; }
+  24.167% { left: 153.81px; top: 133.88px; }
+  25.000% { left: 160.23px; top: 134.00px; }
+  25.833% { left: 166.65px; top: 133.88px; }
+  26.667% { left: 173.04px; top: 133.53px; }
+  27.500% { left: 179.37px; top: 132.95px; }
+  28.333% { left: 185.63px; top: 132.15px; }
+  29.167% { left: 191.79px; top: 131.14px; }
+  30.000% { left: 197.83px; top: 129.92px; }
+  30.833% { left: 203.71px; top: 128.51px; }
+  31.667% { left: 209.43px; top: 126.93px; }
+  32.500% { left: 214.96px; top: 125.20px; }
+  33.333% { left: 220.28px; top: 123.32px; }
+  34.167% { left: 225.37px; top: 121.33px; }
+  35.000% { left: 230.24px; top: 119.24px; }
+  35.833% { left: 234.85px; top: 117.08px; }
+  36.667% { left: 239.20px; top: 114.87px; }
+  37.500% { left: 243.29px; top: 112.64px; }
+  38.333% { left: 247.10px; top: 110.41px; }
+  39.167% { left: 250.64px; top: 108.20px; }
+  40.000% { left: 253.90px; top: 106.04px; }
+  40.833% { left: 256.87px; top: 103.96px; }
+  41.667% { left: 259.57px; top: 101.96px; }
+  42.500% { left: 261.99px; top: 100.09px; }
+  43.333% { left: 264.14px; top: 98.35px; }
+  44.167% { left: 266.02px; top: 96.77px; }
+  45.000% { left: 267.64px; top: 95.36px; }
+  45.833% { left: 269.00px; top: 94.15px; }
+  46.667% { left: 270.10px; top: 93.13px; }
+  47.500% { left: 270.95px; top: 92.33px; }
+  48.333% { left: 271.56px; top: 91.75px; }
+  49.167% { left: 271.92px; top: 91.40px; }
+  50.000% { left: 272.04px; top: 91.28px; }
+  50.833% { left: 271.92px; top: 91.40px; }
+  51.667% { left: 271.56px; top: 91.75px; }
+  52.500% { left: 270.95px; top: 92.33px; }
+  53.333% { left: 270.10px; top: 93.13px; }
+  54.167% { left: 269.00px; top: 94.15px; }
+  55.000% { left: 267.64px; top: 95.36px; }
+  55.833% { left: 266.02px; top: 96.77px; }
+  56.667% { left: 264.14px; top: 98.35px; }
+  57.500% { left: 261.99px; top: 100.09px; }
+  58.333% { left: 259.57px; top: 101.96px; }
+  59.167% { left: 256.87px; top: 103.96px; }
+  60.000% { left: 253.90px; top: 106.04px; }
+  60.833% { left: 250.64px; top: 108.20px; }
+  61.667% { left: 247.10px; top: 110.41px; }
+  62.500% { left: 243.29px; top: 112.64px; }
+  63.333% { left: 239.20px; top: 114.87px; }
+  64.167% { left: 234.85px; top: 117.08px; }
+  65.000% { left: 230.24px; top: 119.24px; }
+  65.833% { left: 225.37px; top: 121.33px; }
+  66.667% { left: 220.28px; top: 123.32px; }
+  67.500% { left: 214.96px; top: 125.20px; }
+  68.333% { left: 209.43px; top: 126.93px; }
+  69.167% { left: 203.71px; top: 128.51px; }
+  70.000% { left: 197.83px; top: 129.92px; }
+  70.833% { left: 191.79px; top: 131.14px; }
+  71.667% { left: 185.63px; top: 132.15px; }
+  72.500% { left: 179.37px; top: 132.95px; }
+  73.333% { left: 173.04px; top: 133.53px; }
+  74.167% { left: 166.65px; top: 133.88px; }
+  75.000% { left: 160.23px; top: 134.00px; }
+  75.833% { left: 153.81px; top: 133.88px; }
+  76.667% { left: 147.42px; top: 133.53px; }
+  77.500% { left: 141.09px; top: 132.95px; }
+  78.333% { left: 134.83px; top: 132.15px; }
+  79.167% { left: 128.67px; top: 131.14px; }
+  80.000% { left: 122.63px; top: 129.92px; }
+  80.833% { left: 116.75px; top: 128.51px; }
+  81.667% { left: 111.03px; top: 126.93px; }
+  82.500% { left: 105.50px; top: 125.20px; }
+  83.333% { left: 100.18px; top: 123.32px; }
+  84.167% { left: 95.09px; top: 121.33px; }
+  85.000% { left: 90.22px; top: 119.24px; }
+  85.833% { left: 85.61px; top: 117.08px; }
+  86.667% { left: 81.26px; top: 114.87px; }
+  87.500% { left: 77.17px; top: 112.64px; }
+  88.333% { left: 73.36px; top: 110.41px; }
+  89.167% { left: 69.82px; top: 108.20px; }
+  90.000% { left: 66.56px; top: 106.04px; }
+  90.833% { left: 63.59px; top: 103.96px; }
+  91.667% { left: 60.89px; top: 101.96px; }
+  92.500% { left: 58.47px; top: 100.09px; }
+  93.333% { left: 56.32px; top: 98.35px; }
+  94.167% { left: 54.44px; top: 96.77px; }
+  95.000% { left: 52.82px; top: 95.36px; }
+  95.833% { left: 51.46px; top: 94.15px; }
+  96.667% { left: 50.36px; top: 93.13px; }
+  97.500% { left: 49.51px; top: 92.33px; }
+  98.333% { left: 48.90px; top: 91.75px; }
+  99.167% { left: 48.54px; top: 91.40px; }
+  100.000% { left: 48.42px; top: 91.28px; }
+}
+
+@keyframes sw4 {
+  0.000% { left: 79.78px; top: 114.08px; }
+  0.833% { left: 79.88px; top: 114.14px; }
+  1.667% { left: 80.18px; top: 114.30px; }
+  2.500% { left: 80.68px; top: 114.57px; }
+  3.333% { left: 81.39px; top: 114.94px; }
+  4.167% { left: 82.30px; top: 115.42px; }
+  5.000% { left: 83.41px; top: 115.99px; }
+  5.833% { left: 84.71px; top: 116.64px; }
+  6.667% { left: 86.22px; top: 117.38px; }
+  7.500% { left: 87.93px; top: 118.19px; }
+  8.333% { left: 89.83px; top: 119.06px; }
+  9.167% { left: 91.92px; top: 119.99px; }
+  10.000% { left: 94.20px; top: 120.96px; }
+  10.833% { left: 96.67px; top: 121.97px; }
+  11.667% { left: 99.33px; top: 123.00px; }
+  12.500% { left: 102.16px; top: 124.04px; }
+  13.333% { left: 105.17px; top: 125.08px; }
+  14.167% { left: 108.34px; top: 126.11px; }
+  15.000% { left: 111.66px; top: 127.12px; }
+  15.833% { left: 115.14px; top: 128.09px; }
+  16.667% { left: 118.76px; top: 129.02px; }
+  17.500% { left: 122.52px; top: 129.90px; }
+  18.333% { left: 126.39px; top: 130.71px; }
+  19.167% { left: 130.37px; top: 131.44px; }
+  20.000% { left: 134.45px; top: 132.10px; }
+  20.833% { left: 138.61px; top: 132.67px; }
+  21.667% { left: 142.85px; top: 133.14px; }
+  22.500% { left: 147.14px; top: 133.51px; }
+  23.333% { left: 151.48px; top: 133.78px; }
+  24.167% { left: 155.85px; top: 133.95px; }
+  25.000% { left: 160.23px; top: 134.00px; }
+  25.833% { left: 164.61px; top: 133.95px; }
+  26.667% { left: 168.98px; top: 133.78px; }
+  27.500% { left: 173.32px; top: 133.51px; }
+  28.333% { left: 177.61px; top: 133.14px; }
+  29.167% { left: 181.85px; top: 132.67px; }
+  30.000% { left: 186.01px; top: 132.10px; }
+  30.833% { left: 190.09px; top: 131.44px; }
+  31.667% { left: 194.07px; top: 130.71px; }
+  32.500% { left: 197.94px; top: 129.90px; }
+  33.333% { left: 201.70px; top: 129.02px; }
+  34.167% { left: 205.32px; top: 128.09px; }
+  35.000% { left: 208.80px; top: 127.12px; }
+  35.833% { left: 212.12px; top: 126.11px; }
+  36.667% { left: 215.29px; top: 125.08px; }
+  37.500% { left: 218.30px; top: 124.04px; }
+  38.333% { left: 221.13px; top: 123.00px; }
+  39.167% { left: 223.79px; top: 121.97px; }
+  40.000% { left: 226.26px; top: 120.96px; }
+  40.833% { left: 228.54px; top: 119.99px; }
+  41.667% { left: 230.63px; top: 119.06px; }
+  42.500% { left: 232.53px; top: 118.19px; }
+  43.333% { left: 234.24px; top: 117.38px; }
+  44.167% { left: 235.75px; top: 116.64px; }
+  45.000% { left: 237.05px; top: 115.99px; }
+  45.833% { left: 238.16px; top: 115.42px; }
+  46.667% { left: 239.07px; top: 114.94px; }
+  47.500% { left: 239.78px; top: 114.57px; }
+  48.333% { left: 240.28px; top: 114.30px; }
+  49.167% { left: 240.58px; top: 114.14px; }
+  50.000% { left: 240.68px; top: 114.08px; }
+  50.833% { left: 240.58px; top: 114.14px; }
+  51.667% { left: 240.28px; top: 114.30px; }
+  52.500% { left: 239.78px; top: 114.57px; }
+  53.333% { left: 239.07px; top: 114.94px; }
+  54.167% { left: 238.16px; top: 115.42px; }
+  55.000% { left: 237.05px; top: 115.99px; }
+  55.833% { left: 235.75px; top: 116.64px; }
+  56.667% { left: 234.24px; top: 117.38px; }
+  57.500% { left: 232.53px; top: 118.19px; }
+  58.333% { left: 230.63px; top: 119.06px; }
+  59.167% { left: 228.54px; top: 119.99px; }
+  60.000% { left: 226.26px; top: 120.96px; }
+  60.833% { left: 223.79px; top: 121.97px; }
+  61.667% { left: 221.13px; top: 123.00px; }
+  62.500% { left: 218.30px; top: 124.04px; }
+  63.333% { left: 215.29px; top: 125.08px; }
+  64.167% { left: 212.12px; top: 126.11px; }
+  65.000% { left: 208.80px; top: 127.12px; }
+  65.833% { left: 205.32px; top: 128.09px; }
+  66.667% { left: 201.70px; top: 129.02px; }
+  67.500% { left: 197.94px; top: 129.90px; }
+  68.333% { left: 194.07px; top: 130.71px; }
+  69.167% { left: 190.09px; top: 131.44px; }
+  70.000% { left: 186.01px; top: 132.10px; }
+  70.833% { left: 181.85px; top: 132.67px; }
+  71.667% { left: 177.61px; top: 133.14px; }
+  72.500% { left: 173.32px; top: 133.51px; }
+  73.333% { left: 168.98px; top: 133.78px; }
+  74.167% { left: 164.61px; top: 133.95px; }
+  75.000% { left: 160.23px; top: 134.00px; }
+  75.833% { left: 155.85px; top: 133.95px; }
+  76.667% { left: 151.48px; top: 133.78px; }
+  77.500% { left: 147.14px; top: 133.51px; }
+  78.333% { left: 142.85px; top: 133.14px; }
+  79.167% { left: 138.61px; top: 132.67px; }
+  80.000% { left: 134.45px; top: 132.10px; }
+  80.833% { left: 130.37px; top: 131.44px; }
+  81.667% { left: 126.39px; top: 130.71px; }
+  82.500% { left: 122.52px; top: 129.90px; }
+  83.333% { left: 118.76px; top: 129.02px; }
+  84.167% { left: 115.14px; top: 128.09px; }
+  85.000% { left: 111.66px; top: 127.12px; }
+  85.833% { left: 108.34px; top: 126.11px; }
+  86.667% { left: 105.17px; top: 125.08px; }
+  87.500% { left: 102.16px; top: 124.04px; }
+  88.333% { left: 99.33px; top: 123.00px; }
+  89.167% { left: 96.67px; top: 121.97px; }
+  90.000% { left: 94.20px; top: 120.96px; }
+  90.833% { left: 91.92px; top: 119.99px; }
+  91.667% { left: 89.83px; top: 119.06px; }
+  92.500% { left: 87.93px; top: 118.19px; }
+  93.333% { left: 86.22px; top: 117.38px; }
+  94.167% { left: 84.71px; top: 116.64px; }
+  95.000% { left: 83.41px; top: 115.99px; }
+  95.833% { left: 82.30px; top: 115.42px; }
+  96.667% { left: 81.39px; top: 114.94px; }
+  97.500% { left: 80.68px; top: 114.57px; }
+  98.333% { left: 80.18px; top: 114.30px; }
+  99.167% { left: 79.88px; top: 114.14px; }
+  100.000% { left: 79.78px; top: 114.08px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .beadT { animation-play-state: paused; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/tautochrone-as/`, a self-contained pure CSS/HTML cycloid bowl in which four beads released from four different heights all reach the bottom at the same instant.

Closes #49651

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

Start a bead higher in a bowl and it travels further but also gains more speed. On an inverted cycloid those two effects cancel exactly, and the descent time is `pi*sqrt(R/g)` regardless of the starting height. Huygens found this in 1659 chasing a clock whose rate would not drift as the swing decayed, since a circular arc is not tautochronous. The same curve is also the brachistochrone.

- **The motion is the exact solution, not an easing curve.** Measured as arc length from the bottom, a bead on a cycloid obeys `s'' = -(g/4R) s`, simple harmonic motion exactly and at any amplitude, so each bead is placed by `s = s0*cos(wt)` mapped back onto the curve. All four therefore share one period, `4*pi*sqrt(R/g)` = 2.663 s.
- **The synchrony is measured in the browser on the rendered beads.** Sweeping the paused animation at 2400 steps and catching every crossing of the lowest point: all four cross at **the same instants**, **0 ms** disagreement, **0 px** spread between them at the crossing.
- **The four starts are genuinely different, and that is checked too.** Drop heights measure **81.5, 65.9, 42.7 and 19.9 px**, four distinct values spanning a factor of four. Without that the synchrony would prove nothing.
- **The bowl is a real cycloid**, `x = R(t - sin t)`, `y = R(1 - cos t)`, drawn from 161 points, with the beads constrained to it rather than animated near it.
- **Keyframes are sampled fine enough that the interpolation is invisible**: linear interpolation between frames never strays more than **0.22 px** from the true path.

Descent times, integrated after a substitution that cancels the inverse-square-root singularity at the release point, agree across all four starts to **3e-11 s** against the exact 0.665676 s.

## Accessibility

`prefers-reduced-motion: reduce` pauses the four beads mid-swing, leaving the bowl and the release markers readable.

## Verification

Opened `demo.html` in the browser and checked the claim on the rendered output: swept the paused animation and detected the beads crossing the lowest point at identical instants, 0 ms apart and 0 px apart, while measuring their release heights as four distinct values from 19.9 px to 81.5 px. Both halves matter, since simultaneous arrival is only interesting if the starts really do differ. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
