### PR TITLE
Add CSS Shimmer Sweep Tooltip component (shimmer-sweep-tooltip-hruthi…

### DIFF
--- a/submissions/examples/shimmer-sweep-tooltip-hruthika18/README.md
+++ b/submissions/examples/shimmer-sweep-tooltip-hruthika18/README.md
@@ -1,0 +1,97 @@
+# Shimmer Sweep Tooltip (`ease-shimmer-tip`)
+
+A pure CSS tooltip with a light band that sweeps across its surface while
+visible — built for minimalist tech UIs (config panels, dev tool
+dashboards) with zero JavaScript.
+
+## What it does
+
+- Reveals a small monospace tooltip on **hover or keyboard focus**, with
+  a quick fade/slide entrance.
+- While visible, a diagonal gradient band continuously sweeps left to
+  right across the bubble (`ease-shimmer-tip-sweep` keyframe animation),
+  clipped to the bubble's rounded corners via `overflow: hidden`.
+- Fully keyboard accessible: the trigger is focusable (`tabindex="0"`),
+  the tooltip opens on `:focus` / `:focus-within`, and there's a visible
+  `:focus-visible` outline.
+- Respects `prefers-reduced-motion`: the shimmer sweep is removed
+  entirely; the tooltip still appears via a plain fade.
+- Configurable via CSS custom properties, including the sweep speed and
+  color.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<span class="ease-shimmer-tip" tabindex="0" aria-describedby="tip-1">
+  ⓘ
+  <span class="ease-shimmer-tip__bubble" id="tip-1" role="tooltip">
+    Your tooltip content goes here.
+  </span>
+</span>
+```
+
+### Placement variant
+
+```html
+<!-- default: opens above the trigger -->
+<span class="ease-shimmer-tip">...</span>
+
+<!-- opens below the trigger -->
+<span class="ease-shimmer-tip ease-shimmer-tip--top">...</span>
+```
+
+### Color variant
+
+```html
+<span class="ease-shimmer-tip ease-shimmer-tip--accent">...</span>
+```
+
+### Custom sweep speed per instance
+
+```html
+<span
+  class="ease-shimmer-tip"
+  style="--ease-shimmer-tip-duration: 1.6s;"
+>
+  ...
+</span>
+```
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-shimmer-tip-fade-duration` | `0.18s` | Length of the show/hide fade |
+| `--ease-shimmer-tip-duration` | `1.1s` | Length of one shimmer sweep cycle (loops while visible) |
+| `--ease-shimmer-tip-gap` | `8px` | Space between the trigger and the bubble |
+| `--ease-shimmer-tip-bg` | `#12151d` | Bubble background color |
+| `--ease-shimmer-tip-fg` | `#d7dbe6` | Bubble text color |
+| `--ease-shimmer-tip-border` | `#2a2f3d` | Bubble border color |
+| `--ease-shimmer-tip-accent` | `#5eead4` | Trigger icon / focus outline color |
+| `--ease-shimmer-tip-sweep` | `rgba(255, 255, 255, 0.16)` | Color/opacity of the sweeping band |
+
+## Why it fits EaseMotion CSS
+
+Self-contained, dependency-free animated component consistent with the
+framework's existing patterns: class-based API (`ease-shimmer-tip`),
+configuration via CSS custom properties, a documented reduced-motion
+fallback, and no required JavaScript. The shimmer sweep gives tech/config
+UI tooltips a subtle "live data" feel distinct from the framework's
+scale/skew/blur popover variants — appropriate for values that suggest
+freshness or activity (build hashes, rate limits, feature flags) rather
+than static help text.
+
+## Accessibility notes
+
+- The trigger uses `tabindex="0"` so it's reachable by keyboard.
+- `aria-describedby` links the trigger to the bubble's `id`, and the
+  bubble carries `role="tooltip"`.
+- The tooltip opens on `:focus-within` as well as `:hover`/`:focus`.
+- The shimmer sweep is purely decorative (a `::before` pseudo-element with
+  no content) and is fully suppressed under `prefers-reduced-motion: reduce`.
+
+## Browser support
+
+Uses standard CSS custom properties, `:focus-visible`, `@keyframes`, and
+`linear-gradient`/`transform` — no vendor prefixes needed for current
+evergreen browsers (Chrome, Edge, Firefox, Safari).

--- a/submissions/examples/shimmer-sweep-tooltip-hruthika18/demo.html
+++ b/submissions/examples/shimmer-sweep-tooltip-hruthika18/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Shimmer Sweep Tooltip — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Shimmer Sweep Tooltip</h1>
+    <p>Pure CSS tooltip with a light sweep animating across its surface on reveal, styled for minimalist tech UIs. Hover or tab to any trigger below.</p>
+  </header>
+
+  <main class="tech-panel">
+
+    <div class="tech-row">
+      <code class="tech-row__key">BUILD_HASH</code>
+      <span
+        class="ease-shimmer-tip"
+        tabindex="0"
+        aria-describedby="tip-hash"
+      >
+        ⓘ
+        <span class="ease-shimmer-tip__bubble" id="tip-hash" role="tooltip">
+          Short commit hash the current build was compiled from.
+        </span>
+      </span>
+    </div>
+
+    <div class="tech-row">
+      <code class="tech-row__key">RATE_LIMIT</code>
+      <span
+        class="ease-shimmer-tip ease-shimmer-tip--top"
+        tabindex="0"
+        aria-describedby="tip-rate"
+      >
+        ⓘ
+        <span class="ease-shimmer-tip__bubble" id="tip-rate" role="tooltip">
+          Max requests per client per minute before throttling kicks in.
+        </span>
+      </span>
+    </div>
+
+    <div class="tech-row">
+      <code class="tech-row__key">FEATURE_FLAGS</code>
+      <span
+        class="ease-shimmer-tip ease-shimmer-tip--accent"
+        tabindex="0"
+        aria-describedby="tip-flags"
+        style="--ease-shimmer-tip-duration: 1.4s;"
+      >
+        ⓘ
+        <span class="ease-shimmer-tip__bubble" id="tip-flags" role="tooltip">
+          Comma-separated list of experimental flags enabled for this environment.
+        </span>
+      </span>
+    </div>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Keyboard users: press <kbd>Tab</kbd> to focus a trigger and reveal its tooltip.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/shimmer-sweep-tooltip-hruthika18/style.css
+++ b/submissions/examples/shimmer-sweep-tooltip-hruthika18/style.css
@@ -1,0 +1,219 @@
+/* ==========================================================================
+   ease-shimmer-tip — CSS Shimmer Sweep Tooltip
+   Pure CSS, keyboard accessible, styled for minimalist tech / dev-tool UIs.
+   A light band sweeps across the tooltip surface once per reveal.
+   ========================================================================== */
+
+.ease-shimmer-tip {
+  /* Public configuration — override per-instance via inline style or a
+     scoped selector, e.g. .ease-shimmer-tip { --ease-shimmer-tip-duration: 1.5s; } */
+  --ease-shimmer-tip-fade-duration: 0.18s;
+  --ease-shimmer-tip-duration: 1.1s;
+  --ease-shimmer-tip-gap: 8px;
+  --ease-shimmer-tip-bg: #12151d;
+  --ease-shimmer-tip-fg: #d7dbe6;
+  --ease-shimmer-tip-border: #2a2f3d;
+  --ease-shimmer-tip-accent: #5eead4;
+  --ease-shimmer-tip-sweep: rgba(255, 255, 255, 0.16);
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 4px;
+  background: rgba(94, 234, 212, 0.1);
+  color: var(--ease-shimmer-tip-accent);
+  font-size: 0.78rem;
+  cursor: pointer;
+  user-select: none;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+.ease-shimmer-tip:focus-visible {
+  outline: 2px solid var(--ease-shimmer-tip-accent);
+  outline-offset: 2px;
+}
+
+.ease-shimmer-tip__bubble {
+  position: absolute;
+  bottom: calc(100% + var(--ease-shimmer-tip-gap));
+  left: 50%;
+  z-index: 20;
+  width: max-content;
+  max-width: 240px;
+  padding: 0.55em 0.8em;
+  border-radius: 6px;
+  background: var(--ease-shimmer-tip-bg);
+  color: var(--ease-shimmer-tip-fg);
+  border: 1px solid var(--ease-shimmer-tip-border);
+  font-size: 0.78rem;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  line-height: 1.45;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  overflow: hidden; /* clip the shimmer sweep to the bubble */
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translate(-50%, 3px);
+  transition:
+    opacity var(--ease-shimmer-tip-fade-duration) ease-out,
+    transform var(--ease-shimmer-tip-fade-duration) ease-out,
+    visibility 0s linear var(--ease-shimmer-tip-fade-duration);
+}
+
+.ease-shimmer-tip__bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  background: var(--ease-shimmer-tip-bg);
+  border-right: 1px solid var(--ease-shimmer-tip-border);
+  border-bottom: 1px solid var(--ease-shimmer-tip-border);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+/* The shimmer band itself: a diagonal gradient that sweeps left-to-right */
+.ease-shimmer-tip__bubble::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    var(--ease-shimmer-tip-sweep) 48%,
+    transparent 66%
+  );
+  transform: translateX(-100%);
+  pointer-events: none;
+}
+
+/* Reveal on hover or keyboard focus */
+.ease-shimmer-tip:hover .ease-shimmer-tip__bubble,
+.ease-shimmer-tip:focus .ease-shimmer-tip__bubble,
+.ease-shimmer-tip:focus-within .ease-shimmer-tip__bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+  transition:
+    opacity var(--ease-shimmer-tip-fade-duration) ease-out,
+    transform var(--ease-shimmer-tip-fade-duration) ease-out,
+    visibility 0s linear;
+}
+
+.ease-shimmer-tip:hover .ease-shimmer-tip__bubble::before,
+.ease-shimmer-tip:focus .ease-shimmer-tip__bubble::before,
+.ease-shimmer-tip:focus-within .ease-shimmer-tip__bubble::before {
+  animation: ease-shimmer-tip-sweep var(--ease-shimmer-tip-duration) ease-in-out infinite;
+}
+
+@keyframes ease-shimmer-tip-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  60%,
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* ---- Placement variant ---- */
+
+.ease-shimmer-tip--top .ease-shimmer-tip__bubble {
+  bottom: auto;
+  top: calc(100% + var(--ease-shimmer-tip-gap));
+}
+.ease-shimmer-tip--top .ease-shimmer-tip__bubble::after {
+  top: auto;
+  bottom: 100%;
+  border-right: none;
+  border-bottom: none;
+  border-left: 1px solid var(--ease-shimmer-tip-border);
+  border-top: 1px solid var(--ease-shimmer-tip-border);
+}
+
+/* ---- Color variant ---- */
+
+.ease-shimmer-tip--accent {
+  --ease-shimmer-tip-accent: #f59e0b;
+  background: rgba(245, 158, 11, 0.12);
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-shimmer-tip__bubble::before {
+    animation: none !important;
+    display: none;
+  }
+  .ease-shimmer-tip__bubble {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translate(-50%, 0) !important;
+  }
+}
+
+/* ---- Demo page chrome: minimalist tech panel (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0b0e14;
+  color: #d7dbe6;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 560px;
+  margin: 0 auto 36px;
+  text-align: center;
+}
+.demo-header p {
+  color: #7d8494;
+}
+
+.tech-panel {
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 8px 22px;
+  border: 1px solid #1e222c;
+  border-radius: 10px;
+  background: #0f131b;
+}
+
+.tech-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px solid #1a1e28;
+  font-size: 0.85rem;
+}
+.tech-row:last-child {
+  border-bottom: none;
+}
+.tech-row__key {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  color: #8fd6c8;
+}
+
+.demo-footer {
+  max-width: 560px;
+  margin: 32px auto 0;
+  text-align: center;
+  color: #6b7286;
+  font-size: 0.85rem;
+}
+.demo-footer kbd {
+  background: #1a1e28;
+  border: 1px solid #2a2f3d;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS Shimmer Sweep tooltip styled for minimalist tech UIs. A
trigger icon wrapped in `.ease-shimmer-tip` reveals a monospace,
panel-styled `.ease-shimmer-tip__bubble` on hover or keyboard focus, with
a diagonal light band continuously sweeping across the bubble surface
while visible (clipped via `overflow: hidden`). Includes a top-placement
variant, a color variant, full `prefers-reduced-motion` support (sweep
disabled, plain fade remains), and configuration via CSS custom
properties (fade duration, sweep duration, gap, colors, sweep tint).
Keyboard accessible via `tabindex`, `:focus-visible`, `:focus-within`, and
`aria-describedby`/`role="tooltip"`.

Resolves #46359

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/shimmer-sweep-tooltip-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only hover/focus tooltip with a continuous shimmer sweep across its
surface, aimed at config/dev-tool style UIs where values feel "live."

**How does a developer use it?**
```html
<span class="ease-shimmer-tip" tabindex="0" aria-describedby="tip-1">
  ⓘ
  <span class="ease-shimmer-tip__bubble" id="tip-1" role="tooltip">
    Your content here.
  </span>
</span>
```

**Why does it fit EaseMotion CSS?**
Self-contained, dependency-free component matching the framework's
existing conventions — class-based API, CSS custom properties for
configuration, documented reduced-motion fallback. Distinct effect from
the scale/skew/blur variants already in the library.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes and the folder use a `-hruthika18` suffix per the naming
convention. No JS required — interaction states are handled via `:hover`,
`:focus`, and `:focus-within`; the shimmer is a pure CSS `@keyframes`
animation on `::before`.