### PR TITLE
feat: add ease-throw-confetti-effect component

### DIFF
--- a/submissions/examples/ease-throw-confetti-effect-sh/README.md
+++ b/submissions/examples/ease-throw-confetti-effect-sh/README.md
@@ -1,0 +1,22 @@
+# Ease Throw Confetti Effect
+
+A celebratory confetti burst effect triggered by a button click — pure CSS/JS, no external libraries.
+
+## What does this do?
+Clicking the button spawns 60 small colored confetti pieces that burst outward from the button in random directions, arc under gravity, spin, and fade out — then automatically clean themselves up from the DOM.
+
+## How is it used?
+Open `demo.html` and click the "🎉 Celebrate" button to trigger the confetti burst. Can be repeated as many times as you like.
+
+```html
+<div class="ease-confetti-stage">
+  <button class="ease-confetti-btn">🎉 Celebrate</button>
+</div>
+<script>
+  // On click, dynamically creates .ease-confetti-piece elements
+  // with randomized direction, distance, and rotation via CSS custom properties.
+</script>
+```
+
+## Why is it useful?
+A fun, lightweight, dependency-free celebration effect for success states, form submissions, achievements, or milestones — fits EaseMotion's animation-first philosophy with zero external libraries.

--- a/submissions/examples/ease-throw-confetti-effect-sh/demo.html
+++ b/submissions/examples/ease-throw-confetti-effect-sh/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ease Throw Confetti Effect</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-confetti-wrapper">
+    <div class="ease-confetti-stage" id="stage">
+      <button class="ease-confetti-btn" id="confettiBtn">🎉 Celebrate</button>
+    </div>
+  </div>
+  <script>
+    const stage = document.getElementById('stage');
+    const btn = document.getElementById('confettiBtn');
+    const colors = ['#6c63ff', '#22c55e', '#f59e0b', '#ef4444', '#38bdf8', '#f472b6'];
+
+    btn.addEventListener('click', () => {
+      const rect = btn.getBoundingClientRect();
+      const stageRect = stage.getBoundingClientRect();
+      const originX = rect.left - stageRect.left + rect.width / 2;
+      const originY = rect.top - stageRect.top;
+
+      for (let i = 0; i < 60; i++) {
+        const piece = document.createElement('span');
+        piece.className = 'ease-confetti-piece';
+        piece.style.left = originX + 'px';
+        piece.style.top = originY + 'px';
+        piece.style.background = colors[Math.floor(Math.random() * colors.length)];
+
+        const angle = Math.random() * Math.PI * 2;
+        const distance = 100 + Math.random() * 220;
+        const dx = Math.cos(angle) * distance;
+        const dy = Math.sin(angle) * distance - 150;
+        const rotate = Math.random() * 720 - 360;
+
+        piece.style.setProperty('--dx', dx + 'px');
+        piece.style.setProperty('--dy', dy + 'px');
+        piece.style.setProperty('--rot', rotate + 'deg');
+        piece.style.animationDelay = (Math.random() * 0.15) + 's';
+
+        stage.appendChild(piece);
+        piece.addEventListener('animationend', () => piece.remove());
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-throw-confetti-effect-sh/style.css
+++ b/submissions/examples/ease-throw-confetti-effect-sh/style.css
@@ -1,0 +1,68 @@
+/* Ease Throw Confetti Effect styles */
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #0f172a;
+}
+
+.ease-confetti-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: #0f172a;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-confetti-stage {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.ease-confetti-btn {
+  padding: 16px 32px;
+  border-radius: 14px;
+  border: none;
+  background: linear-gradient(135deg, #7c3aed, #6c63ff);
+  color: white;
+  font-size: 1.1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(108, 99, 255, 0.35);
+  transition: transform 0.2s;
+  z-index: 2;
+}
+
+.ease-confetti-btn:hover {
+  transform: scale(1.05);
+}
+
+.ease-confetti-piece {
+  position: absolute;
+  width: 8px;
+  height: 14px;
+  border-radius: 2px;
+  pointer-events: none;
+  animation: ease-confetti-fly 1.1s cubic-bezier(0.2, 0.8, 0.3, 1) forwards;
+}
+
+@keyframes ease-confetti-fly {
+  0% {
+    transform: translate(0, 0) rotate(0deg);
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--dx), calc(var(--dy) + 260px)) rotate(var(--rot));
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new "Ease Throw Confetti Effect" component — clicking a button bursts 60 colored confetti pieces outward in randomized directions with arc, spin, and fade-out, then self-cleans from the DOM. Pure CSS/JS, no external libraries.

Fixes #49060 

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-throw-confetti-effect-sh/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A confetti burst celebration effect triggered by a button click.

**How does a developer use it?**
```html
<div class="ease-confetti-stage">
  <button class="ease-confetti-btn">🎉 Celebrate</button>
</div>
```

**Why does it fit EaseMotion CSS?**
A fun, lightweight, dependency-free celebration animation for success states or milestones, matching EaseMotion's animation-first philosophy with zero external libraries.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
<img width="1920" height="1020" alt="ease-throw-confetti-effect" src="https://github.com/user-attachments/assets/42c78746-6b7c-4206-92be-a2b0ccecc245" />

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Tested locally — confetti bursts correctly with randomized colors, direction, and rotation, and cleans itself up after animating (screenshot attached).