### PR TITLE
fix: add missing keyframes mapped in engine and standardize float

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -635,7 +635,66 @@
   }
 }
 
-@keyframes ease-float {
+@keyframes ease-kf-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes ease-kf-wobble {
+  0% { transform: translate3d(0, 0, 0); }
+  15% { transform: translate3d(-25%, 0, 0) rotate(-5deg); }
+  30% { transform: translate3d(20%, 0, 0) rotate(3deg); }
+  45% { transform: translate3d(-15%, 0, 0) rotate(-3deg); }
+  60% { transform: translate3d(10%, 0, 0) rotate(2deg); }
+  75% { transform: translate3d(-5%, 0, 0) rotate(-1deg); }
+  100% { transform: translate3d(0, 0, 0); }
+}
+
+@keyframes ease-kf-flip-x {
+  from {
+    transform: perspective(400px) rotateX(90deg);
+    opacity: 0;
+  }
+  to {
+    transform: perspective(400px) rotateX(0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-flip-y {
+  from {
+    transform: perspective(400px) rotateY(90deg);
+    opacity: 0;
+  }
+  to {
+    transform: perspective(400px) rotateY(0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-heartbeat {
+  0% { transform: scale(1); }
+  14% { transform: scale(1.3); }
+  28% { transform: scale(1); }
+  42% { transform: scale(1.3); }
+  70% { transform: scale(1); }
+}
+
+@keyframes ease-kf-rubber-band {
+  0% { transform: scale(1); }
+  30% { transform: scale3d(1.25, 0.75, 1); }
+  40% { transform: scale3d(0.75, 1.25, 1); }
+  50% { transform: scale3d(1.15, 0.85, 1); }
+  65% { transform: scale3d(0.95, 1.05, 1); }
+  75% { transform: scale3d(1.05, 0.95, 1); }
+  100% { transform: scale(1); }
+}
+
+@keyframes ease-kf-float {
 
   0%,
   100% {
@@ -680,7 +739,7 @@
 }
 
 .ease-float {
-  animation: ease-float 3s ease-in-out infinite;
+  animation: ease-kf-float 3s ease-in-out infinite;
 }
 .ease-zoom-in {
   animation: ease-kf-zoom-in var(--ease-speed-medium) var(--ease-ease-bounce) both;


### PR DESCRIPTION
Fixes #49717.

This PR resolves a bug where the JavaScript engine (compiler.js) mapped several animations (like spin, wobble, rubber-band) that were completely missing from the core/animations.css file, causing them to fail silently when used. It also fixes a naming inconsistency with the float keyframe.
Type of Change
 ✨ New animation / hover effect
 🧩 New component
 📝 Documentation improvement
 🐛 Bug fix in an existing submission
 Other (describe below)
Submission Checklist
⚠️ PRs that fail this checklist will be closed without review.

 All changes are inside submissions/ (e.g., submissions/examples/your-feature-name/ or submissions/docs/your-feature-name/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/ (Note for maintainer: This is a core bug fix, so changes to core/animations.css were strictly necessary to fix #49717)
 No changes to components/
 One feature per PR (no bundled unrelated changes)
Feature Description
What does this add?

Adds missing @keyframes definitions for spin, wobble, flip-x, flip-y, heartbeat, and rubber-band to core/animations.css, and renames ease-float to ease-kf-float to properly match the engine's map.

How does a developer use it?

html

<!-- Developers can now successfully use these standard utilities without silent failures -->
<div em="spin 500ms"></div>
<div em="wobble 800ms"></div>
Why does it fit EaseMotion CSS?

These keyframes were already parsed and expected by the engine, so this fix simply completes the implementation and prevents developer confusion when the classes failed to render any motion.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari (optional but appreciated)
Notes for Maintainer
I noticed the checklist says "No changes to core/" but this was specifically a bug in core/animations.css where keyframes referenced by the compiler were missing. Let me know if you need any adjustments!

