### PR TITLE
fix: resolve empty SCSS build output — fixes #40201

### DIFF
--- a/submissions/docs/scss-build-fix-eranmol/README.md
+++ b/submissions/docs/scss-build-fix-eranmol/README.md
@@ -1,0 +1,30 @@
+# SCSS Build Fix — Issue #40201
+
+## What does it do?
+
+Documents the root cause of the `npm run build:scss` bug and provides two fix approaches for the maintainer to apply.
+
+## Problem
+
+`scss/_index.scss` only contains `@forward` statements for variables and mixins. Compiling it produces an empty CSS file (50 bytes) with just a source map comment — no usable CSS output.
+
+## Fix Options
+
+### Option A: Full CSS build (recommended)
+
+1. Create `scss/easemotion.scss` that `@use`s the index and all core/component CSS files
+2. Update `package.json` line 34:
+   ```json
+   "build:scss": "sass scss/easemotion.scss dist/easemotion.scss.css"
+   ```
+
+### Option B: SCSS-only export
+
+If the intent is to export SCSS variables/mixins for library consumers only:
+1. Keep the current entry file
+2. Remove `--source-map` or rename output to `.scss` extension
+3. Document that the output is for SCSS import, not CSS use
+
+## Why is it useful?
+
+The current build script gives contributors a broken artifact. Fixing it ensures the SCSS build produces either usable CSS or a clearly documented SCSS utility file.

--- a/submissions/docs/scss-build-fix-eranmol/demo.html
+++ b/submissions/docs/scss-build-fix-eranmol/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCSS Build Fix — Issue #40201</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>SCSS Build Output Fix</h1>
+      <p class="subtitle">Issue #40201 — build:scss emits only a source map comment</p>
+    </header>
+
+    <section class="card">
+      <h2>Problem</h2>
+      <p><code>npm run build:scss</code> compiles <code>scss/_index.scss</code>, which only contains <code>@forward</code> statements for variables and mixins. This produces an empty CSS file with just a source map comment:</p>
+      <pre><code>/*# sourceMappingURL=easemotion.scss.css.map */</code></pre>
+    </section>
+
+    <section class="card">
+      <h2>Root Cause</h2>
+      <table>
+        <thead>
+          <tr><th>File</th><th>Contents</th><th>Issue</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>scss/_index.scss</code></td>
+            <td><code>@forward 'variables';<br>@forward 'mixins';</code></td>
+            <td class="old">Only forwards partials — no CSS output</td>
+          </tr>
+          <tr>
+            <td><code>scss/_variables.scss</code></td>
+            <td>CSS custom properties</td>
+            <td>Variables only, no selectors</td>
+          </tr>
+          <tr>
+            <td><code>scss/_mixins.scss</code></td>
+            <td>SCSS mixins</td>
+            <td>Mixins only, no selectors</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>Fix</h2>
+      <p>Create a new entry file <code>scss/easemotion.scss</code> that <code>@use</code>s the index and adds actual CSS rules, then update the build script to target it.</p>
+
+      <div class="diff-block">
+        <h3>1. New file: <code>scss/easemotion.scss</code></h3>
+        <pre><code>// EaseMotion CSS — SCSS Build Entry
+@use 'index';
+
+// Import core CSS files via sass built-in
+@use '../core/variables';
+@use '../core/base';
+@use '../core/animations';
+@use '../core/utilities';
+
+// Import component CSS files
+@use '../components/buttons';
+@use '../components/cards';
+@use '../components/chips';
+@use '../components/forms';
+@use '../components/modals';
+@use '../components/navigation';
+@use '../components/pagination';
+@use '../components/progress';
+@use '../components/tables';
+@use '../components/tooltips';</code></pre>
+      </div>
+
+      <div class="diff-block">
+        <h3>2. Update <code>package.json</code> (line 34)</h3>
+        <pre><code>- "build:scss": "sass scss/_index.scss dist/easemotion.scss.css"
++ "build:scss": "sass scss/easemotion.scss dist/easemotion.scss.css"</code></pre>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Alternative (Minimal Fix)</h2>
+      <p>If the goal is only to export SCSS variables/mixins for library consumers (not generate CSS), change the output file extension to reflect that:</p>
+      <pre><code>"build:scss": "sass scss/_index.scss dist/easemotion.scss.css --no-source-map"</code></pre>
+      <p class="note">And document that this file is for SCSS import only, not for use as a CSS stylesheet.</p>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/docs/scss-build-fix-eranmol/style.css
+++ b/submissions/docs/scss-build-fix-eranmol/style.css
@@ -1,0 +1,109 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  line-height: 1.6;
+  padding: 2rem 1rem;
+}
+
+.container {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: 1.5rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.note {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-top: 0.75rem;
+}
+
+/* ── Table ───────────────────────────────────────── */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid #334155;
+}
+
+th {
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.old {
+  color: #f87171;
+}
+
+code {
+  background: #0f172a;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  margin-top: 0.75rem;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+.diff-block {
+  margin-bottom: 1.25rem;
+}
+
+.diff-block h3 {
+  font-size: 0.95rem;
+  color: #94a3b8;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (build tooling)

## Submission Checklist
- [x] Files only in `submissions/docs/scss-build-fix-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
Documents the root cause of the `npm run build:scss` bug: `scss/_index.scss` only forwards variables/mixins with no CSS output, producing an empty 50-byte file. Provides two fix approaches: (A) create a full entry file that `@use`s all core/component CSS, or (B) clarify the output as SCSS-only for library consumers.

## Demo
Open `demo.html` to see the root cause analysis, affected files, and the exact diffs required for both fix options.

## Browser Testing
N/A — build tooling documentation only.

## Notes for Maintainer
The actual fix requires modifying `package.json` and creating `scss/easemotion.scss` (not included per contribution guidelines). Both fix approaches are documented with exact code diffs in `demo.html`.