### PR TITLE
feat(scss): add fade fab mixin

### DIFF
--- a/submissions/scss/feature-fade-fab-mixin-ag/README.md
+++ b/submissions/scss/feature-fade-fab-mixin-ag/README.md
@@ -1,0 +1,50 @@
+# Fade FAB Mixin
+
+## Description
+The `ease-fade-fab-mixin-ag` is an SCSS mixin designed for Floating Action Buttons (FABs) or similar floating UI elements. It provides a smooth exit animation that combines a fade-out with a slight scale down and downward translation, making the button feel like it is dropping away naturally when it is dismissed or hidden.
+
+## Installation & Usage
+Import the `_fade-fab.scss` file into your styles.
+
+```scss
+@import 'path/to/feature-fade-fab-mixin-ag/fade-fab';
+
+.my-floating-button {
+  /* Basic FAB styling */
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  cursor: pointer;
+  
+  /* Include the mixin */
+  @include ease-fade-fab-mixin-ag(0.3s, ease-in);
+}
+```
+
+When you want to trigger the exit animation (e.g., via JavaScript before unmounting the component), add the `.exiting-ag` class to the element.
+
+```javascript
+const fab = document.querySelector('.my-floating-button');
+fab.classList.add('exiting-ag');
+
+// Remove the element after the animation completes
+fab.addEventListener('animationend', () => {
+  fab.remove();
+});
+```
+
+## Parameters
+The mixin accepts the following optional parameters:
+- `$duration`: How long the exit animation lasts. Default is `0.3s`.
+- `$easing`: The timing function. Default is `ease-in` (best for exit animations).
+
+## Accessibility Considerations
+- **Pointer Events**: The mixin applies `pointer-events: none` while the element is animating out to prevent accidental double-clicks or interaction during the exit phase.
+- **Reduced Motion**: Includes a `@media (prefers-reduced-motion: reduce)` media query. For users who prefer reduced motion, the downward translation and scale down are removed, leaving only a fast, simple opacity fade (`ease-fade-fab-fallback-ag`) to fulfill the exit requirement without triggering discomfort.

--- a/submissions/scss/feature-fade-fab-mixin-ag/_fade-fab.scss
+++ b/submissions/scss/feature-fade-fab-mixin-ag/_fade-fab.scss
@@ -1,0 +1,40 @@
+// _fade-fab.scss
+
+@keyframes ease-fade-fab-keyframes-ag {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+}
+
+/// A mixin that applies a fade out and scale down animation, typically used for dismissing a Floating Action Button (FAB).
+///
+/// @param {Time} $duration [0.3s] - The duration of the exit animation.
+/// @param {Timing-Function} $easing [ease-in] - The timing function.
+@mixin ease-fade-fab-mixin-ag(
+  $duration: 0.3s,
+  $easing: ease-in
+) {
+  will-change: transform, opacity;
+  
+  &.exiting-ag {
+    animation: ease-fade-fab-keyframes-ag $duration $easing forwards;
+    pointer-events: none;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    &.exiting-ag {
+      // Fallback: simple fade without translation/scaling
+      animation: ease-fade-fab-fallback-ag 0.2s linear forwards !important;
+    }
+  }
+}
+
+@keyframes ease-fade-fab-fallback-ag {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}


### PR DESCRIPTION

# Summary
This PR resolves the `[Feature] Fade FAB Mixin` issue by providing a beginner-friendly SCSS mixin that applies a smooth fade-out and scale-down exit animation to Floating Action Buttons (FABs) or similar floating UI elements.

---

# Root Cause
When floating action buttons (FABs) are dismissed or hidden, immediately removing them from the DOM can feel abrupt. Adding a polished exit animation that fades, scales, and translates the element downwards gives the impression that the button is naturally dropping away.

---

# Solution
Created the `feature-fade-fab-mixin-ag` in the `submissions/scss/` directory.
- `_fade-fab.scss`:
  - Contains the `ease-fade-fab-keyframes-ag` keyframes, which animate `opacity` from 1 to 0, `scale` from 1 to 0.9, and `translateY` from 0 to 10px.
  - Exposes the `ease-fade-fab-mixin-ag` mixin, accepting customizable `$duration` and `$easing` parameters.
  - Applies `pointer-events: none` to prevent accidental clicks while the element is animating out.
- **Accessibility**: 
  - A `prefers-reduced-motion: reduce` media query disables the scale and translation in the keyframes, substituting them with a simple `opacity` fade (`ease-fade-fab-fallback-ag`). This respects OS-level accessibility preferences by removing motion while still providing a clear visual exit cue.

---

# Files Changed
* `submissions/scss/feature-fade-fab-mixin-ag/_fade-fab.scss` - The SCSS mixin and keyframes.
* `submissions/scss/feature-fade-fab-mixin-ag/README.md` - Documentation on how to import and use the mixin.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (Verified exit animation, `pointer-events: none` behavior, customizable parameters, and reduced-motion fallback).

---

# Impact
* Breaking changes: No (Standalone feature submission).
* Performance impact: Low (Uses `transform` and `opacity` which are optimized via `will-change`).
* Security impact: None.
* Compatibility: Fully compatible with modern SCSS compilers.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
