### PR TITLE
feat: add deployment risk thermostat demo

### DIFF
--- a/submissions/examples/deployment-risk-thermostat-sm/README.md
+++ b/submissions/examples/deployment-risk-thermostat-sm/README.md
@@ -1,0 +1,23 @@
+# Deployment Risk Thermostat
+
+## What does it do?
+
+This submission adds a self-contained deployment risk thermostat demo for EaseMotion CSS. It visualizes release health with a temperature-style risk gauge, rollout wave controls, guardrail checks, and animated status accents.
+
+## How is it used?
+
+Open `demo.html` directly in a browser. The example is plain HTML and CSS, so it does not require a build step, JavaScript, frameworks, or external assets.
+
+```html
+<div class="thermostat" aria-label="Deployment risk temperature is elevated">
+  <div class="thermostat-tube" aria-hidden="true">
+    <span class="mercury"></span>
+  </div>
+</div>
+```
+
+Useful classes include `thermostat`, `mercury`, `risk-card`, `wave-track`, `wave-active`, `guardrail-list`, `check-pass`, `check-warn`, and `check-stop`.
+
+## Why is it useful for EaseMotion?
+
+Release dashboards need motion that communicates risk quickly without depending on scripts. This demo shows practical CSS motion for rollout controls: a rising gauge, active hold ring, pacing meter, staggered guardrail checks, and reduced-motion support, all isolated inside `submissions/examples`.

