### PR TITLE
fix(tooltip): add submission for tooltip mobile overflow

### DIFF
--- a/submissions/docs/tooltip-overflow-mobile/README.md
+++ b/submissions/docs/tooltip-overflow-mobile/README.md
@@ -1,0 +1,17 @@
+# Tooltip Mobile Overflow Fix
+
+Fixes the issue where long tooltip text is cut off on mobile viewports.
+
+**What does this do?**
+This adds mobile-specific responsive styles (`@media (max-width: 640px)`) to allow multi-line text wrapping on smaller screens for tooltips, preventing the text from flowing outside the screen boundaries.
+
+**How is it used?**
+No structural HTML changes are needed. Simply continue to use the tooltip class normally, and it will now automatically handle long text gracefully on mobile:
+```html
+<span class="ease-tooltip" data-tooltip="This is a very long tooltip text that should wrap but doesn't">
+  Hover me
+</span>
+```
+
+**Why is it useful?**
+It improves accessibility and the overall user experience for mobile device users by ensuring that tooltip content is fully readable, without altering the default desktop appearance. It directly resolves Issue #49876.

--- a/submissions/docs/tooltip-overflow-mobile/demo.html
+++ b/submissions/docs/tooltip-overflow-mobile/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Mobile Overflow Fix Demo</title>
+  
+  <!-- Link to the core framework to show the broken base behavior if not overridden -->
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  
+  <!-- Our specific bug fix -->
+  <link rel="stylesheet" href="style.css" />
+  
+  <style>
+    body {
+      padding: 2rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f8fafc;
+    }
+    
+    .demo-container {
+      border: 2px dashed #cbd5e1;
+      padding: 3rem;
+      border-radius: 8px;
+      text-align: center;
+      background: white;
+      max-width: 100%;
+    }
+    
+    .instruction {
+      margin-bottom: 2rem;
+      color: #64748b;
+      max-width: 400px;
+    }
+  </style>
+</head>
+<body>
+  
+  <div class="demo-container">
+    <h2>Mobile Tooltip Wrap Test</h2>
+    <p class="instruction">
+      Resize your browser window to a mobile width (&lt; 640px) or open DevTools device toolbar (e.g. iPhone SE / 375px), then hover over the element below. The long text should wrap properly instead of being clipped off-screen.
+    </p>
+    
+    <span class="ease-tooltip" data-tooltip="This is a very long tooltip text that previously would not wrap and would overflow off the screen on mobile devices, but now it wraps properly.">
+      <button style="padding: 0.75rem 1.5rem; border: none; background: #3b82f6; color: white; border-radius: 6px; cursor: pointer; font-size: 1rem;">
+        Hover Me
+      </button>
+    </span>
+  </div>
+  
+</body>
+</html>

--- a/submissions/docs/tooltip-overflow-mobile/style.css
+++ b/submissions/docs/tooltip-overflow-mobile/style.css
@@ -1,0 +1,14 @@
+/* Fix for tooltip text overflow on mobile devices */
+@media (max-width: 640px) {
+  .ease-tooltip::after {
+    /* Allow multi-line text wrapping */
+    white-space: normal !important;
+    
+    /* Constrain width to prevent stretching beyond viewport */
+    max-width: 250px;
+    width: max-content;
+    
+    /* Keep text centralized for better readability when wrapped */
+    text-align: center;
+  }
+}


### PR DESCRIPTION
- Added white-space: normal and max-width for multiline wrapping
- Maintained centralized text alignment for better readability on narrow screens Fixes issue #49876

## Pull Request Description

This PR fixes a bug where tooltip text overflows and is cut off on mobile devices. The `.ease-tooltip` component used `white-space: nowrap`, preventing text wrapping. This PR adds mobile-specific responsive styles to allow multi-line text wrapping on smaller screens by adding `white-space: normal` and constraining the `max-width`.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds proper multi-line text wrapping support for tooltips on narrow viewports/mobile devices.

**How does a developer use it?**

```html
<!-- Simply use the tooltip class normally, it now automatically handles long text gracefully on mobile -->
<span class="ease-tooltip" data-tooltip="This is a very long tooltip text that should wrap but doesn't">
  Hover me
</span>
```

**Why does it fit EaseMotion CSS?**

It improves the accessibility and overall user experience for mobile device users without altering the default desktop appearance.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

This PR targets a bug inside `components/tooltips.css` regarding issue #49876. Following the strict submission pipeline guidelines, the proposed bug fix has been isolated and submitted inside `submissions/docs/tooltip-overflow-mobile/` for your review and integration.

---
