### PR TITLE
feat: add ease-thread-comment-viewer component

### DIFF
--- a/submissions/examples/ease-thread-comment-viewer-sh/README.md
+++ b/submissions/examples/ease-thread-comment-viewer-sh/README.md
@@ -1,0 +1,25 @@
+# Ease Thread Comment Viewer
+
+A threaded/nested comment viewer with animated collapse and expand for replies.
+
+## What does this do?
+Displays a discussion thread with top-level comments and nested replies. Clicking "Hide replies" / "Show replies" smoothly collapses or expands the reply thread with an animated height and opacity transition.
+
+## How is it used?
+Open `demo.html` and click "Hide replies (2)" under the first comment to collapse its thread, then click again to expand it.
+
+```html
+<div class="ease-thread-comment">
+  <div class="ease-thread-avatar">A</div>
+  <div class="ease-thread-body">
+    <p class="ease-thread-text">Comment text</p>
+    <button class="ease-thread-toggle-btn" data-target="thread-1">Hide replies (2)</button>
+    <div class="ease-thread-replies" id="thread-1">
+      <!-- nested reply comments -->
+    </div>
+  </div>
+</div>
+```
+
+## Why is it useful?
+A common pattern for forums, social apps, and comment sections needing threaded discussions with clean, lightweight, dependency-free collapse/expand animation — fits EaseMotion's animation-first philosophy.

--- a/submissions/examples/ease-thread-comment-viewer-sh/demo.html
+++ b/submissions/examples/ease-thread-comment-viewer-sh/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ease Thread Comment Viewer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-thread-wrapper">
+    <div class="ease-thread-card">
+      <h2 class="ease-thread-title">💬 Discussion (4)</h2>
+
+      <div class="ease-thread-comment">
+        <div class="ease-thread-avatar">A</div>
+        <div class="ease-thread-body">
+          <div class="ease-thread-meta"><strong>User A</strong> <span>2h ago</span></div>
+          <p class="ease-thread-text">This component looks great! Really clean animation.</p>
+          <button class="ease-thread-toggle-btn" data-target="thread-1">Hide replies (2)</button>
+
+          <div class="ease-thread-replies" id="thread-1">
+            <div class="ease-thread-comment ease-thread-reply">
+              <div class="ease-thread-avatar ease-thread-avatar-sm">B</div>
+              <div class="ease-thread-body">
+                <div class="ease-thread-meta"><strong>User B</strong> <span>1h ago</span></div>
+                <p class="ease-thread-text">Agreed, the collapse animation is smooth.</p>
+              </div>
+            </div>
+            <div class="ease-thread-comment ease-thread-reply">
+              <div class="ease-thread-avatar ease-thread-avatar-sm">C</div>
+              <div class="ease-thread-body">
+                <div class="ease-thread-meta"><strong>User C</strong> <span>40m ago</span></div>
+                <p class="ease-thread-text">Would love a dark/light toggle too.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-thread-comment">
+        <div class="ease-thread-avatar">D</div>
+        <div class="ease-thread-body">
+          <div class="ease-thread-meta"><strong>User D</strong> <span>3h ago</span></div>
+          <p class="ease-thread-text">Nice work on this one, very reusable.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('.ease-thread-toggle-btn').forEach(btn => {
+      const targetId = btn.getAttribute('data-target');
+      const target = document.getElementById(targetId);
+      btn.addEventListener('click', () => {
+        const isHidden = target.classList.toggle('ease-thread-collapsed');
+        const count = target.querySelectorAll('.ease-thread-comment').length;
+        btn.textContent = isHidden
+          ? `Show replies (${count})`
+          : `Hide replies (${count})`;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-thread-comment-viewer-sh/style.css
+++ b/submissions/examples/ease-thread-comment-viewer-sh/style.css
@@ -1,0 +1,118 @@
+/* Ease Thread Comment Viewer styles */
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #0f172a;
+}
+
+.ease-thread-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  padding: 60px 20px;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-thread-card {
+  width: 100%;
+  max-width: 460px;
+  padding: 28px;
+  border-radius: 20px;
+  background: #12131a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.ease-thread-title {
+  color: #f8fafc;
+  font-size: 1.1rem;
+  margin: 0 0 20px;
+}
+
+.ease-thread-comment {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.ease-thread-avatar {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7c3aed, #6c63ff);
+  color: white;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-thread-avatar-sm {
+  width: 28px;
+  height: 28px;
+  font-size: 0.8rem;
+  background: #334155;
+}
+
+.ease-thread-body {
+  flex: 1;
+}
+
+.ease-thread-meta {
+  font-size: 0.85rem;
+  color: #f8fafc;
+  margin-bottom: 4px;
+}
+
+.ease-thread-meta span {
+  color: #64748b;
+  font-weight: 400;
+  margin-left: 6px;
+}
+
+.ease-thread-text {
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0 0 8px;
+}
+
+.ease-thread-toggle-btn {
+  background: none;
+  border: none;
+  color: #6c63ff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 10px;
+}
+
+.ease-thread-toggle-btn:hover {
+  text-decoration: underline;
+}
+
+.ease-thread-replies {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-left: 12px;
+  border-left: 2px solid #1e293b;
+  max-height: 500px;
+  opacity: 1;
+  overflow: hidden;
+  transition: max-height 0.4s ease, opacity 0.3s ease, margin 0.4s ease;
+}
+
+.ease-thread-replies.ease-thread-collapsed {
+  max-height: 0;
+  opacity: 0;
+  margin: 0;
+}
+
+.ease-thread-reply {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new "Ease Thread Comment Viewer" component — a threaded/nested comment display with animated collapse and expand for replies (smooth height + opacity transition). 

Fixes #49055.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-thread-comment-viewer-sh/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A threaded comment viewer with animated collapse/expand for nested replies.

**How does a developer use it?**
```html
<div class="ease-thread-comment">
  <div class="ease-thread-avatar">A</div>
  <div class="ease-thread-body">
    <p class="ease-thread-text">Comment text</p>
    <button class="ease-thread-toggle-btn" data-target="thread-1">Hide replies (2)</button>
    <div class="ease-thread-replies" id="thread-1">
      <!-- nested reply comments -->
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
A common pattern for forums, social apps, and comment sections needing threaded discussions, using lightweight, dependency-free collapse/expand animation — fits EaseMotion's animation-first philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
<img width="1920" height="1020" alt="ease-thread-comment-viewer" src="https://github.com/user-attachments/assets/c756eab6-4c25-4fa9-a0b8-cabc6e940ccd" />

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Tested locally — collapse/expand animation confirmed smooth for the reply thread. Demo content uses generic placeholder names (User A/B/C/D) rather than real-sounding names, to keep sample data neutral (screenshot attached).