--- a/submissions/examples/deployment-risk-thermostat-sm/demo.html
+++ b/submissions/examples/deployment-risk-thermostat-sm/demo.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deployment Risk Thermostat Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="thermostat-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="eyebrow">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Deployment Risk Thermostat</h1>
+        <p>
+          A CSS-only release control panel that visualizes deployment risk with
+          animated temperature bands, guardrail checks, and rollout pacing.
+        </p>
+      </section>
+
+      <section class="control-grid" aria-label="Deployment risk overview">
+        <article class="risk-card">
+          <div
+            class="thermostat"
+            aria-label="Deployment risk temperature is elevated"
+          >
+            <span class="thermostat-glow" aria-hidden="true"></span>
+            <div class="thermostat-scale" aria-hidden="true">
+              <span>low</span>
+              <span>watch</span>
+              <span>high</span>
+            </div>
+            <div class="thermostat-tube" aria-hidden="true">
+              <span class="mercury"></span>
+            </div>
+          </div>
+          <div class="risk-copy">
+            <p class="section-label">Current reading</p>
+            <h2>Elevated rollout heat</h2>
+            <p>
+              API error rate and queue depth are warming up. Keep the release at
+              the current wave until guardrails return to target.
+            </p>
+            <div class="risk-score">
+              <strong>72</strong>
+              <span>risk score</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="release-card">
+          <header class="card-header">
+            <div>
+              <p class="section-label">Rollout pace</p>
+              <h2>Wave three hold</h2>
+            </div>
+            <span class="state-pill state-hold">hold</span>
+          </header>
+          <div class="wave-track" aria-label="Rollout is paused at wave three">
+            <span class="wave wave-done">10%</span>
+            <span class="wave wave-done">25%</span>
+            <span class="wave wave-active">50%</span>
+            <span class="wave">75%</span>
+            <span class="wave">100%</span>
+          </div>
+          <div class="pace-meter" aria-hidden="true">
+            <span></span>
+          </div>
+        </article>
+
+        <article class="guardrail-card">
+          <header class="card-header">
+            <div>
+              <p class="section-label">Guardrails</p>
+              <h2>Release checks</h2>
+            </div>
+            <span class="state-pill">4/6 green</span>
+          </header>
+          <ul class="guardrail-list">
+            <li class="check-pass">
+              <span class="check-dot" aria-hidden="true"></span>
+              <div>
+                <strong>Smoke tests</strong>
+                <p>Passed across primary region.</p>
+              </div>
+            </li>
+            <li class="check-warn">
+              <span class="check-dot" aria-hidden="true"></span>
+              <div>
+                <strong>Latency budget</strong>
+                <p>p95 is 18ms above release target.</p>
+              </div>
+            </li>
+            <li class="check-pass">
+              <span class="check-dot" aria-hidden="true"></span>
+              <div>
+                <strong>Support volume</strong>
+                <p>Inbound tickets remain within baseline.</p>
+              </div>
+            </li>
+            <li class="check-stop">
+              <span class="check-dot" aria-hidden="true"></span>
+              <div>
+                <strong>Error budget</strong>
+                <p>Burn rate requires commander approval.</p>
+              </div>
+            </li>
+          </ul>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/deployment-risk-thermostat-sm/style.css
+++ b/submissions/examples/deployment-risk-thermostat-sm/style.css
@@ -1,0 +1,470 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --panel: #ffffff;
+  --ink: #172033;
+  --muted: #657187;
+  --line: #dce4ef;
+  --blue: #2563eb;
+  --cyan: #0891b2;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --soft-blue: #e9f1ff;
+  --soft-amber: #fff7df;
+  --shadow: 0 20px 55px rgba(34, 45, 70, 0.13);
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(8, 145, 178, 0.1), transparent 34%),
+    linear-gradient(315deg, rgba(217, 119, 6, 0.12), transparent 30%), var(--bg);
+}
+
+.thermostat-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 46px 0;
+}
+
+.intro {
+  display: grid;
+  gap: 12px;
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.eyebrow,
+.section-label {
+  margin: 0;
+  color: var(--blue);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 6vw, 4.5rem);
+  line-height: 1;
+}
+
+.intro p:last-child,
+.risk-copy p,
+.guardrail-list p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.control-grid {
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 18px;
+  align-items: stretch;
+}
+
+.risk-card,
+.release-card,
+.guardrail-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--shadow);
+}
+
+.risk-card {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: 26px;
+  grid-row: span 2;
+  min-height: 520px;
+  padding: 24px;
+}
+
+.thermostat {
+  position: relative;
+  display: grid;
+  grid-template-columns: 82px 1fr;
+  gap: 18px;
+  align-items: center;
+  min-height: 410px;
+}
+
+.thermostat-glow {
+  position: absolute;
+  inset: 40px 22px 40px auto;
+  width: 92px;
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(220, 38, 38, 0.22),
+    rgba(8, 145, 178, 0.18)
+  );
+  filter: blur(22px);
+  animation: heatPulse 2.8s ease-in-out infinite;
+}
+
+.thermostat-scale {
+  z-index: 1;
+  display: flex;
+  min-height: 330px;
+  flex-direction: column;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.thermostat-tube {
+  position: relative;
+  z-index: 1;
+  width: 86px;
+  height: 360px;
+  margin: 0 auto;
+  overflow: hidden;
+  border: 8px solid #edf2f8;
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, rgba(220, 38, 38, 0.16), transparent 30%),
+    linear-gradient(0deg, rgba(22, 163, 74, 0.12), transparent 36%), #ffffff;
+  box-shadow:
+    inset 0 0 0 1px rgba(20, 32, 50, 0.08),
+    0 18px 30px rgba(30, 43, 67, 0.14);
+}
+
+.thermostat-tube::before {
+  position: absolute;
+  inset: 28px 50% 28px auto;
+  width: 1px;
+  content: "";
+  background: repeating-linear-gradient(
+    180deg,
+    rgba(101, 113, 135, 0.34) 0 9px,
+    transparent 9px 20px
+  );
+}
+
+.mercury {
+  position: absolute;
+  inset: auto 13px 13px;
+  height: 72%;
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    var(--red),
+    var(--amber) 55%,
+    var(--cyan)
+  );
+  transform-origin: bottom;
+  animation: mercuryRise 2.2s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.mercury::after {
+  position: absolute;
+  inset: 10px 11px auto auto;
+  width: 9px;
+  height: 72%;
+  border-radius: 999px;
+  content: "";
+  background: rgba(255, 255, 255, 0.42);
+}
+
+.risk-copy {
+  align-self: center;
+}
+
+.risk-copy h2,
+.card-header h2 {
+  margin: 5px 0 10px;
+  font-size: clamp(1.55rem, 3vw, 2.45rem);
+  line-height: 1.05;
+}
+
+.risk-score {
+  display: inline-grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: center;
+  margin-top: 24px;
+  border: 1px solid rgba(217, 119, 6, 0.28);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  background: var(--soft-amber);
+}
+
+.risk-score strong {
+  color: var(--amber);
+  font-size: 2.3rem;
+  line-height: 1;
+}
+
+.risk-score span {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.release-card,
+.guardrail-card {
+  padding: 20px;
+}
+
+.card-header {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.state-pill {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 7px 10px;
+  color: var(--blue);
+  background: var(--soft-blue);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.state-hold {
+  color: var(--amber);
+  background: var(--soft-amber);
+}
+
+.wave-track {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.wave {
+  display: grid;
+  min-height: 54px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: var(--muted);
+  background: #f1f5fa;
+  font-size: 0.8rem;
+  font-weight: 900;
+}
+
+.wave-done {
+  color: #ffffff;
+  background: var(--green);
+}
+
+.wave-active {
+  position: relative;
+  color: #ffffff;
+  background: var(--amber);
+  animation: activeWave 1.8s ease-in-out infinite;
+}
+
+.wave-active::after {
+  position: absolute;
+  inset: -5px;
+  border: 1px solid rgba(217, 119, 6, 0.45);
+  border-radius: inherit;
+  content: "";
+  animation: holdRing 1.8s ease-out infinite;
+}
+
+.pace-meter {
+  height: 14px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e5edf7;
+}
+
+.pace-meter span {
+  display: block;
+  width: 50%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--green), var(--amber));
+  animation: paceGlow 2.4s ease-in-out infinite;
+}
+
+.guardrail-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.guardrail-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: start;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 13px;
+  background: #fbfdff;
+  transform: translateY(10px);
+  animation: checkIn 0.65s ease both;
+}
+
+.guardrail-list li:nth-child(2) {
+  animation-delay: 0.1s;
+}
+
+.guardrail-list li:nth-child(3) {
+  animation-delay: 0.2s;
+}
+
+.guardrail-list li:nth-child(4) {
+  animation-delay: 0.3s;
+}
+
+.check-dot {
+  width: 14px;
+  height: 14px;
+  margin-top: 4px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 5px rgba(22, 163, 74, 0.12);
+}
+
+.check-warn .check-dot {
+  background: var(--amber);
+  box-shadow: 0 0 0 5px rgba(217, 119, 6, 0.14);
+}
+
+.check-stop .check-dot {
+  background: var(--red);
+  box-shadow: 0 0 0 5px rgba(220, 38, 38, 0.12);
+}
+
+.guardrail-list strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+@keyframes heatPulse {
+  50% {
+    opacity: 0.68;
+    transform: scale(1.08);
+  }
+}
+
+@keyframes mercuryRise {
+  from {
+    transform: scaleY(0.18);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes activeWave {
+  50% {
+    filter: saturate(1.35);
+    transform: translateY(-2px);
+  }
+}
+
+@keyframes holdRing {
+  from {
+    opacity: 0.7;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.14);
+  }
+}
+
+@keyframes paceGlow {
+  50% {
+    filter: brightness(1.08);
+    transform: scaleX(0.96);
+  }
+}
+
+@keyframes checkIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 880px) {
+  .control-grid,
+  .risk-card {
+    grid-template-columns: 1fr;
+  }
+
+  .risk-card {
+    grid-row: auto;
+    min-height: auto;
+  }
+
+  .thermostat {
+    max-width: 280px;
+    min-height: 340px;
+  }
+
+  .thermostat-tube {
+    height: 310px;
+  }
+}
+
+@media (max-width: 560px) {
+  .thermostat-shell {
+    width: min(100% - 20px, 1120px);
+    padding: 30px 0;
+  }
+
+  .risk-card,
+  .release-card,
+  .guardrail-card {
+    padding: 16px;
+  }
+
+  .thermostat {
+    grid-template-columns: 62px 1fr;
+  }
+
+  .wave-track {
+    grid-template-columns: 1fr;
+  }
+
+  .card-header {
+    display: grid;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Closes #49940



**PR Text**
```md
Title: feat: add deployment risk thermostat demo

Summary:
- Adds `deployment-risk-thermostat-sm` under `submissions/examples`
- Includes a self-contained HTML/CSS deployment risk dashboard
- Documents usage, classes, and EaseMotion fit in the README

Checks:
- `npx prettier --check submissions/examples/deployment-risk-thermostat-sm/demo.html submissions/examples/deployment-risk-thermostat-sm/style.css submissions/examples/deployment-risk-thermostat-sm/README.md`