### PR TITLE
Add CSS Magnetic Pull Tabs component (magnetic-pull-tabs-hruthika18)

### DIFF
--- a/submissions/examples/magnetic-pull-tabs-hruthika18/README.md
+++ b/submissions/examples/magnetic-pull-tabs-hruthika18/README.md
@@ -1,0 +1,124 @@
+# Magnetic Pull Tabs (`ease-magnet-tabs`)
+
+Pure CSS tabs where a sliding pill indicator "pulls" to the active tab
+with a slight magnetic overshoot — built on the radio-input technique for
+zero-JS tab switching with fully native keyboard support.
+
+## What it does
+
+- **Click a tab, or use arrow keys** — tabs are backed by native radio
+  inputs sharing one `name`, so the browser handles selection and
+  Left/Right arrow-key navigation between tabs automatically. No JS.
+- A pill-shaped **"magnet" indicator** slides behind the active tab label
+  using `transform: translateX()`, timed with a spring-like
+  `cubic-bezier` that slightly overshoots before settling — the
+  "magnetic pull" feel the issue asked for.
+- The revealed panel fades and slides in slightly on each switch.
+- **Fully keyboard accessible**: radio inputs are visually hidden with a
+  standard clip-based technique (not `display: none`, which would remove
+  them from the tab order) and get a visible focus ring on their
+  corresponding label via `:focus-visible`.
+- Respects `prefers-reduced-motion`: the magnet slide, label color
+  transition, and panel entrance animation are all disabled.
+- Configurable via CSS custom properties.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="ease-magnet-tabs">
+
+  <input type="radio" name="my-tabs" id="tab-one" class="ease-magnet-tabs__input" checked />
+  <input type="radio" name="my-tabs" id="tab-two" class="ease-magnet-tabs__input" />
+
+  <div class="ease-magnet-tabs__list" role="tablist" aria-label="My tabs">
+    <label class="ease-magnet-tabs__tab" for="tab-one">One</label>
+    <label class="ease-magnet-tabs__tab" for="tab-two">Two</label>
+    <span class="ease-magnet-tabs__magnet" aria-hidden="true"></span>
+  </div>
+
+  <div class="ease-magnet-tabs__panels">
+    <div class="ease-magnet-tabs__panel" data-panel="tab-one-content">First panel.</div>
+    <div class="ease-magnet-tabs__panel" data-panel="tab-two-content">Second panel.</div>
+  </div>
+
+</div>
+```
+
+### Important: this technique needs per-tab CSS rules
+
+Because pure CSS has no way to compute "which sibling input is checked,
+by index" generically, the magnet-position and panel-visibility rules are
+written **per tab ID**, e.g.:
+
+```css
+#tab-two:checked ~ .ease-magnet-tabs__list .ease-magnet-tabs__magnet {
+  transform: translateX(calc(100% + 4px));
+}
+#tab-two:checked ~ .ease-magnet-tabs__list label[for="tab-two"] {
+  color: var(--ease-magnet-active-fg);
+}
+#tab-two:checked ~ .ease-magnet-tabs__panels [data-panel="tab-two-content"] {
+  display: block;
+}
+```
+
+The shipped `style.css` includes these rules for a 4-tab example
+(`magnet-tab-overview`, `magnet-tab-features`, `magnet-tab-pricing`,
+`magnet-tab-faq`). **To reuse this component with different tab IDs or a
+different tab count**, copy the three rule blocks per tab and update the
+IDs/`data-panel` values and the `translateX` offset (each step over is
+`(index * 100%) + (index * gapPx)`, where `gapPx` matches the grid `gap`
+set in CSS). Also update `--ease-magnet-count` to the new tab count. This
+is a known tradeoff of the radio-input pure-CSS tabs pattern — it trades
+JS-free operation for needing explicit per-instance rules.
+
+### Custom timing per instance
+
+```html
+<div class="ease-magnet-tabs" style="--ease-magnet-duration: 0.5s;">
+  ...
+</div>
+```
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-magnet-duration` | `0.35s` | Length of the magnet slide, label color change, and panel entrance |
+| `--ease-magnet-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Easing curve (magnetic overshoot) |
+| `--ease-magnet-bg` | `#f3f4f8` | Tab list background |
+| `--ease-magnet-fg` | `#4b5163` | Inactive tab / panel text color |
+| `--ease-magnet-active-fg` | `#ffffff` | Active tab label color |
+| `--ease-magnet-accent` | `#4f46e5` | Magnet pill color |
+| `--ease-magnet-border` | `#e5e7eb` | Tab list border color |
+| `--ease-magnet-radius` | `10px` | Outer corner radius |
+| `--ease-magnet-count` | `4` | Number of tabs — must match your markup for the grid columns and magnet width math to line up |
+
+## Why it fits EaseMotion CSS
+
+Self-contained, dependency-free, class-based API consistent with the
+framework's conventions — a zero-JS tab switcher with native keyboard
+support via the radio-input technique, plus a distinctive spring-eased
+sliding indicator rather than a plain instant-jump underline.
+Configuration via CSS custom properties, and a documented
+reduced-motion fallback.
+
+## Accessibility notes
+
+- Radio inputs are hidden with a clip-based visually-hidden technique
+  (not `display: none`), keeping them focusable and operable by keyboard.
+- Native radio-group behavior means arrow keys move between tabs and
+  `Tab` moves in/out of the group — no manual `keydown` handling needed.
+- `role="tablist"` and `aria-label` are included on the tab row; if you
+  need full ARIA tabs semantics (`role="tab"`, `aria-selected`,
+  `role="tabpanel"`, `aria-controls`), you can layer those on manually —
+  they weren't required to make the radio-input pattern itself operable,
+  but they do improve how screen readers announce tab state.
+- The magnet indicator is `aria-hidden="true"` since it's purely visual.
+
+## Browser support
+
+Uses standard CSS custom properties, CSS Grid, `:checked`, `:focus-visible`,
+general sibling combinators (`~`), attribute selectors, and
+`transform`/`transition` — no vendor prefixes needed for current
+evergreen browsers (Chrome, Edge, Firefox, Safari).

