### PR TITLE
Add wheatstone bridge component

### DIFF
--- a/submissions/examples/wheatstone-bridge-as/README.md
+++ b/submissions/examples/wheatstone-bridge-as/README.md
@@ -1,0 +1,38 @@
+# Wheatstone Bridge
+
+A pure CSS/HTML Wheatstone bridge sweeping an unknown resistor while the galvanometer needle swings through an exact null.
+
+## What it shows
+
+Two resistor dividers hang across the same supply, and a galvanometer bridges their midpoints. Adjust the unknown arm until the meter reads nothing at all. At that moment
+
+```
+R1 / R2 = R3 / Rx      so      Rx = R3 * (R2 / R1)
+```
+
+The interesting part is what is missing from that equation. The supply voltage is not in it. The galvanometer's sensitivity is not in it. Neither can affect the answer, because the answer is read at the instant the meter reads **zero**, and zero is zero however badly calibrated the instrument is and whatever the battery happens to be doing.
+
+That is a **null method**, and it is why the bridge is accurate. Measuring a needle's position well is hard: it needs a trustworthy scale, a linear movement, and a steady supply. Noticing that a needle has not moved is easy, and a more sensitive meter makes the null sharper rather than making the calibration harder. All the precision is pushed into the known resistors and the ratio `R2/R1`, where it is cheap to obtain.
+
+Samuel Hunter Christie published the circuit in 1833. Charles Wheatstone popularised it in 1843 and credited Christie plainly, but the name attached to the wrong person and stayed there.
+
+Here the ratio arm is deliberately not 1:1. With `R1 = 1k` and `R2 = 2k` the bridge multiplies, so a `330` reference balances against an unknown of `660`, and the ratio is doing real work rather than being a decoration.
+
+## How it is built
+
+- **The needle is driven by the circuit equation, not by eye.** Each step's deflection is `Vb = V*Rx/(R3+Rx) - V*R2/(R1+R2)`, scaled to full scale. The browser check recomputes that expression from scratch and compares it against the rendered needle rotation at all 20 steps: worst disagreement **0.005 degrees**, which is the rounding in the stylesheet.
+- **The null is exact and it is in the right place.** Across the sweep the needle reads zero at **exactly one** value, **660 ohms**, and that is `R3 * R2/R1 = 330 * 2`. The balance lamp lights at that value and no other.
+- **The readout cannot disagree with the needle.** Both are stepped by `steps(1, end)` off the same 20-phase schedule, so there is no intermediate state in which the displayed resistance and the deflection belong to different moments. The animation is physically incapable of showing a mismatched pair.
+- **The deflection is readable**, against a five-tick scale with the zero mark drawn brighter, since a needle with no scale behind it is decoration.
+- The sweep runs `460` to `860` ohms and back, in 40 ohm steps.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` pauses the sweep, the needle, and the balance lamp together, leaving a single readable state.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/wheatstone-bridge-as/demo.html
+++ b/submissions/examples/wheatstone-bridge-as/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wheatstone Bridge</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="tagW">a null method: the reading you trust is zero</span>
+    <span class="railTop"></span>
+    <span class="railBot"></span>
+    <span class="colL"></span>
+    <span class="colR"></span>
+    <span class="battLead"></span>
+    <span class="battPlus"></span>
+    <span class="battMinus"></span>
+    <span class="battLbl">9 V</span>
+    <span class="wireL"></span>
+    <span class="wireR"></span>
+    <span class="resW rW1"></span>
+    <span class="resW rW2"></span>
+    <span class="resW rW3"></span>
+    <span class="resW rWx"></span>
+    <span class="lblW lW1">R1 1k&#937;</span>
+    <span class="lblW lW2">R2 2k&#937;</span>
+    <span class="lblW lW3">R3 330&#937;</span>
+    <span class="lblW lWx">Rx ?</span>
+    <span class="meterW"></span>
+    <span class="meterG">G</span>
+    <span class="tickW tk1"></span>
+    <span class="tickW tk2"></span>
+    <span class="tickW tk0"></span>
+    <span class="tickW tk3"></span>
+    <span class="tickW tk4"></span>
+    <span class="needleW"></span>
+    <span class="pivotW"></span>
+    <div class="windowW">
+      <div class="stripW">
+        <span class="rowW">Rx = 460 &#937;</span>
+        <span class="rowW">Rx = 500 &#937;</span>
+        <span class="rowW">Rx = 540 &#937;</span>
+        <span class="rowW">Rx = 580 &#937;</span>
+        <span class="rowW">Rx = 620 &#937;</span>
+        <span class="rowW">Rx = 660 &#937;</span>
+        <span class="rowW">Rx = 700 &#937;</span>
+        <span class="rowW">Rx = 740 &#937;</span>
+        <span class="rowW">Rx = 780 &#937;</span>
+        <span class="rowW">Rx = 820 &#937;</span>
+        <span class="rowW">Rx = 860 &#937;</span>
+      </div>
+    </div>
+    <span class="lampW"></span>
+    <span class="balW">balanced</span>
+    <span class="capW">R1 / R2 = R3 / Rx, so Rx = 330 x 2 = 660 &#937;</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/wheatstone-bridge-as/style.css
+++ b/submissions/examples/wheatstone-bridge-as/style.css
@@ -1,0 +1,347 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 20%, #1b2622, #050807 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 264px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 32%, #1f2d29, #060908 86%);
+  color: rgba(200, 230, 215, 0.9);
+}
+
+/* the bridge: two dividers across one supply, meter between the midpoints */
+.railTop, .railBot {
+  position: absolute;
+  left: 46px;
+  width: 184px;
+  height: 2px;
+  background: rgba(150, 200, 180, 0.55);
+}
+
+.railTop { top: 52px; }
+.railBot { top: 184px; }
+
+.colL, .colR {
+  position: absolute;
+  top: 52px;
+  width: 2px;
+  height: 134px;
+  background: rgba(150, 200, 180, 0.55);
+}
+
+.colL { left: 110px; }
+.colR { left: 230px; }
+
+.battLead {
+  position: absolute;
+  left: 46px;
+  top: 52px;
+  width: 2px;
+  height: 134px;
+  background: rgba(150, 200, 180, 0.55);
+}
+
+.battPlus, .battMinus {
+  position: absolute;
+  left: 47px;
+  background: #d8f0e4;
+  transform: translateX(-50%);
+}
+
+.battPlus {
+  top: 111px;
+  width: 20px;
+  height: 2px;
+}
+
+.battMinus {
+  top: 120px;
+  width: 11px;
+  height: 2px;
+}
+
+.battLbl {
+  position: absolute;
+  left: 12px;
+  top: 128px;
+  font-size: 0.46rem;
+  letter-spacing: 0.05em;
+}
+
+.wireL, .wireR {
+  position: absolute;
+  top: 117px;
+  height: 2px;
+  background: rgba(150, 200, 180, 0.55);
+}
+
+.wireL { left: 110px; width: 35px; }
+.wireR { left: 195px; width: 35px; }
+
+.resW {
+  position: absolute;
+  width: 15px;
+  height: 34px;
+  margin-left: -6.5px;
+  border-radius: 2px;
+  background: linear-gradient(#3d5a50, #263a34);
+  box-shadow: inset 0 0 0 1px rgba(170, 220, 200, 0.45);
+}
+
+.rW1 { left: 111px; top: 63px; }
+.rW2 { left: 111px; top: 139px; }
+.rW3 { left: 231px; top: 63px; }
+.rWx { left: 231px; top: 139px; box-shadow: inset 0 0 0 1px rgba(255, 215, 130, 0.75); }
+
+.lblW {
+  position: absolute;
+  font-size: 0.45rem;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.lW1 { left: 58px; top: 74px; }
+.lW2 { left: 58px; top: 150px; }
+.lW3 { left: 244px; top: 74px; }
+.lWx { left: 244px; top: 150px; color: rgba(255, 215, 130, 0.95); }
+
+/* galvanometer */
+.meterW {
+  position: absolute;
+  left: 145px;
+  top: 93px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 34%, #12211d, #060d0b);
+  box-shadow: inset 0 0 0 1.5px rgba(170, 220, 200, 0.6);
+}
+
+.meterG {
+  position: absolute;
+  left: 167px;
+  top: 126px;
+  font-size: 0.42rem;
+  color: rgba(170, 220, 200, 0.7);
+}
+
+/* scale, so the deflection is readable rather than decorative */
+.tickW {
+  position: absolute;
+  left: 170px;
+  top: 118px;
+  width: 1.5px;
+  height: 6px;
+  margin: -24px 0 0 -0.75px;
+  background: rgba(170, 220, 200, 0.55);
+  transform-origin: 50% 24px;
+}
+
+.tk1 { transform: rotate(-42deg); }
+.tk2 { transform: rotate(-21deg); }
+.tk3 { transform: rotate(21deg); }
+.tk4 { transform: rotate(42deg); }
+
+.tk0 {
+  height: 9px;
+  margin-top: -24px;
+  background: rgba(255, 255, 255, 0.85);
+  transform: rotate(0deg);
+}
+
+/*
+  needle deflection is the bridge voltage, Vb = V*Rx/(R3+Rx) - V*R2/(R1+R2),
+  scaled to full scale. it reads exactly zero when R1/R2 = R3/Rx, and that
+  zero is the measurement: it does not depend on the supply voltage or on
+  the meter being calibrated, only on the ratio of the arms.
+*/
+.needleW {
+  position: absolute;
+  left: 170px;
+  top: 118px;
+  width: 2px;
+  height: 21px;
+  margin: -21px 0 0 -1px;
+  border-radius: 1px;
+  background: linear-gradient(rgba(255, 120, 120, 1), rgba(255, 190, 120, 0.85));
+  transform-origin: 50% 100%;
+  animation: needleW 7s linear infinite;
+}
+
+.pivotW {
+  position: absolute;
+  left: 170px;
+  top: 118px;
+  width: 5px;
+  height: 5px;
+  margin: -2.5px 0 0 -2.5px;
+  border-radius: 50%;
+  background: #d8f0e4;
+}
+
+/* readout: a strip of values stepped in lockstep with the needle */
+.windowW {
+  position: absolute;
+  left: 80px;
+  top: 196px;
+  width: 116px;
+  height: 20px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: rgba(10, 20, 17, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(140, 200, 175, 0.35);
+}
+
+.stripW {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  animation: stripW 7s linear infinite;
+}
+
+.rowW {
+  display: block;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  font-size: 0.55rem;
+  letter-spacing: 0.05em;
+  color: rgba(215, 245, 230, 0.95);
+}
+
+.lampW {
+  position: absolute;
+  left: 206px;
+  top: 202px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #4dffae;
+  box-shadow: 0 0 10px rgba(77, 255, 174, 0.95);
+  opacity: 0;
+  animation: lampW 7s linear infinite;
+}
+
+.balW {
+  position: absolute;
+  left: 220px;
+  top: 203px;
+  font-size: 0.46rem;
+  letter-spacing: 0.07em;
+  color: rgba(140, 255, 200, 0.95);
+  opacity: 0;
+  animation: lampW 7s linear infinite;
+}
+
+.tagW {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.48rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(190, 235, 215, 0.88);
+}
+
+.capW {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.03em;
+  color: rgba(185, 220, 205, 0.78);
+}
+
+@keyframes needleW {
+  0.0000% { transform: rotate(-42.00deg); animation-timing-function: steps(1, end); }
+  5.0000% { transform: rotate(-31.98deg); animation-timing-function: steps(1, end); }
+  10.0000% { transform: rotate(-22.88deg); animation-timing-function: steps(1, end); }
+  15.0000% { transform: rotate(-14.58deg); animation-timing-function: steps(1, end); }
+  20.0000% { transform: rotate(-6.99deg); animation-timing-function: steps(1, end); }
+  25.0000% { transform: rotate(0.00deg); animation-timing-function: steps(1, end); }
+  30.0000% { transform: rotate(6.44deg); animation-timing-function: steps(1, end); }
+  35.0000% { transform: rotate(12.40deg); animation-timing-function: steps(1, end); }
+  40.0000% { transform: rotate(17.94deg); animation-timing-function: steps(1, end); }
+  45.0000% { transform: rotate(23.08deg); animation-timing-function: steps(1, end); }
+  50.0000% { transform: rotate(27.88deg); animation-timing-function: steps(1, end); }
+  55.0000% { transform: rotate(23.08deg); animation-timing-function: steps(1, end); }
+  60.0000% { transform: rotate(17.94deg); animation-timing-function: steps(1, end); }
+  65.0000% { transform: rotate(12.40deg); animation-timing-function: steps(1, end); }
+  70.0000% { transform: rotate(6.44deg); animation-timing-function: steps(1, end); }
+  75.0000% { transform: rotate(0.00deg); animation-timing-function: steps(1, end); }
+  80.0000% { transform: rotate(-6.99deg); animation-timing-function: steps(1, end); }
+  85.0000% { transform: rotate(-14.58deg); animation-timing-function: steps(1, end); }
+  90.0000% { transform: rotate(-22.88deg); animation-timing-function: steps(1, end); }
+  95.0000% { transform: rotate(-31.98deg); animation-timing-function: steps(1, end); }
+  100% { transform: rotate(-42.00deg); }
+}
+
+@keyframes stripW {
+  0.0000% { transform: translateY(0px); animation-timing-function: steps(1, end); }
+  5.0000% { transform: translateY(-20px); animation-timing-function: steps(1, end); }
+  10.0000% { transform: translateY(-40px); animation-timing-function: steps(1, end); }
+  15.0000% { transform: translateY(-60px); animation-timing-function: steps(1, end); }
+  20.0000% { transform: translateY(-80px); animation-timing-function: steps(1, end); }
+  25.0000% { transform: translateY(-100px); animation-timing-function: steps(1, end); }
+  30.0000% { transform: translateY(-120px); animation-timing-function: steps(1, end); }
+  35.0000% { transform: translateY(-140px); animation-timing-function: steps(1, end); }
+  40.0000% { transform: translateY(-160px); animation-timing-function: steps(1, end); }
+  45.0000% { transform: translateY(-180px); animation-timing-function: steps(1, end); }
+  50.0000% { transform: translateY(-200px); animation-timing-function: steps(1, end); }
+  55.0000% { transform: translateY(-180px); animation-timing-function: steps(1, end); }
+  60.0000% { transform: translateY(-160px); animation-timing-function: steps(1, end); }
+  65.0000% { transform: translateY(-140px); animation-timing-function: steps(1, end); }
+  70.0000% { transform: translateY(-120px); animation-timing-function: steps(1, end); }
+  75.0000% { transform: translateY(-100px); animation-timing-function: steps(1, end); }
+  80.0000% { transform: translateY(-80px); animation-timing-function: steps(1, end); }
+  85.0000% { transform: translateY(-60px); animation-timing-function: steps(1, end); }
+  90.0000% { transform: translateY(-40px); animation-timing-function: steps(1, end); }
+  95.0000% { transform: translateY(-20px); animation-timing-function: steps(1, end); }
+  100% { transform: translateY(0px); }
+}
+
+@keyframes lampW {
+  0.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  5.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  10.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  15.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  20.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  25.0000% { opacity: 1; animation-timing-function: steps(1, end); }
+  30.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  35.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  40.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  45.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  50.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  55.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  60.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  65.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  70.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  75.0000% { opacity: 1; animation-timing-function: steps(1, end); }
+  80.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  85.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  90.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  95.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .needleW,
+  .stripW,
+  .lampW,
+  .balW { animation-play-state: paused; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/wheatstone-bridge-as/`, a self-contained pure CSS/HTML Wheatstone bridge sweeping an unknown resistor while the galvanometer needle swings through an exact null.

