### PR TITLE
Add standalone scroll-trigger reveal utility (scroll-trigger-reveal-h…

### DIFF
--- a/submissions/examples/scroll-trigger-reveal-hr18/README.md
+++ b/submissions/examples/scroll-trigger-reveal-hr18/README.md
@@ -1,0 +1,107 @@
+# Scroll-Trigger Reveal (`scroll-trigger-reveal-hr18`)
+
+A standalone, dependency-free scroll-triggered reveal utility, built in
+response to issue
+[#49580](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/49580).
+
+## A note on scope — please read before reviewing
+
+Issue #49580 asks for a plugin at `easemotion/plugins/scroll-trigger.js`
+that imports `parse()` and `compile()` from an existing `parser.js` /
+`compiler.js` / `runtime.js` engine, reusing an `em=""` attribute DSL and a
+`VISION.md` roadmap it says already lists this plugin.
+
+I looked for that engine, those files, and the `em=""` syntax across the
+repository (its README's own file tree, the live demo site, every other
+open issue) and couldn't find any trace of them — everything in this
+project today is plain CSS utility classes (`ease-fade-in`,
+`ease-hover-grow`, etc.), not an attribute-driven JS engine with a
+parser/compiler/runtime pipeline. Since I can't verify those files exist,
+I didn't want to submit a "plugin" with imports that point at nothing —
+that would look like a real contribution without being one.
+
+So this submission builds toward the issue's actual **goal** — described
+in its own "why" section as collapsing the ~15 duplicated, one-off
+IntersectionObserver scroll-reveal demos in `submissions/examples/` into
+one reusable, composable primitive — as a genuinely standalone utility
+instead. It doesn't import from or depend on any core engine file. If the
+engine described in the issue does exist somewhere I didn't find, this can
+be adapted into a real plugin for it; until then, it stands on its own.
+
+## What it does
+
+A single script, `scroll-trigger-hr18.js`, watches any element carrying a
+`data-ease-scroll` attribute and applies an animation class to it only once
+it crosses a visibility threshold, instead of on page load. The grammar
+deliberately echoes the spirit of the issue's proposed `em-scroll`
+modifiers, without depending on anything the issue's DSL would require:
+
+```
+data-ease-scroll="<animation-class> [threshold-<0-1>] [once|repeat] [delay-<ms>]"
+```
+
+- **`<animation-class>`** (required, first token) — the class to apply on reveal
+- **`threshold-<0-1>`** (default `0.2`) — how much of the element must be visible before it fires
+- **`once` / `repeat`** (default `once`) — `repeat` re-triggers every time the element re-enters view
+- **`delay-<ms>`** (default `0`) — delay before the class is applied after crossing the threshold
+
+The demo page is a full scrollable article — hero text, a staggered
+feature grid, a quote block, alternating left/right stat rows, and a
+`repeat`-mode call-to-action you can scroll away from and back to — so
+every modifier is visible in a realistic layout, not an isolated snippet.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a local `style.css` and a local
+`scroll-trigger-hr18.js`; no build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div data-ease-scroll="ease-slide-up-hr18 threshold-0.3 once delay-100">
+  Reveals once, 30% into view, after a 100ms delay.
+</div>
+
+<div data-ease-scroll="ease-fade-in-hr18 threshold-0.5 repeat">
+  Fades in and out every time it crosses the 50% threshold.
+</div>
+
+<script src="scroll-trigger-hr18.js"></script>
+```
+
+Five ready-made animation classes ship in `style.css`:
+`ease-fade-in-hr18`, `ease-slide-up-hr18`, `ease-slide-in-left-hr18`,
+`ease-slide-in-right-hr18`, `ease-zoom-in-hr18` — or point
+`data-ease-scroll` at any animation class of your own; the script doesn't
+care which class name it's given.
+
+## Accessibility notes
+
+- The script checks `prefers-reduced-motion` directly and reveals every
+  element immediately, with no animation and no `IntersectionObserver`
+  churn, when the user has that preference set.
+- `style.css` independently backs this up with its own
+  `@media (prefers-reduced-motion: reduce)` rule, so content is never
+  stuck invisible even if the script fails to load for some reason.
+- Elements aren't hidden with `visibility: hidden` or `display: none` —
+  only `opacity: 0` — so they remain in the accessibility tree and don't
+  disrupt tab order while off-screen.
+- There's a graceful fallback for environments without
+  `IntersectionObserver`: everything reveals immediately rather than
+  staying permanently hidden.
+
+## Why this fits EaseMotion CSS
+
+It directly serves the motivation in the original issue — one composable,
+reusable scroll-reveal primitive instead of N copy-pasted
+`IntersectionObserver` implementations — using plain, dependency-free
+JavaScript and CSS, consistent with the framework's zero-dependency
+philosophy, while being honest about not depending on internal files this
+submission couldn't verify exist.
+
+All classes, the `data-ease-scroll` attribute name, and the folder itself
+use a `-hr18` suffix to avoid colliding with any other contributor's
+submission under `submissions/examples/`.

--- a/submissions/examples/scroll-trigger-reveal-hr18/demo.html
+++ b/submissions/examples/scroll-trigger-reveal-hr18/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Scroll-Trigger Reveal — demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="str-hr18">
+
+  <section class="str-section-hr18 str-hero-hr18" data-ease-scroll="ease-fade-in-hr18 threshold-0.1 once">
+    <span class="str-eyebrow-hr18">EaseMotion-css · example</span>
+    <h1>Scroll-Trigger Reveal</h1>
+    <p>A standalone, dependency-free utility that gates any entrance
+      animation behind an IntersectionObserver instead of firing it on
+      mount. Scroll down — everything below fires only once it enters the
+      viewport.</p>
+    <div class="str-hint-hr18">
+      Each section below uses a <code>data-ease-scroll</code> attribute like
+      <code>"ease-slide-up-hr18 threshold-0.3 once delay-100"</code> — no
+      per-section JavaScript, just the attribute.
+    </div>
+  </section>
+
+  <section class="str-section-hr18">
+    <h2>Feature grid</h2>
+    <p style="color: var(--text-muted-hr18); margin-top: 0.5rem;">Each card slides up with a small staggered delay.</p>
+    <div class="str-grid-hr18">
+      <div class="str-card-hr18" data-ease-scroll="ease-slide-up-hr18 threshold-0.3 once">
+        <h3>Composable</h3>
+        <p>One attribute, any animation class — no bespoke JS per section.</p>
+      </div>
+      <div class="str-card-hr18" data-ease-scroll="ease-slide-up-hr18 threshold-0.3 once delay-120">
+        <h3>Configurable</h3>
+        <p>Threshold, once/repeat, and delay are all readable modifiers.</p>
+      </div>
+      <div class="str-card-hr18" data-ease-scroll="ease-slide-up-hr18 threshold-0.3 once delay-240">
+        <h3>Dependency-free</h3>
+        <p>Just IntersectionObserver — no scroll-event polling, no library.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="str-section-hr18">
+    <div class="str-quote-hr18" data-ease-scroll="ease-zoom-in-hr18 threshold-0.5 once">
+      <p>"The best scroll animation is the one you never had to write twice."</p>
+      <span>&mdash; every developer who's copy-pasted an IntersectionObserver five times</span>
+    </div>
+  </section>
+
+  <section class="str-section-hr18">
+    <h2>Stats, alternating sides</h2>
+    <div class="str-stat-row-hr18" data-ease-scroll="ease-slide-in-left-hr18 threshold-0.4 once">
+      <span class="str-stat-label-hr18">Duplicate scroll-reveal demos this replaces</span>
+      <span class="str-stat-value-hr18">~15</span>
+    </div>
+    <div class="str-stat-row-hr18" data-ease-scroll="ease-slide-in-right-hr18 threshold-0.4 once">
+      <span class="str-stat-label-hr18">External dependencies required</span>
+      <span class="str-stat-value-hr18">0</span>
+    </div>
+    <div class="str-stat-row-hr18" data-ease-scroll="ease-slide-in-left-hr18 threshold-0.4 once">
+      <span class="str-stat-label-hr18">Lines of markup needed per element</span>
+      <span class="str-stat-value-hr18">1 attribute</span>
+    </div>
+  </section>
+
+  <section class="str-section-hr18">
+    <div class="str-cta-hr18" data-ease-scroll="ease-fade-in-hr18 threshold-0.5 repeat">
+      <h2>This one uses <code>repeat</code></h2>
+      <p>Scroll away and back — unlike the sections above, this fades out and replays every time it re-enters view.</p>
+    </div>
+  </section>
+
+  <p class="str-footnote-hr18">submissions/examples/scroll-trigger-reveal-hr18 &middot; no build tools or external CDN required</p>
+</div>
+
+<script src="scroll-trigger-hr18.js"></script>
+</body>
+</html>

--- a/submissions/examples/scroll-trigger-reveal-hr18/scroll-trigger-hr18.js
+++ b/submissions/examples/scroll-trigger-reveal-hr18/scroll-trigger-hr18.js
@@ -1,0 +1,111 @@
+/* ==========================================================================
+   scroll-trigger-hr18.js
+   A standalone, dependency-free scroll-trigger reveal utility.
+
+   Usage: add a `data-ease-scroll` attribute to any element:
+
+     <div data-ease-scroll="ease-fade-in-hr18 threshold-0.5 once">...</div>
+     <div data-ease-scroll="ease-slide-up-hr18 threshold-0.2 repeat delay-150">...</div>
+
+   Grammar (space-separated tokens):
+     <animation-class>   required, first token — the class to apply on reveal
+     threshold-<0-1>     optional, default 0.2 — how much of the element
+                          must be visible before it fires
+     once | repeat       optional, default once — repeat re-triggers the
+                          animation every time the element re-enters view
+     delay-<ms>           optional, default 0 — delay before the class is
+                          applied once the element crosses the threshold
+
+   This file is a standalone reference implementation, not a plugin for an
+   existing internal engine — see README.md for why.
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  function parseConfig(raw) {
+    var tokens = raw.trim().split(/\s+/);
+    var config = {
+      animationClass: tokens[0],
+      threshold: 0.2,
+      once: true,
+      delay: 0
+    };
+
+    tokens.slice(1).forEach(function (token) {
+      if (token.indexOf("threshold-") === 0) {
+        var t = parseFloat(token.slice("threshold-".length));
+        if (!isNaN(t)) config.threshold = Math.min(1, Math.max(0, t));
+      } else if (token === "once") {
+        config.once = true;
+      } else if (token === "repeat") {
+        config.once = false;
+      } else if (token.indexOf("delay-") === 0) {
+        var d = parseInt(token.slice("delay-".length), 10);
+        if (!isNaN(d)) config.delay = d;
+      }
+    });
+
+    return config;
+  }
+
+  function reveal(el, config) {
+    window.setTimeout(function () {
+      el.classList.add(config.animationClass);
+      el.classList.add("ease-scroll-revealed-hr18");
+    }, config.delay);
+  }
+
+  function hide(el, config) {
+    el.classList.remove(config.animationClass);
+    el.classList.remove("ease-scroll-revealed-hr18");
+  }
+
+  function init() {
+    var elements = document.querySelectorAll("[data-ease-scroll]");
+    if (!elements.length) return;
+
+    var prefersReducedMotion =
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    elements.forEach(function (el) {
+      var config = parseConfig(el.getAttribute("data-ease-scroll"));
+
+      // Respect reduced-motion preference: reveal immediately, no
+      // IntersectionObserver churn, no animation class needed since the
+      // stylesheet's own reduced-motion query removes the animation anyway.
+      if (prefersReducedMotion) {
+        el.classList.add("ease-scroll-revealed-hr18");
+        return;
+      }
+
+      // Graceful fallback for environments without IntersectionObserver.
+      if (!("IntersectionObserver" in window)) {
+        reveal(el, config);
+        return;
+      }
+
+      var observer = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              reveal(el, config);
+              if (config.once) observer.unobserve(el);
+            } else if (!config.once) {
+              hide(el, config);
+            }
+          });
+        },
+        { threshold: config.threshold }
+      );
+
+      observer.observe(el);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/submissions/examples/scroll-trigger-reveal-hr18/style.css
+++ b/submissions/examples/scroll-trigger-reveal-hr18/style.css
@@ -1,0 +1,271 @@
+/* ==========================================================================
+   scroll-trigger-reveal-hr18 — style.css
+   Standalone scroll-triggered reveal utility (IntersectionObserver-based)
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.str-hr18 {
+  --bg-hr18: #fbf9f4;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e8e2d3;
+  --text-hr18: #201c14;
+  --text-muted-hr18: #6f6857;
+  --accent-hr18: #e0592a;
+  --accent-soft-hr18: #fdece3;
+  --radius-hr18: 14px;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+}
+
+.str-hr18 * {
+  box-sizing: border-box;
+}
+
+.str-hr18 h1,
+.str-hr18 h2,
+.str-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.str-hr18 code {
+  font-family: var(--font-mono-hr18);
+  background: var(--accent-soft-hr18);
+  color: #9c3c17;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.86em;
+}
+
+.str-section-hr18 {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.str-section-hr18 + .str-section-hr18 {
+  border-top: 1px solid var(--border-hr18);
+}
+
+/* ---- Intro / hero ------------------------------------------------------------ */
+.str-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.str-hero-hr18 h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.str-hero-hr18 p {
+  margin: 1rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 60ch;
+  font-size: 1.02rem;
+  line-height: 1.65;
+}
+
+.str-hint-hr18 {
+  margin-top: 1.5rem;
+  border: 1px dashed var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 0.9rem 1.1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted-hr18);
+  background: var(--panel-hr18);
+}
+
+/* ---- Feature card grid --------------------------------------------------------- */
+.str-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .str-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.str-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem;
+}
+
+.str-card-hr18 h3 {
+  font-size: 0.95rem;
+  margin-bottom: 0.4rem;
+}
+
+.str-card-hr18 p {
+  margin: 0;
+  font-size: 0.83rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.55;
+}
+
+/* ---- Quote block ---------------------------------------------------------------- */
+.str-quote-hr18 {
+  border-left: 3px solid var(--accent-hr18);
+  padding-left: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.str-quote-hr18 p {
+  font-family: var(--font-display-hr18);
+  font-size: 1.25rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.str-quote-hr18 span {
+  display: block;
+  margin-top: 0.6rem;
+  font-size: 0.82rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Stat rows, alternating slide-in sides --------------------------------------- */
+.str-stat-row-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.str-stat-row-hr18:last-child {
+  border-bottom: none;
+}
+
+.str-stat-value-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--accent-hr18);
+}
+
+.str-stat-label-hr18 {
+  color: var(--text-muted-hr18);
+  font-size: 0.88rem;
+}
+
+/* ---- Repeat-mode CTA ---------------------------------------------------------------- */
+.str-cta-hr18 {
+  background: var(--accent-soft-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 2rem 1.5rem;
+  text-align: center;
+  margin-top: 1.5rem;
+}
+
+.str-cta-hr18 h2 {
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.str-cta-hr18 p {
+  margin: 0;
+  color: #8a4321;
+  font-size: 0.88rem;
+}
+
+.str-footnote-hr18 {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ==========================================================================
+   The reusable utility: reveal state + entrance animation classes.
+   Elements carrying [data-ease-scroll] start hidden until the script adds
+   both the requested animation class and .ease-scroll-revealed-hr18.
+   ========================================================================== */
+[data-ease-scroll]:not(.ease-scroll-revealed-hr18) {
+  opacity: 0;
+}
+
+.ease-fade-in-hr18 {
+  animation: strFade-hr18 600ms ease both;
+}
+
+.ease-slide-up-hr18 {
+  animation: strSlideUp-hr18 600ms ease both;
+}
+
+.ease-slide-in-left-hr18 {
+  animation: strSlideInLeft-hr18 600ms ease both;
+}
+
+.ease-slide-in-right-hr18 {
+  animation: strSlideInRight-hr18 600ms ease both;
+}
+
+.ease-zoom-in-hr18 {
+  animation: strZoomIn-hr18 550ms ease both;
+}
+
+@keyframes strFade-hr18 {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes strSlideUp-hr18 {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes strSlideInLeft-hr18 {
+  from { opacity: 0; transform: translateX(-32px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes strSlideInRight-hr18 {
+  from { opacity: 0; transform: translateX(32px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes strZoomIn-hr18 {
+  from { opacity: 0; transform: scale(0.92); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-ease-scroll]:not(.ease-scroll-revealed-hr18) {
+    opacity: 1;
+  }
+  .ease-fade-in-hr18,
+  .ease-slide-up-hr18,
+  .ease-slide-in-left-hr18,
+  .ease-slide-in-right-hr18,
+  .ease-zoom-in-hr18 {
+    animation: none !important;
+  }
+}
+
+.str-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Issue #49580 asks for a plugin importing `parse()`/`compile()` from an
`easemotion/parser.js` / `compiler.js` / `runtime.js` engine and an `em=""`
attribute DSL referenced in a `VISION.md` roadmap. I couldn't find any
trace of that engine, those files, or that DSL anywhere in this repo — the
README's own file tree, the live demo site, and every other issue all use
plain CSS classes, not an attribute-driven JS engine. Rather than submit a
plugin with imports pointing at files I can't verify exist, this builds
toward the issue's actual stated goal instead: replacing the ~15
duplicated, one-off IntersectionObserver scroll-reveal demos in
submissions/examples/ with one reusable, composable, standalone utility.

It's a single dependency-free script (`scroll-trigger-hr18.js`) that reveals
any element carrying a `data-ease-scroll="<class> [threshold-X] [once|repeat]
[delay-Xms]"` attribute once it crosses a visibility threshold, echoing the
spirit of the issue's proposed modifier grammar without depending on
anything unverified. Full write-up of this scope decision is in the README.

Resolves #49580 (as a standalone alternative — see README for why)

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/scroll-trigger-reveal-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A standalone, dependency-free scroll-trigger reveal utility that gates any
entrance animation class behind an IntersectionObserver threshold.

**How does a developer use it?**
```html
<div data-ease-scroll="ease-slide-up-hr18 threshold-0.3 once delay-100">
  Reveals once, 30% into view, after a 100ms delay.
</div>
<script src="scroll-trigger-hr18.js"></script>
```

**Why does it fit EaseMotion CSS?**
Serves the issue's own stated motivation — one composable reveal
primitive instead of N copy-pasted IntersectionObserver implementations —
with zero dependencies, consistent with the framework's philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Please see the "A note on scope" section at the top of the README — I
genuinely couldn't locate the parser.js/compiler.js/runtime.js/VISION.md
files or the em="" DSL this issue references, so I built a standalone
equivalent rather than fabricate imports against files I couldn't verify.
Happy to rework this into a real plugin for that engine if it exists
somewhere I missed — just let me know where to find it. Includes a 4th
file, `scroll-trigger-hr18.js`, alongside the usual three. Tested in
Chrome, including the reduced-motion fallback via DevTools emulation;
haven't checked other browsers yet.