### PR TITLE
feat(submission): add ease-text-highlight-marker component (#49046)

### DIFF
--- a/submissions/examples/ease-text-highlight-marker-ksk/README.md
+++ b/submissions/examples/ease-text-highlight-marker-ksk/README.md
@@ -1,0 +1,33 @@
+# Text Highlight Marker (`ease-text-highlight-marker-ksk`)
+
+1. What does this do?  
+An inline text highlight marker component. Hovering over marked text plays a smooth left-to-right drawing animation (mimicking a highlighter pen sweeping across the line). It supports 4 pre-set highlight colors (yellow, green, cyan, pink), custom hand-drawn sketch overlays, and a CSS-driven toolbar selector.
+
+2. How is it used?  
+Add `.ease-marker` around any inline text block. Apply modifier classes for color locks:
+
+```html
+<span class="ease-marker marker-green">Green Highlight</span>
+```
+
+For the hand-drawn sketch variant, use:
+```html
+<span class="ease-marker-sketch marker-pink">Sketch Highlight</span>
+```
+
+Customize highlight dimensions and timing via CSS custom properties:
+```css
+.ease-marker {
+  --ease-marker-color:     var(--marker-yellow);
+  --ease-marker-duration:  0.45s;
+  --ease-marker-height:    65%;             /* thickness of line */
+  --ease-marker-y-offset:  5%;              /* distance from line bottom */
+  --ease-marker-easing:    cubic-bezier(0.25, 1, 0.5, 1);
+}
+```
+
+3. Why is it useful?  
+Provides lightweight, animated, and accessible text highlights for blogs, e-learning platforms, reading interfaces, and portfolios. Fully responsive, wraps perfectly across multi-line text blocks, and functions entirely without JavaScript.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #49046.*

--- a/submissions/examples/ease-text-highlight-marker-ksk/demo.html
+++ b/submissions/examples/ease-text-highlight-marker-ksk/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Highlight Marker — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #f1f5f9;
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 2rem;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 800;
+      color: #0f172a;
+      margin: 0 0 0.4rem;
+      letter-spacing: -0.019em;
+    }
+    .page-header p {
+      color: #475569;
+      font-size: 0.88rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-header">
+    <h1>Ease Text Highlight Marker</h1>
+    <p>Hover sentences to highlight them. Use the toolbar to change colors or toggle all markers.</p>
+  </div>
+
+  <!-- Pure CSS controllers: Radio group for active marker color selection -->
+  <input type="radio" name="marker-color" id="color-yellow" class="marker-radio" checked>
+  <input type="radio" name="marker-color" id="color-green" class="marker-radio">
+  <input type="radio" name="marker-color" id="color-cyan" class="marker-radio">
+  <input type="radio" name="marker-color" id="color-pink" class="marker-radio">
+
+  <!-- Checkbox to highlight all markers simultaneously -->
+  <input type="checkbox" id="toggle-all" class="trigger-all-toggle">
+
+  <!-- Highlight Selection Toolbar -->
+  <div class="marker-toolbar">
+    <span class="toolbar-label">Marker Pen</span>
+    <div class="toolbar-options">
+      <label for="color-yellow" class="toolbar-btn btn-yellow" title="Yellow Pen" aria-label="Yellow Pen"></label>
+      <label for="color-green" class="toolbar-btn btn-green" title="Green Pen" aria-label="Green Pen"></label>
+      <label for="color-cyan" class="toolbar-btn btn-cyan" title="Cyan Pen" aria-label="Cyan Pen"></label>
+      <label for="color-pink" class="toolbar-btn btn-pink" title="Pink Pen" aria-label="Pink Pen"></label>
+    </div>
+    <!-- Clean reset / trigger all checkbox label -->
+    <label for="toggle-all" class="highlight-all-btn" role="button" tabindex="0"></label>
+  </div>
+
+  <!-- Main Article Card -->
+  <article class="article-card">
+    <h2 class="article-title">The Art of Mindful Reading</h2>
+    <div class="article-meta">
+      <span>By Shiv Kumar</span>
+      <span>•</span>
+      <span>4 min read</span>
+      <span>•</span>
+      <span>Design &amp; Layout</span>
+    </div>
+
+    <!-- Paragraph with inline markers -->
+    <p class="article-paragraph">
+      In an era dominated by rapid notifications and endless scrolling, the ability to focus on a single piece of text has become a rare skill. 
+      <span class="ease-marker">Mindfulness in reading is not just about speed; it is about retention and deep connection</span> 
+      with the author's underlying ideas. When we slow down, the words take on a physical weight.
+    </p>
+
+    <p class="article-paragraph">
+      Highlighters and markers have long served as our guides through dense texts. 
+      <span class="ease-marker">By marking key passages, we map out cognitive landmarks</span> 
+      that help our brains catalog insights. In digital mediums, we can capture this tactile joy through fluid, 
+      <span class="ease-marker-sketch">smoothly drawn highlight transitions</span> 
+      that mimic the ink sweeping across paper.
+    </p>
+
+    <!-- Paragraph demonstrating specific color locks -->
+    <p class="article-paragraph">
+      We can also assign colors to signify different themes. For instance, we might use a 
+      <span class="ease-marker marker-green">green highlight for definitions</span>, a 
+      <span class="ease-marker marker-cyan">cyan highlight for citations</span>, or a 
+      <span class="ease-marker marker-pink">pink highlight for warnings and critical notes</span>. 
+      This keeps our annotations structured, readable, and highly referenceable.
+    </p>
+  </article>
+
+</body>
+</html>

--- a/submissions/examples/ease-text-highlight-marker-ksk/style.css
+++ b/submissions/examples/ease-text-highlight-marker-ksk/style.css
@@ -1,0 +1,241 @@
+/* ============================================================
+   EaseMotion CSS — Text Highlight Marker Component
+   submissions/examples/ease-text-highlight-marker-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override these variables on .ease-marker or container.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --marker-yellow:        rgba(254, 240, 138, 0.82);
+  --marker-green:         rgba(187, 247, 208, 0.82);
+  --marker-cyan:          rgba(165, 243, 252, 0.82);
+  --marker-pink:          rgba(251, 207, 232, 0.82);
+
+  --ease-marker-color:     var(--marker-yellow);
+  --ease-marker-duration:  0.45s;
+  --ease-marker-easing:    cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-marker-height:    65%;             /* thickness of the highlighter line */
+  --ease-marker-y-offset:  5%;              /* bottom offset of the highlight    */
+}
+
+/* ── Base Inline Marker Class ───────────────────────────── */
+.ease-marker {
+  position: relative;
+  display: inline;
+  background-image: linear-gradient(
+    to right,
+    var(--ease-marker-color) 100%,
+    transparent 100%
+  );
+  background-position: left calc(100% - var(--ease-marker-y-offset));
+  background-size: 0% var(--ease-marker-height);
+  background-repeat: no-repeat;
+  transition: background-size var(--ease-marker-duration) var(--ease-marker-easing);
+  color: inherit;
+  font-weight: inherit;
+}
+
+/* Hover State: Marker draws across from left to right */
+.ease-marker:hover,
+.ease-marker.is-active {
+  background-size: 100% var(--ease-marker-height);
+}
+
+/* ── Color Variations ───────────────────────────────────── */
+.ease-marker.marker-yellow { --ease-marker-color: var(--marker-yellow); }
+.ease-marker.marker-green  { --ease-marker-color: var(--marker-green); }
+.ease-marker.marker-cyan   { --ease-marker-color: var(--marker-cyan); }
+.ease-marker.marker-pink   { --ease-marker-color: var(--marker-pink); }
+
+/* ── Hand-Drawn Highlight Variant ────────────────────────── */
+/* Adds a slightly irregular, realistic hand-drawn marker effect */
+.ease-marker-sketch {
+  position: relative;
+  display: inline;
+  color: inherit;
+  z-index: 1;
+}
+
+.ease-marker-sketch::after {
+  content: '';
+  position: absolute;
+  left: -2px;
+  right: -2px;
+  bottom: 0;
+  height: var(--ease-marker-height);
+  background: var(--ease-marker-color);
+  z-index: -1;
+  border-radius: 4px 6px 4px 5px;
+  transform: rotate(-0.5deg) scaleY(0.95);
+  transform-origin: left center;
+  /* Animate clip-path to draw clockwise like a hand-drawn stroke */
+  clip-path: inset(0 100% 0 0);
+  transition: clip-path var(--ease-marker-duration) var(--ease-marker-easing);
+}
+
+.ease-marker-sketch:hover::after,
+.ease-marker-sketch.is-active::after {
+  clip-path: inset(0 0 0 0);
+}
+
+/* Sketch colors */
+.ease-marker-sketch.marker-yellow { --ease-marker-color: var(--marker-yellow); }
+.ease-marker-sketch.marker-green  { --ease-marker-color: var(--marker-green); }
+.ease-marker-sketch.marker-cyan   { --ease-marker-color: var(--marker-cyan); }
+.ease-marker-sketch.marker-pink   { --ease-marker-color: var(--marker-pink); }
+
+/* ── Pure CSS Color Selector Controller ────────────────── */
+.marker-radio {
+  display: none;
+}
+
+/* Switch container level highlighter color when radio is checked */
+#color-yellow:checked ~ .article-card { --ease-marker-color: var(--marker-yellow); }
+#color-green:checked ~ .article-card  { --ease-marker-color: var(--marker-green); }
+#color-cyan:checked ~ .article-card   { --ease-marker-color: var(--marker-cyan); }
+#color-pink:checked ~ .article-card   { --ease-marker-color: var(--marker-pink); }
+
+/* Highlight all markers on the card when general checklist is clicked */
+.trigger-all-toggle {
+  display: none;
+}
+
+.trigger-all-toggle:checked ~ .article-card .ease-marker {
+  background-size: 100% var(--ease-marker-height);
+}
+
+.trigger-all-toggle:checked ~ .article-card .ease-marker-sketch::after {
+  clip-path: inset(0 0 0 0);
+}
+
+/* ── Demo Page Styles: Reading Layout ───────────────────── */
+.article-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 20px;
+  padding: 2.25rem;
+  width: 100%;
+  max-width: 580px;
+  box-shadow: 0 10px 30px rgba(148, 163, 184, 0.12);
+  color: #1e293b;
+  font-family: Georgia, serif;
+  line-height: 1.8;
+  box-sizing: border-box;
+  transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.article-title {
+  font-family: system-ui, sans-serif;
+  font-size: 1.45rem;
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0 0 12px;
+  line-height: 1.35;
+}
+
+.article-meta {
+  font-family: system-ui, sans-serif;
+  font-size: 0.76rem;
+  color: #64748b;
+  margin-bottom: 24px;
+  display: flex;
+  gap: 12px;
+  border-bottom: 1px solid #f1f5f9;
+  padding-bottom: 12px;
+}
+
+.article-paragraph {
+  font-size: 1rem;
+  margin: 0 0 1.5rem;
+}
+
+.article-paragraph:last-child { margin-bottom: 0; }
+
+/* Highlighter pen selection toolbar */
+.marker-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 10px 16px;
+  margin-bottom: 1.5rem;
+  max-width: 580px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.toolbar-label {
+  font-family: system-ui, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.toolbar-options {
+  display: flex;
+  gap: 8px;
+}
+
+.toolbar-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  position: relative;
+}
+
+.toolbar-btn:hover {
+  transform: scale(1.15);
+}
+
+.btn-yellow { background-color: #fef08a; }
+.btn-green  { background-color: #bbf7d0; }
+.btn-cyan   { background-color: #a5f3fc; }
+.btn-pink   { background-color: #fbcfe8; }
+
+/* Active button border */
+#color-yellow:checked ~ .marker-toolbar .btn-yellow { border-color: #ca8a04; transform: scale(1.1); }
+#color-green:checked ~ .marker-toolbar .btn-green   { border-color: #16a34a; transform: scale(1.1); }
+#color-cyan:checked ~ .marker-toolbar .btn-cyan     { border-color: #0891b2; transform: scale(1.1); }
+#color-pink:checked ~ .marker-toolbar .btn-pink     { border-color: #db2777; transform: scale(1.1); }
+
+/* "Highlight All" toggle button */
+.highlight-all-btn {
+  margin-left: auto;
+  font-family: system-ui, sans-serif;
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: #64748b;
+  padding: 4px 10px;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.highlight-all-btn:hover {
+  background: #f1f5f9;
+  color: #334155;
+}
+
+.trigger-all-toggle:checked ~ .marker-toolbar .highlight-all-btn {
+  background: #64748b;
+  color: #fff;
+  border-color: #64748b;
+}
+
+.trigger-all-toggle:checked ~ .marker-toolbar .highlight-all-btn::before {
+  content: 'Unhighlight All';
+}
+
+.highlight-all-btn::before {
+  content: 'Highlight All';
+}


### PR DESCRIPTION
Closes #49046

Adds an interactive Text Highlight Marker component under `submissions/examples/ease-text-highlight-marker-ksk/`.

#### Key Features

1. **Ink Draw Effect** — Simulates a real highlighter pen drawing across the line of text on hover or focus by animating `background-size` (from `0%` to `100%`) with a smooth cubic-bezier easing.
2. **Hand-Drawn Sketch Variant** — Features an organic, slightly irregular highlight overlay utilizing `clip-path` animation combined with slight rotation to resemble a realistic hand-drawn highlighter stroke.
3. **Interactive Selector Toolbar** — Includes a pure CSS highlighter pen toolbar (using radio inputs) that lets readers switch active marker colors (Yellow, Green, Cyan, Pink) and a master toggle button to "Highlight All" segments instantly.
4. **5 Customizable Variables** — Override `--ease-marker-color`, `--ease-marker-duration`, `--ease-marker-easing`, `--ease-marker-height` (thickness), and `--ease-marker-y-offset` inline on any span or parent container.
5. **No JavaScript** — Works out-of-the-box on responsive, wrapping, multi-line text segments in pure CSS.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Highlighter gradients, clip-path sketch animations, toolbar button selections, and variables config |
| `demo.html` | Premium reading layout article showing inline highlighted sentences and color selectors |
| `README.md` | Usage guidelines and properties definition reference, resolving `#49046` |