### PR TITLE
fix(toast): add offset utility to prevent FAB overlap

### DIFF
--- a/submissions/docs/toast-fab-overlap-mobile-jp/README.md
+++ b/submissions/docs/toast-fab-overlap-mobile-jp/README.md
@@ -1,0 +1,20 @@
+# Toast and FAB Overlap Fix
+
+Fixes the issue where toast notifications inside `.ease-toast-container` overlap and obscure Floating Action Buttons (`.ease-fab`) on mobile screens.
+
+**What does this do?**
+Introduces a new utility class `.ease-toast-offset-fab` that adds a safe bottom margin to the toast container, shifting it upwards enough to avoid overlapping with a standard-sized FAB.
+
+**How is it used?**
+Apply the `.ease-toast-offset-fab` class directly to the `.ease-toast-container` when you have a `.ease-fab` on the same screen:
+
+```html
+<div class="ease-toast-container ease-bottom-right ease-toast-offset-fab">
+  <div class="ease-toast">
+    New message received!
+  </div>
+</div>
+```
+
+**Why is it useful?**
+It resolves Issue #49956 by preventing interactive elements (like the FAB) from being blocked by dynamic notifications, greatly improving the user experience and accessibility on touch devices.

--- a/submissions/docs/toast-fab-overlap-mobile-jp/demo.html
+++ b/submissions/docs/toast-fab-overlap-mobile-jp/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast FAB Overlap Fix Demo</title>
+  
+  <!-- Link to the core framework -->
+  <link rel="stylesheet" href="../../easemotion.css">
+  
+  <!-- Our specific feature CSS fix -->
+  <link rel="stylesheet" href="style.css">
+  
+  <style>
+    body {
+      min-height: 200vh;
+      padding: 2rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      margin: 0;
+    }
+    
+    .demo-info {
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    
+    /* Mock components for demo purposes assuming core has basic setup */
+    .ease-toast-container {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      z-index: 50;
+    }
+    
+    .ease-toast {
+      background: white;
+      padding: 1rem 1.5rem;
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      font-weight: 500;
+      color: #334155;
+    }
+    
+    .ease-fab {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: #2563eb;
+      color: white;
+      border: none;
+      font-size: 24px;
+      z-index: 40;
+      box-shadow: 0 4px 12px rgba(37,99,235,0.3);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+    }
+    
+    .ease-fab:hover {
+      background: #1d4ed8;
+    }
+  </style>
+</head>
+<body>
+  
+  <div class="demo-info">
+    <h2>Toast & FAB Overlap Fix</h2>
+    <p>Look at the bottom right of the screen. By adding the <code>.ease-toast-offset-fab</code> class to the toast container, it intelligently shifts upwards to prevent overlapping and obscuring the Floating Action Button.</p>
+  </div>
+
+  <!-- Toast Container with the new offset class applied -->
+  <div class="ease-toast-container ease-bottom-right ease-toast-offset-fab">
+    <div class="ease-toast">
+      New message received!
+    </div>
+  </div>
+
+  <!-- Floating Action Button -->
+  <button class="ease-fab ease-bottom-right" aria-label="Add new item">
+    +
+  </button>
+  
+</body>
+</html>

--- a/submissions/docs/toast-fab-overlap-mobile-jp/style.css
+++ b/submissions/docs/toast-fab-overlap-mobile-jp/style.css
@@ -1,0 +1,14 @@
+/* Fix for toast notifications overlapping with FAB on mobile */
+
+/* Provides a safe offset for the toast container when a FAB is present on the screen */
+.ease-toast-offset-fab {
+  /* Assumes standard FAB height (56px/3.5rem) + safe spacing (1rem) + original offset (1.5rem) */
+  bottom: 6rem !important;
+}
+
+@media (max-width: 768px) {
+  /* On mobile screens, we ensure the toast container stacks properly above the FAB */
+  .ease-toast-container.ease-toast-offset-fab {
+    transition: bottom 0.3s ease-in-out;
+  }
+}


### PR DESCRIPTION
Closes #49956
# Title
Fix: Toast notifications overlap with Floating Action Button (FAB) on mobile

# Description

## 🐛 What was broken? / What is added?
The `.ease-toast-container` component frequently overlaps and obscures `.ease-fab` elements on mobile screens because both are commonly positioned at the bottom right. This makes the FAB unclickable until the toast disappears.

## ✅ What was changed?
- Created `style.css` containing a new utility class `.ease-toast-offset-fab` that adds a safe bottom offset to the toast container.
- Added a transition to smoothly handle the shift when the offset class is applied.
- Included `demo.html` to showcase the fix with a mock FAB and toast container.
- Added `README.md` to document the usage and integration of the new utility class.

## 🔗 Related Issue
Fixes #49956 (005-toast-fab-overlap-mobile)

## Pull Request Description

This PR introduces an offset utility class for toast containers to prevent them from obscuring Floating Action Buttons, resolving a major mobile UX issue.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A utility class `.ease-toast-offset-fab` that shifts the toast container up by `6rem` to accommodate a standard-sized FAB underneath.

**How does a developer use it?**

```html
<div class="ease-toast-container ease-bottom-right ease-toast-offset-fab">
  <div class="ease-toast">
    New message received!
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

It provides a simple, opt-in utility class to solve a common layout collision, keeping the core flexible and unopinionated.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari (iOS)

---

## Notes for Maintainer

This has been implemented strictly inside `submissions/docs/toast-fab-overlap-mobile-jp/` to comply with the code integrity policy.
