### PR TITLE
Add CSS Skew-Active Popover component (skew-active-popover-hruthika18)

### DIFF
--- a/submissions/examples/skew-active-popover-hruthika18/README.md
+++ b/submissions/examples/skew-active-popover-hruthika18/README.md
@@ -1,0 +1,96 @@
+# Skew-Active Popover (`ease-skew-pop`)
+
+A pure CSS popover/tooltip component with a snappy skew entrance — built
+for e-commerce checkout layouts where you need a quick, energetic info
+trigger next to a form field or price line, with zero JavaScript.
+
+## What it does
+
+- Reveals a small popover on **hover or keyboard focus**.
+- Entrance skews the bubble in from an angle and squashes it slightly on
+  the vertical axis, then snaps to upright using a `cubic-bezier` with a
+  small overshoot — giving it a quick, energetic feel rather than a soft
+  fade or blur.
+- Fully keyboard accessible: the trigger is focusable (`tabindex="0"`),
+  the popover opens on `:focus` / `:focus-within`, and there's a visible
+  `:focus-visible` outline.
+- Respects `prefers-reduced-motion`: the skew/scale is replaced with a
+  simple fade for users who've asked for reduced motion.
+- Configurable via CSS custom properties — no need to touch the source
+  rules to retheme or retime it.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<span class="ease-skew-pop" tabindex="0" aria-describedby="pop-1">
+  ⓘ
+  <span class="ease-skew-pop__bubble" id="pop-1" role="tooltip">
+    Your popover content goes here.
+  </span>
+</span>
+```
+
+### Placement variant
+
+```html
+<!-- default: opens above the trigger -->
+<span class="ease-skew-pop">...</span>
+
+<!-- opens below the trigger -->
+<span class="ease-skew-pop ease-skew-pop--top">...</span>
+```
+
+### Color variant
+
+```html
+<span class="ease-skew-pop ease-skew-pop--accent">...</span>
+```
+
+### Custom timing / angle per instance
+
+```html
+<span
+  class="ease-skew-pop"
+  style="--ease-skew-duration: 0.4s; --ease-skew-angle: -20deg;"
+>
+  ...
+</span>
+```
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-skew-duration` | `0.28s` | Length of the open/close transition |
+| `--ease-skew-easing` | `cubic-bezier(0.2, 0.9, 0.3, 1.3)` | Easing curve (default has a slight overshoot for the snap feel) |
+| `--ease-skew-angle` | `-12deg` | Starting skew angle before it straightens to `0deg` |
+| `--ease-skew-gap` | `10px` | Space between the trigger and the bubble |
+| `--ease-skew-bg` | `#1e2433` | Bubble background color |
+| `--ease-skew-fg` | `#f4f6fb` | Bubble text color |
+| `--ease-skew-accent` | `#ff7a59` | Trigger icon / focus outline color |
+
+## Why it fits EaseMotion CSS
+
+It's a self-contained, dependency-free animated component consistent with
+the framework's existing patterns: class-based API (`ease-skew-pop`),
+configuration via CSS custom properties rather than modifying source
+rules, a documented reduced-motion fallback, and no required JavaScript.
+The skew entrance gives the popover family a distinct, energetic identity
+suited to draw-attention moments in checkout flows, alongside the
+existing pulse/blur/swing variants.
+
+## Accessibility notes
+
+- The trigger uses `tabindex="0"` so it's reachable by keyboard.
+- `aria-describedby` links the trigger to the bubble's `id`, and the
+  bubble carries `role="tooltip"`.
+- The popover opens on `:focus-within` as well as `:hover`/`:focus`, so it
+  also works if you nest a real interactive element inside the trigger
+  instead of relying on the icon span alone.
+- Motion is suppressed under `prefers-reduced-motion: reduce`.
+
+## Browser support
+
+Uses standard CSS custom properties, `:focus-visible`, and
+`transform`/`transition` — no vendor prefixes needed for current
+evergreen browsers (Chrome, Edge, Firefox, Safari).

