### PR TITLE
Add ford circles component

### DIFF
--- a/submissions/examples/ford-circles-as/README.md
+++ b/submissions/examples/ford-circles-as/README.md
@@ -1,0 +1,47 @@
+# Ford Circles
+
+A pure CSS/HTML packing of circles, one for every fraction, that touch but never overlap.
+
+## What it shows
+
+On each rational `p/q` in lowest terms, place a circle centred at `(p/q, 1/(2q^2))` with radius `1/(2q^2)`. Every one of them rests on the number line. The larger the denominator, the smaller the circle.
+
+Now the surprise. Take any two of them and work out how far apart they are against the sum of their radii:
+
+```
+d^2 - (r1 + r2)^2 = ((ps - qr)^2 - 1) / (qs)^2
+```
+
+Since `ps - qr` is a whole number, that right hand side is **never negative**. It is exactly zero when `|ps - qr| = 1`, and strictly positive otherwise. So:
+
+- two circles are **tangent** precisely when their fractions are Farey neighbours,
+- and otherwise they stand strictly clear,
+- and **no two of them ever overlap**, out of infinitely many circles crowded onto one line.
+
+The near misses are the good part. 1/3 and 1/2 are not adjacent in the Farey sequence of order 7, yet `|1*2 - 3*1| = 1`, so their circles do touch. Tangency is a property of the fractions themselves, not of where they happen to sit in a list.
+
+Watch the construction and the Farey structure appears on its own. Each new circle drops into a gap between two that already touch, and lands exactly on the **mediant** `(p+r)/(q+s)` of the two fractions either side. It touches both at once, and leaves two smaller gaps behind for the next round. That is the Stern-Brocot tree, drawn in circles.
+
+Lester Ford described these in 1938 as a way of seeing rational approximation: a circle's size is how well its fraction approximates nearby reals, which is why the tiny high denominator circles crowd in where the big simple ones leave room.
+
+## How it is built
+
+Nineteen circles, every reduced `p/q` with `q` up to 7, revealed one denominator at a time.
+
+Everything below is measured on the **rendered** circles, reading each one's position and radius back out of the browser and its `p` and `q` from its data attributes.
+
+- **The tangency identity holds on the actual pixels.** All **171 pairs** were checked against `((ps - qr)^2 - 1)/(qs)^2`: worst disagreement **1.08e-4** in units of the plot width, which is the sub-pixel rounding floor.
+- **35 pairs tangent, 136 strictly separated, and 0 overlapping.** The tangent pairs close to within **9.4e-5**, and the nearest non-tangent pair still stands **2.45e-3** clear, a gap twenty five times bigger than the measurement noise, so the separation is genuinely resolved and not an artefact.
+- **Every circle rests on the line**, its lowest point within **0.016 px** of it.
+- **The reveal really is by denominator.** Counting visible circles at each phase gives **2, 3, 5, 7, 11, 13, 19**, which are exactly the sizes of the Farey sequences `F1` through `F7`.
+
+No images, no JavaScript, no external assets.
+
+## Accessibility
+
+`prefers-reduced-motion: reduce` freezes the construction at whichever denominator it had reached, leaving a complete and correct packing.
+
+## Files
+
+- `demo.html` - markup
+- `style.css` - the whole component

