### PR TITLE
feat: add rotate-on-hover settings gear icon #49879

### DIFF
--- a/submissions/examples/rotate-gear-icon-ps/README.md
+++ b/submissions/examples/rotate-gear-icon-ps/README.md
@@ -1,0 +1,11 @@
+# Rotate-on-Hover Settings Gear Icon (#49879)
+
+An accessible micro-interaction component that spins a vector settings cog gracefully using smooth spring dynamics when a cursor hovers or a keyboard focuses on the parent panel element.
+
+### How to use
+Add the structural target class `ease-rotate-gear` to any graphic icon tag within your actionable layout anchors:
+
+```html
+<button class="settings-action-trigger">
+    <svg class="ease-rotate-gear"><!-- SVG Path Details --></svg>
+</button>

--- a/submissions/examples/rotate-gear-icon-ps/demo.html
+++ b/submissions/examples/rotate-gear-icon-ps/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rotate-on-Hover Settings Gear Icon</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="panel-dark-theme">
+    <main class="settings-container">
+        <!-- Interactive Dashboard Header Card -->
+        <article class="settings-card">
+            <div class="card-content">
+                <span class="system-badge">System Preferences</span>
+                <h1 class="card-heading">Configuration</h1>
+                <p class="card-subtext">Hover or focus the control block to trigger the mechanical cog interaction.</p>
+            </div>
+            
+            <!-- Accessible Focusable Action Wrapper -->
+            <button class="settings-action-trigger" aria-label="Open System Configuration Panel">
+                <!-- Inline Optimized SVG Settings Gear Icon -->
+                <svg class="ease-rotate-gear" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.1a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
+                    <circle cx="12" cy="12" r="3"></circle>
+                </svg>
+            </button>
+        </article>
+    </main>
+</body>
+</html>

--- a/submissions/examples/rotate-gear-icon-ps/style.css
+++ b/submissions/examples/rotate-gear-icon-ps/style.css
@@ -1,0 +1,124 @@
+/* CSS Document - Rotate-on-Hover Settings Gear Icon (#49879) */
+
+:root {
+    --bg-workspace: #090d16;
+    --surface-card: #111827;
+    --border-card: #1f2937;
+    --text-main: #f9fafb;
+    --text-muted: #9ca3af;
+    
+    /* EaseMotion Exposed Rotation Variables */
+    --ease-gear-color: #93c5fd;
+    --ease-gear-hover-color: #3b82f6;
+    --ease-rotate-angle: 180deg;
+    --ease-rotate-duration: 0.6s;
+    --ease-rotate-curve: cubic-bezier(0.34, 1.56, 0.64, 1); /* Satisfying spring feedback */
+}
+
+body.panel-dark-theme {
+    background-color: var(--bg-workspace);
+    color: var(--text-main);
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.settings-container {
+    width: 90%;
+    max-width: 400px;
+    padding: 16px;
+    box-sizing: border-box;
+}
+
+.settings-card {
+    background-color: var(--surface-card);
+    border: 1px solid var(--border-card);
+    border-radius: 16px;
+    padding: 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.system-badge {
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #60a5fa;
+    background-color: rgba(96, 165, 250, 0.1);
+    padding: 4px 8px;
+    border-radius: 4px;
+}
+
+.card-heading {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 8px 0 4px 0;
+}
+
+.card-subtext {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+    margin: 0;
+}
+
+/* Button Trigger Anchor Reset */
+.settings-action-trigger {
+    background: transparent;
+    border: 1px solid transparent;
+    padding: 10px;
+    border-radius: 10px;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    outline: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.settings-action-trigger:focus-visible {
+    border-color: var(--ease-gear-hover-color);
+    background-color: rgba(59, 130, 246, 0.08);
+}
+
+/* --- THE MOTION ROTATION ENGINE --- */
+
+.ease-rotate-gear {
+    width: 28px;
+    height: 28px;
+    color: var(--ease-gear-color);
+    
+    /* Mount transition details on hardware composite line tracks */
+    transform: rotate(0deg);
+    transition: transform var(--ease-rotate-duration) var(--ease-rotate-curve),
+                color var(--ease-rotate-duration) ease;
+    will-change: transform;
+}
+
+/* Triggers - Handles both hover tracks and master focus accessibility blocks */
+.settings-action-trigger:hover .ease-rotate-gear,
+.settings-action-trigger:focus .ease-rotate-gear,
+.settings-card:hover .ease-rotate-gear {
+    color: var(--ease-gear-hover-color);
+    transform: rotate(var(--ease-rotate-angle));
+}
+
+/* ACCESSIBILITY REDUCED MOTION SAFE GUARDS */
+@media (prefers-reduced-motion: reduce) {
+    .ease-rotate-gear {
+        transition: color 0.2s ease !important;
+        transform: none !important;
+    }
+    .settings-action-trigger:hover .ease-rotate-gear,
+    .settings-action-trigger:focus .ease-rotate-gear,
+    .settings-card:hover .ease-rotate-gear {
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces the `rotate-gear-icon` micro-interaction effect. Designed as a polished, beginner-friendly component for navigation panels and account option bars, it implements an overshooting mechanical rotational curve via pure CSS `:hover` and `:focus-visible` states with zero JavaScript weight.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A performance-optimized, spring-backed vector rotation effect for action cogs that reacts instantly to mouse overlays and standard keyboard tracks.

**How does a developer use it?**

```html
<button class="settings-action-trigger">
    <svg class="ease-rotate-gear">...</svg>
</button>

**Why does it fit EaseMotion CSS?**

It perfectly lines up with the library's design standards by handling movement through the composite rendering thread. This approach provides smooth frame rates without layout shifting, keeping configuration clear via flexible CSS custom properties.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---