### PR TITLE
feat: add horizontal roll tooltip for responsive dashboard layouts (#46264)

### DIFF
--- a/submissions/examples/dashboard-tooltip-er/README.md
+++ b/submissions/examples/dashboard-tooltip-er/README.md
@@ -1,0 +1,60 @@
+# Dashboard Horizontal Roll Tooltip
+
+Pure CSS tooltip with a smooth horizontal roll-in animation, styled for responsive dashboard interfaces.
+
+## What it is
+
+A CSS-only tooltip component that slides in horizontally when the user hovers or focuses a trigger element. Designed for dashboard contexts: KPI cards, chart legends, data tables, and metric detail triggers.
+
+Two animation directions:
+- **Roll Left** — tooltip appears to the left, sliding in from the right
+- **Roll Right** — tooltip appears to the right, sliding in from the left
+
+## How it works
+
+The tooltip uses CSS `translateX()` animations triggered by `:hover` and `:focus-visible` pseudo-classes. No JavaScript is used.
+
+```css
+/* Trigger focus/hover reveals tooltip */
+.kpi-card__info:hover ~ .tooltip--roll-right {
+    animation: ease-kf-roll-in-right 0.3s cubic-bezier(.4,0,.2,1) forwards;
+}
+```
+
+Key techniques:
+- `translateX()` for horizontal slide motion
+- `ease-kf-roll-in-left` / `ease-kf-roll-in-right` keyframes for directional entry
+- `aria-describedby` links trigger to tooltip content
+- `role="tooltip"` for screen reader semantics
+- CSS custom properties for full theme control
+
+## Why it matters
+
+Dashboard users need contextual information without navigating away. Horizontal roll tooltips provide a non-intrusive way to surface data details, calculation methods, and metric definitions directly at the point of interest.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Full dashboard demo with KPI cards, chart, and data table |
+| `style.css` | All tooltip styles, dashboard layout, and animations |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-tooltip-roll-distance` | `20px` | Horizontal travel distance |
+| `--ez-tooltip-duration` | `0.3s` | Animation duration |
+| `--ez-tooltip-easing` | `cubic-bezier(.4,0,.2,1)` | Timing function |
+| `--ez-tooltip-bg` | `#1e293b` | Background color |
+| `--ez-tooltip-color` | `#f1f5f9` | Text color |
+| `--ez-tooltip-accent` | `#38bdf8` | Accent highlight color |
+
+## Keyframes
+
+- `ease-kf-roll-in-left` — slides in from right (+20px → 0)
+- `ease-kf-roll-in-right` — slides in from left (-20px → 0)
+
+## Issue
+
+Closes #46264

--- a/submissions/examples/dashboard-tooltip-er/demo.html
+++ b/submissions/examples/dashboard-tooltip-er/demo.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard Horizontal Roll Tooltip – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dashboard">
+        <aside class="sidebar" role="navigation" aria-label="Main navigation">
+            <div class="sidebar__logo">DashMetrics</div>
+            <nav class="sidebar__nav">
+                <a href="#" class="sidebar__link sidebar__link--active">Overview</a>
+                <a href="#" class="sidebar__link">Analytics</a>
+                <a href="#" class="sidebar__link">Revenue</a>
+                <a href="#" class="sidebar__link">Users</a>
+                <a href="#" class="sidebar__link">Settings</a>
+            </nav>
+        </aside>
+
+        <main class="content">
+            <header class="topbar">
+                <h1 class="topbar__title">Dashboard Overview</h1>
+                <span class="topbar__date">July 2026</span>
+            </header>
+
+            <section class="kpi-grid" role="list">
+                <div class="kpi-card" role="listitem">
+                    <div class="kpi-card__header">
+                        <span class="kpi-card__label">Total Revenue</span>
+                        <span
+                            class="kpi-card__info"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-revenue"
+                        >
+                            &#9432;
+                        </span>
+                        <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-revenue">
+                            <span class="tooltip__content">
+                                <strong>Net revenue after refunds</strong><br>
+                                Calculated from all completed transactions in the billing period.
+                            </span>
+                        </span>
+                    </div>
+                    <div class="kpi-card__value">$48,352</div>
+                    <div class="kpi-card__change kpi-card__change--up">+12.5%</div>
+                </div>
+
+                <div class="kpi-card" role="listitem">
+                    <div class="kpi-card__header">
+                        <span class="kpi-card__label">Active Users</span>
+                        <span
+                            class="kpi-card__info"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-users"
+                        >
+                            &#9432;
+                        </span>
+                        <span class="tooltip tooltip--roll-left" role="tooltip" id="tip-users">
+                            <span class="tooltip__content">
+                                <strong>Users active in last 30 days</strong><br>
+                                Includes both free and paid accounts with at least one session.
+                            </span>
+                        </span>
+                    </div>
+                    <div class="kpi-card__value">12,847</div>
+                    <div class="kpi-card__change kpi-card__change--up">+8.2%</div>
+                </div>
+
+                <div class="kpi-card" role="listitem">
+                    <div class="kpi-card__header">
+                        <span class="kpi-card__label">Churn Rate</span>
+                        <span
+                            class="kpi-card__info"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-churn"
+                        >
+                            &#9432;
+                        </span>
+                        <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-churn">
+                            <span class="tooltip__content">
+                                <strong>Monthly subscriber churn</strong><br>
+                                Percentage of paid users who cancelled this period.
+                            </span>
+                        </span>
+                    </div>
+                    <div class="kpi-card__value">2.4%</div>
+                    <div class="kpi-card__change kpi-card__change--down">-0.8%</div>
+                </div>
+
+                <div class="kpi-card" role="listitem">
+                    <div class="kpi-card__header">
+                        <span class="kpi-card__label">Avg. Session</span>
+                        <span
+                            class="kpi-card__info"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-session"
+                        >
+                            &#9432;
+                        </span>
+                        <span class="tooltip tooltip--roll-left" role="tooltip" id="tip-session">
+                            <span class="tooltip__content">
+                                <strong>Average session duration</strong><br>
+                                Mean time spent per user session across all pages.
+                            </span>
+                        </span>
+                    </div>
+                    <div class="kpi-card__value">4m 32s</div>
+                    <div class="kpi-card__change kpi-card__change--up">+1.3%</div>
+                </div>
+            </section>
+
+            <section class="chart-section">
+                <div class="chart-card">
+                    <div class="chart-card__header">
+                        <h2 class="chart-card__title">Revenue Trend</h2>
+                        <div class="chart-card__legend" role="list">
+                            <span
+                                class="legend-item"
+                                role="listitem"
+                                tabindex="0"
+                                role="button"
+                                aria-describedby="tip-legend-current"
+                            >
+                                <span class="legend-dot legend-dot--current"></span>
+                                Current
+                                <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-legend-current">
+                                    <span class="tooltip__content">Current month revenue data</span>
+                                </span>
+                            </span>
+                            <span
+                                class="legend-item"
+                                role="listitem"
+                                tabindex="0"
+                                role="button"
+                                aria-describedby="tip-legend-prev"
+                            >
+                                <span class="legend-dot legend-dot--prev"></span>
+                                Previous
+                                <span class="tooltip tooltip--roll-left" role="tooltip" id="tip-legend-prev">
+                                    <span class="tooltip__content">Previous month for comparison</span>
+                                </span>
+                            </span>
+                        </div>
+                    </div>
+                    <div class="chart-card__body">
+                        <div class="chart-bars" role="img" aria-label="Monthly revenue bar chart">
+                            <div class="chart-bar-group">
+                                <div class="chart-bar chart-bar--current" style="height: 60%;">
+                                    <span
+                                        class="chart-bar__tooltip-trigger"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-bar-jan"
+                                    ></span>
+                                    <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-bar-jan">
+                                        <span class="tooltip__content"><strong>Jan:</strong> $32,100</span>
+                                    </span>
+                                </div>
+                                <div class="chart-bar chart-bar--prev" style="height: 45%;"></div>
+                                <span class="chart-bar__label">Jan</span>
+                            </div>
+                            <div class="chart-bar-group">
+                                <div class="chart-bar chart-bar--current" style="height: 72%;">
+                                    <span
+                                        class="chart-bar__tooltip-trigger"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-bar-feb"
+                                    ></span>
+                                    <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-bar-feb">
+                                        <span class="tooltip__content"><strong>Feb:</strong> $38,400</span>
+                                    </span>
+                                </div>
+                                <div class="chart-bar chart-bar--prev" style="height: 55%;"></div>
+                                <span class="chart-bar__label">Feb</span>
+                            </div>
+                            <div class="chart-bar-group">
+                                <div class="chart-bar chart-bar--current" style="height: 55%;">
+                                    <span
+                                        class="chart-bar__tooltip-trigger"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-bar-mar"
+                                    ></span>
+                                    <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-bar-mar">
+                                        <span class="tooltip__content"><strong>Mar:</strong> $29,800</span>
+                                    </span>
+                                </div>
+                                <div class="chart-bar chart-bar--prev" style="height: 62%;"></div>
+                                <span class="chart-bar__label">Mar</span>
+                            </div>
+                            <div class="chart-bar-group">
+                                <div class="chart-bar chart-bar--current" style="height: 85%;">
+                                    <span
+                                        class="chart-bar__tooltip-trigger"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-bar-apr"
+                                    ></span>
+                                    <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-bar-apr">
+                                        <span class="tooltip__content"><strong>Apr:</strong> $45,200</span>
+                                    </span>
+                                </div>
+                                <div class="chart-bar chart-bar--prev" style="height: 70%;"></div>
+                                <span class="chart-bar__label">Apr</span>
+                            </div>
+                            <div class="chart-bar-group">
+                                <div class="chart-bar chart-bar--current" style="height: 78%;">
+                                    <span
+                                        class="chart-bar__tooltip-trigger"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-bar-may"
+                                    ></span>
+                                    <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-bar-may">
+                                        <span class="tooltip__content"><strong>May:</strong> $41,600</span>
+                                    </span>
+                                </div>
+                                <div class="chart-bar chart-bar--prev" style="height: 68%;"></div>
+                                <span class="chart-bar__label">May</span>
+                            </div>
+                            <div class="chart-bar-group">
+                                <div class="chart-bar chart-bar--current" style="height: 92%;">
+                                    <span
+                                        class="chart-bar__tooltip-trigger"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-bar-jun"
+                                    ></span>
+                                    <span class="tooltip tooltip--roll-right" role="tooltip" id="tip-bar-jun">
+                                        <span class="tooltip__content"><strong>Jun:</strong> $48,352</span>
+                                    </span>
+                                </div>
+                                <div class="chart-bar chart-bar--prev" style="height: 75%;"></div>
+                                <span class="chart-bar__label">Jun</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="table-section">
+                <div class="table-card">
+                    <div class="table-card__header">
+                        <h2 class="table-card__title">Recent Transactions</h2>
+                    </div>
+                    <div class="table-card__body">
+                        <table class="data-table">
+                            <thead>
+                                <tr>
+                                    <th>Customer</th>
+                                    <th>Plan</th>
+                                    <th>Amount</th>
+                                    <th>Status</th>
+                                    <th>Details</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Alice Johnson</td>
+                                    <td>Pro</td>
+                                    <td>$49.00</td>
+                                    <td><span class="status status--success">Paid</span></td>
+                                    <td>
+                                        <span
+                                            class="table-info"
+                                            tabindex="0"
+                                            role="button"
+                                            aria-describedby="tip-tx-1"
+                                        >
+                                            &#9432;
+                                            <span class="tooltip tooltip--roll-left" role="tooltip" id="tip-tx-1">
+                                                <span class="tooltip__content">
+                                                    <strong>Invoice #INV-2847</strong><br>
+                                                    Pro plan, annual billing, processed via Stripe.
+                                                </span>
+                                            </span>
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Bob Smith</td>
+                                    <td>Enterprise</td>
+                                    <td>$199.00</td>
+                                    <td><span class="status status--success">Paid</span></td>
+                                    <td>
+                                        <span
+                                            class="table-info"
+                                            tabindex="0"
+                                            role="button"
+                                            aria-describedby="tip-tx-2"
+                                        >
+                                            &#9432;
+                                            <span class="tooltip tooltip--roll-left" role="tooltip" id="tip-tx-2">
+                                                <span class="tooltip__content">
+                                                    <strong>Invoice #INV-2848</strong><br>
+                                                    Enterprise plan, monthly billing, includes 5 seats.
+                                                </span>
+                                            </span>
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Carol Lee</td>
+                                    <td>Starter</td>
+                                    <td>$0.00</td>
+                                    <td><span class="status status--info">Free</span></td>
+                                    <td>
+                                        <span
+                                            class="table-info"
+                                            tabindex="0"
+                                            role="button"
+                                            aria-describedby="tip-tx-3"
+                                        >
+                                            &#9432;
+                                            <span class="tooltip tooltip--roll-left" role="tooltip" id="tip-tx-3">
+                                                <span class="tooltip__content">
+                                                    <strong>Free tier user</strong><br>
+                                                    Signed up 3 days ago, 2 projects created.
+                                                </span>
+                                            </span>
+                                        </span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </section>
+
+            <section class="usage-section" id="usage">
+                <h2 class="section-title">Usage</h2>
+                <pre class="code-block"><code>&lt;span class="kpi-card__info" tabindex="0"
+      role="button" aria-describedby="tip-id"&gt;
+    &#9432;
+&lt;/span&gt;
+&lt;span class="tooltip tooltip--roll-right" role="tooltip" id="tip-id"&gt;
+    &lt;span class="tooltip__content"&gt;Your tooltip text&lt;/span&gt;
+&lt;/span&gt;</code></pre>
+
+                <h2 class="section-title">Custom Properties</h2>
+                <div class="props-table">
+                    <div class="props-row props-row--header">
+                        <span>Property</span>
+                        <span>Default</span>
+                        <span>Description</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-roll-distance</code>
+                        <code>20px</code>
+                        <span>Horizontal travel distance</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-duration</code>
+                        <code>0.3s</code>
+                        <span>Animation duration</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-easing</code>
+                        <code>cubic-bezier(.4,0,.2,1)</code>
+                        <span>Timing function</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-bg</code>
+                        <code>#1e293b</code>
+                        <span>Background color</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-color</code>
+                        <code>#f1f5f9</code>
+                        <span>Text color</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-accent</code>
+                        <code>#38bdf8</code>
+                        <span>Accent highlight color</span>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/dashboard-tooltip-er/style.css
+++ b/submissions/examples/dashboard-tooltip-er/style.css
@@ -1,0 +1,753 @@
+/* =============================================
+   Dashboard Horizontal Roll Tooltip
+   Responsive Dashboard Layout Style
+   Pure CSS · Keyboard · ARIA
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-tooltip-roll-distance: 20px;
+    --ez-tooltip-duration: 0.3s;
+    --ez-tooltip-easing: cubic-bezier(0.4, 0, 0.2, 1);
+    --ez-tooltip-bg: #1e293b;
+    --ez-tooltip-color: #f1f5f9;
+    --ez-tooltip-accent: #38bdf8;
+    --ez-tooltip-radius: 8px;
+    --ez-tooltip-padding: 12px 16px;
+    --ez-tooltip-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    --ez-tooltip-offset: 8px;
+    --ez-focus-ring: 3px;
+    --ez-focus-color: #38bdf8;
+    --ez-sidebar-bg: #0f172a;
+    --ez-sidebar-text: #94a3b8;
+    --ez-sidebar-active: #ffffff;
+    --ez-page-bg: #f1f5f9;
+    --ez-card-bg: #ffffff;
+    --ez-card-border: #e2e8f0;
+    --ez-heading: #0f172a;
+    --ez-text: #334155;
+    --ez-muted: #64748b;
+    --ez-success: #22c55e;
+    --ez-danger: #ef4444;
+    --ez-info: #38bdf8;
+    --ez-bar-current: #6366f1;
+    --ez-bar-prev: #c7d2fe;
+    --ez-topbar-bg: #ffffff;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-roll-in-left {
+    0% {
+        opacity: 0;
+        transform: translateX(var(--ez-tooltip-roll-distance));
+        visibility: hidden;
+    }
+    50% {
+        opacity: 0.8;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-roll-out-left {
+    0% {
+        opacity: 1;
+        transform: translateX(0);
+        visibility: visible;
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(var(--ez-tooltip-roll-distance));
+        visibility: hidden;
+    }
+}
+
+@keyframes ease-kf-roll-in-right {
+    0% {
+        opacity: 0;
+        transform: translateX(calc(var(--ez-tooltip-roll-distance) * -1));
+        visibility: hidden;
+    }
+    50% {
+        opacity: 0.8;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-roll-out-right {
+    0% {
+        opacity: 1;
+        transform: translateX(0);
+        visibility: visible;
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(calc(var(--ez-tooltip-roll-distance) * -1));
+        visibility: hidden;
+    }
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+    background: var(--ez-page-bg);
+    color: var(--ez-text);
+    line-height: 1.6;
+}
+
+/* ---------- Dashboard Layout ---------- */
+.dashboard {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-height: 100vh;
+}
+
+/* ---------- Sidebar ---------- */
+.sidebar {
+    background: var(--ez-sidebar-bg);
+    padding: 24px 0;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+}
+
+.sidebar__logo {
+    color: #ffffff;
+    font-size: 1.15rem;
+    font-weight: 700;
+    padding: 0 24px 24px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sidebar__nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 16px 12px;
+}
+
+.sidebar__link {
+    display: block;
+    padding: 10px 16px;
+    color: var(--ez-sidebar-text);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    border-radius: 8px;
+    transition: all 0.15s ease;
+    outline: none;
+}
+
+.sidebar__link:hover {
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.sidebar__link:focus-visible {
+    color: #ffffff;
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.4);
+}
+
+.sidebar__link--active {
+    color: #ffffff;
+    background: rgba(99, 102, 241, 0.2);
+}
+
+/* ---------- Content ---------- */
+.content {
+    padding: 0;
+    overflow-x: hidden;
+}
+
+/* ---------- Topbar ---------- */
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 32px;
+    background: var(--ez-topbar-bg);
+    border-bottom: 1px solid var(--ez-card-border);
+}
+
+.topbar__title {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+}
+
+.topbar__date {
+    color: var(--ez-muted);
+    font-size: 0.9rem;
+}
+
+/* ---------- KPI Grid ---------- */
+.kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    padding: 28px 32px;
+}
+
+.kpi-card {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 12px;
+    padding: 20px 22px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    position: relative;
+}
+
+.kpi-card__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.kpi-card__label {
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--ez-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.kpi-card__info {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--ez-card-border);
+    color: var(--ez-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    cursor: pointer;
+    outline: none;
+    flex-shrink: 0;
+    position: relative;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.kpi-card__info:hover,
+.kpi-card__info:focus-visible {
+    background: var(--ez-info);
+    color: #ffffff;
+}
+
+.kpi-card__info:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.4);
+}
+
+.kpi-card__value {
+    font-size: 1.7rem;
+    font-weight: 800;
+    color: var(--ez-heading);
+    margin-bottom: 4px;
+}
+
+.kpi-card__change {
+    font-size: 0.82rem;
+    font-weight: 600;
+}
+
+.kpi-card__change--up {
+    color: var(--ez-success);
+}
+
+.kpi-card__change--down {
+    color: var(--ez-danger);
+}
+
+/* ---------- Tooltip Base ---------- */
+.tooltip {
+    position: absolute;
+    z-index: 100;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+}
+
+.tooltip__content {
+    display: block;
+    padding: var(--ez-tooltip-padding);
+    background: var(--ez-tooltip-bg);
+    color: var(--ez-tooltip-color);
+    border-radius: var(--ez-tooltip-radius);
+    font-size: 0.82rem;
+    line-height: 1.5;
+    box-shadow: var(--ez-tooltip-shadow);
+    white-space: nowrap;
+    max-width: 260px;
+    width: max-content;
+}
+
+.tooltip__content strong {
+    color: var(--ez-tooltip-accent);
+}
+
+/* ---------- Roll Left ---------- */
+.tooltip--roll-left {
+    bottom: calc(100% + var(--ez-tooltip-offset));
+    right: 0;
+    transform-origin: right center;
+    animation: ease-kf-roll-out-left var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+.tooltip--roll-left::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    right: 16px;
+    border: 5px solid transparent;
+    border-top-color: var(--ez-tooltip-bg);
+}
+
+/* ---------- Roll Right ---------- */
+.tooltip--roll-right {
+    bottom: calc(100% + var(--ez-tooltip-offset));
+    left: 0;
+    transform-origin: left center;
+    animation: ease-kf-roll-out-right var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+.tooltip--roll-right::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 16px;
+    border: 5px solid transparent;
+    border-top-color: var(--ez-tooltip-bg);
+}
+
+/* ---------- Tooltip Show on Hover/Focus ---------- */
+.kpi-card__info:hover ~ .tooltip--roll-right,
+.kpi-card__info:focus-visible ~ .tooltip--roll-right {
+    animation: ease-kf-roll-in-right var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+.kpi-card__info:hover ~ .tooltip--roll-left,
+.kpi-card__info:focus-visible ~ .tooltip--roll-left {
+    animation: ease-kf-roll-in-left var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+.legend-item:hover .tooltip--roll-right,
+.legend-item:focus-visible .tooltip--roll-right {
+    animation: ease-kf-roll-in-right var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+.legend-item:hover .tooltip--roll-left,
+.legend-item:focus-visible .tooltip--roll-left {
+    animation: ease-kf-roll-in-left var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+.chart-bar__tooltip-trigger:hover ~ .tooltip--roll-right,
+.chart-bar__tooltip-trigger:focus-visible ~ .tooltip--roll-right {
+    animation: ease-kf-roll-in-right var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+.table-info:hover .tooltip--roll-left,
+.table-info:focus-visible .tooltip--roll-left {
+    animation: ease-kf-roll-in-left var(--ez-tooltip-duration) var(--ez-tooltip-easing) forwards;
+}
+
+/* ---------- Chart Section ---------- */
+.chart-section {
+    padding: 0 32px 28px;
+}
+
+.chart-card {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+}
+
+.chart-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 18px 24px;
+    border-bottom: 1px solid var(--ez-card-border);
+}
+
+.chart-card__title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+}
+
+.chart-card__legend {
+    display: flex;
+    gap: 18px;
+}
+
+.legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+    color: var(--ez-muted);
+    cursor: pointer;
+    outline: none;
+    padding: 4px 8px;
+    border-radius: 6px;
+    position: relative;
+    transition: background 0.15s ease;
+}
+
+.legend-item:hover,
+.legend-item:focus-visible {
+    background: rgba(0, 0, 0, 0.04);
+}
+
+.legend-item:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.3);
+}
+
+.legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+}
+
+.legend-dot--current {
+    background: var(--ez-bar-current);
+}
+
+.legend-dot--prev {
+    background: var(--ez-bar-prev);
+}
+
+.chart-card__body {
+    padding: 24px;
+}
+
+.chart-bars {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    height: 200px;
+    gap: 12px;
+}
+
+.chart-bar-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    height: 100%;
+    justify-content: flex-end;
+}
+
+.chart-bar {
+    width: 100%;
+    max-width: 40px;
+    border-radius: 6px 6px 0 0;
+    position: relative;
+    transition: opacity 0.15s ease;
+    cursor: default;
+}
+
+.chart-bar:hover {
+    opacity: 0.85;
+}
+
+.chart-bar--current {
+    background: var(--ez-bar-current);
+}
+
+.chart-bar--prev {
+    background: var(--ez-bar-prev);
+}
+
+.chart-bar__tooltip-trigger {
+    position: absolute;
+    inset: 0;
+    cursor: pointer;
+    outline: none;
+}
+
+.chart-bar__tooltip-trigger:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--ez-focus-color);
+    border-radius: inherit;
+}
+
+.chart-bar__label {
+    font-size: 0.72rem;
+    color: var(--ez-muted);
+    font-weight: 500;
+}
+
+/* ---------- Table Section ---------- */
+.table-section {
+    padding: 0 32px 28px;
+}
+
+.table-card {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+}
+
+.table-card__header {
+    padding: 18px 24px;
+    border-bottom: 1px solid var(--ez-card-border);
+}
+
+.table-card__title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+}
+
+.table-card__body {
+    overflow-x: auto;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+}
+
+.data-table th {
+    text-align: left;
+    padding: 12px 20px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--ez-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    background: #f8fafc;
+    border-bottom: 1px solid var(--ez-card-border);
+}
+
+.data-table td {
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--ez-card-border);
+    color: var(--ez-text);
+}
+
+.data-table tr:last-child td {
+    border-bottom: none;
+}
+
+.data-table tr:hover td {
+    background: #f8fafc;
+}
+
+.status {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: 50px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.status--success {
+    background: rgba(34, 197, 94, 0.1);
+    color: #16a34a;
+}
+
+.status--danger {
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+}
+
+.status--info {
+    background: rgba(56, 189, 248, 0.1);
+    color: #0284c7;
+}
+
+.table-info {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--ez-card-border);
+    color: var(--ez-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    cursor: pointer;
+    outline: none;
+    position: relative;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.table-info:hover,
+.table-info:focus-visible {
+    background: var(--ez-info);
+    color: #ffffff;
+}
+
+.table-info:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.4);
+}
+
+/* ---------- Usage Section ---------- */
+.usage-section {
+    padding: 0 32px 40px;
+}
+
+.section-title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+    margin-bottom: 14px;
+    margin-top: 28px;
+}
+
+.code-block {
+    background: #1e293b;
+    color: #e2e8f0;
+    border-radius: 10px;
+    padding: 20px 24px;
+    overflow-x: auto;
+    font-size: 0.82rem;
+    line-height: 1.7;
+    margin-bottom: 28px;
+}
+
+.code-block code {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+}
+
+.props-table {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.props-row {
+    display: grid;
+    grid-template-columns: 220px 140px 1fr;
+    gap: 16px;
+    align-items: center;
+    padding: 11px 20px;
+    border-bottom: 1px solid var(--ez-card-border);
+    font-size: 0.85rem;
+}
+
+.props-row:last-child {
+    border-bottom: none;
+}
+
+.props-row--header {
+    background: #f8fafc;
+    font-weight: 700;
+    color: var(--ez-heading);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.props-row code {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+    font-size: 0.8rem;
+    color: var(--ez-tooltip-accent);
+    background: #f1f5f9;
+    padding: 3px 8px;
+    border-radius: 4px;
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .tooltip {
+        opacity: 1;
+        visibility: visible;
+        transform: none !important;
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+    .dashboard {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        position: fixed;
+        left: -240px;
+        width: 220px;
+        z-index: 200;
+        transition: left 0.3s ease;
+    }
+
+    .topbar {
+        padding: 16px 20px;
+    }
+
+    .kpi-grid {
+        grid-template-columns: repeat(2, 1fr);
+        padding: 20px;
+        gap: 12px;
+    }
+
+    .chart-section,
+    .table-section,
+    .usage-section {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+
+    .chart-bars {
+        height: 150px;
+    }
+
+    .tooltip__content {
+        white-space: normal;
+        max-width: 180px;
+    }
+
+    .props-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+        padding: 10px 16px;
+    }
+
+    .props-row--header {
+        display: none;
+    }
+}
+
+@media (max-width: 480px) {
+    .kpi-grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## What
Pure CSS tooltip with a smooth horizontal roll-in animation, designed for responsive dashboard interfaces — KPI cards, chart legends, and data tables.

Closes #46264

## Why
Dashboard users need contextual information without navigating away. Horizontal roll tooltips provide a non-intrusive way to surface data details directly at the point of interest.

## How
- `ease-kf-roll-in-left` / `ease-kf-roll-in-right` keyframes for directional horizontal entry
- Two variants: `tooltip--roll-left` and `tooltip--roll-right`
- `role="tooltip"` and `aria-describedby` for screen reader semantics
- `:focus-visible` trigger for full keyboard accessibility
- `prefers-reduced-motion: reduce` — instantly shows tooltip without animation
- CSS custom properties for timing, distance, colors, and easing
- Full responsive dashboard layout with sidebar, KPI grid, chart, and data table

## Files (all inside submissions/)
- `submissions/examples/dashboard-tooltip-er/demo.html`
- `submissions/examples/dashboard-tooltip-er/style.css`
- `submissions/examples/dashboard-tooltip-er/README.md`

## Checklist
- [x] Pure CSS, no JavaScript
- [x] Responsive (grid + media queries)
- [x] Uses `ease-*` CSS custom properties and `ease-kf-*` keyframes
- [x] Respects `prefers-reduced-motion`
- [x] Keyboard accessible
- [x] ARIA attributes (role="tooltip", aria-describedby)
- [x] Only new files inside `submissions/` — no other files affected