--- a/submissions/examples/skew-active-popover-hruthika18/demo.html
+++ b/submissions/examples/skew-active-popover-hruthika18/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Skew-Active Popover — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Skew-Active Popover</h1>
+    <p>Pure CSS popover with a snappy skew entrance, styled for e-commerce checkout flows. Hover or tab to any trigger below.</p>
+  </header>
+
+  <main class="checkout">
+
+    <section class="checkout-card">
+      <h2>Shipping Address</h2>
+
+      <label class="field">
+        <span class="field__label">
+          ZIP / Postal code
+          <span
+            class="ease-skew-pop"
+            tabindex="0"
+            aria-describedby="pop-zip"
+          >
+            ⓘ
+            <span class="ease-skew-pop__bubble" id="pop-zip" role="tooltip">
+              Used to estimate delivery time and calculate applicable sales tax.
+            </span>
+          </span>
+        </span>
+        <input type="text" placeholder="94103" />
+      </label>
+
+      <label class="field">
+        <span class="field__label">
+          Delivery instructions
+          <span
+            class="ease-skew-pop ease-skew-pop--accent"
+            tabindex="0"
+            aria-describedby="pop-delivery"
+          >
+            ⓘ
+            <span class="ease-skew-pop__bubble" id="pop-delivery" role="tooltip">
+              Optional notes for the courier — gate codes, safe drop spots, etc.
+            </span>
+          </span>
+        </span>
+        <input type="text" placeholder="Leave at front door" />
+      </label>
+    </section>
+
+    <section class="checkout-card">
+      <h2>Promo Code</h2>
+      <div class="checkout-row">
+        <span>
+          Discount applied
+          <span
+            class="ease-skew-pop ease-skew-pop--top"
+            tabindex="0"
+            aria-describedby="pop-discount"
+          >
+            ⓘ
+            <span class="ease-skew-pop__bubble" id="pop-discount" role="tooltip">
+              Promo codes can't be combined with other active offers on this order.
+            </span>
+          </span>
+        </span>
+        <strong>&minus;$8.00</strong>
+      </div>
+      <div class="checkout-row checkout-row--total">
+        <span>Total</span>
+        <strong>$76.00</strong>
+      </div>
+      <button type="button" class="checkout-btn">Place order</button>
+    </section>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Keyboard users: press <kbd>Tab</kbd> to focus a trigger and reveal its popover. Press <kbd>Tab</kbd> again to move on.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-popover-hruthika18/style.css
+++ b/submissions/examples/skew-active-popover-hruthika18/style.css
@@ -1,0 +1,226 @@
+/* ==========================================================================
+   ease-skew-pop — CSS Skew-Active Popover
+   Pure CSS, keyboard accessible, styled for checkout / form contexts.
+   ========================================================================== */
+
+.ease-skew-pop {
+  /* Public configuration — override per-instance via inline style or a
+     scoped selector, e.g. .ease-skew-pop { --ease-skew-duration: .5s; } */
+  --ease-skew-duration: 0.28s;
+  --ease-skew-easing: cubic-bezier(0.2, 0.9, 0.3, 1.3); /* snappy overshoot */
+  --ease-skew-angle: -12deg;
+  --ease-skew-gap: 10px;
+  --ease-skew-bg: #1e2433;
+  --ease-skew-fg: #f4f6fb;
+  --ease-skew-accent: #ff7a59;
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5em;
+  height: 1.5em;
+  border-radius: 50%;
+  background: rgba(255, 122, 89, 0.12);
+  color: var(--ease-skew-accent);
+  font-size: 0.85rem;
+  cursor: pointer;
+  user-select: none;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+.ease-skew-pop:focus-visible {
+  outline: 2px solid var(--ease-skew-accent);
+  outline-offset: 2px;
+}
+
+.ease-skew-pop__bubble {
+  position: absolute;
+  bottom: calc(100% + var(--ease-skew-gap));
+  left: 50%;
+  z-index: 20;
+  width: max-content;
+  max-width: 240px;
+  padding: 0.6em 0.85em;
+  border-radius: 10px;
+  background: var(--ease-skew-bg);
+  color: var(--ease-skew-fg);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  pointer-events: none;
+
+  /* Hidden + pre-skew state */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%) skewX(var(--ease-skew-angle)) scaleY(0.85);
+  transform-origin: bottom center;
+  transition:
+    opacity var(--ease-skew-duration) var(--ease-skew-easing),
+    transform var(--ease-skew-duration) var(--ease-skew-easing),
+    visibility 0s linear var(--ease-skew-duration);
+}
+
+.ease-skew-pop__bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  background: var(--ease-skew-bg);
+  transform: translateX(-50%) rotate(45deg);
+  border-radius: 2px;
+}
+
+/* Reveal on hover or keyboard focus */
+.ease-skew-pop:hover .ease-skew-pop__bubble,
+.ease-skew-pop:focus .ease-skew-pop__bubble,
+.ease-skew-pop:focus-within .ease-skew-pop__bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) skewX(0deg) scaleY(1);
+  transition:
+    opacity var(--ease-skew-duration) var(--ease-skew-easing),
+    transform var(--ease-skew-duration) var(--ease-skew-easing),
+    visibility 0s linear;
+}
+
+/* ---- Placement variant ---- */
+
+.ease-skew-pop--top .ease-skew-pop__bubble {
+  bottom: auto;
+  top: calc(100% + var(--ease-skew-gap));
+  transform-origin: top center;
+}
+.ease-skew-pop--top .ease-skew-pop__bubble::after {
+  top: auto;
+  bottom: 100%;
+}
+
+/* ---- Color variant ---- */
+
+.ease-skew-pop--accent {
+  --ease-skew-bg: #2b1f4d;
+  --ease-skew-accent: #b892ff;
+  background: rgba(184, 146, 255, 0.14);
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-skew-pop__bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) skewX(0deg) scaleY(1) !important;
+  }
+}
+
+/* ---- Demo page chrome: e-commerce checkout styling (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f4f5f8;
+  color: #1c2028;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 640px;
+  margin: 0 auto 36px;
+  text-align: center;
+}
+.demo-header p {
+  color: #6b7280;
+}
+
+.checkout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.checkout-card {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 22px 24px 26px;
+}
+.checkout-card h2 {
+  margin: 0 0 16px;
+  font-size: 1rem;
+}
+
+.field {
+  display: block;
+  margin-bottom: 16px;
+}
+.field__label {
+  display: flex;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #4b5563;
+  margin-bottom: 6px;
+}
+.field input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+.field input:focus {
+  outline: 2px solid #ff7a59;
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.checkout-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+  color: #4b5563;
+  padding: 8px 0;
+  border-bottom: 1px solid #f0f1f4;
+}
+.checkout-row--total {
+  border-bottom: none;
+  color: #1c2028;
+  font-size: 1rem;
+  padding-top: 12px;
+}
+
+.checkout-btn {
+  width: 100%;
+  margin-top: 18px;
+  padding: 12px;
+  border: none;
+  border-radius: 10px;
+  background: #ff7a59;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.demo-footer {
+  max-width: 640px;
+  margin: 40px auto 0;
+  text-align: center;
+  color: #6b7286;
+  font-size: 0.85rem;
+}
+.demo-footer kbd {
+  background: #e5e7eb;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS Skew-Active popover styled for e-commerce checkout
layouts. A trigger icon wrapped in `.ease-skew-pop` reveals a
`.ease-skew-pop__bubble` on hover or keyboard focus, entering with a skew
+ vertical squash that snaps upright via a slight-overshoot easing curve.
Includes a top-placement variant, a color variant, full
`prefers-reduced-motion` support (falls back to a plain fade), and
configuration via CSS custom properties (duration, easing, skew angle,
gap, colors). Keyboard accessible via `tabindex`, `:focus-visible`,
`:focus-within`, and `aria-describedby`/`role="tooltip"`.

Resolves #46454

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/skew-active-popover-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only hover/focus popover with a snappy skew entrance, aimed at
checkout-flow info triggers (shipping fields, promo/discount lines).

**How does a developer use it?**
```html
<span class="ease-skew-pop" tabindex="0" aria-describedby="pop-1">
  ⓘ
  <span class="ease-skew-pop__bubble" id="pop-1" role="tooltip">
    Your content here.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**
Self-contained, dependency-free component matching the framework's
existing conventions — class-based API, CSS custom properties for
configuration, documented reduced-motion fallback. Gives the popover
family an energetic, snappy-entrance variant distinct from the existing
swing/blur/pulse styles.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes and the folder use a `-hruthika18` suffix per the naming
convention. No JS required — interaction states are handled via `:hover`,
`:focus`, and `:focus-within`.