### PR TITLE
Add responsive Markdown editor with live preview (markdown-editor-hru…

### DIFF
--- a/submissions/examples/markdown-editor-hruthika18/README.md
+++ b/submissions/examples/markdown-editor-hruthika18/README.md
@@ -1,0 +1,112 @@
+# Markdown Editor (`ease-md-editor`)
+
+A responsive markdown editor with a formatting toolbar, live preview, and
+dark mode — built in plain HTML/CSS/vanilla JS with no external
+dependencies (no markdown library, no build step).
+
+## What it does
+
+- **Formatting toolbar**: Bold, Italic, Heading, Quote, Inline code, Link,
+  Bulleted list — each wraps or prefixes the current textarea selection.
+- **Live preview**: The right pane re-renders on every keystroke using a
+  small built-in markdown-to-HTML converter (headings, bold/italic, inline
+  code, links, blockquotes, bulleted lists, paragraphs).
+- **View switching**: `Split` / `Edit` / `Preview` buttons toggle which
+  pane(s) are visible — useful on narrow screens where side-by-side isn't
+  practical.
+- **Responsive layout**: Side-by-side panes on desktop; below 640px the
+  editor shows one pane at a time based on the active view mode.
+- **Dark mode**: A toggle button switches the whole editor's theme via a
+  `data-ease-md-theme` attribute and CSS custom properties — no page
+  reload, no separate stylesheet.
+- **Smooth transitions**: Pane backgrounds, toolbar, and buttons transition
+  on theme/view changes; disabled automatically under
+  `prefers-reduced-motion: reduce`.
+
+## Usage
+
+Include all three files and initialize automatically — no manual JS setup
+required, the script auto-discovers any `[data-ease-md-editor]` element on
+the page:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="ease-md-editor" data-ease-md-editor>
+  <div class="ease-md-editor__toolbar" role="toolbar" aria-label="Formatting toolbar">
+    <button type="button" class="ease-md-editor__btn" data-md-action="bold">B</button>
+    <button type="button" class="ease-md-editor__btn" data-md-action="italic">I</button>
+    <button type="button" class="ease-md-editor__btn" data-md-action="heading">H</button>
+    <button type="button" class="ease-md-editor__btn" data-md-action="quote">"</button>
+    <button type="button" class="ease-md-editor__btn" data-md-action="code">&lt;/&gt;</button>
+    <button type="button" class="ease-md-editor__btn" data-md-action="link">Link</button>
+    <button type="button" class="ease-md-editor__btn" data-md-action="list">List</button>
+
+    <span class="ease-md-editor__spacer"></span>
+
+    <button type="button" class="ease-md-editor__btn ease-md-editor__btn--view" data-md-view="split" aria-pressed="true">Split</button>
+    <button type="button" class="ease-md-editor__btn ease-md-editor__btn--view" data-md-view="edit" aria-pressed="false">Edit</button>
+    <button type="button" class="ease-md-editor__btn ease-md-editor__btn--view" data-md-view="preview" aria-pressed="false">Preview</button>
+
+    <button type="button" class="ease-md-editor__btn ease-md-editor__btn--theme" data-md-theme-toggle>&#9789;</button>
+  </div>
+
+  <div class="ease-md-editor__body" data-md-body>
+    <textarea class="ease-md-editor__pane ease-md-editor__pane--input" data-md-input spellcheck="false"></textarea>
+    <div class="ease-md-editor__pane ease-md-editor__pane--preview" data-md-preview></div>
+  </div>
+</div>
+
+<script src="script.js"></script>
+```
+
+### Configuration via CSS custom properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-md-radius` | `12px` | Outer border radius |
+| `--ease-md-height` | `420px` | Height of the editor body |
+| `--ease-md-transition` | `0.25s ease` | Transition speed for theme/view changes |
+| `--ease-md-accent` | `#5b6cff` (light) / `#8b98ff` (dark) | Link color, active toolbar button, focus ring |
+
+Override on `.ease-md-editor` to retheme or resize an instance:
+
+```css
+.ease-md-editor {
+  --ease-md-height: 600px;
+  --ease-md-accent: #e0526b;
+}
+```
+
+### Markdown subset supported
+
+`#`, `##`, `###` headings · `**bold**` · `*italic*` · `` `inline code` ``
+· `[text](url)` links · `> blockquote` · `- ` / `* ` bulleted lists ·
+paragraphs. This is intentionally a small, dependency-free subset rather
+than full CommonMark — enough for docs snippets, comments, and notes.
+
+## Why it fits EaseMotion CSS
+
+It's a larger, self-contained UI pattern (toolbar + dual-pane layout +
+theme toggle) that's still zero-dependency and framework-agnostic — same
+philosophy as the framework's smaller components, just assembled into a
+complete editor. Markdown editors are a common need in docs sites, blogs,
+and internal tools, and this gives EaseMotion CSS users a drop-in option
+instead of reaching for a heavier third-party editor library.
+
+## Accessibility notes
+
+- Toolbar uses `role="toolbar"` with `aria-label`, and each button has an
+  `aria-label` / `title`.
+- View-mode buttons expose their state via `aria-pressed`.
+- The theme toggle and all formatting buttons are standard `<button>`
+  elements, so they're keyboard-operable and focusable by default; visible
+  focus rings are provided via `:focus-visible`.
+- Links generated in the preview open with `rel="noopener noreferrer"`.
+
+## Browser support
+
+Uses standard CSS custom properties, CSS Grid, `:focus-visible`, and
+`data-*` attribute selectors, plus vanilla JS (`textarea` selection APIs,
+`classList`/`dataset`) — no vendor prefixes needed for current evergreen
+browsers (Chrome, Edge, Firefox, Safari).

