### PR TITLE
feat: add CSS slide-up popover for accessible web layouts

### DIFF
--- a/submissions/examples/slide-up-popover-accessible-ak/README.md
+++ b/submissions/examples/slide-up-popover-accessible-ak/README.md
@@ -1,0 +1,23 @@
+# Slide-Up Accessible Popover
+
+## What does this do?
+A pure CSS popover that slides up smoothly on open, built with accessibility as the primary design constraint (focus trapping, ARIA states, keyboard support).
+
+## How is it used?
+```html
+<div class="access-popover-wrap">
+  <button class="access-popover-trigger" id="accessBtn" aria-expanded="false" aria-controls="accessBox">
+    Show Details
+  </button>
+
+  <div class="access-popover-box" id="accessBox" role="dialog" aria-labelledby="accessBoxTitle" aria-hidden="true">
+    <h3 id="accessBoxTitle">Title</h3>
+    <p>Content goes here.</p>
+    <button class="access-popover-close" id="accessCloseBtn">Close</button>
+  </div>
+</div>
+```
+Toggle the `is-open` class on `.access-popover-box` and update `aria-hidden`/`aria-expanded` to trigger the slide-up animation (handled in `demo.html`'s script). Customize via `--access-offset`, `--access-duration`, `--access-easing`.
+
+## Why is it useful?
+Accessibility is often an afterthought in animated components. This submission bakes in `role="dialog"`, live `aria-hidden`/`aria-expanded` state, Escape-to-close, and focus trapping/return, alongside CSS-only slide-up motion and `prefers-reduced-motion` support — directly matching EaseMotion's philosophy of accessible, human-readable, animation-first components.

--- a/submissions/examples/slide-up-popover-accessible-ak/demo.html
+++ b/submissions/examples/slide-up-popover-accessible-ak/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Slide-Up Accessible Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="access-popover-wrap">
+    <button class="access-popover-trigger" id="accessBtn" aria-expanded="false" aria-controls="accessBox">
+      Show Details
+    </button>
+
+    <div class="access-popover-box" id="accessBox" role="dialog" aria-labelledby="accessBoxTitle" aria-hidden="true">
+      <h3 id="accessBoxTitle">Accessibility Notice</h3>
+      <p>This popover slides up smoothly, supports full keyboard navigation, and traps focus while open.</p>
+      <button class="access-popover-close" id="accessCloseBtn">Close</button>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('accessBtn');
+    const box = document.getElementById('accessBox');
+    const closeBtn = document.getElementById('accessCloseBtn');
+
+    function openPopover() {
+      box.classList.add('is-open');
+      box.setAttribute('aria-hidden', 'false');
+      btn.setAttribute('aria-expanded', 'true');
+      closeBtn.focus();
+    }
+
+    function closePopover() {
+      box.classList.remove('is-open');
+      box.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+      btn.focus();
+    }
+
+    btn.addEventListener('click', () => {
+      box.classList.contains('is-open') ? closePopover() : openPopover();
+    });
+
+    closeBtn.addEventListener('click', closePopover);
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && box.classList.contains('is-open')) {
+        closePopover();
+      }
+    });
+
+    box.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+      const focusable = box.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/slide-up-popover-accessible-ak/style.css
+++ b/submissions/examples/slide-up-popover-accessible-ak/style.css
@@ -1,0 +1,127 @@
+:root {
+  --access-offset: 24px;
+  --access-duration: 220ms;
+  --access-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --access-bg: #ffffff;
+  --access-fg: #14151a;
+  --access-accent: #1d4ed8;
+  --access-border: #d0d3da;
+  --access-radius: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: #f3f4f6;
+  color: #14151a;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.access-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.access-popover-trigger {
+  background: var(--access-accent);
+  color: #fff;
+  border: none;
+  padding: 12px 22px;
+  font-size: 15px;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.access-popover-trigger:hover {
+  background: #1740ad;
+}
+
+.access-popover-trigger:focus-visible {
+  outline: 3px solid #93b4ff;
+  outline-offset: 3px;
+}
+
+.access-popover-box {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  width: 280px;
+  padding: 20px;
+  background: var(--access-bg);
+  color: var(--access-fg);
+  border: 1px solid var(--access-border);
+  border-radius: var(--access-radius);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.16);
+
+  transform: translate(-50%, var(--access-offset));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--access-duration) var(--access-easing),
+    opacity var(--access-duration) ease,
+    visibility 0s linear var(--access-duration);
+}
+
+.access-popover-box.is-open {
+  transform: translate(-50%, 0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--access-duration) var(--access-easing),
+    opacity var(--access-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.access-popover-box h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.access-popover-box p {
+  margin: 0 0 14px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: #40424a;
+}
+
+.access-popover-close {
+  background: transparent;
+  border: 1px solid var(--access-border);
+  color: var(--access-fg);
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.access-popover-close:hover {
+  background: #eceef2;
+}
+
+.access-popover-close:focus-visible {
+  outline: 3px solid var(--access-accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .access-popover-box {
+    transition: opacity var(--access-duration) ease, visibility 0s linear var(--access-duration);
+  }
+  .access-popover-box.is-open {
+    transition: opacity var(--access-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION

 Closes #46391

## Pull Request Description
Adds a pure CSS animated popover that slides up smoothly on open, built with accessibility as the primary design constraint — focus trapping, ARIA dialog semantics, and full keyboard support. Closes #46391.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/slide-up-popover-accessible-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-driven popover that slides up on open, with `role="dialog"` semantics, live ARIA state, focus trapping, and Escape/Close support.

**How does a developer use it?**
```html
<div class="access-popover-wrap">
  <button class="access-popover-trigger" id="accessBtn" aria-expanded="false" aria-controls="accessBox">
    Show Details
  </button>

  <div class="access-popover-box" id="accessBox" role="dialog" aria-labelledby="accessBoxTitle" aria-hidden="true">
    <h3 id="accessBoxTitle">Title</h3>
    <p>Content goes here.</p>
    <button class="access-popover-close" id="accessCloseBtn">Close</button>
  </div>
</div>
```
Toggling the `is-open` class on `.access-popover-box` (alongside updating `aria-hidden`/`aria-expanded`, handled in the demo script) triggers the slide-up transition. Offset, duration, and easing are customizable via `--access-offset`, `--access-duration`, `--access-easing`.

**Why does it fit EaseMotion CSS?**
Accessibility is often bolted on after the fact in animated components. This submission bakes in ARIA dialog semantics, keyboard focus trapping/return, and Escape-to-close alongside CSS-only slide-up motion and `prefers-reduced-motion` support — directly aligned with EaseMotion's philosophy of accessible, human-readable, animation-first components.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Unlike the earlier zoom-in popover series, this one uses a slide-up transition and treats it as a semi-modal dialog (`role="dialog"`, focus trap, ARIA live state) rather than a lightweight tooltip, since the issue specifically called out accessible web layouts. Class names are unprefixed as instructed; happy to have them renamed to `ease-*` on integration.