Closes #49653

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

Two dividers across one supply, a galvanometer between their midpoints, and the unknown adjusted until the meter reads nothing: `R1/R2 = R3/Rx`, so `Rx = R3 * (R2/R1)`. Neither the supply voltage nor the meter's sensitivity appears in that equation, because the reading acted on is zero and zero survives a bad calibration. That is why the bridge is accurate: spotting that a needle has not moved is far easier than trusting where it sits, so all the precision moves into the known resistors.

- **The needle is driven by the circuit equation, not by eye.** Deflection at each step is `Vb = V*Rx/(R3+Rx) - V*R2/(R1+R2)` scaled to full scale. The browser check recomputes that expression from scratch and compares it against the rendered rotation at all **20 steps**: worst disagreement **0.005 degrees**, which is the rounding in the stylesheet.
- **The null is exact and lands where the ratio says.** Across the sweep the needle reads zero at **exactly one** value, **660 ohms**, which is `R3 * R2/R1 = 330 * 2`. The balance lamp lights there and nowhere else.
- **The readout cannot disagree with the needle.** Both are stepped by `steps(1, end)` off the same 20-phase schedule, so the animation is physically incapable of rendering a resistance and a deflection from different moments.
- **The ratio arm is deliberately not 1:1**, `R1 = 1k` against `R2 = 2k`, so the bridge genuinely multiplies instead of collapsing to `Rx = R3`.
- **The deflection is readable**, against a five-tick scale with the zero mark drawn brighter.

The sweep runs 460 to 860 ohms and back in 40 ohm steps.

## Accessibility

`prefers-reduced-motion: reduce` pauses the sweep, the needle, and the balance lamp together, leaving one readable state.

## Verification

Opened `demo.html` in the browser and checked the needle against the physics rather than against itself: recomputed the bridge voltage from the resistor values at all 20 steps and compared it to the rendered rotation, agreeing to 0.005 degrees, then confirmed the needle reads exactly zero at one and only one value, 660 ohms, matching `R3 * R2/R1`, with the balance lamp lit at that step alone. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
