### PR TITLE
fix: prefix view-transitions keyframes with ease-kf-* — fixes #40209

### DIFF
--- a/submissions/docs/view-transitions-keyframe-fix-eranmol/README.md
+++ b/submissions/docs/view-transitions-keyframe-fix-eranmol/README.md
@@ -1,0 +1,22 @@
+# View Transitions Keyframe Prefix Fix — Issue #40209
+
+## What does it do?
+
+Renames the keyframes in `components/view-transitions.css` from generic `view-*` names to the framework convention `ease-kf-*`, preventing naming collisions in consumer projects.
+
+## How is it used?
+
+Replace the contents of `components/view-transitions.css` with the updated version shown in `demo.html`. The keyframe names change from:
+
+| Old | New |
+|---|---|
+| `view-fade-out` | `ease-kf-view-fade-out` |
+| `view-fade-in` | `ease-kf-view-fade-in` |
+| `view-scale-out` | `ease-kf-view-scale-out` |
+| `view-scale-in` | `ease-kf-view-scale-in` |
+
+Also update any `animation-name:` references throughout the codebase.
+
+## Why is it useful?
+
+The `ease-kf-*` prefix convention ensures framework keyframes never collide with user-defined keyframes. This is the same pattern used in `core/animations.css` and documented in the contribution guidelines.

--- a/submissions/docs/view-transitions-keyframe-fix-eranmol/demo.html
+++ b/submissions/docs/view-transitions-keyframe-fix-eranmol/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>View Transitions Keyframe Fix — Issue #40209</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>View Transitions Keyframe Prefix Fix</h1>
+      <p class="subtitle">Issue #40209 — Keyframes should use ease-kf-* convention</p>
+    </header>
+
+    <section class="card">
+      <h2>Problem</h2>
+      <p><code>components/view-transitions.css</code> defines keyframes with generic <code>view-*</code> names that risk collision with consumer projects:</p>
+      <pre><code>@keyframes view-fade-out   /* ❌ generic */
+@keyframes view-fade-in    /* ❌ generic */
+@keyframes view-scale-out  /* ❌ generic */
+@keyframes view-scale-in   /* ❌ generic */</code></pre>
+    </section>
+
+    <section class="card">
+      <h2>Expected Convention</h2>
+      <p>All framework keyframes should use the <code>ease-kf-*</code> prefix, matching the pattern used in <code>core/animations.css</code>:</p>
+      <pre><code>@keyframes ease-kf-view-fade-out   /* ✅ prefixed */
+@keyframes ease-kf-view-fade-in    /* ✅ prefixed */
+@keyframes ease-kf-view-scale-out  /* ✅ prefixed */
+@keyframes ease-kf-view-scale-in   /* ✅ prefixed */</code></pre>
+    </section>
+
+    <section class="card">
+      <h2>Fix — Updated File</h2>
+      <p>Replace the contents of <code>components/view-transitions.css</code> with:</p>
+      <pre><code>@layer easemotion-components {
+  @keyframes ease-kf-view-fade-out {
+    to { opacity: 0; }
+  }
+
+  @keyframes ease-kf-view-fade-in {
+    from { opacity: 0; }
+  }
+
+  @keyframes ease-kf-view-scale-out {
+    from { transform: scale(1); border-radius: 0; }
+    to   { transform: scale(0.95); border-radius: 20px; }
+  }
+
+  @keyframes ease-kf-view-scale-in {
+    from { transform: scale(0.95); border-radius: 20px; }
+    to   { transform: scale(1); border-radius: 0; }
+  }
+}</code></pre>
+    </section>
+
+    <section class="card">
+      <h2>Also Update References</h2>
+      <p>Search the codebase for any <code>animation-name:</code> rules that reference the old unprefixed names and update them:</p>
+      <table>
+        <thead>
+          <tr><th>Old</th><th>New</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>view-fade-out</code></td><td><code>ease-kf-view-fade-out</code></td></tr>
+          <tr><td><code>view-fade-in</code></td><td><code>ease-kf-view-fade-in</code></td></tr>
+          <tr><td><code>view-scale-out</code></td><td><code>ease-kf-view-scale-out</code></td></tr>
+          <tr><td><code>view-scale-in</code></td><td><code>ease-kf-view-scale-in</code></td></tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/docs/view-transitions-keyframe-fix-eranmol/style.css
+++ b/submissions/docs/view-transitions-keyframe-fix-eranmol/style.css
@@ -1,0 +1,88 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  line-height: 1.6;
+  padding: 2rem 1rem;
+}
+
+.container {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: 1.5rem;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+code {
+  background: #0f172a;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  margin-top: 0.75rem;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  margin-top: 0.75rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid #334155;
+}
+
+th {
+  color: #94a3b8;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (component)

## Submission Checklist
- [x] Files only in `submissions/docs/view-transitions-keyframe-fix-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
Renames the keyframes in `components/view-transitions.css` from generic `view-*` names to the framework convention `ease-kf-*`, preventing naming collisions in consumer projects. Four keyframes updated: `view-fade-out`, `view-fade-in`, `view-scale-out`, `view-scale-in`.

## Demo
Open `demo.html` to see the exact before/after diff and the updated keyframe name mapping table.

## Browser Testing
N/A — naming convention fix only.

## Notes for Maintainer
The actual fix requires modifying `components/view-transitions.css` (not included per contribution guidelines). The exact replacement is documented in `demo.html` along with a table of all `animation-name:` references that need updating.