### PR TITLE
Add draggable before/after image comparison slider (before-after-slid…

### DIFF
--- a/submissions/examples/before-after-slider-hruthika18/README.md
+++ b/submissions/examples/before-after-slider-hruthika18/README.md
@@ -1,0 +1,103 @@
+# Before/After Image Slider (`ease-ba-slider`)
+
+A draggable image comparison slider — mouse drag, touch drag, click-to-jump,
+and keyboard arrow-key control — built in plain HTML/CSS/vanilla JS with no
+external dependencies.
+
+## What it does
+
+- **Draggable divider**: drag the circular handle (or click/tap anywhere
+  on the image) to reveal more of the "before" or "after" image.
+- **Touch support**: `touchstart`/`touchmove` handlers mirror the mouse
+  behavior, with `touch-action: pan-y` so vertical page scroll still works
+  on mobile.
+- **Keyboard accessible**: the slider is a focusable `role="slider"` with
+  `aria-valuemin`/`aria-valuemax`/`aria-valuenow`; arrow keys move it in
+  5% steps, `Home`/`End` jump to the extremes.
+- **Smooth animation**: position changes transition smoothly (disabled
+  automatically under `prefers-reduced-motion: reduce`).
+- **Responsive layout**: the slider scales to its container width at a
+  fixed `aspect-ratio`, and recalculates on window resize.
+- **Optional labels**: "Before"/"After" pill labels in the corners, which
+  fade out automatically as the handle approaches that edge so they never
+  overlap it.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div
+  class="ease-ba-slider"
+  data-ease-ba-slider
+  role="slider"
+  tabindex="0"
+  aria-label="Before and after image comparison"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  aria-valuenow="50"
+>
+  <img class="ease-ba-slider__img ease-ba-slider__img--before" src="before.jpg" alt="Before" draggable="false" />
+
+  <div class="ease-ba-slider__after-wrap" data-ease-ba-after-wrap>
+    <img class="ease-ba-slider__img ease-ba-slider__img--after" src="after.jpg" alt="After" draggable="false" />
+  </div>
+
+  <span class="ease-ba-slider__label ease-ba-slider__label--before">Before</span>
+  <span class="ease-ba-slider__label ease-ba-slider__label--after">After</span>
+
+  <div class="ease-ba-slider__handle" data-ease-ba-handle>
+    <span class="ease-ba-slider__handle-grip">&#10094;&#10095;</span>
+  </div>
+</div>
+
+<script src="script.js"></script>
+```
+
+Swap `before.jpg`/`after.jpg` for your own images — they should be the
+same dimensions so the comparison lines up. (The demo ships with two
+generated placeholder SVGs, `before.svg` and `after.svg`, instead of real
+photos.)
+
+### Configuration via CSS custom properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-ba-radius` | `14px` | Corner radius of the whole slider |
+| `--ease-ba-handle-size` | `44px` | Diameter of the drag handle |
+| `--ease-ba-line-width` | `3px` | Width of the divider line |
+| `--ease-ba-accent` | `#ffffff` | Divider line and handle color |
+| `--ease-ba-transition` | `0.15s ease` | Transition speed for position changes |
+
+```css
+.ease-ba-slider {
+  --ease-ba-accent: #ffb347;
+  --ease-ba-handle-size: 56px;
+}
+```
+
+## How it works
+
+The "after" image sits in a wrapper (`.ease-ba-slider__after-wrap`) that's
+clipped to a percentage width driven by a `--ease-ba-position` CSS custom
+property, which JS updates on drag/touch/keyboard input. Because the wrap
+is narrower than the slider, its inner `<img>` is explicitly re-widened to
+the slider's full pixel width (via `--ease-ba-slider-width`, also set by
+JS) so the image doesn't visually squash as the clip narrows.
+
+## Accessibility notes
+
+- The slider root uses `role="slider"` with the standard `aria-value*`
+  triad, kept in sync as the position changes.
+- Fully keyboard-operable: `Tab` to focus, arrow keys to adjust, `Home`/
+  `End` for the extremes.
+- Images use `draggable="false"` so native browser image-drag doesn't
+  fight with the custom drag behavior.
+- Motion is suppressed under `prefers-reduced-motion: reduce`.
+
+## Browser support
+
+Uses standard CSS custom properties, `aspect-ratio`, `object-fit`,
+`:focus-visible`, and vanilla JS pointer/touch/keyboard events — no vendor
+prefixes needed for current evergreen browsers (Chrome, Edge, Firefox,
+Safari).

