### PR TITLE
feat: add copy button check example

### DIFF
--- a/submissions/examples/copy-button-check/README.md
+++ b/submissions/examples/copy-button-check/README.md
@@ -1,0 +1,15 @@
+# Copy Button Check
+
+This example adds a copy button where the label transitions into a checkmark on hover and focus.
+
+## Files
+
+- `demo.html` contains the copy button markup.
+- `style.css` defines the label shift, checkmark reveal, focus state, and reduced-motion fallback.
+
+## Highlights
+
+- Uses a real button for the copy action.
+- Keeps the button size stable while content swaps.
+- Supports hover and keyboard focus.
+- Removes transition movement for reduced-motion users.

--- a/submissions/examples/copy-button-check/demo.html
+++ b/submissions/examples/copy-button-check/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copy Button Check</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="copy-stage" aria-label="Copy button check animation demo">
+      <button class="copy-button" type="button">
+        <span class="copy-text">Copy link</span>
+        <span class="check" aria-hidden="true">✓</span>
+      </button>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/copy-button-check/style.css
+++ b/submissions/examples/copy-button-check/style.css
@@ -1,0 +1,91 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #172033;
+  --panel: #ffffff;
+  --accent: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #f0fdf4, #f8fafc);
+  color: var(--ink);
+}
+
+.copy-stage {
+  width: min(92vw, 24rem);
+  padding: 2rem;
+}
+
+.copy-button {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  min-height: 3.4rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  box-shadow: 0 1.5rem 3rem rgba(22, 163, 74, 0.14);
+}
+
+.copy-text,
+.check {
+  grid-area: 1 / 1;
+  transition: transform 260ms ease, opacity 220ms ease;
+}
+
+.check {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #ffffff;
+  opacity: 0;
+  transform: translateY(1rem) scale(0.75);
+}
+
+.copy-button:hover .copy-text,
+.copy-button:focus-visible .copy-text {
+  opacity: 0;
+  transform: translateY(-1rem);
+}
+
+.copy-button:hover .check,
+.copy-button:focus-visible .check {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.copy-button:focus-visible {
+  outline: 3px solid rgba(22, 163, 74, 0.24);
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-text,
+  .check {
+    transition: none;
+  }
+
+  .copy-button:hover .copy-text,
+  .copy-button:focus-visible .copy-text,
+  .copy-button:hover .check,
+  .copy-button:focus-visible .check {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a copy button check animation example
- include hover and keyboard focus reveal states
- document reduced-motion support

## Verification
- git diff --cached --check