### PR TITLE
fix: add missing keyframes submission for engine KEYFRAME_MAP (closes #49717)

### DIFF
--- a/submissions/examples/fix-missing-keyframes-49717/README.md
+++ b/submissions/examples/fix-missing-keyframes-49717/README.md
@@ -1,0 +1,53 @@
+# Fix: Missing Keyframes for Motion Engine KEYFRAME_MAP
+
+**Fixes #49717**
+
+## What This Fixes
+
+In `easemotion/engine/compiler.js`, the `KEYFRAME_MAP` references several animation names that the parser recognizes and generates CSS classes for. However, the corresponding `@keyframes` declarations were **completely missing** from `core/animations.css`, causing all of them to fail silently.
+
+Additionally, the `float` keyframe was misnamed (`ease-float` instead of `ease-kf-float`), breaking the standard naming convention used by the engine.
+
+## Affected Animations
+
+| Animation Token | CSS Keyframe Expected | Status Before Fix |
+|---|---|---|
+| `spin` | `ease-kf-spin` | ❌ Missing |
+| `wobble` | `ease-kf-wobble` | ❌ Missing |
+| `flip-x` | `ease-kf-flip-x` | ❌ Missing |
+| `flip-y` | `ease-kf-flip-y` | ❌ Missing |
+| `heartbeat` | `ease-kf-heartbeat` | ❌ Missing |
+| `rubber-band` | `ease-kf-rubber-band` | ❌ Missing |
+| `float` | `ease-kf-float` | ⚠️ Misnamed (`ease-float`) |
+
+## How to Use (After Fix is Merged)
+
+```html
+<!-- Spin — continuous rotation -->
+<div em="spin 500ms repeat-infinite">🔄</div>
+
+<!-- Wobble — attention-grabbing shake -->
+<div em="wobble 800ms">⚠️</div>
+
+<!-- Flip from X axis -->
+<div em="flip-x 400ms">Card</div>
+
+<!-- Flip from Y axis -->
+<div em="flip-y 400ms">Card</div>
+
+<!-- Heartbeat — pulsing scale -->
+<div em="heartbeat 1.3s repeat-infinite">❤️</div>
+
+<!-- Rubber band — elastic pop effect -->
+<div em="rubber-band 600ms">🎯</div>
+```
+
+## Why It Fits EaseMotion CSS
+
+These animations are already part of the engine's vocabulary — the parser knows about them, the compiler maps them. This fix simply adds the missing CSS that the engine already expects, making the library consistent and preventing confusing silent failures.
+
+## Files in This Submission
+
+- `style.css` — The proposed `@keyframes` definitions to be merged into `core/animations.css`
+- `demo.html` — Live demo showcasing all 7 animations
+- `README.md` — This file

--- a/submissions/examples/fix-missing-keyframes-49717/demo.html
+++ b/submissions/examples/fix-missing-keyframes-49717/demo.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix: Missing Keyframes Demo — EaseMotion CSS</title>
+  <meta name="description" content="Demo showcasing the 7 missing/broken animations fixed for issue #49717: spin, wobble, flip-x, flip-y, heartbeat, rubber-band, and float." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    /* ── Design tokens (subset) ───────────────────────── */
+    :root {
+      --ease-speed-medium: 300ms;
+      --ease-ease: cubic-bezier(0.4, 0, 0.2, 1);
+      --ease-ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+      --page-bg: #0f0e17;
+      --page-text: #fffffe;
+      --card-bg: rgba(255,255,255,0.05);
+      --card-border: rgba(255,255,255,0.09);
+      --primary: #6c63ff;
+      --primary-light: #a09af8;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--page-bg);
+      color: var(--page-text);
+      min-height: 100vh;
+    }
+
+    header {
+      text-align: center;
+      padding: 4rem 1rem 2rem;
+      background: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(108,99,255,0.18) 0%, transparent 70%);
+    }
+
+    header .label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--primary-light);
+      margin-bottom: 0.5rem;
+    }
+
+    header h1 {
+      font-size: clamp(1.8rem, 5vw, 3rem);
+      font-weight: 800;
+      background: linear-gradient(135deg, #fff 0%, #a78bfa 60%, #6c63ff 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      letter-spacing: -0.03em;
+      margin-bottom: 0.75rem;
+    }
+
+    header p {
+      color: rgba(255,255,255,0.55);
+      max-width: 520px;
+      margin: 0 auto 1.5rem;
+      font-size: 1rem;
+      line-height: 1.6;
+    }
+
+    .badge {
+      display: inline-block;
+      background: rgba(108,99,255,0.2);
+      border: 1px solid rgba(108,99,255,0.35);
+      color: var(--primary-light);
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 0.2em 0.75em;
+      border-radius: 9999px;
+    }
+
+    main {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem 4rem;
+    }
+
+    .section-title {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--primary-light);
+      margin-bottom: 1.5rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 1.25rem;
+      margin-bottom: 2.5rem;
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 12px;
+      padding: 1.5rem 1rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      cursor: pointer;
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .card:hover { border-color: rgba(108,99,255,0.4); background: rgba(108,99,255,0.06); }
+
+    .anim-box {
+      width: 64px;
+      height: 64px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, #6c63ff, #a78bfa);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.6rem;
+    }
+
+    .card-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      background: rgba(108,99,255,0.15);
+      border: 1px solid rgba(108,99,255,0.3);
+      color: var(--primary-light);
+      padding: 0.15em 0.65em;
+      border-radius: 9999px;
+      white-space: nowrap;
+    }
+
+    .card p {
+      font-size: 0.78rem;
+      color: rgba(255,255,255,0.45);
+      text-align: center;
+      line-height: 1.5;
+    }
+
+    .hint {
+      text-align: center;
+      font-size: 0.8rem;
+      color: rgba(255,255,255,0.3);
+      margin-top: 2rem;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 1rem;
+      border-top: 1px solid rgba(255,255,255,0.06);
+      color: rgba(255,255,255,0.25);
+      font-size: 0.8rem;
+    }
+
+    /* ── The actual missing keyframes (from style.css) ── */
+    @keyframes ease-kf-spin {
+      from { transform: rotate(0deg); }
+      to   { transform: rotate(360deg); }
+    }
+    @keyframes ease-kf-wobble {
+      0%   { transform: translate3d(0,0,0); }
+      15%  { transform: translate3d(-25%,0,0) rotate(-5deg); }
+      30%  { transform: translate3d(20%,0,0) rotate(3deg); }
+      45%  { transform: translate3d(-15%,0,0) rotate(-3deg); }
+      60%  { transform: translate3d(10%,0,0) rotate(2deg); }
+      75%  { transform: translate3d(-5%,0,0) rotate(-1deg); }
+      100% { transform: translate3d(0,0,0); }
+    }
+    @keyframes ease-kf-flip-x {
+      from { transform: perspective(400px) rotateX(90deg); opacity: 0; }
+      to   { transform: perspective(400px) rotateX(0deg);  opacity: 1; }
+    }
+    @keyframes ease-kf-flip-y {
+      from { transform: perspective(400px) rotateY(90deg); opacity: 0; }
+      to   { transform: perspective(400px) rotateY(0deg);  opacity: 1; }
+    }
+    @keyframes ease-kf-heartbeat {
+      0%  { transform: scale(1); }
+      14% { transform: scale(1.3); }
+      28% { transform: scale(1); }
+      42% { transform: scale(1.3); }
+      70% { transform: scale(1); }
+    }
+    @keyframes ease-kf-rubber-band {
+      0%   { transform: scale(1); }
+      30%  { transform: scale3d(1.25,0.75,1); }
+      40%  { transform: scale3d(0.75,1.25,1); }
+      50%  { transform: scale3d(1.15,0.85,1); }
+      65%  { transform: scale3d(0.95,1.05,1); }
+      75%  { transform: scale3d(1.05,0.95,1); }
+      100% { transform: scale(1); }
+    }
+    @keyframes ease-kf-float {
+      0%, 100% { transform: translate3d(0,0,0); }
+      50%      { transform: translate3d(0,-10px,0); }
+    }
+
+    /* Utility classes */
+    .ease-spin        { animation: ease-kf-spin 1s linear infinite; }
+    .ease-wobble      { animation: ease-kf-wobble 1s ease both; }
+    .ease-flip-x      { animation: ease-kf-flip-x 400ms cubic-bezier(0.34,1.56,0.64,1) both; }
+    .ease-flip-y      { animation: ease-kf-flip-y 400ms cubic-bezier(0.34,1.56,0.64,1) both; }
+    .ease-heartbeat   { animation: ease-kf-heartbeat 1.3s ease-in-out infinite; }
+    .ease-rubber-band { animation: ease-kf-rubber-band 600ms ease both; }
+    .ease-float-fix   { animation: ease-kf-float 3s ease-in-out infinite; }
+  </style>
+</head>
+<body>
+
+  <header>
+    <div class="label">Bug Fix · Issue #49717</div>
+    <h1>Missing Keyframes — Restored</h1>
+    <p>
+      These 7 animations were registered in the engine's <code>KEYFRAME_MAP</code>
+      but had no matching <code>@keyframes</code> in <code>core/animations.css</code>.
+      They now all work correctly.
+    </p>
+    <span class="badge">Fixes #49717</span>
+  </header>
+
+  <main>
+    <div class="section-title">Click any card to replay the animation</div>
+
+    <div class="grid">
+
+      <div class="card" onclick="replay(this.querySelector('.anim-box'),'ease-spin')">
+        <div class="anim-box ease-spin">🔄</div>
+        <span class="card-label">ease-kf-spin</span>
+        <p>Continuous 360° rotation. Previously missing — engine mapped <code>ease-kf-spin</code> but no keyframe existed.</p>
+      </div>
+
+      <div class="card" onclick="replay(this.querySelector('.anim-box'),'ease-wobble')">
+        <div class="anim-box ease-wobble">⚠️</div>
+        <span class="card-label">ease-kf-wobble</span>
+        <p>Attention-grabbing lateral wobble. Great for form error states.</p>
+      </div>
+
+      <div class="card" onclick="replay(this.querySelector('.anim-box'),'ease-flip-x')">
+        <div class="anim-box ease-flip-x">🃏</div>
+        <span class="card-label">ease-kf-flip-x</span>
+        <p>Perspective flip along the X axis — card reveal effect.</p>
+      </div>
+
+      <div class="card" onclick="replay(this.querySelector('.anim-box'),'ease-flip-y')">
+        <div class="anim-box ease-flip-y">🔀</div>
+        <span class="card-label">ease-kf-flip-y</span>
+        <p>Perspective flip along the Y axis — page turn effect.</p>
+      </div>
+
+      <div class="card" onclick="replay(this.querySelector('.anim-box'),'ease-heartbeat')">
+        <div class="anim-box ease-heartbeat">❤️</div>
+        <span class="card-label">ease-kf-heartbeat</span>
+        <p>Double-pulse scale animation — perfect for like/favourite interactions.</p>
+      </div>
+
+      <div class="card" onclick="replay(this.querySelector('.anim-box'),'ease-rubber-band')">
+        <div class="anim-box ease-rubber-band">🎯</div>
+        <span class="card-label">ease-kf-rubber-band</span>
+        <p>Elastic squish-and-stretch pop effect on click/entrance.</p>
+      </div>
+
+      <div class="card">
+        <div class="anim-box ease-float-fix">🫧</div>
+        <span class="card-label">ease-kf-float (renamed)</span>
+        <p>Was <code>ease-float</code> (no <code>-kf-</code> prefix). Renamed to match engine standard.</p>
+      </div>
+
+    </div>
+
+    <p class="hint">Click a card to replay · All animations respect <code>prefers-reduced-motion</code></p>
+  </main>
+
+  <footer>
+    Submission for EaseMotion CSS · Fixes <strong>#49717</strong> · by khushikakade
+  </footer>
+
+  <script>
+    function replay(el, cls) {
+      el.classList.remove(cls);
+      void el.offsetWidth;
+      el.classList.add(cls);
+    }
+
+    // Respect prefers-reduced-motion
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    if (mq.matches) {
+      document.querySelectorAll('.anim-box').forEach(el => {
+        el.style.animation = 'none';
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/fix-missing-keyframes-49717/style.css
+++ b/submissions/examples/fix-missing-keyframes-49717/style.css
@@ -1,0 +1,118 @@
+/* ============================================================
+   EaseMotion CSS — fix: Missing Keyframes for Engine KEYFRAME_MAP
+   Fixes: https://github.com/saptarshi-coder/EaseMotion-css/issues/49717
+
+   The following @keyframes are referenced in easemotion/engine/compiler.js
+   but were missing from core/animations.css, causing silent failures when
+   developers used em="spin 500ms" or similar attributes.
+
+   These should be merged into core/animations.css.
+   ============================================================ */
+
+/* ── 1. spin ─────────────────────────────────────────────── */
+@keyframes ease-kf-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ease-spin {
+  animation: ease-kf-spin 1s linear infinite;
+}
+
+/* ── 2. wobble ───────────────────────────────────────────── */
+@keyframes ease-kf-wobble {
+  0%   { transform: translate3d(0, 0, 0); }
+  15%  { transform: translate3d(-25%, 0, 0) rotate(-5deg); }
+  30%  { transform: translate3d(20%, 0, 0) rotate(3deg); }
+  45%  { transform: translate3d(-15%, 0, 0) rotate(-3deg); }
+  60%  { transform: translate3d(10%, 0, 0) rotate(2deg); }
+  75%  { transform: translate3d(-5%, 0, 0) rotate(-1deg); }
+  100% { transform: translate3d(0, 0, 0); }
+}
+
+.ease-wobble {
+  animation: ease-kf-wobble 1s var(--ease-ease) both;
+}
+
+/* ── 3. flip-x ───────────────────────────────────────────── */
+@keyframes ease-kf-flip-x {
+  from {
+    transform: perspective(400px) rotateX(90deg);
+    opacity: 0;
+  }
+  to {
+    transform: perspective(400px) rotateX(0deg);
+    opacity: 1;
+  }
+}
+
+.ease-flip-x {
+  animation: ease-kf-flip-x var(--ease-speed-medium) var(--ease-ease-bounce) both;
+}
+
+/* ── 4. flip-y ───────────────────────────────────────────── */
+@keyframes ease-kf-flip-y {
+  from {
+    transform: perspective(400px) rotateY(90deg);
+    opacity: 0;
+  }
+  to {
+    transform: perspective(400px) rotateY(0deg);
+    opacity: 1;
+  }
+}
+
+.ease-flip-y {
+  animation: ease-kf-flip-y var(--ease-speed-medium) var(--ease-ease-bounce) both;
+}
+
+/* ── 5. heartbeat ────────────────────────────────────────── */
+@keyframes ease-kf-heartbeat {
+  0%   { transform: scale(1); }
+  14%  { transform: scale(1.3); }
+  28%  { transform: scale(1); }
+  42%  { transform: scale(1.3); }
+  70%  { transform: scale(1); }
+}
+
+.ease-heartbeat {
+  animation: ease-kf-heartbeat 1.3s ease-in-out infinite;
+}
+
+/* ── 6. rubber-band ──────────────────────────────────────── */
+@keyframes ease-kf-rubber-band {
+  0%   { transform: scale(1); }
+  30%  { transform: scale3d(1.25, 0.75, 1); }
+  40%  { transform: scale3d(0.75, 1.25, 1); }
+  50%  { transform: scale3d(1.15, 0.85, 1); }
+  65%  { transform: scale3d(0.95, 1.05, 1); }
+  75%  { transform: scale3d(1.05, 0.95, 1); }
+  100% { transform: scale(1); }
+}
+
+.ease-rubber-band {
+  animation: ease-kf-rubber-band var(--ease-speed-medium) var(--ease-ease) both;
+}
+
+/* ── 7. float (rename fix) ───────────────────────────────── */
+/*
+  BUG: In core/animations.css the keyframe is named "ease-float" but
+  compiler.js maps it as "ease-kf-float". Rename to standardize.
+  The .ease-float utility class should reference ease-kf-float.
+*/
+@keyframes ease-kf-float {
+  0%, 100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -10px, 0);
+  }
+}
+
+.ease-float {
+  animation: ease-kf-float 3s ease-in-out infinite;
+}


### PR DESCRIPTION
Closes #49717.

Adds a submission under submissions/examples/fix-missing-keyframes-49717/ 
with the proposed @keyframes definitions for the 7 animations that are 
mapped in the engine's KEYFRAME_MAP but missing from core/animations.css.

Includes demo.html, style.css, and README.md as required.
