### PR TITLE
feat(scss): add tada tooltip mixin

### DIFF
--- a/submissions/scss/feature-tada-tooltip-mixin-ag/README.md
+++ b/submissions/scss/feature-tada-tooltip-mixin-ag/README.md
@@ -1,0 +1,40 @@
+# Tada Tooltip Mixin (SCSS)
+
+## Description
+The `ease-tada-tooltip-ag` SCSS mixin provides a playful "Tada" entrance animation for tooltips. When triggered (usually via hovering or focusing a parent wrapper), the tooltip appears and shakes back and forth while slightly scaled up, drawing the user's attention like a celebratory reveal.
+
+## Usage
+Include the `_tada-tooltip.scss` file in your main stylesheet and use the mixin on the active/hover state of your tooltip element.
+
+```scss
+@use 'path/to/submissions/scss/feature-tada-tooltip-mixin-ag/tada-tooltip' as *;
+
+.my-tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  
+  .my-tooltip {
+    opacity: 0;
+    visibility: hidden;
+    position: absolute;
+    /* other styling... */
+  }
+
+  // Apply the mixin to the tooltip when the wrapper is hovered/focused
+  &:hover .my-tooltip,
+  &:focus-within .my-tooltip {
+    @include ease-tada-tooltip-ag(1.2s, 0.1s, ease);
+  }
+}
+```
+
+## Parameters
+- `$duration`: The animation duration (default: `1s`).
+- `$delay`: The animation delay (default: `0s`).
+- `$timing`: The animation timing function (default: `ease-in-out`).
+
+## How it works
+The mixin forces `opacity: 1` and `visibility: visible` to ensure the tooltip appears when the mixin is applied (typically under a pseudo-class like `:hover`). It then applies the `easeTadaTooltipAg` keyframes, which uses `scale3d` and `rotate3d` to create the shaking and expanding "tada" effect.
+
+## Accessibility
+A `@media (prefers-reduced-motion: reduce)` query is built into the mixin. For users who have requested reduced motion at the OS level, the tada animation is completely disabled (`animation: none !important`), but the tooltip will still safely appear due to the `opacity: 1` override within the mixin.

--- a/submissions/scss/feature-tada-tooltip-mixin-ag/_tada-tooltip.scss
+++ b/submissions/scss/feature-tada-tooltip-mixin-ag/_tada-tooltip.scss
@@ -1,0 +1,72 @@
+// _tada-tooltip.scss
+
+@keyframes easeTadaTooltipAg {
+  0% {
+    transform: scale3d(1, 1, 1);
+  }
+  10%, 20% {
+    transform: scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg);
+  }
+  30%, 50%, 70%, 90% {
+    transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg);
+  }
+  40%, 60%, 80% {
+    transform: scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg);
+  }
+  100% {
+    transform: scale3d(1, 1, 1);
+  }
+}
+
+@mixin ease-tada-tooltip-ag(
+  $duration: 1s,
+  $delay: 0s,
+  $timing: ease-in-out
+) {
+  // Setup the base state for a tooltip
+  opacity: 0;
+  visibility: hidden;
+  
+  // The mixin expects to be used within a parent hover/focus context
+  // e.g. .wrapper:hover .tooltip { @include ease-tada-tooltip-ag(); }
+  // When active, it becomes visible and animates
+  opacity: 1;
+  visibility: visible;
+  animation: easeTadaTooltipAg $duration $timing $delay both;
+  
+  // Accessibility for users who prefer reduced motion
+  @media (prefers-reduced-motion: reduce) {
+    animation: none !important;
+  }
+}
+
+// Example usage
+.tooltip-wrapper-ag {
+  position: relative;
+  display: inline-block;
+
+  .tooltip-content-ag {
+    position: absolute;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -60px; /* Adjust based on content width */
+    width: 120px;
+    background-color: #1e293b;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 8px 0;
+    z-index: 1;
+    
+    // Initial hidden state
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s;
+  }
+
+  // Trigger the animation on hover or focus-within
+  &:hover .tooltip-content-ag,
+  &:focus-within .tooltip-content-ag {
+    @include ease-tada-tooltip-ag();
+  }
+}


### PR DESCRIPTION

# Summary
This PR resolves the `[Feature] Tada Tooltip Mixin` issue by providing a beginner-friendly SCSS mixin (`ease-tada-tooltip-ag`) that applies a playful "Tada" entrance animation to tooltips.

---

# Root Cause
Tooltips can easily go unnoticed if they simply fade in or appear instantly. An attention-seeking entrance animation like "Tada" (which combines scaling and rotation) ensures that users notice the newly revealed contextual information, acting as a celebratory reveal.

---

# Solution
Created the `feature-tada-tooltip-mixin-ag` in the `submissions/scss/` directory.
- `_tada-tooltip.scss`: 
  - Implements the `easeTadaTooltipAg` keyframes, which scales the element down and rotates slightly, then scales it up while alternating rotation back and forth, before settling back to normal size and rotation.
  - Implements the `ease-tada-tooltip-ag` mixin. This mixin forces `opacity: 1` and `visibility: visible` and applies the `easeTadaTooltipAg` animation. It's designed to be attached to a tooltip's active state (e.g. `:hover`).
- **Accessibility**: 
  - Includes a `prefers-reduced-motion: reduce` media query that disables the animation. Because the mixin sets `opacity: 1` and `visibility: visible`, the tooltip will still function normally as a static element for users who prefer no motion.

---

# Files Changed
* `submissions/scss/feature-tada-tooltip-mixin-ag/_tada-tooltip.scss` - The SCSS mixin and keyframes, along with an example usage block.
* `submissions/scss/feature-tada-tooltip-mixin-ag/README.md` - Documentation explaining how to include and use the mixin.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (Verified SCSS compilation, tada animation timing, hover triggering, and reduced-motion enforcement).

---

# Impact
* Breaking changes: No (Standalone feature submission).
* Performance impact: Low.
* Security impact: None.
* Compatibility: Fully compatible with modern browsers.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
