### PR TITLE
feat: add CSS slide-up popover for neumorphic soft UI layouts

### DIFF
--- a/submissions/examples/slide-up-popover-neumorphic-ak/README.md
+++ b/submissions/examples/slide-up-popover-neumorphic-ak/README.md
@@ -1,0 +1,23 @@
+# Slide-Up Neumorphic Popover
+
+## What does this do?
+A pure CSS popover with a soft, embossed neumorphic ("soft UI") look that slides up smoothly on open.
+
+## How is it used?
+```html
+<div class="neu-popover-wrap">
+  <button class="neu-popover-trigger" id="neuBtn" aria-expanded="false" aria-controls="neuBox">
+    Open Panel
+  </button>
+
+  <div class="neu-popover-box" id="neuBox" role="dialog" aria-labelledby="neuBoxTitle" aria-hidden="true">
+    <h3 id="neuBoxTitle">Title</h3>
+    <p>Content goes here.</p>
+    <button class="neu-popover-close" id="neuCloseBtn">Close</button>
+  </div>
+</div>
+```
+Toggle `is-open` on `.neu-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) to trigger the slide-up transition. Customize via `--neu-offset`, `--neu-duration`, `--neu-easing`.
+
+## Why is it useful?
+It brings the neumorphic design trend — soft embossed shadows, low-contrast tactile surfaces — into EaseMotion's examples, combined with a smooth CSS-only slide-up motion. Keyboard support (Escape, click-outside close), ARIA dialog semantics, and `prefers-reduced-motion` handling keep it accessible despite the low-contrast aesthetic, fitting EaseMotion's lightweight, animation-first philosophy.

--- a/submissions/examples/slide-up-popover-neumorphic-ak/demo.html
+++ b/submissions/examples/slide-up-popover-neumorphic-ak/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Slide-Up Neumorphic Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="neu-popover-wrap">
+    <button class="neu-popover-trigger" id="neuBtn" aria-expanded="false" aria-controls="neuBox">
+      Open Panel
+    </button>
+
+    <div class="neu-popover-box" id="neuBox" role="dialog" aria-labelledby="neuBoxTitle" aria-hidden="true">
+      <h3 id="neuBoxTitle">Soft UI Panel</h3>
+      <p>A softly embossed popover that slides up with a gentle, tactile motion.</p>
+      <button class="neu-popover-close" id="neuCloseBtn">Close</button>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('neuBtn');
+    const box = document.getElementById('neuBox');
+    const closeBtn = document.getElementById('neuCloseBtn');
+
+    function openPopover() {
+      box.classList.add('is-open');
+      box.setAttribute('aria-hidden', 'false');
+      btn.setAttribute('aria-expanded', 'true');
+      closeBtn.focus();
+    }
+
+    function closePopover() {
+      box.classList.remove('is-open');
+      box.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+      btn.focus();
+    }
+
+    btn.addEventListener('click', () => {
+      box.classList.contains('is-open') ? closePopover() : openPopover();
+    });
+
+    closeBtn.addEventListener('click', closePopover);
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && box.classList.contains('is-open')) {
+        closePopover();
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (box.classList.contains('is-open') && !box.contains(e.target) && !btn.contains(e.target)) {
+        closePopover();
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/slide-up-popover-neumorphic-ak/style.css
+++ b/submissions/examples/slide-up-popover-neumorphic-ak/style.css
@@ -1,0 +1,143 @@
+:root {
+  --neu-offset: 20px;
+  --neu-duration: 260ms;
+  --neu-easing: cubic-bezier(0.34, 1.2, 0.4, 1);
+  --neu-bg: #e6e9ee;
+  --neu-fg: #33363f;
+  --neu-accent: #6c63ff;
+  --neu-shadow-light: #ffffff;
+  --neu-shadow-dark: #b9bec9;
+  --neu-radius: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--neu-bg);
+  color: var(--neu-fg);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.neu-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.neu-popover-trigger {
+  background: var(--neu-bg);
+  color: var(--neu-accent);
+  border: none;
+  padding: 14px 26px;
+  font-size: 15px;
+  font-weight: 600;
+  border-radius: 14px;
+  cursor: pointer;
+  box-shadow:
+    6px 6px 12px var(--neu-shadow-dark),
+    -6px -6px 12px var(--neu-shadow-light);
+  transition: box-shadow 150ms ease, transform 150ms ease;
+}
+
+.neu-popover-trigger:hover {
+  transform: translateY(-1px);
+}
+
+.neu-popover-trigger:active {
+  box-shadow:
+    inset 4px 4px 8px var(--neu-shadow-dark),
+    inset -4px -4px 8px var(--neu-shadow-light);
+}
+
+.neu-popover-trigger:focus-visible {
+  outline: 3px solid var(--neu-accent);
+  outline-offset: 3px;
+}
+
+.neu-popover-box {
+  position: absolute;
+  top: calc(100% + 16px);
+  left: 50%;
+  width: 280px;
+  padding: 22px;
+  background: var(--neu-bg);
+  color: var(--neu-fg);
+  border-radius: var(--neu-radius);
+  box-shadow:
+    9px 9px 18px var(--neu-shadow-dark),
+    -9px -9px 18px var(--neu-shadow-light);
+
+  transform: translate(-50%, var(--neu-offset));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--neu-duration) var(--neu-easing),
+    opacity var(--neu-duration) ease,
+    visibility 0s linear var(--neu-duration);
+}
+
+.neu-popover-box.is-open {
+  transform: translate(-50%, 0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--neu-duration) var(--neu-easing),
+    opacity var(--neu-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.neu-popover-box h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.neu-popover-box p {
+  margin: 0 0 16px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: #575b66;
+}
+
+.neu-popover-close {
+  background: var(--neu-bg);
+  border: none;
+  color: var(--neu-fg);
+  padding: 9px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow:
+    4px 4px 8px var(--neu-shadow-dark),
+    -4px -4px 8px var(--neu-shadow-light);
+  transition: box-shadow 150ms ease;
+}
+
+.neu-popover-close:active {
+  box-shadow:
+    inset 3px 3px 6px var(--neu-shadow-dark),
+    inset -3px -3px 6px var(--neu-shadow-light);
+}
+
+.neu-popover-close:focus-visible {
+  outline: 3px solid var(--neu-accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neu-popover-box {
+    transition: opacity var(--neu-duration) ease, visibility 0s linear var(--neu-duration);
+  }
+  .neu-popover-box.is-open {
+    transition: opacity var(--neu-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated popover with a soft, embossed neumorphic ("soft UI") style that slides up smoothly on open. Closes #46389.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/slide-up-popover-neumorphic-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only popover with a neumorphic, embossed-shadow look that slides up smoothly when triggered.

**How does a developer use it?**
```html
<div class="neu-popover-wrap">
  <button class="neu-popover-trigger" id="neuBtn" aria-expanded="false" aria-controls="neuBox">
    Open Panel
  </button>

  <div class="neu-popover-box" id="neuBox" role="dialog" aria-labelledby="neuBoxTitle" aria-hidden="true">
    <h3 id="neuBoxTitle">Title</h3>
    <p>Content goes here.</p>
    <button class="neu-popover-close" id="neuCloseBtn">Close</button>
  </div>
</div>
```
Toggling the `is-open` class on `.neu-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) triggers the slide-up transition. Offset, duration, and easing are customizable via `--neu-offset`, `--neu-duration`, `--neu-easing`.

**Why does it fit EaseMotion CSS?**
It brings the neumorphic design trend into EaseMotion's examples — soft embossed shadows and low-contrast tactile surfaces — combined with smooth CSS-only slide-up motion. Keyboard support (Escape, click-outside close), ARIA dialog semantics, and `prefers-reduced-motion` handling keep it accessible despite the low-contrast aesthetic, matching EaseMotion's lightweight, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Noticed this issue also has Varad163 assigned alongside me — flagging in case there's overlapping work in progress, happy to have this closed in favor of theirs if so. Styling uses soft embossed box-shadows rather than borders/flat backgrounds to fit the neumorphic aesthetic. Class names are unprefixed as instructed; happy to have them renamed to `ease-*` on integration.