### PR TITLE
Add moire component

### DIFF
--- a/submissions/examples/moire-as/README.md
+++ b/submissions/examples/moire-as/README.md
@@ -1,0 +1,45 @@
+# Moire
+
+A pure CSS/HTML pair of line gratings, 12px and 13px, laid over each other so that sliding one by a hair sends the interference bands racing.
+
+## What it shows
+
+Two gratings of slightly different pitch, one on top of the other. Where their bars fall in step, light gets through the gaps. Where they fall out of step, the bars of one cover the gaps of the other and the strip goes black. The result is a slow beat with period
+
+```
+P = p1 * p2 / |p1 - p2|
+```
+
+When the pitches differ by exactly one unit the beat period is simply their product: 12 and 13 give **156px**, thirteen times coarser than either grating that made it.
+
+The useful part is what happens when one grating moves. Slide it by `s` and the bands do not follow along; they move by
+
+```
+-s * p1 / |p1 - p2|      =  -12 s
+```
+
+Twelve times as far, and in the **opposite direction**. Nudge the grating one pixel and the bands jump twelve, backwards. The pattern is a mechanical lever with no moving parts: a displacement too small to see comfortably is turned into one that is impossible to miss.
+
+That is not a curiosity, it is a measuring instrument. Moire fringe encoders read machine-tool and telescope positions this way, counting fringes instead of grating lines and getting the amplification for free. A vernier scale is the same beat trick frozen in metal. It is also why photographing a screen produces rolling bands, and why misangled halftone screens ruin a print.
+
+The name comes from watered silk, the fabric where the effect was first noticed in overlapping weaves.
+
+## How it is built
+
+Both gratings are real elements, 34 bars and 31 bars, so the pattern is genuinely emergent rather than drawn. Nothing in the stylesheet describes a band.
+
+- **The bands were measured, not assumed.** The browser check reads every bar's rectangle and finds where a bar of one grating coincides with a bar of the other: **0, 156 and 312 px**, so the spacing is **exactly 156** both times, matching `p1*p2/|p1-p2|`.
+- **The amplification is measured across several shifts.** Sampling the transmission profile from the rendered bar geometry and tracking the band phase: a grating shift of 1, 2, 3 and 5 px moves the bands **-12, -24, -36 and -60 px**. The gain is **exactly -12.000** every time, negative because the bands run against the grating.
+- **The marker rides a real band.** The orange caret is checked at five points around the loop against the band position measured from the bars, and never sits more than **0.59 px** off it. It tracks the pattern rather than being animated near it.
+- **The loop is seamless by construction.** Shifting the finer grating by one of its own periods, 13px, returns it to where it started, and in exactly that time the bands sweep one full beat period, 156px. There is no jump at the wrap.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` pauses the grating and both markers together, leaving a static moire pattern.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/moire-as/demo.html
+++ b/submissions/examples/moire-as/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Moire</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="tagM">two gratings, 12 px and 13 px</span>
+    <span class="brkM"></span>
+    <span class="brkLbl">fringe spacing 156 px = 12 x 13</span>
+    <div class="stripM">
+      <div class="layerM g1L">
+        <span class="barM g1" style="left: -36.00px"></span>
+        <span class="barM g1" style="left: -24.00px"></span>
+        <span class="barM g1" style="left: -12.00px"></span>
+        <span class="barM g1" style="left: 0.00px"></span>
+        <span class="barM g1" style="left: 12.00px"></span>
+        <span class="barM g1" style="left: 24.00px"></span>
+        <span class="barM g1" style="left: 36.00px"></span>
+        <span class="barM g1" style="left: 48.00px"></span>
+        <span class="barM g1" style="left: 60.00px"></span>
+        <span class="barM g1" style="left: 72.00px"></span>
+        <span class="barM g1" style="left: 84.00px"></span>
+        <span class="barM g1" style="left: 96.00px"></span>
+        <span class="barM g1" style="left: 108.00px"></span>
+        <span class="barM g1" style="left: 120.00px"></span>
+        <span class="barM g1" style="left: 132.00px"></span>
+        <span class="barM g1" style="left: 144.00px"></span>
+        <span class="barM g1" style="left: 156.00px"></span>
+        <span class="barM g1" style="left: 168.00px"></span>
+        <span class="barM g1" style="left: 180.00px"></span>
+        <span class="barM g1" style="left: 192.00px"></span>
+        <span class="barM g1" style="left: 204.00px"></span>
+        <span class="barM g1" style="left: 216.00px"></span>
+        <span class="barM g1" style="left: 228.00px"></span>
+        <span class="barM g1" style="left: 240.00px"></span>
+        <span class="barM g1" style="left: 252.00px"></span>
+        <span class="barM g1" style="left: 264.00px"></span>
+        <span class="barM g1" style="left: 276.00px"></span>
+        <span class="barM g1" style="left: 288.00px"></span>
+        <span class="barM g1" style="left: 300.00px"></span>
+        <span class="barM g1" style="left: 312.00px"></span>
+        <span class="barM g1" style="left: 324.00px"></span>
+        <span class="barM g1" style="left: 336.00px"></span>
+        <span class="barM g1" style="left: 348.00px"></span>
+        <span class="barM g1" style="left: 360.00px"></span>
+      </div>
+      <div class="layerM g2L">
+        <span class="barM g2" style="left: -39.00px"></span>
+        <span class="barM g2" style="left: -26.00px"></span>
+        <span class="barM g2" style="left: -13.00px"></span>
+        <span class="barM g2" style="left: 0.00px"></span>
+        <span class="barM g2" style="left: 13.00px"></span>
+        <span class="barM g2" style="left: 26.00px"></span>
+        <span class="barM g2" style="left: 39.00px"></span>
+        <span class="barM g2" style="left: 52.00px"></span>
+        <span class="barM g2" style="left: 65.00px"></span>
+        <span class="barM g2" style="left: 78.00px"></span>
+        <span class="barM g2" style="left: 91.00px"></span>
+        <span class="barM g2" style="left: 104.00px"></span>
+        <span class="barM g2" style="left: 117.00px"></span>
+        <span class="barM g2" style="left: 130.00px"></span>
+        <span class="barM g2" style="left: 143.00px"></span>
+        <span class="barM g2" style="left: 156.00px"></span>
+        <span class="barM g2" style="left: 169.00px"></span>
+        <span class="barM g2" style="left: 182.00px"></span>
+        <span class="barM g2" style="left: 195.00px"></span>
+        <span class="barM g2" style="left: 208.00px"></span>
+        <span class="barM g2" style="left: 221.00px"></span>
+        <span class="barM g2" style="left: 234.00px"></span>
+        <span class="barM g2" style="left: 247.00px"></span>
+        <span class="barM g2" style="left: 260.00px"></span>
+        <span class="barM g2" style="left: 273.00px"></span>
+        <span class="barM g2" style="left: 286.00px"></span>
+        <span class="barM g2" style="left: 299.00px"></span>
+        <span class="barM g2" style="left: 312.00px"></span>
+        <span class="barM g2" style="left: 325.00px"></span>
+        <span class="barM g2" style="left: 338.00px"></span>
+        <span class="barM g2" style="left: 351.00px"></span>
+      </div>
+    </div>
+    <span class="markF"></span>
+    <span class="lblF">a band: 156 px per loop</span>
+    <span class="markG"></span>
+    <span class="lblG">a bar: 13 px</span>
+    <span class="capM">slide one grating by 1 px and the bands jump 12 px, the other way</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/moire-as/style.css
+++ b/submissions/examples/moire-as/style.css
@@ -1,0 +1,167 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #1a1c26, #05060a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 250px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 40%, #232637, #07080e 86%);
+}
+
+/*
+  two line gratings of slightly different pitch, laid one over the other.
+  where their bars fall in step, light gets through; where they fall out of
+  step, the bars of one cover the gaps of the other and the strip goes black.
+  that beat repeats every p1*p2/|p1-p2| = 12*13/1 = 156 px.
+*/
+.stripM {
+  position: absolute;
+  left: 20px;
+  top: 62px;
+  width: 320px;
+  height: 92px;
+  overflow: hidden;
+  border-radius: 3px;
+  background: #f4efe3;
+  box-shadow: 0 0 0 1px rgba(190, 200, 230, 0.28), 0 6px 18px rgba(0, 0, 0, 0.5);
+}
+
+.layerM {
+  position: absolute;
+  inset: 0;
+}
+
+/*
+  shifting the finer grating by one of its own periods returns it to where
+  it started, so the loop is seamless. in that time the fringes travel one
+  whole beat period, 156 px, which is the 12x amplification made visible.
+*/
+.g2L { animation: slideM 6s linear infinite; }
+
+.barM {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: #14121a;
+}
+
+.g1 { width: 6.00px; }
+.g2 { width: 6.50px; }
+
+.brkM {
+  position: absolute;
+  left: 20px;
+  top: 44px;
+  width: 156px;
+  height: 6px;
+  border: 1px solid rgba(180, 200, 240, 0.5);
+  border-bottom: 0;
+}
+
+.brkLbl {
+  position: absolute;
+  left: 20px;
+  top: 28px;
+  width: 156px;
+  text-align: center;
+  font-size: 0.46rem;
+  letter-spacing: 0.04em;
+  color: rgba(190, 210, 245, 0.85);
+}
+
+.tagM {
+  position: absolute;
+  top: 10px;
+  right: 18px;
+  font-size: 0.48rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(200, 215, 245, 0.9);
+}
+
+.capM {
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.52rem;
+  letter-spacing: 0.03em;
+  color: rgba(205, 220, 245, 0.88);
+}
+
+/*
+  two markers, so the amplification is visible rather than asserted: one
+  rides a bar of the moving grating, the other rides a bright band. over
+  one loop the bar creeps 13 px while the band sweeps 156 px, backwards.
+*/
+.markF, .markG {
+  position: absolute;
+  top: 160px;
+  width: 0;
+  height: 0;
+  margin-left: -5px;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+}
+
+.markF {
+  left: 176px;
+  border-bottom: 7px solid rgba(255, 190, 90, 0.95);
+  animation: bandM 6s linear infinite;
+}
+
+.markG {
+  left: 300px;
+  border-bottom: 7px solid rgba(120, 200, 255, 0.95);
+  animation: barM 6s linear infinite;
+}
+
+.lblF, .lblG {
+  position: absolute;
+  top: 172px;
+  font-size: 0.44rem;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.lblF {
+  left: 26px;
+  color: rgba(255, 200, 120, 0.95);
+}
+
+.lblG {
+  right: 26px;
+  color: rgba(140, 210, 255, 0.95);
+}
+
+@keyframes bandM {
+  from { transform: translateX(0); }
+  to { transform: translateX(-156px); }
+}
+
+@keyframes barM {
+  from { transform: translateX(0); }
+  to { transform: translateX(13.00px); }
+}
+
+@keyframes slideM {
+  from { transform: translateX(0); }
+  to { transform: translateX(13.00px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .g2L,
+  .markF,
+  .markG { animation-play-state: paused; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/moire-as/`, a self-contained pure CSS/HTML pair of overlaid line gratings in which sliding one by a hair sends the interference bands racing the other way.

