### PR TITLE
feat: add CSS slide-up popover for minimalist tech layouts

### DIFF
--- a/submissions/examples/slide-up-popover-minimal-tech-ak/README.md
+++ b/submissions/examples/slide-up-popover-minimal-tech-ak/README.md
@@ -1,0 +1,24 @@
+# Slide-Up Minimal Tech Popover
+
+## What does this do?
+A pure CSS popover styled for minimalist tech interfaces, sliding up smoothly from its trigger with a compact, dark, low-noise design.
+
+## How is it used?
+```html
+<div class="tsu-popover-wrap">
+  <button class="tsu-popover-trigger" id="tsuBtn" aria-expanded="false" aria-controls="tsuBox">
+    Configure
+  </button>
+
+  <div class="tsu-popover-box" id="tsuBox" role="dialog" aria-labelledby="tsuBoxTitle" aria-hidden="true">
+    <span class="tsu-popover-label">Settings</span>
+    <h3 id="tsuBoxTitle">Title</h3>
+    <p>Content goes here.</p>
+    <button class="tsu-popover-close" id="tsuCloseBtn">Close</button>
+  </div>
+</div>
+```
+Toggle `is-open` on `.tsu-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) to trigger the slide-up transition. Customize via `--tsu-offset`, `--tsu-duration`, `--tsu-easing`.
+
+## Why is it useful?
+It offers a snappy, dark-themed slide-up popover suited to minimalist tech UIs (settings panels, config popovers) — CSS-only animation, minimal JS for state, keyboard accessible (Escape, click-outside close), and respects `prefers-reduced-motion`, matching EaseMotion's lightweight, animation-first philosophy.

--- a/submissions/examples/slide-up-popover-minimal-tech-ak/demo.html
+++ b/submissions/examples/slide-up-popover-minimal-tech-ak/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Slide-Up Minimal Tech Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="tsu-popover-wrap">
+    <button class="tsu-popover-trigger" id="tsuBtn" aria-expanded="false" aria-controls="tsuBox">
+      Configure
+    </button>
+
+    <div class="tsu-popover-box" id="tsuBox" role="dialog" aria-labelledby="tsuBoxTitle" aria-hidden="true">
+      <span class="tsu-popover-label">Settings</span>
+      <h3 id="tsuBoxTitle">Runtime Options</h3>
+      <p>Adjust build flags and environment variables for this deployment.</p>
+      <button class="tsu-popover-close" id="tsuCloseBtn">Close</button>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('tsuBtn');
+    const box = document.getElementById('tsuBox');
+    const closeBtn = document.getElementById('tsuCloseBtn');
+
+    function openPopover() {
+      box.classList.add('is-open');
+      box.setAttribute('aria-hidden', 'false');
+      btn.setAttribute('aria-expanded', 'true');
+      closeBtn.focus();
+    }
+
+    function closePopover() {
+      box.classList.remove('is-open');
+      box.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+      btn.focus();
+    }
+
+    btn.addEventListener('click', () => {
+      box.classList.contains('is-open') ? closePopover() : openPopover();
+    });
+
+    closeBtn.addEventListener('click', closePopover);
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && box.classList.contains('is-open')) {
+        closePopover();
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (box.classList.contains('is-open') && !box.contains(e.target) && !btn.contains(e.target)) {
+        closePopover();
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/slide-up-popover-minimal-tech-ak/style.css
+++ b/submissions/examples/slide-up-popover-minimal-tech-ak/style.css
@@ -1,0 +1,141 @@
+:root {
+  --tsu-offset: 18px;
+  --tsu-duration: 190ms;
+  --tsu-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tsu-bg: #101114;
+  --tsu-fg: #e8e8ea;
+  --tsu-accent: #00d4b0;
+  --tsu-border: #26272c;
+  --tsu-radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, sans-serif;
+  background: #050506;
+  color: #e8e8ea;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.tsu-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.tsu-popover-trigger {
+  background: transparent;
+  color: var(--tsu-accent);
+  border: 1px solid var(--tsu-accent);
+  padding: 10px 20px;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border-radius: var(--tsu-radius);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.tsu-popover-trigger:hover {
+  background: var(--tsu-accent);
+  color: #050506;
+}
+
+.tsu-popover-trigger:focus-visible {
+  outline: 2px solid var(--tsu-accent);
+  outline-offset: 3px;
+}
+
+.tsu-popover-box {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  width: 250px;
+  padding: 16px;
+  background: var(--tsu-bg);
+  color: var(--tsu-fg);
+  border: 1px solid var(--tsu-border);
+  border-radius: var(--tsu-radius);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+
+  transform: translateY(var(--tsu-offset));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--tsu-duration) var(--tsu-easing),
+    opacity var(--tsu-duration) ease,
+    visibility 0s linear var(--tsu-duration);
+}
+
+.tsu-popover-box.is-open {
+  transform: translateY(0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--tsu-duration) var(--tsu-easing),
+    opacity var(--tsu-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.tsu-popover-label {
+  display: inline-block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tsu-accent);
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.tsu-popover-box h3 {
+  margin: 0 0 6px;
+  font-size: 14.5px;
+  font-weight: 600;
+}
+
+.tsu-popover-box p {
+  margin: 0 0 12px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: #9a9aa2;
+}
+
+.tsu-popover-close {
+  background: transparent;
+  border: 1px solid var(--tsu-border);
+  color: var(--tsu-fg);
+  padding: 7px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.tsu-popover-close:hover {
+  border-color: var(--tsu-accent);
+  color: var(--tsu-accent);
+}
+
+.tsu-popover-close:focus-visible {
+  outline: 2px solid var(--tsu-accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tsu-popover-box {
+    transition: opacity var(--tsu-duration) ease, visibility 0s linear var(--tsu-duration);
+  }
+  .tsu-popover-box.is-open {
+    transition: opacity var(--tsu-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated popover styled for minimalist tech interfaces, sliding up smoothly from its trigger. Closes #46387.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/slide-up-popover-minimal-tech-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only popover with a compact, dark, minimalist styling that slides up smoothly from its trigger button.

**How does a developer use it?**
```html
<div class="tsu-popover-wrap">
  <button class="tsu-popover-trigger" id="tsuBtn" aria-expanded="false" aria-controls="tsuBox">
    Configure
  </button>

  <div class="tsu-popover-box" id="tsuBox" role="dialog" aria-labelledby="tsuBoxTitle" aria-hidden="true">
    <span class="tsu-popover-label">Settings</span>
    <h3 id="tsuBoxTitle">Title</h3>
    <p>Content goes here.</p>
    <button class="tsu-popover-close" id="tsuCloseBtn">Close</button>
  </div>
</div>
```
Toggling the `is-open` class on `.tsu-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) triggers the slide-up transition. Offset, duration, and easing are customizable via `--tsu-offset`, `--tsu-duration`, `--tsu-easing`.

**Why does it fit EaseMotion CSS?**
It offers a snappy, dark-themed slide-up popover suited to minimalist tech UIs like settings or config panels — CSS-only animation, minimal JS for state, keyboard accessibility (Escape, click-outside close), and `prefers-reduced-motion` support, matching EaseMotion's lightweight, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a slide-up companion to the earlier zoom-in minimal tech popover (#46401, merged) — same dark palette and accent color for visual consistency across the two transition styles. Class names are unprefixed as instructed; happy to have them renamed to `ease-*` on integration.