### PR TITLE
feat: add incident command switchboard demo

### DIFF
--- a/submissions/examples/incident-command-switchboard-sm/README.md
+++ b/submissions/examples/incident-command-switchboard-sm/README.md
@@ -1,0 +1,28 @@
+# Incident Command Switchboard
+
+## What does it do?
+
+This submission adds a self-contained incident command switchboard demo for EaseMotion CSS. It shows animated response lanes, live task cards, service health tiles, escalation pressure, and stakeholder communication updates in a single operational dashboard pattern.
+
+## How is it used?
+
+Open `demo.html` in a browser. The demo only needs local HTML and CSS, with no framework, CDN, or build step.
+
+```html
+<article class="lane lane-live">
+  <header class="lane-header">
+    <span class="lane-dot" aria-hidden="true"></span>
+    <div>
+      <p>Live Action</p>
+      <h2>Mitigation squad</h2>
+    </div>
+    <span class="lane-status">active</span>
+  </header>
+</article>
+```
+
+Useful classes include `switchboard`, `lane`, `lane-live`, `lane-watch`, `lane-comms`, `task-card`, `service-tile`, `pulse-rail`, and `meter`.
+
+## Why is it useful for EaseMotion?
+
+Incident response interfaces need motion that highlights urgency without making the screen noisy. This example demonstrates practical CSS motion for command centers: pulsing ownership markers, scanning rails, progressive card entry, and reduced-motion fallbacks while staying fully isolated inside `submissions/examples`.

