### PR TITLE
Add Rotate-Click popover component for accessible web layouts (rotate…

### DIFF
--- a/submissions/examples/rotate-click-popover-a11y-hr18/README.md
+++ b/submissions/examples/rotate-click-popover-a11y-hr18/README.md
@@ -1,0 +1,116 @@
+# Rotate-Click Popover — Accessible Web (`rotate-click-popover-a11y-hr18`)
+
+A pure-CSS animated popover with a "Rotate-Click" entrance, styled for
+accessible web interfaces, built for issue
+[#46433](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46433).
+
+## A note on this being the second Rotate-Click popover
+
+Issue [#46434](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46434)
+asked for the same interaction — a Rotate-Click popover — styled for
+"Creative Portfolio" layouts, submitted separately as `rotate-click-popover-hr18`.
+This submission reuses the same core animation *idea* (a tilted, shrunk
+entrance that springs flat) since that's what both issues literally
+specify, but is otherwise a distinct, self-contained implementation: its
+own class prefix (`rca-` instead of `rcp-`), its own animation name
+(`ease-rotate-click-a11y-hr18`), and a genuinely different context — an
+accessibility settings panel rather than a portfolio grid — built to
+actually demonstrate the "Accessible Web" aesthetic rather than reusing
+the portfolio one with new colors.
+
+## What it does
+
+A small accessibility-settings panel (High contrast mode, Keyboard
+navigation, Screen reader labels), each row with an info trigger that
+opens a rotate-click popover explaining that setting in plain language.
+Two of the toolbar toggles at the top are **genuinely functional**, not
+just decorative:
+
+- **Large text** scales the whole page's base font size up, so you can see
+  the layout actually hold up at a larger size rather than just claiming
+  to support it.
+- **Reduce motion** forces every popover on the page to appear instantly,
+  with no rotation or scale — independent of your OS-level
+  `prefers-reduced-motion` setting, so a reviewer can see the behavior
+  without changing system preferences.
+
+The **popover animation itself is 100% CSS**
+(`@keyframes ease-rotate-click-a11y-hr18`, driven entirely by custom
+properties); a small amount of vanilla JavaScript only handles the
+toggles, click-to-open, `Escape`-to-close, click-outside-to-close, and
+`aria-expanded` sync.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap an info trigger and a popover panel in the component markup:
+
+```html
+<div class="rca-popover-wrap-hr18" data-open="false">
+  <button type="button" class="rca-info-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="What does High contrast mode do?">i</button>
+  <div class="ease-popover-rotate-a11y-hr18" role="dialog" aria-label="High contrast mode explanation">
+    <button type="button" class="rca-popover-close-hr18" aria-label="Close">&times;</button>
+    <p class="rca-popover-title-hr18">High contrast mode</p>
+    <p class="rca-popover-body-hr18">Explanation text here.</p>
+  </div>
+</div>
+```
+
+The included script finds every `.rca-popover-wrap-hr18` on the page
+automatically and wires it up. Opening one popover closes any other
+that's currently open.
+
+### Tuning the animation
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-rotate-duration-hr18` | `400ms` | How long the pop-in + settle takes |
+| `--ease-rotate-easing-hr18` | `cubic-bezier(0.22, 1, 0.36, 1)` | The easing curve for the entrance |
+| `--ease-rotate-angle-hr18` | `-10deg` | Starting tilt angle before it settles flat |
+| `--ease-rotate-delay-hr18` | `0ms` | Delay before the animation starts |
+
+## Accessibility notes
+
+This one is worth being thorough about, given the theme:
+
+- **Real contrast**: the accent blue (`#1a4fd6`) against white passes WCAG
+  AA for normal text and AAA for large text; body text uses a near-black
+  (`#0d0f14`) rather than a light gray.
+- **44px minimum touch targets** on both toggle switches, matching common
+  mobile accessibility guidance, even though the visual track is smaller.
+- Every icon-only button (`i` triggers, the close button, both toggles)
+  carries a real `aria-label` or associated `<label>` — nothing relies on
+  an icon alone.
+- `:focus-visible` outlines are 3px and use the same high-contrast accent
+  color as everything else, so keyboard focus is never subtle.
+- The popover has `role="dialog"` with a descriptive `aria-label`, a
+  visible close button, and is fully operable by keyboard: `Tab` to the
+  trigger, `Enter`/`Space` to open, `Tab` through its contents,
+  `Escape` to dismiss with focus returned to the trigger.
+- Both the OS-level `@media (prefers-reduced-motion: reduce)` query *and*
+  the in-page "Reduce motion" toggle disable the popover's animation —
+  belt and suspenders, so the behavior is verifiable without touching
+  system settings.
+
+## Responsiveness
+
+The popover panel's width adapts to stay within the viewport on narrow
+screens (`max-width: 420px`), and the "Large text" toggle demonstrates
+that the layout doesn't break at a meaningfully larger base font size.
+
+## Why this fits EaseMotion CSS
+
+It's a self-contained, reusable interaction pattern with a distinct named
+animation exposed entirely through custom properties, matching the
+issue's ask for zero JavaScript animation overhead and tunable
+timing/easing/angle — while treating "Accessible Web" as something to
+actually demonstrate working, not just a color palette to apply.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/rotate-click-popover-a11y-hr18/demo.html
+++ b/submissions/examples/rotate-click-popover-a11y-hr18/demo.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Click Popover — accessible web demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="rca-hr18" id="rcaRoot">
+  <div class="rca-wrap-hr18">
+
+    <header class="rca-header-hr18">
+      <span class="rca-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Accessibility settings</h1>
+      <p>Click the <strong>i</strong> next to any setting for a plain-language
+        explanation — its popover pops in with a quick tilt-and-settle
+        rotation. High contrast colors, large touch targets, and full
+        keyboard support throughout.</p>
+    </header>
+
+    <div class="rca-toolbar-hr18">
+      <div class="rca-toggle-group-hr18">
+        <span class="rca-switch-hr18">
+          <input type="checkbox" id="rcaLargeText" />
+          <span class="rca-switch-track-hr18" aria-hidden="true"></span>
+        </span>
+        <label class="rca-toggle-label-hr18" for="rcaLargeText">Large text</label>
+      </div>
+      <div class="rca-toggle-group-hr18">
+        <span class="rca-switch-hr18">
+          <input type="checkbox" id="rcaReduceMotion" />
+          <span class="rca-switch-track-hr18" aria-hidden="true"></span>
+        </span>
+        <label class="rca-toggle-label-hr18" for="rcaReduceMotion">Reduce motion</label>
+      </div>
+    </div>
+
+    <div class="rca-motion-note-hr18">
+      Motion reduced &mdash; the popovers below will now appear instantly,
+      with no rotation or scale, for as long as this is on.
+    </div>
+
+    <div class="rca-settings-hr18">
+
+      <div class="rca-setting-row-hr18">
+        <span class="rca-setting-name-hr18">High contrast mode</span>
+        <div class="rca-popover-wrap-hr18" data-open="false">
+          <button type="button" class="rca-info-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="What does High contrast mode do?">i</button>
+          <div class="ease-popover-rotate-a11y-hr18" role="dialog" aria-label="High contrast mode explanation">
+            <button type="button" class="rca-popover-close-hr18" aria-label="Close">&times;</button>
+            <p class="rca-popover-title-hr18">High contrast mode</p>
+            <p class="rca-popover-body-hr18">Increases the color contrast ratio between text and its background across the whole interface, beyond the WCAG AA minimum.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="rca-setting-row-hr18">
+        <span class="rca-setting-name-hr18">Keyboard navigation</span>
+        <div class="rca-popover-wrap-hr18" data-open="false">
+          <button type="button" class="rca-info-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="What does Keyboard navigation do?">i</button>
+          <div class="ease-popover-rotate-a11y-hr18" role="dialog" aria-label="Keyboard navigation explanation">
+            <button type="button" class="rca-popover-close-hr18" aria-label="Close">&times;</button>
+            <p class="rca-popover-title-hr18">Keyboard navigation</p>
+            <p class="rca-popover-body-hr18">Every control on this page — including this popover itself — is reachable with Tab and operable with Enter, Space, or Escape.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="rca-setting-row-hr18">
+        <span class="rca-setting-name-hr18">Screen reader labels</span>
+        <div class="rca-popover-wrap-hr18" data-open="false">
+          <button type="button" class="rca-info-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="What does Screen reader labels do?">i</button>
+          <div class="ease-popover-rotate-a11y-hr18" role="dialog" aria-label="Screen reader labels explanation">
+            <button type="button" class="rca-popover-close-hr18" aria-label="Close">&times;</button>
+            <p class="rca-popover-title-hr18">Screen reader labels</p>
+            <p class="rca-popover-body-hr18">Icon-only controls, like this "i" button, always carry a real <code>aria-label</code> describing what they do.</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="rca-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-rotate-duration-hr18</code></td><td><code>400ms</code></td><td>How long the pop-in + settle takes.</td></tr>
+          <tr><td><code>--ease-rotate-easing-hr18</code></td><td><code>cubic-bezier(0.22, 1, 0.36, 1)</code></td><td>The easing curve for the entrance.</td></tr>
+          <tr><td><code>--ease-rotate-angle-hr18</code></td><td><code>-10deg</code></td><td>Starting tilt angle before it settles flat.</td></tr>
+          <tr><td><code>--ease-rotate-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the animation starts.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="rca-footnote-hr18">submissions/examples/rotate-click-popover-a11y-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var root = document.getElementById("rcaRoot");
+
+  // ---- Real, working accessibility toggles ----
+  document.getElementById("rcaLargeText").addEventListener("change", function (e) {
+    root.classList.toggle("rca-large-text-hr18", e.target.checked);
+  });
+
+  document.getElementById("rcaReduceMotion").addEventListener("change", function (e) {
+    root.classList.toggle("rca-force-reduced-motion-hr18", e.target.checked);
+  });
+
+  // ---- Popover: click to toggle, Escape to close, click outside to close ----
+  var wraps = document.querySelectorAll(".rca-popover-wrap-hr18");
+
+  wraps.forEach(function (wrap) {
+    var trigger = wrap.querySelector(".rca-info-trigger-hr18");
+    var closeBtn = wrap.querySelector(".rca-popover-close-hr18");
+
+    function open() {
+      wraps.forEach(function (other) {
+        if (other !== wrap && other.__rcaCloseHr18) other.__rcaCloseHr18(false);
+      });
+      wrap.setAttribute("data-open", "true");
+      trigger.setAttribute("aria-expanded", "true");
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("keydown", onKeydown);
+    }
+
+    function close(returnFocus) {
+      wrap.setAttribute("data-open", "false");
+      trigger.setAttribute("aria-expanded", "false");
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKeydown);
+      if (returnFocus) trigger.focus();
+    }
+
+    function onDocClick(e) {
+      if (!wrap.contains(e.target)) close(false);
+    }
+
+    function onKeydown(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close(true);
+      }
+    }
+
+    trigger.addEventListener("click", function () {
+      var isOpen = wrap.getAttribute("data-open") === "true";
+      if (isOpen) close(false); else open();
+    });
+
+    closeBtn.addEventListener("click", function () {
+      close(true);
+    });
+
+    wrap.__rcaCloseHr18 = close;
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/rotate-click-popover-a11y-hr18/style.css
+++ b/submissions/examples/rotate-click-popover-a11y-hr18/style.css
@@ -1,0 +1,379 @@
+/* ==========================================================================
+   rotate-click-popover-a11y-hr18 — style.css
+   CSS Rotate-Click Popover for Accessible Web layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.rca-hr18 {
+  --bg-hr18: #ffffff;
+  --panel-hr18: #ffffff;
+  --panel-raised-hr18: #f4f6f9;
+  --border-hr18: #c9ced9;
+  --text-hr18: #0d0f14;
+  --text-muted-hr18: #454b57;
+  --accent-hr18: #1a4fd6;
+  --accent-soft-hr18: #e7edff;
+  --focus-hr18: #1a4fd6;
+  --radius-hr18: 12px;
+
+  /* Exposed animation parameters. */
+  --ease-rotate-duration-hr18: 400ms;
+  --ease-rotate-easing-hr18: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-rotate-angle-hr18: -10deg;
+  --ease-rotate-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4.5rem;
+  min-height: 100%;
+}
+
+/* Larger-text mode, toggled in the demo — a real, working example of one
+   of the settings the popovers below describe. */
+.rca-hr18.rca-large-text-hr18 {
+  font-size: 1.14em;
+}
+
+.rca-hr18 * {
+  box-sizing: border-box;
+}
+
+.rca-hr18 h1,
+.rca-hr18 h2,
+.rca-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.rca-wrap-hr18 {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+/* ---- Header ------------------------------------------------------------------ */
+.rca-header-hr18 {
+  margin-bottom: 2rem;
+}
+
+.rca-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 700;
+  font-family: var(--font-mono-hr18);
+}
+
+.rca-header-hr18 h1 {
+  font-size: clamp(1.6rem, 2.6vw, 2.2rem);
+}
+
+.rca-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 62ch;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+/* ---- Accessibility toolbar ------------------------------------------------------ */
+.rca-toolbar-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.rca-toggle-group-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* Real, working toggle switch — not just decorative. */
+.rca-switch-hr18 {
+  position: relative;
+  width: 44px;
+  height: 26px;
+  flex-shrink: 0;
+}
+
+.rca-switch-hr18 input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.rca-switch-track-hr18 {
+  position: absolute;
+  inset: 0;
+  background: var(--border-hr18);
+  border-radius: 999px;
+  transition: background 0.15s ease;
+  pointer-events: none;
+}
+
+.rca-switch-track-hr18::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.15s ease;
+}
+
+.rca-switch-hr18 input:checked + .rca-switch-track-hr18 {
+  background: var(--accent-hr18);
+}
+
+.rca-switch-hr18 input:checked + .rca-switch-track-hr18::before {
+  transform: translateX(18px);
+}
+
+.rca-switch-hr18 input:focus-visible + .rca-switch-track-hr18 {
+  outline: 2px solid var(--focus-hr18);
+  outline-offset: 2px;
+}
+
+.rca-toggle-label-hr18 {
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+/* ---- Settings list, each row with an info trigger ------------------------------- */
+.rca-settings-hr18 {
+  margin-top: 1.5rem;
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  background: var(--panel-hr18);
+  overflow: visible;
+}
+
+.rca-setting-row-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  position: relative;
+}
+
+.rca-setting-row-hr18 + .rca-setting-row-hr18 {
+  border-top: 1px solid var(--border-hr18);
+}
+
+.rca-setting-name-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+/* ---- The reusable popover component ---------------------------------------------
+   Drop-in markup: a .rca-popover-wrap-hr18 containing an info trigger
+   button and a .ease-popover-rotate-a11y-hr18 panel. Toggling the
+   wrapper's data-open attribute reveals the panel and plays the
+   rotate-click entrance — 100% CSS, driven by the custom properties
+   declared above. */
+.rca-popover-wrap-hr18 {
+  position: relative;
+}
+
+.rca-info-trigger-hr18 {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent-hr18);
+  background: var(--panel-hr18);
+  color: var(--accent-hr18);
+  font-family: var(--font-display-hr18);
+  font-weight: 700;
+  font-size: 0.78rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rca-info-trigger-hr18[aria-expanded="true"] {
+  background: var(--accent-hr18);
+  color: #fff;
+}
+
+.ease-popover-rotate-a11y-hr18 {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 260px;
+  background: var(--panel-hr18);
+  border: 1.5px solid var(--accent-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1rem 1.1rem;
+  box-shadow: 0 18px 40px rgba(13, 15, 20, 0.18);
+  z-index: 20;
+  display: none;
+  transform-origin: top right;
+}
+
+.rca-popover-wrap-hr18[data-open="true"] .ease-popover-rotate-a11y-hr18 {
+  display: block;
+  animation: ease-rotate-click-a11y-hr18 var(--ease-rotate-duration-hr18) var(--ease-rotate-easing-hr18) var(--ease-rotate-delay-hr18) both;
+}
+
+/* The rotate-click entrance: pops in tilted and shrunk, settles flat. */
+@keyframes ease-rotate-click-a11y-hr18 {
+  0% {
+    opacity: 0;
+    transform: rotate(var(--ease-rotate-angle-hr18)) scale(0.65);
+  }
+  100% {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+.rca-popover-close-hr18 {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted-hr18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rca-popover-close-hr18:hover {
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+}
+
+.rca-popover-title-hr18 {
+  font-size: 0.88rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+  padding-right: 1.2rem;
+}
+
+.rca-popover-body-hr18 {
+  font-size: 0.83rem;
+  color: var(--text-muted-hr18);
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* ---- Live-demo note, only visible when the "reduce motion" toggle is on ------------ */
+.rca-motion-note-hr18 {
+  display: none;
+  margin-top: 1rem;
+  border: 1px solid var(--accent-hr18);
+  background: var(--accent-soft-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 0.9rem 1.1rem;
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.rca-hr18.rca-force-reduced-motion-hr18 .rca-motion-note-hr18 {
+  display: block;
+}
+
+/* Demo-only forced reduced motion, toggled independently of the OS
+   setting so reviewers can see the behavior without changing system
+   preferences. */
+.rca-hr18.rca-force-reduced-motion-hr18 .rca-popover-wrap-hr18[data-open="true"] .ease-popover-rotate-a11y-hr18 {
+  animation: none;
+  opacity: 1;
+  transform: none;
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.rca-tuning-hr18 {
+  margin-top: 2rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.rca-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.rca-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.rca-tuning-hr18 th,
+.rca-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.rca-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.rca-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+}
+
+.rca-footnote-hr18 {
+  margin-top: 2rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Focus & reduced motion (OS-level) --------------------------------------------- */
+.rca-hr18 :focus-visible {
+  outline: 3px solid var(--focus-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rca-popover-wrap-hr18[data-open="true"] .ease-popover-rotate-a11y-hr18 {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (max-width: 420px) {
+  .ease-popover-rotate-a11y-hr18 {
+    width: min(260px, calc(100vw - 3rem));
+    right: -0.5rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Popover with a "Rotate-Click" entrance, styled
for accessible web interfaces. An accessibility-settings panel (High
contrast mode, Keyboard navigation, Screen reader labels) with info
triggers that open rotate-click popovers explaining each setting. Two
toolbar toggles are genuinely functional, not decorative: "Large text"
scales the page's base font size up, and "Reduce motion" forces every
popover to appear instantly with no animation, independent of the OS
prefers-reduced-motion setting, so the behavior is checkable without
touching system settings.

Resolves #46433

Note for the maintainer: issue #46434 asked for the same Rotate-Click
interaction styled for "Creative Portfolio" layouts, which I submitted
separately as `rotate-click-popover-hr18`. This one reuses the same core
animation idea (both issues specify it) but is a distinct implementation
— its own class prefix, its own animation name
(`ease-rotate-click-a11y-hr18`), and a genuinely different context built
to demonstrate the "Accessible Web" theme rather than reusing the
portfolio one with new colors. Full explanation in the README.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/rotate-click-popover-a11y-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS "rotate-click" pop-in popover, demonstrated in an
accessibility settings panel with genuinely functional large-text and
reduce-motion toggles.

**How does a developer use it?**
```html
<div class="rca-popover-wrap-hr18" data-open="false">
  <button type="button" class="rca-info-trigger-hr18" aria-haspopup="dialog" aria-expanded="false" aria-label="What does this do?">i</button>
  <div class="ease-popover-rotate-a11y-hr18" role="dialog" aria-label="Explanation">...</div>
</div>
```

**Why does it fit EaseMotion CSS?**
A self-contained interaction with a distinct named animation exposed
entirely through custom properties, per the issue's ask for zero JS
animation overhead — while treating "Accessible Web" as something to
demonstrate working (real contrast ratios, 44px touch targets, functional
reduce-motion toggle), not just a palette choice.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix,
distinct from `rotate-click-popover-hr18` (portfolio version) to avoid any
collision. Tested keyboard flow, the in-page reduce-motion toggle, and the
large-text toggle in Chrome; haven't checked other browsers yet.