### PR TITLE
Add reuleaux triangle component

### DIFF
--- a/submissions/examples/reuleaux-triangle-as/README.md
+++ b/submissions/examples/reuleaux-triangle-as/README.md
@@ -1,0 +1,44 @@
+# Reuleaux Triangle
+
+A pure CSS/HTML plate riding on rollers that are not round, and not bumping.
+
+## What it shows
+
+Take an equilateral triangle and, from each corner, draw an arc through the other two. The shape you are left with is a **Reuleaux triangle**, and it has a property that looks impossible: its **width is the same in every direction**. Squeeze it between two parallel lines at any angle and the gap is identical.
+
+So it rolls. Put several under a flat plate and the plate glides along without rising or falling by so much as a hair, exactly as it would on cylinders. Nothing about a roller requires it to be round; it only requires constant width.
+
+What it will *not* do is make a wheel. A circle's centre stays at a fixed height, which is why you can put an axle through it. A Reuleaux triangle's centre **bobs up and down** as it rolls, by about 15% of its width here. Flat on top, lurching in the middle. That difference is the whole reason wheels are round and rollers need not be.
+
+Two theorems make the shape more than a curiosity:
+
+- **Barbier's theorem** (1860): every curve of constant width `w` has perimeter exactly `pi*w`, the same as a circle of diameter `w`. So one full turn always advances the roller by `pi*w`, whatever shape it is.
+- **Blaschke and Lebesgue**: of all curves of a given constant width, the Reuleaux triangle encloses the *least* area. It is the extreme case, as far from a circle as constant width permits.
+
+It gets used. The rotor of a Wankel engine is close to this shape, Watts Brothers drill bits of this profile cut nearly square holes, and the British 20p and 50p are Reuleaux heptagons, so a vending machine can gauge them by width without caring which way up they fell.
+
+Franz Reuleaux, whose name it carries, was a founder of the study of machine kinematics in the nineteenth century; the shape itself was known long before, to Euler among others.
+
+## How it is built
+
+Each roller is a 180 point outline, generated from the three arcs and cut with `clip-path`. The rolling motion is derived rather than eyeballed: the support function of the outline gives the centre's height at each rotation, and the no-slip condition `dX/dphi = -Y` is integrated to get the horizontal travel.
+
+Everything below was measured on the **rendered** outline, by reading each roller's computed `clip-path` polygon back out of the browser and putting all 180 points through its computed transform matrix.
+
+- **The plate really does ride flat.** Across **186 outline samples** (6 rollers at 31 rotations) the topmost point of the shape varies by **0.0062 px**, sitting at **98.000**, which is the ground at 168 minus the 70 px width.
+- **They are genuinely rolling, not floating.** The lowest point varies by **0.0059 px** and sits at **167.999** against a ground line at 168.
+- **The width is constant, and that is checked in every direction**, not just vertically: **4464 measurements** across 24 directions and every sampled rotation, worst deviation from 70 px is **0.0035 px**.
+- **The centre bobs, and that is the point.** The hub moves through **10.83 px** vertically while the plate above it does not move at all. Against a circle this is the only difference that matters.
+- **Barbier checks out.** One full turn advances a roller **219.94 px**, against `pi * 70 = 219.91`.
+- The rollers are spaced at exactly half the per-turn advance, so the row of them is periodic and the loop closes with no jump.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` stops the rollers and their hubs together, leaving the plate resting on three shapes caught mid-turn.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/reuleaux-triangle-as/demo.html
+++ b/submissions/examples/reuleaux-triangle-as/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reuleaux Triangle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="tagR">a wheel does not have to be round</span>
+    <span class="midR"></span>
+    <span class="groundR"></span>
+    <span class="rollR" style="left: -109.954px"></span>
+    <span class="rollR" style="left: 0.000px"></span>
+    <span class="rollR" style="left: 109.954px"></span>
+    <span class="rollR" style="left: 219.909px"></span>
+    <span class="rollR" style="left: 329.863px"></span>
+    <span class="rollR" style="left: 439.818px"></span>
+    <span class="hubR" style="left: -109.954px"></span>
+    <span class="hubR" style="left: 0.000px"></span>
+    <span class="hubR" style="left: 109.954px"></span>
+    <span class="hubR" style="left: 219.909px"></span>
+    <span class="hubR" style="left: 329.863px"></span>
+    <span class="hubR" style="left: 439.818px"></span>
+    <span class="plateR"></span>
+    <span class="plateLbl">the plate never rises or falls</span>
+    <span class="midLbl">dashed line: the mean height of the hubs</span>
+    <span class="capR">constant width: every roller is exactly 70 px thick, whichever way it lies</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/reuleaux-triangle-as/style.css
+++ b/submissions/examples/reuleaux-triangle-as/style.css
@@ -1,0 +1,738 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 24%, #241f1a, #0a0705 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 360px;
+  height: 220px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 40%, #33291f, #0b0806 86%);
+}
+
+.groundR {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 168px;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(200, 170, 120, 0) 0%, rgba(210, 180, 130, 0.75) 12%, rgba(210, 180, 130, 0.75) 88%, rgba(200, 170, 120, 0) 100%);
+}
+
+/*
+  a Reuleaux triangle: the overlap of three discs, each centred on a corner
+  of an equilateral triangle and drawn through the other two. its width is
+  the same in every direction, so it rolls under a flat plate without ever
+  raising or lowering it. what it does NOT do is turn about a fixed axle:
+  the centre bobs, which is why it makes a fine roller and a poor wheel.
+*/
+.rollR {
+  position: absolute;
+  top: 168px;
+  width: 82.829px;
+  height: 82.829px;
+  margin: -41.415px 0 0 -41.415px;
+  background: linear-gradient(150deg, #f0d9a8, #b9853f 70%);
+  clip-path: polygon(92.256% 74.396%, 90.972% 75.123%, 89.676% 75.826%, 88.367% 76.508%, 87.047% 77.166%, 85.716% 77.801%, 84.374% 78.412%, 83.021% 79.000%, 81.659% 79.565%, 80.286% 80.106%, 78.905% 80.622%, 77.514% 81.114%, 76.115% 81.582%, 74.709% 82.026%, 73.295% 82.445%, 71.873% 82.839%, 70.445% 83.208%, 69.011% 83.553%, 67.571% 83.872%, 66.126% 84.166%, 64.675% 84.435%, 63.220% 84.678%, 61.762% 84.896%, 60.299% 85.089%, 58.834% 85.256%, 57.366% 85.397%, 55.895% 85.513%, 54.423% 85.603%, 52.949% 85.667%, 51.475% 85.706%, 50.000% 85.719%, 48.525% 85.706%, 47.051% 85.667%, 45.577% 85.603%, 44.105% 85.513%, 42.634% 85.397%, 41.166% 85.256%, 39.701% 85.089%, 38.238% 84.896%, 36.780% 84.678%, 35.325% 84.435%, 33.874% 84.166%, 32.429% 83.872%, 30.989% 83.553%, 29.555% 83.208%, 28.127% 82.839%, 26.705% 82.445%, 25.291% 82.026%, 23.885% 81.582%, 22.486% 81.114%, 21.095% 80.622%, 19.714% 80.106%, 18.341% 79.565%, 16.979% 79.000%, 15.626% 78.412%, 14.284% 77.801%, 12.953% 77.166%, 11.633% 76.508%, 10.324% 75.826%, 9.028% 75.123%, 50.000% 1.207%, 51.271% 1.956%, 52.529% 2.727%, 53.773% 3.519%, 55.002% 4.333%, 56.218% 5.169%, 57.419% 6.025%, 58.605% 6.903%, 59.775% 7.800%, 60.929% 8.719%, 62.067% 9.657%, 63.189% 10.615%, 64.293% 11.592%, 65.381% 12.589%, 66.451% 13.604%, 67.503% 14.638%, 68.537% 15.690%, 69.552% 16.760%, 70.549% 17.847%, 71.526% 18.952%, 72.484% 20.073%, 73.422% 21.212%, 74.340% 22.366%, 75.238% 23.536%, 76.115% 24.722%, 76.972% 25.923%, 77.807% 27.138%, 78.622% 28.368%, 79.414% 29.612%, 80.185% 30.870%, 80.933% 32.141%, 81.660% 33.424%, 82.363% 34.721%, 83.045% 36.029%, 83.703% 37.349%, 84.338% 38.680%, 84.949% 40.022%, 85.537% 41.375%, 86.102% 42.738%, 86.642% 44.110%, 87.159% 45.492%, 87.651% 46.882%, 88.119% 48.281%, 88.563% 49.688%, 88.982% 51.102%, 89.376% 52.523%, 89.745% 53.951%, 90.090% 55.385%, 90.409% 56.825%, 90.703% 58.271%, 90.972% 59.721%, 91.215% 61.176%, 91.433% 62.635%, 91.626% 64.097%, 91.793% 65.562%, 91.934% 67.031%, 92.050% 68.501%, 92.140% 69.973%, 92.204% 71.447%, 92.243% 72.921%, 7.744% 74.396%, 7.757% 72.921%, 7.796% 71.447%, 7.860% 69.973%, 7.950% 68.501%, 8.066% 67.031%, 8.207% 65.562%, 8.374% 64.097%, 8.567% 62.635%, 8.785% 61.176%, 9.028% 59.721%, 9.297% 58.271%, 9.591% 56.825%, 9.910% 55.385%, 10.255% 53.951%, 10.624% 52.523%, 11.018% 51.102%, 11.437% 49.688%, 11.881% 48.281%, 12.349% 46.882%, 12.841% 45.492%, 13.358% 44.110%, 13.898% 42.738%, 14.463% 41.375%, 15.051% 40.022%, 15.662% 38.680%, 16.297% 37.349%, 16.955% 36.029%, 17.637% 34.721%, 18.340% 33.424%, 19.067% 32.141%, 19.815% 30.870%, 20.586% 29.612%, 21.378% 28.368%, 22.193% 27.138%, 23.028% 25.923%, 23.885% 24.722%, 24.762% 23.536%, 25.660% 22.366%, 26.578% 21.212%, 27.516% 20.073%, 28.474% 18.952%, 29.451% 17.847%, 30.448% 16.760%, 31.463% 15.690%, 32.497% 14.638%, 33.549% 13.604%, 34.619% 12.589%, 35.707% 11.592%, 36.811% 10.615%, 37.933% 9.657%, 39.071% 8.719%, 40.225% 7.800%, 41.395% 6.903%, 42.581% 6.025%, 43.782% 5.169%, 44.998% 4.333%, 46.227% 3.519%, 47.471% 2.727%, 48.729% 1.956%);
+  animation: rollR 9s linear infinite;
+}
+
+/* the centre of each roller, so the bobbing is visible against the dashed line */
+.hubR {
+  position: absolute;
+  top: 168px;
+  width: 7px;
+  height: 7px;
+  margin: -3.5px 0 0 -3.5px;
+  border-radius: 50%;
+  background: #2a1a0c;
+  box-shadow: 0 0 0 1.5px rgba(255, 230, 180, 0.8);
+  animation: hubR 9s linear infinite;
+}
+
+.midR {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  top: 133.00px;
+  height: 0;
+  border-top: 1px dashed rgba(255, 220, 160, 0.35);
+}
+
+.midLbl {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 176.00px;
+  text-align: center;
+  font-size: 0.43rem;
+  letter-spacing: 0.04em;
+  color: rgba(255, 225, 170, 0.6);
+}
+
+.plateR {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: 85.00px;
+  height: 13px;
+  border-radius: 3px;
+  background: linear-gradient(#e8eef5, #9aa8b6);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5);
+}
+
+.plateLbl {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 71.00px;
+  text-align: center;
+  font-size: 0.46rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(235, 240, 250, 0.9);
+}
+
+.tagR {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.48rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(240, 215, 170, 0.9);
+}
+
+.capR {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.03em;
+  color: rgba(235, 210, 170, 0.8);
+}
+
+@keyframes rollR {
+  0.0000% { transform: translate(0.000px, -29.585px) rotate(-0.0000deg); }
+  0.3333% { transform: translate(0.620px, -29.594px) rotate(-1.2000deg); }
+  0.6667% { transform: translate(1.240px, -29.619px) rotate(-2.4000deg); }
+  1.0000% { transform: translate(1.861px, -29.664px) rotate(-3.6000deg); }
+  1.3333% { transform: translate(2.483px, -29.727px) rotate(-4.8000deg); }
+  1.6667% { transform: translate(3.106px, -29.807px) rotate(-6.0000deg); }
+  2.0000% { transform: translate(3.731px, -29.904px) rotate(-7.2000deg); }
+  2.3333% { transform: translate(4.359px, -30.017px) rotate(-8.4000deg); }
+  2.6667% { transform: translate(4.989px, -30.150px) rotate(-9.6000deg); }
+  3.0000% { transform: translate(5.622px, -30.301px) rotate(-10.8000deg); }
+  3.3333% { transform: translate(6.258px, -30.469px) rotate(-12.0000deg); }
+  3.6667% { transform: translate(6.898px, -30.653px) rotate(-13.2000deg); }
+  4.0000% { transform: translate(7.542px, -30.853px) rotate(-14.4000deg); }
+  4.3333% { transform: translate(8.191px, -31.073px) rotate(-15.6000deg); }
+  4.6667% { transform: translate(8.844px, -31.310px) rotate(-16.8000deg); }
+  5.0000% { transform: translate(9.503px, -31.564px) rotate(-18.0000deg); }
+  5.3333% { transform: translate(10.166px, -31.833px) rotate(-19.2000deg); }
+  5.6667% { transform: translate(10.836px, -32.118px) rotate(-20.4000deg); }
+  6.0000% { transform: translate(11.512px, -32.422px) rotate(-21.6000deg); }
+  6.3333% { transform: translate(12.194px, -32.743px) rotate(-22.8000deg); }
+  6.6667% { transform: translate(12.884px, -33.079px) rotate(-24.0000deg); }
+  7.0000% { transform: translate(13.580px, -33.431px) rotate(-25.2000deg); }
+  7.3333% { transform: translate(14.284px, -33.799px) rotate(-26.4000deg); }
+  7.6667% { transform: translate(14.996px, -34.183px) rotate(-27.6000deg); }
+  8.0000% { transform: translate(15.716px, -34.584px) rotate(-28.8000deg); }
+  8.3333% { transform: translate(16.445px, -35.000px) rotate(-30.0000deg); }
+  8.6667% { transform: translate(17.182px, -35.416px) rotate(-31.2000deg); }
+  9.0000% { transform: translate(17.928px, -35.815px) rotate(-32.4000deg); }
+  9.3333% { transform: translate(18.682px, -36.200px) rotate(-33.6000deg); }
+  9.6667% { transform: translate(19.444px, -36.568px) rotate(-34.8000deg); }
+  10.0000% { transform: translate(20.214px, -36.921px) rotate(-36.0000deg); }
+  10.3333% { transform: translate(20.991px, -37.257px) rotate(-37.2000deg); }
+  10.6667% { transform: translate(21.774px, -37.576px) rotate(-38.4000deg); }
+  11.0000% { transform: translate(22.565px, -37.880px) rotate(-39.6000deg); }
+  11.3333% { transform: translate(23.361px, -38.167px) rotate(-40.8000deg); }
+  11.6667% { transform: translate(24.163px, -38.436px) rotate(-42.0000deg); }
+  12.0000% { transform: translate(24.971px, -38.690px) rotate(-43.2000deg); }
+  12.3333% { transform: translate(25.784px, -38.926px) rotate(-44.4000deg); }
+  12.6667% { transform: translate(26.601px, -39.145px) rotate(-45.6000deg); }
+  13.0000% { transform: translate(27.423px, -39.347px) rotate(-46.8000deg); }
+  13.3333% { transform: translate(28.249px, -39.531px) rotate(-48.0000deg); }
+  13.6667% { transform: translate(29.079px, -39.699px) rotate(-49.2000deg); }
+  14.0000% { transform: translate(29.912px, -39.849px) rotate(-50.4000deg); }
+  14.3333% { transform: translate(30.748px, -39.981px) rotate(-51.6000deg); }
+  14.6667% { transform: translate(31.586px, -40.096px) rotate(-52.8000deg); }
+  15.0000% { transform: translate(32.427px, -40.193px) rotate(-54.0000deg); }
+  15.3333% { transform: translate(33.270px, -40.273px) rotate(-55.2000deg); }
+  15.6667% { transform: translate(34.114px, -40.335px) rotate(-56.4000deg); }
+  16.0000% { transform: translate(34.959px, -40.379px) rotate(-57.6000deg); }
+  16.3333% { transform: translate(35.805px, -40.406px) rotate(-58.8000deg); }
+  16.6667% { transform: translate(36.651px, -40.415px) rotate(-60.0000deg); }
+  17.0000% { transform: translate(37.498px, -40.406px) rotate(-61.2000deg); }
+  17.3333% { transform: translate(38.344px, -40.379px) rotate(-62.4000deg); }
+  17.6667% { transform: translate(39.189px, -40.335px) rotate(-63.6000deg); }
+  18.0000% { transform: translate(40.033px, -40.273px) rotate(-64.8000deg); }
+  18.3333% { transform: translate(40.876px, -40.193px) rotate(-66.0000deg); }
+  18.6667% { transform: translate(41.717px, -40.096px) rotate(-67.2000deg); }
+  19.0000% { transform: translate(42.555px, -39.981px) rotate(-68.4000deg); }
+  19.3333% { transform: translate(43.391px, -39.849px) rotate(-69.6000deg); }
+  19.6667% { transform: translate(44.224px, -39.699px) rotate(-70.8000deg); }
+  20.0000% { transform: translate(45.054px, -39.531px) rotate(-72.0000deg); }
+  20.3333% { transform: translate(45.880px, -39.347px) rotate(-73.2000deg); }
+  20.6667% { transform: translate(46.702px, -39.145px) rotate(-74.4000deg); }
+  21.0000% { transform: translate(47.519px, -38.926px) rotate(-75.6000deg); }
+  21.3333% { transform: translate(48.332px, -38.690px) rotate(-76.8000deg); }
+  21.6667% { transform: translate(49.140px, -38.436px) rotate(-78.0000deg); }
+  22.0000% { transform: translate(49.942px, -38.167px) rotate(-79.2000deg); }
+  22.3333% { transform: translate(50.738px, -37.880px) rotate(-80.4000deg); }
+  22.6667% { transform: translate(51.529px, -37.576px) rotate(-81.6000deg); }
+  23.0000% { transform: translate(52.312px, -37.257px) rotate(-82.8000deg); }
+  23.3333% { transform: translate(53.089px, -36.921px) rotate(-84.0000deg); }
+  23.6667% { transform: translate(53.859px, -36.568px) rotate(-85.2000deg); }
+  24.0000% { transform: translate(54.621px, -36.200px) rotate(-86.4000deg); }
+  24.3333% { transform: translate(55.375px, -35.815px) rotate(-87.6000deg); }
+  24.6667% { transform: translate(56.121px, -35.416px) rotate(-88.8000deg); }
+  25.0000% { transform: translate(56.858px, -35.000px) rotate(-90.0000deg); }
+  25.3333% { transform: translate(57.587px, -34.584px) rotate(-91.2000deg); }
+  25.6667% { transform: translate(58.307px, -34.183px) rotate(-92.4000deg); }
+  26.0000% { transform: translate(59.019px, -33.799px) rotate(-93.6000deg); }
+  26.3333% { transform: translate(59.723px, -33.431px) rotate(-94.8000deg); }
+  26.6667% { transform: translate(60.419px, -33.079px) rotate(-96.0000deg); }
+  27.0000% { transform: translate(61.109px, -32.743px) rotate(-97.2000deg); }
+  27.3333% { transform: translate(61.791px, -32.422px) rotate(-98.4000deg); }
+  27.6667% { transform: translate(62.467px, -32.118px) rotate(-99.6000deg); }
+  28.0000% { transform: translate(63.136px, -31.833px) rotate(-100.8000deg); }
+  28.3333% { transform: translate(63.800px, -31.564px) rotate(-102.0000deg); }
+  28.6667% { transform: translate(64.459px, -31.310px) rotate(-103.2000deg); }
+  29.0000% { transform: translate(65.112px, -31.073px) rotate(-104.4000deg); }
+  29.3333% { transform: translate(65.761px, -30.853px) rotate(-105.6000deg); }
+  29.6667% { transform: translate(66.405px, -30.653px) rotate(-106.8000deg); }
+  30.0000% { transform: translate(67.045px, -30.469px) rotate(-108.0000deg); }
+  30.3333% { transform: translate(67.681px, -30.301px) rotate(-109.2000deg); }
+  30.6667% { transform: translate(68.314px, -30.150px) rotate(-110.4000deg); }
+  31.0000% { transform: translate(68.944px, -30.017px) rotate(-111.6000deg); }
+  31.3333% { transform: translate(69.572px, -29.904px) rotate(-112.8000deg); }
+  31.6667% { transform: translate(70.197px, -29.807px) rotate(-114.0000deg); }
+  32.0000% { transform: translate(70.820px, -29.727px) rotate(-115.2000deg); }
+  32.3333% { transform: translate(71.442px, -29.664px) rotate(-116.4000deg); }
+  32.6667% { transform: translate(72.063px, -29.619px) rotate(-117.6000deg); }
+  33.0000% { transform: translate(72.683px, -29.594px) rotate(-118.8000deg); }
+  33.3333% { transform: translate(73.303px, -29.585px) rotate(-120.0000deg); }
+  33.6667% { transform: translate(73.923px, -29.594px) rotate(-121.2000deg); }
+  34.0000% { transform: translate(74.543px, -29.619px) rotate(-122.4000deg); }
+  34.3333% { transform: translate(75.164px, -29.664px) rotate(-123.6000deg); }
+  34.6667% { transform: translate(75.785px, -29.727px) rotate(-124.8000deg); }
+  35.0000% { transform: translate(76.409px, -29.807px) rotate(-126.0000deg); }
+  35.3333% { transform: translate(77.034px, -29.904px) rotate(-127.2000deg); }
+  35.6667% { transform: translate(77.662px, -30.017px) rotate(-128.4000deg); }
+  36.0000% { transform: translate(78.292px, -30.150px) rotate(-129.6000deg); }
+  36.3333% { transform: translate(78.925px, -30.301px) rotate(-130.8000deg); }
+  36.6667% { transform: translate(79.561px, -30.469px) rotate(-132.0000deg); }
+  37.0000% { transform: translate(80.201px, -30.653px) rotate(-133.2000deg); }
+  37.3333% { transform: translate(80.845px, -30.853px) rotate(-134.4000deg); }
+  37.6667% { transform: translate(81.494px, -31.073px) rotate(-135.6000deg); }
+  38.0000% { transform: translate(82.147px, -31.310px) rotate(-136.8000deg); }
+  38.3333% { transform: translate(82.805px, -31.564px) rotate(-138.0000deg); }
+  38.6667% { transform: translate(83.469px, -31.833px) rotate(-139.2000deg); }
+  39.0000% { transform: translate(84.139px, -32.118px) rotate(-140.4000deg); }
+  39.3333% { transform: translate(84.815px, -32.422px) rotate(-141.6000deg); }
+  39.6667% { transform: translate(85.497px, -32.743px) rotate(-142.8000deg); }
+  40.0000% { transform: translate(86.187px, -33.079px) rotate(-144.0000deg); }
+  40.3333% { transform: translate(86.883px, -33.431px) rotate(-145.2000deg); }
+  40.6667% { transform: translate(87.587px, -33.799px) rotate(-146.4000deg); }
+  41.0000% { transform: translate(88.299px, -34.183px) rotate(-147.6000deg); }
+  41.3333% { transform: translate(89.019px, -34.584px) rotate(-148.8000deg); }
+  41.6667% { transform: translate(89.748px, -35.000px) rotate(-150.0000deg); }
+  42.0000% { transform: translate(90.485px, -35.416px) rotate(-151.2000deg); }
+  42.3333% { transform: translate(91.231px, -35.815px) rotate(-152.4000deg); }
+  42.6667% { transform: translate(91.985px, -36.200px) rotate(-153.6000deg); }
+  43.0000% { transform: translate(92.747px, -36.568px) rotate(-154.8000deg); }
+  43.3333% { transform: translate(93.517px, -36.921px) rotate(-156.0000deg); }
+  43.6667% { transform: translate(94.294px, -37.257px) rotate(-157.2000deg); }
+  44.0000% { transform: translate(95.077px, -37.576px) rotate(-158.4000deg); }
+  44.3333% { transform: translate(95.868px, -37.880px) rotate(-159.6000deg); }
+  44.6667% { transform: translate(96.664px, -38.167px) rotate(-160.8000deg); }
+  45.0000% { transform: translate(97.466px, -38.436px) rotate(-162.0000deg); }
+  45.3333% { transform: translate(98.274px, -38.690px) rotate(-163.2000deg); }
+  45.6667% { transform: translate(99.087px, -38.926px) rotate(-164.4000deg); }
+  46.0000% { transform: translate(99.904px, -39.145px) rotate(-165.6000deg); }
+  46.3333% { transform: translate(100.726px, -39.347px) rotate(-166.8000deg); }
+  46.6667% { transform: translate(101.552px, -39.531px) rotate(-168.0000deg); }
+  47.0000% { transform: translate(102.382px, -39.699px) rotate(-169.2000deg); }
+  47.3333% { transform: translate(103.215px, -39.849px) rotate(-170.4000deg); }
+  47.6667% { transform: translate(104.051px, -39.981px) rotate(-171.6000deg); }
+  48.0000% { transform: translate(104.889px, -40.096px) rotate(-172.8000deg); }
+  48.3333% { transform: translate(105.730px, -40.193px) rotate(-174.0000deg); }
+  48.6667% { transform: translate(106.573px, -40.273px) rotate(-175.2000deg); }
+  49.0000% { transform: translate(107.417px, -40.335px) rotate(-176.4000deg); }
+  49.3333% { transform: translate(108.262px, -40.379px) rotate(-177.6000deg); }
+  49.6667% { transform: translate(109.108px, -40.406px) rotate(-178.8000deg); }
+  50.0000% { transform: translate(109.954px, -40.415px) rotate(-180.0000deg); }
+  50.3333% { transform: translate(110.801px, -40.406px) rotate(-181.2000deg); }
+  50.6667% { transform: translate(111.647px, -40.379px) rotate(-182.4000deg); }
+  51.0000% { transform: translate(112.492px, -40.335px) rotate(-183.6000deg); }
+  51.3333% { transform: translate(113.336px, -40.273px) rotate(-184.8000deg); }
+  51.6667% { transform: translate(114.179px, -40.193px) rotate(-186.0000deg); }
+  52.0000% { transform: translate(115.020px, -40.096px) rotate(-187.2000deg); }
+  52.3333% { transform: translate(115.858px, -39.981px) rotate(-188.4000deg); }
+  52.6667% { transform: translate(116.694px, -39.849px) rotate(-189.6000deg); }
+  53.0000% { transform: translate(117.527px, -39.699px) rotate(-190.8000deg); }
+  53.3333% { transform: translate(118.357px, -39.531px) rotate(-192.0000deg); }
+  53.6667% { transform: translate(119.183px, -39.347px) rotate(-193.2000deg); }
+  54.0000% { transform: translate(120.005px, -39.145px) rotate(-194.4000deg); }
+  54.3333% { transform: translate(120.822px, -38.926px) rotate(-195.6000deg); }
+  54.6667% { transform: translate(121.635px, -38.690px) rotate(-196.8000deg); }
+  55.0000% { transform: translate(122.443px, -38.436px) rotate(-198.0000deg); }
+  55.3333% { transform: translate(123.245px, -38.167px) rotate(-199.2000deg); }
+  55.6667% { transform: translate(124.041px, -37.880px) rotate(-200.4000deg); }
+  56.0000% { transform: translate(124.831px, -37.576px) rotate(-201.6000deg); }
+  56.3333% { transform: translate(125.615px, -37.257px) rotate(-202.8000deg); }
+  56.6667% { transform: translate(126.392px, -36.921px) rotate(-204.0000deg); }
+  57.0000% { transform: translate(127.161px, -36.568px) rotate(-205.2000deg); }
+  57.3333% { transform: translate(127.923px, -36.200px) rotate(-206.4000deg); }
+  57.6667% { transform: translate(128.678px, -35.815px) rotate(-207.6000deg); }
+  58.0000% { transform: translate(129.424px, -35.416px) rotate(-208.8000deg); }
+  58.3333% { transform: translate(130.161px, -35.000px) rotate(-210.0000deg); }
+  58.6667% { transform: translate(130.890px, -34.584px) rotate(-211.2000deg); }
+  59.0000% { transform: translate(131.610px, -34.183px) rotate(-212.4000deg); }
+  59.3333% { transform: translate(132.322px, -33.799px) rotate(-213.6000deg); }
+  59.6667% { transform: translate(133.026px, -33.431px) rotate(-214.8000deg); }
+  60.0000% { transform: translate(133.722px, -33.079px) rotate(-216.0000deg); }
+  60.3333% { transform: translate(134.411px, -32.743px) rotate(-217.2000deg); }
+  60.6667% { transform: translate(135.094px, -32.422px) rotate(-218.4000deg); }
+  61.0000% { transform: translate(135.770px, -32.118px) rotate(-219.6000deg); }
+  61.3333% { transform: translate(136.439px, -31.833px) rotate(-220.8000deg); }
+  61.6667% { transform: translate(137.103px, -31.564px) rotate(-222.0000deg); }
+  62.0000% { transform: translate(137.762px, -31.310px) rotate(-223.2000deg); }
+  62.3333% { transform: translate(138.415px, -31.073px) rotate(-224.4000deg); }
+  62.6667% { transform: translate(139.063px, -30.853px) rotate(-225.6000deg); }
+  63.0000% { transform: translate(139.708px, -30.653px) rotate(-226.8000deg); }
+  63.3333% { transform: translate(140.348px, -30.469px) rotate(-228.0000deg); }
+  63.6667% { transform: translate(140.984px, -30.301px) rotate(-229.2000deg); }
+  64.0000% { transform: translate(141.617px, -30.150px) rotate(-230.4000deg); }
+  64.3333% { transform: translate(142.247px, -30.017px) rotate(-231.6000deg); }
+  64.6667% { transform: translate(142.875px, -29.904px) rotate(-232.8000deg); }
+  65.0000% { transform: translate(143.500px, -29.807px) rotate(-234.0000deg); }
+  65.3333% { transform: translate(144.123px, -29.727px) rotate(-235.2000deg); }
+  65.6667% { transform: translate(144.745px, -29.664px) rotate(-236.4000deg); }
+  66.0000% { transform: translate(145.366px, -29.619px) rotate(-237.6000deg); }
+  66.3333% { transform: translate(145.986px, -29.594px) rotate(-238.8000deg); }
+  66.6667% { transform: translate(146.606px, -29.585px) rotate(-240.0000deg); }
+  67.0000% { transform: translate(147.226px, -29.594px) rotate(-241.2000deg); }
+  67.3333% { transform: translate(147.846px, -29.619px) rotate(-242.4000deg); }
+  67.6667% { transform: translate(148.466px, -29.664px) rotate(-243.6000deg); }
+  68.0000% { transform: translate(149.088px, -29.727px) rotate(-244.8000deg); }
+  68.3333% { transform: translate(149.712px, -29.807px) rotate(-246.0000deg); }
+  68.6667% { transform: translate(150.337px, -29.904px) rotate(-247.2000deg); }
+  69.0000% { transform: translate(150.965px, -30.017px) rotate(-248.4000deg); }
+  69.3333% { transform: translate(151.595px, -30.150px) rotate(-249.6000deg); }
+  69.6667% { transform: translate(152.228px, -30.301px) rotate(-250.8000deg); }
+  70.0000% { transform: translate(152.864px, -30.469px) rotate(-252.0000deg); }
+  70.3333% { transform: translate(153.504px, -30.653px) rotate(-253.2000deg); }
+  70.6667% { transform: translate(154.148px, -30.853px) rotate(-254.4000deg); }
+  71.0000% { transform: translate(154.797px, -31.073px) rotate(-255.6000deg); }
+  71.3333% { transform: translate(155.450px, -31.310px) rotate(-256.8000deg); }
+  71.6667% { transform: translate(156.108px, -31.564px) rotate(-258.0000deg); }
+  72.0000% { transform: translate(156.772px, -31.833px) rotate(-259.2000deg); }
+  72.3333% { transform: translate(157.442px, -32.118px) rotate(-260.4000deg); }
+  72.6667% { transform: translate(158.118px, -32.422px) rotate(-261.6000deg); }
+  73.0000% { transform: translate(158.800px, -32.743px) rotate(-262.8000deg); }
+  73.3333% { transform: translate(159.490px, -33.079px) rotate(-264.0000deg); }
+  73.6667% { transform: translate(160.186px, -33.431px) rotate(-265.2000deg); }
+  74.0000% { transform: translate(160.890px, -33.799px) rotate(-266.4000deg); }
+  74.3333% { transform: translate(161.602px, -34.183px) rotate(-267.6000deg); }
+  74.6667% { transform: translate(162.322px, -34.584px) rotate(-268.8000deg); }
+  75.0000% { transform: translate(163.051px, -35.000px) rotate(-270.0000deg); }
+  75.3333% { transform: translate(163.788px, -35.416px) rotate(-271.2000deg); }
+  75.6667% { transform: translate(164.534px, -35.815px) rotate(-272.4000deg); }
+  76.0000% { transform: translate(165.288px, -36.200px) rotate(-273.6000deg); }
+  76.3333% { transform: translate(166.050px, -36.568px) rotate(-274.8000deg); }
+  76.6667% { transform: translate(166.820px, -36.921px) rotate(-276.0000deg); }
+  77.0000% { transform: translate(167.597px, -37.257px) rotate(-277.2000deg); }
+  77.3333% { transform: translate(168.380px, -37.576px) rotate(-278.4000deg); }
+  77.6667% { transform: translate(169.170px, -37.880px) rotate(-279.6000deg); }
+  78.0000% { transform: translate(169.967px, -38.167px) rotate(-280.8000deg); }
+  78.3333% { transform: translate(170.769px, -38.436px) rotate(-282.0000deg); }
+  78.6667% { transform: translate(171.577px, -38.690px) rotate(-283.2000deg); }
+  79.0000% { transform: translate(172.389px, -38.926px) rotate(-284.4000deg); }
+  79.3333% { transform: translate(173.207px, -39.145px) rotate(-285.6000deg); }
+  79.6667% { transform: translate(174.029px, -39.347px) rotate(-286.8000deg); }
+  80.0000% { transform: translate(174.855px, -39.531px) rotate(-288.0000deg); }
+  80.3333% { transform: translate(175.685px, -39.699px) rotate(-289.2000deg); }
+  80.6667% { transform: translate(176.518px, -39.849px) rotate(-290.4000deg); }
+  81.0000% { transform: translate(177.354px, -39.981px) rotate(-291.6000deg); }
+  81.3333% { transform: translate(178.192px, -40.096px) rotate(-292.8000deg); }
+  81.6667% { transform: translate(179.033px, -40.193px) rotate(-294.0000deg); }
+  82.0000% { transform: translate(179.876px, -40.273px) rotate(-295.2000deg); }
+  82.3333% { transform: translate(180.720px, -40.335px) rotate(-296.4000deg); }
+  82.6667% { transform: translate(181.565px, -40.379px) rotate(-297.6000deg); }
+  83.0000% { transform: translate(182.411px, -40.406px) rotate(-298.8000deg); }
+  83.3333% { transform: translate(183.257px, -40.415px) rotate(-300.0000deg); }
+  83.6667% { transform: translate(184.104px, -40.406px) rotate(-301.2000deg); }
+  84.0000% { transform: translate(184.950px, -40.379px) rotate(-302.4000deg); }
+  84.3333% { transform: translate(185.795px, -40.335px) rotate(-303.6000deg); }
+  84.6667% { transform: translate(186.639px, -40.273px) rotate(-304.8000deg); }
+  85.0000% { transform: translate(187.482px, -40.193px) rotate(-306.0000deg); }
+  85.3333% { transform: translate(188.322px, -40.096px) rotate(-307.2000deg); }
+  85.6667% { transform: translate(189.161px, -39.981px) rotate(-308.4000deg); }
+  86.0000% { transform: translate(189.997px, -39.849px) rotate(-309.6000deg); }
+  86.3333% { transform: translate(190.830px, -39.699px) rotate(-310.8000deg); }
+  86.6667% { transform: translate(191.660px, -39.531px) rotate(-312.0000deg); }
+  87.0000% { transform: translate(192.486px, -39.347px) rotate(-313.2000deg); }
+  87.3333% { transform: translate(193.308px, -39.145px) rotate(-314.4000deg); }
+  87.6667% { transform: translate(194.125px, -38.926px) rotate(-315.6000deg); }
+  88.0000% { transform: translate(194.938px, -38.690px) rotate(-316.8000deg); }
+  88.3333% { transform: translate(195.746px, -38.436px) rotate(-318.0000deg); }
+  88.6667% { transform: translate(196.548px, -38.167px) rotate(-319.2000deg); }
+  89.0000% { transform: translate(197.344px, -37.880px) rotate(-320.4000deg); }
+  89.3333% { transform: translate(198.134px, -37.576px) rotate(-321.6000deg); }
+  89.6667% { transform: translate(198.918px, -37.257px) rotate(-322.8000deg); }
+  90.0000% { transform: translate(199.695px, -36.921px) rotate(-324.0000deg); }
+  90.3333% { transform: translate(200.464px, -36.568px) rotate(-325.2000deg); }
+  90.6667% { transform: translate(201.226px, -36.200px) rotate(-326.4000deg); }
+  91.0000% { transform: translate(201.981px, -35.815px) rotate(-327.6000deg); }
+  91.3333% { transform: translate(202.726px, -35.416px) rotate(-328.8000deg); }
+  91.6667% { transform: translate(203.464px, -35.000px) rotate(-330.0000deg); }
+  92.0000% { transform: translate(204.193px, -34.584px) rotate(-331.2000deg); }
+  92.3333% { transform: translate(204.913px, -34.183px) rotate(-332.4000deg); }
+  92.6667% { transform: translate(205.625px, -33.799px) rotate(-333.6000deg); }
+  93.0000% { transform: translate(206.329px, -33.431px) rotate(-334.8000deg); }
+  93.3333% { transform: translate(207.025px, -33.079px) rotate(-336.0000deg); }
+  93.6667% { transform: translate(207.714px, -32.743px) rotate(-337.2000deg); }
+  94.0000% { transform: translate(208.397px, -32.422px) rotate(-338.4000deg); }
+  94.3333% { transform: translate(209.073px, -32.118px) rotate(-339.6000deg); }
+  94.6667% { transform: translate(209.742px, -31.833px) rotate(-340.8000deg); }
+  95.0000% { transform: translate(210.406px, -31.564px) rotate(-342.0000deg); }
+  95.3333% { transform: translate(211.065px, -31.310px) rotate(-343.2000deg); }
+  95.6667% { transform: translate(211.718px, -31.073px) rotate(-344.4000deg); }
+  96.0000% { transform: translate(212.366px, -30.853px) rotate(-345.6000deg); }
+  96.3333% { transform: translate(213.011px, -30.653px) rotate(-346.8000deg); }
+  96.6667% { transform: translate(213.651px, -30.469px) rotate(-348.0000deg); }
+  97.0000% { transform: translate(214.287px, -30.301px) rotate(-349.2000deg); }
+  97.3333% { transform: translate(214.920px, -30.150px) rotate(-350.4000deg); }
+  97.6667% { transform: translate(215.550px, -30.017px) rotate(-351.6000deg); }
+  98.0000% { transform: translate(216.178px, -29.904px) rotate(-352.8000deg); }
+  98.3333% { transform: translate(216.803px, -29.807px) rotate(-354.0000deg); }
+  98.6667% { transform: translate(217.426px, -29.727px) rotate(-355.2000deg); }
+  99.0000% { transform: translate(218.048px, -29.664px) rotate(-356.4000deg); }
+  99.3333% { transform: translate(218.669px, -29.619px) rotate(-357.6000deg); }
+  99.6667% { transform: translate(219.289px, -29.594px) rotate(-358.8000deg); }
+  100.0000% { transform: translate(219.909px, -29.585px) rotate(-360.0000deg); }
+}
+
+@keyframes hubR {
+  0.0000% { transform: translate(0.000px, -29.585px); }
+  0.3333% { transform: translate(0.620px, -29.594px); }
+  0.6667% { transform: translate(1.240px, -29.619px); }
+  1.0000% { transform: translate(1.861px, -29.664px); }
+  1.3333% { transform: translate(2.483px, -29.727px); }
+  1.6667% { transform: translate(3.106px, -29.807px); }
+  2.0000% { transform: translate(3.731px, -29.904px); }
+  2.3333% { transform: translate(4.359px, -30.017px); }
+  2.6667% { transform: translate(4.989px, -30.150px); }
+  3.0000% { transform: translate(5.622px, -30.301px); }
+  3.3333% { transform: translate(6.258px, -30.469px); }
+  3.6667% { transform: translate(6.898px, -30.653px); }
+  4.0000% { transform: translate(7.542px, -30.853px); }
+  4.3333% { transform: translate(8.191px, -31.073px); }
+  4.6667% { transform: translate(8.844px, -31.310px); }
+  5.0000% { transform: translate(9.503px, -31.564px); }
+  5.3333% { transform: translate(10.166px, -31.833px); }
+  5.6667% { transform: translate(10.836px, -32.118px); }
+  6.0000% { transform: translate(11.512px, -32.422px); }
+  6.3333% { transform: translate(12.194px, -32.743px); }
+  6.6667% { transform: translate(12.884px, -33.079px); }
+  7.0000% { transform: translate(13.580px, -33.431px); }
+  7.3333% { transform: translate(14.284px, -33.799px); }
+  7.6667% { transform: translate(14.996px, -34.183px); }
+  8.0000% { transform: translate(15.716px, -34.584px); }
+  8.3333% { transform: translate(16.445px, -35.000px); }
+  8.6667% { transform: translate(17.182px, -35.416px); }
+  9.0000% { transform: translate(17.928px, -35.815px); }
+  9.3333% { transform: translate(18.682px, -36.200px); }
+  9.6667% { transform: translate(19.444px, -36.568px); }
+  10.0000% { transform: translate(20.214px, -36.921px); }
+  10.3333% { transform: translate(20.991px, -37.257px); }
+  10.6667% { transform: translate(21.774px, -37.576px); }
+  11.0000% { transform: translate(22.565px, -37.880px); }
+  11.3333% { transform: translate(23.361px, -38.167px); }
+  11.6667% { transform: translate(24.163px, -38.436px); }
+  12.0000% { transform: translate(24.971px, -38.690px); }
+  12.3333% { transform: translate(25.784px, -38.926px); }
+  12.6667% { transform: translate(26.601px, -39.145px); }
+  13.0000% { transform: translate(27.423px, -39.347px); }
+  13.3333% { transform: translate(28.249px, -39.531px); }
+  13.6667% { transform: translate(29.079px, -39.699px); }
+  14.0000% { transform: translate(29.912px, -39.849px); }
+  14.3333% { transform: translate(30.748px, -39.981px); }
+  14.6667% { transform: translate(31.586px, -40.096px); }
+  15.0000% { transform: translate(32.427px, -40.193px); }
+  15.3333% { transform: translate(33.270px, -40.273px); }
+  15.6667% { transform: translate(34.114px, -40.335px); }
+  16.0000% { transform: translate(34.959px, -40.379px); }
+  16.3333% { transform: translate(35.805px, -40.406px); }
+  16.6667% { transform: translate(36.651px, -40.415px); }
+  17.0000% { transform: translate(37.498px, -40.406px); }
+  17.3333% { transform: translate(38.344px, -40.379px); }
+  17.6667% { transform: translate(39.189px, -40.335px); }
+  18.0000% { transform: translate(40.033px, -40.273px); }
+  18.3333% { transform: translate(40.876px, -40.193px); }
+  18.6667% { transform: translate(41.717px, -40.096px); }
+  19.0000% { transform: translate(42.555px, -39.981px); }
+  19.3333% { transform: translate(43.391px, -39.849px); }
+  19.6667% { transform: translate(44.224px, -39.699px); }
+  20.0000% { transform: translate(45.054px, -39.531px); }
+  20.3333% { transform: translate(45.880px, -39.347px); }
+  20.6667% { transform: translate(46.702px, -39.145px); }
+  21.0000% { transform: translate(47.519px, -38.926px); }
+  21.3333% { transform: translate(48.332px, -38.690px); }
+  21.6667% { transform: translate(49.140px, -38.436px); }
+  22.0000% { transform: translate(49.942px, -38.167px); }
+  22.3333% { transform: translate(50.738px, -37.880px); }
+  22.6667% { transform: translate(51.529px, -37.576px); }
+  23.0000% { transform: translate(52.312px, -37.257px); }
+  23.3333% { transform: translate(53.089px, -36.921px); }
+  23.6667% { transform: translate(53.859px, -36.568px); }
+  24.0000% { transform: translate(54.621px, -36.200px); }
+  24.3333% { transform: translate(55.375px, -35.815px); }
+  24.6667% { transform: translate(56.121px, -35.416px); }
+  25.0000% { transform: translate(56.858px, -35.000px); }
+  25.3333% { transform: translate(57.587px, -34.584px); }
+  25.6667% { transform: translate(58.307px, -34.183px); }
+  26.0000% { transform: translate(59.019px, -33.799px); }
+  26.3333% { transform: translate(59.723px, -33.431px); }
+  26.6667% { transform: translate(60.419px, -33.079px); }
+  27.0000% { transform: translate(61.109px, -32.743px); }
+  27.3333% { transform: translate(61.791px, -32.422px); }
+  27.6667% { transform: translate(62.467px, -32.118px); }
+  28.0000% { transform: translate(63.136px, -31.833px); }
+  28.3333% { transform: translate(63.800px, -31.564px); }
+  28.6667% { transform: translate(64.459px, -31.310px); }
+  29.0000% { transform: translate(65.112px, -31.073px); }
+  29.3333% { transform: translate(65.761px, -30.853px); }
+  29.6667% { transform: translate(66.405px, -30.653px); }
+  30.0000% { transform: translate(67.045px, -30.469px); }
+  30.3333% { transform: translate(67.681px, -30.301px); }
+  30.6667% { transform: translate(68.314px, -30.150px); }
+  31.0000% { transform: translate(68.944px, -30.017px); }
+  31.3333% { transform: translate(69.572px, -29.904px); }
+  31.6667% { transform: translate(70.197px, -29.807px); }
+  32.0000% { transform: translate(70.820px, -29.727px); }
+  32.3333% { transform: translate(71.442px, -29.664px); }
+  32.6667% { transform: translate(72.063px, -29.619px); }
+  33.0000% { transform: translate(72.683px, -29.594px); }
+  33.3333% { transform: translate(73.303px, -29.585px); }
+  33.6667% { transform: translate(73.923px, -29.594px); }
+  34.0000% { transform: translate(74.543px, -29.619px); }
+  34.3333% { transform: translate(75.164px, -29.664px); }
+  34.6667% { transform: translate(75.785px, -29.727px); }
+  35.0000% { transform: translate(76.409px, -29.807px); }
+  35.3333% { transform: translate(77.034px, -29.904px); }
+  35.6667% { transform: translate(77.662px, -30.017px); }
+  36.0000% { transform: translate(78.292px, -30.150px); }
+  36.3333% { transform: translate(78.925px, -30.301px); }
+  36.6667% { transform: translate(79.561px, -30.469px); }
+  37.0000% { transform: translate(80.201px, -30.653px); }
+  37.3333% { transform: translate(80.845px, -30.853px); }
+  37.6667% { transform: translate(81.494px, -31.073px); }
+  38.0000% { transform: translate(82.147px, -31.310px); }
+  38.3333% { transform: translate(82.805px, -31.564px); }
+  38.6667% { transform: translate(83.469px, -31.833px); }
+  39.0000% { transform: translate(84.139px, -32.118px); }
+  39.3333% { transform: translate(84.815px, -32.422px); }
+  39.6667% { transform: translate(85.497px, -32.743px); }
+  40.0000% { transform: translate(86.187px, -33.079px); }
+  40.3333% { transform: translate(86.883px, -33.431px); }
+  40.6667% { transform: translate(87.587px, -33.799px); }
+  41.0000% { transform: translate(88.299px, -34.183px); }
+  41.3333% { transform: translate(89.019px, -34.584px); }
+  41.6667% { transform: translate(89.748px, -35.000px); }
+  42.0000% { transform: translate(90.485px, -35.416px); }
+  42.3333% { transform: translate(91.231px, -35.815px); }
+  42.6667% { transform: translate(91.985px, -36.200px); }
+  43.0000% { transform: translate(92.747px, -36.568px); }
+  43.3333% { transform: translate(93.517px, -36.921px); }
+  43.6667% { transform: translate(94.294px, -37.257px); }
+  44.0000% { transform: translate(95.077px, -37.576px); }
+  44.3333% { transform: translate(95.868px, -37.880px); }
+  44.6667% { transform: translate(96.664px, -38.167px); }
+  45.0000% { transform: translate(97.466px, -38.436px); }
+  45.3333% { transform: translate(98.274px, -38.690px); }
+  45.6667% { transform: translate(99.087px, -38.926px); }
+  46.0000% { transform: translate(99.904px, -39.145px); }
+  46.3333% { transform: translate(100.726px, -39.347px); }
+  46.6667% { transform: translate(101.552px, -39.531px); }
+  47.0000% { transform: translate(102.382px, -39.699px); }
+  47.3333% { transform: translate(103.215px, -39.849px); }
+  47.6667% { transform: translate(104.051px, -39.981px); }
+  48.0000% { transform: translate(104.889px, -40.096px); }
+  48.3333% { transform: translate(105.730px, -40.193px); }
+  48.6667% { transform: translate(106.573px, -40.273px); }
+  49.0000% { transform: translate(107.417px, -40.335px); }
+  49.3333% { transform: translate(108.262px, -40.379px); }
+  49.6667% { transform: translate(109.108px, -40.406px); }
+  50.0000% { transform: translate(109.954px, -40.415px); }
+  50.3333% { transform: translate(110.801px, -40.406px); }
+  50.6667% { transform: translate(111.647px, -40.379px); }
+  51.0000% { transform: translate(112.492px, -40.335px); }
+  51.3333% { transform: translate(113.336px, -40.273px); }
+  51.6667% { transform: translate(114.179px, -40.193px); }
+  52.0000% { transform: translate(115.020px, -40.096px); }
+  52.3333% { transform: translate(115.858px, -39.981px); }
+  52.6667% { transform: translate(116.694px, -39.849px); }
+  53.0000% { transform: translate(117.527px, -39.699px); }
+  53.3333% { transform: translate(118.357px, -39.531px); }
+  53.6667% { transform: translate(119.183px, -39.347px); }
+  54.0000% { transform: translate(120.005px, -39.145px); }
+  54.3333% { transform: translate(120.822px, -38.926px); }
+  54.6667% { transform: translate(121.635px, -38.690px); }
+  55.0000% { transform: translate(122.443px, -38.436px); }
+  55.3333% { transform: translate(123.245px, -38.167px); }
+  55.6667% { transform: translate(124.041px, -37.880px); }
+  56.0000% { transform: translate(124.831px, -37.576px); }
+  56.3333% { transform: translate(125.615px, -37.257px); }
+  56.6667% { transform: translate(126.392px, -36.921px); }
+  57.0000% { transform: translate(127.161px, -36.568px); }
+  57.3333% { transform: translate(127.923px, -36.200px); }
+  57.6667% { transform: translate(128.678px, -35.815px); }
+  58.0000% { transform: translate(129.424px, -35.416px); }
+  58.3333% { transform: translate(130.161px, -35.000px); }
+  58.6667% { transform: translate(130.890px, -34.584px); }
+  59.0000% { transform: translate(131.610px, -34.183px); }
+  59.3333% { transform: translate(132.322px, -33.799px); }
+  59.6667% { transform: translate(133.026px, -33.431px); }
+  60.0000% { transform: translate(133.722px, -33.079px); }
+  60.3333% { transform: translate(134.411px, -32.743px); }
+  60.6667% { transform: translate(135.094px, -32.422px); }
+  61.0000% { transform: translate(135.770px, -32.118px); }
+  61.3333% { transform: translate(136.439px, -31.833px); }
+  61.6667% { transform: translate(137.103px, -31.564px); }
+  62.0000% { transform: translate(137.762px, -31.310px); }
+  62.3333% { transform: translate(138.415px, -31.073px); }
+  62.6667% { transform: translate(139.063px, -30.853px); }
+  63.0000% { transform: translate(139.708px, -30.653px); }
+  63.3333% { transform: translate(140.348px, -30.469px); }
+  63.6667% { transform: translate(140.984px, -30.301px); }
+  64.0000% { transform: translate(141.617px, -30.150px); }
+  64.3333% { transform: translate(142.247px, -30.017px); }
+  64.6667% { transform: translate(142.875px, -29.904px); }
+  65.0000% { transform: translate(143.500px, -29.807px); }
+  65.3333% { transform: translate(144.123px, -29.727px); }
+  65.6667% { transform: translate(144.745px, -29.664px); }
+  66.0000% { transform: translate(145.366px, -29.619px); }
+  66.3333% { transform: translate(145.986px, -29.594px); }
+  66.6667% { transform: translate(146.606px, -29.585px); }
+  67.0000% { transform: translate(147.226px, -29.594px); }
+  67.3333% { transform: translate(147.846px, -29.619px); }
+  67.6667% { transform: translate(148.466px, -29.664px); }
+  68.0000% { transform: translate(149.088px, -29.727px); }
+  68.3333% { transform: translate(149.712px, -29.807px); }
+  68.6667% { transform: translate(150.337px, -29.904px); }
+  69.0000% { transform: translate(150.965px, -30.017px); }
+  69.3333% { transform: translate(151.595px, -30.150px); }
+  69.6667% { transform: translate(152.228px, -30.301px); }
+  70.0000% { transform: translate(152.864px, -30.469px); }
+  70.3333% { transform: translate(153.504px, -30.653px); }
+  70.6667% { transform: translate(154.148px, -30.853px); }
+  71.0000% { transform: translate(154.797px, -31.073px); }
+  71.3333% { transform: translate(155.450px, -31.310px); }
+  71.6667% { transform: translate(156.108px, -31.564px); }
+  72.0000% { transform: translate(156.772px, -31.833px); }
+  72.3333% { transform: translate(157.442px, -32.118px); }
+  72.6667% { transform: translate(158.118px, -32.422px); }
+  73.0000% { transform: translate(158.800px, -32.743px); }
+  73.3333% { transform: translate(159.490px, -33.079px); }
+  73.6667% { transform: translate(160.186px, -33.431px); }
+  74.0000% { transform: translate(160.890px, -33.799px); }
+  74.3333% { transform: translate(161.602px, -34.183px); }
+  74.6667% { transform: translate(162.322px, -34.584px); }
+  75.0000% { transform: translate(163.051px, -35.000px); }
+  75.3333% { transform: translate(163.788px, -35.416px); }
+  75.6667% { transform: translate(164.534px, -35.815px); }
+  76.0000% { transform: translate(165.288px, -36.200px); }
+  76.3333% { transform: translate(166.050px, -36.568px); }
+  76.6667% { transform: translate(166.820px, -36.921px); }
+  77.0000% { transform: translate(167.597px, -37.257px); }
+  77.3333% { transform: translate(168.380px, -37.576px); }
+  77.6667% { transform: translate(169.170px, -37.880px); }
+  78.0000% { transform: translate(169.967px, -38.167px); }
+  78.3333% { transform: translate(170.769px, -38.436px); }
+  78.6667% { transform: translate(171.577px, -38.690px); }
+  79.0000% { transform: translate(172.389px, -38.926px); }
+  79.3333% { transform: translate(173.207px, -39.145px); }
+  79.6667% { transform: translate(174.029px, -39.347px); }
+  80.0000% { transform: translate(174.855px, -39.531px); }
+  80.3333% { transform: translate(175.685px, -39.699px); }
+  80.6667% { transform: translate(176.518px, -39.849px); }
+  81.0000% { transform: translate(177.354px, -39.981px); }
+  81.3333% { transform: translate(178.192px, -40.096px); }
+  81.6667% { transform: translate(179.033px, -40.193px); }
+  82.0000% { transform: translate(179.876px, -40.273px); }
+  82.3333% { transform: translate(180.720px, -40.335px); }
+  82.6667% { transform: translate(181.565px, -40.379px); }
+  83.0000% { transform: translate(182.411px, -40.406px); }
+  83.3333% { transform: translate(183.257px, -40.415px); }
+  83.6667% { transform: translate(184.104px, -40.406px); }
+  84.0000% { transform: translate(184.950px, -40.379px); }
+  84.3333% { transform: translate(185.795px, -40.335px); }
+  84.6667% { transform: translate(186.639px, -40.273px); }
+  85.0000% { transform: translate(187.482px, -40.193px); }
+  85.3333% { transform: translate(188.322px, -40.096px); }
+  85.6667% { transform: translate(189.161px, -39.981px); }
+  86.0000% { transform: translate(189.997px, -39.849px); }
+  86.3333% { transform: translate(190.830px, -39.699px); }
+  86.6667% { transform: translate(191.660px, -39.531px); }
+  87.0000% { transform: translate(192.486px, -39.347px); }
+  87.3333% { transform: translate(193.308px, -39.145px); }
+  87.6667% { transform: translate(194.125px, -38.926px); }
+  88.0000% { transform: translate(194.938px, -38.690px); }
+  88.3333% { transform: translate(195.746px, -38.436px); }
+  88.6667% { transform: translate(196.548px, -38.167px); }
+  89.0000% { transform: translate(197.344px, -37.880px); }
+  89.3333% { transform: translate(198.134px, -37.576px); }
+  89.6667% { transform: translate(198.918px, -37.257px); }
+  90.0000% { transform: translate(199.695px, -36.921px); }
+  90.3333% { transform: translate(200.464px, -36.568px); }
+  90.6667% { transform: translate(201.226px, -36.200px); }
+  91.0000% { transform: translate(201.981px, -35.815px); }
+  91.3333% { transform: translate(202.726px, -35.416px); }
+  91.6667% { transform: translate(203.464px, -35.000px); }
+  92.0000% { transform: translate(204.193px, -34.584px); }
+  92.3333% { transform: translate(204.913px, -34.183px); }
+  92.6667% { transform: translate(205.625px, -33.799px); }
+  93.0000% { transform: translate(206.329px, -33.431px); }
+  93.3333% { transform: translate(207.025px, -33.079px); }
+  93.6667% { transform: translate(207.714px, -32.743px); }
+  94.0000% { transform: translate(208.397px, -32.422px); }
+  94.3333% { transform: translate(209.073px, -32.118px); }
+  94.6667% { transform: translate(209.742px, -31.833px); }
+  95.0000% { transform: translate(210.406px, -31.564px); }
+  95.3333% { transform: translate(211.065px, -31.310px); }
+  95.6667% { transform: translate(211.718px, -31.073px); }
+  96.0000% { transform: translate(212.366px, -30.853px); }
+  96.3333% { transform: translate(213.011px, -30.653px); }
+  96.6667% { transform: translate(213.651px, -30.469px); }
+  97.0000% { transform: translate(214.287px, -30.301px); }
+  97.3333% { transform: translate(214.920px, -30.150px); }
+  97.6667% { transform: translate(215.550px, -30.017px); }
+  98.0000% { transform: translate(216.178px, -29.904px); }
+  98.3333% { transform: translate(216.803px, -29.807px); }
+  98.6667% { transform: translate(217.426px, -29.727px); }
+  99.0000% { transform: translate(218.048px, -29.664px); }
+  99.3333% { transform: translate(218.669px, -29.619px); }
+  99.6667% { transform: translate(219.289px, -29.594px); }
+  100.0000% { transform: translate(219.909px, -29.585px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rollR,
+  .hubR { animation-play-state: paused; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/reuleaux-triangle-as/`, a self-contained pure CSS/HTML plate riding on rollers that are not round and still do not bump.

