### PR TITLE
feat: add service dependency pulse demo

### DIFF
--- a/submissions/examples/service-dependency-pulse-sm/README.md
+++ b/submissions/examples/service-dependency-pulse-sm/README.md
@@ -1,0 +1,30 @@
+# Service Dependency Pulse
+
+## What does this do?
+
+Service Dependency Pulse is a self-contained HTML and CSS operations dashboard pattern with animated dependency nodes, health pulses, connection routes, and readable service cards.
+
+## How is it used?
+
+Create a `dependency-layout` with a `graph-card` for the dependency map and `dependency-card` items with state classes such as `dependency-healthy`, `dependency-watch`, or `dependency-critical`.
+
+```html
+<article class="dependency-card dependency-watch">
+  <span class="dependency-dot" aria-hidden="true"></span>
+  <div>
+    <p>Cache layer</p>
+    <h3>Freshness lag detected</h3>
+    <span>2 regions warming</span>
+  </div>
+</article>
+```
+
+Available dependency classes:
+
+- `dependency-healthy`
+- `dependency-watch`
+- `dependency-critical`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make service health easier to scan: dependency nodes pulse, connection routes animate to show relationships, and service cards enter gently for quick review. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/service-dependency-pulse-sm/demo.html
+++ b/submissions/examples/service-dependency-pulse-sm/demo.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Service Dependency Pulse Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="dependency-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Service Dependency Pulse</h1>
+        <p>
+          A self-contained operations dashboard pattern with animated dependency
+          nodes, health pulses, connection routes, and readable service cards.
+        </p>
+      </section>
+
+      <section
+        class="dependency-summary"
+        aria-label="Service dependency summary"
+      >
+        <article>
+          <span class="summary-value">12</span>
+          <span class="summary-label">Dependencies watched</span>
+        </article>
+        <article>
+          <span class="summary-value">02</span>
+          <span class="summary-label">Services degraded</span>
+        </article>
+        <article>
+          <span class="summary-value">98.8%</span>
+          <span class="summary-label">Route health</span>
+        </article>
+      </section>
+
+      <section
+        class="dependency-layout"
+        aria-label="Service dependency pulse map"
+      >
+        <article class="graph-card">
+          <div class="dependency-map" aria-hidden="true">
+            <span class="connection connection-auth"></span>
+            <span class="connection connection-cache"></span>
+            <span class="connection connection-billing"></span>
+            <span class="service-node node-api">API</span>
+            <span class="service-node node-auth">Auth</span>
+            <span class="service-node node-cache">Cache</span>
+            <span class="service-node node-billing">Billing</span>
+          </div>
+          <div class="graph-copy">
+            <p class="graph-kicker">Dependency Graph</p>
+            <h2>Checkout API dependency path</h2>
+            <p>
+              The API node is healthy, but billing latency is elevated and cache
+              freshness needs a closer look before traffic increases.
+            </p>
+          </div>
+        </article>
+
+        <section class="dependency-stack" aria-label="Dependency health cards">
+          <article class="dependency-card dependency-healthy">
+            <span class="dependency-dot" aria-hidden="true"></span>
+            <div>
+              <p>Auth service</p>
+              <h3>Token checks stable</h3>
+              <span>32ms median latency</span>
+            </div>
+          </article>
+
+          <article class="dependency-card dependency-watch">
+            <span class="dependency-dot" aria-hidden="true"></span>
+            <div>
+              <p>Cache layer</p>
+              <h3>Freshness lag detected</h3>
+              <span>2 regions warming</span>
+            </div>
+          </article>
+
+          <article class="dependency-card dependency-critical">
+            <span class="dependency-dot" aria-hidden="true"></span>
+            <div>
+              <p>Billing service</p>
+              <h3>Retry pressure elevated</h3>
+              <span>5.4% transient failures</span>
+            </div>
+          </article>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/service-dependency-pulse-sm/style.css
+++ b/submissions/examples/service-dependency-pulse-sm/style.css
@@ -1,0 +1,387 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.dependency-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label,
+.graph-kicker {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.dependency-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.dependency-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.dependency-layout {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.95fr) minmax(0, 1.05fr);
+  gap: 20px;
+  align-items: stretch;
+}
+
+.graph-card,
+.dependency-card {
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.graph-card {
+  overflow: hidden;
+  padding: 24px;
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  animation: panel-enter 680ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.dependency-map {
+  position: relative;
+  min-height: 330px;
+  margin-bottom: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.1), transparent),
+    radial-gradient(circle at center, rgba(22, 163, 74, 0.12), transparent 56%),
+    #f8fafc;
+}
+
+.dependency-map::before {
+  position: absolute;
+  inset: 22px;
+  border: 1px dashed rgba(37, 99, 235, 0.18);
+  border-radius: 8px;
+  content: "";
+}
+
+.connection {
+  position: absolute;
+  left: 28%;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--blue), transparent);
+  opacity: 0.75;
+  transform-origin: left;
+  animation: connection-flow 1.9s ease-in-out infinite;
+}
+
+.connection-auth {
+  top: 36%;
+  width: 36%;
+  transform: rotate(-24deg);
+}
+
+.connection-cache {
+  top: 52%;
+  width: 44%;
+  background: linear-gradient(90deg, transparent, var(--amber), transparent);
+  transform: rotate(8deg);
+  animation-delay: 320ms;
+}
+
+.connection-billing {
+  top: 67%;
+  width: 48%;
+  background: linear-gradient(90deg, transparent, var(--red), transparent);
+  transform: rotate(24deg);
+  animation-delay: 640ms;
+}
+
+.service-node {
+  position: absolute;
+  display: grid;
+  width: 68px;
+  height: 68px;
+  place-items: center;
+  border: 6px solid #ffffff;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 14px 32px var(--accent-soft);
+  font-size: 0.8rem;
+  font-weight: 950;
+  animation: node-pulse 2.2s ease-out infinite;
+}
+
+.node-api {
+  --accent: var(--blue);
+  --accent-soft: rgba(37, 99, 235, 0.16);
+  top: 42%;
+  left: 16%;
+}
+
+.node-auth {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.16);
+  top: 16%;
+  right: 22%;
+  animation-delay: 240ms;
+}
+
+.node-cache {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.16);
+  top: 43%;
+  right: 14%;
+  animation-delay: 480ms;
+}
+
+.node-billing {
+  --accent: var(--red);
+  --accent-soft: rgba(220, 38, 38, 0.16);
+  right: 26%;
+  bottom: 14%;
+  animation-delay: 720ms;
+}
+
+.graph-copy h2 {
+  margin-bottom: 10px;
+  font-size: 1.35rem;
+}
+
+.graph-copy p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.dependency-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.dependency-card {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+  padding: 20px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: panel-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.dependency-card:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.dependency-card:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+.dependency-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 18px 42px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.dependency-dot {
+  width: 38px;
+  height: 38px;
+  border: 5px solid #ffffff;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 12px 24px var(--accent-soft);
+  animation: node-pulse 2s ease-out infinite;
+}
+
+.dependency-card p {
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.dependency-card h3 {
+  margin-bottom: 8px;
+  font-size: 1.08rem;
+}
+
+.dependency-card span:not(.dependency-dot) {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 750;
+}
+
+.dependency-healthy {
+  --accent: var(--green);
+  --accent-soft: rgba(22, 163, 74, 0.14);
+}
+
+.dependency-watch {
+  --accent: var(--amber);
+  --accent-soft: rgba(217, 119, 6, 0.15);
+}
+
+.dependency-critical {
+  --accent: var(--red);
+  --accent-soft: rgba(220, 38, 38, 0.14);
+}
+
+@keyframes panel-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes connection-flow {
+  0%,
+  100% {
+    opacity: 0.42;
+    filter: saturate(0.9);
+  }
+
+  50% {
+    opacity: 1;
+    filter: saturate(1.35);
+  }
+}
+
+@keyframes node-pulse {
+  70% {
+    box-shadow:
+      0 0 0 12px rgba(255, 255, 255, 0),
+      0 14px 32px var(--accent-soft);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(255, 255, 255, 0),
+      0 14px 32px var(--accent-soft);
+  }
+}
+
+@media (max-width: 820px) {
+  .dependency-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .dependency-summary,
+  .dependency-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes  #49911


**PR Text**

Title: `feat: add service dependency pulse demo`

```md
## Pull Request Description
Adds a self-contained Service Dependency Pulse demo under `submissions/examples/`, featuring animated dependency nodes, health pulses, connection routes, and service health cards.

## Type of Change
- [x] New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A CSS-only service dependency health map for operations dashboards.

**How does a developer use it?**
Use a `dependency-layout` with a `graph-card` and `dependency-card` items using classes like `dependency-healthy`, `dependency-watch`, or `dependency-critical`.

**Why does it fit EaseMotion CSS?**
It uses purposeful motion to communicate service relationships, dependency health, and elevated risk while staying standalone and reduced-motion friendly.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The dependency naming, health colors, and route animation timing can be standardized during framework integration.