Closes #49655

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

Two gratings of slightly different pitch, one over the other. In step, light passes; out of step, the bars of one cover the gaps of the other. The beat period is `p1*p2/|p1-p2|`, which for pitches differing by one unit is just their product: 12 and 13 give 156 px. Slide one grating by `s` and the bands move `-s*p1/|p1-p2|`, twelve times as far and backwards. That is the principle behind moire fringe encoders and behind the vernier scale.

Both gratings are real elements, **34 bars and 31 bars**, so the pattern is genuinely emergent. Nothing in the stylesheet describes a band.

- **The bands were measured, not assumed.** The check reads every bar rectangle and finds where a bar of one grating coincides with a bar of the other: **0, 156 and 312 px**, so the spacing is **exactly 156** both times.
- **The amplification is measured across several shifts.** Sampling the transmission profile from the rendered geometry and tracking the band phase, grating shifts of 1, 2, 3 and 5 px move the bands **-12, -24, -36 and -60 px**: a gain of **exactly -12.000** every time, negative because the bands run against the grating.
- **The marker rides a real band.** The orange caret is checked at five points around the loop against the band position measured from the bars and never sits more than **0.59 px** off it.
- **The loop is seamless by construction.** Shifting the finer grating by one of its own periods, 13 px, returns it to identity, and in exactly that time the bands sweep one full beat period, 156 px, so there is no jump at the wrap.

## Accessibility

`prefers-reduced-motion: reduce` pauses the grating and both markers together, leaving a static moire pattern.

## Verification

Opened `demo.html` in the browser and measured the emergent pattern rather than trusting it: read all 65 bar rectangles to locate the bright bands at 0, 156 and 312 px, then swept the paused animation and tracked the band phase against known grating shifts, getting a gain of exactly -12.000 at 1, 2, 3 and 5 px, opposite in direction as predicted. Also confirmed the band marker stays within 0.59 px of the measured band across the loop. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
