### PR TITLE
feat: add runbook step progress demo

### DIFF
--- a/submissions/examples/runbook-step-progress-sm/README.md
+++ b/submissions/examples/runbook-step-progress-sm/README.md
@@ -1,0 +1,32 @@
+# Runbook Step Progress
+
+## What does this do?
+
+Runbook Step Progress is a self-contained HTML and CSS incident runbook pattern with animated step cards, progress rails, owner chips, and clear action states for responders.
+
+## How is it used?
+
+Create a `runbook-panel` wrapper and add `step-card` items with step state classes such as `step-done`, `step-active`, or `step-waiting`.
+
+```html
+<article class="step-card step-active">
+  <div class="step-marker" aria-hidden="true">2</div>
+  <div class="step-content">
+    <p class="step-kicker">Stabilize</p>
+    <h2>Apply temporary mitigation</h2>
+    <div class="step-bar" aria-hidden="true">
+      <span></span>
+    </div>
+  </div>
+</article>
+```
+
+Available step classes:
+
+- `step-done`
+- `step-active`
+- `step-waiting`
+
+## Why is it useful?
+
+It fits EaseMotion's philosophy by using motion to make incident work easier to follow: steps enter gently, markers pulse for current attention, progress bars show completion, and focus states keep actions accessible. The demo works directly by opening `demo.html` in a browser.

--- a/submissions/examples/runbook-step-progress-sm/demo.html
+++ b/submissions/examples/runbook-step-progress-sm/demo.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Runbook Step Progress Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="runbook-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="label">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Runbook Step Progress</h1>
+        <p>
+          A self-contained incident runbook pattern with animated step cards,
+          progress rails, owner chips, and clear action states for responders.
+        </p>
+      </section>
+
+      <section class="runbook-summary" aria-label="Runbook progress summary">
+        <article>
+          <span class="summary-value">06</span>
+          <span class="summary-label">Steps complete</span>
+        </article>
+        <article>
+          <span class="summary-value">02</span>
+          <span class="summary-label">Actions pending</span>
+        </article>
+        <article>
+          <span class="summary-value">74%</span>
+          <span class="summary-label">Runbook progress</span>
+        </article>
+      </section>
+
+      <section class="runbook-panel" aria-label="Runbook progress steps">
+        <article class="step-card step-done">
+          <div class="step-marker" aria-hidden="true">1</div>
+          <div class="step-content">
+            <p class="step-kicker">Detect</p>
+            <h2>Confirm alert signal</h2>
+            <p>
+              Validate the primary alert against logs, metrics, and customer
+              reports before changing incident severity.
+            </p>
+            <div class="step-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Owner: Observability</span>
+              <button type="button">Done</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="step-card step-active">
+          <div class="step-marker" aria-hidden="true">2</div>
+          <div class="step-content">
+            <p class="step-kicker">Stabilize</p>
+            <h2>Apply temporary mitigation</h2>
+            <p>
+              Shift traffic, reduce queue pressure, and confirm the mitigation
+              is improving the customer-facing symptom.
+            </p>
+            <div class="step-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Owner: Reliability</span>
+              <button type="button">Update</button>
+            </footer>
+          </div>
+        </article>
+
+        <article class="step-card step-waiting">
+          <div class="step-marker" aria-hidden="true">3</div>
+          <div class="step-content">
+            <p class="step-kicker">Review</p>
+            <h2>Prepare follow-up notes</h2>
+            <p>
+              Capture root cause, mitigation timeline, customer impact, and the
+              next set of prevention tasks.
+            </p>
+            <div class="step-bar" aria-hidden="true"><span></span></div>
+            <footer>
+              <span>Owner: Incident lead</span>
+              <button type="button">Start</button>
+            </footer>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/runbook-step-progress-sm/style.css
+++ b/submissions/examples/runbook-step-progress-sm/style.css
@@ -1,0 +1,330 @@
+:root {
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #647184;
+  --line: #dbe4ef;
+  --blue: #2563eb;
+  --green: #16a34a;
+  --amber: #d97706;
+  --shadow: 0 24px 64px rgba(23, 32, 51, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(22, 163, 74, 0.1), transparent 36%),
+    var(--page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.runbook-shell {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.label {
+  margin: 0 0 10px;
+  color: #315180;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: 2.72rem;
+  line-height: 1.05;
+}
+
+.intro p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.runbook-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.runbook-summary article {
+  display: flex;
+  min-height: 84px;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(23, 32, 51, 0.08);
+  padding: 16px 18px;
+}
+
+.summary-value {
+  color: var(--ink);
+  font-size: 1.65rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.summary-label {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.runbook-panel {
+  display: grid;
+  gap: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--shadow);
+  padding: 22px;
+}
+
+.step-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  gap: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 18px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: step-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.step-card:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.step-card:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.step-card:hover,
+.step-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 16px 34px var(--accent-soft);
+  transform: translateY(-3px);
+}
+
+.step-marker {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border: 5px solid #ffffff;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 0 var(--accent-soft),
+    0 12px 24px var(--accent-soft);
+  font-weight: 950;
+  animation: marker-pulse 2s ease-out infinite;
+}
+
+.step-kicker {
+  width: fit-content;
+  margin-bottom: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.step-content h2 {
+  margin-bottom: 8px;
+  font-size: 1.18rem;
+}
+
+.step-content > p:not(.step-kicker) {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.step-bar {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8eef7;
+  margin: 18px 0;
+}
+
+.step-bar span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--progress);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light));
+  transform-origin: left;
+  animation: bar-fill 950ms 240ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.step-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.step-content footer span {
+  color: var(--accent);
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.step-content button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--accent);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 900;
+  cursor: pointer;
+  padding: 0 14px;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.step-content button:hover,
+.step-content button:focus-visible {
+  box-shadow: 0 12px 26px var(--accent-soft);
+  outline: 2px solid transparent;
+  transform: translateY(-2px);
+}
+
+.step-done {
+  --accent: var(--green);
+  --accent-light: #4ade80;
+  --accent-soft: rgba(22, 163, 74, 0.14);
+  --progress: 100%;
+}
+
+.step-active {
+  --accent: var(--blue);
+  --accent-light: #60a5fa;
+  --accent-soft: rgba(37, 99, 235, 0.14);
+  --progress: 74%;
+}
+
+.step-waiting {
+  --accent: var(--amber);
+  --accent-light: #fbbf24;
+  --accent-soft: rgba(217, 119, 6, 0.15);
+  --progress: 26%;
+}
+
+@keyframes step-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes marker-pulse {
+  70% {
+    box-shadow:
+      0 0 0 12px rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(255, 255, 255, 0),
+      0 12px 24px var(--accent-soft);
+  }
+}
+
+@media (max-width: 720px) {
+  .runbook-shell {
+    width: min(100% - 24px, 560px);
+    padding: 30px 0;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  .runbook-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .step-card {
+    grid-template-columns: 1fr;
+  }
+
+  .step-content footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
Closes #49919


**PR Text**
```md
Title: feat: add runbook step progress demo

Summary:
- Adds a new `runbook-step-progress-sm` example under `submissions/examples`
- Includes a self-contained HTML/CSS runbook progress pattern
- Documents usage, states, and why it fits EaseMotion

Checks:
- `npx prettier --check submissions/examples/runbook-step-progress-sm/demo.html submissions/examples/runbook-step-progress-sm/style.css submissions/examples/runbook-step-progress-sm/README.md`