### PR TITLE
Add Rotate-Click popover component for portfolio layouts (rotate-clic…

### DIFF
--- a/submissions/examples/rotate-click-popover-hr18/README.md
+++ b/submissions/examples/rotate-click-popover-hr18/README.md
@@ -1,0 +1,103 @@
+# Rotate-Click Popover (`rotate-click-popover-hr18`)
+
+A pure-CSS animated popover with a "Rotate-Click" entrance, styled for
+creative portfolio layouts, built for issue
+[#46434](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46434).
+
+## What it does
+
+Clicking a "Details" trigger reveals a popover panel that pops in from a
+tilted, shrunk, transparent start and springs to a flat, full-size, opaque
+rest state — a quick, playful entrance suited to a portfolio grid. The
+**animation itself is 100% CSS** (`@keyframes ease-rotate-click-hr18`,
+driven entirely by custom properties); a small amount of vanilla
+JavaScript only handles click-to-toggle, `Escape`-to-close,
+click-outside-to-close, and keeping `aria-expanded` in sync — there's no
+animation logic in JavaScript at all.
+
+The demo shows it applied across a three-project portfolio grid (Aperture,
+Loose Leaf, Northbound), each card opening its own independent popover
+with project details.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap a trigger button and a popover panel in the component markup:
+
+```html
+<div class="rcp-popover-wrap-hr18" data-open="false">
+  <button type="button" class="rcp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">
+    Details
+  </button>
+  <div class="ease-popover-rotate-hr18" role="dialog" aria-label="Project details">
+    <button type="button" class="rcp-popover-close-hr18" aria-label="Close">&times;</button>
+    <p class="rcp-popover-title-hr18">Aperture</p>
+    <p class="rcp-popover-body-hr18">A booking flow and gallery for a portrait photographer.</p>
+    <a href="#" class="rcp-popover-link-hr18">View case study</a>
+  </div>
+</div>
+```
+
+The included script finds every `.rcp-popover-wrap-hr18` on the page
+automatically and wires it up — a new popover only needs the markup above,
+no extra JavaScript per instance. Opening one popover closes any other
+that's currently open.
+
+### Tuning the animation
+
+Every timing/angle value is a CSS custom property, overridable per instance
+or globally:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-rotate-duration-hr18` | `420ms` | How long the pop-in + settle takes |
+| `--ease-rotate-easing-hr18` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | The overshoot curve that gives it a springy settle |
+| `--ease-rotate-angle-hr18` | `-14deg` | Starting tilt angle — try a positive value to tilt the other way |
+| `--ease-rotate-delay-hr18` | `0ms` | Delay before the animation starts |
+
+```css
+.rcp-popover-wrap-hr18.subtle .ease-popover-rotate-hr18 {
+  --ease-rotate-angle-hr18: -6deg;
+  --ease-rotate-duration-hr18: 280ms;
+}
+```
+
+## Accessibility notes
+
+- The trigger is a native `<button>` with `aria-haspopup="dialog"` and
+  `aria-expanded` kept in sync with the popover's open state.
+- `Escape` closes the popover and returns focus to its trigger.
+- Clicking outside the open popover closes it.
+- The panel has `role="dialog"` and a descriptive `aria-label`, plus a
+  visible, keyboard-reachable close button.
+- Fully keyboard operable: `Tab` to the trigger, `Enter`/`Space` to open,
+  `Tab` to the close button or link inside, `Escape` to dismiss.
+- The rotate/scale entrance respects
+  `@media (prefers-reduced-motion: reduce)` and appears instantly at its
+  final position instead.
+- Uses `--ease-rotate-angle-hr18` rather than a hardcoded `.ease-rotate`
+  class name, since EaseMotion already ships a core `ease-rotate` utility
+  — this avoids any naming collision with it.
+
+## Responsiveness
+
+The three-card portfolio grid collapses from three columns to one under a
+`700px` viewport width; the popover panel's width adapts to stay within
+the viewport on narrow screens (`max-width: 420px`).
+
+## Why this fits EaseMotion CSS
+
+It's a self-contained, reusable interaction pattern with a distinct named
+animation (`ease-rotate-click`) exposed entirely through custom
+properties — matching the issue's ask for zero JavaScript animation
+overhead and tunable timing/easing/angle — while staying genuinely
+keyboard accessible.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/rotate-click-popover-hr18/demo.html
+++ b/submissions/examples/rotate-click-popover-hr18/demo.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Click Popover — portfolio demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="rcp-hr18">
+  <div class="rcp-wrap-hr18">
+
+    <header class="rcp-header-hr18">
+      <span class="rcp-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Selected Work</h1>
+      <p>Click "Details" on any project — its popover pops in with a
+        quick tilt-and-settle rotation, built for bold, playful
+        portfolio layouts.</p>
+    </header>
+
+    <section class="rcp-grid-hr18">
+
+      <!-- Project 1 -->
+      <article class="rcp-card-hr18">
+        <div class="rcp-thumb-hr18 c1" aria-hidden="true">01</div>
+        <div class="rcp-card-body-hr18">
+          <h3>Aperture</h3>
+          <p>Photography portfolio &amp; booking site.</p>
+          <div class="rcp-popover-wrap-hr18" data-open="false">
+            <button type="button" class="rcp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Details</button>
+            <div class="ease-popover-rotate-hr18" role="dialog" aria-label="Aperture project details">
+              <button type="button" class="rcp-popover-close-hr18" aria-label="Close">&times;</button>
+              <p class="rcp-popover-title-hr18">Aperture</p>
+              <p class="rcp-popover-meta-hr18">Design &amp; Frontend &middot; 2025</p>
+              <p class="rcp-popover-body-hr18">A booking flow and gallery for a portrait photographer, built around large, unhurried imagery.</p>
+              <a href="#" class="rcp-popover-link-hr18">View case study</a>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <!-- Project 2 -->
+      <article class="rcp-card-hr18">
+        <div class="rcp-thumb-hr18 c2" aria-hidden="true">02</div>
+        <div class="rcp-card-body-hr18">
+          <h3>Loose Leaf</h3>
+          <p>Tea subscription brand identity.</p>
+          <div class="rcp-popover-wrap-hr18" data-open="false">
+            <button type="button" class="rcp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Details</button>
+            <div class="ease-popover-rotate-hr18" role="dialog" aria-label="Loose Leaf project details">
+              <button type="button" class="rcp-popover-close-hr18" aria-label="Close">&times;</button>
+              <p class="rcp-popover-title-hr18">Loose Leaf</p>
+              <p class="rcp-popover-meta-hr18">Brand Identity &middot; 2024</p>
+              <p class="rcp-popover-body-hr18">Packaging, logotype, and a small ecommerce storefront for a small-batch tea subscription.</p>
+              <a href="#" class="rcp-popover-link-hr18">View case study</a>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <!-- Project 3 -->
+      <article class="rcp-card-hr18">
+        <div class="rcp-thumb-hr18 c3" aria-hidden="true">03</div>
+        <div class="rcp-card-body-hr18">
+          <h3>Northbound</h3>
+          <p>Hiking trail-log mobile app.</p>
+          <div class="rcp-popover-wrap-hr18" data-open="false">
+            <button type="button" class="rcp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Details</button>
+            <div class="ease-popover-rotate-hr18" role="dialog" aria-label="Northbound project details">
+              <button type="button" class="rcp-popover-close-hr18" aria-label="Close">&times;</button>
+              <p class="rcp-popover-title-hr18">Northbound</p>
+              <p class="rcp-popover-meta-hr18">Product Design &middot; 2024</p>
+              <p class="rcp-popover-body-hr18">An offline-first trail log with elevation tracking, built for a small outdoor-gear startup.</p>
+              <a href="#" class="rcp-popover-link-hr18">View case study</a>
+            </div>
+          </div>
+        </div>
+      </article>
+
+    </section>
+
+    <div class="rcp-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-rotate-duration-hr18</code></td><td><code>420ms</code></td><td>How long the pop-in + settle takes.</td></tr>
+          <tr><td><code>--ease-rotate-easing-hr18</code></td><td><code>cubic-bezier(0.34, 1.56, 0.64, 1)</code></td><td>The overshoot curve that gives it a springy settle.</td></tr>
+          <tr><td><code>--ease-rotate-angle-hr18</code></td><td><code>-14deg</code></td><td>Starting tilt angle — try a positive value to tilt the other way.</td></tr>
+          <tr><td><code>--ease-rotate-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the animation starts.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="rcp-footnote-hr18">submissions/examples/rotate-click-popover-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var wraps = document.querySelectorAll(".rcp-popover-wrap-hr18");
+
+  wraps.forEach(function (wrap) {
+    var trigger = wrap.querySelector(".rcp-trigger-hr18");
+    var panel = wrap.querySelector(".ease-popover-rotate-hr18");
+    var closeBtn = wrap.querySelector(".rcp-popover-close-hr18");
+
+    function open() {
+      wraps.forEach(function (other) {
+        if (other !== wrap && other.__rcpCloseHr18) other.__rcpCloseHr18(false);
+      });
+      wrap.setAttribute("data-open", "true");
+      trigger.setAttribute("aria-expanded", "true");
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("keydown", onKeydown);
+    }
+
+    function close(returnFocus) {
+      wrap.setAttribute("data-open", "false");
+      trigger.setAttribute("aria-expanded", "false");
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKeydown);
+      if (returnFocus) trigger.focus();
+    }
+
+    function onDocClick(e) {
+      if (!wrap.contains(e.target)) close(false);
+    }
+
+    function onKeydown(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close(true);
+      }
+    }
+
+    trigger.addEventListener("click", function () {
+      var isOpen = wrap.getAttribute("data-open") === "true";
+      if (isOpen) close(false); else open();
+    });
+
+    closeBtn.addEventListener("click", function () {
+      close(true);
+    });
+
+    wrap.__rcpCloseHr18 = close;
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/rotate-click-popover-hr18/style.css
+++ b/submissions/examples/rotate-click-popover-hr18/style.css
@@ -1,0 +1,311 @@
+/* ==========================================================================
+   rotate-click-popover-hr18 — style.css
+   CSS Rotate-Click Popover for Creative Portfolio layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.rcp-hr18 {
+  --bg-hr18: #0b0b0f;
+  --panel-hr18: #17171e;
+  --panel-raised-hr18: #1e1e27;
+  --border-hr18: #2b2b35;
+  --text-hr18: #f5f4f2;
+  --text-muted-hr18: #a7a5b0;
+  --accent-hr18: #ff5470;
+  --accent-2-hr18: #ffd166;
+  --accent-3-hr18: #4cc9f0;
+  --radius-hr18: 18px;
+
+  /* Exposed animation parameters. */
+  --ease-rotate-duration-hr18: 420ms;
+  --ease-rotate-easing-hr18: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-rotate-angle-hr18: -14deg;
+  --ease-rotate-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3.5rem 1.5rem 5rem;
+  min-height: 100%;
+}
+
+.rcp-hr18 * {
+  box-sizing: border-box;
+}
+
+.rcp-hr18 h1,
+.rcp-hr18 h2,
+.rcp-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.rcp-wrap-hr18 {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+/* ---- Header --------------------------------------------------------------- */
+.rcp-header-hr18 {
+  text-align: center;
+  margin-bottom: 2.75rem;
+}
+
+.rcp-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--accent-hr18);
+  font-family: var(--font-mono-hr18);
+}
+
+.rcp-header-hr18 h1 {
+  font-size: clamp(1.9rem, 4vw, 2.7rem);
+}
+
+.rcp-header-hr18 p {
+  margin: 0.9rem auto 0;
+  color: var(--text-muted-hr18);
+  max-width: 52ch;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* ---- Portfolio grid ------------------------------------------------------------ */
+.rcp-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+@media (max-width: 700px) {
+  .rcp-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rcp-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  overflow: visible;
+  position: relative;
+}
+
+.rcp-thumb-hr18 {
+  height: 140px;
+  border-radius: var(--radius-hr18) var(--radius-hr18) 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display-hr18);
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.rcp-thumb-hr18.c1 { background: linear-gradient(135deg, var(--accent-hr18), #ff8fa3); }
+.rcp-thumb-hr18.c2 { background: linear-gradient(135deg, var(--accent-2-hr18), #ffe8a3); }
+.rcp-thumb-hr18.c3 { background: linear-gradient(135deg, var(--accent-3-hr18), #a3e8ff); }
+
+.rcp-card-body-hr18 {
+  padding: 1rem 1.1rem 1.2rem;
+}
+
+.rcp-card-body-hr18 h3 {
+  font-size: 0.95rem;
+  margin-bottom: 0.3rem;
+}
+
+.rcp-card-body-hr18 p {
+  margin: 0 0 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.5;
+}
+
+/* ---- The reusable popover component ---------------------------------------------
+   Drop-in markup: a .rcp-popover-wrap-hr18 containing a trigger button and a
+   .ease-popover-rotate-hr18 panel. Toggling the wrapper's data-open
+   attribute reveals the panel and plays the rotate-click entrance — the
+   animation itself is 100% CSS, driven entirely by the custom properties
+   declared above. */
+.rcp-popover-wrap-hr18 {
+  position: relative;
+}
+
+.rcp-trigger-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--bg-hr18);
+  background: var(--text-hr18);
+  border: none;
+  padding: 0.5rem 1.05rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.rcp-trigger-hr18[aria-expanded="true"] {
+  background: var(--accent-hr18);
+  color: #1a0509;
+}
+
+.ease-popover-rotate-hr18 {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 0;
+  width: 250px;
+  background: var(--panel-raised-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.1rem 1.2rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  z-index: 20;
+  display: none;
+  transform-origin: bottom left;
+}
+
+.rcp-popover-wrap-hr18[data-open="true"] .ease-popover-rotate-hr18 {
+  display: block;
+  animation: ease-rotate-click-hr18 var(--ease-rotate-duration-hr18) var(--ease-rotate-easing-hr18) var(--ease-rotate-delay-hr18) both;
+}
+
+/* The rotate-click entrance: pops in from a tilted, shrunk, transparent
+   start and settles flat. Angle and duration are both tunable. */
+@keyframes ease-rotate-click-hr18 {
+  0% {
+    opacity: 0;
+    transform: rotate(var(--ease-rotate-angle-hr18)) scale(0.6);
+  }
+  100% {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+.rcp-popover-close-hr18 {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted-hr18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rcp-popover-close-hr18:hover {
+  background: var(--border-hr18);
+  color: var(--text-hr18);
+}
+
+.rcp-popover-title-hr18 {
+  font-family: var(--font-display-hr18);
+  font-size: 0.95rem;
+  margin-bottom: 0.3rem;
+}
+
+.rcp-popover-meta-hr18 {
+  font-size: 0.72rem;
+  color: var(--accent-hr18);
+  font-family: var(--font-mono-hr18);
+  margin-bottom: 0.6rem;
+}
+
+.rcp-popover-body-hr18 {
+  font-size: 0.82rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.55;
+  margin: 0 0 0.8rem;
+}
+
+.rcp-popover-link-hr18 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-hr18);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-hr18);
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.rcp-tuning-hr18 {
+  margin-top: 3rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.rcp-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.rcp-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.rcp-tuning-hr18 th,
+.rcp-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.rcp-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.rcp-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+  color: var(--accent-2-hr18);
+}
+
+.rcp-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+  text-align: center;
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.rcp-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rcp-popover-wrap-hr18[data-open="true"] .ease-popover-rotate-hr18 {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (max-width: 420px) {
+  .ease-popover-rotate-hr18 {
+    width: min(250px, calc(100vw - 3rem));
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Popover with a "Rotate-Click" entrance, styled
for creative portfolio layouts. Clicking a "Details" trigger reveals a
popover that pops in from a tilted, shrunk, transparent start and springs
to a flat, full-size rest state. The animation itself is 100% CSS, driven
by exposed custom properties for duration, easing, angle, and delay; a
small vanilla-JS layer only handles click-toggle, Escape-to-close,
click-outside-to-close, and aria-expanded sync. Demo shows it applied
across a 3-project portfolio grid.

Resolves #46434

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/rotate-click-popover-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS "rotate-click" pop-in animation for click-triggered
popovers, with tunable timing/angle via custom properties.

**How does a developer use it?**
```html
<div class="rcp-popover-wrap-hr18" data-open="false">
  <button type="button" class="rcp-trigger-hr18" aria-haspopup="dialog" aria-expanded="false">Details</button>
  <div class="ease-popover-rotate-hr18" role="dialog" aria-label="Project details">...</div>
</div>
```

**Why does it fit EaseMotion CSS?**
A self-contained interaction with a distinct named animation
(`ease-rotate-click`) exposed entirely through custom properties, per the
issue's ask for zero JS animation overhead and tunable timing/easing —
while being genuinely keyboard accessible.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
Deliberately named the animation `ease-rotate-click` (not `ease-rotate`)
since EaseMotion already ships a core `ease-rotate` utility — wanted to
avoid any naming collision. Same toggle-script pattern as
`tada-popover-hr18`, `swing-hover-popover-hr18`, and
`blur-entrance-popover-hr18` from earlier in this batch of popover issues.
Tested keyboard flow and click-outside-to-close in Chrome; haven't checked
other browsers yet.