### PR TITLE
feat: add rollback readiness radar demo

### DIFF
--- a/submissions/examples/rollback-readiness-radar-sm/README.md
+++ b/submissions/examples/rollback-readiness-radar-sm/README.md
@@ -1,0 +1,26 @@
+# Rollback Readiness Radar
+
+## What does it do?
+
+This submission adds a self-contained rollback readiness radar demo for EaseMotion CSS. It presents a release safety dashboard with a sweeping radar, readiness score, recovery checkpoints, rollback timeline, and dependency status rows.
+
+## How is it used?
+
+Open `demo.html` directly in a browser. The demo is built with plain HTML and CSS, with no JavaScript, external assets, frameworks, or build step.
+
+```html
+<div class="radar" aria-label="Rollback readiness score is 86 percent">
+  <span class="radar-sweep" aria-hidden="true"></span>
+  <span class="radar-blip blip-one" aria-hidden="true"></span>
+  <div class="radar-score">
+    <strong>86%</strong>
+    <span>ready</span>
+  </div>
+</div>
+```
+
+Useful classes include `radar`, `radar-sweep`, `radar-blip`, `checkpoint-list`, `checkpoint-watch`, `timeline-step`, `step-active`, and `dependency-row`.
+
+## Why is it useful for EaseMotion?
+
+Rollback workflows need status motion that is urgent but readable. This example demonstrates practical CSS-only motion for operational readiness: radar sweep, pulsing blips, staggered checkpoints, active timeline markers, responsive layout, and reduced-motion support while staying isolated inside `submissions/examples`.

