### PR TITLE
feat: add CSS slide-up popover for SaaS showcase layouts

### DIFF
--- a/submissions/examples/slide-up-popover-saas-showcase-ak/README.md
+++ b/submissions/examples/slide-up-popover-saas-showcase-ak/README.md
@@ -1,0 +1,27 @@
+# Slide-Up SaaS Showcase Popover
+
+## What does this do?
+A pure CSS popover styled for SaaS marketing/pricing pages, revealing plan details with a smooth slide-up transition.
+
+## How is it used?
+```html
+<div class="saas-popover-wrap">
+  <button class="saas-popover-trigger" id="saasBtn" aria-expanded="false" aria-controls="saasBox">
+    See Plan Details
+  </button>
+
+  <div class="saas-popover-box" id="saasBox" role="dialog" aria-labelledby="saasBoxTitle" aria-hidden="true">
+    <span class="saas-popover-badge">Pro Plan</span>
+    <h3 id="saasBoxTitle">Title</h3>
+    <ul class="saas-popover-list">
+      <li>Feature one</li>
+      <li>Feature two</li>
+    </ul>
+    <button class="saas-popover-close" id="saasCloseBtn">Close</button>
+  </div>
+</div>
+```
+Toggle `is-open` on `.saas-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) to trigger the slide-up transition. Customize via `--saas-offset`, `--saas-duration`, `--saas-easing`.
+
+## Why is it useful?
+It provides a clean, conversion-friendly "plan details" reveal pattern common in SaaS pricing/showcase pages — CSS-only animation, minimal JS for state, keyboard accessible (Escape, click-outside close), and respects `prefers-reduced-motion`, matching EaseMotion's lightweight, animation-first philosophy.

--- a/submissions/examples/slide-up-popover-saas-showcase-ak/demo.html
+++ b/submissions/examples/slide-up-popover-saas-showcase-ak/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Slide-Up SaaS Showcase Popover Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="saas-popover-wrap">
+    <button class="saas-popover-trigger" id="saasBtn" aria-expanded="false" aria-controls="saasBox">
+      See Plan Details
+    </button>
+
+    <div class="saas-popover-box" id="saasBox" role="dialog" aria-labelledby="saasBoxTitle" aria-hidden="true">
+      <span class="saas-popover-badge">Pro Plan</span>
+      <h3 id="saasBoxTitle">Everything in Pro</h3>
+      <ul class="saas-popover-list">
+        <li>Unlimited projects</li>
+        <li>Priority support</li>
+        <li>Advanced analytics</li>
+      </ul>
+      <button class="saas-popover-close" id="saasCloseBtn">Close</button>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById('saasBtn');
+    const box = document.getElementById('saasBox');
+    const closeBtn = document.getElementById('saasCloseBtn');
+
+    function openPopover() {
+      box.classList.add('is-open');
+      box.setAttribute('aria-hidden', 'false');
+      btn.setAttribute('aria-expanded', 'true');
+      closeBtn.focus();
+    }
+
+    function closePopover() {
+      box.classList.remove('is-open');
+      box.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+      btn.focus();
+    }
+
+    btn.addEventListener('click', () => {
+      box.classList.contains('is-open') ? closePopover() : openPopover();
+    });
+
+    closeBtn.addEventListener('click', closePopover);
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && box.classList.contains('is-open')) {
+        closePopover();
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (box.classList.contains('is-open') && !box.contains(e.target) && !btn.contains(e.target)) {
+        closePopover();
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/slide-up-popover-saas-showcase-ak/style.css
+++ b/submissions/examples/slide-up-popover-saas-showcase-ak/style.css
@@ -1,0 +1,157 @@
+:root {
+  --saas-offset: 20px;
+  --saas-duration: 220ms;
+  --saas-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --saas-bg: #ffffff;
+  --saas-fg: #1a1d23;
+  --saas-accent: #4f46e5;
+  --saas-border: #e4e5ea;
+  --saas-radius: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: #f7f7fb;
+  color: #1a1d23;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.saas-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.saas-popover-trigger {
+  background: var(--saas-accent);
+  color: #fff;
+  border: none;
+  padding: 13px 24px;
+  font-size: 14.5px;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(79, 70, 229, 0.3);
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.saas-popover-trigger:hover {
+  background: #4338ca;
+  transform: translateY(-1px);
+}
+
+.saas-popover-trigger:focus-visible {
+  outline: 2px solid var(--saas-accent);
+  outline-offset: 3px;
+}
+
+.saas-popover-box {
+  position: absolute;
+  top: calc(100% + 14px);
+  left: 50%;
+  width: 260px;
+  padding: 20px;
+  background: var(--saas-bg);
+  color: var(--saas-fg);
+  border: 1px solid var(--saas-border);
+  border-radius: var(--saas-radius);
+  box-shadow: 0 18px 40px rgba(20, 20, 40, 0.14);
+
+  transform: translate(-50%, var(--saas-offset));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--saas-duration) var(--saas-easing),
+    opacity var(--saas-duration) ease,
+    visibility 0s linear var(--saas-duration);
+}
+
+.saas-popover-box.is-open {
+  transform: translate(-50%, 0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--saas-duration) var(--saas-easing),
+    opacity var(--saas-duration) ease,
+    visibility 0s linear 0s;
+}
+
+.saas-popover-badge {
+  display: inline-block;
+  background: #eef2ff;
+  color: var(--saas-accent);
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  border-radius: 999px;
+  margin-bottom: 10px;
+}
+
+.saas-popover-box h3 {
+  margin: 0 0 10px;
+  font-size: 15.5px;
+}
+
+.saas-popover-list {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  font-size: 13px;
+  color: #4a4d57;
+}
+
+.saas-popover-list li {
+  padding-left: 18px;
+  position: relative;
+  margin-bottom: 6px;
+}
+
+.saas-popover-list li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: var(--saas-accent);
+  font-weight: 700;
+}
+
+.saas-popover-close {
+  background: transparent;
+  border: 1px solid var(--saas-border);
+  color: var(--saas-fg);
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.saas-popover-close:hover {
+  background: #f2f2f6;
+}
+
+.saas-popover-close:focus-visible {
+  outline: 2px solid var(--saas-accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .saas-popover-box {
+    transition: opacity var(--saas-duration) ease, visibility 0s linear var(--saas-duration);
+  }
+  .saas-popover-box.is-open {
+    transition: opacity var(--saas-duration) ease, visibility 0s linear 0s;
+  }
+}


### PR DESCRIPTION
Closes #46385

## Pull Request Description
Adds a pure CSS animated popover styled for SaaS marketing/pricing pages, revealing plan details with a smooth slide-up transition. 
---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/slide-up-popover-saas-showcase-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only popover for SaaS pricing/marketing pages that reveals plan details — badge, title, feature list — with a slide-up transition.

**How does a developer use it?**
```html
<div class="saas-popover-wrap">
  <button class="saas-popover-trigger" id="saasBtn" aria-expanded="false" aria-controls="saasBox">
    See Plan Details
  </button>

  <div class="saas-popover-box" id="saasBox" role="dialog" aria-labelledby="saasBoxTitle" aria-hidden="true">
    <span class="saas-popover-badge">Pro Plan</span>
    <h3 id="saasBoxTitle">Title</h3>
    <ul class="saas-popover-list">
      <li>Feature one</li>
      <li>Feature two</li>
    </ul>
    <button class="saas-popover-close" id="saasCloseBtn">Close</button>
  </div>
</div>
```
Toggling the `is-open` class on `.saas-popover-box` (with `aria-hidden`/`aria-expanded` updates, handled in the demo script) triggers the slide-up transition. Offset, duration, and easing are customizable via `--saas-offset`, `--saas-duration`, `--saas-easing`.

**Why does it fit EaseMotion CSS?**
It provides a clean, conversion-friendly "plan details" reveal pattern common in SaaS pricing/showcase pages — CSS-only animation, minimal JS for state, keyboard accessibility (Escape, click-outside close), and `prefers-reduced-motion` support, matching EaseMotion's lightweight, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Styled with a checklist-style feature list and plan badge to match common SaaS pricing-page patterns. Class names are unprefixed as instructed; happy to have them renamed to `ease-*` on integration.