### PR TITLE
Add neumorphic CSS Blur-Entrance Popover (neumorphic-blur-popover-hru…

### DIFF
--- a/submissions/examples/neumorphic-blur-popover-hruthika18/README.md
+++ b/submissions/examples/neumorphic-blur-popover-hruthika18/README.md
@@ -1,0 +1,114 @@
+# Neumorphic Blur-Entrance Popover (`ease-neu-blur-pop`)
+
+A pure CSS popover/tooltip component that resolves in from a soft blur —
+styled specifically for neumorphic ("soft UI") surfaces, where the trigger
+and bubble both use dual-direction soft shadows on a low-contrast surface
+color rather than a hard-edged card. Zero JavaScript.
+
+## What it does
+
+- Reveals a small popover on **hover or keyboard focus**.
+- Entrance combines a `filter: blur()` fade-in with a short rise, so the
+  bubble resolves from soft to sharp.
+- The trigger itself is neumorphic: an extruded soft-shadow circle at
+  rest, which presses into an inset shadow on hover/focus — reinforcing
+  the "soft UI" tactile feel rather than using a flat hover background.
+- Fully keyboard accessible: the trigger is focusable (`tabindex="0"`),
+  the popover opens on `:focus` / `:focus-within`, and there's a visible
+  `:focus-visible` outline.
+- Respects `prefers-reduced-motion`: blur and movement are removed in
+  favor of a simple opacity fade.
+- Configurable via CSS custom properties, including the neumorphic
+  surface and shadow colors — so it can be retinted to match any soft-UI
+  palette without touching the source rules.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<span class="ease-neu-blur-pop" tabindex="0" aria-describedby="pop-1">
+  ⓘ
+  <span class="ease-neu-blur-pop__bubble" id="pop-1" role="tooltip">
+    Your popover content goes here.
+  </span>
+</span>
+```
+
+### Placement variants
+
+```html
+<!-- default: opens above the trigger -->
+<span class="ease-neu-blur-pop">...</span>
+
+<!-- opens below the trigger -->
+<span class="ease-neu-blur-pop ease-neu-blur-pop--top">...</span>
+
+<!-- opens to the right of the trigger -->
+<span class="ease-neu-blur-pop ease-neu-blur-pop--right">...</span>
+```
+
+### Custom timing / blur amount per instance
+
+```html
+<span
+  class="ease-neu-blur-pop"
+  style="--ease-neu-blur-duration: 0.5s; --ease-neu-blur-amount: 10px;"
+>
+  ...
+</span>
+```
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-neu-blur-duration` | `0.32s` | Length of the open/close transition |
+| `--ease-neu-blur-easing` | `ease-out` | Easing curve for the transition |
+| `--ease-neu-blur-amount` | `6px` | Starting blur radius before it resolves to `0` |
+| `--ease-neu-blur-rise` | `6px` | Starting offset before the bubble settles into place |
+| `--ease-neu-blur-gap` | `12px` | Space between the trigger and the bubble |
+| `--ease-neu-surface` | `#e6e9f0` | Shared surface color for the trigger and bubble |
+| `--ease-neu-fg` | `#3a3f52` | Bubble text color |
+| `--ease-neu-accent` | `#6c7bff` | Trigger icon / focus outline color |
+| `--ease-neu-shadow-light` | `#ffffff` | Light-side neumorphic shadow color |
+| `--ease-neu-shadow-dark` | `#b9bfd1` | Dark-side neumorphic shadow color |
+
+To retint for a different soft-UI palette, override the surface and
+shadow pair together so the extrusion effect stays convincing:
+
+```css
+.ease-neu-blur-pop {
+  --ease-neu-surface: #2a2f3d;
+  --ease-neu-shadow-light: #3a4055;
+  --ease-neu-shadow-dark: #1a1e28;
+  --ease-neu-fg: #e2e5ee;
+}
+```
+
+## Why it fits EaseMotion CSS
+
+It's a self-contained, dependency-free animated component consistent with
+the framework's existing patterns: class-based API (`ease-neu-blur-pop`),
+configuration via CSS custom properties, a documented reduced-motion
+fallback, and no required JavaScript. It gives the popover family a
+dedicated neumorphic treatment — the dual-shadow surface and press-in
+hover state aren't just a color swap, they change how the trigger itself
+behaves, which regular flat-UI popovers don't need.
+
+## Accessibility notes
+
+- The trigger uses `tabindex="0"` so it's reachable by keyboard.
+- `aria-describedby` links the trigger to the bubble's `id`, and the
+  bubble carries `role="tooltip"`.
+- The popover opens on `:focus-within` as well as `:hover`/`:focus`.
+- Motion and blur are suppressed under `prefers-reduced-motion: reduce`.
+- Neumorphic UI is known for low contrast by design; the default palette
+  keeps text at a contrast ratio suitable for body copy, but if you retint
+  the surface, re-check contrast between `--ease-neu-fg` and
+  `--ease-neu-surface`.
+
+## Browser support
+
+Uses standard CSS custom properties, `:focus-visible`, `filter: blur()`,
+multi-value `box-shadow`, and `transform`/`transition` — no vendor
+prefixes needed for current evergreen browsers (Chrome, Edge, Firefox,
+Safari).

--- a/submissions/examples/neumorphic-blur-popover-hruthika18/demo.html
+++ b/submissions/examples/neumorphic-blur-popover-hruthika18/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Neumorphic Blur-Entrance Popover — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Neumorphic Blur-Entrance Popover</h1>
+    <p>Pure CSS popover that resolves from a soft blur, styled for neumorphic "soft UI" surfaces. Hover or tab to any trigger below.</p>
+  </header>
+
+  <main class="neu-panel">
+
+    <div class="neu-row">
+      <span class="neu-row__label">Volume</span>
+      <span
+        class="ease-neu-blur-pop"
+        tabindex="0"
+        aria-describedby="pop-volume"
+      >
+        ⓘ
+        <span class="ease-neu-blur-pop__bubble" id="pop-volume" role="tooltip">
+          Adjusts system output level. Synced across all connected devices.
+        </span>
+      </span>
+    </div>
+
+    <div class="neu-row">
+      <span class="neu-row__label">Auto-Sync</span>
+      <span
+        class="ease-neu-blur-pop ease-neu-blur-pop--top"
+        tabindex="0"
+        aria-describedby="pop-sync"
+      >
+        ⓘ
+        <span class="ease-neu-blur-pop__bubble" id="pop-sync" role="tooltip">
+          When enabled, changes save automatically every 30 seconds.
+        </span>
+      </span>
+    </div>
+
+    <div class="neu-row">
+      <span class="neu-row__label">Privacy Mode</span>
+      <span
+        class="ease-neu-blur-pop ease-neu-blur-pop--right"
+        tabindex="0"
+        aria-describedby="pop-privacy"
+        style="--ease-neu-blur-duration: 0.5s; --ease-neu-blur-amount: 10px;"
+      >
+        ⓘ
+        <span class="ease-neu-blur-pop__bubble" id="pop-privacy" role="tooltip">
+          Hides your activity status from other users while enabled.
+        </span>
+      </span>
+    </div>
+
+    <button type="button" class="neu-button">Save Settings</button>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Keyboard users: press <kbd>Tab</kbd> to focus a trigger and reveal its popover. Press <kbd>Tab</kbd> again to move on.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/neumorphic-blur-popover-hruthika18/style.css
+++ b/submissions/examples/neumorphic-blur-popover-hruthika18/style.css
@@ -1,0 +1,210 @@
+/* ==========================================================================
+   ease-neu-blur-pop — CSS Blur-Entrance Popover (Neumorphic Soft variant)
+   Pure CSS, keyboard accessible, styled for soft-UI / neumorphic surfaces.
+   ========================================================================== */
+
+.ease-neu-blur-pop {
+  /* Public configuration — override per-instance via inline style or a
+     scoped selector, e.g. .ease-neu-blur-pop { --ease-neu-blur-duration: .6s; } */
+  --ease-neu-blur-duration: 0.32s;
+  --ease-neu-blur-easing: ease-out;
+  --ease-neu-blur-amount: 6px;
+  --ease-neu-blur-rise: 6px;
+  --ease-neu-blur-gap: 12px;
+  --ease-neu-surface: #e6e9f0;
+  --ease-neu-fg: #3a3f52;
+  --ease-neu-accent: #6c7bff;
+  --ease-neu-shadow-light: #ffffff;
+  --ease-neu-shadow-dark: #b9bfd1;
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7em;
+  height: 1.7em;
+  border-radius: 50%;
+  background: var(--ease-neu-surface);
+  color: var(--ease-neu-accent);
+  font-size: 0.9rem;
+  cursor: pointer;
+  user-select: none;
+  box-shadow:
+    4px 4px 8px var(--ease-neu-shadow-dark),
+    -4px -4px 8px var(--ease-neu-shadow-light);
+  transition: box-shadow 0.15s ease;
+}
+
+.ease-neu-blur-pop:hover,
+.ease-neu-blur-pop:focus-visible {
+  box-shadow:
+    inset 3px 3px 6px var(--ease-neu-shadow-dark),
+    inset -3px -3px 6px var(--ease-neu-shadow-light);
+}
+
+.ease-neu-blur-pop:focus-visible {
+  outline: 2px solid var(--ease-neu-accent);
+  outline-offset: 3px;
+}
+
+.ease-neu-blur-pop__bubble {
+  position: absolute;
+  bottom: calc(100% + var(--ease-neu-blur-gap));
+  left: 50%;
+  z-index: 20;
+  width: max-content;
+  max-width: 240px;
+  padding: 0.65em 0.9em;
+  border-radius: 12px;
+  background: var(--ease-neu-surface);
+  color: var(--ease-neu-fg);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  box-shadow:
+    6px 6px 14px var(--ease-neu-shadow-dark),
+    -6px -6px 14px var(--ease-neu-shadow-light);
+  pointer-events: none;
+
+  /* Hidden + pre-blur state */
+  opacity: 0;
+  visibility: hidden;
+  transform: translate(-50%, var(--ease-neu-blur-rise));
+  filter: blur(var(--ease-neu-blur-amount));
+  transition:
+    opacity var(--ease-neu-blur-duration) var(--ease-neu-blur-easing),
+    transform var(--ease-neu-blur-duration) var(--ease-neu-blur-easing),
+    filter var(--ease-neu-blur-duration) var(--ease-neu-blur-easing),
+    visibility 0s linear var(--ease-neu-blur-duration);
+}
+
+/* Reveal on hover or keyboard focus */
+.ease-neu-blur-pop:hover .ease-neu-blur-pop__bubble,
+.ease-neu-blur-pop:focus .ease-neu-blur-pop__bubble,
+.ease-neu-blur-pop:focus-within .ease-neu-blur-pop__bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+  filter: blur(0);
+  transition:
+    opacity var(--ease-neu-blur-duration) var(--ease-neu-blur-easing),
+    transform var(--ease-neu-blur-duration) var(--ease-neu-blur-easing),
+    filter var(--ease-neu-blur-duration) var(--ease-neu-blur-easing),
+    visibility 0s linear;
+}
+
+/* ---- Placement variants ---- */
+
+.ease-neu-blur-pop--top .ease-neu-blur-pop__bubble {
+  bottom: auto;
+  top: calc(100% + var(--ease-neu-blur-gap));
+  transform: translate(-50%, calc(-1 * var(--ease-neu-blur-rise)));
+}
+.ease-neu-blur-pop--top:hover .ease-neu-blur-pop__bubble,
+.ease-neu-blur-pop--top:focus .ease-neu-blur-pop__bubble,
+.ease-neu-blur-pop--top:focus-within .ease-neu-blur-pop__bubble {
+  transform: translate(-50%, 0);
+}
+
+.ease-neu-blur-pop--right .ease-neu-blur-pop__bubble {
+  bottom: auto;
+  left: calc(100% + var(--ease-neu-blur-gap));
+  top: 50%;
+  transform: translate(var(--ease-neu-blur-rise), -50%);
+}
+.ease-neu-blur-pop--right:hover .ease-neu-blur-pop__bubble,
+.ease-neu-blur-pop--right:focus .ease-neu-blur-pop__bubble,
+.ease-neu-blur-pop--right:focus-within .ease-neu-blur-pop__bubble {
+  transform: translate(0, -50%);
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-neu-blur-pop__bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translate(-50%, 0) !important;
+    filter: blur(0) !important;
+  }
+  .ease-neu-blur-pop--right .ease-neu-blur-pop__bubble {
+    transform: translate(0, -50%) !important;
+  }
+}
+
+/* ---- Demo page chrome: neumorphic soft-UI panel (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #e6e9f0;
+  color: #3a3f52;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 560px;
+  margin: 0 auto 36px;
+  text-align: center;
+}
+.demo-header p {
+  color: #6b7086;
+}
+
+.neu-panel {
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 28px 26px;
+  border-radius: 20px;
+  background: #e6e9f0;
+  box-shadow:
+    9px 9px 18px #b9bfd1,
+    -9px -9px 18px #ffffff;
+}
+
+.neu-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 4px;
+}
+.neu-row__label {
+  font-size: 0.92rem;
+  font-weight: 500;
+}
+
+.neu-button {
+  width: 100%;
+  margin-top: 18px;
+  padding: 12px;
+  border: none;
+  border-radius: 12px;
+  background: #e6e9f0;
+  color: #3a3f52;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow:
+    5px 5px 10px #b9bfd1,
+    -5px -5px 10px #ffffff;
+  transition: box-shadow 0.15s ease;
+}
+.neu-button:active {
+  box-shadow:
+    inset 4px 4px 8px #b9bfd1,
+    inset -4px -4px 8px #ffffff;
+}
+
+.demo-footer {
+  max-width: 560px;
+  margin: 32px auto 0;
+  text-align: center;
+  color: #6b7086;
+  font-size: 0.85rem;
+}
+.demo-footer kbd {
+  background: #d7dbe6;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-neu-blur-pop`, a pure CSS Blur-Entrance popover styled for
neumorphic ("soft UI") surfaces. The trigger is an extruded dual-shadow
circle that presses into an inset shadow on hover/focus, and the bubble
resolves in from `filter: blur()` combined with a short rise, sharing the
same soft-surface treatment as the trigger. Includes top/right placement
variants, full `prefers-reduced-motion` support, and configuration via
CSS custom properties for timing, blur amount, and the full neumorphic
surface/shadow palette (so it can be retinted for light or dark soft-UI
themes). Keyboard accessible via `tabindex`, `:focus-visible`,
`:focus-within`, and `aria-describedby`/`role="tooltip"`.

Resolves #46474

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/neumorphic-blur-popover-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only hover/focus popover with a blur-resolve entrance, purpose-built
for neumorphic soft-UI panels (settings rows, dashboards, soft cards).

**How does a developer use it?**
```html
<span class="ease-neu-blur-pop" tabindex="0" aria-describedby="pop-1">
  ⓘ
  <span class="ease-neu-blur-pop__bubble" id="pop-1" role="tooltip">
    Your content here.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**
Self-contained, dependency-free component matching the framework's
existing conventions. Distinct from the existing dashboard-styled
Blur-Entrance Popover — this one changes the trigger's own interaction
model (extrude/press) to match neumorphic conventions, not just the color
palette.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes and the folder use a `-hruthika18` suffix per the naming
convention. No JS required. Note the low-contrast-by-design nature of
neumorphism — default palette is contrast-checked, but flagged in the
README for anyone retinting the surface/shadow pair.