Closes #49678

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

An equilateral triangle with an arc drawn from each corner through the other two has the same width in every direction, so it rolls under a flat plate without ever raising or lowering it. What it cannot do is take an axle: its centre bobs while the plate above stays still, which is exactly why wheels are round and rollers need not be. Barbier's theorem adds that any constant width curve has perimeter `pi*w`, so a turn advances it by `pi*w` whatever its shape.

Each roller is a 180 point outline cut with `clip-path`. The motion is derived, not eyeballed: the outline's support function gives the centre height at each rotation and the no-slip condition `dX/dphi = -Y` is integrated for the travel.

Everything below was measured on the **rendered** outline, by reading each roller's computed `clip-path` polygon back out of the browser and putting all 180 points through its computed transform matrix.

- **The plate really does ride flat.** Across **186 outline samples** (6 rollers at 31 rotations) the topmost point varies by **0.0062 px**, sitting at **98.000**, the ground at 168 minus the 70 px width.
- **They are rolling, not floating.** The lowest point varies by **0.0059 px** and sits at **167.999** against a ground line at 168.
- **Constant width is checked in every direction**, not only vertically: **4464 measurements** over 24 directions and every sampled rotation, worst deviation from 70 px **0.0035 px**.
- **The centre bobs, and that is the point.** The hub travels **10.83 px** vertically while the plate does not move at all.
- **Barbier checks out**: one full turn advances a roller **219.94 px** against `pi * 70 = 219.91`.
- Rollers are spaced at exactly half the per-turn advance, so the row is periodic and the loop closes with no jump.

## Accessibility

`prefers-reduced-motion: reduce` stops the rollers and hubs together, leaving the plate resting on shapes caught mid-turn.

## Verification

Opened `demo.html` in the browser and measured the rendered outline rather than the source geometry: read each roller's computed `clip-path` polygon back out, pushed all 180 points through its computed transform, and found the top of the shape holding 98.000 to within 0.0062 px and the bottom holding the ground line to within 0.0059 px. Checked width in 24 directions at every sampled rotation, 4464 measurements, worst error 0.0035 px from 70. Confirmed the hub bobs 10.83 px while the plate does not move, and that one turn advances 219.94 px against Barbier's 219.91. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
