### PR TITLE
fix: add missing ease-ping utility class (closes #49739)

### DIFF
--- a/submissions/examples/fix-ping-utility/README.md
+++ b/submissions/examples/fix-ping-utility/README.md
@@ -1,0 +1,11 @@
+# Fix: Missing `.ease-ping` Utility Class
+
+## Bug Description
+In `core/animations.css`, the keyframes for ping exist (`@keyframes ease-kf-ping`), but the corresponding `.ease-ping` utility class is completely missing. This prevents developers from applying the ping animation using the standard class-based approach (they can only use it via the `em="ping"` engine attribute).
+
+## Fix
+This submission adds the missing `.ease-ping` utility class linking to `ease-kf-ping` with standard animation timings, which should be merged into `core/animations.css`.
+
+## Files
+- `style.css` - The missing `.ease-ping` utility class.
+- `demo.html` - A demonstration of the ping animation used as a notification dot.

--- a/submissions/examples/fix-ping-utility/demo.html
+++ b/submissions/examples/fix-ping-utility/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Missing Ping Utility Demo</title>
+    
+    <!-- Link the proposed fix -->
+    <link rel="stylesheet" href="style.css">
+    
+    <!-- Include the existing keyframe for demo purposes -->
+    <style>
+        @keyframes ease-kf-ping {
+          75%, 100% {
+            transform: scale(2);
+            opacity: 0;
+          }
+        }
+        
+        body {
+            font-family: sans-serif;
+            background: #111;
+            color: white;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+
+        .notification {
+            position: relative;
+            background: #333;
+            padding: 20px;
+            border-radius: 8px;
+        }
+        
+        /* The ping dot */
+        .dot {
+            position: absolute;
+            top: -5px;
+            right: -5px;
+            width: 15px;
+            height: 15px;
+            background: #ef4444;
+            border-radius: 50%;
+        }
+        
+        /* The pinging aura (using the fixed class) */
+        .dot::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            border-radius: 50%;
+            background: #ef4444;
+        }
+    </style>
+</head>
+<body>
+    <h1>Missing .ease-ping Utility</h1>
+    <p>The ping animation is applied to the red dot's aura.</p>
+    
+    <div class="notification">
+        Messages
+        <!-- The ::before pseudo-element applies the ping -->
+        <span class="dot ease-ping"></span>
+    </div>
+</body>
+</html>

--- a/submissions/examples/fix-ping-utility/style.css
+++ b/submissions/examples/fix-ping-utility/style.css
@@ -1,0 +1,11 @@
+/* ============================================================
+   Fix for core/animations.css
+   
+   The @keyframes ease-kf-ping is defined, but the utility class
+   .ease-ping was missing entirely, preventing users from applying
+   the ping animation via utility classes.
+   ============================================================ */
+
+.ease-ping {
+  animation: ease-kf-ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+}


### PR DESCRIPTION
Closes #49739 .

Adds a submission under `submissions/examples/fix-ping-utility/` providing the missing `.ease-ping` utility class. The `@keyframes ease-kf-ping` exists in core, but the utility class was missing, preventing class-based usage.

Includes demo.html, style.css, and README.md.
