### PR TITLE
feat: add retro CRT monitor text effect (closes #49777)

### DIFF
--- a/submissions/examples/feature-retro-crt/README.md
+++ b/submissions/examples/feature-retro-crt/README.md
@@ -1,0 +1,15 @@
+# Feature: Retro CRT Monitor Effect
+
+## Description
+This submission introduces a highly unique `.ease-retro-crt` text animation effect that simulates an old cathode-ray tube (CRT) monitor or retro television screen.
+
+This is perfect for cyberpunk-themed interfaces, retro gaming websites, or unique 404 error pages, offering developers a creative and distinctive typography animation right out of the box.
+
+## Implementation Details
+- Uses high-frequency `@keyframes` to simulate phosphor screen flickering by rapidly shifting opacity between 0.85 and 1.0.
+- Implements CSS `text-shadow` to create an RGB split (chromatic aberration) effect, mimicking misaligned electron beams in older televisions.
+- Highly performant, requiring no JS or heavy SVG filters.
+
+## Files
+- `style.css` - The CSS definitions for the new effect.
+- `demo.html` - A visual demonstration showing the CRT text on a dark terminal screen.

--- a/submissions/examples/feature-retro-crt/demo.html
+++ b/submissions/examples/feature-retro-crt/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro CRT Effect Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: 'Courier New', Courier, monospace;
+            background: #050505; /* Deep black for monitor background */
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        
+        .monitor-frame {
+            padding: 40px;
+            border: 15px solid #222;
+            border-radius: 20px;
+            background: #111;
+            box-shadow: inset 0 0 40px rgba(0,0,0,0.8), 0 10px 30px rgba(0,0,0,0.5);
+            text-align: center;
+        }
+
+        h1 {
+            font-size: 3rem;
+            margin: 0;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+        }
+        p {
+            color: #4ade80;
+            margin-top: 20px;
+            font-size: 1.2rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="monitor-frame">
+        <!-- The CRT effect is applied here -->
+        <h1 class="ease-retro-crt">SYSTEM OVERRIDE</h1>
+        <p>Terminal connection established...</p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/feature-retro-crt/style.css
+++ b/submissions/examples/feature-retro-crt/style.css
@@ -1,0 +1,32 @@
+/* ============================================================
+   Feature Submission: Retro CRT Monitor Effect
+   
+   A highly unique text animation that simulates an old CRT 
+   monitor with flickering opacity and RGB chromatic aberration.
+   ============================================================ */
+
+.ease-retro-crt {
+  position: relative;
+  display: inline-block;
+  color: #fff;
+  /* Chromatic aberration via text-shadow */
+  text-shadow: 
+    0.1rem 0 0 rgba(255, 0, 0, 0.8),
+    -0.1rem 0 0 rgba(0, 255, 255, 0.8);
+  animation: ease-kf-crt-flicker 0.15s infinite;
+}
+
+/* Simulate the high-frequency phosphor flicker of an old TV */
+@keyframes ease-kf-crt-flicker {
+  0% { opacity: 0.95; }
+  10% { opacity: 0.85; text-shadow: 0.15rem 0 0 rgba(255,0,0,0.8), -0.15rem 0 0 rgba(0,255,255,0.8); }
+  20% { opacity: 0.95; }
+  30% { opacity: 1; }
+  40% { opacity: 0.9; }
+  50% { opacity: 1; }
+  60% { opacity: 0.85; }
+  70% { opacity: 0.95; text-shadow: 0.1rem 0 0 rgba(255,0,0,0.8), -0.1rem 0 0 rgba(0,255,255,0.8); }
+  80% { opacity: 1; }
+  90% { opacity: 0.9; }
+  100% { opacity: 1; }
+}


### PR DESCRIPTION
Closes #49777 .

Adds a submission under `submissions/examples/feature-retro-crt/` introducing 
`.ease-retro-crt` — a unique CSS animation simulating an old CRT monitor screen 
with phosphor flicker and RGB chromatic aberration (text-shadow split).

Completely pure CSS — no JS or SVG filters required.
Includes demo.html, style.css, and README.md.
