### PR TITLE
fix: remove dead code in modal initialization (#44509)

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -25,10 +25,6 @@
 
           const modal = overlay.querySelector('.ease-modal');
           if (modal) {
-            if (!overlay.classList.contains('is-active')) {
-              previousFocusedElement = document.activeElement;
-            }
-
             modal.setAttribute('tabindex', '-1');
             modal.focus();
           }


### PR DESCRIPTION
## Pull Request Description

Removes unreachable dead code in the `checkModal` function in `core/modal.js`, fixing issue #44509.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## What was the bug?

In `core/modal.js`, the `checkModal` function has a redundant conditional check that is impossible to satisfy:

```javascript
// Line 24: class is added
overlay.classList.add('is-active');

const modal = overlay.querySelector('.ease-modal');
if (modal) {
  // Line 28: This check ALWAYS evaluates to false
  // because 'is-active' was just added on line 24
  if (!overlay.classList.contains('is-active')) {
    previousFocusedElement = document.activeElement; // DEAD CODE - never runs
  }

  modal.setAttribute('tabindex', '-1');
  modal.focus();
}