### PR TITLE
feat: add card stack fan example

### DIFF
--- a/submissions/examples/card-stack-fan/README.md
+++ b/submissions/examples/card-stack-fan/README.md
@@ -1,0 +1,15 @@
+# Card Stack Fan
+
+This example adds a stacked card control where cards fan outward on hover and focus.
+
+## Files
+
+- `demo.html` contains the stacked card button markup.
+- `style.css` defines the card stack, fan transform, focus state, and reduced-motion fallback.
+
+## Highlights
+
+- Uses a real button for the interactive stack.
+- Keeps the stack container dimensions stable while cards move.
+- Applies the same motion to hover and keyboard focus.
+- Removes fan movement when reduced motion is requested.

--- a/submissions/examples/card-stack-fan/demo.html
+++ b/submissions/examples/card-stack-fan/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Card Stack Fan</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stack-stage" aria-label="Card stack fan animation demo">
+      <button class="stack" type="button" aria-label="Open stacked project cards">
+        <span class="card one">Plan</span>
+        <span class="card two">Build</span>
+        <span class="card three">Ship</span>
+      </button>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/card-stack-fan/style.css
+++ b/submissions/examples/card-stack-fan/style.css
@@ -1,0 +1,101 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #f8fafc;
+  --accent: #f97316;
+  --blue: #38bdf8;
+  --green: #34d399;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #111827, #431407);
+}
+
+.stack-stage {
+  width: min(92vw, 30rem);
+  min-height: 22rem;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.stack {
+  position: relative;
+  width: 16rem;
+  height: 11rem;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.stack:focus-visible {
+  outline: 3px solid rgba(249, 115, 22, 0.45);
+  outline-offset: 1rem;
+  border-radius: 8px;
+}
+
+.card {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--ink);
+  font-size: 1.45rem;
+  font-weight: 900;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.28);
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.one {
+  background: var(--green);
+  transform: translateY(0.8rem) rotate(-3deg);
+}
+
+.two {
+  background: var(--blue);
+  transform: translateY(0.4rem) rotate(0deg);
+}
+
+.three {
+  background: var(--accent);
+  transform: rotate(3deg);
+}
+
+.stack:hover .one,
+.stack:focus-visible .one {
+  transform: translate(-3rem, 1rem) rotate(-11deg);
+}
+
+.stack:hover .two,
+.stack:focus-visible .two {
+  transform: translateY(-0.35rem) rotate(0deg);
+}
+
+.stack:hover .three,
+.stack:focus-visible .three {
+  transform: translate(3rem, 1rem) rotate(11deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .stack:hover .one,
+  .stack:focus-visible .one,
+  .stack:hover .two,
+  .stack:focus-visible .two,
+  .stack:hover .three,
+  .stack:focus-visible .three {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a card stack fan animation example
- include hover and keyboard focus fan states
- document reduced-motion support

## Verification
- git diff --cached --check