### PR TITLE
feat: add accessible web zoom-out tooltip (#46251)

### DIFF
--- a/submissions/examples/accessible-tooltip-er/README.md
+++ b/submissions/examples/accessible-tooltip-er/README.md
@@ -1,0 +1,62 @@
+# Accessible Web Zoom-Out Tooltip
+
+Pure CSS zoom-out tooltip designed for accessible web interfaces — keyboard navigable, screen reader friendly, and WCAG 2.1 compliant.
+
+## What it is
+
+A CSS-only tooltip component that reveals content with a smooth zoom-out animation when triggered by **hover** or **keyboard focus**. Built with accessibility as the primary design constraint:
+
+- **Keyboard accessible** — `Tab` through triggers, tooltip appears on focus
+- **ARIA compliant** — uses `role="tooltip"` and `aria-describedby`
+- **High contrast** — exceeds WCAG AAA 7:1 ratio for text
+- **Reduced motion** — instantly shows tooltip when `prefers-reduced-motion: reduce` is active
+- **Focus visible** — clear 3px focus ring on all interactive elements
+- **Skip link** — included in demo for full keyboard navigation
+
+## How it works
+
+The tooltip uses CSS animations (`ease-kf-zoomout-tooltip`) triggered by the `:focus` and `:hover` pseudo-classes on the trigger element. No JavaScript is used.
+
+```css
+/* Trigger focus/hover reveals tooltip */
+.trigger-label:focus ~ .tooltip--accessible {
+    animation: ease-kf-zoomout-tooltip 0.3s ease-out forwards;
+}
+```
+
+Key techniques:
+- `transform: scale()` for the zoom-out effect
+- `aria-describedby` links trigger to tooltip content
+- `role="tooltip"` for screen reader semantics
+- `:focus-visible` for keyboard-only focus ring
+- CSS custom properties for full theme control
+
+## Why it matters
+
+Most tooltips only work with hover, excluding keyboard and screen reader users. This component ensures tooltips are accessible to everyone without sacrificing visual quality.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Standalone demo with two theme variants |
+| `style.css` | All tooltip styles and animations |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-tooltip-scale` | `0.3` | Initial scale for zoom-out |
+| `--ez-tooltip-duration` | `0.3s` | Animation duration |
+| `--ez-tooltip-offset` | `12px` | Gap from trigger |
+| `--ez-tooltip-bg` | `#1a1a2e` | Background color |
+| `--ez-tooltip-color` | `#ffffff` | Text color |
+| `--ez-focus-ring-color` | `#005fcc` | Focus indicator color |
+
+## Keyframe
+
+- `ease-kf-zoomout-tooltip` — zoom from 0.3 to 1.0 with fade-in
+
+## Issue
+
+Closes #46251

--- a/submissions/examples/accessible-tooltip-er/demo.html
+++ b/submissions/examples/accessible-tooltip-er/demo.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessible Web Zoom-Out Tooltip – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
+    <header class="header">
+        <div class="header__inner">
+            <h1 class="header__title">Accessible Web Tooltip</h1>
+            <p class="header__sub">CSS Zoom-Out Tooltip for Accessible Interfaces</p>
+        </div>
+    </header>
+
+    <main id="main-content" class="main">
+        <section class="intro">
+            <h2>Why Accessibility Matters in Tooltips</h2>
+            <p>
+                This tooltip follows WCAG 2.1 guidelines with keyboard support,
+                proper ARIA attributes, and high contrast. Navigate using
+                <kbd>Tab</kbd> to reveal tooltips — no hover required.
+            </p>
+        </section>
+
+        <section class="demo-section">
+            <h2>Interactive Demo</h2>
+
+            <div class="tooltip-grid" role="list">
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-contrast"
+                    >
+                        Contrast
+                        <span class="focus-ring"></span>
+                    </span>
+                    <span class="tooltip tooltip--accessible" role="tooltip" id="tip-contrast">
+                        <span class="tooltip__content">WCAG AAA 7:1 contrast ratio for text</span>
+                    </span>
+                </div>
+
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-focus"
+                    >
+                        Focus Order
+                        <span class="focus-ring"></span>
+                    </span>
+                    <span class="tooltip tooltip--accessible" role="tooltip" id="tip-focus">
+                        <span class="tooltip__content">Logical tab order follows visual layout</span>
+                    </span>
+                </div>
+
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-motion"
+                    >
+                        Motion
+                        <span class="focus-ring"></span>
+                    </span>
+                    <span class="tooltip tooltip--accessible" role="tooltip" id="tip-motion">
+                        <span class="tooltip__content">Respects prefers-reduced-motion setting</span>
+                    </span>
+                </div>
+
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-keyboard"
+                    >
+                        Keyboard
+                        <span class="focus-ring"></span>
+                    </span>
+                    <span class="tooltip tooltip--accessible" role="tooltip" id="tip-keyboard">
+                        <span class="tooltip__content">Fully operable without a mouse</span>
+                    </span>
+                </div>
+
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-scale"
+                    >
+                        Scalable
+                        <span class="focus-ring"></span>
+                    </span>
+                    <span class="tooltip tooltip--accessible" role="tooltip" id="tip-scale">
+                        <span class="tooltip__content">Text scales up to 200% without layout break</span>
+                    </span>
+                </div>
+
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-color"
+                    >
+                        Color
+                        <span class="focus-ring"></span>
+                    </span>
+                    <span class="tooltip tooltip--accessible" role="tooltip" id="tip-color">
+                        <span class="tooltip__content">Never relies on color alone to convey info</span>
+                    </span>
+                </div>
+            </div>
+        </section>
+
+        <section class="demo-section">
+            <h2>High Contrast Theme</h2>
+            <div class="tooltip-grid tooltip-grid--dark" role="list">
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label trigger-label--dark"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-dark-1"
+                    >
+                        Screen Reader
+                        <span class="focus-ring focus-ring--light"></span>
+                    </span>
+                    <span class="tooltip tooltip--dark" role="tooltip" id="tip-dark-1">
+                        <span class="tooltip__content">Semantic HTML ensures screen reader compatibility</span>
+                    </span>
+                </div>
+
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label trigger-label--dark"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-dark-2"
+                    >
+                        Target Size
+                        <span class="focus-ring focus-ring--light"></span>
+                    </span>
+                    <span class="tooltip tooltip--dark" role="tooltip" id="tip-dark-2">
+                        <span class="tooltip__content">Minimum 44×44px touch targets per WCAG 2.5.5</span>
+                    </span>
+                </div>
+
+                <div class="tooltip-trigger" role="listitem">
+                    <span
+                        class="trigger-label trigger-label--dark"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-dark-3"
+                    >
+                        Reflow
+                        <span class="focus-ring focus-ring--light"></span>
+                    </span>
+                    <span class="tooltip tooltip--dark" role="tooltip" id="tip-dark-3">
+                        <span class="tooltip__content">Content reflows at 320px without horizontal scroll</span>
+                    </span>
+                </div>
+            </div>
+        </section>
+
+        <section class="code-section">
+            <h2>Usage</h2>
+            <pre><code>&lt;span tabindex="0" role="button" aria-describedby="tip-id"&gt;
+    Hover or Focus Me
+&lt;/span&gt;
+&lt;span class="tooltip tooltip--accessible" role="tooltip" id="tip-id"&gt;
+    &lt;span class="tooltip__content"&gt;Your tooltip text&lt;/span&gt;
+&lt;/span&gt;</code></pre>
+        </section>
+
+        <section class="props-section">
+            <h2>Custom Properties</h2>
+            <div class="props-table">
+                <div class="props-row props-row--header">
+                    <span>Property</span>
+                    <span>Default</span>
+                    <span>Description</span>
+                </div>
+                <div class="props-row">
+                    <code>--ez-tooltip-scale</code>
+                    <code>0.3</code>
+                    <span>Initial scale for zoom-out</span>
+                </div>
+                <div class="props-row">
+                    <code>--ez-tooltip-duration</code>
+                    <code>0.3s</code>
+                    <span>Animation duration</span>
+                </div>
+                <div class="props-row">
+                    <code>--ez-tooltip-offset</code>
+                    <code>12px</code>
+                    <span>Gap from trigger</span>
+                </div>
+                <div class="props-row">
+                    <code>--ez-tooltip-bg</code>
+                    <code>#1a1a2e</code>
+                    <span>Background color</span>
+                </div>
+                <div class="props-row">
+                    <code>--ez-tooltip-color</code>
+                    <code>#ffffff</code>
+                    <span>Text color</span>
+                </div>
+                <div class="props-row">
+                    <code>--ez-focus-ring-color</code>
+                    <code>#005fcc</code>
+                    <span>Focus indicator color</span>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>Part of <strong>EaseMotion CSS</strong> – Pure CSS animation library</p>
+    </footer>
+</body>
+</html>

--- a/submissions/examples/accessible-tooltip-er/style.css
+++ b/submissions/examples/accessible-tooltip-er/style.css
@@ -1,0 +1,482 @@
+/* =============================================
+   Accessible Web Zoom-Out Tooltip
+   Pure CSS · Keyboard · ARIA · High Contrast
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-tooltip-scale: 0.3;
+    --ez-tooltip-duration: 0.3s;
+    --ez-tooltip-offset: 12px;
+    --ez-tooltip-bg: #1a1a2e;
+    --ez-tooltip-color: #ffffff;
+    --ez-tooltip-radius: 6px;
+    --ez-tooltip-padding: 10px 16px;
+    --ez-focus-ring-color: #005fcc;
+    --ez-focus-ring-width: 3px;
+    --ez-trigger-bg: #e8f0fe;
+    --ez-trigger-border: #b0c4de;
+    --ez-trigger-text: #1a1a2e;
+    --ez-page-bg: #f5f7fa;
+    --ez-page-text: #2c3e50;
+    --ez-heading-color: #1a1a2e;
+    --ez-muted: #6b7b8d;
+    --ez-card-bg: #ffffff;
+    --ez-card-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    --ez-border: #e1e8ed;
+    --ez-kbd-bg: #e9ecef;
+    --ez-kbd-border: #ced4da;
+    --ez-code-bg: #f0f4f8;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-zoomout-tooltip {
+    0% {
+        opacity: 0;
+        transform: scale(var(--ez-tooltip-scale)) translateY(-4px);
+        visibility: hidden;
+    }
+    40% {
+        opacity: 0.6;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-zoomin-tooltip {
+    0% {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+        visibility: visible;
+    }
+    60% {
+        opacity: 0.4;
+        visibility: visible;
+    }
+    100% {
+        opacity: 0;
+        transform: scale(var(--ez-tooltip-scale)) translateY(-4px);
+        visibility: hidden;
+    }
+}
+
+/* ---------- Reset & Base ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+    background: var(--ez-page-bg);
+    color: var(--ez-page-text);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+/* ---------- Skip Link ---------- */
+.skip-link {
+    position: absolute;
+    top: -100%;
+    left: 16px;
+    z-index: 1000;
+    padding: 12px 24px;
+    background: var(--ez-focus-ring-color);
+    color: #fff;
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: var(--ez-tooltip-radius);
+    transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+    top: 16px;
+    outline: var(--ez-focus-ring-width) solid var(--ez-focus-ring-color);
+    outline-offset: 2px;
+}
+
+/* ---------- Header ---------- */
+.header {
+    background: var(--ez-tooltip-bg);
+    color: var(--ez-tooltip-color);
+    padding: 48px 24px;
+    text-align: center;
+}
+
+.header__title {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.header__sub {
+    font-size: 1.05rem;
+    opacity: 0.85;
+}
+
+/* ---------- Main ---------- */
+.main {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+}
+
+.intro {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-border);
+    border-radius: 10px;
+    padding: 28px 32px;
+    margin-bottom: 48px;
+    box-shadow: var(--ez-card-shadow);
+}
+
+.intro h2 {
+    font-size: 1.25rem;
+    color: var(--ez-heading-color);
+    margin-bottom: 12px;
+}
+
+.intro p {
+    color: var(--ez-muted);
+    font-size: 0.98rem;
+}
+
+kbd {
+    display: inline-block;
+    padding: 2px 8px;
+    font-size: 0.85em;
+    font-family: inherit;
+    background: var(--ez-kbd-bg);
+    border: 1px solid var(--ez-kbd-border);
+    border-radius: 4px;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.12);
+    vertical-align: baseline;
+}
+
+/* ---------- Demo Sections ---------- */
+.demo-section {
+    margin-bottom: 48px;
+}
+
+.demo-section h2 {
+    font-size: 1.25rem;
+    color: var(--ez-heading-color);
+    margin-bottom: 20px;
+}
+
+/* ---------- Tooltip Grid ---------- */
+.tooltip-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 20px;
+}
+
+/* ---------- Tooltip Trigger ---------- */
+.tooltip-trigger {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 56px;
+}
+
+.trigger-label {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 14px 20px;
+    background: var(--ez-trigger-bg);
+    border: 2px solid var(--ez-trigger-border);
+    border-radius: 8px;
+    color: var(--ez-trigger-text);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    text-align: center;
+    transition:
+        border-color 0.2s ease,
+        background 0.2s ease,
+        box-shadow 0.2s ease;
+    outline: none;
+}
+
+.trigger-label:hover {
+    border-color: var(--ez-focus-ring-color);
+    background: #d8e8fc;
+}
+
+.trigger-label:focus-visible,
+.trigger-label:focus {
+    border-color: var(--ez-focus-ring-color);
+    box-shadow: 0 0 0 var(--ez-focus-ring-width) rgba(0, 95, 204, 0.3);
+    background: #d8e8fc;
+}
+
+/* ---------- Focus Ring ---------- */
+.focus-ring {
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    pointer-events: none;
+    border: 2px solid transparent;
+    transition: border-color 0.15s ease;
+}
+
+.trigger-label:focus-visible .focus-ring,
+.trigger-label:focus .focus-ring {
+    border-color: var(--ez-focus-ring-color);
+}
+
+.focus-ring--light {
+    border-color: transparent;
+}
+
+.trigger-label--dark:focus-visible .focus-ring--light,
+.trigger-label--dark:focus .focus-ring--light {
+    border-color: #66b2ff;
+}
+
+/* ---------- Tooltip (Light) ---------- */
+.tooltip--accessible {
+    position: absolute;
+    bottom: calc(100% + var(--ez-tooltip-offset));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transform-origin: bottom center;
+    animation: ease-kf-zoomin-tooltip var(--ez-tooltip-duration) ease-in forwards;
+    transform: translateX(-50%) scale(var(--ez-tooltip-scale)) translateY(-4px);
+}
+
+.tooltip__content {
+    display: block;
+    padding: var(--ez-tooltip-padding);
+    background: var(--ez-tooltip-bg);
+    color: var(--ez-tooltip-color);
+    border-radius: var(--ez-tooltip-radius);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    font-weight: 500;
+    white-space: nowrap;
+    max-width: 280px;
+    width: max-content;
+    text-align: center;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+/* Arrow */
+.tooltip--accessible::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: var(--ez-tooltip-bg);
+}
+
+/* Show on hover */
+.trigger-label:hover ~ .tooltip--accessible,
+.trigger-label:focus-visible ~ .tooltip--accessible,
+.trigger-label:focus ~ .tooltip--accessible {
+    animation: ease-kf-zoomout-tooltip var(--ez-tooltip-duration) ease-out forwards;
+}
+
+/* ---------- Tooltip (Dark variant) ---------- */
+.tooltip--dark {
+    position: absolute;
+    bottom: calc(100% + var(--ez-tooltip-offset));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transform-origin: bottom center;
+    animation: ease-kf-zoomin-tooltip var(--ez-tooltip-duration) ease-in forwards;
+    transform: translateX(-50%) scale(var(--ez-tooltip-scale)) translateY(-4px);
+}
+
+.tooltip--dark .tooltip__content {
+    background: #e0e0e0;
+    color: #1a1a2e;
+}
+
+.tooltip--dark::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #e0e0e0;
+}
+
+.trigger-label--dark:hover ~ .tooltip--dark,
+.trigger-label--dark:focus-visible ~ .tooltip--dark,
+.trigger-label--dark:focus ~ .tooltip--dark {
+    animation: ease-kf-zoomout-tooltip var(--ez-tooltip-duration) ease-out forwards;
+}
+
+/* ---------- Dark trigger ---------- */
+.trigger-label--dark {
+    background: #2a2a4a;
+    border-color: #4a4a6a;
+    color: #e0e0e0;
+}
+
+.trigger-label--dark:hover,
+.trigger-label--dark:focus-visible,
+.trigger-label--dark:focus {
+    border-color: #66b2ff;
+    background: #35356a;
+    box-shadow: 0 0 0 var(--ez-focus-ring-width) rgba(102, 178, 255, 0.3);
+}
+
+/* ---------- Dark grid background ---------- */
+.tooltip-grid--dark {
+    background: #1a1a2e;
+    padding: 24px;
+    border-radius: 10px;
+}
+
+/* ---------- Code Section ---------- */
+.code-section {
+    margin-bottom: 48px;
+}
+
+.code-section h2 {
+    font-size: 1.25rem;
+    color: var(--ez-heading-color);
+    margin-bottom: 16px;
+}
+
+.code-section pre {
+    background: var(--ez-code-bg);
+    border: 1px solid var(--ez-border);
+    border-radius: 8px;
+    padding: 20px 24px;
+    overflow-x: auto;
+    font-size: 0.875rem;
+    line-height: 1.7;
+    color: var(--ez-page-text);
+}
+
+.code-section code {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+}
+
+/* ---------- Props Section ---------- */
+.props-section {
+    margin-bottom: 48px;
+}
+
+.props-section h2 {
+    font-size: 1.25rem;
+    color: var(--ez-heading-color);
+    margin-bottom: 16px;
+}
+
+.props-table {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-border);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: var(--ez-card-shadow);
+}
+
+.props-row {
+    display: grid;
+    grid-template-columns: 200px 100px 1fr;
+    gap: 16px;
+    align-items: center;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--ez-border);
+    font-size: 0.9rem;
+}
+
+.props-row:last-child {
+    border-bottom: none;
+}
+
+.props-row--header {
+    background: var(--ez-code-bg);
+    font-weight: 700;
+    color: var(--ez-heading-color);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.props-row code {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+    font-size: 0.85rem;
+    color: var(--ez-focus-ring-color);
+    background: var(--ez-code-bg);
+    padding: 3px 8px;
+    border-radius: 4px;
+}
+
+/* ---------- Footer ---------- */
+.footer {
+    text-align: center;
+    padding: 32px 24px;
+    border-top: 1px solid var(--ez-border);
+    color: var(--ez-muted);
+    font-size: 0.9rem;
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .tooltip--accessible,
+    .tooltip--dark {
+        opacity: 1;
+        visibility: visible;
+        transform: translateX(-50%) scale(1);
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 600px) {
+    .tooltip-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+    }
+
+    .tooltip__content {
+        white-space: normal;
+        max-width: 200px;
+    }
+
+    .props-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+        padding: 10px 16px;
+    }
+
+    .props-row--header {
+        display: none;
+    }
+}