--- a/submissions/examples/before-after-slider-hruthika18/after.svg
+++ b/submissions/examples/before-after-slider-hruthika18/after.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="skyAfter" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="55%" stop-color="#ffb84d"/>
+      <stop offset="100%" stop-color="#ffe08a"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#skyAfter)"/>
+  <circle cx="640" cy="110" r="55" fill="#fff4d6"/>
+  <polygon points="0,500 220,260 340,420 460,220 620,420 800,300 800,500" fill="#2f6f5e"/>
+  <polygon points="0,500 180,340 320,440 480,320 650,460 800,380 800,500" fill="#1f4f43"/>
+  <rect x="0" y="470" width="800" height="30" fill="#173a31"/>
+</svg>

--- a/submissions/examples/before-after-slider-hruthika18/before.svg
+++ b/submissions/examples/before-after-slider-hruthika18/before.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="skyBefore" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8a8f99"/>
+      <stop offset="100%" stop-color="#c7cad1"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#skyBefore)"/>
+  <circle cx="640" cy="110" r="55" fill="#e7e9ee"/>
+  <polygon points="0,500 220,260 340,420 460,220 620,420 800,300 800,500" fill="#6d7178"/>
+  <polygon points="0,500 180,340 320,440 480,320 650,460 800,380 800,500" fill="#54575d"/>
+  <rect x="0" y="470" width="800" height="30" fill="#3f4146"/>
+</svg>

