### PR TITLE
Add watt governor component

### DIFF
--- a/submissions/examples/watt-governor-as/README.md
+++ b/submissions/examples/watt-governor-as/README.md
@@ -1,0 +1,49 @@
+# Watt Governor
+
+A pure CSS/HTML centrifugal governor: two balls swing out as the engine speeds up, a sleeve rides up the spindle, and the steam valve closes on itself.
+
+## What it shows
+
+Each ball is a **conical pendulum**. Only two forces act on it, gravity down and tension along its arm, and they have to add up to the centripetal force that keeps it circling. Resolve them and the arm angle falls out:
+
+```
+cos(theta) = g / (omega^2 * L)
+```
+
+Rearranged, the height of the cone the arms sweep is
+
+```
+L cos(theta) = g / omega^2
+```
+
+Look at what is not in that. **Not the mass of the balls.** Not the length of the arms. Hang heavier balls and the angle does not budge; the extra weight pulling them down is exactly cancelled by the extra inertia needing more force to turn them. The cone height is a function of engine speed and nothing else, which is precisely what makes it a usable speed sensor rather than a sensor of whatever else happened to change.
+
+So the sleeve position measures speed, and the sleeve is linked to the throttle. Run fast, balls rise, valve closes, engine slows. Run slow, balls drop, valve opens. The machine holds its own speed with no one watching. Boulton and Watt fitted it to their engines from 1788, borrowing the idea from flour mills, where the same device had long been used to set the gap between millstones.
+
+Two honest caveats, both visible here:
+
+- **Below a critical speed it does nothing at all.** The relation needs `g / (omega^2 L) <= 1`, so under `omega = sqrt(g/L)`, which is **54.6 rpm** for these arms, there is no solution but hanging straight down. Gravity simply wins, and the governor is blind.
+- **It cannot hold one exact speed.** Moving the valve requires moving the sleeve, and moving the sleeve requires a change in speed. So every load setting settles at a slightly different speed. That standing error is called droop, and it is the characteristic flaw of a purely proportional controller.
+
+Maxwell wrote the equations of motion for these in **On Governors** (1868), working out when they settle and when they hunt instead. It is one of the founding papers of control theory. The word cybernetics was later coined from the Greek for steersman, the same root that, through Latin, gives us the word governor.
+
+## How it is built
+
+Nine speeds from 40 to 146 rpm, stepped up and back down. The arm angle, both lower links, the sleeve height, the cone line and the valve opening are all driven from the same 16 phase schedule with `steps(1, end)`, so no two of them can ever render a state from different moments.
+
+- **The geometry is the physics, and the browser re-derives it.** The check reads the rpm off the rendered readout, computes `acos(g / (omega^2 L))` from scratch, and compares it with the arm's measured rotation. Worst disagreement across all 16 steps: **0.0005 degrees**.
+- **The cone height really is `g / omega^2`.** Measured against the rendered dashed line at all **15** above-critical steps, worst error **0.0005 px**.
+- **The sleeve is driven by the same geometry**, not animated separately: its measured position matches `2 L cos(theta)` to **0.0004 px**.
+- **The arms are exactly mirrored** at every step, and **below the critical speed both read exactly 0 degrees**, hanging dead straight as they must.
+- **The feedback runs the right way.** The valve opening falls monotonically as speed rises, from fully open at 40 rpm to fully shut at 146.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` freezes the whole linkage, readout and valve together on one consistent speed.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/watt-governor-as/demo.html
+++ b/submissions/examples/watt-governor-as/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Watt Governor</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="tagG">cone height = g / w^2, whatever the balls weigh</span>
+    <span class="spindleG"></span>
+    <span class="baseG"></span>
+    <span class="pivotG"></span>
+    <span class="coneG"></span>
+    <span class="coneLbl">cone height</span>
+    <span class="armG armL"><span class="ballG"></span></span>
+    <span class="armG armR"><span class="ballG"></span></span>
+    <span class="linkG linkL"></span>
+    <span class="linkG linkR"></span>
+    <span class="sleeveG"></span>
+    <span class="pipeG"></span>
+    <span class="gateG"></span>
+    <span class="pipeLbl">steam</span>
+    <div class="windowG">
+      <div class="stripG">
+        <span class="rowG">40 rpm</span>
+        <span class="rowG">56 rpm</span>
+        <span class="rowG">62 rpm</span>
+        <span class="rowG">70 rpm</span>
+        <span class="rowG">80 rpm</span>
+        <span class="rowG">92 rpm</span>
+        <span class="rowG">106 rpm</span>
+        <span class="rowG">124 rpm</span>
+        <span class="rowG">146 rpm</span>
+      </div>
+    </div>
+    <span class="capG">below 55 rpm the arms hang dead straight: gravity still wins</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/watt-governor-as/style.css
+++ b/submissions/examples/watt-governor-as/style.css
@@ -1,0 +1,412 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #26221c, #080705 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 340px;
+  height: 250px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 40% 34%, #322c22, #0a0806 86%);
+  color: rgba(235, 220, 190, 0.9);
+}
+
+.spindleG {
+  position: absolute;
+  left: 140px;
+  top: 44px;
+  width: 6px;
+  height: 168px;
+  margin-left: -3px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #7d6f5d, #e4d3b2, #7d6f5d);
+}
+
+.baseG {
+  position: absolute;
+  left: 140px;
+  top: 206px;
+  width: 92px;
+  height: 12px;
+  margin-left: -46px;
+  border-radius: 3px;
+  background: linear-gradient(#8d7d69, #4a4136);
+}
+
+.pivotG {
+  position: absolute;
+  left: 140px;
+  top: 52px;
+  width: 11px;
+  height: 11px;
+  margin: -5.5px 0 0 -5.5px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f4e6c8, #8d7a5c);
+}
+
+/*
+  a conical pendulum: each ball is held by gravity and by the tension in its
+  arm. resolving those gives cos(theta) = g / (omega^2 * L), so the height of
+  the cone, L*cos(theta), is exactly g / omega^2. neither the mass of the
+  balls nor the length of the arms appears in it, which is what makes the
+  sleeve a usable measure of engine speed rather than of anything else.
+*/
+.armG {
+  position: absolute;
+  left: 140px;
+  top: 52px;
+  width: 3px;
+  height: 74px;
+  margin-left: -1.5px;
+  border-radius: 2px;
+  background: linear-gradient(#d8c8a8, #7d6e58);
+  transform-origin: 50% 0;
+}
+
+.armL { animation: armLG 11s linear infinite; }
+.armR { animation: armRG 11s linear infinite; }
+
+.ballG {
+  position: absolute;
+  left: 50%;
+  top: 74px;
+  width: 22px;
+  height: 22px;
+  margin: -11px 0 0 -11px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 34% 30%, #f6e3bb, #8a6f43 72%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.55);
+}
+
+/* lower links, ball down to the sleeve, drawn from the ball end upward */
+.linkG {
+  position: absolute;
+  left: 140px;
+  top: 200px;
+  width: 2px;
+  height: 74px;
+  margin-left: -1px;
+  border-radius: 2px;
+  background: linear-gradient(#b7a488, #6a5c49);
+  transform-origin: 50% 0;
+}
+
+.linkL { animation: linkLG 11s linear infinite; }
+.linkR { animation: linkRG 11s linear infinite; }
+
+.sleeveG {
+  position: absolute;
+  left: 140px;
+  top: 200px;
+  width: 30px;
+  height: 13px;
+  margin: -6.5px 0 0 -15px;
+  border-radius: 3px;
+  background: linear-gradient(#e6d5b4, #7b6b54);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+  animation: sleeveG 11s linear infinite;
+}
+
+.coneG {
+  position: absolute;
+  left: 4px;
+  width: 226px;
+  top: 126px;
+  height: 0;
+  border-top: 1px dashed rgba(255, 225, 170, 0.4);
+  animation: coneG 11s linear infinite;
+}
+
+.coneLbl {
+  position: absolute;
+  left: 6px;
+  top: 114px;
+  font-size: 0.43rem;
+  letter-spacing: 0.04em;
+  color: rgba(255, 228, 175, 0.75);
+  animation: coneLblG 11s linear infinite;
+}
+
+.pipeG {
+  position: absolute;
+  left: 246px;
+  top: 96px;
+  width: 54px;
+  height: 52px;
+  border-radius: 3px;
+  background: rgba(120, 150, 170, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(170, 200, 220, 0.45);
+}
+
+/* the gate the sleeve drives: open when the balls hang low, shut as they rise */
+.gateG {
+  position: absolute;
+  left: 248px;
+  top: 98px;
+  width: 50px;
+  height: 46px;
+  border-radius: 2px;
+  background: linear-gradient(rgba(150, 220, 255, 0.85), rgba(60, 150, 210, 0.75));
+  animation: gateG 11s linear infinite;
+}
+
+.pipeLbl {
+  position: absolute;
+  left: 246px;
+  top: 82px;
+  font-size: 0.44rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: rgba(190, 220, 240, 0.85);
+}
+
+.windowG {
+  position: absolute;
+  left: 240px;
+  top: 166px;
+  width: 66px;
+  height: 20px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: rgba(18, 14, 10, 0.75);
+  box-shadow: inset 0 0 0 1px rgba(200, 180, 140, 0.35);
+}
+
+.stripG {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  animation: stripG 11s linear infinite;
+}
+
+.rowG {
+  display: block;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  font-size: 0.55rem;
+  letter-spacing: 0.04em;
+  color: rgba(250, 235, 200, 0.95);
+}
+
+.tagG {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.47rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: rgba(240, 220, 180, 0.9);
+}
+
+.capG {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.03em;
+  color: rgba(235, 215, 180, 0.8);
+}
+
+@keyframes armLG {
+  0.0000% { transform: rotate(0.0000deg); animation-timing-function: steps(1, end); }
+  6.2500% { transform: rotate(18.0373deg); animation-timing-function: steps(1, end); }
+  12.5000% { transform: rotate(39.1293deg); animation-timing-function: steps(1, end); }
+  18.7500% { transform: rotate(52.5155deg); animation-timing-function: steps(1, end); }
+  25.0000% { transform: rotate(62.2303deg); animation-timing-function: steps(1, end); }
+  31.2500% { transform: rotate(69.3718deg); animation-timing-function: steps(1, end); }
+  37.5000% { transform: rotate(74.6101deg); animation-timing-function: steps(1, end); }
+  43.7500% { transform: rotate(78.8177deg); animation-timing-function: steps(1, end); }
+  50.0000% { transform: rotate(81.9586deg); animation-timing-function: steps(1, end); }
+  56.2500% { transform: rotate(78.8177deg); animation-timing-function: steps(1, end); }
+  62.5000% { transform: rotate(74.6101deg); animation-timing-function: steps(1, end); }
+  68.7500% { transform: rotate(69.3718deg); animation-timing-function: steps(1, end); }
+  75.0000% { transform: rotate(62.2303deg); animation-timing-function: steps(1, end); }
+  81.2500% { transform: rotate(52.5155deg); animation-timing-function: steps(1, end); }
+  87.5000% { transform: rotate(39.1293deg); animation-timing-function: steps(1, end); }
+  93.7500% { transform: rotate(18.0373deg); animation-timing-function: steps(1, end); }
+  100% { transform: rotate(0.0000deg); }
+}
+
+@keyframes armRG {
+  0.0000% { transform: rotate(-0.0000deg); animation-timing-function: steps(1, end); }
+  6.2500% { transform: rotate(-18.0373deg); animation-timing-function: steps(1, end); }
+  12.5000% { transform: rotate(-39.1293deg); animation-timing-function: steps(1, end); }
+  18.7500% { transform: rotate(-52.5155deg); animation-timing-function: steps(1, end); }
+  25.0000% { transform: rotate(-62.2303deg); animation-timing-function: steps(1, end); }
+  31.2500% { transform: rotate(-69.3718deg); animation-timing-function: steps(1, end); }
+  37.5000% { transform: rotate(-74.6101deg); animation-timing-function: steps(1, end); }
+  43.7500% { transform: rotate(-78.8177deg); animation-timing-function: steps(1, end); }
+  50.0000% { transform: rotate(-81.9586deg); animation-timing-function: steps(1, end); }
+  56.2500% { transform: rotate(-78.8177deg); animation-timing-function: steps(1, end); }
+  62.5000% { transform: rotate(-74.6101deg); animation-timing-function: steps(1, end); }
+  68.7500% { transform: rotate(-69.3718deg); animation-timing-function: steps(1, end); }
+  75.0000% { transform: rotate(-62.2303deg); animation-timing-function: steps(1, end); }
+  81.2500% { transform: rotate(-52.5155deg); animation-timing-function: steps(1, end); }
+  87.5000% { transform: rotate(-39.1293deg); animation-timing-function: steps(1, end); }
+  93.7500% { transform: rotate(-18.0373deg); animation-timing-function: steps(1, end); }
+  100% { transform: rotate(-0.0000deg); }
+}
+
+@keyframes sleeveG {
+  0.0000% { top: 200.000px; animation-timing-function: steps(1, end); }
+  6.2500% { top: 192.727px; animation-timing-function: steps(1, end); }
+  12.5000% { top: 166.807px; animation-timing-function: steps(1, end); }
+  18.7500% { top: 142.065px; animation-timing-function: steps(1, end); }
+  25.0000% { top: 120.956px; animation-timing-function: steps(1, end); }
+  31.2500% { top: 104.141px; animation-timing-function: steps(1, end); }
+  37.5000% { top: 91.277px; animation-timing-function: steps(1, end); }
+  43.7500% { top: 80.702px; animation-timing-function: steps(1, end); }
+  50.0000% { top: 72.704px; animation-timing-function: steps(1, end); }
+  56.2500% { top: 80.702px; animation-timing-function: steps(1, end); }
+  62.5000% { top: 91.277px; animation-timing-function: steps(1, end); }
+  68.7500% { top: 104.141px; animation-timing-function: steps(1, end); }
+  75.0000% { top: 120.956px; animation-timing-function: steps(1, end); }
+  81.2500% { top: 142.065px; animation-timing-function: steps(1, end); }
+  87.5000% { top: 166.807px; animation-timing-function: steps(1, end); }
+  93.7500% { top: 192.727px; animation-timing-function: steps(1, end); }
+  100% { top: 200.000px; }
+}
+
+@keyframes coneG {
+  0.0000% { top: 126.000px; animation-timing-function: steps(1, end); }
+  6.2500% { top: 122.363px; animation-timing-function: steps(1, end); }
+  12.5000% { top: 109.404px; animation-timing-function: steps(1, end); }
+  18.7500% { top: 97.033px; animation-timing-function: steps(1, end); }
+  25.0000% { top: 86.478px; animation-timing-function: steps(1, end); }
+  31.2500% { top: 78.070px; animation-timing-function: steps(1, end); }
+  37.5000% { top: 71.639px; animation-timing-function: steps(1, end); }
+  43.7500% { top: 66.351px; animation-timing-function: steps(1, end); }
+  50.0000% { top: 62.352px; animation-timing-function: steps(1, end); }
+  56.2500% { top: 66.351px; animation-timing-function: steps(1, end); }
+  62.5000% { top: 71.639px; animation-timing-function: steps(1, end); }
+  68.7500% { top: 78.070px; animation-timing-function: steps(1, end); }
+  75.0000% { top: 86.478px; animation-timing-function: steps(1, end); }
+  81.2500% { top: 97.033px; animation-timing-function: steps(1, end); }
+  87.5000% { top: 109.404px; animation-timing-function: steps(1, end); }
+  93.7500% { top: 122.363px; animation-timing-function: steps(1, end); }
+  100% { top: 126.000px; }
+}
+
+@keyframes coneLblG {
+  0.0000% { top: 114.000px; animation-timing-function: steps(1, end); }
+  6.2500% { top: 110.363px; animation-timing-function: steps(1, end); }
+  12.5000% { top: 97.404px; animation-timing-function: steps(1, end); }
+  18.7500% { top: 85.033px; animation-timing-function: steps(1, end); }
+  25.0000% { top: 74.478px; animation-timing-function: steps(1, end); }
+  31.2500% { top: 66.070px; animation-timing-function: steps(1, end); }
+  37.5000% { top: 59.639px; animation-timing-function: steps(1, end); }
+  43.7500% { top: 54.351px; animation-timing-function: steps(1, end); }
+  50.0000% { top: 50.352px; animation-timing-function: steps(1, end); }
+  56.2500% { top: 54.351px; animation-timing-function: steps(1, end); }
+  62.5000% { top: 59.639px; animation-timing-function: steps(1, end); }
+  68.7500% { top: 66.070px; animation-timing-function: steps(1, end); }
+  75.0000% { top: 74.478px; animation-timing-function: steps(1, end); }
+  81.2500% { top: 85.033px; animation-timing-function: steps(1, end); }
+  87.5000% { top: 97.404px; animation-timing-function: steps(1, end); }
+  93.7500% { top: 110.363px; animation-timing-function: steps(1, end); }
+  100% { top: 114.000px; }
+}
+
+@keyframes gateG {
+  0.0000% { height: 46.000px; animation-timing-function: steps(1, end); }
+  6.2500% { height: 43.372px; animation-timing-function: steps(1, end); }
+  12.5000% { height: 34.005px; animation-timing-function: steps(1, end); }
+  18.7500% { height: 25.065px; animation-timing-function: steps(1, end); }
+  25.0000% { height: 17.437px; animation-timing-function: steps(1, end); }
+  31.2500% { height: 11.360px; animation-timing-function: steps(1, end); }
+  37.5000% { height: 6.712px; animation-timing-function: steps(1, end); }
+  43.7500% { height: 2.890px; animation-timing-function: steps(1, end); }
+  50.0000% { height: 0.000px; animation-timing-function: steps(1, end); }
+  56.2500% { height: 2.890px; animation-timing-function: steps(1, end); }
+  62.5000% { height: 6.712px; animation-timing-function: steps(1, end); }
+  68.7500% { height: 11.360px; animation-timing-function: steps(1, end); }
+  75.0000% { height: 17.437px; animation-timing-function: steps(1, end); }
+  81.2500% { height: 25.065px; animation-timing-function: steps(1, end); }
+  87.5000% { height: 34.005px; animation-timing-function: steps(1, end); }
+  93.7500% { height: 43.372px; animation-timing-function: steps(1, end); }
+  100% { height: 46.000px; }
+}
+
+@keyframes linkLG {
+  0.0000% { top: 200.000px; transform: rotate(180.0000deg); animation-timing-function: steps(1, end); }
+  6.2500% { top: 192.727px; transform: rotate(161.9627deg); animation-timing-function: steps(1, end); }
+  12.5000% { top: 166.807px; transform: rotate(140.8707deg); animation-timing-function: steps(1, end); }
+  18.7500% { top: 142.065px; transform: rotate(127.4845deg); animation-timing-function: steps(1, end); }
+  25.0000% { top: 120.956px; transform: rotate(117.7697deg); animation-timing-function: steps(1, end); }
+  31.2500% { top: 104.141px; transform: rotate(110.6282deg); animation-timing-function: steps(1, end); }
+  37.5000% { top: 91.277px; transform: rotate(105.3899deg); animation-timing-function: steps(1, end); }
+  43.7500% { top: 80.702px; transform: rotate(101.1823deg); animation-timing-function: steps(1, end); }
+  50.0000% { top: 72.704px; transform: rotate(98.0414deg); animation-timing-function: steps(1, end); }
+  56.2500% { top: 80.702px; transform: rotate(101.1823deg); animation-timing-function: steps(1, end); }
+  62.5000% { top: 91.277px; transform: rotate(105.3899deg); animation-timing-function: steps(1, end); }
+  68.7500% { top: 104.141px; transform: rotate(110.6282deg); animation-timing-function: steps(1, end); }
+  75.0000% { top: 120.956px; transform: rotate(117.7697deg); animation-timing-function: steps(1, end); }
+  81.2500% { top: 142.065px; transform: rotate(127.4845deg); animation-timing-function: steps(1, end); }
+  87.5000% { top: 166.807px; transform: rotate(140.8707deg); animation-timing-function: steps(1, end); }
+  93.7500% { top: 192.727px; transform: rotate(161.9627deg); animation-timing-function: steps(1, end); }
+  100% { top: 200.000px; transform: rotate(180.0000deg); }
+}
+
+@keyframes linkRG {
+  0.0000% { top: 200.000px; transform: rotate(180.0000deg); animation-timing-function: steps(1, end); }
+  6.2500% { top: 192.727px; transform: rotate(198.0373deg); animation-timing-function: steps(1, end); }
+  12.5000% { top: 166.807px; transform: rotate(219.1293deg); animation-timing-function: steps(1, end); }
+  18.7500% { top: 142.065px; transform: rotate(232.5155deg); animation-timing-function: steps(1, end); }
+  25.0000% { top: 120.956px; transform: rotate(242.2303deg); animation-timing-function: steps(1, end); }
+  31.2500% { top: 104.141px; transform: rotate(249.3718deg); animation-timing-function: steps(1, end); }
+  37.5000% { top: 91.277px; transform: rotate(254.6101deg); animation-timing-function: steps(1, end); }
+  43.7500% { top: 80.702px; transform: rotate(258.8177deg); animation-timing-function: steps(1, end); }
+  50.0000% { top: 72.704px; transform: rotate(261.9586deg); animation-timing-function: steps(1, end); }
+  56.2500% { top: 80.702px; transform: rotate(258.8177deg); animation-timing-function: steps(1, end); }
+  62.5000% { top: 91.277px; transform: rotate(254.6101deg); animation-timing-function: steps(1, end); }
+  68.7500% { top: 104.141px; transform: rotate(249.3718deg); animation-timing-function: steps(1, end); }
+  75.0000% { top: 120.956px; transform: rotate(242.2303deg); animation-timing-function: steps(1, end); }
+  81.2500% { top: 142.065px; transform: rotate(232.5155deg); animation-timing-function: steps(1, end); }
+  87.5000% { top: 166.807px; transform: rotate(219.1293deg); animation-timing-function: steps(1, end); }
+  93.7500% { top: 192.727px; transform: rotate(198.0373deg); animation-timing-function: steps(1, end); }
+  100% { top: 200.000px; transform: rotate(180.0000deg); }
+}
+
+@keyframes stripG {
+  0.0000% { transform: translateY(0px); animation-timing-function: steps(1, end); }
+  6.2500% { transform: translateY(-20px); animation-timing-function: steps(1, end); }
+  12.5000% { transform: translateY(-40px); animation-timing-function: steps(1, end); }
+  18.7500% { transform: translateY(-60px); animation-timing-function: steps(1, end); }
+  25.0000% { transform: translateY(-80px); animation-timing-function: steps(1, end); }
+  31.2500% { transform: translateY(-100px); animation-timing-function: steps(1, end); }
+  37.5000% { transform: translateY(-120px); animation-timing-function: steps(1, end); }
+  43.7500% { transform: translateY(-140px); animation-timing-function: steps(1, end); }
+  50.0000% { transform: translateY(-160px); animation-timing-function: steps(1, end); }
+  56.2500% { transform: translateY(-140px); animation-timing-function: steps(1, end); }
+  62.5000% { transform: translateY(-120px); animation-timing-function: steps(1, end); }
+  68.7500% { transform: translateY(-100px); animation-timing-function: steps(1, end); }
+  75.0000% { transform: translateY(-80px); animation-timing-function: steps(1, end); }
+  81.2500% { transform: translateY(-60px); animation-timing-function: steps(1, end); }
+  87.5000% { transform: translateY(-40px); animation-timing-function: steps(1, end); }
+  93.7500% { transform: translateY(-20px); animation-timing-function: steps(1, end); }
+  100% { transform: translateY(0px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .armG,
+  .linkG,
+  .sleeveG,
+  .coneG,
+  .coneLbl,
+  .gateG,
+  .stripG { animation-play-state: paused; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/watt-governor-as/`, a self-contained pure CSS/HTML centrifugal governor whose balls swing out with speed, lifting a sleeve that closes the steam valve.

