### PR TITLE
feat(scss): add fade tooltip mixin

### DIFF
--- a/submissions/scss/feature-fade-tooltip-mixin-ag/README.md
+++ b/submissions/scss/feature-fade-tooltip-mixin-ag/README.md
@@ -1,0 +1,39 @@
+# Fade Tooltip Mixin
+
+## Description
+The `ease-fade-tooltip-mixin-ag` is an SCSS mixin designed for the exit animation of tooltips. It smoothly fades out the element by animating `opacity` from 1 down to 0, ensuring a clean and polished UI interaction as the tooltip disappears.
+
+## Installation
+Copy `_fade-tooltip.scss` into your project's SCSS directory and import it where needed.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `$duration` | Time | `0.2s` | The duration of the fade out animation. |
+| `$timing` | String | `ease-out` | The CSS timing function. |
+| `$delay` | Time | `0s` | The delay before the animation starts. |
+
+## Usage Example
+
+```scss
+// Import the mixin
+@use 'path/to/fade-tooltip' as *;
+
+.my-tooltip {
+    // Basic styling
+    background: #333;
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 4px;
+}
+
+// Apply the exit animation when the tooltip is hiding
+.my-tooltip.is-hiding {
+    @include ease-fade-tooltip-mixin-ag(0.2s, ease-in);
+}
+```
+
+## Accessibility Considerations
+- **Reduced Motion:** If a user has `prefers-reduced-motion: reduce` enabled in their system preferences, the animation is skipped and the element immediately jumps to `opacity: 0`.
+- **Performance:** Applies `will-change: opacity` to guarantee smooth compositing without layout recalculations.

--- a/submissions/scss/feature-fade-tooltip-mixin-ag/_fade-tooltip.scss
+++ b/submissions/scss/feature-fade-tooltip-mixin-ag/_fade-tooltip.scss
@@ -1,0 +1,30 @@
+// _fade-tooltip.scss
+
+@keyframes ease-fade-tooltip-exit-keyframes-ag {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/// Applies a smooth fade out (exit) animation for tooltips.
+/// 
+/// @param {Time} $duration [0.2s] - The duration of the exit animation.
+/// @param {String} $timing [ease-out] - The timing function.
+/// @param {Time} $delay [0s] - The delay before the animation starts.
+@mixin ease-fade-tooltip-mixin-ag(
+  $duration: 0.2s,
+  $timing: ease-out,
+  $delay: 0s
+) {
+  animation: ease-fade-tooltip-exit-keyframes-ag $duration $timing $delay both;
+  will-change: opacity;
+
+  // Accessibility: Disable motion for users who prefer reduced motion
+  @media (prefers-reduced-motion: reduce) {
+    animation: none !important;
+    opacity: 0 !important;
+  }
+}


### PR DESCRIPTION

# Summary
This PR resolves the `[Feature] Fade Tooltip Mixin` issue by introducing a reusable SCSS mixin for smoothly fading out tooltips on exit.

---

# Root Cause
Tooltips that instantly disappear when the user's cursor leaves can feel jarring and broken. Applying a quick, smooth fade-out (exit) animation gives the user a better mental model of the UI state changing without being abrupt. Providing this as a generic SCSS mixin ensures it can be applied to any tooltip component.

---

# Solution
Created the `_fade-tooltip.scss` mixin in the `submissions/scss/` directory.
- The `@keyframes ease-fade-tooltip-exit-keyframes-ag` handles the `opacity: 1` to `opacity: 0` transition.
- The `ease-fade-tooltip-mixin-ag` accepts `$duration`, `$timing`, and `$delay` parameters, defaulting to a quick `0.2s ease-out` which is standard for exits.
- Implements a strict `prefers-reduced-motion: reduce` block that suppresses the animation and applies the final state (`opacity: 0`) instantly.

---

# Files Changed
* `submissions/scss/feature-fade-tooltip-mixin-ag/_fade-tooltip.scss` - The SCSS file containing the exit keyframes and configurable mixin.
* `submissions/scss/feature-fade-tooltip-mixin-ag/README.md` - Documentation and an SCSS usage example.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (Verified opacity exit keyframes and reduced-motion override logic).

---

# Impact
* Breaking changes: No (Standalone feature submission).
* Performance impact: Low (Hardware accelerated `opacity` via `will-change`).
* Security impact: None.
* Compatibility: Fully compatible with modern standard SCSS processors.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
