### PR TITLE
Add Spring Physics tooltip component for portfolio layouts (spring-to…

### DIFF
--- a/submissions/examples/spring-tooltip-hr18/README.md
+++ b/submissions/examples/spring-tooltip-hr18/README.md
@@ -1,0 +1,97 @@
+# Spring Physics Tooltip (`spring-tooltip-hr18`)
+
+A pure-CSS animated tooltip with a "Spring Physics" entrance, styled for
+creative portfolio layouts, built for issue
+[#46294](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46294).
+
+## What it does
+
+Hovering — or tabbing to, with a keyboard — a nav icon reveals a tooltip
+label that springs into place: it overshoots past its resting size, settles
+back, overshoots again more gently, and comes to rest — a damped-oscillation
+approximation of real spring physics using plain `@keyframes`, rather than a
+one-shot ease-in fade. Both the **show/hide behavior and the spring
+animation are pure CSS**, driven by `:hover`/`:focus-within` plus
+`@keyframes ease-spring-hr18` — no JavaScript is required for the core
+interaction. A few lines of optional script only add `Escape`-to-dismiss.
+
+The demo applies it to a four-icon portfolio nav bar (Home, Work, Contact,
+Resume), each showing its label on hover or focus.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap a trigger and a tooltip bubble in the component markup:
+
+```html
+<span class="spt-tooltip-wrap-hr18">
+  <button type="button" class="spt-nav-icon-hr18" aria-describedby="myTip">
+    <!-- icon SVG -->
+  </button>
+  <span class="ease-tooltip-spring-hr18" id="myTip" role="tooltip">Home</span>
+</span>
+```
+
+That's the entire component — no JavaScript wiring is needed per instance.
+
+### Tuning the animation
+
+Every timing/scale value is a CSS custom property, overridable per instance
+or globally:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-spring-duration-hr18` | `650ms` | How long the full settle sequence takes |
+| `--ease-spring-easing-hr18` | `cubic-bezier(0.16, 1, 0.3, 1)` | The overall pacing curve applied across the sequence |
+| `--ease-spring-peak-scale-hr18` | `1.18` | How far past full size the first overshoot goes — lower for a gentler spring |
+| `--ease-spring-delay-hr18` | `0ms` | Delay before the spring starts after hover/focus |
+
+```css
+.spt-tooltip-wrap-hr18.gentle .ease-tooltip-spring-hr18 {
+  --ease-spring-peak-scale-hr18: 1.06;
+  --ease-spring-duration-hr18: 400ms;
+}
+```
+
+A true spring simulation is a damped harmonic oscillator, which modern CSS
+can approximate more precisely with the `linear()` easing function — but
+that has notably narrower browser support than plain `@keyframes`, so this
+component uses a hand-tuned multi-stage keyframe sequence instead, which
+works everywhere `@keyframes` does.
+
+## Accessibility notes
+
+- The trigger is a native `<button>`, reachable and triggerable by keyboard
+  without any extra scripting.
+- The tooltip shows on `:focus-within` as well as `:hover`, so keyboard-only
+  users see the same label sighted mouse users do.
+- The trigger and its tooltip are connected with `aria-describedby`, and the
+  tooltip carries `role="tooltip"`, so it's announced together with the
+  icon button it describes.
+- The tooltip contains only text — no interactive content — matching the
+  WAI-ARIA tooltip pattern's expectations.
+- `Escape` blurs the trigger (via the small optional script) to dismiss the
+  tooltip early without needing to tab away.
+- The spring animation respects `@media (prefers-reduced-motion: reduce)`
+  and appears instantly at rest instead.
+
+## Responsiveness
+
+The nav bar wraps onto a second line on narrow viewports rather than
+overflowing, since it's a flex row with `flex-wrap: wrap`.
+
+## Why this fits EaseMotion CSS
+
+The entire interaction runs on plain CSS selectors and a single
+`@keyframes` block, matching the issue's explicit ask for zero JavaScript
+overhead, while exposing every timing/scale value as a tunable custom
+property and remaining keyboard accessible via `:focus-within`.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/spring-tooltip-hr18/demo.html
+++ b/submissions/examples/spring-tooltip-hr18/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Spring Physics Tooltip — portfolio demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="spt-hr18">
+  <div class="spt-wrap-hr18">
+
+    <header class="spt-header-hr18">
+      <span class="spt-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Nav tooltips</h1>
+      <p>Hover or tab to any icon below &mdash; its label springs in with a
+        touch of overshoot, like it's settling on an actual spring, instead
+        of a plain fade.</p>
+    </header>
+
+    <nav class="spt-nav-hr18" aria-label="Portfolio">
+
+      <span class="spt-tooltip-wrap-hr18">
+        <button type="button" class="spt-nav-icon-hr18" aria-describedby="sptTip1">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
+        </button>
+        <span class="ease-tooltip-spring-hr18" id="sptTip1" role="tooltip">Home</span>
+      </span>
+
+      <span class="spt-tooltip-wrap-hr18">
+        <button type="button" class="spt-nav-icon-hr18" aria-describedby="sptTip2">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>
+        </button>
+        <span class="ease-tooltip-spring-hr18" id="sptTip2" role="tooltip">Work</span>
+      </span>
+
+      <span class="spt-tooltip-wrap-hr18">
+        <button type="button" class="spt-nav-icon-hr18" aria-describedby="sptTip3">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
+        </button>
+        <span class="ease-tooltip-spring-hr18" id="sptTip3" role="tooltip">Contact</span>
+      </span>
+
+      <span class="spt-tooltip-wrap-hr18">
+        <button type="button" class="spt-nav-icon-hr18" aria-describedby="sptTip4">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line></svg>
+        </button>
+        <span class="ease-tooltip-spring-hr18" id="sptTip4" role="tooltip">Resume</span>
+      </span>
+
+    </nav>
+
+    <div class="spt-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-spring-duration-hr18</code></td><td><code>650ms</code></td><td>How long the full settle sequence takes.</td></tr>
+          <tr><td><code>--ease-spring-easing-hr18</code></td><td><code>cubic-bezier(0.16, 1, 0.3, 1)</code></td><td>The overall pacing curve applied across the sequence.</td></tr>
+          <tr><td><code>--ease-spring-peak-scale-hr18</code></td><td><code>1.18</code></td><td>How far past full size the first overshoot goes &mdash; lower for a gentler spring.</td></tr>
+          <tr><td><code>--ease-spring-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the spring starts after hover/focus.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="spt-footnote-hr18">submissions/examples/spring-tooltip-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // The core show/hide and spring animation are pure CSS (:hover /
+  // :focus-within) — no JavaScript is required for them to work. This
+  // script only adds one convenience: pressing Escape while a tooltip is
+  // showing via keyboard focus blurs the trigger, which naturally hides
+  // the tooltip since it's no longer within a :focus-within wrapper.
+  document.addEventListener("keydown", function (e) {
+    if (e.key !== "Escape") return;
+    var active = document.activeElement;
+    if (active && active.classList.contains("spt-nav-icon-hr18")) {
+      active.blur();
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/spring-tooltip-hr18/style.css
+++ b/submissions/examples/spring-tooltip-hr18/style.css
@@ -1,0 +1,247 @@
+/* ==========================================================================
+   spring-tooltip-hr18 — style.css
+   CSS Spring Physics Tooltip for Creative Portfolio layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.spt-hr18 {
+  --bg-hr18: #0e0e12;
+  --panel-hr18: #17171d;
+  --border-hr18: #2b2b34;
+  --text-hr18: #f3f2f6;
+  --text-muted-hr18: #a29fb0;
+  --accent-hr18: #7c3aed;
+  --accent-2-hr18: #22d3ee;
+  --radius-hr18: 16px;
+
+  /* Exposed animation parameters. */
+  --ease-spring-duration-hr18: 650ms;
+  --ease-spring-easing-hr18: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring-peak-scale-hr18: 1.18;
+  --ease-spring-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background:
+    radial-gradient(circle at 15% 10%, rgba(124, 58, 237, 0.16), transparent 45%),
+    radial-gradient(circle at 85% 30%, rgba(34, 211, 238, 0.1), transparent 40%),
+    var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3.5rem 1.5rem 5rem;
+  min-height: 100%;
+}
+
+.spt-hr18 * {
+  box-sizing: border-box;
+}
+
+.spt-hr18 h1,
+.spt-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.spt-wrap-hr18 {
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+/* ---- Header --------------------------------------------------------------- */
+.spt-header-hr18 {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.spt-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--accent-2-hr18);
+  font-family: var(--font-mono-hr18);
+}
+
+.spt-header-hr18 h1 {
+  font-size: clamp(1.8rem, 3.4vw, 2.5rem);
+}
+
+.spt-header-hr18 p {
+  margin: 0.9rem auto 0;
+  color: var(--text-muted-hr18);
+  max-width: 52ch;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* ---- Portfolio nav bar ------------------------------------------------------- */
+.spt-nav-hr18 {
+  display: flex;
+  justify-content: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  padding: 1.5rem;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 999px;
+  max-width: fit-content;
+  margin: 0 auto;
+}
+
+/* ---- The reusable tooltip component ---------------------------------------------
+   Drop-in markup: a .spt-tooltip-wrap-hr18 containing a trigger and a
+   .ease-tooltip-spring-hr18 bubble. Visibility and the spring animation
+   are both driven purely by :hover / :focus-within — no JavaScript is
+   required for the core interaction. */
+.spt-tooltip-wrap-hr18 {
+  position: relative;
+}
+
+.spt-nav-icon-hr18 {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 1px solid var(--border-hr18);
+  background: #1d1d25;
+  color: var(--text-hr18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.spt-nav-icon-hr18:hover,
+.spt-nav-icon-hr18:focus-visible {
+  border-color: var(--accent-hr18);
+  transform: translateY(-2px);
+}
+
+.ease-tooltip-spring-hr18 {
+  position: absolute;
+  bottom: calc(100% + 14px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text-hr18);
+  color: var(--bg-hr18);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.45rem 0.85rem;
+  border-radius: 8px;
+  white-space: nowrap;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 20;
+}
+
+.ease-tooltip-spring-hr18::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--text-hr18);
+}
+
+.spt-tooltip-wrap-hr18:hover .ease-tooltip-spring-hr18,
+.spt-tooltip-wrap-hr18:focus-within .ease-tooltip-spring-hr18 {
+  visibility: visible;
+  opacity: 1;
+  animation: ease-spring-hr18 var(--ease-spring-duration-hr18) var(--ease-spring-easing-hr18) var(--ease-spring-delay-hr18) both;
+}
+
+/* A damped-oscillation approximation of spring physics: overshoot past
+   rest, settle back, overshoot again more gently, then come to rest.
+   Peak scale is tunable via --ease-spring-peak-scale-hr18. */
+@keyframes ease-spring-hr18 {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(6px) scale(0.5);
+  }
+  45% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(-3px) scale(var(--ease-spring-peak-scale-hr18));
+  }
+  65% {
+    transform: translateX(-50%) translateY(1px) scale(0.94);
+  }
+  80% {
+    transform: translateX(-50%) translateY(-1px) scale(1.04);
+  }
+  92% {
+    transform: translateX(-50%) translateY(0) scale(0.99);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.spt-tuning-hr18 {
+  margin-top: 3rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.spt-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.spt-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.spt-tuning-hr18 th,
+.spt-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.spt-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.spt-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+  color: var(--accent-2-hr18);
+}
+
+.spt-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+  text-align: center;
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.spt-hr18 :focus-visible {
+  outline: 2px solid var(--accent-2-hr18);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spt-tooltip-wrap-hr18:hover .ease-tooltip-spring-hr18,
+  .spt-tooltip-wrap-hr18:focus-within .ease-tooltip-spring-hr18 {
+    animation: none;
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Tooltip with a "Spring Physics" entrance, styled
for creative portfolio layouts. Hovering — or tabbing to, with a keyboard
— a nav icon reveals a tooltip label that overshoots past its resting
size, settles back, overshoots again more gently, then comes to rest — a
damped-oscillation approximation of spring physics via plain @keyframes.
Both the show/hide behavior and the spring animation are pure CSS
(:hover/:focus-within + one @keyframes block) — no JavaScript required for
the core interaction. Demo applies it to a 4-icon portfolio nav bar.

Resolves #46294

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/spring-tooltip-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS spring-physics tooltip with tunable
timing/overshoot via custom properties.

**How does a developer use it?**
```html
<span class="spt-tooltip-wrap-hr18">
  <button type="button" class="spt-nav-icon-hr18" aria-describedby="myTip">...</button>
  <span class="ease-tooltip-spring-hr18" id="myTip" role="tooltip">Home</span>
</span>
```

**Why does it fit EaseMotion CSS?**
The entire interaction runs on plain CSS selectors and one `@keyframes`
block, matching the issue's ask for zero JS overhead, while exposing every
timing/scale value as a tunable custom property and staying keyboard
accessible via `:focus-within`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
Used a hand-tuned multi-stage `@keyframes` sequence rather than the newer
`linear()` easing function for the spring curve, since `linear()` has
narrower browser support — noted the tradeoff in the README. Show/hide and
the spring itself need zero JS; the only script adds Escape-to-dismiss.
Tested keyboard flow in Chrome; haven't checked other browsers yet.