### PR TITLE
feat: add progressive base64 blurhash image component (React)

### DIFF
--- a/submissions/react/ease-blurhash-viidhii19/EaseImage.jsx
+++ b/submissions/react/ease-blurhash-viidhii19/EaseImage.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import './style.css';
+
+export const EaseImage = ({ src, placeholder, alt, className = '' }) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  return (
+    <div className={`ease-progressive-wrapper-viidhii19 ${className}`}>
+      <img
+        src={placeholder}
+        alt={alt ? `${alt} placeholder` : ''}
+        className="ease-placeholder-img-viidhii19"
+        aria-hidden="true"
+      />
+      {src && (
+        <img
+          src={src}
+          alt={alt}
+          className={`ease-highres-img-viidhii19 ${isLoaded ? 'ease-fade-in' : ''}`}
+          onLoad={() => setIsLoaded(true)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default EaseImage;

--- a/submissions/react/ease-blurhash-viidhii19/README.md
+++ b/submissions/react/ease-blurhash-viidhii19/README.md
@@ -1,0 +1,45 @@
+# Progressive Image Loader (ease-blurhash-viidhii19)
+
+A zero-dependency React component optimized to prevent Cumulative Layout Shift (CLS) and maximize perceived load speed using heavily blurred base64 placeholders that smoothly crossfade into high-res images.
+
+## Features
+- **Zero Dependencies**: Relies purely on native React `img` `onLoad` events and `useState`.
+- **CLS Prevention**: Absolute positioning and CSS object-fit maintain the container aspect ratio, ensuring the layout doesn't shift when the high-res image resolves.
+- **EaseMotion Integration**: Utilizes EaseMotion's `ease-fade-in` CSS utility for a hardware-accelerated, smooth crossfade transition.
+
+## Usage
+
+```jsx
+import { EaseImage } from './EaseImage';
+
+const App = () => {
+  const placeholder = 'data:image/jpeg;base64,...';
+  const url = 'https://images.unsplash.com/photo-1682687220063...';
+
+  return (
+    <div style={{ width: '400px', height: '300px' }}>
+      <EaseImage 
+        src={url} 
+        placeholder={placeholder} 
+        alt="Beautiful landscape" 
+        className="my-custom-class"
+      />
+    </div>
+  );
+};
+```
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `src` | `string` | The URL of the high-res image to load. |
+| `placeholder` | `string` | The base64 or BlurHash string encoded as a data URI to use as the blurry placeholder. |
+| `alt` | `string` | Alt text for accessibility. |
+| `className` | `string` | Optional CSS class to apply to the wrapper. |
+
+## How it Works
+1. An outer wrapper `div` creates a positioning context.
+2. The `placeholder` image is rendered instantly, stretched to cover the container, with a heavy `blur(20px)` and `scale(1.1)` CSS filter to aggressively smooth out artifacts.
+3. The actual high-res `img` is overlaid absolutely with an initial opacity of `0`.
+4. Once the high-res `img` triggers its native `onLoad` event, it is conditionally assigned EaseMotion's `ease-fade-in` class, which triggers the CSS crossfade animation directly over the blurred canvas placeholder.

--- a/submissions/react/ease-blurhash-viidhii19/demo.html
+++ b/submissions/react/ease-blurhash-viidhii19/demo.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Progressive Image Loader Demo</title>
+  
+  <!-- Import style.css -->
+  <link rel="stylesheet" href="style.css">
+  
+  <!-- Mock EaseMotion CDN for standalone demo -->
+  <style>
+    .ease-fade-in {
+      animation: easeFadeIn 1s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    }
+    @keyframes easeFadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+  </style>
+
+  <!-- Import React 18 and Babel -->
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <style>
+    /* Aesthetic demo styling */
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: #09090b;
+      color: #fafafa;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+    }
+    .demo-container {
+      width: 100%;
+      max-width: 600px;
+      aspect-ratio: 16 / 9;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 20px 40px -10px rgba(0,0,0,0.5);
+      border: 1px solid #27272a;
+      margin-bottom: 2rem;
+      background: #18181b;
+    }
+    .controls {
+      display: flex;
+      gap: 1rem;
+    }
+    button {
+      background: #3b82f6;
+      color: #fff;
+      border: none;
+      padding: 12px 24px;
+      border-radius: 8px;
+      font-weight: 600;
+      cursor: pointer;
+      font-size: 1rem;
+      transition: all 0.2s;
+    }
+    button:hover {
+      background: #2563eb;
+      transform: translateY(-1px);
+    }
+    button:active {
+      transform: translateY(1px);
+    }
+    h2 {
+      margin-bottom: 0.5rem;
+      background: linear-gradient(to right, #60a5fa, #c084fc);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    p {
+      color: #a1a1aa;
+      margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    // Inline EaseImage for standalone demo environment (avoids file:// CORS on JSX import)
+    const EaseImage = ({ src, placeholder, alt, className = '' }) => {
+      const [isLoaded, setIsLoaded] = useState(false);
+
+      useEffect(() => {
+        setIsLoaded(false);
+      }, [src]);
+
+      return (
+        <div className={`ease-progressive-wrapper-viidhii19 ${className}`}>
+          <img
+            src={placeholder}
+            alt={alt ? `${alt} placeholder` : ''}
+            className="ease-placeholder-img-viidhii19"
+            aria-hidden="true"
+          />
+          {src && (
+            <img
+              src={src}
+              alt={alt}
+              className={`ease-highres-img-viidhii19 ${isLoaded ? 'ease-fade-in' : ''}`}
+              onLoad={() => setIsLoaded(true)}
+            />
+          )}
+        </div>
+      );
+    };
+
+    const App = () => {
+      const [imgSrc, setImgSrc] = useState(null);
+      
+      // Extremely compressed base64 placeholder
+      const placeholderBase64 = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/4gIcSUNDX1BST0ZJTEUAAQEAAAIMbGNtcwIQAABtbnRyUkdCIFhZWiAH3AABABkAAwApADlhY3NwQVBQTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLWxjbXMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApkZXNjAAAA/AAAAF5jcHJ0AAABXAAAAAt3dHB0AAABaAAAABRia3B0AAABfAAAABRyWFlaAAABkAAAABRnWFlaAAABpAAAABRiWFlaAAABuAAAABRyVFJDAAABzAAAAEBnVFJDAAABzAAAAEBiVFJDAAABzAAAAEBkZXNjAAAAAAAAAANjMgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0ZXh0AAAAAElYAABYWVogAAAAAAAA9tYAAQAAAADTLVhZWiAAAAAAAAAD2AAAMAAAAAABW1hZWiAAAAAAAABvoAAA6QAAAOpYWVogAAAAAAAAb6AAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9jdXJ2AAAAAAAAABoAAADLAckBqwPAA/8AAEQgAAgADAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A+rNMsI9Yk1S91C4vDN/aFzCqxXcsSokcjKqhUYAAD2oorRRS2RzTm+Z6n//Z';
+      const highResUrl = 'https://images.unsplash.com/photo-1682687220063-4742bd7fd538?q=80&w=1200&auto=format&fit=crop';
+
+      const simulateNetwork = () => {
+        setImgSrc(null); // Clear first to show placeholder
+        setTimeout(() => {
+          setImgSrc(highResUrl);
+        }, 1500); // 1.5s simulated network delay
+      };
+
+      useEffect(() => {
+        simulateNetwork();
+      }, []);
+
+      return (
+        <div style={{ textAlign: 'center', width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <h2>EaseImage Component</h2>
+          <p>Progressive Base64 Placeholder &rarr; High-Res Crossfade</p>
+          
+          <div className="demo-container">
+            <EaseImage 
+              src={imgSrc} 
+              placeholder={placeholderBase64}
+              alt="Mountain landscape"
+            />
+          </div>
+
+          <div className="controls">
+            <button onClick={simulateNetwork}>
+              Simulate Network Delay
+            </button>
+          </div>
+        </div>
+      );
+    };
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
+</body>
+</html>

--- a/submissions/react/ease-blurhash-viidhii19/style.css
+++ b/submissions/react/ease-blurhash-viidhii19/style.css
@@ -1,0 +1,30 @@
+.ease-progressive-wrapper-viidhii19 {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.ease-progressive-wrapper-viidhii19 .ease-placeholder-img-viidhii19 {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(20px);
+  transform: scale(1.1);
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
+
+.ease-progressive-wrapper-viidhii19 .ease-highres-img-viidhii19 {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  opacity: 0;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #48879 by introducing `<EaseImage>`, a zero-dependency React component optimized to prevent Cumulative Layout Shift (CLS). It leverages absolute positioning and native `onLoad` events to instantly display a heavily blurred base64 placeholder. Once the network request for the actual image completes, it utilizes EaseMotion's `ease-fade-in` utility for a hardware-accelerated, smooth crossfade transition.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A React image component that seamlessly transitions from an ultra-lightweight blurry placeholder to a high-resolution image without causing layout shifts.

**How does a developer use it?**

```jsx
import { EaseImage } from './EaseImage';

// Inside your React component:
<EaseImage 
  src="https://images.unsplash.com/photo-1682687220063..." 
  placeholder="data:image/jpeg;base64,/9j/4AAQSk..." 
  alt="Beautiful landscape" 
  className="my-custom-wrapper-class"
/>

```
**Why does it fit EaseMotion CSS?**

It perfectly complements EaseMotion's human-readable, animation-first philosophy by replacing the jarring "pop-in" effect of standard network images with a premium, smooth transition powered entirely by the framework's existing ease-fade-in CSS utility.

---

## Demo

- [X] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Since this addresses a React track issue, the submission folder (submissions/react/ease-blurhash-viidhii19/) contains EaseImage.jsx in addition to the standard demo.html, style.css, and README.md required by the validators. The class names have also been properly suffixed with -viidhii19 to avoid any global CSS conflicts as per the contribution guidelines.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
