### PR TITLE
feat: add CSS slide-up popover for glassmorphism UI layouts

### DIFF
--- a/submissions/examples/slide-up-popover-glassmorphism-ak/README.md
+++ b/submissions/examples/slide-up-popover-glassmorphism-ak/README.md
@@ -1,0 +1,23 @@
+# Slide-Up Glassmorphism Popover
+
+## What does this do?
+A pure CSS popover with a frosted-glass (glassmorphism) look — translucent background, blur, and subtle border — that slides up smoothly on open.
+
+## How is it used?
+```html
+<div class="glass-popover-wrap">
+  <button class="glass-popover-trigger" id="glassBtn" aria-expanded="false" aria-controls="glassBox">
+    Show Info
+  </button>
+
+  <div class="glass-popover-box" id="glassBox" role="dialog" aria-labelledby="glassBoxTitle" aria-hidden="true">
+    <h3 id="glassBoxTitle">Title</h3>
+    <p>Content goes here.</p>
+    <button class="glass-popover-close" id="glassCloseBtn">Close</button>
+  </div>
+</div>
+```
+Toggle `is-open` on `.glass-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) to trigger the slide-up transition. Customize via `--glass-offset`, `--glass-duration`, `--glass-easing`.
+
+## Why is it useful?
+It brings the popular glassmorphism aesthetic — `backdrop-filter` blur, translucent tint, soft borders — into EaseMotion's examples, paired with smooth CSS-only slide-up motion. Keyboard support (Escape, click-outside close), ARIA dialog semantics, and `prefers-reduced-motion` handling keep it accessible, in line with EaseMotion's lightweight animation-first philosophy.

--- a/submissions/examples/slide-up-popover-glassmorphism-ak/demo.html
+++ b/submissions/examples/slide-up-popover-glassmorphism-ak/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Slide-Up Glassmorphism Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="glass-popover-wrap">
+    <button class="glass-popover-trigger" id="glassBtn" aria-expanded="false" aria-controls="glassBox">
+      Show Info
+    </button>
+
+    <div class="glass-popover-box" id="glassBox" role="dialog" aria-labelledby="glassBoxTitle" aria-hidden="true">
+      <h3 id="glassBoxTitle">Frosted Glass Panel</h3>
+      <p>A translucent, blurred popover that slides up gently over a vivid background.</p>
+      <button class="glass-popover-close" id="glassCloseBtn">Close</button>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('glassBtn');
+    const box = document.getElementById('glassBox');
+    const closeBtn = document.getElementById('glassCloseBtn');
+
+    function openPopover() {
+      box.classList.add('is-open');
+      box.setAttribute('aria-hidden', 'false');
+      btn.setAttribute('aria-expanded', 'true');
+      closeBtn.focus();
+    }
+
+    function closePopover() {
+      box.classList.remove('is-open');
+      box.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+      btn.focus();
+    }
+
+    btn.addEventListener('click', () => {
+      box.classList.contains('is-open') ? closePopover() : openPopover();
+    });
+
+    closeBtn.addEventListener('click', closePopover);
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && box.classList.contains('is-open')) {
+        closePopover();
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (box.classList.contains('is-open') && !box.contains(e.target) && !btn.contains(e.target)) {
+        closePopover();
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/slide-up-popover-glassmorphism-ak/style.css
+++ b/submissions/examples/slide-up-popover-glassmorphism-ak/style.css
@@ -1,0 +1,131 @@
+:root {
+  --glass-offset: 22px;
+  --glass-duration: 240ms;
+  --glass-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --glass-fg: #ffffff;
+  --glass-tint: rgba(255, 255, 255, 0.14);
+  --glass-border: rgba(255, 255, 255, 0.3);
+  --glass-accent: #ffffff;
+  --glass-radius: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: linear-gradient(135deg, #6a5cff 0%, #ff5ca8 50%, #ff9a5c 100%);
+  color: var(--glass-fg);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.glass-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.glass-popover-trigger {
+  background: var(--glass-tint);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  color: var(--glass-fg);
+  border: 1px solid var(--glass-border);
+  padding: 13px 24px;
+  font-size: 15px;
+  font-weight: 600;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.glass-popover-trigger:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.glass-popover-trigger:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+.glass-popover-box {
+  position: absolute;
+  top: calc(100% + 14px);
+  left: 50%;
+  width: 280px;
+  padding: 22px;
+  background: var(--glass-tint);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  color: var(--glass-fg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--glass-radius);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+
+  transform: translate(-50%, var(--glass-offset));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--glass-duration) var(--glass-easing),
+    opacity var(--glass-duration) ease,
+    visibility 0s linear var(--glass-duration);
+}
+
+.glass-popover-box.is-open {
+  transform: translate(-50%, 0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--glass-duration) var(--glass-easing),
+    opacity var(--glass-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.glass-popover-box h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.glass-popover-box p {
+  margin: 0 0 16px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.glass-popover-close {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--glass-border);
+  color: var(--glass-fg);
+  padding: 9px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.glass-popover-close:hover {
+  background: rgba(255, 255, 255, 0.32);
+}
+
+.glass-popover-close:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glass-popover-box {
+    transition: opacity var(--glass-duration) ease, visibility 0s linear var(--glass-duration);
+  }
+  .glass-popover-box.is-open {
+    transition: opacity var(--glass-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION
Closes #46386
## Pull Request Description
Adds a pure CSS animated popover with a frosted-glass (glassmorphism) look — translucent background, blur, and subtle border — that slides up smoothly on open. Closes #46386.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/slide-up-popover-glassmorphism-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only popover using `backdrop-filter` blur and a translucent tint to create a glassmorphism effect, sliding up smoothly on open.

**How does a developer use it?**
```html
<div class="glass-popover-wrap">
  <button class="glass-popover-trigger" id="glassBtn" aria-expanded="false" aria-controls="glassBox">
    Show Info
  </button>

  <div class="glass-popover-box" id="glassBox" role="dialog" aria-labelledby="glassBoxTitle" aria-hidden="true">
    <h3 id="glassBoxTitle">Title</h3>
    <p>Content goes here.</p>
    <button class="glass-popover-close" id="glassCloseBtn">Close</button>
  </div>
</div>
```
Toggling the `is-open` class on `.glass-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) triggers the slide-up transition. Offset, duration, and easing are customizable via `--glass-offset`, `--glass-duration`, `--glass-easing`.

**Why does it fit EaseMotion CSS?**
It brings the popular glassmorphism aesthetic — blur, translucency, soft borders — into EaseMotion's examples, paired with smooth CSS-only slide-up motion. Keyboard support (Escape, click-outside close), ARIA dialog semantics, and `prefers-reduced-motion` handling keep it accessible, matching EaseMotion's lightweight, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Uses `backdrop-filter` for the frosted glass effect, which needs a vivid/patterned background to read well — the demo includes a gradient background for that reason. Class names are unprefixed as instructed; happy to have them renamed to `ease-*` on integration.