### PR TITLE
feat: add regional failover map demo

### DIFF
--- a/submissions/examples/regional-failover-map-sm/README.md
+++ b/submissions/examples/regional-failover-map-sm/README.md
@@ -1,0 +1,30 @@
+# Regional Failover Map
+
+## What does this do?
+
+Regional Failover Map is a self-contained HTML and CSS infrastructure dashboard pattern with animated region nodes, failover routes, health cards, and readable recovery states.
+
+## How is it used?
+
+Create a `failover-layout` with a `map-card` for the visual route map and `region-card` items with state classes such as `region-healthy`, `region-warning`, or `region-backup`.
+
+```html
+<article class="region-card region-warning">
+  <span class="region-dot" aria-hidden="true"></span>
+  <div>
+    <p>EU West</p>
+    <h3>Latency elevated</h3>
+    <span>Failover ready</span>
+  </div>
+</article>
+```
+
+Available region classes:
+
+- `region-healthy`
+- `region-warning`
+- `region-backup`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make regional status easier to scan: nodes pulse for health, routes animate to show traffic paths, and cards enter gently for quick review. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/regional-failover-map-sm/demo.html
+++ b/submissions/examples/regional-failover-map-sm/demo.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Regional Failover Map Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="failover-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Regional Failover Map</h1>
+        <p>
+          A self-contained infrastructure dashboard pattern with animated region
+          nodes, failover routes, health cards, and readable recovery states.
+        </p>
+      </section>
+
+      <section class="failover-summary" aria-label="Regional failover summary">
+        <article>
+          <span class="summary-value">05</span>
+          <span class="summary-label">Regions online</span>
+        </article>
+        <article>
+          <span class="summary-value">01</span>
+          <span class="summary-label">Failover active</span>
+        </article>
+        <article>
+          <span class="summary-value">99.9%</span>
+          <span class="summary-label">Traffic healthy</span>
+        </article>
+      </section>
+
+      <section class="failover-layout" aria-label="Regional failover status">
+        <article class="map-card">
+          <div class="region-map" aria-hidden="true">
+            <span class="route route-primary"></span>
+            <span class="route route-backup"></span>
+            <span class="region-node node-us">US</span>
+            <span class="region-node node-eu">EU</span>
+            <span class="region-node node-apac">APAC</span>
+            <span class="region-node node-backup">DR</span>
+          </div>
+          <div class="map-copy">
+            <p class="map-kicker">Traffic routing</p>
+            <h2>Failover path is active</h2>
+            <p>
+              Primary traffic is routing through the US region while the
+              disaster recovery node keeps a warm standby path ready.
+            </p>
+          </div>
+        </article>
+
+        <section class="region-stack" aria-label="Region health cards">
+          <article class="region-card region-healthy">
+            <span class="region-dot" aria-hidden="true"></span>
+            <div>
+              <p>US East</p>
+              <h3>Primary traffic stable</h3>
+              <span>64% traffic share</span>
+            </div>
+          </article>
+
+          <article class="region-card region-warning">
+            <span class="region-dot" aria-hidden="true"></span>
+            <div>
+              <p>EU West</p>
+              <h3>Latency elevated</h3>
+              <span>Failover ready</span>
+            </div>
+          </article>
+
+          <article class="region-card region-backup">
+            <span class="region-dot" aria-hidden="true"></span>
+            <div>
+              <p>DR Region</p>
+              <h3>Warm standby synced</h3>
+              <span>Replication current</span>
+            </div>
+          </article>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/regional-failover-map-sm/style.css
+++ b/submissions/examples/regional-failover-map-sm/style.css
@@ -1,0 +1,379 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.failover-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.map-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.failover-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.failover-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.failover-layout {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.95fr) minmax(0, 1.05fr);
+  gap: 20px;
+  align-items: stretch;
+}
+
+.map-card,
+.region-card {
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.map-card {
+  overflow: hidden;
+  padding: 24px;
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  animation: panel-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.region-map {
+  position: relative;
+  min-height: 330px;
+  margin-bottom: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.1), transparent),
+    radial-gradient(circle at center, rgba(22, 163, 74, 0.12), transparent 56%),
+    #f8fafc;
+}
+
+.region-map::before {
+  position: absolute;
+  inset: 22px;
+  border: 1px dashed rgba(37, 99, 235, 0.18);
+  border-radius: 8px;
+  content: "";
+}
+
+.route {
+  position: absolute;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--blue), transparent);
+  opacity: 0.75;
+  transform-origin: left;
+  animation: route-flow 1.9s ease-in-out infinite;
+}
+
+.route-primary {
+  top: 42%;
+  left: 25%;
+  width: 52%;
+  transform: rotate(10deg);
+}
+
+.route-backup {
+  top: 66%;
+  left: 38%;
+  width: 42%;
+  background: linear-gradient(90deg, transparent, var(--green), transparent);
+  transform: rotate(-18deg);
+  animation-delay: 420ms;
+}
+
+.region-node {
+  position: absolute;
+  display: grid;
+  width: 64px;
+  height: 64px;
+  place-items: center;
+  border: 6px solid #ffffff;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 14px 32px var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 950;
+  animation: node-pulse 2.2s ease-out infinite;
+}
+
+.node-us {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.16);
+  top: 30%;
+  left: 17%;
+}
+
+.node-eu {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.16);
+  top: 22%;
+  right: 24%;
+  animation-delay: 240ms;
+}
+
+.node-apac {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.16);
+  right: 16%;
+  bottom: 24%;
+  animation-delay: 480ms;
+}
+
+.node-backup {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.16);
+  bottom: 18%;
+  left: 34%;
+  animation-delay: 720ms;
+}
+
+.map-copy h2 {
+  margin-bottom: 10px;
+  font-size: 1.35rem;
+}
+
+.map-copy p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.region-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.region-card {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+  padding: 20px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: panel-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.region-card:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.region-card:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+.region-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 18px 42px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.region-dot {
+  width: 38px;
+  height: 38px;
+  border: 5px solid #ffffff;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 12px 24px var(--accent-soft);
+  animation: node-pulse 2s ease-out infinite;
+}
+
+.region-card p {
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.region-card h3 {
+  margin-bottom: 8px;
+  font-size: 1.08rem;
+}
+
+.region-card span:not(.region-dot) {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 750;
+}
+
+.region-healthy {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.14);
+}
+
+.region-warning {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.15);
+}
+
+.region-backup {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.14);
+}
+
+@keyframes panel-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes route-flow {
+  0%,
+  100% {
+    opacity: 0.42;
+    filter: saturate(0.9);
+  }
+
+  50% {
+    opacity: 1;
+    filter: saturate(1.35);
+  }
+}
+
+@keyframes node-pulse {
+  70% {
+    box-shadow:
+      0 0 0 12px rgba(255, 255, 255, 0),
+      0 14px 32px var(--accent-soft);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(255, 255, 255, 0),
+      0 14px 32px var(--accent-soft);
+  }
+}
+
+@media (max-width: 820px) {
+  .failover-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .failover-summary,
+  .failover-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #49889


**PR Text**

Title: `feat: add regional failover map demo`

```md
## Pull Request Description
Adds a self-contained Regional Failover Map demo under `submissions/examples/`, featuring animated region nodes, failover routes, health cards, and recovery state details.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only regional failover status map for infrastructure dashboards.

**How does a developer use it?**
Use a `failover-layout` with a `map-card` and `region-card` items using classes like `region-healthy`, `region-warning`, or `region-backup`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate traffic routing, regional health, and failover readiness while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The region naming, health colors, and route animation timing can be standardized during framework integration.