--- a/submissions/examples/incident-command-switchboard-sm/demo.html
+++ b/submissions/examples/incident-command-switchboard-sm/demo.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Incident Command Switchboard Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="switchboard-shell">
+      <section class="hero" aria-labelledby="demo-title">
+        <p class="eyebrow">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Incident Command Switchboard</h1>
+        <p>
+          A CSS-only response console with animated command lanes, escalation
+          meters, service pips, and priority cards for operations teams.
+        </p>
+      </section>
+
+      <section class="signal-strip" aria-label="Incident response summary">
+        <article class="signal-card signal-critical">
+          <span class="signal-label">Priority</span>
+          <strong>P1</strong>
+          <span class="signal-note">Customer-facing degradation</span>
+        </article>
+        <article class="signal-card">
+          <span class="signal-label">Commander</span>
+          <strong>Riya S.</strong>
+          <span class="signal-note">handoff in 18 min</span>
+        </article>
+        <article class="signal-card">
+          <span class="signal-label">Clock</span>
+          <strong>42m</strong>
+          <span class="signal-note">since declaration</span>
+        </article>
+      </section>
+
+      <section class="switchboard" aria-label="Incident command lanes">
+        <article class="lane lane-live">
+          <header class="lane-header">
+            <span class="lane-dot" aria-hidden="true"></span>
+            <div>
+              <p>Live Action</p>
+              <h2>Mitigation squad</h2>
+            </div>
+            <span class="lane-status">active</span>
+          </header>
+          <div class="task-stack">
+            <div class="task-card task-hot">
+              <span class="task-rank">01</span>
+              <div>
+                <h3>Drain failing region</h3>
+                <p>Shift 35% traffic to stable capacity pool.</p>
+              </div>
+              <span class="task-chip">now</span>
+            </div>
+            <div class="task-card">
+              <span class="task-rank">02</span>
+              <div>
+                <h3>Pin release artifact</h3>
+                <p>Freeze deploy queue until smoke tests pass.</p>
+              </div>
+              <span class="task-chip">5m</span>
+            </div>
+            <div class="pulse-rail" aria-hidden="true">
+              <span></span>
+            </div>
+          </div>
+        </article>
+
+        <article class="lane lane-watch">
+          <header class="lane-header">
+            <span class="lane-dot" aria-hidden="true"></span>
+            <div>
+              <p>Watch Points</p>
+              <h2>Service telemetry</h2>
+            </div>
+            <span class="lane-status">tracking</span>
+          </header>
+          <div class="service-grid">
+            <div class="service-tile service-warning">
+              <span>API</span>
+              <strong>88%</strong>
+            </div>
+            <div class="service-tile">
+              <span>Jobs</span>
+              <strong>96%</strong>
+            </div>
+            <div class="service-tile service-danger">
+              <span>DB</span>
+              <strong>71%</strong>
+            </div>
+            <div class="service-tile">
+              <span>CDN</span>
+              <strong>99%</strong>
+            </div>
+          </div>
+          <div class="meter" aria-label="Escalation pressure at 64 percent">
+            <span></span>
+          </div>
+        </article>
+
+        <article class="lane lane-comms">
+          <header class="lane-header">
+            <span class="lane-dot" aria-hidden="true"></span>
+            <div>
+              <p>Comms</p>
+              <h2>Stakeholder updates</h2>
+            </div>
+            <span class="lane-status">queued</span>
+          </header>
+          <ol class="comms-list">
+            <li>
+              <span class="time">12:20</span>
+              <p>Status page updated with mitigation notice.</p>
+            </li>
+            <li>
+              <span class="time">12:31</span>
+              <p>Support macro drafted for affected customers.</p>
+            </li>
+            <li>
+              <span class="time">12:45</span>
+              <p>Executive summary waits for impact estimate.</p>
+            </li>
+          </ol>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/incident-command-switchboard-sm/style.css
+++ b/submissions/examples/incident-command-switchboard-sm/style.css
@@ -1,0 +1,494 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f7fb;
+  --panel: #ffffff;
+  --panel-soft: #eef4fb;
+  --ink: #14202f;
+  --muted: #66758a;
+  --line: #dce5f0;
+  --blue: #2563eb;
+  --teal: #0f9f8f;
+  --amber: #d97706;
+  --red: #dc2626;
+  --green: #16a34a;
+  --shadow: 0 20px 55px rgba(34, 47, 73, 0.14);
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.08), transparent 28%),
+    linear-gradient(315deg, rgba(15, 159, 143, 0.08), transparent 30%),
+    var(--bg);
+}
+
+.switchboard-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.hero {
+  display: grid;
+  gap: 12px;
+  max-width: 760px;
+  margin-bottom: 26px;
+}
+
+.eyebrow,
+.signal-label,
+.lane-header p {
+  margin: 0;
+  color: var(--blue);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 6vw, 4.4rem);
+  line-height: 1;
+}
+
+.hero p:last-child {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.signal-card,
+.lane {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--shadow);
+}
+
+.signal-card {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+}
+
+.signal-card::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  content: "";
+  background: var(--teal);
+  transform-origin: bottom;
+  animation: riseLine 1.8s ease both;
+}
+
+.signal-critical::before {
+  background: var(--red);
+}
+
+.signal-card strong {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.signal-note {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.switchboard {
+  display: grid;
+  grid-template-columns: 1.12fr 0.9fr 0.95fr;
+  gap: 18px;
+  align-items: stretch;
+}
+
+.lane {
+  position: relative;
+  overflow: hidden;
+  min-height: 420px;
+  padding: 18px;
+}
+
+.lane::after {
+  position: absolute;
+  inset: auto 16px 16px 16px;
+  height: 2px;
+  content: "";
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(37, 99, 235, 0.35),
+    transparent
+  );
+  transform: translateX(-110%);
+  animation: scanLine 3.8s ease-in-out infinite;
+}
+
+.lane-header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.lane-dot {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  border-radius: 50%;
+  background: var(--teal);
+}
+
+.lane-dot::after {
+  position: absolute;
+  inset: -6px;
+  border: 1px solid currentColor;
+  border-radius: inherit;
+  color: var(--teal);
+  content: "";
+  animation: ping 1.7s ease-out infinite;
+}
+
+.lane-live .lane-dot {
+  background: var(--red);
+}
+
+.lane-live .lane-dot::after {
+  color: var(--red);
+}
+
+.lane-watch .lane-dot {
+  background: var(--amber);
+}
+
+.lane-watch .lane-dot::after {
+  color: var(--amber);
+}
+
+.lane-header h2 {
+  margin: 3px 0 0;
+  font-size: 1.05rem;
+}
+
+.lane-status {
+  margin-left: auto;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: var(--muted);
+  background: var(--panel-soft);
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.task-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.task-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: start;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
+  background: var(--panel);
+  transform: translateY(12px);
+  animation: cardIn 0.7s ease both;
+}
+
+.task-card:nth-child(2) {
+  animation-delay: 0.12s;
+}
+
+.task-hot {
+  border-color: rgba(220, 38, 38, 0.3);
+  background: linear-gradient(135deg, rgba(220, 38, 38, 0.08), #fff);
+}
+
+.task-rank {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--blue);
+  background: #eaf1ff;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.task-card h3,
+.task-card p {
+  margin: 0;
+}
+
+.task-card h3 {
+  font-size: 1rem;
+}
+
+.task-card p {
+  margin-top: 6px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.task-chip {
+  border-radius: 999px;
+  padding: 6px 9px;
+  color: #ffffff;
+  background: var(--ink);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.pulse-rail {
+  height: 13px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e4ecf7;
+}
+
+.pulse-rail span {
+  display: block;
+  width: 68%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--red), var(--amber), var(--teal));
+  animation: railBreath 2.4s ease-in-out infinite;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.service-tile {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
+  background: var(--panel);
+}
+
+.service-tile span {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.service-tile strong {
+  font-size: 2rem;
+}
+
+.service-tile::after {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  content: "";
+  background: linear-gradient(90deg, var(--green) 70%, #dbe5f1 70%);
+}
+
+.service-warning::after {
+  background: linear-gradient(90deg, var(--amber) 58%, #dbe5f1 58%);
+}
+
+.service-danger::after {
+  background: linear-gradient(90deg, var(--red) 42%, #dbe5f1 42%);
+}
+
+.meter {
+  height: 18px;
+  margin-top: 22px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #e7eef7;
+}
+
+.meter span {
+  display: block;
+  width: 64%;
+  height: 100%;
+  border-radius: inherit;
+  background: repeating-linear-gradient(
+    45deg,
+    var(--blue) 0 12px,
+    #4f8df6 12px 24px
+  );
+  animation: stripeMove 1.2s linear infinite;
+}
+
+.comms-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.comms-list li {
+  display: grid;
+  grid-template-columns: 58px 1fr;
+  gap: 10px;
+  align-items: start;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 14px;
+  background: var(--panel);
+  animation: fadeSlide 0.7s ease both;
+}
+
+.comms-list li:nth-child(2) {
+  animation-delay: 0.14s;
+}
+
+.comms-list li:nth-child(3) {
+  animation-delay: 0.28s;
+}
+
+.time {
+  color: var(--blue);
+  font-weight: 900;
+}
+
+.comms-list p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+@keyframes riseLine {
+  from {
+    transform: scaleY(0);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes scanLine {
+  0%,
+  35% {
+    transform: translateX(-110%);
+  }
+  70%,
+  100% {
+    transform: translateX(110%);
+  }
+}
+
+@keyframes ping {
+  from {
+    opacity: 0.7;
+    transform: scale(0.75);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.8);
+  }
+}
+
+@keyframes cardIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes railBreath {
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(0.94);
+  }
+}
+
+@keyframes stripeMove {
+  to {
+    background-position: 34px 0;
+  }
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .signal-strip,
+  .switchboard {
+    grid-template-columns: 1fr;
+  }
+
+  .lane {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 560px) {
+  .switchboard-shell {
+    width: min(100% - 20px, 1180px);
+    padding: 28px 0;
+  }
+
+  .task-card,
+  .comms-list li {
+    grid-template-columns: 1fr;
+  }
+
+  .task-chip {
+    width: fit-content;
+  }
+
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Closes #49929


**PR Text**
```md
Title: feat: add incident command switchboard demo

Summary:
- Adds `incident-command-switchboard-sm` under `submissions/examples`
- Includes a self-contained HTML/CSS incident command dashboard
- Documents usage, classes, and EaseMotion fit in the README

Checks:
- `npx prettier --check submissions/examples/incident-command-switchboard-sm/demo.html submissions/examples/incident-command-switchboard-sm/style.css submissions/examples/incident-command-switchboard-sm/README.md`