### PR TITLE
Add CSS 3D Perspective Tilt Tooltip for Neumorphic Soft Layouts

### DIFF
--- a/submissions/examples/Add CSS 3D Perspective Tilt Tooltip for Neumorphic Soft Layouts #46319/README.md
+++ b/submissions/examples/Add CSS 3D Perspective Tilt Tooltip for Neumorphic Soft Layouts #46319/README.md
@@ -1,0 +1,28 @@
+# CSS 3D Perspective Tilt Tooltip (Neumorphic Soft Aesthetics)
+
+This example demonstrates how to create a highly polished, pure CSS animated Tooltip featuring a 3D Perspective Tilt interaction transition. 
+
+## Features
+- **Pure CSS**: Fully functional interactivity and 3D transforms without JavaScript.
+- **3D Perspective Tilt Transition**: The tooltip is anchored in a 3D space (`perspective`) and rotates along the X-axis (`rotateX`) while translating upwards. This mimics a physical panel flipping open, enhancing the tactile feel of the Neumorphic design.
+- **Modern CSS APIs**: Uses `allow-discrete` and `@starting-style` to gracefully animate the tooltip from `display: none` to `display: block` upon hover or focus.
+- **Neumorphic Soft Aesthetics**: Incorporates the popular "soft UI" design paradigm using dual drop shadows (one light, one dark) to create extruded and debossed elements on a low-contrast background.
+- **Fully Customizable**: Timing, easing curves, perspective depths, and rotation angles are all exposed via well-documented CSS Custom Properties (Variables).
+
+## Custom Properties Configuration
+You can tweak the 3D physics and animation speeds via these exposed CSS custom properties:
+```css
+:root {
+  --tooltip-duration: 0.4s;
+  --tooltip-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275); /* Slight bounce */
+  --tooltip-perspective: 800px;
+  --tooltip-start-rotateX: -25deg;
+  --tooltip-start-translateY: 15px;
+  --tooltip-start-opacity: 0;
+}
+```
+
+## Browser Support
+This demo uses modern CSS features. For the full experience, it relies on:
+- **CSS `@starting-style` & `allow-discrete`** (Supported in Chrome 117+, Edge 117+, Firefox 129+, Safari 17.4+)
+- **CSS 3D Transforms** (Baseline Support across all modern browsers)

