### PR TITLE
feat: add tooltip arrow sway example

### DIFF
--- a/submissions/examples/tooltip-arrow-sway/README.md
+++ b/submissions/examples/tooltip-arrow-sway/README.md
@@ -1,0 +1,15 @@
+# Tooltip Arrow Sway
+
+This example adds a tooltip that appears on hover or keyboard focus with a small arrow sway.
+
+## Files
+
+- `demo.html` contains the button and tooltip markup.
+- `style.css` defines the tooltip reveal, arrow motion, focus state, and reduced-motion fallback.
+
+## Highlights
+
+- Uses `aria-describedby` and `role="tooltip"` for the demo relationship.
+- Keeps the button dimensions stable while the tooltip appears.
+- Supports hover and keyboard focus.
+- Removes transition and arrow animation for reduced-motion users.

--- a/submissions/examples/tooltip-arrow-sway/demo.html
+++ b/submissions/examples/tooltip-arrow-sway/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tooltip Arrow Sway</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="tooltip-stage" aria-label="Tooltip arrow sway animation demo">
+      <button class="hint" type="button" aria-describedby="tip">
+        Hover details
+        <span id="tip" role="tooltip">Status updates every minute</span>
+      </button>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/tooltip-arrow-sway/style.css
+++ b/submissions/examples/tooltip-arrow-sway/style.css
@@ -1,0 +1,104 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #f8fafc;
+  --panel: #111827;
+  --accent: #22d3ee;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #0f172a, #155e75);
+}
+
+.tooltip-stage {
+  width: min(92vw, 28rem);
+  min-height: 18rem;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.hint {
+  position: relative;
+  min-height: 3.2rem;
+  padding: 0 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.hint:focus-visible {
+  outline: 3px solid rgba(34, 211, 238, 0.35);
+  outline-offset: 4px;
+}
+
+.hint span {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.85rem);
+  width: max-content;
+  max-width: min(18rem, 80vw);
+  padding: 0.7rem 0.85rem;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #172033;
+  font-size: 0.9rem;
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.28);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.5rem);
+  transition: opacity 180ms ease, transform 240ms ease;
+}
+
+.hint span::after {
+  content: "";
+  position: absolute;
+  left: calc(50% - 0.4rem);
+  top: calc(100% - 0.1rem);
+  width: 0.8rem;
+  height: 0.8rem;
+  background: #f8fafc;
+  transform: rotate(45deg);
+}
+
+.hint:hover span,
+.hint:focus-visible span {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.hint:hover span::after,
+.hint:focus-visible span::after {
+  animation: arrow-sway 900ms ease-in-out infinite;
+}
+
+@keyframes arrow-sway {
+  0%,
+  100% {
+    transform: translateX(-0.12rem) rotate(45deg);
+  }
+
+  50% {
+    transform: translateX(0.12rem) rotate(45deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hint span,
+  .hint span::after {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a tooltip arrow sway animation example
- include hover and keyboard focus states
- document reduced-motion support

## Verification
- git diff --cached --check