--- a/submissions/examples/magnetic-pull-tabs-hruthika18/demo.html
+++ b/submissions/examples/magnetic-pull-tabs-hruthika18/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Magnetic Pull Tabs — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Magnetic Pull Tabs</h1>
+    <p>Pure CSS tabs where the active indicator snaps to the selected tab with a slight magnetic overshoot. Click a tab, or use arrow keys after focusing one.</p>
+  </header>
+
+  <main class="demo-wrap">
+
+    <div class="ease-magnet-tabs">
+
+      <input type="radio" name="magnet-demo" id="magnet-tab-overview" class="ease-magnet-tabs__input" checked />
+      <input type="radio" name="magnet-demo" id="magnet-tab-features" class="ease-magnet-tabs__input" />
+      <input type="radio" name="magnet-demo" id="magnet-tab-pricing" class="ease-magnet-tabs__input" />
+      <input type="radio" name="magnet-demo" id="magnet-tab-faq" class="ease-magnet-tabs__input" />
+
+      <div class="ease-magnet-tabs__list" role="tablist" aria-label="Product information">
+        <label class="ease-magnet-tabs__tab" for="magnet-tab-overview">Overview</label>
+        <label class="ease-magnet-tabs__tab" for="magnet-tab-features">Features</label>
+        <label class="ease-magnet-tabs__tab" for="magnet-tab-pricing">Pricing</label>
+        <label class="ease-magnet-tabs__tab" for="magnet-tab-faq">FAQ</label>
+        <span class="ease-magnet-tabs__magnet" aria-hidden="true"></span>
+      </div>
+
+      <div class="ease-magnet-tabs__panels">
+        <div class="ease-magnet-tabs__panel" data-panel="overview">
+          <h2>Overview</h2>
+          <p>EaseMotion CSS is a zero-dependency, animation-first framework — readable class names, no build step required.</p>
+        </div>
+        <div class="ease-magnet-tabs__panel" data-panel="features">
+          <h2>Features</h2>
+          <p>Fade, slide, scale, and hover utilities, plus a growing library of self-contained community components like this one.</p>
+        </div>
+        <div class="ease-magnet-tabs__panel" data-panel="pricing">
+          <h2>Pricing</h2>
+          <p>Free and open source under the MIT license. No paid tiers, no usage limits.</p>
+        </div>
+        <div class="ease-magnet-tabs__panel" data-panel="faq">
+          <h2>FAQ</h2>
+          <p>Works with any framework that renders standard HTML class attributes — React, Vue, Svelte, plain HTML.</p>
+        </div>
+      </div>
+
+    </div>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Keyboard users: press <kbd>Tab</kbd> to reach the tab list, then <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> to move between tabs — this is native radio-group keyboard behavior, no JS involved.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-pull-tabs-hruthika18/style.css
+++ b/submissions/examples/magnetic-pull-tabs-hruthika18/style.css
@@ -1,0 +1,208 @@
+/* ==========================================================================
+   ease-magnet-tabs — CSS Magnetic Pull Tabs
+   Pure CSS, built on the radio-input technique for zero-JS tab switching
+   with native keyboard support. The active indicator "pulls" toward the
+   selected tab with a slight magnetic overshoot.
+   ========================================================================== */
+
+.ease-magnet-tabs {
+  /* Public configuration — override per-instance via inline style or a
+     scoped selector, e.g. .ease-magnet-tabs { --ease-magnet-duration: .5s; } */
+  --ease-magnet-duration: 0.35s;
+  --ease-magnet-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* magnetic overshoot */
+  --ease-magnet-bg: #f3f4f8;
+  --ease-magnet-fg: #4b5163;
+  --ease-magnet-active-fg: #ffffff;
+  --ease-magnet-accent: #4f46e5;
+  --ease-magnet-border: #e5e7eb;
+  --ease-magnet-radius: 10px;
+
+  --ease-magnet-count: 4; /* must match the number of tabs below */
+
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+/* Visually hide the radio inputs but keep them in the tab order and
+   operable by keyboard — do NOT use display:none, which would remove
+   them from the accessibility tree and break keyboard navigation. */
+.ease-magnet-tabs__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-magnet-tabs__list {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(var(--ease-magnet-count), 1fr);
+  background: var(--ease-magnet-bg);
+  border: 1px solid var(--ease-magnet-border);
+  border-radius: var(--ease-magnet-radius);
+  padding: 4px;
+  gap: 4px;
+}
+
+.ease-magnet-tabs__tab {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 9px 4px;
+  border-radius: calc(var(--ease-magnet-radius) - 4px);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ease-magnet-fg);
+  cursor: pointer;
+  user-select: none;
+  text-align: center;
+  transition: color var(--ease-magnet-duration) var(--ease-magnet-easing);
+}
+
+/* The sliding "magnet" pill behind the active tab label */
+.ease-magnet-tabs__magnet {
+  position: absolute;
+  z-index: 1;
+  top: 4px;
+  left: 4px;
+  width: calc((100% - 4px) / var(--ease-magnet-count) - 4px);
+  height: calc(100% - 8px);
+  background: var(--ease-magnet-accent);
+  border-radius: calc(var(--ease-magnet-radius) - 4px);
+  transition: transform var(--ease-magnet-duration) var(--ease-magnet-easing);
+}
+
+/* Position the magnet under whichever tab's radio input is checked.
+   translateX uses percentages relative to the magnet's own width, so
+   translateX(100%) always moves exactly one tab-slot over regardless of
+   the tab list's actual pixel width. Add one rule per tab. */
+#magnet-tab-overview:checked ~ .ease-magnet-tabs__list .ease-magnet-tabs__magnet {
+  transform: translateX(0%);
+}
+#magnet-tab-features:checked ~ .ease-magnet-tabs__list .ease-magnet-tabs__magnet {
+  transform: translateX(calc(100% + 4px));
+}
+#magnet-tab-pricing:checked ~ .ease-magnet-tabs__list .ease-magnet-tabs__magnet {
+  transform: translateX(calc(200% + 8px));
+}
+#magnet-tab-faq:checked ~ .ease-magnet-tabs__list .ease-magnet-tabs__magnet {
+  transform: translateX(calc(300% + 12px));
+}
+
+/* Active tab label color */
+#magnet-tab-overview:checked ~ .ease-magnet-tabs__list label[for="magnet-tab-overview"],
+#magnet-tab-features:checked ~ .ease-magnet-tabs__list label[for="magnet-tab-features"],
+#magnet-tab-pricing:checked ~ .ease-magnet-tabs__list label[for="magnet-tab-pricing"],
+#magnet-tab-faq:checked ~ .ease-magnet-tabs__list label[for="magnet-tab-faq"] {
+  color: var(--ease-magnet-active-fg);
+}
+
+/* Keyboard focus ring on whichever radio is focused, drawn on its label */
+.ease-magnet-tabs__input:focus-visible + .ease-magnet-tabs__list,
+.ease-magnet-tabs__input:focus-visible ~ .ease-magnet-tabs__list {
+  outline: none;
+}
+#magnet-tab-overview:focus-visible ~ .ease-magnet-tabs__list label[for="magnet-tab-overview"],
+#magnet-tab-features:focus-visible ~ .ease-magnet-tabs__list label[for="magnet-tab-features"],
+#magnet-tab-pricing:focus-visible ~ .ease-magnet-tabs__list label[for="magnet-tab-pricing"],
+#magnet-tab-faq:focus-visible ~ .ease-magnet-tabs__list label[for="magnet-tab-faq"] {
+  outline: 2px solid var(--ease-magnet-accent);
+  outline-offset: 2px;
+}
+
+/* Panels: hidden by default, shown when their matching radio is checked */
+.ease-magnet-tabs__panel {
+  display: none;
+  padding: 20px 4px 4px;
+  animation: ease-magnet-panel-in var(--ease-magnet-duration) var(--ease-magnet-easing) forwards;
+}
+.ease-magnet-tabs__panel h2 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+}
+.ease-magnet-tabs__panel p {
+  margin: 0;
+  color: var(--ease-magnet-fg);
+  line-height: 1.6;
+  font-size: 0.92rem;
+}
+
+#magnet-tab-overview:checked ~ .ease-magnet-tabs__panels [data-panel="overview"],
+#magnet-tab-features:checked ~ .ease-magnet-tabs__panels [data-panel="features"],
+#magnet-tab-pricing:checked ~ .ease-magnet-tabs__panels [data-panel="pricing"],
+#magnet-tab-faq:checked ~ .ease-magnet-tabs__panels [data-panel="faq"] {
+  display: block;
+}
+
+@keyframes ease-magnet-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-magnet-tabs__magnet,
+  .ease-magnet-tabs__tab,
+  .ease-magnet-tabs__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+  .ease-magnet-tabs__panel {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #ffffff;
+  color: #1c2028;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 560px;
+  margin: 0 auto 32px;
+  text-align: center;
+}
+.demo-header p {
+  color: #6b7280;
+}
+
+.demo-wrap {
+  padding: 0 8px;
+}
+
+.demo-footer {
+  max-width: 560px;
+  margin: 32px auto 0;
+  text-align: center;
+  color: #9aa1b5;
+  font-size: 0.85rem;
+}
+.demo-footer kbd {
+  background: #f0f0f3;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-magnet-tabs`, a pure CSS tab switcher built on the radio-input
technique for zero-JS operation with fully native keyboard support
(arrow-key navigation between tabs comes from the browser's native radio
group behavior). A pill-shaped "magnet" indicator slides behind the
active tab using a spring-eased `cubic-bezier` with a slight overshoot,
and the revealed panel fades/slides in on each switch. Radio inputs are
visually hidden with a clip-based technique (not `display: none`) to stay
in the tab order. Includes full `prefers-reduced-motion` support and
configuration via CSS custom properties.

Resolves #50342

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/magnetic-pull-tabs-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A zero-JS tab switcher with a spring-eased sliding "magnet" indicator,
built on the radio-input pure-CSS tabs pattern.

**How does a developer use it?**
See the README — the shipped example is a 4-tab pattern; reusing it with
different tab counts/IDs requires copying a small set of per-tab CSS
rules (documented in the README as a known tradeoff of the technique).

**Why does it fit EaseMotion CSS?**
Self-contained, dependency-free, class-based API. Demonstrates a
zero-JS interactive tabs pattern with native keyboard support, which the
library doesn't currently have — most existing motion patterns are
hover/focus based rather than a stateful multi-panel switcher.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes and the folder use a `-hruthika18` suffix. No JS required —
built on the radio-input tabs technique. One real limitation, documented
in the README: the magnet-position and panel-visibility rules are written
per tab ID rather than generically (a known constraint of pure-CSS radio
tabs), so extending the tab count requires copying a few rule blocks.
Also flagged: full ARIA tabs semantics (`role="tab"`, `aria-selected`,
`aria-controls`) aren't included — `role="tablist"` is present but I kept
scope to what the radio-input pattern needs to be keyboard-operable.
Happy to add full ARIA roles if that's a requirement for merge.