Closes #49680

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

Each ball is a conical pendulum, so gravity and arm tension must sum to the centripetal force, giving `cos(theta) = g / (omega^2 L)` and a cone height of `L cos(theta) = g / omega^2`. Neither the mass of the balls nor the length of the arms appears in that height, which is what makes the sleeve a measure of speed rather than of anything else. The sleeve works the throttle, so the engine holds its own speed.

Nine speeds from 40 to 146 rpm, stepped up and back down. Arm angle, both lower links, sleeve height, cone line and valve opening all run off the same 16 phase schedule with `steps(1, end)`, so no two can render states from different moments.

- **The browser re-derives the physics.** The check reads the rpm off the rendered readout, computes `acos(g / (omega^2 L))` from scratch and compares against the arm's measured rotation: worst disagreement over all 16 steps **0.0005 degrees**.
- **The cone height really is `g / omega^2`**, measured against the rendered dashed line at all **15** above-critical steps, worst error **0.0005 px**.
- **The sleeve is driven by that same geometry** rather than animated separately: measured position matches `2 L cos(theta)` to **0.0004 px**.
- **The arms are exactly mirrored** at every step, and **below the critical speed of 54.6 rpm both read exactly 0 degrees**, hanging dead straight as they must, since the law has no solution there.
- **The feedback runs the right way**: valve opening falls monotonically as speed rises, fully open at 40 rpm and fully shut at 146.

Both classic flaws of the device are visible: it is blind below the critical speed, and being purely proportional it settles at a slightly different speed for every load, the droop Maxwell analysed in **On Governors** (1868).

## Accessibility

`prefers-reduced-motion: reduce` freezes linkage, readout and valve together on one consistent speed.

## Verification

Opened `demo.html` in the browser and checked the linkage against the physics rather than against itself: read the rpm from the rendered readout, recomputed `acos(g / (omega^2 L))` independently and matched it to the measured arm rotation within 0.0005 degrees across all 16 steps, confirmed the cone height equals `g / omega^2` to 0.0005 px at every above-critical step, and confirmed the arms sit at exactly 0 degrees below the critical speed where the law has no solution. Also confirmed the valve closes monotonically as speed rises. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
