### PR TITLE
Add CSS Rotate-Click Popover for interactive rows (rotate-click-inter…

### DIFF
--- a/submissions/examples/rotate-click-interactive-popover-hruthika18/README.md
+++ b/submissions/examples/rotate-click-interactive-popover-hruthika18/README.md
@@ -1,0 +1,110 @@
+# Rotate-Click Popover — Interactive Interface (`ease-rotate-int-pop`)
+
+A pure CSS, click-triggered popover/disclosure row with a rotating
+chevron indicator — built on native `<details>`/`<summary>`, styled for
+feature lists, FAQs, and other interactive-row interfaces. Zero
+JavaScript.
+
+This is a distinct variant from the marketing-landing-page Rotate-Click
+Popover already in the library (`ease-rotate-pop`, a small inline "+"
+that rotates into an "×" next to a headline). This one is a full-width
+accordion-style row with a chevron that rotates 180° open/closed — the
+more common real-world pattern for feature lists and FAQ sections.
+
+## What it does
+
+- **Click to open, click to close** — built on `<details>`/`<summary>`,
+  so the browser handles all open/close state natively.
+- A chevron (CSS-drawn border corner, no icon font/SVG needed) **rotates
+  from pointing down to pointing up** as the row opens, and changes color
+  to the accent tone while open.
+- The revealed panel fades and slides in slightly via `@keyframes`,
+  re-triggering each time the row opens (browsers restart CSS animations
+  when `display` changes from `none` to visible, which `<details>` does
+  natively on open).
+- **Fully keyboard accessible out of the box**: `<summary>` is natively
+  focusable and toggles on `Enter` or `Space`.
+- Respects `prefers-reduced-motion`: rotation and panel animation are
+  disabled; the open/closed state itself is unaffected.
+- Stacks cleanly: adjacent `.ease-rotate-int-pop` elements get automatic
+  spacing via an adjacent-sibling margin rule, so a list of rows needs no
+  extra wrapper CSS.
+- Configurable via CSS custom properties.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<details class="ease-rotate-int-pop">
+  <summary class="ease-rotate-int-pop__trigger">
+    <span class="ease-rotate-int-pop__title">Row title</span>
+    <span class="ease-rotate-int-pop__chevron"></span>
+  </summary>
+  <div class="ease-rotate-int-pop__panel">
+    Row content goes here.
+  </div>
+</details>
+```
+
+Stack multiple rows directly — spacing between them is automatic:
+
+```html
+<details class="ease-rotate-int-pop">...</details>
+<details class="ease-rotate-int-pop">...</details>
+<details class="ease-rotate-int-pop ease-rotate-int-pop--accent">...</details>
+```
+
+### Color variant
+
+```html
+<details class="ease-rotate-int-pop ease-rotate-int-pop--accent">...</details>
+```
+
+### Custom timing per instance
+
+```html
+<details class="ease-rotate-int-pop" style="--ease-rotate-int-duration: 0.4s;">
+  ...
+</details>
+```
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-rotate-int-duration` | `0.24s` | Length of the chevron rotation and panel entrance |
+| `--ease-rotate-int-easing` | `ease-out` | Easing curve |
+| `--ease-rotate-int-bg` | `#ffffff` | Row background color |
+| `--ease-rotate-int-fg` | `#1c2028` | Title text color |
+| `--ease-rotate-int-muted` | `#6b7280` | Panel text and chevron (closed) color |
+| `--ease-rotate-int-border` | `#e5e7eb` | Row border color |
+| `--ease-rotate-int-accent` | `#4f46e5` | Chevron color while open, and focus outline |
+
+## Why it fits EaseMotion CSS
+
+Self-contained, dependency-free, class-based API consistent with the
+framework's conventions, CSS-custom-property configuration, a documented
+reduced-motion fallback, and no required JavaScript — built on a native
+disclosure element rather than hand-rolled click/keyboard/ARIA handling.
+Gives the rotate-click interaction a full-width, list-friendly variant
+distinct from the small inline "+/×" trigger already in the library.
+
+## Accessibility notes
+
+- `<details>`/`<summary>` is a native disclosure widget: it's in the tab
+  order automatically, opens/closes on `Enter`/`Space`, and its open state
+  is exposed to assistive technology without manual `aria-expanded`
+  bookkeeping.
+- The chevron is purely decorative (no meaningful content, just a
+  rotating border shape), so it carries no `alt`/`aria-*` attributes of
+  its own — the semantics live on `<summary>`.
+- As with the other `<details>`-based popover in this library, there's no
+  built-in click-outside-to-close; only clicking the trigger again closes
+  it. This is native `<details>` behavior.
+
+## Browser support
+
+Uses standard CSS custom properties, `<details>`/`<summary>`,
+`:focus-visible`, the `[open]` attribute selector, and `@keyframes` — no
+vendor prefixes needed for current evergreen browsers (Chrome, Edge,
+Firefox, Safari). The `::-webkit-details-marker` rule hides the default
+disclosure triangle in WebKit browsers.

--- a/submissions/examples/rotate-click-interactive-popover-hruthika18/demo.html
+++ b/submissions/examples/rotate-click-interactive-popover-hruthika18/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Click Popover — Interactive Interface — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Rotate-Click Popover — Interactive Interface</h1>
+    <p>Pure CSS, click-triggered popover with a rotating chevron indicator, built for feature lists and FAQ-style interactive rows. Click any row below.</p>
+  </header>
+
+  <main class="feature-list">
+
+    <details class="ease-rotate-int-pop">
+      <summary class="ease-rotate-int-pop__trigger">
+        <span class="ease-rotate-int-pop__title">Real-time collaboration</span>
+        <span class="ease-rotate-int-pop__chevron"></span>
+      </summary>
+      <div class="ease-rotate-int-pop__panel">
+        Multiple people can edit the same document at once, with cursors
+        and changes syncing in real time across every connected client.
+      </div>
+    </details>
+
+    <details class="ease-rotate-int-pop">
+      <summary class="ease-rotate-int-pop__trigger">
+        <span class="ease-rotate-int-pop__title">Version history</span>
+        <span class="ease-rotate-int-pop__chevron"></span>
+      </summary>
+      <div class="ease-rotate-int-pop__panel">
+        Every change is saved automatically. Roll back to any previous
+        version, or compare two versions side by side.
+      </div>
+    </details>
+
+    <details class="ease-rotate-int-pop ease-rotate-int-pop--accent">
+      <summary class="ease-rotate-int-pop__trigger">
+        <span class="ease-rotate-int-pop__title">Offline mode</span>
+        <span class="ease-rotate-int-pop__chevron"></span>
+      </summary>
+      <div class="ease-rotate-int-pop__panel">
+        Keep working without a connection — changes sync automatically the
+        next time you're back online, with conflict resolution built in.
+      </div>
+    </details>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Keyboard users: press <kbd>Tab</kbd> to reach a row, then <kbd>Enter</kbd> or <kbd>Space</kbd> to open or close it.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/rotate-click-interactive-popover-hruthika18/style.css
+++ b/submissions/examples/rotate-click-interactive-popover-hruthika18/style.css
@@ -1,0 +1,150 @@
+/* ==========================================================================
+   ease-rotate-int-pop — CSS Rotate-Click Popover (Interactive Interface variant)
+   Pure CSS, built on native <details>/<summary>. A chevron indicator
+   rotates as each row opens/closes — styled for feature lists / FAQs.
+   ========================================================================== */
+
+.ease-rotate-int-pop {
+  /* Public configuration — override per-instance via inline style or a
+     scoped selector, e.g. .ease-rotate-int-pop { --ease-rotate-int-duration: .4s; } */
+  --ease-rotate-int-duration: 0.24s;
+  --ease-rotate-int-easing: ease-out;
+  --ease-rotate-int-bg: #ffffff;
+  --ease-rotate-int-fg: #1c2028;
+  --ease-rotate-int-muted: #6b7280;
+  --ease-rotate-int-border: #e5e7eb;
+  --ease-rotate-int-accent: #4f46e5;
+
+  border: 1px solid var(--ease-rotate-int-border);
+  border-radius: 12px;
+  background: var(--ease-rotate-int-bg);
+  overflow: hidden;
+}
+
+.ease-rotate-int-pop + .ease-rotate-int-pop {
+  margin-top: 10px;
+}
+
+.ease-rotate-int-pop__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+.ease-rotate-int-pop__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.ease-rotate-int-pop__trigger:focus-visible {
+  outline: 2px solid var(--ease-rotate-int-accent);
+  outline-offset: -2px;
+}
+
+.ease-rotate-int-pop__title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--ease-rotate-int-fg);
+}
+
+.ease-rotate-int-pop__chevron {
+  flex: none;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid var(--ease-rotate-int-muted);
+  border-bottom: 2px solid var(--ease-rotate-int-muted);
+  transform: rotate(45deg); /* pointing down, closed state */
+  transition: transform var(--ease-rotate-int-duration) var(--ease-rotate-int-easing),
+    border-color var(--ease-rotate-int-duration) var(--ease-rotate-int-easing);
+}
+
+.ease-rotate-int-pop[open] .ease-rotate-int-pop__chevron {
+  transform: rotate(225deg); /* pointing up, open state */
+  border-color: var(--ease-rotate-int-accent);
+}
+
+.ease-rotate-int-pop__panel {
+  padding: 0 18px 16px;
+  color: var(--ease-rotate-int-muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  animation: ease-rotate-int-panel-in var(--ease-rotate-int-duration) var(--ease-rotate-int-easing) forwards;
+}
+
+@keyframes ease-rotate-int-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ---- Color variant ---- */
+
+.ease-rotate-int-pop--accent {
+  --ease-rotate-int-accent: #ec4899;
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-rotate-int-pop__chevron,
+  .ease-rotate-int-pop__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+  .ease-rotate-int-pop[open] .ease-rotate-int-pop__chevron {
+    transform: rotate(225deg);
+  }
+  .ease-rotate-int-pop__panel {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f7f7fa;
+  color: #1c2028;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 560px;
+  margin: 0 auto 36px;
+  text-align: center;
+}
+.demo-header p {
+  color: #6b7280;
+}
+
+.feature-list {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.demo-footer {
+  max-width: 560px;
+  margin: 32px auto 0;
+  text-align: center;
+  color: #9aa1b5;
+  font-size: 0.85rem;
+}
+.demo-footer kbd {
+  background: #eceef2;
+  border: 1px solid #e0e2e8;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS, click-triggered Rotate-Click popover built on native
`<details>`/`<summary>`, styled as a full-width accordion row for feature
lists and FAQs. A CSS-drawn chevron rotates 180° between closed/open
states and changes to an accent color while open; the revealed panel
fades and slides in via `@keyframes`, re-triggering on each open. All
open/close and keyboard behavior comes from the native disclosure
element. Distinct from the existing inline "+/×" Rotate-Click Popover —
this is a stackable, list-friendly row variant. Includes a color variant,
full `prefers-reduced-motion` support, and configuration via CSS custom
properties.

Resolves #46435

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/rotate-click-interactive-popover-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A stackable, click-to-open accordion row with a rotating chevron
indicator, built on native `<details>`/`<summary>` for zero-JS behavior.

**How does a developer use it?**
```html
<details class="ease-rotate-int-pop">
  <summary class="ease-rotate-int-pop__trigger">
    <span class="ease-rotate-int-pop__title">Row title</span>
    <span class="ease-rotate-int-pop__chevron"></span>
  </summary>
  <div class="ease-rotate-int-pop__panel">Row content.</div>
</details>
```

**Why does it fit EaseMotion CSS?**
Self-contained, dependency-free, class-based API matching the framework's
conventions. Complements the existing inline rotate-click trigger with a
full-row variant suited to FAQ/feature-list layouts, a very common
real-world use case for this interaction pattern.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes and the folder use a `-hruthika18` suffix per the naming
convention. No JS required — built on native `<details>`/`<summary>`.
Same click-outside-to-close tradeoff as the other `<details>`-based
popover: documented in the README, not fixed here to stay JS-free.