### PR TITLE
feat: add glitch dark mode toggle for space (#41514)

### DIFF
--- a/submissions/examples/glitch-dark-mode-toggle-er/README.md
+++ b/submissions/examples/glitch-dark-mode-toggle-er/README.md
@@ -1,0 +1,60 @@
+# Glitch Dark Mode Toggle
+
+A pure CSS dark/light mode toggle with a glitch animation effect that plays during state transitions — no JavaScript required.
+
+## What it does
+
+A reusable dark mode toggle switch that uses the native `<input type="checkbox">` `:checked` pseudo-class and CSS `:has()` selector to switch the page between light and dark themes, with animated glitch artifacts on the track, thumb, and label text during the transition.
+
+## How it is used
+
+```html
+<label class="ease-glitch-toggle" aria-label="Toggle dark mode">
+  <input type="checkbox" class="ease-glitch-toggle-input" />
+  <span class="ease-glitch-toggle-track">
+    <span class="ease-glitch-toggle-thumb">
+      <svg class="ease-glitch-toggle-icon ease-glitch-toggle-icon--sun" ...>...</svg>
+      <svg class="ease-glitch-toggle-icon ease-glitch-toggle-icon--moon" ...>...</svg>
+    </span>
+  </span>
+  <span class="ease-glitch-toggle-label-text">
+    <span class="ease-glitch-toggle-word--light">Light</span>
+    <span class="ease-glitch-toggle-word--dark">Dark</span>
+  </span>
+</label>
+```
+
+Wrap the entire control in a `<label>` so clicking anywhere toggles the checkbox. To apply dark mode to your page, use `:has(.ease-glitch-toggle-input:checked)` on a parent element to swap CSS custom properties.
+
+## Why it fits EaseMotion CSS
+
+This component follows EaseMotion's zero-dependency, animation-first, pure-CSS philosophy. It uses `ease-kf-*` prefixed keyframes (`ease-kf-glitch-track-flash`, `ease-kf-glitch-thumb-jitter`, `ease-kf-glitch-text-artifact`), CSS custom properties for theming, and respects `prefers-reduced-motion` for accessibility. The glitch effect is built entirely with CSS pseudo-elements, `clip-path`, and `mix-blend-mode` — no JavaScript or external libraries needed.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-glitch-toggle-duration` | `0.35s` | Transition duration |
+| `--ease-glitch-toggle-easing` | `cubic-bezier(0.4, 0, 0.2, 1)` | Transition easing curve |
+| `--ease-glitch-track-light` | `#d1d5db` | Track color in light mode |
+| `--ease-glitch-track-dark` | `#1e293b` | Track color in dark mode |
+| `--ease-glitch-thumb` | `#ffffff` | Thumb color (light mode) |
+| `--ease-glitch-accent` | `#6366f1` | Focus ring accent color |
+| `--ease-glitch-cyan` | `#00e5ff` | Glitch cyan artifact color |
+| `--ease-glitch-magenta` | `#ff006e` | Glitch magenta artifact color |
+| `--ease-glitch-track-width` | `72px` | Track width |
+| `--ease-glitch-track-height` | `36px` | Track height |
+| `--ease-glitch-thumb-size` | `28px` | Thumb diameter |
+
+## Accessibility
+
+- Uses a real `<input type="checkbox">`, natively keyboard operable (Tab + Space) and screen-reader accessible.
+- Wrapping `<label>` provides a large click target.
+- Visible `:focus-visible` outline on the hidden input reflects onto the track.
+- `prefers-reduced-motion: reduce` collapses all transitions and animations to near-instant.
+
+## Files included
+
+- `demo.html` — self-contained browser demo
+- `style.css` — pure CSS implementation
+- `README.md` — this documentation

--- a/submissions/examples/glitch-dark-mode-toggle-er/demo.html
+++ b/submissions/examples/glitch-dark-mode-toggle-er/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glitch Dark Mode Toggle — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-section">
+    <h1>Glitch Dark Mode Toggle</h1>
+    <p>Pure CSS dark/light mode toggle with a glitch animation effect. No JavaScript required — state is handled entirely by the checkbox's native <code>:checked</code> pseudo-class and the <code>:has()</code> selector.</p>
+
+    <label class="ease-glitch-toggle" aria-label="Toggle dark mode">
+      <input type="checkbox" class="ease-glitch-toggle-input" />
+      <span class="ease-glitch-toggle-track">
+        <span class="ease-glitch-toggle-thumb">
+          <!-- Sun icon -->
+          <svg class="ease-glitch-toggle-icon ease-glitch-toggle-icon--sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5" />
+            <line x1="12" y1="1" x2="12" y2="3" />
+            <line x1="12" y1="21" x2="12" y2="23" />
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+            <line x1="1" y1="12" x2="3" y2="12" />
+            <line x1="21" y1="12" x2="23" y2="12" />
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+          </svg>
+          <!-- Moon icon -->
+          <svg class="ease-glitch-toggle-icon ease-glitch-toggle-icon--moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+        </span>
+      </span>
+      <span class="ease-glitch-toggle-label-text">
+        <span class="ease-glitch-toggle-word--light">Light</span>
+        <span class="ease-glitch-toggle-word--dark">Dark</span>
+      </span>
+    </label>
+
+    <div class="demo-card">
+      <h2>Sample Card</h2>
+      <p>This card transitions between light and dark themes when you toggle the switch above. The glitch effect plays on the track and thumb during the transition.</p>
+      <div class="demo-badges">
+        <span class="demo-badge">Pure CSS</span>
+        <span class="demo-badge">Accessible</span>
+        <span class="demo-badge">Responsive</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/glitch-dark-mode-toggle-er/style.css
+++ b/submissions/examples/glitch-dark-mode-toggle-er/style.css
@@ -1,0 +1,364 @@
+:root {
+  --ease-glitch-toggle-duration: 0.35s;
+  --ease-glitch-toggle-easing: cubic-bezier(0.4, 0, 0.2, 1);
+
+  --ease-glitch-track-light: #d1d5db;
+  --ease-glitch-track-dark: #1e293b;
+  --ease-glitch-thumb: #ffffff;
+
+  --ease-glitch-accent: #6366f1;
+  --ease-glitch-cyan: #00e5ff;
+  --ease-glitch-magenta: #ff006e;
+
+  --ease-glitch-track-width: 72px;
+  --ease-glitch-track-height: 36px;
+  --ease-glitch-thumb-size: 28px;
+  --ease-glitch-thumb-offset: 4px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 2rem;
+  background: var(--ease-glitch-bg, #f8fafc);
+  color: var(--ease-glitch-fg, #1e293b);
+  transition: background var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing),
+    color var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+}
+
+/* ── Dark mode via :has() ── */
+body:has(.ease-glitch-toggle-input:checked) {
+  --ease-glitch-bg: #0f172a;
+  --ease-glitch-fg: #e2e8f0;
+  background: var(--ease-glitch-bg);
+  color: var(--ease-glitch-fg);
+}
+
+/* ── Toggle wrapper ── */
+.ease-glitch-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* ── Hidden checkbox (accessible) ── */
+.ease-glitch-toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* ── Track ── */
+.ease-glitch-toggle-track {
+  position: relative;
+  width: var(--ease-glitch-track-width);
+  height: var(--ease-glitch-track-height);
+  border-radius: 999px;
+  background: var(--ease-glitch-track-light);
+  transition: background var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+  overflow: hidden;
+}
+
+.ease-glitch-toggle-input:checked + .ease-glitch-toggle-track {
+  background: var(--ease-glitch-toggle-thumb);
+}
+
+/* ── Glitch overlay layers on track ── */
+.ease-glitch-toggle-track::before,
+.ease-glitch-toggle-track::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.ease-glitch-toggle-track::before {
+  background: linear-gradient(
+    90deg,
+    transparent 10%,
+    var(--ease-glitch-cyan) 30%,
+    transparent 50%,
+    var(--ease-glitch-magenta) 70%,
+    transparent 90%
+  );
+}
+
+.ease-glitch-toggle-track::after {
+  background: linear-gradient(
+    90deg,
+    var(--ease-glitch-magenta) 5%,
+    transparent 25%,
+    var(--ease-glitch-cyan) 55%,
+    transparent 80%
+  );
+}
+
+.ease-glitch-toggle-input:checked + .ease-glitch-toggle-track::before {
+  opacity: 0.35;
+  animation: ease-kf-glitch-track-flash 0.6s steps(2, end) 1;
+}
+
+.ease-glitch-toggle-input:checked + .ease-glitch-toggle-track::after {
+  opacity: 0.2;
+  animation: ease-kf-glitch-track-flash 0.6s steps(3, end) 1 0.05s;
+}
+
+/* ── Thumb ── */
+.ease-glitch-toggle-thumb {
+  position: absolute;
+  top: var(--ease-glitch-thumb-offset);
+  left: var(--ease-glitch-thumb-offset);
+  width: var(--ease-glitch-thumb-size);
+  height: var(--ease-glitch-thumb-size);
+  border-radius: 50%;
+  background: var(--ease-glitch-thumb);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  transition: transform var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing),
+    box-shadow var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+  z-index: 2;
+}
+
+.ease-glitch-toggle-input:checked + .ease-glitch-toggle-track .ease-glitch-toggle-thumb {
+  transform: translateX(calc(var(--ease-glitch-track-width) - var(--ease-glitch-thumb-size) - var(--ease-glitch-thumb-offset) * 2));
+  background: var(--ease-glitch-track-dark);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+}
+
+/* ── Glitch jitter on thumb when toggling ── */
+.ease-glitch-toggle-input:checked + .ease-glitch-toggle-track .ease-glitch-toggle-thumb {
+  animation: ease-kf-glitch-thumb-jitter 0.4s ease-out 1;
+}
+
+/* ── Sun / Moon icons inside thumb ── */
+.ease-glitch-toggle-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+}
+
+.ease-glitch-toggle-icon--sun {
+  opacity: 1;
+  transition: opacity var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+}
+
+.ease-glitch-toggle-icon--moon {
+  opacity: 0;
+  transition: opacity var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+}
+
+.ease-glitch-toggle-input:checked + .ease-glitch-toggle-track .ease-glitch-toggle-icon--sun {
+  opacity: 0;
+}
+
+.ease-glitch-toggle-input:checked + .ease-glitch-toggle-track .ease-glitch-toggle-icon--moon {
+  opacity: 1;
+}
+
+/* ── Focus ring ── */
+.ease-glitch-toggle-input:focus-visible + .ease-glitch-toggle-track {
+  outline: 3px solid var(--ease-glitch-accent);
+  outline-offset: 3px;
+}
+
+/* ── Label text ── */
+.ease-glitch-toggle-label-text {
+  position: relative;
+  display: inline-flex;
+  height: 1.4em;
+  overflow: hidden;
+  min-width: 50px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ease-glitch-fg);
+  transition: color var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+}
+
+.ease-glitch-toggle-label-text span {
+  display: block;
+  height: 1.4em;
+  line-height: 1.4em;
+  transition: transform var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing),
+    opacity var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+}
+
+.ease-glitch-toggle-label-text .ease-glitch-toggle-word--dark {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(100%);
+  opacity: 0;
+}
+
+.ease-glitch-toggle-input:checked ~ .ease-glitch-toggle-label-text .ease-glitch-toggle-word--light {
+  transform: translateY(-100%);
+  opacity: 0;
+}
+
+.ease-glitch-toggle-input:checked ~ .ease-glitch-toggle-label-text .ease-glitch-toggle-word--dark {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+/* ── Glitch text artifact on label during toggle ── */
+.ease-glitch-toggle-label-text::before,
+.ease-glitch-toggle-label-text::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-glitch-toggle-label-text::before {
+  background: var(--ease-glitch-cyan);
+  mix-blend-mode: multiply;
+}
+
+.ease-glitch-toggle-label-text::after {
+  background: var(--ease-glitch-magenta);
+  mix-blend-mode: multiply;
+}
+
+.ease-glitch-toggle-input:checked ~ .ease-glitch-toggle-label-text::before {
+  animation: ease-kf-glitch-text-artifact 0.5s steps(2, end) 1;
+}
+
+.ease-glitch-toggle-input:checked ~ .ease-glitch-toggle-label-text::after {
+  animation: ease-kf-glitch-text-artifact 0.5s steps(3, end) 1 0.03s;
+}
+
+/* ── Demo page specific ── */
+.demo-section {
+  text-align: center;
+  max-width: 600px;
+}
+
+.demo-section h1 {
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.03em;
+}
+
+.demo-section p {
+  font-size: 0.95rem;
+  opacity: 0.7;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.demo-card {
+  background: var(--ease-glitch-card-bg, #ffffff);
+  border: 1px solid var(--ease-glitch-card-border, #e5e7eb);
+  border-radius: 12px;
+  padding: 2rem;
+  margin-top: 1.5rem;
+  text-align: left;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  transition: background var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing),
+    border-color var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing),
+    box-shadow var(--ease-glitch-toggle-duration) var(--ease-glitch-toggle-easing);
+}
+
+body:has(.ease-glitch-toggle-input:checked) .demo-card {
+  --ease-glitch-card-bg: #1e293b;
+  --ease-glitch-card-border: #334155;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+}
+
+.demo-card h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo-card p {
+  margin: 0;
+  opacity: 0.65;
+  font-size: 0.875rem;
+}
+
+.demo-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.demo-badge {
+  display: inline-block;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--ease-glitch-accent);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+body:has(.ease-glitch-toggle-input:checked) .demo-badge {
+  background: rgba(99, 102, 241, 0.2);
+}
+
+/* ── Keyframes ── */
+@keyframes ease-kf-glitch-track-flash {
+  0% { clip-path: inset(0 0 0 0); opacity: 0.35; }
+  20% { clip-path: inset(20% 0 60% 0); opacity: 0.5; }
+  40% { clip-path: inset(50% 0 20% 0); opacity: 0.25; }
+  60% { clip-path: inset(10% 0 70% 0); opacity: 0.4; }
+  80% { clip-path: inset(70% 0 5% 0); opacity: 0.3; }
+  100% { clip-path: inset(0 0 0 0); opacity: 0; }
+}
+
+@keyframes ease-kf-glitch-thumb-jitter {
+  0% { transform: translateX(calc(var(--ease-glitch-track-width) - var(--ease-glitch-thumb-size) - var(--ease-glitch-thumb-offset) * 2)); }
+  15% { transform: translateX(calc(var(--ease-glitch-track-width) - var(--ease-glitch-thumb-size) - var(--ease-glitch-thumb-offset) * 2 - 3px)) translateY(-2px); }
+  30% { transform: translateX(calc(var(--ease-glitch-track-width) - var(--ease-glitch-thumb-size) - var(--ease-glitch-thumb-offset) * 2 + 2px)) translateY(1px); }
+  45% { transform: translateX(calc(var(--ease-glitch-track-width) - var(--ease-glitch-thumb-size) - var(--ease-glitch-thumb-offset) * 2 - 1px)); }
+  60% { transform: translateX(calc(var(--ease-glitch-track-width) - var(--ease-glitch-thumb-size) - var(--ease-glitch-thumb-offset) * 2 + 1px)) translateY(-1px); }
+  100% { transform: translateX(calc(var(--ease-glitch-track-width) - var(--ease-glitch-thumb-size) - var(--ease-glitch-thumb-offset) * 2)); }
+}
+
+@keyframes ease-kf-glitch-text-artifact {
+  0% { clip-path: inset(0 0 0 0); opacity: 0; transform: translateX(0); }
+  15% { clip-path: inset(15% 0 65% 0); opacity: 0.4; transform: translateX(-2px); }
+  35% { clip-path: inset(55% 0 15% 0); opacity: 0.3; transform: translateX(2px); }
+  55% { clip-path: inset(25% 0 55% 0); opacity: 0.25; transform: translateX(-1px); }
+  75% { clip-path: inset(65% 0 10% 0); opacity: 0.35; transform: translateX(1px); }
+  100% { clip-path: inset(0 0 0 0); opacity: 0; transform: translateX(0); }
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-glitch-toggle-track,
+  .ease-glitch-toggle-thumb,
+  .ease-glitch-toggle-label-text span,
+  .ease-glitch-toggle-icon {
+    transition-duration: 0.01s !important;
+    animation-duration: 0.01s !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure-CSS glitch dark mode toggle component inspired by Space design patterns, implementing the feature request in #41514.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/glitch-dark-mode-toggle-er/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure-CSS dark/light mode toggle with animated glitch effects — RGB channel splitting, clip-path jitter, and scanline overlays — all triggered during the toggle state transition.

**How does a developer use it?**

```html
<label class="glitch-dm-toggle" aria-label="Toggle dark mode">
  <input type="checkbox" class="glitch-dm-toggle__input" />
  <span class="glitch-dm-toggle__track">
    <span class="glitch-dm-toggle__thumb"></span>
  </span>
  <span class="glitch-dm-toggle__label">
    <span class="glitch-dm-toggle__sun">☀️</span>
    <span class="glitch-dm-toggle__moon">🌙</span>
  </span>
</label>