--- a/submissions/examples/rollback-readiness-radar-sm/demo.html
+++ b/submissions/examples/rollback-readiness-radar-sm/demo.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rollback Readiness Radar Demo</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="radar-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="eyebrow">EaseMotion CSS Submission</p>
+        <h1 id="demo-title">Rollback Readiness Radar</h1>
+        <p>
+          A CSS-only release safety panel that visualizes rollback readiness
+          with sweeping radar motion, recovery signals, and dependency
+          checkpoints.
+        </p>
+      </section>
+
+      <section class="readiness-grid" aria-label="Rollback readiness dashboard">
+        <article class="radar-card">
+          <div
+            class="radar"
+            aria-label="Rollback readiness score is 86 percent"
+          >
+            <span class="radar-ring ring-one" aria-hidden="true"></span>
+            <span class="radar-ring ring-two" aria-hidden="true"></span>
+            <span class="radar-ring ring-three" aria-hidden="true"></span>
+            <span class="radar-sweep" aria-hidden="true"></span>
+            <span class="radar-blip blip-one" aria-hidden="true"></span>
+            <span class="radar-blip blip-two" aria-hidden="true"></span>
+            <span class="radar-blip blip-three" aria-hidden="true"></span>
+            <div class="radar-score">
+              <strong>86%</strong>
+              <span>ready</span>
+            </div>
+          </div>
+          <div class="radar-caption">
+            <p class="section-label">Rollback posture</p>
+            <h2>Safe to reverse within six minutes</h2>
+            <p>
+              Snapshot integrity, traffic steering, and schema compatibility are
+              all inside the rollback window. One async worker queue still needs
+              approval before full confidence.
+            </p>
+          </div>
+        </article>
+
+        <article class="checkpoint-card">
+          <header class="card-header">
+            <div>
+              <p class="section-label">Checkpoints</p>
+              <h2>Recovery path</h2>
+            </div>
+            <span class="status-pill">4/5 armed</span>
+          </header>
+          <ul class="checkpoint-list">
+            <li class="checkpoint-pass">
+              <span class="checkpoint-dot" aria-hidden="true"></span>
+              <div>
+                <strong>Database snapshot</strong>
+                <p>Latest restore point verified at 12:08.</p>
+              </div>
+            </li>
+            <li class="checkpoint-pass">
+              <span class="checkpoint-dot" aria-hidden="true"></span>
+              <div>
+                <strong>Traffic switch</strong>
+                <p>Blue pool is warm and accepting shadow traffic.</p>
+              </div>
+            </li>
+            <li class="checkpoint-watch">
+              <span class="checkpoint-dot" aria-hidden="true"></span>
+              <div>
+                <strong>Worker queue</strong>
+                <p>Drain estimate is trending above target.</p>
+              </div>
+            </li>
+          </ul>
+        </article>
+
+        <article class="timeline-card">
+          <header class="card-header">
+            <div>
+              <p class="section-label">Rollback timer</p>
+              <h2>Six-minute route</h2>
+            </div>
+            <span class="status-pill status-live">live</span>
+          </header>
+          <div class="timeline" aria-label="Rollback steps timeline">
+            <div class="timeline-step step-complete">
+              <span>01</span>
+              <p>Freeze deploys</p>
+            </div>
+            <div class="timeline-step step-complete">
+              <span>02</span>
+              <p>Shift traffic</p>
+            </div>
+            <div class="timeline-step step-active">
+              <span>03</span>
+              <p>Restore snapshot</p>
+            </div>
+            <div class="timeline-step">
+              <span>04</span>
+              <p>Verify health</p>
+            </div>
+          </div>
+        </article>
+
+        <article class="dependency-card">
+          <p class="section-label">Dependencies</p>
+          <div class="dependency-row">
+            <span>API Gateway</span>
+            <strong>clear</strong>
+          </div>
+          <div class="dependency-row row-warning">
+            <span>Async Jobs</span>
+            <strong>watch</strong>
+          </div>
+          <div class="dependency-row">
+            <span>Schema Guard</span>
+            <strong>clear</strong>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/rollback-readiness-radar-sm/style.css
+++ b/submissions/examples/rollback-readiness-radar-sm/style.css
@@ -1,0 +1,472 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f8fc;
+  --panel: #ffffff;
+  --ink: #152033;
+  --muted: #64748b;
+  --line: #dce6f2;
+  --blue: #2563eb;
+  --teal: #0f9f8f;
+  --green: #16a34a;
+  --amber: #d97706;
+  --red: #dc2626;
+  --soft-blue: #eaf1ff;
+  --soft-green: #eaf8ef;
+  --soft-amber: #fff7df;
+  --shadow: 0 20px 55px rgba(28, 40, 62, 0.14);
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.09), transparent 34%),
+    linear-gradient(315deg, rgba(15, 159, 143, 0.1), transparent 32%), var(--bg);
+}
+
+.radar-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 46px 0;
+}
+
+.intro {
+  display: grid;
+  gap: 12px;
+  max-width: 780px;
+  margin-bottom: 24px;
+}
+
+.eyebrow,
+.section-label {
+  margin: 0;
+  color: var(--blue);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 6vw, 4.55rem);
+  line-height: 1;
+}
+
+.intro p:last-child,
+.radar-caption p,
+.checkpoint-list p,
+.timeline-step p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.readiness-grid {
+  display: grid;
+  grid-template-columns: 1.08fr 0.92fr;
+  gap: 18px;
+}
+
+.radar-card,
+.checkpoint-card,
+.timeline-card,
+.dependency-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow);
+}
+
+.radar-card {
+  display: grid;
+  grid-template-columns: 330px 1fr;
+  gap: 28px;
+  grid-row: span 3;
+  align-items: center;
+  min-height: 560px;
+  padding: 24px;
+}
+
+.radar {
+  position: relative;
+  display: grid;
+  aspect-ratio: 1;
+  width: min(100%, 330px);
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(15, 159, 143, 0.1) 0 18%, transparent 19%),
+    radial-gradient(
+      circle,
+      transparent 0 35%,
+      rgba(37, 99, 235, 0.06) 36% 37%,
+      transparent 38%
+    ),
+    #fbfdff;
+}
+
+.radar::before,
+.radar::after {
+  position: absolute;
+  inset: 50% 0 auto;
+  height: 1px;
+  content: "";
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.radar::after {
+  transform: rotate(90deg);
+}
+
+.radar-ring {
+  position: absolute;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 50%;
+}
+
+.ring-one {
+  inset: 18%;
+}
+
+.ring-two {
+  inset: 32%;
+}
+
+.ring-three {
+  inset: 46%;
+}
+
+.radar-sweep {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(15, 159, 143, 0.38),
+    rgba(15, 159, 143, 0.08) 36deg,
+    transparent 72deg
+  );
+  animation: sweep 3.2s linear infinite;
+}
+
+.radar-blip {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 8px rgba(22, 163, 74, 0.13);
+  animation: blipPulse 1.8s ease-in-out infinite;
+}
+
+.blip-one {
+  top: 27%;
+  left: 61%;
+}
+
+.blip-two {
+  right: 24%;
+  bottom: 28%;
+  animation-delay: 0.35s;
+}
+
+.blip-three {
+  bottom: 38%;
+  left: 28%;
+  background: var(--amber);
+  box-shadow: 0 0 0 8px rgba(217, 119, 6, 0.16);
+  animation-delay: 0.7s;
+}
+
+.radar-score {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 122px;
+  height: 122px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 18px 34px rgba(26, 42, 68, 0.14);
+}
+
+.radar-score strong {
+  margin-top: 18px;
+  color: var(--teal);
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.radar-score span {
+  margin-top: -24px;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.radar-caption h2,
+.card-header h2 {
+  margin: 5px 0 10px;
+  font-size: clamp(1.45rem, 3vw, 2.35rem);
+  line-height: 1.06;
+}
+
+.checkpoint-card,
+.timeline-card,
+.dependency-card {
+  padding: 20px;
+}
+
+.card-header {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.status-pill {
+  border: 1px solid rgba(15, 159, 143, 0.24);
+  border-radius: 999px;
+  padding: 7px 10px;
+  color: var(--teal);
+  background: rgba(15, 159, 143, 0.09);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.status-live {
+  color: var(--blue);
+  background: var(--soft-blue);
+}
+
+.checkpoint-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.checkpoint-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: start;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 13px;
+  background: #fbfdff;
+  transform: translateY(10px);
+  animation: checkpointIn 0.65s ease both;
+}
+
+.checkpoint-list li:nth-child(2) {
+  animation-delay: 0.12s;
+}
+
+.checkpoint-list li:nth-child(3) {
+  animation-delay: 0.24s;
+}
+
+.checkpoint-dot {
+  width: 14px;
+  height: 14px;
+  margin-top: 4px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 5px rgba(22, 163, 74, 0.13);
+}
+
+.checkpoint-watch .checkpoint-dot {
+  background: var(--amber);
+  box-shadow: 0 0 0 5px rgba(217, 119, 6, 0.14);
+}
+
+.checkpoint-list strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.timeline {
+  position: relative;
+  display: grid;
+  gap: 12px;
+}
+
+.timeline::before {
+  position: absolute;
+  top: 22px;
+  bottom: 22px;
+  left: 19px;
+  width: 2px;
+  content: "";
+  background: linear-gradient(var(--green) 0 50%, #dbe5f1 50%);
+}
+
+.timeline-step {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 48px;
+}
+
+.timeline-step span {
+  z-index: 1;
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  color: var(--muted);
+  background: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.step-complete span {
+  color: #ffffff;
+  border-color: var(--green);
+  background: var(--green);
+}
+
+.step-active span {
+  color: #ffffff;
+  border-color: var(--blue);
+  background: var(--blue);
+  animation: activeStep 1.8s ease-in-out infinite;
+}
+
+.dependency-card {
+  display: grid;
+  gap: 12px;
+}
+
+.dependency-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 13px 14px;
+  background: var(--soft-green);
+}
+
+.dependency-row span {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.dependency-row strong {
+  color: var(--green);
+  text-transform: uppercase;
+}
+
+.row-warning {
+  background: var(--soft-amber);
+}
+
+.row-warning strong {
+  color: var(--amber);
+}
+
+@keyframes sweep {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes blipPulse {
+  50% {
+    opacity: 0.62;
+    transform: scale(0.82);
+  }
+}
+
+@keyframes checkpointIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes activeStep {
+  50% {
+    box-shadow: 0 0 0 8px rgba(37, 99, 235, 0.12);
+    transform: scale(1.04);
+  }
+}
+
+@media (max-width: 940px) {
+  .readiness-grid,
+  .radar-card {
+    grid-template-columns: 1fr;
+  }
+
+  .radar-card {
+    grid-row: auto;
+    min-height: auto;
+  }
+
+  .radar {
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 560px) {
+  .radar-shell {
+    width: min(100% - 20px, 1180px);
+    padding: 30px 0;
+  }
+
+  .radar-card,
+  .checkpoint-card,
+  .timeline-card,
+  .dependency-card {
+    padding: 16px;
+  }
+
+  .card-header {
+    display: grid;
+  }
+
+  .dependency-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Closes #49972


**PR Text**
```md
Title: feat: add rollback readiness radar demo

Summary:
- Adds `rollback-readiness-radar-sm` under `submissions/examples`
- Includes a self-contained HTML/CSS rollback readiness dashboard
- Documents usage, classes, and EaseMotion fit in the README

Checks:
- `npx prettier --check submissions/examples/rollback-readiness-radar-sm/demo.html submissions/examples/rollback-readiness-radar-sm/style.css submissions/examples/rollback-readiness-radar-sm/README.md`