### PR TITLE
feat: add badge count bump example

### DIFF
--- a/submissions/examples/badge-count-bump/README.md
+++ b/submissions/examples/badge-count-bump/README.md
@@ -1,0 +1,15 @@
+# Badge Count Bump
+
+This example adds an inbox button where the unread-count badge bumps on hover and focus.
+
+## Files
+
+- `demo.html` contains the inbox button and badge markup.
+- `style.css` defines the badge bump animation, focus state, and reduced-motion fallback.
+
+## Highlights
+
+- Uses a real button for the interactive control.
+- Keeps the badge size stable during animation.
+- Supports both hover and keyboard focus triggers.
+- Skips the bump animation when reduced motion is requested.

--- a/submissions/examples/badge-count-bump/demo.html
+++ b/submissions/examples/badge-count-bump/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Badge Count Bump</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="badge-stage" aria-label="Badge count bump animation demo">
+      <button class="inbox" type="button">
+        <span>Inbox</span>
+        <strong aria-label="Nine unread messages">9</strong>
+      </button>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/badge-count-bump/style.css
+++ b/submissions/examples/badge-count-bump/style.css
@@ -1,0 +1,92 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #f8fafc;
+  --panel: #111827;
+  --accent: #ef4444;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #111827, #7f1d1d);
+}
+
+.badge-stage {
+  width: min(92vw, 24rem);
+  padding: 2rem;
+}
+
+.inbox {
+  width: 100%;
+  min-height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+  font-weight: 850;
+  cursor: pointer;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+.inbox:focus-visible {
+  outline: 3px solid rgba(239, 68, 68, 0.42);
+  outline-offset: 4px;
+}
+
+.inbox span {
+  font-size: 1.25rem;
+}
+
+strong {
+  min-width: 2.35rem;
+  height: 2.35rem;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #ffffff;
+  font-size: 1rem;
+  box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.42);
+}
+
+.inbox:hover strong,
+.inbox:focus-visible strong {
+  animation: badge-bump 620ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes badge-bump {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.42);
+  }
+
+  50% {
+    transform: scale(1.2);
+    box-shadow: 0 0 0 0.5rem rgba(239, 68, 68, 0);
+  }
+
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inbox:hover strong,
+  .inbox:focus-visible strong {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a badge count bump animation example
- include hover and keyboard focus triggers
- document reduced-motion support

## Verification
- git diff --cached --check