### PR TITLE
Add CSS Staggered Entrance Tooltip for Marketing Landing Page Layouts

### DIFF
--- a/submissions/examples/Add CSS Staggered Entrance Tooltip for Marketing Landing Page Layouts #46270/README.md
+++ b/submissions/examples/Add CSS Staggered Entrance Tooltip for Marketing Landing Page Layouts #46270/README.md
@@ -1,0 +1,28 @@
+# CSS Staggered Entrance Tooltip (Marketing Landing Page Aesthetics)
+
+This example demonstrates how to create a rich, purely CSS-animated Tooltip featuring a Staggered Entrance interaction transition. 
+
+## Features
+- **Pure CSS**: Fully functional interactivity and rich staggered animations without JavaScript.
+- **Staggered Entrance**: Leveraging child selectors and `transition-delay`, the internal elements of the tooltip (header, description, bullet points) cascade into view one after another, creating a highly polished, premium marketing feel.
+- **Modern CSS APIs**: Uses `allow-discrete` and `@starting-style` to gracefully animate the tooltip from `display: none` to `display: flex` upon hover or focus.
+- **Marketing Aesthetics**: Incorporates modern landing page design paradigms, including glassmorphism (`backdrop-filter`), vibrant gradients, bouncy bezier curves, and rounded, welcoming UI shapes.
+- **Fully Customizable**: Timing, easing curves, stagger delays, and translation offsets are all exposed via well-documented CSS Custom Properties (Variables).
+
+## Custom Properties Configuration
+You can tweak the stagger delays and animation speeds via these exposed CSS custom properties:
+```css
+:root {
+  --tooltip-duration: 0.35s;
+  --tooltip-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --stagger-offset-y: 10px;
+  
+  --stagger-delay-1: 0.05s;
+  --stagger-delay-2: 0.1s;
+  --stagger-delay-3: 0.15s;
+}
+```
+
+## Browser Support
+This demo uses modern CSS features. For the full experience, it relies on:
+- **CSS `@starting-style` & `allow-discrete`** (Supported in Chrome 117+, Edge 117+, Firefox 129+, Safari 17.4+)

