### PR TITLE
fix(tooltip): prevent text overflow on mobile devices

### DIFF
--- a/components/tooltips.css
+++ b/components/tooltips.css
@@ -189,6 +189,10 @@
     .ease-tooltip::after {
       font-size: 0.72rem;
       padding: var(--ease-space-1, 0.25rem) var(--ease-space-1, 0.25rem);
+      white-space: normal;
+      max-width: 250px;
+      width: max-content;
+      text-align: center;
     }
 
     /* Fallback to bottom positioning on narrow viewports to avoid cropping */


### PR DESCRIPTION
- Added white-space: normal and max-width for multiline wrapping
- Maintained centralized text alignment for better readability on narrow screens Fixes issue #49876

## Pull Request Description

This PR fixes a bug where tooltip text overflows and is cut off on mobile devices. The `.ease-tooltip` component used `white-space: nowrap`, preventing text wrapping. This PR adds mobile-specific responsive styles to allow multi-line text wrapping on smaller screens by adding `white-space: normal` and constraining the `max-width`.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [ ] **No changes to `core/`**
- [ ] **No changes to `components/`**
- [ ] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds proper multi-line text wrapping support for tooltips on narrow viewports/mobile devices.

**How does a developer use it?**

```html
<!-- Simply use the tooltip class normally, it now automatically handles long text gracefully on mobile -->
<span class="ease-tooltip" data-tooltip="This is a very long tooltip text that should wrap but doesn't">
  Hover me
</span>
```

**Why does it fit EaseMotion CSS?**

It improves the accessibility and overall user experience for mobile device users without altering the default desktop appearance.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

This PR targets a bug inside `components/tooltips.css`. Please note that this conflicts with the submission checklist requirement of "No changes to components/", but modifying `components/tooltips.css` is necessary to resolve the tooltip core bug defined in Issue #49876.

---
