### PR TITLE
feat: add data sync drift demo

### DIFF
--- a/submissions/examples/data-sync-drift-sm/README.md
+++ b/submissions/examples/data-sync-drift-sm/README.md
@@ -1,0 +1,34 @@
+# Data Sync Drift
+
+## What does this do?
+
+Data Sync Drift is a self-contained HTML and CSS data operations dashboard pattern with animated drift meters, sync status cards, lag indicators, and readable reconciliation signals.
+
+## How is it used?
+
+Create a `sync-board` wrapper and add `sync-card` items with drift classes such as `drift-low`, `drift-medium`, or `drift-high`.
+
+```html
+<article class="sync-card drift-high">
+  <div class="drift-ring" aria-hidden="true">
+    <span>3m</span>
+  </div>
+  <div class="sync-content">
+    <p class="sync-kicker">Inventory source</p>
+    <h2>Stock counts are drifting</h2>
+    <div class="drift-bar" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available drift classes:
+
+- `drift-low`
+- `drift-medium`
+- `drift-high`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make data drift easier to scan: cards enter gently, rings show lag severity, bars reveal drift pressure, and focus states keep reconciliation actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/data-sync-drift-sm/demo.html
+++ b/submissions/examples/data-sync-drift-sm/demo.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Data Sync Drift Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="sync-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Data Sync Drift</h1>
+        <p>
+          A self-contained data operations pattern with animated drift meters,
+          sync status cards, lag indicators, and readable reconciliation
+          signals.
+        </p>
+      </section>
+
+      <section class="sync-summary" aria-label="Data sync summary">
+        <article>
+          <span class="summary-value">12s</span>
+          <span class="summary-label">Median sync lag</span>
+        </article>
+        <article>
+          <span class="summary-value">03</span>
+          <span class="summary-label">Sources drifting</span>
+        </article>
+        <article>
+          <span class="summary-value">99.4%</span>
+          <span class="summary-label">Records aligned</span>
+        </article>
+      </section>
+
+      <section class="sync-board" aria-label="Data sync drift cards">
+        <article class="sync-card drift-low">
+          <div class="drift-ring" aria-hidden="true">
+            <span>8s</span>
+          </div>
+          <div class="sync-content">
+            <p class="sync-kicker">CRM source</p>
+            <h2>Customer profiles aligned</h2>
+            <p>
+              Profile updates are flowing within the expected delay window and
+              no reconciliation task is required.
+            </p>
+            <div class="drift-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Stable</span>
+              <button type="button">Inspect</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="sync-card drift-medium">
+          <div class="drift-ring" aria-hidden="true">
+            <span>47s</span>
+          </div>
+          <div class="sync-content">
+            <p class="sync-kicker">Billing source</p>
+            <h2>Invoice records delayed</h2>
+            <p>
+              The billing export is behind the warehouse by one batch and should
+              be watched during the next scheduler pass.
+            </p>
+            <div class="drift-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Watch</span>
+              <button type="button">Queue sync</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="sync-card drift-high">
+          <div class="drift-ring" aria-hidden="true">
+            <span>3m</span>
+          </div>
+          <div class="sync-content">
+            <p class="sync-kicker">Inventory source</p>
+            <h2>Stock counts are drifting</h2>
+            <p>
+              Regional inventory counts are out of sync and need reconciliation
+              before the next storefront cache refresh.
+            </p>
+            <div class="drift-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Drifting</span>
+              <button type="button">Reconcile</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/data-sync-drift-sm/style.css
+++ b/submissions/examples/data-sync-drift-sm/style.css
@@ -1,0 +1,354 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --green: #16a34a;
+  --blue: #2563eb;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.sync-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.sync-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.sync-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.sync-board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.sync-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 470px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  padding: 24px;
+  transform: translateY(18px) scale(0.98);
+  animation: card-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.sync-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.sync-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.sync-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background:
+    linear-gradient(
+      130deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(255, 255, 255, 0.72)
+    ),
+    radial-gradient(circle at top right, var(--accent-soft), transparent 42%);
+}
+
+.sync-card:hover,
+.sync-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 28px 72px var(--accent-soft);
+  transform: translateY(-5px);
+}
+
+.drift-ring {
+  display: grid;
+  width: 138px;
+  height: 138px;
+  margin-bottom: 24px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    conic-gradient(var(--accent) 0 var(--drift), #e4edf8 var(--drift) 100%),
+    var(--surface);
+  box-shadow:
+    inset 0 0 0 13px var(--surface),
+    0 18px 38px var(--accent-soft);
+  animation: ring-enter 760ms 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.drift-ring span {
+  display: grid;
+  width: 88px;
+  height: 88px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--surface);
+  font-size: 1.45rem;
+  font-weight: 950;
+}
+
+.sync-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.sync-kicker {
+  width: fit-content;
+  margin-bottom: 14px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.sync-content h2 {
+  margin-bottom: 10px;
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.sync-content > p:not(.sync-kicker) {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.drift-bar {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 20px 0;
+}
+
+.drift-bar span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--drift);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: bar-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.sync-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.sync-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.sync-content button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.sync-content button:hover,
+.sync-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.drift-low {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --drift: 22%;
+}
+
+.drift-medium {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --drift: 58%;
+}
+
+.drift-high {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --drift: 86%;
+}
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ring-enter {
+  from {
+    transform: scale(0.82);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .sync-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .sync-summary,
+  .sync-board {
+    grid-template-columns: 1fr;
+  }
+
+  .sync-card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #49903


**PR Text**

Title: `feat: add data sync drift demo`

```md
## Pull Request Description
Adds a self-contained Data Sync Drift demo under `submissions/examples/`, featuring animated drift meters, sync status cards, lag indicators, and reconciliation actions.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only data sync drift dashboard pattern for data operations.

**How does a developer use it?**
Use a `sync-board` wrapper with `sync-card` items and drift classes like `drift-low`, `drift-medium`, or `drift-high`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate sync lag, drift severity, and reconciliation priority while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The drift naming, data health colors, and meter timing can be standardized during framework integration.