### PR TITLE
Add ease-thesaurus-lookup-tool component

### DIFF
--- a/submissions/examples/ease-thesaurus-lookup-tool-sh/README.md
+++ b/submissions/examples/ease-thesaurus-lookup-tool-sh/README.md
@@ -1,0 +1,53 @@
+# Thesaurus Lookup Tool
+
+A small, dependency-free word lookup tool styled like a library card catalog.
+Type a word, and it returns synonym "index cards" plus a rail of antonyms.
+
+## What it does
+
+- Looks up synonyms and related words for anything you type, using the free
+  [Datamuse API](https://www.datamuse.com/api/) (`ml=` "means like" query —
+  no API key or signup required).
+- Also fetches antonyms (`rel_ant=`) and shows them in a separate "see also"
+  rail when available.
+- Ships five quick-pick example words (happy, difficult, beautiful, quick,
+  honest) so a reviewer can test it with one click.
+- Shows a friendly empty state when a word has no matches, and a clear error
+  state if the network request fails.
+
+## Files
+
+- `demo.html` — markup + logic (vanilla JS, no build step, no frameworks)
+- `style.css` — all styling, card-catalog visual theme
+- `README.md` — this file
+
+## Running it
+
+Just open `demo.html` in any modern browser. It calls the Datamuse API over
+HTTPS directly from the browser, so an internet connection is required; no
+server, build step, or API key is needed.
+
+## Design notes
+
+The visual concept is a library reference drawer at night: an ink-navy page,
+warm parchment-colored index cards for each synonym, and a rubber-stamp red
+accent used for the search field and the small decorative "call number" in
+the corner of each card. Typography pairs a serif display face (Libre Caslon
+Text) for headwords with a monospace face (IBM Plex Mono) for labels and
+metadata, echoing typewritten catalog cards.
+
+## Accessibility
+
+- The search input and button both have visible focus outlines.
+- Status updates (loading, result count, errors) are announced via an
+  `aria-live="polite"` region.
+- Respects `prefers-reduced-motion` by disabling the card entrance animation.
+- Fully responsive down to narrow mobile widths.
+
+## Known limitations
+
+- Datamuse's `ml=` endpoint returns "related words" rather than a strictly
+  curated thesaurus, so results occasionally include loosely related terms
+  alongside true synonyms. This is a reasonable trade-off for a free,
+  keyless API and is called out in the footer of the demo itself.
+- No offline/cached mode — every lookup is a live network request.

