### PR TITLE
feat: add ease-throttle-control-lever component

### DIFF
--- a/submissions/examples/ease-throttle-control-lever-sh/README.md
+++ b/submissions/examples/ease-throttle-control-lever-sh/README.md
@@ -1,0 +1,19 @@
+# Ease Throttle Control Lever
+
+A draggable vertical throttle lever with a color-coded fill and live percentage readout.
+
+## What does this do?
+A vertical slider styled like a physical throttle lever. Dragging the handle (or clicking anywhere on the track) sets a value from 0–100%, with the fill color changing from green (low) to amber (mid) to red (high). Also supports keyboard control via arrow keys when focused.
+
+## How is it used?
+Open `demo.html` and drag the white handle up and down, or click anywhere on the track to jump to that position. The percentage readout updates live below the lever.
+
+```html
+<div class="ease-throttle-track">
+  <div class="ease-throttle-fill ease-throttle-mid"></div>
+  <div class="ease-throttle-handle" tabindex="0"></div>
+</div>
+```
+
+## Why is it useful?
+A reusable, dependency-free control pattern for dashboards, audio mixers, or settings panels needing a vertical range input with clear visual feedback — fits EaseMotion's animation-first, accessible-by-default philosophy.

--- a/submissions/examples/ease-throttle-control-lever-sh/demo.html
+++ b/submissions/examples/ease-throttle-control-lever-sh/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ease Throttle Control Lever</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-throttle-wrapper">
+    <div class="ease-throttle-card">
+      <h2 class="ease-throttle-title">Throttle</h2>
+      <div class="ease-throttle-track" id="track">
+        <div class="ease-throttle-fill" id="fill"></div>
+        <div class="ease-throttle-handle" id="handle" tabindex="0"></div>
+      </div>
+      <div class="ease-throttle-readout" id="readout">0%</div>
+    </div>
+  </div>
+  <script>
+    const track = document.getElementById('track');
+    const fill = document.getElementById('fill');
+    const handle = document.getElementById('handle');
+    const readout = document.getElementById('readout');
+
+    let dragging = false;
+    let value = 0; // 0 - 100
+
+    function update(val) {
+      value = Math.max(0, Math.min(100, val));
+      const trackHeight = track.clientHeight;
+      const handlePos = trackHeight - (value / 100) * trackHeight;
+      handle.style.top = handlePos + 'px';
+      fill.style.height = value + '%';
+      readout.textContent = Math.round(value) + '%';
+
+      fill.classList.remove('ease-throttle-low', 'ease-throttle-mid', 'ease-throttle-high');
+      if (value < 34) fill.classList.add('ease-throttle-low');
+      else if (value < 75) fill.classList.add('ease-throttle-mid');
+      else fill.classList.add('ease-throttle-high');
+    }
+
+    function setFromClientY(clientY) {
+      const rect = track.getBoundingClientRect();
+      const relY = clientY - rect.top;
+      const pct = 100 - (relY / rect.height) * 100;
+      update(pct);
+    }
+
+    handle.addEventListener('mousedown', () => { dragging = true; });
+    window.addEventListener('mouseup', () => { dragging = false; });
+    window.addEventListener('mousemove', (e) => {
+      if (dragging) setFromClientY(e.clientY);
+    });
+
+    track.addEventListener('click', (e) => {
+      if (e.target === handle) return;
+      setFromClientY(e.clientY);
+    });
+
+    handle.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowUp') update(value + 5);
+      if (e.key === 'ArrowDown') update(value - 5);
+    });
+
+    update(0);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-throttle-control-lever-sh/style.css
+++ b/submissions/examples/ease-throttle-control-lever-sh/style.css
@@ -1,0 +1,89 @@
+/* Ease Throttle Control Lever styles */
+.ease-throttle-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: #0f172a;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-throttle-card {
+  width: 220px;
+  padding: 32px 24px;
+  border-radius: 20px;
+  background: #12131a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.ease-throttle-title {
+  color: #f8fafc;
+  font-size: 1.1rem;
+  margin-bottom: 20px;
+}
+
+.ease-throttle-track {
+  position: relative;
+  width: 40px;
+  height: 220px;
+  margin: 0 auto;
+  background: #1e293b;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.ease-throttle-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 0%;
+  border-radius: 20px;
+  transition: height 0.15s ease-out, background 0.3s ease;
+}
+
+.ease-throttle-low {
+  background: linear-gradient(0deg, #22c55e, #4ade80);
+}
+
+.ease-throttle-mid {
+  background: linear-gradient(0deg, #f59e0b, #fbbf24);
+}
+
+.ease-throttle-high {
+  background: linear-gradient(0deg, #ef4444, #f87171);
+}
+
+.ease-throttle-handle {
+  position: absolute;
+  left: 50%;
+  top: 220px;
+  width: 56px;
+  height: 26px;
+  margin-left: -28px;
+  border-radius: 8px;
+  background: #f8fafc;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+  cursor: grab;
+  transition: top 0.15s ease-out;
+}
+
+.ease-throttle-handle:active {
+  cursor: grabbing;
+}
+
+.ease-throttle-handle:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+.ease-throttle-readout {
+  margin-top: 16px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #f8fafc;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new "Ease Throttle Control Lever" component — a draggable vertical throttle slider with a color-coded fill (green/amber/red based on value) and live percentage readout. Supports mouse drag, click-to-jump, and keyboard arrow key control.

Fixes: #49059 

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-throttle-control-lever-sh/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A draggable vertical throttle-style slider with color-coded fill and live percentage readout.

**How does a developer use it?**
```html
<div class="ease-throttle-track">
  <div class="ease-throttle-fill ease-throttle-mid"></div>
  <div class="ease-throttle-handle" tabindex="0"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
A reusable, dependency-free vertical range-input pattern with smooth animated transitions and built-in keyboard accessibility, matching EaseMotion's animation-first philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
<img width="1920" height="1020" alt="ease-throttle-control-lever" src="https://github.com/user-attachments/assets/45ec632e-3bed-40fa-92e0-42ba93575798" />


## Browser Testing
- [x] Chrome

## Notes for Maintainer
Tested locally — drag, click-to-jump, and keyboard arrow-key control all confirmed working, with fill color transitioning green → amber → red across the range (screenshot shows 70%, amber state).