### PR TITLE
feat: add color shift pricing card component — fixes #41471

### DIFF
--- a/submissions/examples/color-shift-pricing-card-eranmol/README.md
+++ b/submissions/examples/color-shift-pricing-card-eranmol/README.md
@@ -1,0 +1,45 @@
+# Color Shift Pricing Card — Issue #41471
+
+## What does it do?
+
+A pricing card component with a smooth gradient color-shift effect on hover. The card reveals a subtle blue→purple gradient glow when hovered, creating a polished "Creative Agency" aesthetic. Pure CSS, zero JavaScript.
+
+## How is it used?
+
+```html
+<div class="pricing-card">
+  <div class="card-glow"></div>
+  <div class="card-content">
+    <span class="plan-name">Pro</span>
+    <div class="price">
+      <span class="currency">$</span>
+      <span class="amount">12</span>
+      <span class="period">/month</span>
+    </div>
+    <ul class="features">
+      <li>Feature one</li>
+      <li>Feature two</li>
+    </ul>
+    <button class="cta-btn">Get Started</button>
+  </div>
+</div>
+```
+
+### CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--card-bg` | `#1e293b` | Card background |
+| `--card-border` | `#334155` | Border color |
+| `--card-accent` | `#3b82f6` | Accent / CTA color |
+| `--card-radius` | `16px` | Border radius |
+| `--shift-speed` | `0.5s` | Color shift animation speed |
+
+### Modifiers
+
+- `.featured` — Scaled up with always-visible glow and "Most Popular" badge
+- Default cards — Glow appears only on hover
+
+## Why is it useful?
+
+Pricing cards are among the most commonly needed UI elements. The color-shift variant provides a modern, polished aesthetic that works for SaaS, agency, and product landing pages — all in pure CSS with no dependencies.