--- a/submissions/examples/ease-thesaurus-lookup-tool-sh/demo.html
+++ b/submissions/examples/ease-thesaurus-lookup-tool-sh/demo.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Thesaurus Lookup Tool — Card Catalog</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Libre+Caslon+Text:ital@0;1&display=swap"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="drawer">
+    <header class="drawer-label">
+      <div>
+        <span class="tag">Reference Desk · Drawer 12</span>
+        <h1>Thesaurus Lookup Tool</h1>
+        <div class="sub">Type a word. Pull its synonym card.</div>
+      </div>
+    </header>
+
+    <section class="search-rail">
+      <form id="search-form" autocomplete="off">
+        <div class="search-row">
+          <label for="word-input">Word to look up</label>
+          <input
+            id="word-input"
+            name="word"
+            type="text"
+            placeholder="e.g. happy, difficult, quick…"
+            aria-label="Word to look up"
+            required
+          />
+          <button id="lookup-btn" type="submit">Look Up</button>
+        </div>
+      </form>
+      <div class="quick-picks" id="quick-picks">
+        <button class="chip" type="button" data-word="happy">happy</button>
+        <button class="chip" type="button" data-word="difficult">difficult</button>
+        <button class="chip" type="button" data-word="beautiful">beautiful</button>
+        <button class="chip" type="button" data-word="quick">quick</button>
+        <button class="chip" type="button" data-word="honest">honest</button>
+      </div>
+    </section>
+
+    <div id="status" role="status" aria-live="polite"></div>
+
+    <section id="results" aria-label="Synonym results"></section>
+
+    <section id="antonyms-section" hidden>
+      <h2>See also — opposite meaning</h2>
+      <div id="antonyms"></div>
+    </section>
+
+    <footer>
+      Word data from the free
+      <a href="https://www.datamuse.com/api/" target="_blank" rel="noopener noreferrer">Datamuse API</a>.
+      No key or account required. Unofficial results — always sanity-check a word before publishing it.
+    </footer>
+  </div>
+
+  <script>
+    const form = document.getElementById('search-form');
+    const input = document.getElementById('word-input');
+    const status = document.getElementById('status');
+    const results = document.getElementById('results');
+    const antonymsSection = document.getElementById('antonyms-section');
+    const antonymsEl = document.getElementById('antonyms');
+    const quickPicks = document.getElementById('quick-picks');
+
+    function setStatus(text, state) {
+      status.textContent = text;
+      if (state) {
+        status.setAttribute('data-state', state);
+      } else {
+        status.removeAttribute('data-state');
+      }
+    }
+
+    function catalogNumber(index) {
+      // Purely decorative "call number" in the style of a library card,
+      // derived from the result's position so it stays stable per lookup.
+      return 'S.' + String(index + 1).padStart(3, '0');
+    }
+
+    function renderResults(word, synonyms) {
+      results.innerHTML = '';
+
+      if (synonyms.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = `No cards on file for "${word}". Try a simpler or more common form of the word.`;
+        results.appendChild(empty);
+        return;
+      }
+
+      synonyms.forEach((entry, i) => {
+        const card = document.createElement('article');
+        card.className = 'index-card';
+
+        const pos = document.createElement('span');
+        pos.className = 'pos';
+        pos.textContent = entry.tags && entry.tags.length ? entry.tags[0] : '—';
+        card.appendChild(pos);
+
+        const catalogNo = document.createElement('span');
+        catalogNo.className = 'catalog-no';
+        catalogNo.textContent = catalogNumber(i);
+        card.appendChild(catalogNo);
+
+        const head = document.createElement('span');
+        head.className = 'headword';
+        head.textContent = entry.word;
+        card.appendChild(head);
+
+        results.appendChild(card);
+      });
+    }
+
+    function renderAntonyms(antonyms) {
+      antonymsEl.innerHTML = '';
+      if (antonyms.length === 0) {
+        antonymsSection.hidden = true;
+        return;
+      }
+      antonymsSection.hidden = false;
+      antonyms.forEach((entry) => {
+        const tab = document.createElement('span');
+        tab.className = 'antonym-tab';
+        tab.textContent = entry.word;
+        antonymsEl.appendChild(tab);
+      });
+    }
+
+    async function lookup(word) {
+      const trimmed = word.trim().toLowerCase();
+      if (!trimmed) return;
+
+      input.value = trimmed;
+      setStatus('Pulling the card…');
+      results.innerHTML = '';
+      antonymsSection.hidden = true;
+
+      try {
+        const [synRes, antRes] = await Promise.all([
+          fetch(`https://api.datamuse.com/words?ml=${encodeURIComponent(trimmed)}&max=24`),
+          fetch(`https://api.datamuse.com/words?rel_ant=${encodeURIComponent(trimmed)}&max=8`),
+        ]);
+
+        if (!synRes.ok || !antRes.ok) {
+          throw new Error('network');
+        }
+
+        const synonyms = await synRes.json();
+        const antonyms = await antRes.json();
+
+        renderResults(trimmed, synonyms);
+        renderAntonyms(antonyms);
+
+        setStatus(
+          synonyms.length
+            ? `${synonyms.length} card${synonyms.length === 1 ? '' : 's'} filed under "${trimmed}".`
+            : `Drawer searched — nothing filed under "${trimmed}".`,
+          synonyms.length ? 'ok' : 'error'
+        );
+      } catch (err) {
+        setStatus('Could not reach the catalog. Check your connection and try again.', 'error');
+      }
+    }
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      lookup(input.value);
+    });
+
+    quickPicks.addEventListener('click', (e) => {
+      const btn = e.target.closest('.chip');
+      if (!btn) return;
+      lookup(btn.dataset.word);
+    });
+
+    // Prime the drawer with an example on load.
+    lookup('curious');
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-thesaurus-lookup-tool-sh/style.css
+++ b/submissions/examples/ease-thesaurus-lookup-tool-sh/style.css
@@ -1,0 +1,352 @@
+/* ==========================================================================
+   Ease Thesaurus Lookup Tool
+   Visual concept: a library card-catalog drawer. Ink-navy room, warm
+   parchment index cards, a rubber-stamp accent for the "entry number".
+   ========================================================================== */
+
+:root {
+  --ink-navy: #1b2430;
+  --ink-navy-deep: #131a24;
+  --drawer-wood: #2b2420;
+  --parchment: #f0ead8;
+  --parchment-dim: #e4dcc6;
+  --card-line: #c9bf9e;
+  --stamp-red: #a53a2e;
+  --stamp-red-dim: #8b3126;
+  --pencil-grey: #6b6355;
+  --ok-green: #3f6b4e;
+
+  --font-display: "Libre Caslon Text", Georgia, serif;
+  --font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  --radius-card: 3px;
+  --shadow-card: 0 6px 14px rgba(0, 0, 0, 0.28), 0 1px 0 rgba(255, 255, 255, 0.04) inset;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--ink-navy);
+  background-image:
+    radial-gradient(circle at 15% 10%, rgba(255, 255, 255, 0.03), transparent 40%),
+    radial-gradient(circle at 85% 90%, rgba(255, 255, 255, 0.02), transparent 45%);
+  color: var(--parchment);
+  font-family: var(--font-mono);
+  min-height: 100vh;
+  padding: 32px 20px 60px;
+}
+
+.drawer {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+/* -- Drawer label / header -------------------------------------------- */
+
+.drawer-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 2px solid var(--card-line);
+  padding-bottom: 14px;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.drawer-label .tag {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pencil-grey-light, #a49a80);
+  background: rgba(240, 234, 216, 0.06);
+  border: 1px solid var(--card-line);
+  padding: 4px 8px;
+  border-radius: 2px;
+}
+
+.drawer-label h1 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 28px;
+  letter-spacing: 0.01em;
+  margin: 6px 0 0;
+  color: var(--parchment);
+}
+
+.drawer-label .sub {
+  font-size: 12px;
+  color: #a49a80;
+  margin-top: 4px;
+  letter-spacing: 0.04em;
+}
+
+/* -- Search rail --------------------------------------------------------- */
+
+.search-rail {
+  background: var(--drawer-wood);
+  border: 1px solid #3a322b;
+  border-radius: var(--radius-card);
+  padding: 18px;
+  box-shadow: var(--shadow-card);
+  margin-bottom: 24px;
+}
+
+.search-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.search-row label {
+  display: none;
+}
+
+#word-input {
+  flex: 1 1 240px;
+  background: var(--parchment);
+  color: #2a2420;
+  border: none;
+  border-bottom: 3px solid var(--stamp-red);
+  padding: 12px 14px;
+  font-family: var(--font-display);
+  font-size: 20px;
+  border-radius: 2px;
+  outline: none;
+}
+
+#word-input::placeholder {
+  color: #7b7260;
+  font-style: italic;
+}
+
+#word-input:focus-visible {
+  outline: 3px solid #e7c86b;
+  outline-offset: 2px;
+}
+
+#lookup-btn {
+  background: var(--stamp-red);
+  color: var(--parchment);
+  border: none;
+  padding: 0 22px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: transform 0.08s ease, background 0.15s ease;
+}
+
+#lookup-btn:hover {
+  background: var(--stamp-red-dim);
+}
+
+#lookup-btn:active {
+  transform: scale(0.97);
+}
+
+#lookup-btn:focus-visible {
+  outline: 3px solid #e7c86b;
+  outline-offset: 2px;
+}
+
+.quick-picks {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  background: transparent;
+  border: 1px dashed var(--card-line);
+  color: var(--parchment-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 20px;
+  cursor: pointer;
+}
+
+.chip:hover {
+  border-style: solid;
+  border-color: var(--parchment);
+  color: var(--parchment);
+}
+
+.chip:focus-visible {
+  outline: 3px solid #e7c86b;
+  outline-offset: 2px;
+}
+
+/* -- Status line ---------------------------------------------------------- */
+
+#status {
+  min-height: 20px;
+  font-size: 12px;
+  color: #a49a80;
+  letter-spacing: 0.03em;
+  margin-bottom: 16px;
+}
+
+#status[data-state="error"] {
+  color: #e0a598;
+}
+
+#status[data-state="ok"] {
+  color: #9fc7ab;
+}
+
+/* -- Results: index cards -------------------------------------------------- */
+
+#results {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 14px;
+}
+
+.index-card {
+  position: relative;
+  background: var(--parchment);
+  color: #2a2420;
+  border-radius: var(--radius-card);
+  padding: 14px 14px 12px;
+  box-shadow: var(--shadow-card);
+  border: 1px solid #d8cfae;
+  animation: settle 0.25s ease both;
+}
+
+.index-card::before {
+  /* faint ruled line, like an index card */
+  content: "";
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  top: 34px;
+  border-top: 1px solid var(--card-line);
+}
+
+@keyframes settle {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.index-card .headword {
+  font-family: var(--font-display);
+  font-size: 19px;
+  display: block;
+  margin-bottom: 16px;
+}
+
+.index-card .pos {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pencil-grey);
+  border: 1px solid var(--pencil-grey);
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+
+.index-card .catalog-no {
+  font-size: 10px;
+  color: var(--stamp-red);
+  letter-spacing: 0.05em;
+}
+
+/* -- Antonyms rail ---------------------------------------------------------- */
+
+#antonyms-section {
+  margin-top: 30px;
+}
+
+#antonyms-section h2 {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #a49a80;
+  border-bottom: 1px dashed var(--card-line);
+  padding-bottom: 8px;
+  margin-bottom: 10px;
+}
+
+#antonyms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.antonym-tab {
+  background: var(--ink-navy-deep);
+  border: 1px solid var(--card-line);
+  color: var(--parchment-dim);
+  font-family: var(--font-display);
+  font-size: 14px;
+  padding: 6px 12px;
+  border-radius: 2px 12px 12px 2px;
+}
+
+/* -- Empty state -------------------------------------------------------- */
+
+.empty-state {
+  border: 1px dashed var(--card-line);
+  border-radius: var(--radius-card);
+  padding: 24px;
+  text-align: center;
+  color: #a49a80;
+  font-size: 13px;
+  grid-column: 1 / -1;
+}
+
+/* -- Footer --------------------------------------------------------------- */
+
+footer {
+  margin-top: 36px;
+  font-size: 11px;
+  color: #6b6355;
+  text-align: center;
+  letter-spacing: 0.03em;
+}
+
+footer a {
+  color: #9fc7ab;
+}
+
+/* -- Reduced motion --------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .index-card {
+    animation: none;
+  }
+}
+
+/* -- Responsive ------------------------------------------------------------ */
+
+@media (max-width: 480px) {
+  .drawer-label h1 {
+    font-size: 22px;
+  }
+
+  #lookup-btn {
+    padding: 12px 18px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #49054

### Type of Change
- [x] New component/example submission
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

### Submission Checklist
- [x] Component lives in `submissions/examples/ease-thesaurus-lookup-tool-sh/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Demo runs standalone by opening `demo.html` directly (no build step)
- [x] Tested in at least one browser
- [x] Keyboard accessible (visible focus states, no keyboard traps)
- [x] Responsive down to mobile widths
- [x] No console errors on load or interaction

### Feature Description
A thesaurus lookup tool styled as a library card catalog. Users type a word
and get back a grid of synonym "index cards" plus a rail of antonyms, using
the free, keyless Datamuse API (`ml=` and `rel_ant=` endpoints). Includes
quick-pick example words, loading/empty/error states, and a decorative but
lightweight card-catalog visual theme (ink-navy background, parchment cards,
serif + monospace type pairing).

### Demo
Open `submissions/examples/ease-thesaurus-lookup-tool-sh/demo.html` in any
modern browser with an internet connection. No API key, build step, or
server required.
<img width="1920" height="1020" alt="Thesaurus Lookup Tool" src="https://github.com/user-attachments/assets/d7d8e826-c10c-45aa-b3a0-e6ebe1f15c3d" />

### Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Notes for Maintainer
- Uses the Datamuse API directly from the client over HTTPS; no secrets or
  API keys involved.
- Synonym results come from Datamuse's "means like" endpoint, which returns
  related words rather than a strictly curated thesaurus — this trade-off
  is noted in the README and in the demo's footer.
- No external JS dependencies; only Google Fonts are loaded via CDN link tags.