### PR TITLE
feat: add error budget burn demo

### DIFF
--- a/submissions/examples/error-budget-burn-sm/README.md
+++ b/submissions/examples/error-budget-burn-sm/README.md
@@ -1,0 +1,34 @@
+# Error Budget Burn
+
+## What does this do?
+
+Error Budget Burn is a self-contained HTML and CSS reliability dashboard pattern with animated burn-rate cards, budget rings, alert bands, and clear service health signals.
+
+## How is it used?
+
+Create a `budget-board` wrapper and add `budget-card` items with burn state classes such as `burn-healthy`, `burn-watch`, or `burn-critical`.
+
+```html
+<article class="budget-card burn-critical">
+  <div class="budget-ring" aria-hidden="true">
+    <span>18%</span>
+  </div>
+  <div class="budget-content">
+    <p class="budget-kicker">Checkout API</p>
+    <h2>Budget burn is critical</h2>
+    <div class="burn-bar" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available burn classes:
+
+- `burn-healthy`
+- `burn-watch`
+- `burn-critical`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make reliability risk easier to scan: cards enter gently, rings show budget remaining, bars reveal burn pressure, and focus states keep mitigation actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/error-budget-burn-sm/demo.html
+++ b/submissions/examples/error-budget-burn-sm/demo.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Error Budget Burn Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="budget-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Error Budget Burn</h1>
+        <p>
+          A self-contained reliability dashboard pattern with animated burn-rate
+          cards, budget rings, alert bands, and clear service health signals.
+        </p>
+      </section>
+
+      <section class="budget-summary" aria-label="Error budget summary">
+        <article>
+          <span class="summary-value">72%</span>
+          <span class="summary-label">Budget remaining</span>
+        </article>
+        <article>
+          <span class="summary-value">1.4x</span>
+          <span class="summary-label">Current burn rate</span>
+        </article>
+        <article>
+          <span class="summary-value">28d</span>
+          <span class="summary-label">Window left</span>
+        </article>
+      </section>
+
+      <section class="budget-board" aria-label="Error budget burn cards">
+        <article class="budget-card burn-healthy">
+          <div class="budget-ring" aria-hidden="true">
+            <span>82%</span>
+          </div>
+          <div class="budget-content">
+            <p class="budget-kicker">Auth service</p>
+            <h2>Budget burn is healthy</h2>
+            <p>
+              Authentication errors are below the weekly SLO threshold and the
+              service is comfortably inside the allowed error budget.
+            </p>
+            <div class="burn-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Healthy</span>
+              <button type="button">View SLO</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="budget-card burn-watch">
+          <div class="budget-ring" aria-hidden="true">
+            <span>51%</span>
+          </div>
+          <div class="budget-content">
+            <p class="budget-kicker">Search API</p>
+            <h2>Burn rate needs watching</h2>
+            <p>
+              Query timeout spikes are consuming more budget than expected
+              during peak workspace traffic.
+            </p>
+            <div class="burn-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Watch</span>
+              <button type="button">Tune cache</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="budget-card burn-critical">
+          <div class="budget-ring" aria-hidden="true">
+            <span>18%</span>
+          </div>
+          <div class="budget-content">
+            <p class="budget-kicker">Checkout API</p>
+            <h2>Budget burn is critical</h2>
+            <p>
+              Failed payment confirmations are burning the monthly budget
+              quickly and need immediate mitigation.
+            </p>
+            <div class="burn-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Critical</span>
+              <button type="button">Mitigate</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/error-budget-burn-sm/style.css
+++ b/submissions/examples/error-budget-burn-sm/style.css
@@ -1,0 +1,357 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.budget-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.budget-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.budget-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.budget-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.budget-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.budget-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.budget-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.budget-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.budget-card:hover,
+.budget-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.budget-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--budget), #e4edf8 var(--budget) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-enter 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.budget-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.45rem;
+  font-weight: 950;
+}
+
+.budget-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.budget-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.budget-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.budget-content > p:not(.budget-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.burn-bar {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.burn-bar span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--burn);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: bar-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.budget-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.budget-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.budget-content button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.budget-content button:hover,
+.budget-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.burn-healthy {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --budget: 82%;
+  --burn: 24%;
+}
+
+.burn-watch {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --budget: 51%;
+  --burn: 58%;
+}
+
+.burn-critical {
+  --accent: var(--red);
+  --accent-light: #fb7185;
+  --accent-soft: rgba(220, 38, 38, 0.14);
+  --budget: 18%;
+  --burn: 91%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-enter {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .budget-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .budget-summary,
+  .budget-board {
+    grid-template-columns: 1fr;
+  }
+
+  .budget-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #49882


**PR Text**

Title: `feat: add error budget burn demo`

```md
## Pull Request Description
Adds a self-contained Error Budget Burn demo under `submissions/examples/`, featuring animated burn-rate cards, budget rings, alert bands, and service health signals.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only error budget burn dashboard pattern for reliability monitoring.

**How does a developer use it?**
Use a `budget-board` wrapper with `budget-card` items and burn classes like `burn-healthy`, `burn-watch`, or `burn-critical`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate budget remaining, burn pressure, and mitigation priority while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The burn naming, reliability colors, and meter timing can be standardized during framework integration.