--- a/submissions/examples/color-shift-pricing-card-eranmol/demo.html
+++ b/submissions/examples/color-shift-pricing-card-eranmol/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Color Shift Pricing Card — Issue #41471</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="page">
+    <header>
+      <h1>Color Shift Pricing Card</h1>
+      <p class="subtitle">A pricing card with a smooth gradient shift on hover — pure CSS</p>
+    </header>
+
+    <section class="pricing-grid">
+
+      <!-- Free Plan -->
+      <div class="pricing-card">
+        <div class="card-glow"></div>
+        <div class="card-content">
+          <span class="plan-name">Free</span>
+          <div class="price">
+            <span class="currency">$</span>
+            <span class="amount">0</span>
+            <span class="period">/month</span>
+          </div>
+          <ul class="features">
+            <li>5 animation utilities</li>
+            <li>Community support</li>
+            <li>Basic documentation</li>
+          </ul>
+          <button class="cta-btn">Get Started</button>
+        </div>
+      </div>
+
+      <!-- Pro Plan (Featured) -->
+      <div class="pricing-card featured">
+        <div class="card-glow"></div>
+        <div class="badge">Most Popular</div>
+        <div class="card-content">
+          <span class="plan-name">Pro</span>
+          <div class="price">
+            <span class="currency">$</span>
+            <span class="amount">12</span>
+            <span class="period">/month</span>
+          </div>
+          <ul class="features">
+            <li>50+ animation utilities</li>
+            <li>Priority support</li>
+            <li>Full documentation</li>
+            <li>Custom keyframes</li>
+          </ul>
+          <button class="cta-btn">Get Started</button>
+        </div>
+      </div>
+
+      <!-- Enterprise Plan -->
+      <div class="pricing-card">
+        <div class="card-glow"></div>
+        <div class="card-content">
+          <span class="plan-name">Enterprise</span>
+          <div class="price">
+            <span class="currency">$</span>
+            <span class="amount">49</span>
+            <span class="period">/month</span>
+          </div>
+          <ul class="features">
+            <li>Unlimited animations</li>
+            <li>24/7 support</li>
+            <li>Custom branding</li>
+            <li>SLA guarantee</li>
+          </ul>
+          <button class="cta-btn">Contact Sales</button>
+        </div>
+      </div>
+
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/color-shift-pricing-card-eranmol/style.css
+++ b/submissions/examples/color-shift-pricing-card-eranmol/style.css
@@ -1,0 +1,255 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --card-bg: #1e293b;
+  --card-border: #334155;
+  --card-text: #e2e8f0;
+  --card-muted: #94a3b8;
+  --card-accent: #3b82f6;
+  --card-radius: 16px;
+  --shift-speed: 0.5s;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: var(--card-text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.page {
+  max-width: 900px;
+  width: 100%;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+header h1 {
+  font-size: 1.8rem;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: var(--card-muted);
+  font-size: 0.95rem;
+}
+
+/* ── Pricing Grid ────────────────────────────────── */
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+/* ── Card ────────────────────────────────────────── */
+
+.pricing-card {
+  position: relative;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.pricing-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+/* ── Color Shift Glow ────────────────────────────── */
+
+.card-glow {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity var(--shift-speed) ease;
+  z-index: 0;
+}
+
+/* Default card: blue→purple shift */
+.pricing-card .card-glow {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(168, 85, 247, 0.15));
+}
+
+.pricing-card:hover .card-glow {
+  opacity: 1;
+}
+
+/* Featured card: always subtle glow, stronger on hover */
+.pricing-card.featured .card-glow {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(168, 85, 247, 0.25));
+  opacity: 0.6;
+}
+
+.pricing-card.featured:hover .card-glow {
+  opacity: 1;
+}
+
+/* ── Featured Card ───────────────────────────────── */
+
+.pricing-card.featured {
+  border-color: rgba(59, 130, 246, 0.4);
+  transform: scale(1.03);
+}
+
+.pricing-card.featured:hover {
+  transform: scale(1.03) translateY(-6px);
+}
+
+.badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: var(--card-accent);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.35em 0.9em;
+  border-radius: 0 var(--card-radius) 0 10px;
+  z-index: 2;
+}
+
+/* ── Card Content ────────────────────────────────── */
+
+.card-content {
+  position: relative;
+  z-index: 1;
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+
+.plan-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--card-muted);
+}
+
+.price {
+  margin: 1rem 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.1em;
+}
+
+.currency {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--card-muted);
+}
+
+.amount {
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.period {
+  font-size: 0.9rem;
+  color: var(--card-muted);
+}
+
+/* ── Features List ───────────────────────────────── */
+
+.features {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+
+.features li {
+  padding: 0.4rem 0;
+  font-size: 0.9rem;
+  color: var(--card-muted);
+  border-bottom: 1px solid rgba(51, 65, 85, 0.5);
+}
+
+.features li:last-child {
+  border-bottom: none;
+}
+
+.features li::before {
+  content: "✓ ";
+  color: #4ade80;
+  font-weight: 700;
+}
+
+/* ── CTA Button ──────────────────────────────────── */
+
+.cta-btn {
+  width: 100%;
+  padding: 0.7em 1.5em;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: 2px solid var(--card-border);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--card-text);
+  cursor: pointer;
+  transition: background 0.25s, border-color 0.25s, color 0.25s;
+  margin-top: 0.5rem;
+}
+
+.cta-btn:hover {
+  background: var(--card-accent);
+  border-color: var(--card-accent);
+  color: #fff;
+}
+
+.pricing-card.featured .cta-btn {
+  background: var(--card-accent);
+  border-color: var(--card-accent);
+  color: #fff;
+}
+
+.pricing-card.featured .cta-btn:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+/* ── Reduced Motion ──────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .pricing-card,
+  .card-glow,
+  .cta-btn {
+    transition: none;
+  }
+}
+
+/* ── Responsive ──────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .pricing-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pricing-card.featured {
+    transform: none;
+  }
+
+  .pricing-card.featured:hover {
+    transform: translateY(-6px);
+  }
+}


### PR DESCRIPTION
## Type of Change
- [x] New component (animation)

## Submission Checklist
- [x] Files only in `submissions/examples/color-shift-pricing-card-eranmol/`
- [x] `demo.html`, `style.css`, `README.md` included
- [x] No changes to `core/`, `components/`, or root configs

## Feature Description
A pricing card component with a smooth gradient color-shift effect on hover. Reveals a blue→purple gradient glow when hovered, creating a polished "Creative Agency" aesthetic. Includes three pricing tiers (Free, Pro, Enterprise), a featured card variant with badge, responsive grid layout, and `prefers-reduced-motion` support. Pure CSS, zero JavaScript.

## Demo
Open `demo.html` — hover over any pricing card to see the color-shift gradient glow appear.

## Browser Testing
Tested on Chrome, Firefox, Safari.

## Notes for Maintainer
Customizable via CSS custom properties: `--card-bg`, `--card-border`, `--card-accent`, `--card-radius`, `--shift-speed`. The `.featured` modifier scales the card and keeps the glow partially visible at rest.