### PR TITLE
Add glassmorphism CSS Skew-Active Tabs (skew-active-glass-tabs-hruthi…

### DIFF
--- a/submissions/examples/skew-active-glass-tabs-hruthika18/README.md
+++ b/submissions/examples/skew-active-glass-tabs-hruthika18/README.md
@@ -1,0 +1,131 @@
+# Skew-Active Tabs — Glassmorphism (`ease-skew-tabs`)
+
+Pure CSS tabs on a genuine frosted-glass surface, with a skewed
+parallelogram indicator that slides to the active tab — built on the
+radio-input technique for zero-JS tab switching with fully native
+keyboard support.
+
+This is a distinct variant from the Magnetic Pull Tabs already in the
+library (`ease-magnet-tabs`, a straight rectangular pill with a spring
+overshoot): same underlying radio-input mechanism, but the indicator is a
+constantly-skewed parallelogram (not a rectangle that becomes skewed on
+interaction — the skew is the shape's resting identity, giving the whole
+control a dynamic, angular feel), and the surface uses real
+`backdrop-filter` glassmorphism rather than a solid or dashboard-style
+background.
+
+## What it does
+
+- **Click a tab, or use arrow keys** — tabs are backed by native radio
+  inputs sharing one `name`; the browser handles selection and
+  Left/Right arrow-key navigation natively. No JS.
+- A **skewed parallelogram indicator** slides behind the active tab label
+  using `translateX()` combined with a constant `skewX()`, so it always
+  reads as a slanted shape rather than a plain rectangle.
+- The tab list and form fields sit on a `backdrop-filter: blur()` glass
+  surface with a translucent tint and light border — the defining trait
+  of glassmorphism.
+- Includes an `@supports` fallback: browsers without `backdrop-filter`
+  get a solid dark translucent background instead of a transparent,
+  unreadable one.
+- **Fully keyboard accessible**: radio inputs are visually hidden with a
+  clip-based technique (not `display: none`) and get a visible focus
+  ring via `:focus-visible` on their label.
+- Respects `prefers-reduced-motion`.
+- Configurable via CSS custom properties, including the skew angle and
+  glass tint/blur.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="ease-skew-tabs">
+
+  <input type="radio" name="my-tabs" id="tab-a" class="ease-skew-tabs__input" checked />
+  <input type="radio" name="my-tabs" id="tab-b" class="ease-skew-tabs__input" />
+
+  <div class="ease-skew-tabs__list" role="tablist" aria-label="My tabs">
+    <label class="ease-skew-tabs__tab" for="tab-a">A</label>
+    <label class="ease-skew-tabs__tab" for="tab-b">B</label>
+    <span class="ease-skew-tabs__indicator" aria-hidden="true"></span>
+  </div>
+
+  <div class="ease-skew-tabs__panels">
+    <div class="ease-skew-tabs__panel" data-panel="a">First panel.</div>
+    <div class="ease-skew-tabs__panel" data-panel="b">Second panel.</div>
+  </div>
+
+</div>
+```
+
+Works best over a colorful, gradient, or photographic background — like
+the other glass component in this library, the frosted effect needs
+something behind it to blur.
+
+### Important: this technique needs per-tab CSS rules
+
+As with the Magnetic Pull Tabs, pure CSS can't compute "which sibling
+input is checked, by index" generically. The indicator-position,
+label-color, and panel-visibility rules are written **per tab ID**. The
+shipped `style.css` covers a 3-tab example (`skew-tab-login`,
+`skew-tab-signup`, `skew-tab-guest`). To reuse with different IDs or a
+different tab count, copy the rule blocks per tab, update the
+`translateX` offset (`(index * 100%) + (index * gapPx)`, `gapPx` matching
+the grid `gap`), and update `--ease-skew-tabs-count`.
+
+### Custom skew / tint per instance
+
+```html
+<div
+  class="ease-skew-tabs"
+  style="--ease-skew-tabs-skew: -14deg; --ease-skew-tabs-tint: 20, 20, 30;"
+>
+  ...
+</div>
+```
+
+| Property | Default | Description |
+|---|---|---|
+| `--ease-skew-tabs-duration` | `0.3s` | Length of the indicator slide, label color change, panel entrance |
+| `--ease-skew-tabs-easing` | `cubic-bezier(0.2, 0.9, 0.3, 1.25)` | Easing curve (slight overshoot) |
+| `--ease-skew-tabs-skew` | `-8deg` | Constant skew angle of the indicator |
+| `--ease-skew-tabs-count` | `3` | Number of tabs — must match your markup |
+| `--ease-skew-tabs-tint` | `255, 255, 255` | RGB triplet for the glass tint/border |
+| `--ease-skew-tabs-blur` | `16px` | Backdrop blur radius |
+| `--ease-skew-tabs-fg` | `#ffffff` | Active tab / heading text color |
+| `--ease-skew-tabs-muted` | `rgba(255, 255, 255, 0.75)` | Inactive tab / body text color |
+| `--ease-skew-tabs-accent` | `#ff6b9d` | Indicator and submit-button color |
+| `--ease-skew-tabs-radius` | `12px` | Outer corner radius |
+
+## Why it fits EaseMotion CSS
+
+Self-contained, dependency-free, class-based API consistent with the
+framework's conventions — a zero-JS tab switcher with native keyboard
+support, styled with a genuine `backdrop-filter` glass surface rather
+than a themed color palette. Gives the tabs family a second variant with
+a distinctly different indicator shape and surface treatment from the
+Magnetic Pull Tabs already contributed.
+
+## Accessibility notes
+
+- Radio inputs are hidden with a clip-based visually-hidden technique,
+  keeping them focusable and keyboard-operable.
+- Native radio-group behavior provides arrow-key navigation and `Tab`
+  in/out of the group with no manual `keydown` handling.
+- `role="tablist"` and `aria-label` are included on the tab row; as with
+  the Magnetic Pull Tabs, full ARIA tabs semantics (`role="tab"`,
+  `aria-selected`, `role="tabpanel"`) can be layered on manually if
+  required.
+- The skewed indicator is `aria-hidden="true"` since it's purely visual.
+- Glassmorphism risks low text contrast depending on the background;
+  test against your specific backdrop and adjust `--ease-skew-tabs-fg` /
+  `--ease-skew-tabs-tint` if needed.
+
+## Browser support
+
+Uses standard CSS custom properties, CSS Grid, `:checked`,
+`:focus-visible`, general sibling combinators, `backdrop-filter` (with
+`-webkit-` prefix and an `@supports` fallback), and `transform`/
+`transition` — evergreen Chrome, Edge, Firefox, and Safari all support
+`backdrop-filter` natively as of recent versions.

--- a/submissions/examples/skew-active-glass-tabs-hruthika18/demo.html
+++ b/submissions/examples/skew-active-glass-tabs-hruthika18/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Skew-Active Tabs — Glassmorphism — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Skew-Active Tabs</h1>
+    <p>Pure CSS tabs on a frosted-glass surface, with a skewed parallelogram indicator that slides to the active tab. Click a tab, or use arrow keys after focusing one.</p>
+  </header>
+
+  <main class="demo-wrap">
+
+    <div class="ease-skew-tabs">
+
+      <input type="radio" name="skew-tabs-demo" id="skew-tab-login" class="ease-skew-tabs__input" checked />
+      <input type="radio" name="skew-tabs-demo" id="skew-tab-signup" class="ease-skew-tabs__input" />
+      <input type="radio" name="skew-tabs-demo" id="skew-tab-guest" class="ease-skew-tabs__input" />
+
+      <div class="ease-skew-tabs__list" role="tablist" aria-label="Account access">
+        <label class="ease-skew-tabs__tab" for="skew-tab-login">Log In</label>
+        <label class="ease-skew-tabs__tab" for="skew-tab-signup">Sign Up</label>
+        <label class="ease-skew-tabs__tab" for="skew-tab-guest">Guest</label>
+        <span class="ease-skew-tabs__indicator" aria-hidden="true"></span>
+      </div>
+
+      <div class="ease-skew-tabs__panels">
+        <div class="ease-skew-tabs__panel" data-panel="login">
+          <label class="ease-skew-tabs__field">
+            Email
+            <input type="text" placeholder="you@example.com" />
+          </label>
+          <label class="ease-skew-tabs__field">
+            Password
+            <input type="password" placeholder="••••••••" />
+          </label>
+          <button type="button" class="ease-skew-tabs__submit">Log In</button>
+        </div>
+        <div class="ease-skew-tabs__panel" data-panel="signup">
+          <label class="ease-skew-tabs__field">
+            Full name
+            <input type="text" placeholder="Jordan Lee" />
+          </label>
+          <label class="ease-skew-tabs__field">
+            Email
+            <input type="text" placeholder="you@example.com" />
+          </label>
+          <button type="button" class="ease-skew-tabs__submit">Create account</button>
+        </div>
+        <div class="ease-skew-tabs__panel" data-panel="guest">
+          <p class="ease-skew-tabs__note">
+            Continue without an account — you can browse everything, but
+            saved preferences won't sync across devices.
+          </p>
+          <button type="button" class="ease-skew-tabs__submit">Continue as guest</button>
+        </div>
+      </div>
+
+    </div>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Keyboard users: press <kbd>Tab</kbd> to reach the tab list, then <kbd>&larr;</kbd>/<kbd>&rarr;</kbd> to switch tabs.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-glass-tabs-hruthika18/style.css
+++ b/submissions/examples/skew-active-glass-tabs-hruthika18/style.css
@@ -1,0 +1,246 @@
+/* ==========================================================================
+   ease-skew-tabs — CSS Skew-Active Tabs (Glassmorphism variant)
+   Pure CSS, built on the radio-input technique for zero-JS tab switching
+   with native keyboard support. A skewed parallelogram indicator slides
+   to the active tab on a frosted-glass surface.
+   ========================================================================== */
+
+.ease-skew-tabs {
+  /* Public configuration — override per-instance via inline style or a
+     scoped selector, e.g. .ease-skew-tabs { --ease-skew-tabs-duration: .5s; } */
+  --ease-skew-tabs-duration: 0.3s;
+  --ease-skew-tabs-easing: cubic-bezier(0.2, 0.9, 0.3, 1.25);
+  --ease-skew-tabs-skew: -8deg;
+  --ease-skew-tabs-count: 3; /* must match the number of tabs below */
+  --ease-skew-tabs-tint: 255, 255, 255;
+  --ease-skew-tabs-blur: 16px;
+  --ease-skew-tabs-fg: #ffffff;
+  --ease-skew-tabs-muted: rgba(255, 255, 255, 0.75);
+  --ease-skew-tabs-accent: #ff6b9d;
+  --ease-skew-tabs-radius: 12px;
+
+  max-width: 380px;
+  margin: 0 auto;
+}
+
+/* Visually hide the radio inputs but keep them focusable/keyboard-operable */
+.ease-skew-tabs__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-skew-tabs__list {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(var(--ease-skew-tabs-count), 1fr);
+  gap: 4px;
+  padding: 4px;
+  border-radius: var(--ease-skew-tabs-radius);
+  background: rgba(var(--ease-skew-tabs-tint), 0.14);
+  border: 1px solid rgba(var(--ease-skew-tabs-tint), 0.3);
+  backdrop-filter: blur(var(--ease-skew-tabs-blur));
+  -webkit-backdrop-filter: blur(var(--ease-skew-tabs-blur));
+}
+
+.ease-skew-tabs__tab {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 4px;
+  border-radius: calc(var(--ease-skew-tabs-radius) - 4px);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ease-skew-tabs-muted);
+  cursor: pointer;
+  user-select: none;
+  text-align: center;
+  transition: color var(--ease-skew-tabs-duration) var(--ease-skew-tabs-easing);
+}
+
+/* The sliding skewed indicator behind the active tab label */
+.ease-skew-tabs__indicator {
+  position: absolute;
+  z-index: 1;
+  top: 4px;
+  left: 4px;
+  width: calc((100% - 4px) / var(--ease-skew-tabs-count) - 4px);
+  height: calc(100% - 8px);
+  background: var(--ease-skew-tabs-accent);
+  border-radius: calc(var(--ease-skew-tabs-radius) - 4px);
+  transform: translateX(0%) skewX(var(--ease-skew-tabs-skew));
+  transition: transform var(--ease-skew-tabs-duration) var(--ease-skew-tabs-easing);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+}
+
+/* Position the indicator under whichever tab's radio input is checked.
+   translateX percentages are relative to the indicator's own width, so
+   each step moves exactly one tab-slot regardless of container size. */
+#skew-tab-login:checked ~ .ease-skew-tabs__list .ease-skew-tabs__indicator {
+  transform: translateX(0%) skewX(var(--ease-skew-tabs-skew));
+}
+#skew-tab-signup:checked ~ .ease-skew-tabs__list .ease-skew-tabs__indicator {
+  transform: translateX(calc(100% + 4px)) skewX(var(--ease-skew-tabs-skew));
+}
+#skew-tab-guest:checked ~ .ease-skew-tabs__list .ease-skew-tabs__indicator {
+  transform: translateX(calc(200% + 8px)) skewX(var(--ease-skew-tabs-skew));
+}
+
+/* Active tab label color */
+#skew-tab-login:checked ~ .ease-skew-tabs__list label[for="skew-tab-login"],
+#skew-tab-signup:checked ~ .ease-skew-tabs__list label[for="skew-tab-signup"],
+#skew-tab-guest:checked ~ .ease-skew-tabs__list label[for="skew-tab-guest"] {
+  color: var(--ease-skew-tabs-fg);
+}
+
+/* Keyboard focus ring on whichever tab is focused */
+#skew-tab-login:focus-visible ~ .ease-skew-tabs__list label[for="skew-tab-login"],
+#skew-tab-signup:focus-visible ~ .ease-skew-tabs__list label[for="skew-tab-signup"],
+#skew-tab-guest:focus-visible ~ .ease-skew-tabs__list label[for="skew-tab-guest"] {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* Panels: hidden by default, shown when their matching radio is checked */
+.ease-skew-tabs__panel {
+  display: none;
+  padding: 18px 4px 4px;
+  animation: ease-skew-tabs-panel-in var(--ease-skew-tabs-duration) var(--ease-skew-tabs-easing) forwards;
+}
+
+#skew-tab-login:checked ~ .ease-skew-tabs__panels [data-panel="login"],
+#skew-tab-signup:checked ~ .ease-skew-tabs__panels [data-panel="signup"],
+#skew-tab-guest:checked ~ .ease-skew-tabs__panels [data-panel="guest"] {
+  display: block;
+}
+
+@keyframes ease-skew-tabs-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-skew-tabs__field {
+  display: block;
+  margin-bottom: 12px;
+  font-size: 0.8rem;
+  color: var(--ease-skew-tabs-muted);
+}
+.ease-skew-tabs__field input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 5px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(var(--ease-skew-tabs-tint), 0.35);
+  background: rgba(var(--ease-skew-tabs-tint), 0.12);
+  color: var(--ease-skew-tabs-fg);
+  font-size: 0.85rem;
+}
+.ease-skew-tabs__field input::placeholder {
+  color: rgba(255, 255, 255, 0.55);
+}
+.ease-skew-tabs__field input:focus-visible {
+  outline: 2px solid var(--ease-skew-tabs-accent);
+  outline-offset: 1px;
+}
+
+.ease-skew-tabs__note {
+  margin: 0 0 16px;
+  color: var(--ease-skew-tabs-muted);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.ease-skew-tabs__submit {
+  width: 100%;
+  padding: 11px;
+  border: none;
+  border-radius: 9px;
+  background: var(--ease-skew-tabs-accent);
+  color: #fff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ease-skew-tabs__submit:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-skew-tabs__indicator,
+  .ease-skew-tabs__tab,
+  .ease-skew-tabs__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+  .ease-skew-tabs__panel {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ---- No backdrop-filter fallback ---- */
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ease-skew-tabs__list {
+    background: rgba(20, 22, 30, 0.55);
+  }
+}
+
+/* ---- Demo page chrome: glassmorphism scene (not part of the component) ---- */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #ff6b9d 100%);
+  color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 48px 20px 80px;
+  box-sizing: border-box;
+}
+
+.demo-header {
+  max-width: 480px;
+  margin: 0 auto 36px;
+  text-align: center;
+}
+.demo-header p {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.demo-wrap {
+  padding: 0 8px;
+}
+
+.demo-footer {
+  max-width: 480px;
+  margin: 32px auto 0;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+}
+.demo-footer kbd {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-skew-tabs`, a pure CSS tab switcher on a genuine glassmorphic
surface. Built on the radio-input technique for zero-JS operation with
native keyboard support (arrow-key navigation comes from the browser's
native radio group behavior). A constantly-skewed parallelogram indicator
slides behind the active tab via `translateX()` + `skewX()`, distinct
from the straight rectangular pill used in the existing Magnetic Pull
Tabs. The tab list and form fields sit on a real `backdrop-filter: blur()`
surface with an `@supports` fallback for browsers that lack it. Includes
full `prefers-reduced-motion` support and configuration via CSS custom
properties (skew angle, glass tint, blur radius, timing).

Resolves #50101

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/skew-active-glass-tabs-hruthika18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A zero-JS tab switcher with a skewed sliding indicator on a frosted-glass
surface, built on the radio-input pure-CSS tabs pattern (demoed as a
login/signup/guest account-access control).

**How does a developer use it?**
See the README — the shipped example is a 3-tab pattern; reusing it with
different tab counts/IDs requires copying a small set of per-tab CSS
rules, same documented tradeoff as the Magnetic Pull Tabs.

**Why does it fit EaseMotion CSS?**
Self-contained, dependency-free, class-based API. Gives the tabs family a
second variant with a genuinely different indicator shape and a true
glass surface treatment, rather than reusing the existing pill/solid-bg
approach with a new color scheme.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes and the folder use a `-hruthika18` suffix. No JS required —
built on the radio-input tabs technique, same per-tab-ID rule limitation
as the Magnetic Pull Tabs (documented in the README). Includes an
`@supports` fallback so the glass surface doesn't go transparent/unreadable
on browsers without `backdrop-filter`. Full ARIA tabs semantics
(`role="tab"`, `aria-selected`) aren't included beyond `role="tablist"` —
happy to add if required for merge.