### PR TITLE
feat: add file drop zone glow example

### DIFF
--- a/submissions/examples/file-drop-zone-glow/README.md
+++ b/submissions/examples/file-drop-zone-glow/README.md
@@ -1,0 +1,15 @@
+# File Drop Zone Glow
+
+This example adds a file drop-zone surface with a glow sweep on hover and focus.
+
+## Files
+
+- `demo.html` contains the file input label and upload copy.
+- `style.css` defines the dashed drop zone, glow sweep, icon lift, and reduced-motion fallback.
+
+## Highlights
+
+- Uses a real file input wrapped in a label.
+- Keeps the drop-zone size stable during interaction.
+- Supports hover and keyboard focus through `:focus-within`.
+- Disables sweep and lift transitions for reduced-motion users.

--- a/submissions/examples/file-drop-zone-glow/demo.html
+++ b/submissions/examples/file-drop-zone-glow/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>File Drop Zone Glow</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="drop-stage" aria-label="File drop zone glow animation demo">
+      <label class="drop-zone">
+        <input type="file" />
+        <span class="icon">↑</span>
+        <strong>Drop files here</strong>
+        <small>or click to browse uploads</small>
+      </label>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/file-drop-zone-glow/style.css
+++ b/submissions/examples/file-drop-zone-glow/style.css
@@ -1,0 +1,111 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #172033;
+  --muted: #64748b;
+  --panel: #ffffff;
+  --accent: #8b5cf6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #f5f3ff, #f8fafc);
+  color: var(--ink);
+}
+
+.drop-stage {
+  width: min(92vw, 34rem);
+  padding: 2rem;
+}
+
+.drop-zone {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 18rem;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 0.55rem;
+  padding: 2rem;
+  border: 2px dashed rgba(139, 92, 246, 0.42);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  cursor: pointer;
+  box-shadow: 0 1.5rem 3rem rgba(139, 92, 246, 0.14);
+}
+
+.drop-zone::before {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  z-index: -1;
+  background: linear-gradient(110deg, transparent 30%, rgba(139, 92, 246, 0.18), transparent 70%);
+  transform: translateX(-45%) rotate(8deg);
+  transition: transform 650ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.drop-zone:hover::before,
+.drop-zone:focus-within::before {
+  transform: translateX(45%) rotate(8deg);
+}
+
+input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.icon {
+  width: 4rem;
+  height: 4rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #ede9fe;
+  color: var(--accent);
+  font-size: 2rem;
+  font-weight: 900;
+  transition: transform 220ms ease;
+}
+
+.drop-zone:hover .icon,
+.drop-zone:focus-within .icon {
+  transform: translateY(-0.2rem);
+}
+
+strong {
+  font-size: 1.45rem;
+}
+
+small {
+  color: var(--muted);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.drop-zone:focus-within {
+  outline: 3px solid rgba(139, 92, 246, 0.28);
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drop-zone::before,
+  .icon {
+    transition: none;
+  }
+
+  .drop-zone:hover .icon,
+  .drop-zone:focus-within .icon {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a file drop zone glow animation example
- include hover and focus-within interaction states
- document reduced-motion support

## Verification
- git diff --cached --check