--- a/submissions/examples/markdown-editor-hruthika18/demo.html
+++ b/submissions/examples/markdown-editor-hruthika18/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-markdown-editor — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>ease-markdown-editor</h1>
+    <p>A responsive markdown editor with live preview, formatting toolbar, and dark mode — pure HTML/CSS/vanilla JS, zero dependencies.</p>
+  </header>
+
+  <main class="demo-wrap">
+
+    <div class="ease-md-editor" data-ease-md-editor>
+
+      <div class="ease-md-editor__toolbar" role="toolbar" aria-label="Formatting toolbar">
+        <button type="button" class="ease-md-editor__btn" data-md-action="bold" title="Bold" aria-label="Bold"><strong>B</strong></button>
+        <button type="button" class="ease-md-editor__btn" data-md-action="italic" title="Italic" aria-label="Italic"><em>I</em></button>
+        <button type="button" class="ease-md-editor__btn" data-md-action="heading" title="Heading" aria-label="Heading">H</button>
+        <button type="button" class="ease-md-editor__btn" data-md-action="quote" title="Quote" aria-label="Quote">&ldquo;</button>
+        <button type="button" class="ease-md-editor__btn" data-md-action="code" title="Inline code" aria-label="Inline code">&lt;/&gt;</button>
+        <button type="button" class="ease-md-editor__btn" data-md-action="link" title="Link" aria-label="Insert link">&#128279;</button>
+        <button type="button" class="ease-md-editor__btn" data-md-action="list" title="Bulleted list" aria-label="Bulleted list">&#8226; &#8226;</button>
+
+        <span class="ease-md-editor__spacer"></span>
+
+        <button type="button" class="ease-md-editor__btn ease-md-editor__btn--view" data-md-view="split" aria-pressed="true">Split</button>
+        <button type="button" class="ease-md-editor__btn ease-md-editor__btn--view" data-md-view="edit" aria-pressed="false">Edit</button>
+        <button type="button" class="ease-md-editor__btn ease-md-editor__btn--view" data-md-view="preview" aria-pressed="false">Preview</button>
+
+        <button type="button" class="ease-md-editor__btn ease-md-editor__btn--theme" data-md-theme-toggle title="Toggle dark mode" aria-label="Toggle dark mode">&#9789;</button>
+      </div>
+
+      <div class="ease-md-editor__body" data-md-body>
+        <textarea
+          class="ease-md-editor__pane ease-md-editor__pane--input"
+          data-md-input
+          spellcheck="false"
+          aria-label="Markdown source"
+        ># Welcome to ease-markdown-editor
+
+Type **markdown** on the left, see it rendered on the *right*.
+
+## Features
+- Formatting toolbar (bold, italic, heading, quote, code, link, list)
+- Live preview, updated as you type
+- Responsive: side-by-side on desktop, switchable tabs on mobile
+- Dark mode toggle
+
+> Try editing this text, or use the toolbar buttons above.
+
+Inline `code` and [links](https://example.com) are supported too.
+</textarea>
+        <div
+          class="ease-md-editor__pane ease-md-editor__pane--preview"
+          data-md-preview
+          aria-label="Rendered preview"
+        ></div>
+      </div>
+
+    </div>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Resize your browser window to see the responsive layout switch to stacked tabs on narrow screens.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/markdown-editor-hruthika18/script.js
+++ b/submissions/examples/markdown-editor-hruthika18/script.js
@@ -1,0 +1,169 @@
+/* ==========================================================================
+   ease-md-editor — behavior
+   Vanilla JS, no dependencies. Handles: live preview rendering (lightweight
+   markdown subset), toolbar formatting actions, view mode switching, and
+   dark mode toggling.
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  /**
+   * Very small markdown-to-HTML converter covering the subset used by the
+   * toolbar: headings, bold, italic, inline code, links, blockquotes,
+   * bulleted lists, and paragraphs. Not a full CommonMark implementation —
+   * intentionally minimal to stay dependency-free.
+   */
+  function renderMarkdown(src) {
+    const escapeHtml = (str) =>
+      str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+
+    const lines = src.split("\n");
+    const html = [];
+    let inList = false;
+
+    const closeList = () => {
+      if (inList) {
+        html.push("</ul>");
+        inList = false;
+      }
+    };
+
+    const inlineFormat = (text) =>
+      escapeHtml(text)
+        .replace(/`([^`]+)`/g, "<code>$1</code>")
+        .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+        .replace(/\*([^*]+)\*/g, "<em>$1</em>")
+        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+
+    lines.forEach((rawLine) => {
+      const line = rawLine.trimEnd();
+
+      if (/^###\s+/.test(line)) {
+        closeList();
+        html.push(`<h3>${inlineFormat(line.replace(/^###\s+/, ""))}</h3>`);
+      } else if (/^##\s+/.test(line)) {
+        closeList();
+        html.push(`<h2>${inlineFormat(line.replace(/^##\s+/, ""))}</h2>`);
+      } else if (/^#\s+/.test(line)) {
+        closeList();
+        html.push(`<h1>${inlineFormat(line.replace(/^#\s+/, ""))}</h1>`);
+      } else if (/^>\s?/.test(line)) {
+        closeList();
+        html.push(`<blockquote>${inlineFormat(line.replace(/^>\s?/, ""))}</blockquote>`);
+      } else if (/^[-*]\s+/.test(line)) {
+        if (!inList) {
+          html.push("<ul>");
+          inList = true;
+        }
+        html.push(`<li>${inlineFormat(line.replace(/^[-*]\s+/, ""))}</li>`);
+      } else if (line.trim() === "") {
+        closeList();
+      } else {
+        closeList();
+        html.push(`<p>${inlineFormat(line)}</p>`);
+      }
+    });
+
+    closeList();
+    return html.join("\n");
+  }
+
+  /** Wraps or inserts syntax around the current textarea selection. */
+  function applyInlineFormat(textarea, before, after, placeholder) {
+    const { selectionStart, selectionEnd, value } = textarea;
+    const selected = value.slice(selectionStart, selectionEnd) || placeholder;
+    const next =
+      value.slice(0, selectionStart) + before + selected + after + value.slice(selectionEnd);
+
+    textarea.value = next;
+    const cursorStart = selectionStart + before.length;
+    textarea.setSelectionRange(cursorStart, cursorStart + selected.length);
+    textarea.focus();
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  /** Prefixes the current line (or each selected line) with a marker. */
+  function applyLinePrefix(textarea, prefix) {
+    const { selectionStart, selectionEnd, value } = textarea;
+    const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+    let lineEnd = value.indexOf("\n", selectionEnd);
+    if (lineEnd === -1) lineEnd = value.length;
+
+    const block = value.slice(lineStart, lineEnd);
+    const updated = block
+      .split("\n")
+      .map((line) => (line.startsWith(prefix) ? line : prefix + line))
+      .join("\n");
+
+    textarea.value = value.slice(0, lineStart) + updated + value.slice(lineEnd);
+    textarea.focus();
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  function initEditor(root) {
+    const textarea = root.querySelector("[data-md-input]");
+    const preview = root.querySelector("[data-md-preview]");
+    const toolbar = root.querySelector(".ease-md-editor__toolbar");
+
+    const update = () => {
+      preview.innerHTML = renderMarkdown(textarea.value);
+    };
+
+    textarea.addEventListener("input", update);
+    update();
+
+    toolbar.addEventListener("click", (event) => {
+      const btn = event.target.closest("button");
+      if (!btn) return;
+
+      const action = btn.dataset.mdAction;
+      const view = btn.dataset.mdView;
+
+      if (action) {
+        switch (action) {
+          case "bold":
+            applyInlineFormat(textarea, "**", "**", "bold text");
+            break;
+          case "italic":
+            applyInlineFormat(textarea, "*", "*", "italic text");
+            break;
+          case "code":
+            applyInlineFormat(textarea, "`", "`", "code");
+            break;
+          case "link":
+            applyInlineFormat(textarea, "[", "](https://)", "link text");
+            break;
+          case "heading":
+            applyLinePrefix(textarea, "## ");
+            break;
+          case "quote":
+            applyLinePrefix(textarea, "> ");
+            break;
+          case "list":
+            applyLinePrefix(textarea, "- ");
+            break;
+        }
+        return;
+      }
+
+      if (view) {
+        root.setAttribute("data-ease-md-view", view);
+        toolbar.querySelectorAll("[data-md-view]").forEach((b) => {
+          b.setAttribute("aria-pressed", String(b === btn));
+        });
+        return;
+      }
+
+      if (btn.hasAttribute("data-md-theme-toggle")) {
+        const isDark = root.getAttribute("data-ease-md-theme") === "dark";
+        root.setAttribute("data-ease-md-theme", isDark ? "light" : "dark");
+      }
+    });
+  }
+
+  document.querySelectorAll("[data-ease-md-editor]").forEach(initEditor);
+})();