--- a/submissions/examples/Add CSS Staggered Entrance Tooltip for Marketing Landing Page Layouts #46270/demo.html
+++ b/submissions/examples/Add CSS Staggered Entrance Tooltip for Marketing Landing Page Layouts #46270/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Staggered Entrance Tooltip - Marketing Landing Page</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="marketing-layout">
+    <div class="pricing-card">
+      <div class="card-header">
+        <h2>Pro Plan</h2>
+        <div class="price"><span>$</span>29<span>/mo</span></div>
+      </div>
+      
+      <ul class="feature-list">
+        <li>
+          <svg class="check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+          Unlimited Projects
+        </li>
+        <li>
+          <svg class="check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+          Advanced Analytics
+          
+          <!-- Tooltip Container -->
+          <div class="tooltip-container">
+            <button class="info-btn" aria-label="More information about Advanced Analytics" aria-describedby="tooltip-1">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+            </button>
+            
+            <div id="tooltip-1" class="tooltip glass-panel" role="tooltip">
+              <div class="stagger-item tooltip-header">
+                <div class="icon-box">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+                </div>
+                <h3>Advanced Analytics</h3>
+              </div>
+              <p class="stagger-item">Gain deep insights into your audience behavior with real-time tracking.</p>
+              <ul class="stagger-item tooltip-bullets">
+                <li>Heatmaps & Click Tracking</li>
+                <li>Custom Report Builder</li>
+                <li>90-Day Data Retention</li>
+              </ul>
+            </div>
+          </div>
+          
+        </li>
+        <li>
+          <svg class="check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+          Priority Support
+        </li>
+      </ul>
+      
+      <button class="cta-btn">Get Started</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/Add CSS Staggered Entrance Tooltip for Marketing Landing Page Layouts #46270/style.css
+++ b/submissions/examples/Add CSS Staggered Entrance Tooltip for Marketing Landing Page Layouts #46270/style.css
@@ -1,0 +1,301 @@
+:root {
+  /* --- Tooltip Custom Properties --- */
+  --tooltip-duration: 0.35s;
+  --tooltip-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* Bouncy entrance */
+  --stagger-offset-y: 10px;
+  
+  /* Staggered entrance delays */
+  --stagger-delay-1: 0.05s;
+  --stagger-delay-2: 0.1s;
+  --stagger-delay-3: 0.15s;
+  
+  /* Marketing Theme Properties */
+  --color-bg: #09090b;
+  --color-text: #ffffff;
+  --color-text-muted: #a1a1aa;
+  --color-primary: #6366f1; /* Indigo */
+  --color-secondary: #ec4899; /* Pink */
+  --gradient-brand: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  
+  --tooltip-shadow: 0 30px 60px -15px rgba(99, 102, 241, 0.3);
+}
+
+body {
+  margin: 0;
+  font-family: 'Outfit', system-ui, sans-serif;
+  background-color: var(--color-bg);
+  background-image: 
+    radial-gradient(circle at top right, rgba(99, 102, 241, 0.15), transparent 40%),
+    radial-gradient(circle at bottom left, rgba(236, 72, 153, 0.15), transparent 40%);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  -webkit-font-smoothing: antialiased;
+}
+
+.marketing-layout {
+  padding: 2rem;
+}
+
+.pricing-card {
+  background: rgba(24, 24, 27, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  padding: 40px;
+  border-radius: 24px;
+  width: 340px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.4);
+}
+
+.card-header {
+  margin-bottom: 32px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.card-header h2 {
+  margin: 0 0 12px 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.price {
+  font-size: 3.5rem;
+  font-weight: 700;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.price span:first-child { font-size: 1.5rem; color: var(--color-text-muted); }
+.price span:last-child { font-size: 1rem; color: var(--color-text-muted); font-weight: 500; }
+
+.feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 40px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.feature-list li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.05rem;
+  font-weight: 500;
+}
+
+.check {
+  color: var(--color-primary);
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.cta-btn {
+  width: 100%;
+  padding: 16px;
+  border-radius: 12px;
+  border: none;
+  background: var(--gradient-brand);
+  color: white;
+  font-family: inherit;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 20px -5px rgba(236, 72, 153, 0.4);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.cta-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 25px -5px rgba(236, 72, 153, 0.5);
+}
+
+/* --- TOOLTIP TRIGGER --- */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.info-btn {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  color: var(--color-text-muted);
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.2s;
+}
+
+.info-btn:hover, .info-btn:focus-visible {
+  color: white;
+  background: rgba(255,255,255,0.15);
+  border-color: rgba(255,255,255,0.3);
+  outline: none;
+}
+
+/* --- TOOLTIP CORE STYLES --- */
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  width: 260px;
+  z-index: 100;
+  pointer-events: none; /* Ignore pointer events */
+  
+  /* Glassmorphism Styling */
+  background: rgba(24, 24, 27, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: var(--tooltip-shadow);
+  
+  /* Flex layout for staggered items */
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  
+  /* Initial State */
+  display: none;
+  opacity: 0;
+  transform: translateX(-50%) translateY(10px) scale(0.95);
+  transform-origin: bottom center;
+  
+  /* Container transition */
+  transition: opacity var(--tooltip-duration) var(--tooltip-easing),
+              transform var(--tooltip-duration) var(--tooltip-easing),
+              display var(--tooltip-duration) var(--tooltip-easing) allow-discrete;
+}
+
+/* Tooltip connector arrow */
+.tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: rgba(24, 24, 27, 0.85);
+  border-right: 1px solid rgba(255, 255, 255, 0.15);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+/* Show Tooltip on Hover/Focus */
+.tooltip-container:hover .tooltip,
+.tooltip-container:focus-within .tooltip {
+  display: flex;
+  opacity: 1;
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+/* Entry Animation Initial Styles (Container) */
+@starting-style {
+  .tooltip-container:hover .tooltip,
+  .tooltip-container:focus-within .tooltip {
+    opacity: 0;
+    transform: translateX(-50%) translateY(10px) scale(0.95);
+  }
+}
+
+/* --- STAGGERED ENTRANCE ITEMS --- */
+.stagger-item {
+  /* Initial/Exit state: pushed down and transparent */
+  opacity: 0;
+  transform: translateY(var(--stagger-offset-y));
+  /* Fast exit transition (no delay) */
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+/* Hover state: slow entry with delays */
+.tooltip-container:hover .tooltip .stagger-item,
+.tooltip-container:focus-within .tooltip .stagger-item {
+  opacity: 1;
+  transform: translateY(0);
+  /* Slower bouncy entry transition */
+  transition: opacity 0.4s var(--tooltip-easing),
+              transform 0.4s var(--tooltip-easing);
+}
+
+/* Apply staggered delays on entry ONLY */
+.tooltip-container:hover .tooltip .stagger-item:nth-child(1),
+.tooltip-container:focus-within .tooltip .stagger-item:nth-child(1) { transition-delay: var(--stagger-delay-1); }
+
+.tooltip-container:hover .tooltip .stagger-item:nth-child(2),
+.tooltip-container:focus-within .tooltip .stagger-item:nth-child(2) { transition-delay: var(--stagger-delay-2); }
+
+.tooltip-container:hover .tooltip .stagger-item:nth-child(3),
+.tooltip-container:focus-within .tooltip .stagger-item:nth-child(3) { transition-delay: var(--stagger-delay-3); }
+
+/* --- TOOLTIP INTERNAL UI --- */
+.tooltip-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.icon-box {
+  background: var(--gradient-brand);
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  flex-shrink: 0;
+}
+
+.tooltip-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.tooltip p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.tooltip-bullets {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tooltip-bullets li {
+  font-size: 0.8rem;
+  color: #e4e4e7;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tooltip-bullets li::before {
+  content: '';
+  width: 4px;
+  height: 4px;
+  background: var(--color-secondary);
+  border-radius: 50%;
+}


### PR DESCRIPTION
#46270

## Pull Request Description

<!-- Briefly describe what you're submitting and the problem it solves. -->
- Implements the Staggered Entrance transition. By leveraging CSS transition-delay with :nth-child() selectors on the tooltip's inner .stagger-item elements, the header, description, and bullet points cascade smoothly into view one after the other. This creates a very premium, polished feel. The styling perfectly matches modern Marketing aesthetics, utilizing dark-mode glassmorphism (backdrop-filter), vibrant indigo/pink gradients, and bouncy entry curves.
- Resolves #46270 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---



## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