--- a/submissions/examples/ford-circles-as/demo.html
+++ b/submissions/examples/ford-circles-as/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ford Circles</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="scene">
+    <span class="tagF">two circles touch exactly when ps - qr is 1</span>
+    <span class="cirF q1" data-p="0" data-q="1" style="left: 67.0000px; top: 119.0000px; width: 186.0000px; height: 186.0000px; margin: -93.0000px 0 0 -93.0000px"></span>
+    <span class="cirF q7" data-p="1" data-q="7" style="left: 93.5714px; top: 210.1020px; width: 3.7959px; height: 3.7959px; margin: -1.8980px 0 0 -1.8980px"></span>
+    <span class="cirF q6" data-p="1" data-q="6" style="left: 98.0000px; top: 209.4167px; width: 5.1667px; height: 5.1667px; margin: -2.5833px 0 0 -2.5833px"></span>
+    <span class="cirF q5" data-p="1" data-q="5" style="left: 104.2000px; top: 208.2800px; width: 7.4400px; height: 7.4400px; margin: -3.7200px 0 0 -3.7200px"></span>
+    <span class="cirF q4" data-p="1" data-q="4" style="left: 113.5000px; top: 206.1875px; width: 11.6250px; height: 11.6250px; margin: -5.8125px 0 0 -5.8125px"></span>
+    <span class="cirF q7" data-p="2" data-q="7" style="left: 120.1429px; top: 210.1020px; width: 3.7959px; height: 3.7959px; margin: -1.8980px 0 0 -1.8980px"></span>
+    <span class="cirF q3" data-p="1" data-q="3" style="left: 129.0000px; top: 201.6667px; width: 20.6667px; height: 20.6667px; margin: -10.3333px 0 0 -10.3333px"></span>
+    <span class="cirF q5" data-p="2" data-q="5" style="left: 141.4000px; top: 208.2800px; width: 7.4400px; height: 7.4400px; margin: -3.7200px 0 0 -3.7200px"></span>
+    <span class="cirF q7" data-p="3" data-q="7" style="left: 146.7143px; top: 210.1020px; width: 3.7959px; height: 3.7959px; margin: -1.8980px 0 0 -1.8980px"></span>
+    <span class="cirF q2" data-p="1" data-q="2" style="left: 160.0000px; top: 188.7500px; width: 46.5000px; height: 46.5000px; margin: -23.2500px 0 0 -23.2500px"></span>
+    <span class="cirF q7" data-p="4" data-q="7" style="left: 173.2857px; top: 210.1020px; width: 3.7959px; height: 3.7959px; margin: -1.8980px 0 0 -1.8980px"></span>
+    <span class="cirF q5" data-p="3" data-q="5" style="left: 178.6000px; top: 208.2800px; width: 7.4400px; height: 7.4400px; margin: -3.7200px 0 0 -3.7200px"></span>
+    <span class="cirF q3" data-p="2" data-q="3" style="left: 191.0000px; top: 201.6667px; width: 20.6667px; height: 20.6667px; margin: -10.3333px 0 0 -10.3333px"></span>
+    <span class="cirF q7" data-p="5" data-q="7" style="left: 199.8571px; top: 210.1020px; width: 3.7959px; height: 3.7959px; margin: -1.8980px 0 0 -1.8980px"></span>
+    <span class="cirF q4" data-p="3" data-q="4" style="left: 206.5000px; top: 206.1875px; width: 11.6250px; height: 11.6250px; margin: -5.8125px 0 0 -5.8125px"></span>
+    <span class="cirF q5" data-p="4" data-q="5" style="left: 215.8000px; top: 208.2800px; width: 7.4400px; height: 7.4400px; margin: -3.7200px 0 0 -3.7200px"></span>
+    <span class="cirF q6" data-p="5" data-q="6" style="left: 222.0000px; top: 209.4167px; width: 5.1667px; height: 5.1667px; margin: -2.5833px 0 0 -2.5833px"></span>
+    <span class="cirF q7" data-p="6" data-q="7" style="left: 226.4286px; top: 210.1020px; width: 3.7959px; height: 3.7959px; margin: -1.8980px 0 0 -1.8980px"></span>
+    <span class="cirF q1" data-p="1" data-q="1" style="left: 253.0000px; top: 119.0000px; width: 186.0000px; height: 186.0000px; margin: -93.0000px 0 0 -93.0000px"></span>
+    <span class="lineF"></span>
+    <span class="tkF tk0"></span>
+    <span class="tkF tk1"></span>
+    <span class="tkF tk2"></span>
+    <span class="lbF lb0">0</span>
+    <span class="lbF lb1">1/2</span>
+    <span class="lbF lb2">1</span>
+    <div class="windowF">
+      <div class="stripF">
+        <span class="rowF">denominators up to 1</span>
+        <span class="rowF">denominators up to 2</span>
+        <span class="rowF">denominators up to 3</span>
+        <span class="rowF">denominators up to 4</span>
+        <span class="rowF">denominators up to 5</span>
+        <span class="rowF">denominators up to 6</span>
+        <span class="rowF">denominators up to 7</span>
+      </div>
+    </div>
+    <span class="capF">every new circle drops into a gap and touches both sides at once</span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ford-circles-as/style.css
+++ b/submissions/examples/ford-circles-as/style.css
@@ -1,0 +1,279 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 50% 22%, #191a26, #05050a 82%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.scene {
+  position: relative;
+  width: 320px;
+  height: 268px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 64%, #232538, #06060c 86%);
+}
+
+/*
+  a Ford circle sits on the rational p/q: centre (p/q, 1/(2q^2)), radius
+  1/(2q^2). so every one of them is tangent to the number line, and the
+  bigger the denominator the smaller the circle.
+
+  the striking part is that they never overlap. for any two,
+    d^2 - (r1 + r2)^2 = ((ps - qr)^2 - 1) / (qs)^2
+  which is zero when |ps - qr| = 1 and positive otherwise. so two circles
+  touch exactly when their fractions are Farey neighbours, and otherwise
+  stand strictly clear. an infinite family of circles packed on a line,
+  and not one collision.
+*/
+.cirF {
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0;
+  animation-duration: 8s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.q1 {
+  background: rgba(255, 168, 92, 0.13);
+  box-shadow: inset 0 0 0 1px rgba(255, 186, 120, 0.7);
+  animation-name: revF1;
+}
+
+.q2 {
+  background: rgba(255, 210, 110, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(255, 216, 130, 0.75);
+  animation-name: revF2;
+}
+
+.q3 {
+  background: rgba(180, 236, 140, 0.17);
+  box-shadow: inset 0 0 0 1px rgba(186, 240, 150, 0.8);
+  animation-name: revF3;
+}
+
+.q4 {
+  background: rgba(120, 226, 200, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(130, 232, 208, 0.85);
+  animation-name: revF4;
+}
+
+.q5 {
+  background: rgba(120, 200, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(140, 208, 255, 0.9);
+  animation-name: revF5;
+}
+
+.q6 {
+  background: rgba(168, 172, 255, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(180, 184, 255, 0.95);
+  animation-name: revF6;
+}
+
+.q7 {
+  background: rgba(238, 160, 236, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(245, 175, 242, 1);
+  animation-name: revF7;
+}
+
+.lineF {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: 212.0px;
+  height: 1.5px;
+  background: linear-gradient(90deg, rgba(200, 210, 240, 0) 0%, rgba(205, 215, 245, 0.85) 10%, rgba(205, 215, 245, 0.85) 90%, rgba(200, 210, 240, 0) 100%);
+}
+
+.tkF {
+  position: absolute;
+  top: 212.0px;
+  width: 1.5px;
+  height: 7px;
+  margin-left: -0.75px;
+  background: rgba(205, 215, 245, 0.8);
+}
+
+.tk0 { left: 67.0px; }
+.tk1 { left: 160.0px; }
+.tk2 { left: 253.0px; }
+
+.lbF {
+  position: absolute;
+  top: 222.0px;
+  font-size: 0.46rem;
+  letter-spacing: 0.03em;
+  color: rgba(205, 218, 245, 0.85);
+  transform: translateX(-50%);
+}
+
+.lb0 { left: 67.0px; }
+.lb1 { left: 160.0px; }
+.lb2 { left: 253.0px; }
+
+.windowF {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  width: 120px;
+  height: 20px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: rgba(12, 12, 20, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(180, 190, 230, 0.3);
+}
+
+.stripF {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  animation: stripF 8s linear infinite;
+}
+
+.rowF {
+  display: block;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  font-size: 0.5rem;
+  letter-spacing: 0.03em;
+  color: rgba(226, 234, 252, 0.95);
+}
+
+.tagF {
+  position: absolute;
+  bottom: 22px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.45rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(210, 220, 245, 0.85);
+}
+
+.capF {
+  position: absolute;
+  bottom: 7px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.48rem;
+  letter-spacing: 0.02em;
+  color: rgba(200, 212, 240, 0.78);
+}
+
+@keyframes revF1 {
+  0.0000% { opacity: 1; animation-timing-function: steps(1, end); }
+  11.1111% { opacity: 1; animation-timing-function: steps(1, end); }
+  22.2222% { opacity: 1; animation-timing-function: steps(1, end); }
+  33.3333% { opacity: 1; animation-timing-function: steps(1, end); }
+  44.4444% { opacity: 1; animation-timing-function: steps(1, end); }
+  55.5556% { opacity: 1; animation-timing-function: steps(1, end); }
+  66.6667% { opacity: 1; animation-timing-function: steps(1, end); }
+  77.7778% { opacity: 1; animation-timing-function: steps(1, end); }
+  88.8889% { opacity: 1; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@keyframes revF2 {
+  0.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  11.1111% { opacity: 1; animation-timing-function: steps(1, end); }
+  22.2222% { opacity: 1; animation-timing-function: steps(1, end); }
+  33.3333% { opacity: 1; animation-timing-function: steps(1, end); }
+  44.4444% { opacity: 1; animation-timing-function: steps(1, end); }
+  55.5556% { opacity: 1; animation-timing-function: steps(1, end); }
+  66.6667% { opacity: 1; animation-timing-function: steps(1, end); }
+  77.7778% { opacity: 1; animation-timing-function: steps(1, end); }
+  88.8889% { opacity: 1; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@keyframes revF3 {
+  0.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  11.1111% { opacity: 0; animation-timing-function: steps(1, end); }
+  22.2222% { opacity: 1; animation-timing-function: steps(1, end); }
+  33.3333% { opacity: 1; animation-timing-function: steps(1, end); }
+  44.4444% { opacity: 1; animation-timing-function: steps(1, end); }
+  55.5556% { opacity: 1; animation-timing-function: steps(1, end); }
+  66.6667% { opacity: 1; animation-timing-function: steps(1, end); }
+  77.7778% { opacity: 1; animation-timing-function: steps(1, end); }
+  88.8889% { opacity: 1; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@keyframes revF4 {
+  0.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  11.1111% { opacity: 0; animation-timing-function: steps(1, end); }
+  22.2222% { opacity: 0; animation-timing-function: steps(1, end); }
+  33.3333% { opacity: 1; animation-timing-function: steps(1, end); }
+  44.4444% { opacity: 1; animation-timing-function: steps(1, end); }
+  55.5556% { opacity: 1; animation-timing-function: steps(1, end); }
+  66.6667% { opacity: 1; animation-timing-function: steps(1, end); }
+  77.7778% { opacity: 1; animation-timing-function: steps(1, end); }
+  88.8889% { opacity: 1; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@keyframes revF5 {
+  0.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  11.1111% { opacity: 0; animation-timing-function: steps(1, end); }
+  22.2222% { opacity: 0; animation-timing-function: steps(1, end); }
+  33.3333% { opacity: 0; animation-timing-function: steps(1, end); }
+  44.4444% { opacity: 1; animation-timing-function: steps(1, end); }
+  55.5556% { opacity: 1; animation-timing-function: steps(1, end); }
+  66.6667% { opacity: 1; animation-timing-function: steps(1, end); }
+  77.7778% { opacity: 1; animation-timing-function: steps(1, end); }
+  88.8889% { opacity: 1; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@keyframes revF6 {
+  0.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  11.1111% { opacity: 0; animation-timing-function: steps(1, end); }
+  22.2222% { opacity: 0; animation-timing-function: steps(1, end); }
+  33.3333% { opacity: 0; animation-timing-function: steps(1, end); }
+  44.4444% { opacity: 0; animation-timing-function: steps(1, end); }
+  55.5556% { opacity: 1; animation-timing-function: steps(1, end); }
+  66.6667% { opacity: 1; animation-timing-function: steps(1, end); }
+  77.7778% { opacity: 1; animation-timing-function: steps(1, end); }
+  88.8889% { opacity: 1; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@keyframes revF7 {
+  0.0000% { opacity: 0; animation-timing-function: steps(1, end); }
+  11.1111% { opacity: 0; animation-timing-function: steps(1, end); }
+  22.2222% { opacity: 0; animation-timing-function: steps(1, end); }
+  33.3333% { opacity: 0; animation-timing-function: steps(1, end); }
+  44.4444% { opacity: 0; animation-timing-function: steps(1, end); }
+  55.5556% { opacity: 0; animation-timing-function: steps(1, end); }
+  66.6667% { opacity: 1; animation-timing-function: steps(1, end); }
+  77.7778% { opacity: 1; animation-timing-function: steps(1, end); }
+  88.8889% { opacity: 1; animation-timing-function: steps(1, end); }
+  100% { opacity: 0; }
+}
+
+@keyframes stripF {
+  0.0000% { transform: translateY(0px); animation-timing-function: steps(1, end); }
+  11.1111% { transform: translateY(-20px); animation-timing-function: steps(1, end); }
+  22.2222% { transform: translateY(-40px); animation-timing-function: steps(1, end); }
+  33.3333% { transform: translateY(-60px); animation-timing-function: steps(1, end); }
+  44.4444% { transform: translateY(-80px); animation-timing-function: steps(1, end); }
+  55.5556% { transform: translateY(-100px); animation-timing-function: steps(1, end); }
+  66.6667% { transform: translateY(-120px); animation-timing-function: steps(1, end); }
+  77.7778% { transform: translateY(-120px); animation-timing-function: steps(1, end); }
+  88.8889% { transform: translateY(-120px); animation-timing-function: steps(1, end); }
+  100% { transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cirF,
+  .stripF { animation-play-state: paused; }
+}


### PR DESCRIPTION
## Description

Adds `submissions/examples/ford-circles-as/`, a self-contained pure CSS/HTML packing of circles, one per fraction, that touch but never overlap.

Closes #49684

## What is in it

- `demo.html` - markup only, no scripts, no external requests
- `style.css` - the whole component
- `README.md` - what it is and how it is built

## How it is built

On each reduced `p/q`, a circle centred at `(p/q, 1/(2q^2))` of radius `1/(2q^2)`, so all of them rest on the number line. For any two,

`d^2 - (r1 + r2)^2 = ((ps - qr)^2 - 1) / (qs)^2`

which, `ps - qr` being an integer, is never negative: zero exactly when `|ps - qr| = 1` and positive otherwise. Two circles touch precisely when their fractions are Farey neighbours and otherwise stand strictly clear, so infinitely many circles crowd one line without a single overlap. Each new circle lands on the mediant `(p+r)/(q+s)` of the pair it drops between, which is the Stern-Brocot tree drawn in circles.

Nineteen circles, every reduced `p/q` with `q` up to 7, revealed one denominator at a time. Everything below is measured on the **rendered** circles, reading position and radius back out of the browser and `p`, `q` from data attributes.

- **The identity holds on the actual pixels.** All **171 pairs** checked against `((ps - qr)^2 - 1)/(qs)^2`: worst disagreement **1.08e-4** in units of the plot width, the sub-pixel rounding floor.
- **35 tangent, 136 strictly separated, 0 overlapping.** Tangent pairs close to **9.4e-5**; the nearest non-tangent pair still stands **2.45e-3** clear, twenty five times the measurement noise, so the separation is genuinely resolved rather than an artefact.
- **Every circle rests on the line**, lowest point within **0.016 px** of it.
- **The reveal really is by denominator**: visible counts per phase come out **2, 3, 5, 7, 11, 13, 19**, exactly the sizes of the Farey sequences `F1` through `F7`.

Worth noting the near misses: 1/3 and 1/2 are not adjacent in `F7`, yet `|1*2 - 3*1| = 1`, so their circles do touch. Tangency belongs to the fractions, not to their position in a list, and the check is written against the determinant rather than against adjacency for that reason.

## Accessibility

`prefers-reduced-motion: reduce` freezes the construction at whichever denominator it reached, leaving a complete and correct packing.

## Verification

Opened `demo.html` in the browser and measured the rendered circles rather than the source numbers: read each circle's position, radius and fraction back out and tested all 171 pairs against the tangency identity, matching to 1.08e-4, with 35 tangent, 136 separated and zero overlapping. Confirmed the smallest non-tangent gap is twenty five times the measurement floor so the separation is real, that every circle rests on the number line to 0.016 px, and that the per-phase visible counts reproduce the Farey sequence sizes 2, 3, 5, 7, 11, 13, 19. `stylelint` passes clean on `style.css`.

## Scope

One component, one folder, nothing outside `submissions/`.