--- a/submissions/examples/Add CSS 3D Perspective Tilt Tooltip for Neumorphic Soft Layouts #46319/demo.html
+++ b/submissions/examples/Add CSS 3D Perspective Tilt Tooltip for Neumorphic Soft Layouts #46319/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 3D Perspective Tilt Tooltip - Neumorphic Soft</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="neumorphic-layout">
+    
+    <div class="control-panel">
+      <h2>Smart Home</h2>
+      <p class="subtitle">Living Room</p>
+      
+      <div class="controls-grid">
+        
+        <!-- Tooltip Container 1 -->
+        <div class="tooltip-container">
+          <button class="neu-btn active" aria-label="Lighting Controls" aria-describedby="tooltip-light">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+          </button>
+          
+          <div id="tooltip-light" class="tooltip neu-panel" role="tooltip">
+            <div class="tooltip-content">
+              <strong>Main Lights</strong>
+              <div class="status-row">
+                <span>Status</span>
+                <span class="active-text">ON</span>
+              </div>
+              <div class="status-row">
+                <span>Intensity</span>
+                <span>85%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Tooltip Container 2 -->
+        <div class="tooltip-container">
+          <button class="neu-btn" aria-label="Thermostat Controls" aria-describedby="tooltip-temp">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/></svg>
+          </button>
+          
+          <div id="tooltip-temp" class="tooltip neu-panel" role="tooltip">
+            <div class="tooltip-content">
+              <strong>Thermostat</strong>
+              <div class="status-row">
+                <span>Current</span>
+                <span>72°F</span>
+              </div>
+              <div class="status-row">
+                <span>Target</span>
+                <span>68°F</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        <!-- Tooltip Container 3 -->
+        <div class="tooltip-container">
+          <button class="neu-btn" aria-label="Security Controls" aria-describedby="tooltip-lock">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          </button>
+          
+          <div id="tooltip-lock" class="tooltip neu-panel" role="tooltip">
+            <div class="tooltip-content">
+              <strong>Front Door</strong>
+              <div class="status-row">
+                <span>Lock</span>
+                <span>Secured</span>
+              </div>
+              <div class="status-row">
+                <span>Alarm</span>
+                <span class="active-text">Armed</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/Add CSS 3D Perspective Tilt Tooltip for Neumorphic Soft Layouts #46319/style.css
+++ b/submissions/examples/Add CSS 3D Perspective Tilt Tooltip for Neumorphic Soft Layouts #46319/style.css
@@ -1,0 +1,206 @@
+:root {
+  /* --- Tooltip Custom Properties --- */
+  --tooltip-duration: 0.4s;
+  --tooltip-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  --tooltip-perspective: 800px;
+  --tooltip-start-rotateX: -25deg;
+  --tooltip-start-translateY: 15px;
+  --tooltip-start-opacity: 0;
+  
+  /* Neumorphic Theme Properties */
+  --color-bg: #e0e5ec;
+  --color-text: #4a5568;
+  --color-text-muted: #a0aec0;
+  --color-accent: #4299e1;
+  
+  /* Neumorphic Shadows */
+  --shadow-light: #ffffff;
+  --shadow-dark: #a3b1c6;
+  
+  --neu-shadow-flat: 
+    9px 9px 16px rgba(163, 177, 198, 0.6), 
+    -9px -9px 16px rgba(255, 255, 255, 0.5);
+    
+  --neu-shadow-pressed: 
+    inset 6px 6px 10px rgba(163, 177, 198, 0.6), 
+    inset -6px -6px 10px rgba(255, 255, 255, 0.5);
+    
+  --neu-shadow-tooltip: 
+    12px 12px 24px rgba(163, 177, 198, 0.7), 
+    -12px -12px 24px rgba(255, 255, 255, 0.8);
+}
+
+body {
+  margin: 0;
+  font-family: 'Quicksand', sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  -webkit-font-smoothing: antialiased;
+}
+
+.neumorphic-layout {
+  padding: 2rem;
+}
+
+.control-panel {
+  background: var(--color-bg);
+  border-radius: 30px;
+  padding: 40px;
+  box-shadow: var(--neu-shadow-flat);
+  width: 300px;
+  text-align: center;
+}
+
+.control-panel h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #2d3748;
+}
+
+.subtitle {
+  margin: 4px 0 32px 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.controls-grid {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+
+/* --- TOOLTIP TRIGGER --- */
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+  perspective: var(--tooltip-perspective); /* Establish 3D space */
+}
+
+.neu-btn {
+  background: var(--color-bg);
+  border: none;
+  color: var(--color-text-muted);
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: var(--neu-shadow-flat);
+  transition: all 0.2s ease;
+}
+
+.neu-btn.active {
+  color: var(--color-accent);
+}
+
+.neu-btn:hover, .neu-btn:focus-visible {
+  color: var(--color-accent);
+  outline: none;
+}
+
+.neu-btn:active {
+  box-shadow: var(--neu-shadow-pressed);
+  transform: scale(0.95);
+}
+
+/* --- TOOLTIP CORE STYLES --- */
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 20px);
+  left: 50%;
+  width: max-content;
+  min-width: 160px;
+  z-index: 100;
+  pointer-events: none; /* Ignore pointer events */
+  
+  /* Neumorphic Styling */
+  background: var(--color-bg);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: var(--neu-shadow-tooltip);
+  
+  /* 3D Perspective Tilt Initial State */
+  display: none;
+  opacity: var(--tooltip-start-opacity);
+  transform: translateX(-50%) translateY(var(--tooltip-start-translateY)) rotateX(var(--tooltip-start-rotateX));
+  transform-origin: bottom center; /* Tilt from the bottom edge */
+  
+  /* Smooth transitions */
+  transition: opacity var(--tooltip-duration) var(--tooltip-easing),
+              transform var(--tooltip-duration) var(--tooltip-easing),
+              display var(--tooltip-duration) var(--tooltip-easing) allow-discrete;
+}
+
+/* Tooltip connector (Neumorphic) */
+.tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 20px;
+  background: var(--color-bg);
+  box-shadow: 
+    2px 2px 5px rgba(163, 177, 198, 0.4), 
+    -2px -2px 5px rgba(255, 255, 255, 0.4);
+  z-index: -1;
+}
+
+/* Show Tooltip on Hover/Focus */
+.tooltip-container:hover .tooltip,
+.tooltip-container:focus-within .tooltip {
+  display: block;
+  opacity: 1;
+  transform: translateX(-50%) translateY(0) rotateX(0deg);
+}
+
+/* Entry Animation Initial Styles (Container) */
+@starting-style {
+  .tooltip-container:hover .tooltip,
+  .tooltip-container:focus-within .tooltip {
+    opacity: var(--tooltip-start-opacity);
+    transform: translateX(-50%) translateY(var(--tooltip-start-translateY)) rotateX(var(--tooltip-start-rotateX));
+  }
+}
+
+/* --- TOOLTIP INTERNAL UI --- */
+.tooltip-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: left;
+}
+
+.tooltip-content strong {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #2d3748;
+  border-bottom: 2px solid rgba(163, 177, 198, 0.2);
+  padding-bottom: 8px;
+  text-align: center;
+}
+
+.status-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  font-weight: 600;
+  gap: 20px;
+}
+
+.status-row span:first-child {
+  color: var(--color-text-muted);
+}
+
+.active-text {
+  color: var(--color-accent);
+}


### PR DESCRIPTION
#46319

## Pull Request Description

<!-- Briefly describe what you're submitting and the problem it solves. -->
- Implements the 3D Perspective Tilt transition (rotateX(-25deg) to 0deg). This creates the illusion that the tooltip panel is physically swinging upward to face the user. To complement the Neumorphic "soft UI" aesthetics, it utilizes heavily rounded corners, low-contrast grayish-blue backgrounds, and dual drop shadows (a light top-left shadow and a dark bottom-right shadow) to create the extruded and debossed button effects
- Resolves #46319 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---



## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
