### PR TITLE
feat: add staggered entrance tooltip for dashboard analytics (#46269)

### DIFF
--- a/submissions/examples/staggered-tooltip-er/README.md
+++ b/submissions/examples/staggered-tooltip-er/README.md
@@ -1,0 +1,64 @@
+# Staggered Entrance Tooltip – Dashboard Analytics
+
+Pure CSS tooltip with a smooth staggered entrance animation, styled for dashboard analytics interfaces.
+
+## What it is
+
+A CSS-only tooltip component where multiple tooltips in a group animate in sequentially with configurable delays. Designed for analytics dashboards: KPI cards, chart legends, funnel steps, and data tables.
+
+Each tooltip uses a `--stagger-index` custom property to calculate its animation delay, creating a cascading entrance effect.
+
+## How it works
+
+The tooltip uses CSS `translateY()` + `scale()` animations with `animation-delay` calculated from the stagger index. No JavaScript is used.
+
+```css
+/* Each tooltip gets a delay based on its index */
+.tooltip--stagger {
+    animation-delay: calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay));
+}
+
+/* On hover/focus, staggered entrance */
+.kpi__info:hover ~ .tooltip--stagger {
+    animation: ease-kf-stagger-in 0.28s ease-out forwards;
+    animation-delay: calc(var(--stagger-index) * 60ms);
+}
+```
+
+Key techniques:
+- `--stagger-index` on each tooltip element controls delay position
+- `calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay))` for timing
+- `ease-kf-stagger-in` keyframe with `translateY()` + `scale()` for entrance
+- `aria-describedby` links trigger to tooltip content
+- `role="tooltip"` for screen reader semantics
+
+## Why it matters
+
+Analytics dashboards often display groups of related metrics. Staggered tooltips provide a polished, professional feel when revealing related data points — showing context in a deliberate, readable sequence rather than all at once.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Full analytics dashboard with KPIs, donut chart, funnel, and table |
+| `style.css` | All tooltip styles, dashboard layout, and stagger animations |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-tooltip-stagger-delay` | `60ms` | Delay per stagger index |
+| `--ez-tooltip-duration` | `0.28s` | Animation duration |
+| `--ez-tooltip-scale` | `0.85` | Initial scale for entrance |
+| `--ez-tooltip-bg` | `#1e293b` | Background color |
+| `--ez-tooltip-color` | `#f1f5f9` | Text color |
+| `--ez-tooltip-accent` | `#38bdf8` | Accent highlight color |
+
+## Keyframes
+
+- `ease-kf-stagger-in` — scale from 0.85 to 1.0 with translateY and fade-in
+- `ease-kf-stagger-out` — reverse animation for hide
+
+## Issue
+
+Closes #46269

--- a/submissions/examples/staggered-tooltip-er/demo.html
+++ b/submissions/examples/staggered-tooltip-er/demo.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Staggered Entrance Tooltip – Dashboard Analytics – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dashboard">
+        <aside class="sidebar">
+            <div class="sidebar__brand">Analytics</div>
+            <nav class="sidebar__nav">
+                <a href="#" class="sidebar__link sidebar__link--active">Overview</a>
+                <a href="#" class="sidebar__link">Reports</a>
+                <a href="#" class="sidebar__link">Funnels</a>
+                <a href="#" class="sidebar__link">Cohorts</a>
+            </nav>
+        </aside>
+
+        <main class="content">
+            <header class="topbar">
+                <h1 class="topbar__title">Analytics Dashboard</h1>
+                <span class="topbar__badge">Live</span>
+            </header>
+
+            <section class="kpi-row" role="list">
+                <div class="kpi" role="listitem">
+                    <span class="kpi__label">Sessions</span>
+                    <span class="kpi__value">284,102</span>
+                    <span class="kpi__delta kpi__delta--up">+14.2%</span>
+                    <span
+                        class="kpi__info"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-sessions"
+                    >&#9432;</span>
+                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-sessions" style="--stagger-index: 0;">
+                        <span class="tooltip__content"><strong>284,102 sessions</strong> in the last 30 days. Unique visitors: 198,441.</span>
+                    </span>
+                </div>
+
+                <div class="kpi" role="listitem">
+                    <span class="kpi__label">Bounce Rate</span>
+                    <span class="kpi__value">38.7%</span>
+                    <span class="kpi__delta kpi__delta--down">-3.1%</span>
+                    <span
+                        class="kpi__info"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-bounce"
+                    >&#9432;</span>
+                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-bounce" style="--stagger-index: 1;">
+                        <span class="tooltip__content"><strong>38.7% bounce rate</strong> — down from 41.8% last month. Industry avg: 45%.</span>
+                    </span>
+                </div>
+
+                <div class="kpi" role="listitem">
+                    <span class="kpi__label">Avg. Duration</span>
+                    <span class="kpi__value">3m 48s</span>
+                    <span class="kpi__delta kpi__delta--up">+0.8%</span>
+                    <span
+                        class="kpi__info"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-duration"
+                    >&#9432;</span>
+                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-duration" style="--stagger-index: 2;">
+                        <span class="tooltip__content"><strong>3m 48s avg session</strong> — pages per session: 4.2. Goal completion: 6.8%.</span>
+                    </span>
+                </div>
+
+                <div class="kpi" role="listitem">
+                    <span class="kpi__label">Conversions</span>
+                    <span class="kpi__value">12,847</span>
+                    <span class="kpi__delta kpi__delta--up">+22.5%</span>
+                    <span
+                        class="kpi__info"
+                        tabindex="0"
+                        role="button"
+                        aria-describedby="tip-conv"
+                    >&#9432;</span>
+                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-conv" style="--stagger-index: 3;">
+                        <span class="tooltip__content"><strong>12,847 conversions</strong> — revenue: $384,210. Top channel: organic search.</span>
+                    </span>
+                </div>
+            </section>
+
+            <section class="charts-row">
+                <div class="chart-card">
+                    <h2 class="chart-card__title">Traffic Sources</h2>
+                    <div class="donut-wrap">
+                        <div class="donut" role="img" aria-label="Donut chart: Traffic sources">
+                            <div class="donut__segment donut__segment--organic" style="--pct: 42;"></div>
+                            <div class="donut__segment donut__segment--direct" style="--pct: 28;"></div>
+                            <div class="donut__segment donut__segment--social" style="--pct: 18;"></div>
+                            <div class="donut__segment donut__segment--referral" style="--pct: 12;"></div>
+                        </div>
+                    </div>
+                    <div class="legend" role="list">
+                        <span
+                            class="legend__item"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-organic"
+                        >
+                            <span class="legend__dot legend__dot--organic"></span>
+                            Organic
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-organic" style="--stagger-index: 0;">
+                                <span class="tooltip__content"><strong>42% organic</strong> — 119,323 sessions. Top keyword: "analytics dashboard".</span>
+                            </span>
+                        </span>
+                        <span
+                            class="legend__item"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-direct"
+                        >
+                            <span class="legend__dot legend__dot--direct"></span>
+                            Direct
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-direct" style="--stagger-index: 1;">
+                                <span class="tooltip__content"><strong>28% direct</strong> — 79,549 sessions. Returning visitors: 64%.</span>
+                            </span>
+                        </span>
+                        <span
+                            class="legend__item"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-social"
+                        >
+                            <span class="legend__dot legend__dot--social"></span>
+                            Social
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-social" style="--stagger-index: 2;">
+                                <span class="tooltip__content"><strong>18% social</strong> — 51,138 sessions. Top platform: Twitter/X.</span>
+                            </span>
+                        </span>
+                        <span
+                            class="legend__item"
+                            tabindex="0"
+                            role="button"
+                            aria-describedby="tip-referral"
+                        >
+                            <span class="legend__dot legend__dot--referral"></span>
+                            Referral
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-referral" style="--stagger-index: 3;">
+                                <span class="tooltip__content"><strong>12% referral</strong> — 34,092 sessions. Top referrer: ProductHunt.</span>
+                            </span>
+                        </span>
+                    </div>
+                </div>
+
+                <div class="chart-card">
+                    <h2 class="chart-card__title">Funnel Drop-off</h2>
+                    <div class="funnel" role="list">
+                        <div class="funnel__step" role="listitem">
+                            <span class="funnel__bar" style="--width: 100%;"></span>
+                            <span class="funnel__label">Visit</span>
+                            <span class="funnel__count">284,102</span>
+                            <span
+                                class="funnel__info"
+                                tabindex="0"
+                                role="button"
+                                aria-describedby="tip-funnel-1"
+                            >&#9432;</span>
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-funnel-1" style="--stagger-index: 0;">
+                                <span class="tooltip__content"><strong>All sessions</strong> — entry point of the conversion funnel.</span>
+                            </span>
+                        </div>
+                        <div class="funnel__step" role="listitem">
+                            <span class="funnel__bar" style="--width: 72%;"></span>
+                            <span class="funnel__label">Sign Up</span>
+                            <span class="funnel__count">204,553</span>
+                            <span
+                                class="funnel__info"
+                                tabindex="0"
+                                role="button"
+                                aria-describedby="tip-funnel-2"
+                            >&#9432;</span>
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-funnel-2" style="--stagger-index: 1;">
+                                <span class="tooltip__content"><strong>72% sign-up rate</strong> — 71.9% from mobile, 28.1% from desktop.</span>
+                            </span>
+                        </div>
+                        <div class="funnel__step" role="listitem">
+                            <span class="funnel__bar" style="--width: 41%;"></span>
+                            <span class="funnel__label">Activate</span>
+                            <span class="funnel__count">116,482</span>
+                            <span
+                                class="funnel__info"
+                                tabindex="0"
+                                role="button"
+                                aria-describedby="tip-funnel-3"
+                            >&#9432;</span>
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-funnel-3" style="--stagger-index: 2;">
+                                <span class="tooltip__content"><strong>41% activation</strong> — completed onboarding within 7 days.</span>
+                            </span>
+                        </div>
+                        <div class="funnel__step" role="listitem">
+                            <span class="funnel__bar" style="--width: 19%;"></span>
+                            <span class="funnel__label">Convert</span>
+                            <span class="funnel__count">53,979</span>
+                            <span
+                                class="funnel__info"
+                                tabindex="0"
+                                role="button"
+                                aria-describedby="tip-funnel-4"
+                            >&#9432;</span>
+                            <span class="tooltip tooltip--stagger" role="tooltip" id="tip-funnel-4" style="--stagger-index: 3;">
+                                <span class="tooltip__content"><strong>19% conversion</strong> — paid plan purchase. Avg. order value: $47.20.</span>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="table-section">
+                <div class="table-card">
+                    <h2 class="table-card__title">Top Pages</h2>
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th>Page</th>
+                                <th>Views</th>
+                                <th>Bounce</th>
+                                <th>Avg. Time</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>/dashboard</td>
+                                <td>48,201</td>
+                                <td>22.1%</td>
+                                <td>5m 12s</td>
+                                <td>
+                                    <span
+                                        class="row-info"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-page-1"
+                                    >&#9432;</span>
+                                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-page-1" style="--stagger-index: 0;">
+                                        <span class="tooltip__content"><strong>/dashboard</strong> — 16.9% of traffic. Top entry page. Conversion rate: 8.2%.</span>
+                                    </span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>/pricing</td>
+                                <td>31,847</td>
+                                <td>35.4%</td>
+                                <td>2m 48s</td>
+                                <td>
+                                    <span
+                                        class="row-info"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-page-2"
+                                    >&#9432;</span>
+                                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-page-2" style="--stagger-index: 1;">
+                                        <span class="tooltip__content"><strong>/pricing</strong> — 11.2% of traffic. Plan selection rate: 34.7%.</span>
+                                    </span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>/docs/getting-started</td>
+                                <td>24,102</td>
+                                <td>18.9%</td>
+                                <td>6m 34s</td>
+                                <td>
+                                    <span
+                                        class="row-info"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-page-3"
+                                    >&#9432;</span>
+                                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-page-3" style="--stagger-index: 2;">
+                                        <span class="tooltip__content"><strong>/docs/getting-started</strong> — longest avg. time on page. High engagement.</span>
+                                    </span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>/blog/css-animations</td>
+                                <td>18,934</td>
+                                <td>42.8%</td>
+                                <td>1m 56s</td>
+                                <td>
+                                    <span
+                                        class="row-info"
+                                        tabindex="0"
+                                        role="button"
+                                        aria-describedby="tip-page-4"
+                                    >&#9432;</span>
+                                    <span class="tooltip tooltip--stagger" role="tooltip" id="tip-page-4" style="--stagger-index: 3;">
+                                        <span class="tooltip__content"><strong>/blog/css-animations</strong> — top blog post. 72% from organic search.</span>
+                                    </span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="usage-section" id="usage">
+                <h2 class="section-title">Usage</h2>
+                <pre class="code-block"><code>&lt;span class="kpi__info" tabindex="0"
+      role="button" aria-describedby="tip-id"&gt;
+    &#9432;
+&lt;/span&gt;
+&lt;span class="tooltip tooltip--stagger" role="tooltip"
+      id="tip-id" style="--stagger-index: 0;"&gt;
+    &lt;span class="tooltip__content"&gt;Your text&lt;/span&gt;
+&lt;/span&gt;</code></pre>
+
+                <h2 class="section-title">Custom Properties</h2>
+                <div class="props-table">
+                    <div class="props-row props-row--header">
+                        <span>Property</span>
+                        <span>Default</span>
+                        <span>Description</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-stagger-delay</code>
+                        <code>60ms</code>
+                        <span>Delay per stagger index</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-duration</code>
+                        <code>0.28s</code>
+                        <span>Animation duration</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-scale</code>
+                        <code>0.85</code>
+                        <span>Initial scale for entrance</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-bg</code>
+                        <code>#1e293b</code>
+                        <span>Background color</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-color</code>
+                        <code>#f1f5f9</code>
+                        <span>Text color</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tooltip-accent</code>
+                        <code>#38bdf8</code>
+                        <span>Accent highlight color</span>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/staggered-tooltip-er/style.css
+++ b/submissions/examples/staggered-tooltip-er/style.css
@@ -1,0 +1,697 @@
+/* =============================================
+   Staggered Entrance Tooltip
+   Dashboard Analytics Layout Style
+   Pure CSS · Keyboard · ARIA
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-tooltip-stagger-delay: 60ms;
+    --ez-tooltip-duration: 0.28s;
+    --ez-tooltip-scale: 0.85;
+    --ez-tooltip-bg: #1e293b;
+    --ez-tooltip-color: #f1f5f9;
+    --ez-tooltip-accent: #38bdf8;
+    --ez-tooltip-radius: 8px;
+    --ez-tooltip-padding: 12px 16px;
+    --ez-tooltip-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    --ez-tooltip-offset: 8px;
+    --ez-focus-ring: 3px;
+    --ez-sidebar-bg: #0f172a;
+    --ez-sidebar-text: #94a3b8;
+    --ez-page-bg: #f1f5f9;
+    --ez-card-bg: #ffffff;
+    --ez-card-border: #e2e8f0;
+    --ez-heading: #0f172a;
+    --ez-text: #334155;
+    --ez-muted: #64748b;
+    --ez-success: #22c55e;
+    --ez-danger: #ef4444;
+    --stagger-index: 0;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-stagger-in {
+    0% {
+        opacity: 0;
+        transform: translateY(8px) scale(var(--ez-tooltip-scale));
+        visibility: hidden;
+    }
+    60% {
+        opacity: 0.9;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-stagger-out {
+    0% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        visibility: visible;
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(8px) scale(var(--ez-tooltip-scale));
+        visibility: hidden;
+    }
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+    background: var(--ez-page-bg);
+    color: var(--ez-text);
+    line-height: 1.6;
+}
+
+/* ---------- Dashboard Layout ---------- */
+.dashboard {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    min-height: 100vh;
+}
+
+/* ---------- Sidebar ---------- */
+.sidebar {
+    background: var(--ez-sidebar-bg);
+    padding: 24px 0;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+}
+
+.sidebar__brand {
+    color: #ffffff;
+    font-size: 1.05rem;
+    font-weight: 700;
+    padding: 0 20px 20px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sidebar__nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 14px 10px;
+}
+
+.sidebar__link {
+    display: block;
+    padding: 9px 14px;
+    color: var(--ez-sidebar-text);
+    text-decoration: none;
+    font-size: 0.88rem;
+    font-weight: 500;
+    border-radius: 7px;
+    transition: all 0.15s ease;
+    outline: none;
+}
+
+.sidebar__link:hover,
+.sidebar__link:focus-visible {
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.sidebar__link:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.4);
+}
+
+.sidebar__link--active {
+    color: #ffffff;
+    background: rgba(99, 102, 241, 0.2);
+}
+
+/* ---------- Content ---------- */
+.content {
+    overflow-x: hidden;
+}
+
+/* ---------- Topbar ---------- */
+.topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 28px;
+    background: var(--ez-card-bg);
+    border-bottom: 1px solid var(--ez-card-border);
+}
+
+.topbar__title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+}
+
+.topbar__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 10px;
+    background: rgba(34, 197, 94, 0.1);
+    color: #16a34a;
+    font-size: 0.72rem;
+    font-weight: 700;
+    border-radius: 50px;
+    text-transform: uppercase;
+}
+
+.topbar__badge::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #22c55e;
+    animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
+/* ---------- KPI Row ---------- */
+.kpi-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    padding: 24px 28px;
+}
+
+.kpi {
+    position: relative;
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 10px;
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.kpi__label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--ez-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.kpi__value {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--ez-heading);
+}
+
+.kpi__delta {
+    font-size: 0.78rem;
+    font-weight: 600;
+}
+
+.kpi__delta--up {
+    color: var(--ez-success);
+}
+
+.kpi__delta--down {
+    color: var(--ez-danger);
+}
+
+.kpi__info {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--ez-card-border);
+    color: var(--ez-muted);
+    font-size: 0.65rem;
+    font-weight: 700;
+    cursor: pointer;
+    outline: none;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.kpi__info:hover,
+.kpi__info:focus-visible {
+    background: var(--ez-tooltip-accent);
+    color: #ffffff;
+}
+
+.kpi__info:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.4);
+}
+
+/* ---------- Tooltip Base ---------- */
+.tooltip {
+    position: absolute;
+    z-index: 100;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    bottom: calc(100% + var(--ez-tooltip-offset));
+    left: 0;
+    transform-origin: bottom left;
+    animation: ease-kf-stagger-out var(--ez-tooltip-duration) ease-in forwards;
+}
+
+.tooltip__content {
+    display: block;
+    padding: var(--ez-tooltip-padding);
+    background: var(--ez-tooltip-bg);
+    color: var(--ez-tooltip-color);
+    border-radius: var(--ez-tooltip-radius);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    box-shadow: var(--ez-tooltip-shadow);
+    white-space: nowrap;
+    max-width: 280px;
+    width: max-content;
+}
+
+.tooltip__content strong {
+    color: var(--ez-tooltip-accent);
+}
+
+/* Arrow */
+.tooltip::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 20px;
+    border: 5px solid transparent;
+    border-top-color: var(--ez-tooltip-bg);
+}
+
+/* ---------- Stagger Delay ---------- */
+.tooltip--stagger {
+    animation-delay: calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay));
+}
+
+/* ---------- Show on Hover / Focus ---------- */
+.kpi__info:hover ~ .tooltip--stagger,
+.kpi__info:focus-visible ~ .tooltip--stagger {
+    animation: ease-kf-stagger-in var(--ez-tooltip-duration) ease-out forwards;
+    animation-delay: calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay));
+}
+
+.legend__item:hover .tooltip--stagger,
+.legend__item:focus-visible .tooltip--stagger {
+    animation: ease-kf-stagger-in var(--ez-tooltip-duration) ease-out forwards;
+    animation-delay: calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay));
+}
+
+.funnel__info:hover ~ .tooltip--stagger,
+.funnel__info:focus-visible ~ .tooltip--stagger {
+    animation: ease-kf-stagger-in var(--ez-tooltip-duration) ease-out forwards;
+    animation-delay: calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay));
+}
+
+.row-info:hover ~ .tooltip--stagger,
+.row-info:focus-visible ~ .tooltip--stagger {
+    animation: ease-kf-stagger-in var(--ez-tooltip-duration) ease-out forwards;
+    animation-delay: calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay));
+}
+
+/* ---------- Charts Row ---------- */
+.charts-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    padding: 0 28px 24px;
+}
+
+.chart-card {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 12px;
+    padding: 22px 24px;
+}
+
+.chart-card__title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+    margin-bottom: 20px;
+}
+
+/* ---------- Donut (CSS conic-gradient) ---------- */
+.donut-wrap {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 20px;
+}
+
+.donut {
+    width: 160px;
+    height: 160px;
+    border-radius: 50%;
+    position: relative;
+    background: conic-gradient(
+        #22c55e 0% 42%,
+        #6366f1 42% 70%,
+        #f59e0b 70% 88%,
+        #ef4444 88% 100%
+    );
+}
+
+.donut::after {
+    content: "";
+    position: absolute;
+    inset: 36px;
+    border-radius: 50%;
+    background: var(--ez-card-bg);
+}
+
+/* ---------- Legend ---------- */
+.legend {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.legend__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.82rem;
+    color: var(--ez-text);
+    cursor: pointer;
+    outline: none;
+    padding: 5px 8px;
+    border-radius: 6px;
+    position: relative;
+    transition: background 0.15s ease;
+}
+
+.legend__item:hover,
+.legend__item:focus-visible {
+    background: rgba(0, 0, 0, 0.04);
+}
+
+.legend__item:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.3);
+}
+
+.legend__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+
+.legend__dot--organic { background: #22c55e; }
+.legend__dot--direct { background: #6366f1; }
+.legend__dot--social { background: #f59e0b; }
+.legend__dot--referral { background: #ef4444; }
+
+/* ---------- Funnel ---------- */
+.funnel {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.funnel__step {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.funnel__bar {
+    height: 28px;
+    width: var(--width);
+    background: linear-gradient(90deg, #6366f1, #818cf8);
+    border-radius: 6px;
+    flex-shrink: 0;
+    min-width: 20px;
+}
+
+.funnel__label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--ez-text);
+    white-space: nowrap;
+}
+
+.funnel__count {
+    font-size: 0.78rem;
+    color: var(--ez-muted);
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+.funnel__info {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--ez-card-border);
+    color: var(--ez-muted);
+    font-size: 0.6rem;
+    font-weight: 700;
+    cursor: pointer;
+    outline: none;
+    flex-shrink: 0;
+    transition: background 0.15s ease, color 0.15s ease;
+    position: relative;
+}
+
+.funnel__info:hover,
+.funnel__info:focus-visible {
+    background: var(--ez-tooltip-accent);
+    color: #ffffff;
+}
+
+.funnel__info:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.4);
+}
+
+/* ---------- Table ---------- */
+.table-section {
+    padding: 0 28px 28px;
+}
+
+.table-card {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.table-card__title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+    padding: 18px 22px;
+    border-bottom: 1px solid var(--ez-card-border);
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+
+.data-table th {
+    text-align: left;
+    padding: 11px 18px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--ez-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    background: #f8fafc;
+    border-bottom: 1px solid var(--ez-card-border);
+}
+
+.data-table td {
+    padding: 13px 18px;
+    border-bottom: 1px solid var(--ez-card-border);
+    color: var(--ez-text);
+}
+
+.data-table tr:last-child td {
+    border-bottom: none;
+}
+
+.data-table tr:hover td {
+    background: #f8fafc;
+}
+
+.row-info {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--ez-card-border);
+    color: var(--ez-muted);
+    font-size: 0.6rem;
+    font-weight: 700;
+    cursor: pointer;
+    outline: none;
+    position: relative;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.row-info:hover,
+.row-info:focus-visible {
+    background: var(--ez-tooltip-accent);
+    color: #ffffff;
+}
+
+.row-info:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(56, 189, 248, 0.4);
+}
+
+/* ---------- Usage Section ---------- */
+.usage-section {
+    padding: 0 28px 40px;
+}
+
+.section-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--ez-heading);
+    margin-bottom: 12px;
+    margin-top: 24px;
+}
+
+.code-block {
+    background: #1e293b;
+    color: #e2e8f0;
+    border-radius: 10px;
+    padding: 18px 22px;
+    overflow-x: auto;
+    font-size: 0.8rem;
+    line-height: 1.7;
+    margin-bottom: 24px;
+    font-family: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+}
+
+.props-table {
+    background: var(--ez-card-bg);
+    border: 1px solid var(--ez-card-border);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.props-row {
+    display: grid;
+    grid-template-columns: 220px 100px 1fr;
+    gap: 16px;
+    align-items: center;
+    padding: 10px 18px;
+    border-bottom: 1px solid var(--ez-card-border);
+    font-size: 0.82rem;
+}
+
+.props-row:last-child {
+    border-bottom: none;
+}
+
+.props-row--header {
+    background: #f8fafc;
+    font-weight: 700;
+    color: var(--ez-heading);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.props-row code {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+    font-size: 0.78rem;
+    color: var(--ez-tooltip-accent);
+    background: #f1f5f9;
+    padding: 3px 7px;
+    border-radius: 4px;
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .tooltip {
+        opacity: 1;
+        visibility: visible;
+        transform: none !important;
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+    .dashboard {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        display: none;
+    }
+
+    .kpi-row {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .charts-row {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .kpi-row {
+        grid-template-columns: 1fr;
+        padding: 16px;
+        gap: 10px;
+    }
+
+    .charts-row,
+    .table-section,
+    .usage-section {
+        padding-left: 16px;
+        padding-right: 16px;
+    }
+
+    .tooltip__content {
+        white-space: normal;
+        max-width: 200px;
+    }
+
+    .props-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+        padding: 8px 14px;
+    }
+
+    .props-row--header {
+        display: none;
+    }
+}


### PR DESCRIPTION
## What
Pure CSS tooltip with a staggered entrance animation, designed for dashboard analytics — KPI cards, chart legends, funnel steps, and data tables. Each tooltip in a group animates in sequentially with configurable delays.

Closes #46269

## Why
Analytics dashboards display groups of related metrics. Staggered tooltips reveal context in a deliberate, readable sequence rather than all at once — creating a polished, professional feel.

## How
- `--stagger-index` on each tooltip element controls delay position
- `calc(var(--stagger-index) * var(--ez-tooltip-stagger-delay))` for cascading timing
- `ease-kf-stagger-in` keyframe with `translateY()` + `scale()` for entrance
- `role="tooltip"` and `aria-describedby` for screen reader semantics
- `:focus-visible` trigger for full keyboard accessibility
- `prefers-reduced-motion: reduce` — instantly shows tooltip without animation
- CSS custom properties for delay, duration, scale, colors, and easing
- Full analytics dashboard with KPIs, donut chart, funnel, and data table

## Files (all inside submissions/)
- `submissions/examples/staggered-tooltip-er/demo.html`
- `submissions/examples/staggered-tooltip-er/style.css`
- `submissions/examples/staggered-tooltip-er/README.md`

## Checklist
- [x] Pure CSS, no JavaScript
- [x] Responsive (grid + media queries)
- [x] Uses `ease-*` CSS custom properties and `ease-kf-*` keyframes
- [x] Respects `prefers-reduced-motion`
- [x] Keyboard accessible
- [x] ARIA attributes (role="tooltip", aria-describedby)
- [x] Only new files inside `submissions/` — no other files affected