### PR TITLE
feat(example): add ripple modal example

### DIFF
--- a/submissions/examples/feature-ripple-modal-example-ag/README.md
+++ b/submissions/examples/feature-ripple-modal-example-ag/README.md
@@ -1,0 +1,22 @@
+# Ripple Modal Example
+
+## Description
+This is a standard HTML/CSS/JS implementation of a modal that utilizes a "ripple" exit animation. Instead of abruptly disappearing, the modal performs a subtle inward squeeze followed by a scale-up and blur effect, giving the impression of a ripple dissipating into the background.
+
+## Installation & Usage
+1. Copy the HTML structure from `demo.html` into your project.
+2. Include the CSS from `style.css`.
+3. Include the JavaScript logic from `demo.html` to handle the opening and closing state classes.
+
+To trigger the exit animation, add the `.exiting-ag` class to both the modal overlay and the modal content. The JavaScript listens for the `animationend` event to finally remove the visibility classes.
+
+## How It Works
+- **State Management**: The modal visibility is toggled by adding/removing the `.visible` class on the overlay.
+- **Exit Animation**: The `rippleExit-ag` keyframes first scale the modal down slightly (to 0.95) to build anticipation, then scale it up (to 1.15) while applying a `blur(4px)` filter and fading to 0 opacity.
+- **Animation Sync**: JavaScript (`animationend` event listener) is used to ensure the element is only hidden (via `display: none` or `visibility: hidden`) after the CSS animation has completed.
+
+## Accessibility Considerations
+- **ARIA Attributes**: Uses `aria-hidden`, `aria-modal`, `role="dialog"`, and `aria-labelledby` to ensure screen readers correctly interpret the modal state.
+- **Keyboard Navigation**: Implements an event listener to close the modal when the `Escape` key is pressed.
+- **Pointer Events**: Applies `pointer-events: none` to the modal content while it is animating out, preventing accidental clicks during the transition.
+- **Reduced Motion**: Includes a `prefers-reduced-motion: reduce` media query that disables the complex ripple (scale and blur) and replaces it with a simple, fast opacity fade (`rippleExitFallback-ag`).

