### PR TITLE
Add Blur-Entrance popover component for dashboard layouts (blur-entra…

### DIFF
--- a/submissions/examples/blur-entrance-popover-hr18/README.md
+++ b/submissions/examples/blur-entrance-popover-hr18/README.md
@@ -1,0 +1,101 @@
+# Blur-Entrance Popover (`blur-entrance-popover-hr18`)
+
+A pure-CSS animated popover with a "Blur-Entrance" transition, styled for
+responsive dashboard layouts, built for issue
+[#46475](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46475).
+
+## What it does
+
+Clicking a toolbar icon reveals a popover panel that sharpens into view —
+starting slightly blurred, scaled down, and transparent, then settling to
+fully sharp, full size, and opaque. The **animation itself is 100% CSS**
+(`@keyframes ease-blur-entrance-hr18`, driven entirely by custom
+properties); a small amount of vanilla JavaScript only handles click-to-
+toggle, `Escape`-to-close, click-outside-to-close, and keeping
+`aria-expanded` in sync — no animation logic lives in JavaScript.
+
+The demo shows it applied to a small dashboard toolbar with two icon
+triggers — Notifications and Quick settings — each opening its own
+independent popover with a short list inside.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap an icon trigger and a popover panel in the component markup:
+
+```html
+<div class="bep-popover-wrap-hr18" data-open="false">
+  <button type="button" class="bep-icon-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="Notifications">
+    <!-- icon SVG -->
+  </button>
+  <div class="ease-popover-blur-hr18" role="dialog" aria-label="Notifications">
+    <div class="bep-popover-head-hr18">
+      <strong>Notifications</strong>
+      <button type="button" class="bep-popover-close-hr18" aria-label="Close">&times;</button>
+    </div>
+    <!-- popover content -->
+  </div>
+</div>
+```
+
+The included script finds every `.bep-popover-wrap-hr18` on the page
+automatically and wires it up — a new popover only needs the markup above.
+Opening one popover closes any other that's currently open.
+
+### Tuning the animation
+
+Every timing/blur/scale value is a CSS custom property, overridable per
+instance or globally:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-blur-duration-hr18` | `380ms` | How long the sharpen-in takes |
+| `--ease-blur-easing-hr18` | `cubic-bezier(0.22, 1, 0.36, 1)` | The easing curve for the entrance |
+| `--ease-blur-amount-hr18` | `10px` | Starting blur radius — higher looks softer/further away |
+| `--ease-blur-scale-hr18` | `0.96` | Starting scale, so the panel also grows slightly into place |
+| `--ease-blur-delay-hr18` | `0ms` | Delay before the entrance starts |
+
+```css
+.bep-popover-wrap-hr18.dramatic .ease-popover-blur-hr18 {
+  --ease-blur-amount-hr18: 20px;
+  --ease-blur-duration-hr18: 550ms;
+}
+```
+
+## Accessibility notes
+
+- The trigger is a native `<button>` with `aria-haspopup="dialog"` and
+  `aria-expanded` kept in sync with the popover's open state, plus a real
+  `aria-label` since it's icon-only.
+- `Escape` closes the popover and returns focus to its trigger.
+- Clicking outside the open popover closes it.
+- The panel has `role="dialog"` and an `aria-label`, plus a visible,
+  keyboard-reachable close button.
+- Fully keyboard operable: `Tab` to the trigger, `Enter`/`Space` to open,
+  `Tab` through the close button and list items, `Escape` to dismiss.
+- The blur/scale entrance respects
+  `@media (prefers-reduced-motion: reduce)` and appears instantly at full
+  clarity instead.
+
+## Responsiveness
+
+The popover panel's width adapts to stay within the viewport on narrow
+screens (`max-width: 420px`), and its item list scrolls internally rather
+than growing the panel indefinitely.
+
+## Why this fits EaseMotion CSS
+
+It's a self-contained, reusable interaction pattern with a distinct named
+animation (`ease-blur-entrance`) exposed entirely through custom
+properties — matching the issue's ask for zero JavaScript animation
+overhead and tunable timing/easing/scale — while remaining genuinely
+keyboard accessible.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/blur-entrance-popover-hr18/demo.html
+++ b/submissions/examples/blur-entrance-popover-hr18/demo.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Blur-Entrance Popover — dashboard demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="bep-hr18">
+  <div class="bep-wrap-hr18">
+
+    <header class="bep-header-hr18">
+      <span class="bep-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Dashboard toolbar</h1>
+      <p>Click either icon below — its popover sharpens into view from a
+        soft blur instead of just fading, a subtle cue that fits a clean
+        dashboard header.</p>
+    </header>
+
+    <div class="bep-toolbar-hr18">
+      <span class="bep-toolbar-title-hr18">Project Overview</span>
+      <div class="bep-toolbar-actions-hr18">
+
+        <!-- Notifications -->
+        <div class="bep-popover-wrap-hr18" data-open="false">
+          <button type="button" class="bep-icon-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="Notifications">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>
+            <span class="bep-badge-hr18" aria-hidden="true"></span>
+          </button>
+          <div class="ease-popover-blur-hr18" role="dialog" aria-label="Notifications">
+            <div class="bep-popover-head-hr18">
+              <strong>Notifications</strong>
+              <button type="button" class="bep-popover-close-hr18" aria-label="Close">&times;</button>
+            </div>
+            <ul class="bep-popover-list-hr18">
+              <li class="bep-popover-item-hr18">
+                <span class="bep-item-dot-hr18" aria-hidden="true"></span>
+                <span class="bep-item-text-hr18"><strong>Deploy succeeded</strong><span>main branch &middot; 2 min ago</span></span>
+              </li>
+              <li class="bep-popover-item-hr18">
+                <span class="bep-item-dot-hr18" aria-hidden="true"></span>
+                <span class="bep-item-text-hr18"><strong>New comment</strong><span>on "Q3 roadmap" &middot; 1 hr ago</span></span>
+              </li>
+              <li class="bep-popover-item-hr18">
+                <span class="bep-item-dot-hr18" aria-hidden="true"></span>
+                <span class="bep-item-text-hr18"><strong>Usage at 80%</strong><span>billing cycle resets in 6 days</span></span>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- Quick settings -->
+        <div class="bep-popover-wrap-hr18" data-open="false">
+          <button type="button" class="bep-icon-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="Quick settings">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
+          </button>
+          <div class="ease-popover-blur-hr18" role="dialog" aria-label="Quick settings">
+            <div class="bep-popover-head-hr18">
+              <strong>Quick settings</strong>
+              <button type="button" class="bep-popover-close-hr18" aria-label="Close">&times;</button>
+            </div>
+            <ul class="bep-popover-list-hr18">
+              <li class="bep-popover-item-hr18">
+                <span class="bep-item-dot-hr18" aria-hidden="true"></span>
+                <span class="bep-item-text-hr18"><strong>Compact view</strong><span>Tighter row spacing across tables</span></span>
+              </li>
+              <li class="bep-popover-item-hr18">
+                <span class="bep-item-dot-hr18" aria-hidden="true"></span>
+                <span class="bep-item-text-hr18"><strong>Auto-refresh</strong><span>Poll for updates every 30s</span></span>
+              </li>
+              <li class="bep-popover-item-hr18">
+                <span class="bep-item-dot-hr18" aria-hidden="true"></span>
+                <span class="bep-item-text-hr18"><strong>Keyboard shortcuts</strong><span>Enable single-key navigation</span></span>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="bep-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-blur-duration-hr18</code></td><td><code>380ms</code></td><td>How long the sharpen-in takes.</td></tr>
+          <tr><td><code>--ease-blur-easing-hr18</code></td><td><code>cubic-bezier(0.22, 1, 0.36, 1)</code></td><td>The easing curve for the entrance.</td></tr>
+          <tr><td><code>--ease-blur-amount-hr18</code></td><td><code>10px</code></td><td>Starting blur radius — higher looks softer/further away.</td></tr>
+          <tr><td><code>--ease-blur-scale-hr18</code></td><td><code>0.96</code></td><td>Starting scale, so the panel also grows slightly into place.</td></tr>
+          <tr><td><code>--ease-blur-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the entrance starts.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="bep-footnote-hr18">submissions/examples/blur-entrance-popover-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var wraps = document.querySelectorAll(".bep-popover-wrap-hr18");
+
+  wraps.forEach(function (wrap) {
+    var trigger = wrap.querySelector(".bep-icon-trigger-hr18");
+    var panel = wrap.querySelector(".ease-popover-blur-hr18");
+    var closeBtn = wrap.querySelector(".bep-popover-close-hr18");
+
+    function open() {
+      wraps.forEach(function (other) {
+        if (other !== wrap && other.__bepCloseHr18) other.__bepCloseHr18(false);
+      });
+      wrap.setAttribute("data-open", "true");
+      trigger.setAttribute("aria-expanded", "true");
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("keydown", onKeydown);
+    }
+
+    function close(returnFocus) {
+      wrap.setAttribute("data-open", "false");
+      trigger.setAttribute("aria-expanded", "false");
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKeydown);
+      if (returnFocus) trigger.focus();
+    }
+
+    function onDocClick(e) {
+      if (!wrap.contains(e.target)) close(false);
+    }
+
+    function onKeydown(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close(true);
+      }
+    }
+
+    trigger.addEventListener("click", function () {
+      var isOpen = wrap.getAttribute("data-open") === "true";
+      if (isOpen) close(false); else open();
+    });
+
+    closeBtn.addEventListener("click", function () {
+      close(true);
+    });
+
+    wrap.__bepCloseHr18 = close;
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/blur-entrance-popover-hr18/style.css
+++ b/submissions/examples/blur-entrance-popover-hr18/style.css
@@ -1,0 +1,322 @@
+/* ==========================================================================
+   blur-entrance-popover-hr18 — style.css
+   CSS Blur-Entrance Popover for Responsive Dashboard layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.bep-hr18 {
+  --bg-hr18: #f4f6f9;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e3e7ee;
+  --text-hr18: #151a24;
+  --text-muted-hr18: #667085;
+  --accent-hr18: #6d5ef7;
+  --accent-soft-hr18: #efedfe;
+  --danger-hr18: #d1453a;
+  --radius-hr18: 14px;
+
+  /* Exposed animation parameters. */
+  --ease-blur-duration-hr18: 380ms;
+  --ease-blur-easing-hr18: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-blur-amount-hr18: 10px;
+  --ease-blur-scale-hr18: 0.96;
+  --ease-blur-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4.5rem;
+  min-height: 100%;
+}
+
+.bep-hr18 * {
+  box-sizing: border-box;
+}
+
+.bep-hr18 h1,
+.bep-hr18 h2,
+.bep-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.bep-wrap-hr18 {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+/* ---- Header ------------------------------------------------------------------ */
+.bep-header-hr18 {
+  margin-bottom: 2rem;
+}
+
+.bep-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.bep-header-hr18 h1 {
+  font-size: clamp(1.6rem, 2.6vw, 2.2rem);
+}
+
+.bep-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 60ch;
+  font-size: 0.96rem;
+  line-height: 1.6;
+}
+
+/* ---- Mock dashboard toolbar ---------------------------------------------------- */
+.bep-toolbar-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1rem 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  box-shadow: 0 1px 2px rgba(10, 15, 30, 0.03), 0 8px 20px rgba(10, 15, 30, 0.04);
+}
+
+.bep-toolbar-title-hr18 {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.bep-toolbar-actions-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* ---- The reusable popover component ---------------------------------------------
+   Drop-in markup: a .bep-popover-wrap-hr18 containing an icon trigger
+   button and a .ease-popover-blur-hr18 panel. Toggling the wrapper's
+   data-open attribute reveals the panel and plays the blur-entrance
+   animation — the animation itself is 100% CSS, driven entirely by the
+   custom properties declared above. */
+.bep-popover-wrap-hr18 {
+  position: relative;
+}
+
+.bep-icon-trigger-hr18 {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  color: var(--text-muted-hr18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  position: relative;
+}
+
+.bep-icon-trigger-hr18:hover {
+  border-color: var(--accent-hr18);
+  color: var(--accent-hr18);
+}
+
+.bep-icon-trigger-hr18[aria-expanded="true"] {
+  border-color: var(--accent-hr18);
+  color: var(--accent-hr18);
+  background: var(--accent-soft-hr18);
+}
+
+.bep-badge-hr18 {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--danger-hr18);
+  border: 2px solid var(--panel-hr18);
+}
+
+.ease-popover-blur-hr18 {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 270px;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  box-shadow: 0 24px 55px rgba(10, 15, 30, 0.18);
+  z-index: 20;
+  display: none;
+  overflow: hidden;
+}
+
+.bep-popover-wrap-hr18[data-open="true"] .ease-popover-blur-hr18 {
+  display: block;
+  animation: ease-blur-entrance-hr18 var(--ease-blur-duration-hr18) var(--ease-blur-easing-hr18) var(--ease-blur-delay-hr18) both;
+}
+
+/* The blur entrance: starts soft and slightly scaled down, sharpens and
+   settles to full size. Blur amount and scale are both tunable. */
+@keyframes ease-blur-entrance-hr18 {
+  0% {
+    opacity: 0;
+    filter: blur(var(--ease-blur-amount-hr18));
+    transform: scale(var(--ease-blur-scale-hr18)) translateY(4px);
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1) translateY(0);
+  }
+}
+
+.bep-popover-head-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.bep-popover-head-hr18 strong {
+  font-size: 0.86rem;
+}
+
+.bep-popover-close-hr18 {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted-hr18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bep-popover-close-hr18:hover {
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+}
+
+.bep-popover-list-hr18 {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.bep-popover-item-hr18 {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.55rem 0.6rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+}
+
+.bep-popover-item-hr18:hover {
+  background: var(--accent-soft-hr18);
+}
+
+.bep-item-dot-hr18 {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-hr18);
+  margin-top: 0.4rem;
+  flex-shrink: 0;
+}
+
+.bep-item-text-hr18 strong {
+  display: block;
+  font-weight: 600;
+  color: var(--text-hr18);
+}
+
+.bep-item-text-hr18 span {
+  color: var(--text-muted-hr18);
+  font-size: 0.76rem;
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.bep-tuning-hr18 {
+  margin-top: 3rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.bep-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.bep-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.bep-tuning-hr18 th,
+.bep-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.bep-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.bep-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+}
+
+.bep-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.bep-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bep-popover-wrap-hr18[data-open="true"] .ease-popover-blur-hr18 {
+    animation: none;
+    opacity: 1;
+    filter: none;
+    transform: none;
+  }
+}
+
+@media (max-width: 420px) {
+  .ease-popover-blur-hr18 {
+    width: min(270px, calc(100vw - 3rem));
+    right: -0.5rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Popover with a "Blur-Entrance" transition, styled
for responsive dashboard layouts. Clicking a toolbar icon reveals a
popover that sharpens into view — starting blurred, scaled down, and
transparent, settling to sharp, full size, and opaque. The animation
itself is 100% CSS, driven by exposed custom properties for duration,
easing, blur amount, and scale; a small vanilla-JS layer only handles
click-toggle, Escape-to-close, click-outside-to-close, and aria-expanded
sync. Demo shows it applied to a dashboard toolbar with Notifications and
Quick Settings popovers.

Resolves #46475

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/blur-entrance-popover-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS "blur entrance" pop-in animation for click-triggered
popovers, with tunable blur/scale/timing via custom properties.

**How does a developer use it?**
```html
<div class="bep-popover-wrap-hr18" data-open="false">
  <button type="button" class="bep-icon-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="Notifications">...</button>
  <div class="ease-popover-blur-hr18" role="dialog" aria-label="Notifications">...</div>
</div>
```

**Why does it fit EaseMotion CSS?**
A self-contained interaction with a distinct named animation
(`ease-blur-entrance`) exposed entirely through custom properties, per the
issue's ask for zero JS animation overhead and tunable timing/easing/scale
— while being genuinely keyboard accessible.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
The toggle script auto-discovers every `.bep-popover-wrap-hr18` and closes
any other open popover when a new one opens — same pattern as
`tada-popover-hr18` and `swing-hover-popover-hr18`, submitted earlier for
similar popover issues in this batch. Tested keyboard flow and
click-outside-to-close in Chrome; haven't checked other browsers yet.