### PR TITLE
feat: add privacy consent stack demo

### DIFF
--- a/submissions/examples/privacy-consent-stack-sm/README.md
+++ b/submissions/examples/privacy-consent-stack-sm/README.md
@@ -1,0 +1,5 @@
+# Privacy Consent Stack
+
+1. What does this do? Adds responsive privacy consent rows with animated toggle states, consent chips, staggered row entry, and hover or focus feedback.
+2. How is it used? Apply `.consent-list` to the wrapper and `.consent-row` with tone classes like `.required-row`, `.active-row`, `.optional-row`, or `.paused-row` for each preference.
+3. Why is it useful? It makes consent choices easier to scan with purposeful CSS-only motion and keyboard-friendly focus treatment.

--- a/submissions/examples/privacy-consent-stack-sm/demo.html
+++ b/submissions/examples/privacy-consent-stack-sm/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Consent Stack</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-shell">
+    <section class="consent-panel" aria-labelledby="consent-title">
+      <div class="panel-heading">
+        <p class="eyebrow">Privacy center</p>
+        <h1 id="consent-title">Consent preferences with animated stack states</h1>
+        <p>
+          Preference rows use sliding toggles, soft priority colors, and keyboard-visible focus
+          feedback to make consent choices clearer without JavaScript.
+        </p>
+      </div>
+
+      <div class="consent-card" aria-label="Privacy consent preferences">
+        <div class="consent-summary">
+          <div>
+            <span class="summary-chip">Workspace privacy</span>
+            <strong>Manage consent settings</strong>
+          </div>
+          <span class="saved-pill">Auto-saved</span>
+        </div>
+
+        <div class="consent-list">
+          <label class="consent-row required-row">
+            <input type="checkbox" checked disabled>
+            <span class="toggle-ui" aria-hidden="true"></span>
+            <span class="consent-copy">
+              <strong>Required session cookies</strong>
+              <small>Keep sign-in, security, and workspace routing active.</small>
+            </span>
+            <span class="state-chip">Always on</span>
+          </label>
+
+          <label class="consent-row active-row">
+            <input type="checkbox" checked>
+            <span class="toggle-ui" aria-hidden="true"></span>
+            <span class="consent-copy">
+              <strong>Product analytics</strong>
+              <small>Help improve motion examples and interface usage flows.</small>
+            </span>
+            <span class="state-chip">Enabled</span>
+          </label>
+
+          <label class="consent-row optional-row">
+            <input type="checkbox">
+            <span class="toggle-ui" aria-hidden="true"></span>
+            <span class="consent-copy">
+              <strong>Personalized tips</strong>
+              <small>Show relevant shortcuts, snippets, and onboarding prompts.</small>
+            </span>
+            <span class="state-chip">Optional</span>
+          </label>
+
+          <label class="consent-row paused-row">
+            <input type="checkbox">
+            <span class="toggle-ui" aria-hidden="true"></span>
+            <span class="consent-copy">
+              <strong>Partner integrations</strong>
+              <small>Share limited signals with connected workflow tools.</small>
+            </span>
+            <span class="state-chip">Off</span>
+          </label>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/privacy-consent-stack-sm/style.css
+++ b/submissions/examples/privacy-consent-stack-sm/style.css
@@ -1,0 +1,325 @@
+:root {
+  color-scheme: light;
+  --page: #f5f7fb;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e1ec;
+  --required: #3158e8;
+  --required-soft: #e9eeff;
+  --active: #12805c;
+  --active-soft: #e7f7ef;
+  --optional: #a95d00;
+  --optional-soft: #fff5e5;
+  --paused: #667085;
+  --paused-soft: #eef2f7;
+  --shadow: 0 20px 54px rgba(31, 42, 68, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(49, 88, 232, 0.14), transparent 30rem),
+    radial-gradient(circle at 86% 82%, rgba(18, 128, 92, 0.12), transparent 26rem),
+    var(--page);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.consent-panel {
+  width: min(100%, 980px);
+}
+
+.panel-heading {
+  max-width: 760px;
+  margin-bottom: 1.45rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--required);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4.25rem);
+  line-height: 1;
+}
+
+.panel-heading p:last-child {
+  max-width: 680px;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.consent-card {
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: var(--shadow);
+}
+
+.consent-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 1rem;
+}
+
+.consent-summary div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.consent-summary strong {
+  font-size: 1.3rem;
+}
+
+.summary-chip,
+.saved-pill,
+.state-chip {
+  display: inline-flex;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.34rem 0.72rem;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.summary-chip {
+  color: var(--required);
+  background: var(--required-soft);
+}
+
+.saved-pill {
+  color: var(--active);
+  background: var(--active-soft);
+  white-space: nowrap;
+}
+
+.consent-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.consent-row {
+  --tone: var(--optional);
+  --tone-soft: var(--optional-soft);
+  position: relative;
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  gap: 0.9rem;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 0.95rem;
+  background: var(--surface);
+  box-shadow: 0 10px 26px rgba(31, 42, 68, 0.08);
+  cursor: pointer;
+  animation: row-enter 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition:
+    border-color 230ms ease,
+    box-shadow 230ms ease,
+    transform 230ms ease;
+}
+
+.consent-row::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--tone-soft), transparent 58%);
+  opacity: 0;
+  transition: opacity 230ms ease;
+}
+
+.consent-row:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.consent-row:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.consent-row:nth-child(4) {
+  animation-delay: 240ms;
+}
+
+.consent-row:hover,
+.consent-row:focus-within {
+  border-color: color-mix(in srgb, var(--tone) 42%, var(--line));
+  box-shadow: 0 16px 38px rgba(31, 42, 68, 0.13);
+  transform: translateY(-3px);
+}
+
+.consent-row:hover::before,
+.consent-row:focus-within::before {
+  opacity: 1;
+}
+
+.required-row {
+  --tone: var(--required);
+  --tone-soft: var(--required-soft);
+  cursor: not-allowed;
+}
+
+.active-row {
+  --tone: var(--active);
+  --tone-soft: var(--active-soft);
+}
+
+.optional-row {
+  --tone: var(--optional);
+  --tone-soft: var(--optional-soft);
+}
+
+.paused-row {
+  --tone: var(--paused);
+  --tone-soft: var(--paused-soft);
+}
+
+.consent-row input {
+  position: relative;
+  z-index: 1;
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--tone);
+}
+
+.consent-row input:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tone) 24%, transparent);
+  outline-offset: 4px;
+}
+
+.toggle-ui,
+.consent-copy,
+.state-chip {
+  position: relative;
+  z-index: 1;
+}
+
+.toggle-ui {
+  width: 3.2rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: var(--paused-soft);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tone) 18%, var(--line));
+  transition:
+    background-color 230ms ease,
+    box-shadow 230ms ease;
+}
+
+.toggle-ui::before {
+  content: "";
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 5px 12px rgba(31, 42, 68, 0.18);
+  transition: transform 230ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.consent-row input:checked + .toggle-ui {
+  background: var(--tone);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--tone) 12%, transparent);
+}
+
+.consent-row input:checked + .toggle-ui::before {
+  transform: translateX(1.45rem);
+}
+
+.consent-copy {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.consent-copy strong,
+.consent-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.consent-copy small {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.state-chip {
+  color: var(--tone);
+  background: var(--tone-soft);
+  white-space: nowrap;
+}
+
+@keyframes row-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.99);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 760px) {
+  .demo-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .consent-summary,
+  .consent-row {
+    grid-template-columns: 1fr;
+  }
+
+  .consent-summary {
+    align-items: start;
+  }
+
+  .state-chip {
+    justify-self: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .consent-row,
+  .consent-row::before,
+  .toggle-ui,
+  .toggle-ui::before {
+    animation: none;
+    transition: none;
+  }
+
+  .consent-row:hover,
+  .consent-row:focus-within {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #49950

## Pull Request Description

Adds a self-contained Privacy Consent Stack demo with responsive consent preference rows, animated toggle states, consent chips, staggered row entry, hover/focus feedback, and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Responsive privacy consent rows with animated toggle states, readable consent chips, staggered row entry, and hover/focus motion feedback.

**How does a developer use it?**

```html
<div class="consent-list">
  <label class="consent-row active-row">
    <input type="checkbox" checked>
    <span class="toggle-ui" aria-hidden="true"></span>
    <span class="consent-copy">
      <strong>Product analytics</strong>
      <small>Help improve motion examples and interface usage flows.</small>
    </span>
    <span class="state-chip">Enabled</span>
  </label>
</div>