--- a/submissions/examples/feature-ripple-modal-example-ag/demo.html
+++ b/submissions/examples/feature-ripple-modal-example-ag/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ripple Modal Exit Animation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <button id="openModalBtn-ag" class="btn-ag">Open Modal</button>
+
+  <div id="modalOverlay-ag" class="modal-overlay-ag" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle-ag">
+    <div class="modal-content-ag">
+      <h2 id="modalTitle-ag">Important Information</h2>
+      <p>This is a ripple modal. When you close it, you'll see a smooth ripple-like exit animation radiating from the center as it scales down and fades away.</p>
+      <button id="closeModalBtn-ag" class="btn-ag btn-outline-ag">Dismiss</button>
+    </div>
+  </div>
+
+  <script>
+    const openBtn = document.getElementById('openModalBtn-ag');
+    const closeBtn = document.getElementById('closeModalBtn-ag');
+    const modalOverlay = document.getElementById('modalOverlay-ag');
+    const modalContent = document.querySelector('.modal-content-ag');
+
+    // Open Modal
+    openBtn.addEventListener('click', () => {
+      modalOverlay.classList.add('visible');
+      modalOverlay.setAttribute('aria-hidden', 'false');
+    });
+
+    // Close Modal with animation
+    const closeModal = () => {
+      // Add the exiting class to trigger the animation
+      modalOverlay.classList.add('exiting-ag');
+      modalContent.classList.add('exiting-ag');
+
+      // Wait for the animation to finish before actually hiding
+      modalContent.addEventListener('animationend', function handler(e) {
+        if (e.animationName === 'rippleExit-ag' || e.animationName === 'rippleExitFallback-ag') {
+          modalContent.removeEventListener('animationend', handler);
+          
+          modalOverlay.classList.remove('visible', 'exiting-ag');
+          modalContent.classList.remove('exiting-ag');
+          modalOverlay.setAttribute('aria-hidden', 'true');
+        }
+      });
+    };
+
+    closeBtn.addEventListener('click', closeModal);
+
+    // Close on overlay click
+    modalOverlay.addEventListener('click', (e) => {
+      if (e.target === modalOverlay) closeModal();
+    });
+
+    // Close on Escape key
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && modalOverlay.classList.contains('visible') && !modalOverlay.classList.contains('exiting-ag')) {
+        closeModal();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/feature-ripple-modal-example-ag/style.css
+++ b/submissions/examples/feature-ripple-modal-example-ag/style.css
@@ -1,0 +1,125 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  background-color: #f3f4f6;
+}
+
+.btn-ag {
+  padding: 0.75rem 1.5rem;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-ag:hover {
+  background-color: #2563eb;
+}
+
+.btn-outline-ag {
+  background-color: transparent;
+  color: #3b82f6;
+  border: 1px solid #3b82f6;
+  margin-top: 1rem;
+}
+
+.btn-outline-ag:hover {
+  background-color: #eff6ff;
+}
+
+/* Modal Overlay */
+.modal-overlay-ag {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+  z-index: 1000;
+}
+
+.modal-overlay-ag.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal-overlay-ag.exiting-ag {
+  /* Overlay fades out smoothly alongside the modal ripple */
+  transition: opacity 0.4s ease 0.1s;
+  opacity: 0;
+}
+
+/* Modal Content */
+.modal-content-ag {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  /* Hint for compositor */
+  will-change: transform, opacity, filter;
+}
+
+/* Initial enter transition */
+.modal-overlay-ag.visible .modal-content-ag:not(.exiting-ag) {
+  animation: modalEnter-ag 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes modalEnter-ag {
+  from { opacity: 0; transform: scale(0.95) translateY(10px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* Exit Animation: Ripple */
+@keyframes rippleExit-ag {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0px);
+  }
+  30% {
+    /* Slight inward squeeze before bursting */
+    transform: scale(0.95);
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    /* Ripple out (scale up and blur) */
+    transform: scale(1.15);
+    filter: blur(4px);
+  }
+}
+
+.modal-content-ag.exiting-ag {
+  animation: rippleExit-ag 0.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  pointer-events: none; /* Prevent clicks during exit */
+}
+
+/* Accessibility: Disable motion for users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  @keyframes rippleExitFallback-ag {
+    from { opacity: 1; }
+    to { opacity: 0; }
+  }
+
+  .modal-overlay-ag.visible .modal-content-ag:not(.exiting-ag) {
+    animation: none;
+  }
+
+  .modal-content-ag.exiting-ag {
+    animation: rippleExitFallback-ag 0.2s ease forwards !important;
+  }
+}


### PR DESCRIPTION

# Summary
This PR resolves the `[Feature] Ripple Modal Example` issue by providing a standard HTML/CSS/JS implementation of a modal with a "ripple" exit animation (scaling up and blurring as it fades out).

---

# Root Cause
Standard modals often dismiss instantly or with a simple opacity fade. A "ripple" exit effect adds a touch of playfulness and physical metaphor (like a drop dissipating in water) that makes the UI feel more premium.

---

# Solution
Created the `feature-ripple-modal-example-ag` in the `submissions/examples/` directory.
- `demo.html`: Contains the standard modal markup (overlay + content) and the Vanilla JS needed to manage the `.visible` and `.exiting-ag` classes, ensuring the modal is only removed after the CSS animation completes.
- `style.css`:
  - Contains the `rippleExit-ag` keyframes: the modal scales down slightly to build anticipation, then scales up while applying a `blur` filter and fading opacity to 0.
  - The overlay also fades out smoothly.
  - Prevents interaction during the exit phase using `pointer-events: none`.
- **Accessibility**: 
  - Standard ARIA attributes (`aria-hidden`, `aria-modal`, `role="dialog"`) are maintained.
  - Keyboard accessibility (pressing Escape closes the modal) is implemented.
  - A `prefers-reduced-motion: reduce` media query disables the scale and blur keyframes, substituting them with a simple `opacity` fade (`rippleExitFallback-ag`).

---

# Files Changed
* `submissions/examples/feature-ripple-modal-example-ag/demo.html` - Markup and logic for the modal.
* `submissions/examples/feature-ripple-modal-example-ag/style.css` - CSS containing the ripple exit animation.
* `submissions/examples/feature-ripple-modal-example-ag/README.md` - Documentation and explanation of the animation mechanics.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (Verified modal open/close, ripple animation, Escape key to close, overlay click to close, and reduced-motion fallback).

---

# Impact
* Breaking changes: No (Standalone feature submission).
* Performance impact: Low (Uses `transform`, `opacity`, and `filter` which are hinted via `will-change`).
* Security impact: None.
* Compatibility: Fully compatible with modern browsers.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
