### PR TITLE
Add responsive Markdown editor component (ease-markdown-editor-hr18)

### DIFF
--- a/submissions/examples/ease-markdown-editor-hr18/README.md
+++ b/submissions/examples/ease-markdown-editor-hr18/README.md
@@ -1,0 +1,71 @@
+# Markdown Editor (`ease-markdown-editor-hr18`)
+
+A responsive Markdown editor UI with a formatting toolbar, live preview,
+and dark mode, built for issue
+[#49546](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/49546).
+
+## What it does
+
+A two-pane editor: a plain `<textarea>` on the left for Markdown source, and
+a live-rendered preview pane on the right that updates on every keystroke.
+A formatting toolbar (Bold, Italic, Heading, Link, Inline code, Blockquote,
+Bulleted list, Numbered list) inserts or wraps the current selection with
+the right Markdown syntax instead of requiring it to be typed by hand.
+
+Markdown is parsed by a small, dependency-free renderer included directly
+in `demo.html` — headings, bold/italic, inline code, fenced code blocks,
+blockquotes, links, ordered/unordered lists, horizontal rules, and
+paragraphs. It's a deliberate subset, not a full CommonMark
+implementation, sized for a lightweight docs/notes/comment editor rather
+than arbitrary Markdown documents.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN — including no Markdown
+parsing library.
+
+## Usage
+
+Type Markdown in the left pane; the right pane updates live. Use the
+toolbar to insert formatting — with text selected, most buttons wrap the
+selection (e.g. select a word and click **B** to bold it); without a
+selection, they insert placeholder text you can type over. Toggle **Dark
+mode** in the header, and on narrow screens the two panes collapse into
+**Edit** / **Preview** tabs instead of a side-by-side split.
+
+## Accessibility notes
+
+- Every toolbar button is a real `<button>` with an `aria-label`
+  describing its action (e.g. "Bold", "Bulleted list"), so icon-only
+  controls are still announced correctly.
+- The preview pane has `aria-live="polite"`, so screen reader users get a
+  reasonable indication that content updated as they type, without being
+  interrupted on every keystroke the way `aria-live="assertive"` would.
+- The mobile Edit/Preview switcher uses proper `role="tablist"` /
+  `role="tab"` semantics with `aria-selected` state.
+- Toolbar formatting works entirely through native `<textarea>` selection
+  APIs (`selectionStart`/`selectionEnd`/`setSelectionRange`), so it's
+  usable with a keyboard alone, not just a mouse.
+- The theme toggle uses `aria-pressed` to announce its current state.
+
+## Responsiveness
+
+Above `760px`, the editor and preview panes sit side by side. Below that,
+they stack and are switched between with the Edit/Preview tabs in the
+toolbar, so neither pane is ever squeezed into an unreadable column on a
+phone.
+
+## Why this fits EaseMotion CSS
+
+It's a self-contained, reusable UI component — exactly what the issue
+asks for — built with plain HTML/CSS/vanilla JS and zero dependencies,
+including for the Markdown parsing itself, consistent with the framework's
+zero-dependency philosophy. The preview pane's update and the dark-mode
+toggle both use small CSS transitions, matching EaseMotion's animation-
+first character rather than updating instantly and jarringly.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/ease-markdown-editor-hr18/demo.html
+++ b/submissions/examples/ease-markdown-editor-hr18/demo.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ease-markdown-editor — demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="eme-hr18" id="emeRoot" data-theme="light">
+  <div class="eme-wrap-hr18">
+
+    <header class="eme-header-hr18">
+      <div>
+        <span class="eme-eyebrow-hr18">EaseMotion-css · component</span>
+        <h1>Markdown editor</h1>
+      </div>
+      <button type="button" class="eme-theme-toggle-hr18" id="emeThemeToggle" aria-pressed="false">
+        <span id="emeThemeIcon" aria-hidden="true">&#9789;</span>
+        <span id="emeThemeLabel">Dark mode</span>
+      </button>
+    </header>
+
+    <div class="eme-editor-shell-hr18">
+      <div class="eme-toolbar-hr18" role="toolbar" aria-label="Formatting">
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="bold" aria-label="Bold"><strong>B</strong></button>
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="italic" aria-label="Italic"><em>I</em></button>
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="heading" aria-label="Heading">H</button>
+        <span class="eme-tool-sep-hr18"></span>
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="link" aria-label="Link">&#128279;</button>
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="code" aria-label="Inline code">&lt;/&gt;</button>
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="quote" aria-label="Blockquote">&#8220;</button>
+        <span class="eme-tool-sep-hr18"></span>
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="ul" aria-label="Bulleted list">&#8226;</button>
+        <button type="button" class="eme-tool-btn-hr18" data-cmd="ol" aria-label="Numbered list">1.</button>
+
+        <div class="eme-view-tabs-hr18" role="tablist" aria-label="Editor view">
+          <button type="button" class="eme-view-tab-hr18" role="tab" aria-selected="true" data-view="edit">Edit</button>
+          <button type="button" class="eme-view-tab-hr18" role="tab" aria-selected="false" data-view="preview">Preview</button>
+        </div>
+      </div>
+
+      <div class="eme-panes-hr18" id="emePanes" data-view="edit">
+        <div class="eme-pane-hr18 eme-editor-pane-hr18">
+          <label class="eme-pane-label-hr18" for="emeTextarea">Markdown</label>
+          <textarea class="eme-textarea-hr18" id="emeTextarea" spellcheck="false"># Welcome to the editor
+
+Type **Markdown** on the left, see it rendered on the right.
+
+- Live preview
+- Formatting toolbar
+- Dark mode
+- Fully responsive
+
+> Try the toolbar buttons above, or just type `**bold**`, `*italic*`, or a [link](https://example.com).</textarea>
+        </div>
+        <div class="eme-pane-hr18 eme-preview-pane-hr18">
+          <span class="eme-pane-label-hr18">Preview</span>
+          <div class="eme-preview-hr18" id="emePreview" aria-live="polite"></div>
+        </div>
+      </div>
+    </div>
+
+    <p class="eme-footnote-hr18">submissions/examples/ease-markdown-editor-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var root = document.getElementById("emeRoot");
+  var textarea = document.getElementById("emeTextarea");
+  var preview = document.getElementById("emePreview");
+  var panes = document.getElementById("emePanes");
+
+  /* ---------------- Minimal Markdown renderer ----------------
+     A small, dependency-free subset parser: headings, bold, italic,
+     inline code, fenced code blocks, blockquotes, links, unordered and
+     ordered lists, horizontal rules, and paragraphs. Not a full
+     CommonMark implementation — enough for a lightweight docs/notes
+     editor. HTML is escaped before any markdown transform is applied. */
+
+  function escapeHtml(str) {
+    return str
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  function renderInline(text) {
+    text = text.replace(/`([^`]+)`/g, "<code>$1</code>");
+    text = text.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    text = text.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+    text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    return text;
+  }
+
+  function renderMarkdown(raw) {
+    var escaped = escapeHtml(raw);
+    var lines = escaped.split("\n");
+    var html = [];
+    var i = 0;
+
+    while (i < lines.length) {
+      var line = lines[i];
+
+      // Fenced code block.
+      if (/^```/.test(line)) {
+        var codeLines = [];
+        i++;
+        while (i < lines.length && !/^```/.test(lines[i])) {
+          codeLines.push(lines[i]);
+          i++;
+        }
+        html.push("<pre><code>" + codeLines.join("\n") + "</code></pre>");
+        i++;
+        continue;
+      }
+
+      // Headings.
+      var headingMatch = line.match(/^(#{1,3})\s+(.*)$/);
+      if (headingMatch) {
+        var level = headingMatch[1].length;
+        html.push("<h" + level + ">" + renderInline(headingMatch[2]) + "</h" + level + ">");
+        i++;
+        continue;
+      }
+
+      // Horizontal rule.
+      if (/^-{3,}$/.test(line.trim())) {
+        html.push("<hr>");
+        i++;
+        continue;
+      }
+
+      // Blockquote (consecutive lines).
+      if (/^&gt;\s?/.test(line)) {
+        var quoteLines = [];
+        while (i < lines.length && /^&gt;\s?/.test(lines[i])) {
+          quoteLines.push(lines[i].replace(/^&gt;\s?/, ""));
+          i++;
+        }
+        html.push("<blockquote>" + renderInline(quoteLines.join(" ")) + "</blockquote>");
+        continue;
+      }
+
+      // Unordered list.
+      if (/^[-*]\s+/.test(line)) {
+        var ulItems = [];
+        while (i < lines.length && /^[-*]\s+/.test(lines[i])) {
+          ulItems.push("<li>" + renderInline(lines[i].replace(/^[-*]\s+/, "")) + "</li>");
+          i++;
+        }
+        html.push("<ul>" + ulItems.join("") + "</ul>");
+        continue;
+      }
+
+      // Ordered list.
+      if (/^\d+\.\s+/.test(line)) {
+        var olItems = [];
+        while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+          olItems.push("<li>" + renderInline(lines[i].replace(/^\d+\.\s+/, "")) + "</li>");
+          i++;
+        }
+        html.push("<ol>" + olItems.join("") + "</ol>");
+        continue;
+      }
+
+      // Blank line — skip.
+      if (line.trim() === "") {
+        i++;
+        continue;
+      }
+
+      // Paragraph (consecutive non-blank, non-special lines).
+      var pLines = [];
+      while (
+        i < lines.length &&
+        lines[i].trim() !== "" &&
+        !/^(#{1,3})\s+/.test(lines[i]) &&
+        !/^```/.test(lines[i]) &&
+        !/^[-*]\s+/.test(lines[i]) &&
+        !/^\d+\.\s+/.test(lines[i]) &&
+        !/^&gt;\s?/.test(lines[i]) &&
+        !/^-{3,}$/.test(lines[i].trim())
+      ) {
+        pLines.push(lines[i]);
+        i++;
+      }
+      html.push("<p>" + renderInline(pLines.join(" ")) + "</p>");
+    }
+
+    return html.join("\n");
+  }
+
+  function updatePreview() {
+    var value = textarea.value;
+    if (!value.trim()) {
+      preview.innerHTML = '<p class="eme-preview-empty-hr18">Nothing to preview yet &mdash; start typing on the left.</p>';
+      return;
+    }
+    preview.innerHTML = renderMarkdown(value);
+  }
+
+  textarea.addEventListener("input", updatePreview);
+  updatePreview();
+
+  /* ---------------- Toolbar: wrap/insert at cursor ---------------- */
+  function applyCommand(cmd) {
+    var start = textarea.selectionStart;
+    var end = textarea.selectionEnd;
+    var value = textarea.value;
+    var selected = value.slice(start, end);
+    var before = value.slice(0, start);
+    var after = value.slice(end);
+    var insertText = selected;
+    var cursorOffset = 0;
+
+    function wrap(marker, placeholder) {
+      var text = selected || placeholder;
+      insertText = marker + text + marker;
+      cursorOffset = selected ? insertText.length : marker.length;
+    }
+
+    function linePrefix(prefix, placeholder) {
+      var text = selected || placeholder;
+      insertText = prefix + text;
+      cursorOffset = insertText.length;
+    }
+
+    switch (cmd) {
+      case "bold":
+        wrap("**", "bold text");
+        break;
+      case "italic":
+        wrap("*", "italic text");
+        break;
+      case "code":
+        wrap("`", "code");
+        break;
+      case "heading":
+        linePrefix("## ", "Heading");
+        break;
+      case "quote":
+        linePrefix("> ", "Quote");
+        break;
+      case "ul":
+        linePrefix("- ", "List item");
+        break;
+      case "ol":
+        linePrefix("1. ", "List item");
+        break;
+      case "link":
+        var linkText = selected || "link text";
+        insertText = "[" + linkText + "](https://)";
+        cursorOffset = insertText.length;
+        break;
+      default:
+        return;
+    }
+
+    textarea.value = before + insertText + after;
+    var newPos = start + cursorOffset;
+    textarea.focus();
+    textarea.setSelectionRange(newPos, newPos);
+    updatePreview();
+  }
+
+  document.querySelectorAll(".eme-tool-btn-hr18").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      applyCommand(btn.getAttribute("data-cmd"));
+    });
+  });
+
+  /* ---------------- Mobile view tabs ---------------- */
+  var viewTabs = document.querySelectorAll(".eme-view-tab-hr18");
+  viewTabs.forEach(function (tab) {
+    tab.addEventListener("click", function () {
+      viewTabs.forEach(function (t) { t.setAttribute("aria-selected", "false"); });
+      tab.setAttribute("aria-selected", "true");
+      panes.setAttribute("data-view", tab.getAttribute("data-view"));
+    });
+  });
+
+  /* ---------------- Dark mode toggle ---------------- */
+  var themeToggle = document.getElementById("emeThemeToggle");
+  var themeLabel = document.getElementById("emeThemeLabel");
+  var themeIcon = document.getElementById("emeThemeIcon");
+
+  themeToggle.addEventListener("click", function () {
+    var isDark = root.getAttribute("data-theme") === "dark";
+    var next = isDark ? "light" : "dark";
+    root.setAttribute("data-theme", next);
+    themeToggle.setAttribute("aria-pressed", String(!isDark));
+    themeLabel.textContent = next === "dark" ? "Light mode" : "Dark mode";
+    themeIcon.textContent = next === "dark" ? "\u2600" : "\u263D";
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-markdown-editor-hr18/style.css
+++ b/submissions/examples/ease-markdown-editor-hr18/style.css
@@ -1,0 +1,336 @@
+/* ==========================================================================
+   ease-markdown-editor-hr18 — style.css
+   Responsive Markdown editor with toolbar, live preview, and dark mode
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.eme-hr18 {
+  --bg-hr18: #f7f7f4;
+  --panel-hr18: #ffffff;
+  --panel-raised-hr18: #f1f1ec;
+  --border-hr18: #e2e0d6;
+  --text-hr18: #1c1b18;
+  --text-muted-hr18: #6b6a62;
+  --accent-hr18: #0f8a6a;
+  --accent-soft-hr18: #e2f5ee;
+  --code-bg-hr18: #edece5;
+  --radius-hr18: 12px;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 2.5rem 1.5rem 3.5rem;
+  min-height: 100%;
+  transition: background 0.25s ease, color 0.25s ease;
+}
+
+[data-theme="dark"].eme-hr18 {
+  --bg-hr18: #14161a;
+  --panel-hr18: #1b1e24;
+  --panel-raised-hr18: #21252c;
+  --border-hr18: #2c313a;
+  --text-hr18: #e7e9ee;
+  --text-muted-hr18: #929aa6;
+  --accent-hr18: #34d399;
+  --accent-soft-hr18: #163229;
+  --code-bg-hr18: #23272f;
+}
+
+.eme-hr18 * {
+  box-sizing: border-box;
+}
+
+.eme-hr18 h1,
+.eme-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.eme-wrap-hr18 {
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+/* ---- Header ------------------------------------------------------------------- */
+.eme-header-hr18 {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.eme-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.eme-header-hr18 h1 {
+  font-size: clamp(1.4rem, 2.2vw, 1.9rem);
+}
+
+.eme-theme-toggle-hr18 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  color: var(--text-hr18);
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  font-family: var(--font-body-hr18);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+.eme-theme-toggle-hr18:hover {
+  border-color: var(--accent-hr18);
+}
+
+/* ---- Editor shell --------------------------------------------------------------- */
+.eme-editor-shell-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(20, 20, 15, 0.04), 0 10px 26px rgba(20, 20, 15, 0.05);
+  transition: background 0.25s ease, border-color 0.25s ease;
+}
+
+/* ---- Toolbar ---------------------------------------------------------------------- */
+.eme-toolbar-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.6rem 0.7rem;
+  border-bottom: 1px solid var(--border-hr18);
+  background: var(--panel-raised-hr18);
+  flex-wrap: wrap;
+}
+
+.eme-tool-btn-hr18 {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-hr18);
+  font-family: var(--font-mono-hr18);
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.eme-tool-btn-hr18:hover {
+  background: var(--accent-soft-hr18);
+  border-color: var(--accent-hr18);
+  color: var(--accent-hr18);
+}
+
+.eme-tool-sep-hr18 {
+  width: 1px;
+  height: 20px;
+  background: var(--border-hr18);
+  margin: 0 0.3rem;
+}
+
+.eme-view-tabs-hr18 {
+  margin-left: auto;
+  display: none;
+  gap: 0.3rem;
+}
+
+.eme-view-tab-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.76rem;
+  font-weight: 600;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  color: var(--text-muted-hr18);
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.eme-view-tab-hr18[aria-selected="true"] {
+  color: var(--bg-hr18);
+  background: var(--accent-hr18);
+  border-color: var(--accent-hr18);
+}
+
+/* ---- Panes ------------------------------------------------------------------------- */
+.eme-panes-hr18 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 320px;
+}
+
+.eme-pane-hr18 {
+  min-width: 0;
+}
+
+.eme-pane-hr18 + .eme-pane-hr18 {
+  border-left: 1px solid var(--border-hr18);
+}
+
+.eme-pane-label-hr18 {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted-hr18);
+  padding: 0.6rem 0.9rem 0;
+}
+
+.eme-textarea-hr18 {
+  width: 100%;
+  height: 320px;
+  border: none;
+  background: transparent;
+  color: var(--text-hr18);
+  font-family: var(--font-mono-hr18);
+  font-size: 0.86rem;
+  line-height: 1.6;
+  padding: 0.6rem 0.9rem 1rem;
+  resize: vertical;
+}
+
+.eme-textarea-hr18:focus {
+  outline: none;
+}
+
+.eme-preview-hr18 {
+  padding: 0.6rem 1.1rem 1.2rem;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  height: 320px;
+  overflow-y: auto;
+  animation: emeFade-hr18 220ms ease both;
+}
+
+@keyframes emeFade-hr18 {
+  from { opacity: 0.4; }
+  to { opacity: 1; }
+}
+
+.eme-preview-hr18 h1,
+.eme-preview-hr18 h2,
+.eme-preview-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  margin: 1em 0 0.4em;
+}
+
+.eme-preview-hr18 h1:first-child,
+.eme-preview-hr18 h2:first-child,
+.eme-preview-hr18 h3:first-child {
+  margin-top: 0;
+}
+
+.eme-preview-hr18 p {
+  margin: 0 0 0.8em;
+}
+
+.eme-preview-hr18 code {
+  font-family: var(--font-mono-hr18);
+  background: var(--code-bg-hr18);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.eme-preview-hr18 pre {
+  background: var(--code-bg-hr18);
+  border-radius: 8px;
+  padding: 0.8rem 0.9rem;
+  overflow-x: auto;
+  margin: 0 0 0.8em;
+}
+
+.eme-preview-hr18 pre code {
+  background: none;
+  padding: 0;
+}
+
+.eme-preview-hr18 blockquote {
+  border-left: 3px solid var(--accent-hr18);
+  margin: 0 0 0.8em;
+  padding: 0.1rem 0 0.1rem 1rem;
+  color: var(--text-muted-hr18);
+}
+
+.eme-preview-hr18 ul,
+.eme-preview-hr18 ol {
+  margin: 0 0 0.8em;
+  padding-left: 1.4rem;
+}
+
+.eme-preview-hr18 a {
+  color: var(--accent-hr18);
+}
+
+.eme-preview-hr18 hr {
+  border: none;
+  border-top: 1px solid var(--border-hr18);
+  margin: 1.2em 0;
+}
+
+.eme-preview-empty-hr18 {
+  color: var(--text-muted-hr18);
+  font-style: italic;
+}
+
+/* ---- Responsive: stack panes, show mobile view tabs ---------------------------------- */
+@media (max-width: 760px) {
+  .eme-view-tabs-hr18 {
+    display: flex;
+  }
+
+  .eme-panes-hr18 {
+    grid-template-columns: 1fr;
+  }
+
+  .eme-pane-hr18 + .eme-pane-hr18 {
+    border-left: none;
+    border-top: 1px solid var(--border-hr18);
+  }
+
+  .eme-panes-hr18[data-view="edit"] .eme-preview-pane-hr18,
+  .eme-panes-hr18[data-view="preview"] .eme-editor-pane-hr18 {
+    display: none;
+  }
+}
+
+.eme-footnote-hr18 {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.eme-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eme-preview-hr18 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a responsive Markdown editor UI with a formatting toolbar, live
preview pane, and dark mode. The left pane is a plain textarea for
Markdown source; the right pane renders it live via a small,
dependency-free Markdown subset parser (headings, bold/italic, inline
code, fenced code blocks, blockquotes, links, ordered/unordered lists,
horizontal rules, paragraphs). The toolbar (Bold, Italic, Heading, Link,
Code, Quote, bulleted/numbered lists) wraps or inserts syntax at the
cursor using native textarea selection APIs. Below 760px the two panes
collapse into Edit/Preview tabs instead of a side-by-side split.

Resolves #49546

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-markdown-editor-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A responsive Markdown editor with a formatting toolbar, live preview, and
dark mode — no external Markdown library, no build step.

**How does a developer use it?**
```html
<div class="eme-hr18" data-theme="light">
  <div class="eme-editor-shell-hr18">
    <div class="eme-toolbar-hr18" role="toolbar"><!-- formatting buttons --></div>
    <div class="eme-panes-hr18" data-view="edit">
      <textarea class="eme-textarea-hr18" id="emeTextarea"></textarea>
      <div class="eme-preview-hr18" id="emePreview" aria-live="polite"></div>
    </div>
  </div>
</div>
<!-- see demo.html for the full markup + renderMarkdown() script -->
```

**Why does it fit EaseMotion CSS?**
A self-contained, reusable UI component built with plain HTML/CSS/vanilla
JS and zero dependencies — including the Markdown parsing itself — with
small CSS transitions on preview updates and the dark-mode toggle,
matching EaseMotion's animation-first character.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
The Markdown parser is a deliberate subset (not full CommonMark) sized for
a lightweight docs/notes editor — documented in the README. Tested
formatting toolbar, dark mode, and the mobile Edit/Preview tabs in Chrome;
haven't checked other browsers yet.