--- a/submissions/examples/markdown-editor-hruthika18/style.css
+++ b/submissions/examples/markdown-editor-hruthika18/style.css
@@ -1,0 +1,250 @@
+/* ==========================================================================
+   ease-md-editor — Responsive Markdown Editor with Live Preview
+   Pure CSS layout/theme, paired with a small vanilla-JS behavior file.
+   ========================================================================== */
+
+.ease-md-editor {
+  /* Public configuration */
+  --ease-md-radius: 12px;
+  --ease-md-gap: 1px;
+  --ease-md-transition: 0.25s ease;
+  --ease-md-height: 420px;
+
+  /* Light theme (default) */
+  --ease-md-bg: #ffffff;
+  --ease-md-bg-alt: #f6f7fa;
+  --ease-md-fg: #1c2028;
+  --ease-md-fg-muted: #6b7280;
+  --ease-md-border: #e2e5eb;
+  --ease-md-accent: #5b6cff;
+  --ease-md-code-bg: #eef0f6;
+  --ease-md-quote-border: #c7cbe8;
+
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ease-md-border);
+  border-radius: var(--ease-md-radius);
+  overflow: hidden;
+  background: var(--ease-md-border);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ease-md-fg);
+  transition: background var(--ease-md-transition), border-color var(--ease-md-transition);
+}
+
+/* Dark theme, toggled via [data-ease-md-theme="dark"] on the root element */
+.ease-md-editor[data-ease-md-theme="dark"] {
+  --ease-md-bg: #171a21;
+  --ease-md-bg-alt: #1e222b;
+  --ease-md-fg: #e7e9ee;
+  --ease-md-fg-muted: #9aa1b5;
+  --ease-md-border: #2b303c;
+  --ease-md-accent: #8b98ff;
+  --ease-md-code-bg: #232838;
+  --ease-md-quote-border: #3a4058;
+}
+
+/* ---- Toolbar ---- */
+
+.ease-md-editor__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px;
+  background: var(--ease-md-bg-alt);
+  border-bottom: 1px solid var(--ease-md-border);
+  flex-wrap: wrap;
+  transition: background var(--ease-md-transition), border-color var(--ease-md-transition);
+}
+
+.ease-md-editor__spacer {
+  flex: 1;
+}
+
+.ease-md-editor__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ease-md-fg);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background var(--ease-md-transition), border-color var(--ease-md-transition), transform 0.15s ease;
+}
+
+.ease-md-editor__btn:hover {
+  background: var(--ease-md-bg);
+  border-color: var(--ease-md-border);
+}
+
+.ease-md-editor__btn:active {
+  transform: scale(0.94);
+}
+
+.ease-md-editor__btn:focus-visible {
+  outline: 2px solid var(--ease-md-accent);
+  outline-offset: 1px;
+}
+
+.ease-md-editor__btn--view[aria-pressed="true"] {
+  background: var(--ease-md-accent);
+  border-color: var(--ease-md-accent);
+  color: #fff;
+}
+
+.ease-md-editor__btn--theme {
+  font-size: 1rem;
+}
+
+/* ---- Body / panes ---- */
+
+.ease-md-editor__body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ease-md-gap);
+  background: var(--ease-md-border);
+  height: var(--ease-md-height);
+  transition: background var(--ease-md-transition);
+}
+
+.ease-md-editor__pane {
+  background: var(--ease-md-bg);
+  padding: 16px 18px;
+  overflow-y: auto;
+  transition: background var(--ease-md-transition), color var(--ease-md-transition), opacity var(--ease-md-transition);
+}
+
+.ease-md-editor__pane--input {
+  border: none;
+  resize: none;
+  outline: none;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--ease-md-fg);
+}
+
+.ease-md-editor__pane--input::placeholder {
+  color: var(--ease-md-fg-muted);
+}
+
+.ease-md-editor__pane--preview {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--ease-md-fg);
+}
+
+.ease-md-editor__pane--preview h1,
+.ease-md-editor__pane--preview h2,
+.ease-md-editor__pane--preview h3 {
+  margin: 0 0 0.5em;
+  line-height: 1.3;
+}
+
+.ease-md-editor__pane--preview p {
+  margin: 0 0 1em;
+}
+
+.ease-md-editor__pane--preview ul {
+  margin: 0 0 1em;
+  padding-left: 1.4em;
+}
+
+.ease-md-editor__pane--preview blockquote {
+  margin: 0 0 1em;
+  padding: 0.4em 1em;
+  border-left: 3px solid var(--ease-md-quote-border);
+  color: var(--ease-md-fg-muted);
+}
+
+.ease-md-editor__pane--preview code {
+  background: var(--ease-md-code-bg);
+  padding: 0.15em 0.4em;
+  border-radius: 5px;
+  font-size: 0.85em;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.ease-md-editor__pane--preview a {
+  color: var(--ease-md-accent);
+}
+
+/* ---- View mode: edit-only / preview-only (mainly for mobile tabs) ---- */
+
+.ease-md-editor[data-ease-md-view="edit"] .ease-md-editor__pane--preview,
+.ease-md-editor[data-ease-md-view="preview"] .ease-md-editor__pane--input {
+  display: none;
+}
+
+.ease-md-editor[data-ease-md-view="edit"] .ease-md-editor__body,
+.ease-md-editor[data-ease-md-view="preview"] .ease-md-editor__body {
+  grid-template-columns: 1fr;
+}
+
+/* ---- Responsive: stack into tabs below 640px ---- */
+
+@media (max-width: 640px) {
+  .ease-md-editor__body {
+    grid-template-columns: 1fr;
+  }
+
+  /* On narrow screens, only the active view's pane shows.
+     Default view is "split" -> show input, hide preview, so
+     the layout doesn't try to render two full-height panes stacked. */
+  .ease-md-editor:not([data-ease-md-view="preview"]) .ease-md-editor__pane--preview {
+    display: none;
+  }
+  .ease-md-editor[data-ease-md-view="preview"] .ease-md-editor__pane--input {
+    display: none;
+  }
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-md-editor,
+  .ease-md-editor__toolbar,
+  .ease-md-editor__body,
+  .ease-md-editor__pane,
+  .ease-md-editor__btn {
+    transition: none !important;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #eef0f5;
+  color: #1c2028;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 720px;
+  margin: 0 auto 32px;
+  text-align: center;
+}
+.demo-header p {
+  color: #5b6270;
+}
+
+.demo-wrap {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.demo-footer {
+  max-width: 720px;
+  margin: 32px auto 0;
+  text-align: center;
+  color: #6b7286;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-md-editor`, a responsive markdown editor with a formatting
toolbar (bold, italic, heading, quote, inline code, link, bulleted list),
live preview, Split/Edit/Preview view modes, and a dark mode toggle. The
preview renders via a small built-in markdown-to-HTML subset (no external
markdown library) with HTML-escaping to avoid unsafe injection from typed
content. Layout is a CSS Grid dual-pane on desktop that collapses to a
single active pane on screens under 640px. Theming is CSS-custom-property
driven; motion is disabled under `prefers-reduced-motion`.

Resolves #49546

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/markdown-editor-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `script.js` — vanilla JS behavior (toolbar actions, live preview, view/theme toggles)
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A drop-in responsive markdown editor: toolbar + live preview + dark mode,
zero external dependencies.

**How does a developer use it?**
Include `style.css` and `script.js`, drop in the markup with
`data-ease-md-editor` on the wrapper — the script auto-initializes every
instance on the page, no manual JS setup required.

**Why does it fit EaseMotion CSS?**
Same zero-dependency, framework-agnostic philosophy as the framework's
smaller components, assembled into a complete, commonly-needed UI pattern
for docs sites and internal tools.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Markdown support is intentionally a small subset (headings, bold/italic,
inline code, links, blockquotes, bulleted lists, paragraphs) rather than
full CommonMark, to keep this dependency-free. All output is HTML-escaped
before markdown syntax is applied, so typed content can't inject raw HTML
into the preview pane.