### PR TITLE
fix(forms): align custom checkbox vertically with multiline text

### DIFF
--- a/submissions/docs/checkbox-vertical-alignment-jp/README.md
+++ b/submissions/docs/checkbox-vertical-alignment-jp/README.md
@@ -1,0 +1,19 @@
+# Checkbox Vertical Alignment Fix
+
+Fixes the issue where custom checkboxes (`.ease-checkbox`) are vertically misaligned with their adjacent label text, especially noticeable when the text wraps to multiple lines.
+
+**What does this do?**
+Applies a flexbox layout to the `.ease-checkbox-wrapper` with `align-items: flex-start`, and uses a carefully calculated top margin on the checkbox to perfectly align it with the vertical center of the first line of text.
+
+**How is it used?**
+Wrap your checkbox and label text inside the wrapper:
+
+```html
+<label class="ease-checkbox-wrapper">
+  <input type="checkbox" class="ease-checkbox" />
+  <span class="ease-checkbox-label">Label text goes here...</span>
+</label>
+```
+
+**Why is it useful?**
+It resolves a common UI polish issue (Issue #49968), ensuring that forms look professional and structurally sound regardless of font size or text wrapping on smaller screens.

--- a/submissions/docs/checkbox-vertical-alignment-jp/demo.html
+++ b/submissions/docs/checkbox-vertical-alignment-jp/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Checkbox Vertical Alignment Fix Demo</title>
+  
+  <!-- Link to the core framework -->
+  <link rel="stylesheet" href="../../easemotion.css">
+  
+  <!-- Our specific feature CSS fix -->
+  <link rel="stylesheet" href="style.css">
+  
+  <style>
+    body {
+      padding: 3rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #334155;
+      margin: 0;
+    }
+    
+    .demo-container {
+      max-width: 400px;
+      margin: 0 auto;
+      background: white;
+      padding: 2rem;
+      border-radius: 12px;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+    
+    h2 {
+      margin-top: 0;
+      margin-bottom: 1.5rem;
+      font-size: 1.25rem;
+    }
+    
+    /* Mock checkbox for demo purposes if core doesn't have it explicitly */
+    .ease-checkbox {
+      width: 1.25rem;
+      height: 1.25rem;
+      border-radius: 4px;
+      border: 2px solid #cbd5e1;
+      appearance: none;
+      outline: none;
+      background: white;
+    }
+    
+    .ease-checkbox:checked {
+      background-color: #2563eb;
+      border-color: #2563eb;
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+    }
+    
+    .ease-checkbox-label {
+      line-height: 1.5;
+      font-size: 1rem;
+    }
+  </style>
+</head>
+<body>
+  
+  <div class="demo-container">
+    <h2>Checkbox Alignment Fix</h2>
+    
+    <!-- Checkbox Wrapper with fix applied -->
+    <label class="ease-checkbox-wrapper">
+      <input type="checkbox" class="ease-checkbox" checked />
+      <span class="ease-checkbox-label">
+        I agree to the terms and conditions and privacy policy. Notice how the checkbox stays perfectly aligned with the first line of text even when it wraps to multiple lines.
+      </span>
+    </label>
+    
+  </div>
+  
+</body>
+</html>

--- a/submissions/docs/checkbox-vertical-alignment-jp/style.css
+++ b/submissions/docs/checkbox-vertical-alignment-jp/style.css
@@ -1,0 +1,20 @@
+/* Fix for checkbox vertical alignment bug */
+
+.ease-checkbox-wrapper {
+  /* Use inline-flex to properly align the checkbox and text */
+  display: inline-flex;
+  /* Align to top so multiline text doesn't center the checkbox against the whole paragraph */
+  align-items: flex-start;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.ease-checkbox-wrapper .ease-checkbox {
+  /* Remove default margins */
+  margin: 0;
+  /* Push down slightly to align with the vertical center of the first line of text */
+  /* This assumes a standard line-height of 1.5 on the label text */
+  margin-top: 0.125em; 
+  /* Prevent the checkbox from shrinking if the text is very long */
+  flex-shrink: 0;
+}


### PR DESCRIPTION
Closes #49968

# Description

## 🐛 What was broken? / What is added?
When using `.ease-checkbox` alongside label text, the custom checkbox square was misaligned vertically with the adjacent text. It sat slightly higher, causing the layout to look unpolished, especially when the text wrapped to multiple lines.

## ✅ What was changed?
- Created `style.css` containing an improved flexbox layout for `.ease-checkbox-wrapper` (`align-items: flex-start`).
- Added a precise top margin and `flex-shrink: 0` to the `.ease-checkbox` to align it perfectly with the first line of text.
- Included `demo.html` to showcase the fix with a long, wrapping label text.
- Added `README.md` to document the usage and integration of the fix.

## 🔗 Related Issue
Fixes #49968 (007-checkbox-vertical-alignment)

## Pull Request Description

This PR fixes a highly visible UI polish bug by properly aligning custom checkboxes with adjacent multiline label text.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Proper flexbox alignment rules for the `.ease-checkbox-wrapper` and `.ease-checkbox` classes to ensure perfect alignment regardless of text wrapping or font size.

**How does a developer use it?**

```html
<label class="ease-checkbox-wrapper">
  <input type="checkbox" class="ease-checkbox" />
  <span class="ease-checkbox-label">I agree to the terms...</span>
</label>
```

**Why does it fit EaseMotion CSS?**

It resolves a common form styling bug natively via CSS flexbox, preventing developers from needing to write their own messy margin overrides.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer

This fix is fully contained within `submissions/docs/checkbox-vertical-alignment-jp/` to adhere to the repository's strict no-overwrite policy.
