### PR TITLE
Add CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts

### DIFF
--- a/submissions/examples/Add CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts #46347/README.md
+++ b/submissions/examples/Add CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts #46347/README.md
@@ -1,0 +1,38 @@
+# CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts
+
+A pure CSS tooltip component utilizing a "Draw-Border Line" animation, styled with a soft Neumorphic (soft UI) aesthetic. It employs light and dark drop shadows to create the illusion of extruded triggers and intruded tooltips.
+
+## Features
+- **Pure CSS**: Zero JavaScript required for the tooltip display or the drawing border animation.
+- **Draw-Border Animation**: Utilizes an SVG `rect` with `pathLength="100"`. The `stroke-dashoffset` is animated from 100 to 0 via a smooth CSS easing curve when triggered. The stroke incorporates a subtle `drop-shadow` to create a glowing, soft border effect.
+- **Neumorphic Aesthetic**: Features carefully calculated light (`#ffffff`) and dark (`#a3b1c6`) shadows against a matching soft background (`#e0e5ec`). The triggers appear extruded, while the tooltip box appears carved in (inset shadows).
+- **Responsive & Accessible**: Keyboard accessible through `:focus-within`. The visual focus state utilizes color shifts and scaling instead of harsh outlines to maintain the soft aesthetic without sacrificing usability.
+- **Custom Properties**: Easily tweak the motion and styling via variables such as `--draw-duration`, `--neu-bg`, and `--tooltip-border-color`.
+
+## Usage
+
+Include the `easemotion.css` framework and the local `style.css`. The animation relies on standard CSS transitions combined with `@starting-style` for the entrance, and SVG stroke properties for the border tracing effect.
+
+```html
+<div class="tooltip-container">
+  <!-- Trigger Button -->
+  <button class="neumorphic-btn" aria-describedby="tooltip-neu-1">
+    <svg>...</svg>
+  </button>
+  
+  <!-- Tooltip Wrapper -->
+  <div class="tooltip-wrapper" id="tooltip-neu-1" role="tooltip">
+    <div class="tooltip-box">
+      <!-- SVG for the draw-border effect -->
+      <!-- Make sure rx/ry match the border-radius of the tooltip-box -->
+      <svg class="tooltip-border-svg" aria-hidden="true" width="100%" height="100%">
+        <rect x="0" y="0" width="100%" height="100%" rx="16" ry="16" pathLength="100" />
+      </svg>
+      
+      <div class="tooltip-text">
+        <!-- Text Content -->
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/submissions/examples/Add CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts #46347/demo.html
+++ b/submissions/examples/Add CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts #46347/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Draw-Border Tooltip - Neumorphic Soft</title>
+  <link rel="stylesheet" href="../../../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="neumorphic-layout">
+    <div class="app-interface">
+      <h2 class="title">Sound Settings</h2>
+      
+      <div class="controls-row">
+        
+        <!-- Neumorphic Button 1 with Tooltip -->
+        <div class="tooltip-container">
+          <button class="neumorphic-btn" aria-describedby="tooltip-neu-1">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+              <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+            </svg>
+          </button>
+          
+          <!-- Tooltip Wrapper -->
+          <div class="tooltip-wrapper" id="tooltip-neu-1" role="tooltip">
+            <div class="tooltip-box">
+              <!-- Decorative Draw Border SVG -->
+              <svg class="tooltip-border-svg" aria-hidden="true" width="100%" height="100%">
+                <rect x="0" y="0" width="100%" height="100%" rx="16" ry="16" pathLength="100" />
+              </svg>
+              <div class="tooltip-text">
+                <strong>Master Volume</strong>
+                <span>Adjust global output level.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Neumorphic Button 2 with Tooltip -->
+        <div class="tooltip-container">
+          <button class="neumorphic-btn" aria-describedby="tooltip-neu-2">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path>
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+              <line x1="12" y1="19" x2="12" y2="23"></line>
+              <line x1="8" y1="23" x2="16" y2="23"></line>
+            </svg>
+          </button>
+          
+          <!-- Tooltip Wrapper -->
+          <div class="tooltip-wrapper" id="tooltip-neu-2" role="tooltip">
+            <div class="tooltip-box">
+              <!-- Decorative Draw Border SVG -->
+              <svg class="tooltip-border-svg" aria-hidden="true" width="100%" height="100%">
+                <rect x="0" y="0" width="100%" height="100%" rx="16" ry="16" pathLength="100" />
+              </svg>
+              <div class="tooltip-text">
+                <strong>Input Device</strong>
+                <span>Configure microphone sensitivity.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/Add CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts #46347/style.css
+++ b/submissions/examples/Add CSS Draw-Border Line Tooltip for Neumorphic Soft Layouts #46347/style.css
@@ -1,0 +1,203 @@
+:root {
+  /* --- Tooltip Custom Properties --- */
+  --draw-duration: 0.8s;
+  --tooltip-entrance-duration: var(--ease-speed-medium);
+  
+  /* Neumorphic specific colors */
+  --neu-bg: #e0e5ec;
+  --neu-text: #4a5568;
+  --neu-accent: #7f9cf5;
+  
+  /* Soft shadows */
+  --neu-shadow-light: #ffffff;
+  --neu-shadow-dark: #a3b1c6;
+  
+  --tooltip-border-color: var(--neu-accent);
+}
+
+body {
+  margin: 0;
+  font-family: 'Nunito', var(--ease-font-sans);
+  background-color: var(--neu-bg);
+  color: var(--neu-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  -webkit-font-smoothing: antialiased;
+}
+
+.neumorphic-layout {
+  padding: var(--ease-space-8);
+}
+
+.app-interface {
+  padding: var(--ease-space-10);
+  background: var(--neu-bg);
+  border-radius: 30px;
+  box-shadow: 9px 9px 16px var(--neu-shadow-dark), 
+              -9px -9px 16px var(--neu-shadow-light);
+  text-align: center;
+}
+
+.title {
+  font-size: var(--ease-text-2xl);
+  font-weight: 700;
+  color: #2d3748;
+  margin: 0 0 var(--ease-space-8) 0;
+}
+
+.controls-row {
+  display: flex;
+  gap: var(--ease-space-8);
+  justify-content: center;
+}
+
+/* --- TOOLTIP TRIGGER (Neumorphic Button) --- */
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.neumorphic-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--neu-bg);
+  border: none;
+  color: var(--neu-text);
+  cursor: pointer;
+  
+  /* Extruded state */
+  box-shadow: 7px 7px 15px var(--neu-shadow-dark),
+             -7px -7px 15px var(--neu-shadow-light);
+  
+  transition: all var(--ease-speed-fast) var(--ease-ease-out);
+}
+
+.neumorphic-btn svg {
+  transition: color var(--ease-speed-fast) var(--ease-ease-out),
+              transform var(--ease-speed-fast) var(--ease-ease-out);
+}
+
+/* Hover / Focus visual state */
+.neumorphic-btn:hover,
+.neumorphic-btn:focus-visible {
+  color: var(--neu-accent);
+  outline: none;
+}
+
+.neumorphic-btn:hover svg,
+.neumorphic-btn:focus-visible svg {
+  transform: scale(1.1);
+}
+
+/* Active / Pressed state (Intruded) */
+.neumorphic-btn:active {
+  box-shadow: inset 5px 5px 10px var(--neu-shadow-dark),
+              inset -5px -5px 10px var(--neu-shadow-light);
+}
+.neumorphic-btn:active svg {
+  transform: scale(0.95);
+}
+
+
+/* --- TOOLTIP WRAPPER --- */
+.tooltip-wrapper {
+  position: absolute;
+  bottom: calc(100% + var(--ease-space-6));
+  left: 50%;
+  width: 220px;
+  z-index: var(--ease-z-overlay);
+  pointer-events: none;
+  
+  display: none;
+  opacity: 0;
+  transform: translateX(-50%) translateY(8px);
+  transform-origin: bottom center;
+  
+  transition: opacity var(--tooltip-entrance-duration) var(--ease-ease-out),
+              transform var(--tooltip-entrance-duration) var(--ease-ease-out),
+              display var(--tooltip-entrance-duration) var(--ease-ease-out) allow-discrete;
+}
+
+/* Activate on Hover or Focus */
+.tooltip-container:hover .tooltip-wrapper,
+.tooltip-container:focus-within .tooltip-wrapper {
+  display: block;
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+@starting-style {
+  .tooltip-container:hover .tooltip-wrapper,
+  .tooltip-container:focus-within .tooltip-wrapper {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px);
+  }
+}
+
+/* --- TOOLTIP BOX & DRAW-BORDER --- */
+.tooltip-box {
+  display: block;
+  position: relative;
+  background: var(--neu-bg);
+  padding: var(--ease-space-4);
+  border-radius: 16px;
+  text-align: center;
+  /* Intruded shadow for tooltip content box */
+  box-shadow: inset 4px 4px 8px var(--neu-shadow-dark), 
+              inset -4px -4px 8px var(--neu-shadow-light);
+}
+
+.tooltip-border-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.tooltip-border-svg rect {
+  fill: none;
+  stroke: var(--tooltip-border-color);
+  stroke-width: 2px;
+  stroke-linecap: round;
+  /* Use pathLength="100" in SVG */
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100; /* Hidden state */
+  /* Soft easing for neumorphic feel */
+  transition: stroke-dashoffset var(--draw-duration) cubic-bezier(0.4, 0, 0.2, 1);
+  /* Slight blur for a softer line */
+  filter: drop-shadow(0 0 2px rgba(127, 156, 245, 0.5));
+}
+
+/* Draw the border when the container is hovered/focused */
+.tooltip-container:hover .tooltip-border-svg rect,
+.tooltip-container:focus-within .tooltip-border-svg rect {
+  stroke-dashoffset: 0;
+}
+
+/* --- TOOLTIP CONTENT --- */
+.tooltip-text {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-1);
+}
+
+.tooltip-text strong {
+  font-size: var(--ease-text-base);
+  font-weight: 700;
+  color: #2d3748;
+}
+
+.tooltip-text span {
+  font-size: var(--ease-text-xs);
+  color: var(--neu-text);
+}


### PR DESCRIPTION
#46347

## Pull Request Description

<!-- Briefly describe what you're submitting and the problem it solves. -->
-  created the CSS Draw-Border Tooltip with the smooth Neumorphic Soft aesthetic!
- Resolves #46347 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---



## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