--- a/submissions/examples/before-after-slider-hruthika18/demo.html
+++ b/submissions/examples/before-after-slider-hruthika18/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-before-after-slider — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>ease-before-after-slider</h1>
+    <p>A draggable image comparison slider — mouse, touch, and keyboard all supported. Two placeholder SVGs stand in for real before/after photos below.</p>
+  </header>
+
+  <main class="demo-wrap">
+
+    <div
+      class="ease-ba-slider"
+      data-ease-ba-slider
+      role="slider"
+      tabindex="0"
+      aria-label="Before and after image comparison"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow="50"
+    >
+      <img class="ease-ba-slider__img ease-ba-slider__img--before" src="before.svg" alt="Before" draggable="false" />
+
+      <div class="ease-ba-slider__after-wrap" data-ease-ba-after-wrap>
+        <img class="ease-ba-slider__img ease-ba-slider__img--after" src="after.svg" alt="After" draggable="false" />
+      </div>
+
+      <span class="ease-ba-slider__label ease-ba-slider__label--before">Before</span>
+      <span class="ease-ba-slider__label ease-ba-slider__label--after">After</span>
+
+      <div class="ease-ba-slider__handle" data-ease-ba-handle>
+        <span class="ease-ba-slider__handle-grip">&#10094;&#10095;</span>
+      </div>
+    </div>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Drag the handle, tap/swipe on touch devices, or focus the slider and use the <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> arrow keys.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/before-after-slider-hruthika18/script.js
+++ b/submissions/examples/before-after-slider-hruthika18/script.js
@@ -1,0 +1,112 @@
+/* ==========================================================================
+   ease-ba-slider — behavior
+   Vanilla JS, no dependencies. Handles mouse drag, touch drag, click-to-jump,
+   and keyboard (arrow key) control of the comparison position.
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  function initSlider(root) {
+    const handle = root.querySelector("[data-ease-ba-handle]");
+    const afterWrap = root.querySelector("[data-ease-ba-after-wrap]");
+    let dragging = false;
+
+    function setPosition(percent) {
+      const clamped = Math.min(100, Math.max(0, percent));
+      const rect = root.getBoundingClientRect();
+
+      root.style.setProperty("--ease-ba-position", clamped + "%");
+      root.style.setProperty("--ease-ba-slider-width", rect.width + "px");
+      root.setAttribute("aria-valuenow", Math.round(clamped));
+
+      if (clamped <= 6) {
+        root.setAttribute("data-ease-ba-near", "before");
+      } else if (clamped >= 94) {
+        root.setAttribute("data-ease-ba-near", "after");
+      } else {
+        root.removeAttribute("data-ease-ba-near");
+      }
+    }
+
+    function percentFromClientX(clientX) {
+      const rect = root.getBoundingClientRect();
+      const x = clientX - rect.left;
+      return (x / rect.width) * 100;
+    }
+
+    function onPointerMove(clientX) {
+      setPosition(percentFromClientX(clientX));
+    }
+
+    // Mouse drag
+    handle.addEventListener("mousedown", (e) => {
+      dragging = true;
+      e.preventDefault();
+    });
+
+    root.addEventListener("mousedown", (e) => {
+      // Clicking anywhere on the slider jumps to that position, then allows dragging
+      dragging = true;
+      onPointerMove(e.clientX);
+    });
+
+    window.addEventListener("mousemove", (e) => {
+      if (dragging) onPointerMove(e.clientX);
+    });
+
+    window.addEventListener("mouseup", () => {
+      dragging = false;
+    });
+
+    // Touch drag
+    root.addEventListener(
+      "touchstart",
+      (e) => {
+        dragging = true;
+        onPointerMove(e.touches[0].clientX);
+      },
+      { passive: true }
+    );
+
+    root.addEventListener(
+      "touchmove",
+      (e) => {
+        if (dragging) onPointerMove(e.touches[0].clientX);
+      },
+      { passive: true }
+    );
+
+    root.addEventListener("touchend", () => {
+      dragging = false;
+    });
+
+    // Keyboard control
+    root.addEventListener("keydown", (e) => {
+      const current = parseFloat(root.getAttribute("aria-valuenow")) || 50;
+      if (e.key === "ArrowLeft") {
+        setPosition(current - 5);
+        e.preventDefault();
+      } else if (e.key === "ArrowRight") {
+        setPosition(current + 5);
+        e.preventDefault();
+      } else if (e.key === "Home") {
+        setPosition(0);
+        e.preventDefault();
+      } else if (e.key === "End") {
+        setPosition(100);
+        e.preventDefault();
+      }
+    });
+
+    // Keep the "after" image sized correctly if the slider resizes
+    window.addEventListener("resize", () => {
+      const current = parseFloat(root.getAttribute("aria-valuenow")) || 50;
+      setPosition(current);
+    });
+
+    setPosition(50);
+  }
+
+  document.querySelectorAll("[data-ease-ba-slider]").forEach(initSlider);
+})();

--- a/submissions/examples/before-after-slider-hruthika18/style.css
+++ b/submissions/examples/before-after-slider-hruthika18/style.css
@@ -1,0 +1,181 @@
+/* ==========================================================================
+   ease-ba-slider — Before/After Image Comparison Slider
+   Pure CSS layout/visuals, paired with a small vanilla-JS drag handler.
+   ========================================================================== */
+
+.ease-ba-slider {
+  /* Public configuration */
+  --ease-ba-radius: 14px;
+  --ease-ba-handle-size: 44px;
+  --ease-ba-line-width: 3px;
+  --ease-ba-accent: #ffffff;
+  --ease-ba-transition: 0.15s ease;
+  --ease-ba-position: 50%; /* driven by JS as the slider moves */
+
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  aspect-ratio: 8 / 5;
+  margin: 0 auto;
+  overflow: hidden;
+  border-radius: var(--ease-ba-radius);
+  cursor: ew-resize;
+  user-select: none;
+  touch-action: pan-y;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+}
+
+.ease-ba-slider:focus-visible {
+  outline: 3px solid #5b6cff;
+  outline-offset: 3px;
+}
+
+.ease-ba-slider__img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+
+.ease-ba-slider__img--before {
+  z-index: 1;
+}
+
+/* The "after" image is revealed by clipping its wrapper to the slider position */
+.ease-ba-slider__after-wrap {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  width: var(--ease-ba-position);
+  overflow: hidden;
+  transition: width var(--ease-ba-transition);
+}
+
+.ease-ba-slider__after-wrap .ease-ba-slider__img {
+  width: var(--ease-ba-slider-width, 100%);
+}
+
+/* Because the wrapper is clipped, size the inner image to the slider's full
+   width (set inline by JS as --ease-ba-slider-width) so it doesn't squash. */
+
+.ease-ba-slider__handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--ease-ba-position);
+  z-index: 3;
+  width: var(--ease-ba-line-width);
+  background: var(--ease-ba-accent);
+  transform: translateX(-50%);
+  transition: left var(--ease-ba-transition);
+  pointer-events: none;
+}
+
+.ease-ba-slider__handle::before,
+.ease-ba-slider__handle::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  width: 200vmax;
+  height: 0;
+}
+
+.ease-ba-slider__handle-grip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: var(--ease-ba-handle-size);
+  height: var(--ease-ba-handle-size);
+  border-radius: 50%;
+  background: var(--ease-ba-accent);
+  color: #1c2028;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+}
+
+.ease-ba-slider__label {
+  position: absolute;
+  top: 14px;
+  z-index: 4;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 0.78rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0.5px;
+  pointer-events: none;
+  transition: opacity var(--ease-ba-transition);
+}
+
+.ease-ba-slider__label--before {
+  left: 14px;
+}
+
+.ease-ba-slider__label--after {
+  right: 14px;
+}
+
+/* Fade labels out near their own edge so they don't overlap the handle */
+.ease-ba-slider[data-ease-ba-near="before"] .ease-ba-slider__label--before,
+.ease-ba-slider[data-ease-ba-near="after"] .ease-ba-slider__label--after {
+  opacity: 0;
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-ba-slider__after-wrap,
+  .ease-ba-slider__handle,
+  .ease-ba-slider__label {
+    transition: none !important;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #11141c;
+  color: #e6e9f2;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 640px;
+  margin: 0 auto 32px;
+  text-align: center;
+}
+.demo-header p {
+  color: #9aa1b5;
+}
+
+.demo-wrap {
+  padding: 0 8px;
+}
+
+.demo-footer {
+  max-width: 640px;
+  margin: 32px auto 0;
+  text-align: center;
+  color: #6b7286;
+  font-size: 0.85rem;
+}
+.demo-footer kbd {
+  background: #232838;
+  border: 1px solid #333a4f;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-ba-slider`, a draggable before/after image comparison slider.
Drag the handle, tap/swipe on touch devices, click anywhere to jump, or
use arrow keys / Home / End while focused. The "after" image is revealed
via a clipped wrapper driven by a `--ease-ba-position` custom property,
with the inner image re-widened via `--ease-ba-slider-width` so it doesn't
distort as the clip narrows. Includes optional Before/After corner labels
that fade near their own edge, full `aria-slider` semantics, and
`prefers-reduced-motion` support.

Resolves #49542

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/before-after-slider-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Includes `script.js` — vanilla JS for drag/touch/keyboard handling
- [x] Includes `before.svg` / `after.svg` — placeholder demo images (generated, not real photos)
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable draggable image comparison slider for before/after use cases —
photography, design showcases, AI-generated image comparisons, renovation
before/afters, product demos.

**How does a developer use it?**
Drop in the markup with `data-ease-ba-slider` on the root and swap in your
own `before`/`after` images of matching dimensions; the script
auto-initializes every instance on the page.

**Why does it fit EaseMotion CSS?**
Self-contained, dependency-free, class-based API consistent with the
framework's other components. Fills a commonly requested gap — image
comparison sliders are widely used across portfolio and product sites and
currently require reaching for a third-party library.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Demo images are generated placeholder SVGs, not real photographs, to keep
the submission dependency-free and avoid any licensing questions. Swap in
real before/after photos of matching dimensions for production use.