### PR DESCRIPTION
## What
Pure CSS zoom-out tooltip designed for accessible web interfaces — keyboard navigable, screen reader friendly, and WCAG 2.1 compliant.

Closes #46251

## Why
Most tooltips only work with hover, excluding keyboard and screen reader users. This component ensures tooltips are accessible to everyone without sacrificing visual quality.

## How
- `ease-kf-zoomout-tooltip` / `ease-kf-zoomin-tooltip` keyframes for smooth zoom animation
- `role="tooltip"` and `aria-describedby` for screen reader semantics
- `:focus` / `:focus-visible` trigger for full keyboard accessibility
- `prefers-reduced-motion: reduce` — instantly shows tooltip without animation
- 3px visible focus ring on all interactive elements
- Skip link included for keyboard navigation
- High contrast theme (WCAG AAA 7:1 ratio)

## Files
- `submissions/examples/accessible-tooltip-er/demo.html`
- `submissions/examples/accessible-tooltip-er/style.css`
- `submissions/examples/accessible-tooltip-er/README.md`

## Checklist
- [x] Pure CSS, no JavaScript
- [x] Responsive (grid + clamp)
- [x] Uses `ease-*` CSS custom properties and `ease-kf-*` keyframes
- [x] Respects `prefers-reduced-motion`
- [x] Keyboard accessible
- [x] Self-contained (only new files in `submissions/`)