### PR TITLE
feat: add sidebar nav reveal example

### DIFF
--- a/submissions/examples/sidebar-nav-reveal/README.md
+++ b/submissions/examples/sidebar-nav-reveal/README.md
@@ -1,0 +1,15 @@
+# Sidebar Nav Reveal
+
+This example adds a compact sidebar navigation where links reveal with a staggered slide.
+
+## Files
+
+- `demo.html` contains the sidebar navigation markup.
+- `style.css` defines the staggered reveal, hover and focus states, and reduced-motion fallback.
+
+## Highlights
+
+- Uses semantic `nav` with a clear label.
+- Keeps each link at a stable height while animating with transforms.
+- Provides visible hover and keyboard focus states.
+- Shows all links statically when reduced motion is enabled.

--- a/submissions/examples/sidebar-nav-reveal/demo.html
+++ b/submissions/examples/sidebar-nav-reveal/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sidebar Nav Reveal</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="sidebar-stage" aria-label="Sidebar navigation reveal animation demo">
+      <nav class="sidebar" aria-label="Project navigation">
+        <h1>Workspace</h1>
+        <a href="#" style="--delay: 0ms">Overview</a>
+        <a href="#" style="--delay: 100ms">Tasks</a>
+        <a href="#" style="--delay: 200ms">Reports</a>
+        <a href="#" style="--delay: 300ms">Settings</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/sidebar-nav-reveal/style.css
+++ b/submissions/examples/sidebar-nav-reveal/style.css
@@ -1,0 +1,84 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #f8fafc;
+  --muted: #a8b3c7;
+  --panel: #111827;
+  --accent: #a3e635;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #111827, #365314);
+  color: var(--ink);
+}
+
+.sidebar-stage {
+  width: min(92vw, 24rem);
+  padding: 2rem;
+}
+
+.sidebar {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(17, 24, 39, 0.94);
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.45rem;
+}
+
+a {
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  padding: 0 0.85rem;
+  border-radius: 8px;
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 800;
+  opacity: 0;
+  transform: translateX(-1rem);
+  animation: nav-reveal 520ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: var(--delay);
+  transition: color 180ms ease, background 180ms ease;
+}
+
+a:hover,
+a:focus-visible {
+  background: rgba(163, 230, 53, 0.12);
+  color: var(--ink);
+  outline: none;
+}
+
+a:focus-visible {
+  box-shadow: 0 0 0 3px rgba(163, 230, 53, 0.28);
+}
+
+@keyframes nav-reveal {
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  a {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a sidebar navigation reveal animation example
- include staggered link motion and keyboard focus states
- document reduced-motion support

## Verification
- git diff --cached --check