### PR TITLE
feat(scss): add glitch avatar mixin

### DIFF
--- a/submissions/scss/feature-glitch-avatar-mixin-ag/README.md
+++ b/submissions/scss/feature-glitch-avatar-mixin-ag/README.md
@@ -1,0 +1,33 @@
+# Glitch Avatar Mixin
+
+## Description
+The `ease-glitch-avatar-mixin-ag` is an SCSS mixin that provides a dynamic "glitch" entrance animation. It uses translations, scaling, and colored `drop-shadow` filters (cyan and magenta) to simulate a digital screen glitch. This effect is perfect for gaming interfaces, cyberpunk-themed sites, or bringing a tech-focused avatar to life on initial load.
+
+## Installation & Usage
+Import the `_glitch-avatar.scss` file into your styles.
+
+```scss
+@import 'path/to/feature-glitch-avatar-mixin-ag/glitch-avatar';
+
+.my-user-avatar {
+  /* Basic avatar styling */
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+  
+  /* Apply the glitch entrance animation */
+  @include ease-glitch-avatar-mixin-ag(0.6s);
+}
+```
+
+## Parameters
+The mixin accepts the following optional parameters:
+- `$duration`: How long the glitch animation lasts. Default is `0.6s`.
+- `$easing`: The timing function. Default is `cubic-bezier(0.25, 0.46, 0.45, 0.94)`.
+
+## How It Works
+The `@keyframes ease-glitch-avatar-keyframes-ag` shifts the element slightly back and forth using `translate` and `scale`. Simultaneously, it applies aggressive cyan and magenta `drop-shadow` filters that alternate positions, mimicking RGB color separation seen in digital glitches, before settling into its final state at `40%` and staying static until `100%`.
+
+## Accessibility Considerations
+- **Reduced Motion**: The glitch effect includes intense flashing and erratic movement which can trigger discomfort or seizures in sensitive individuals. Therefore, a `@media (prefers-reduced-motion: reduce)` media query is strictly enforced. It completely bypasses the glitch keyframes and replaces them with a smooth, simple opacity fade (`ease-glitch-avatar-fallback-ag`).

--- a/submissions/scss/feature-glitch-avatar-mixin-ag/_glitch-avatar.scss
+++ b/submissions/scss/feature-glitch-avatar-mixin-ag/_glitch-avatar.scss
@@ -1,0 +1,53 @@
+// _glitch-avatar.scss
+
+@keyframes ease-glitch-avatar-keyframes-ag {
+  0% {
+    transform: translate(0) scale(0.9);
+    filter: drop-shadow(0px 0px 0px rgba(0,255,255,0)) drop-shadow(0px 0px 0px rgba(255,0,255,0));
+    opacity: 0;
+  }
+  10% {
+    transform: translate(-3px, 2px) scale(1.02);
+    filter: drop-shadow(4px 0px 0px rgba(0,255,255,0.7)) drop-shadow(-4px 0px 0px rgba(255,0,255,0.7));
+    opacity: 1;
+  }
+  20% {
+    transform: translate(3px, -2px) scale(0.98);
+    filter: drop-shadow(-4px 2px 0px rgba(0,255,255,0.7)) drop-shadow(4px -2px 0px rgba(255,0,255,0.7));
+  }
+  30% {
+    transform: translate(-2px, -1px) scale(1.01);
+    filter: drop-shadow(2px -2px 0px rgba(0,255,255,0.5)) drop-shadow(-2px 2px 0px rgba(255,0,255,0.5));
+  }
+  40% {
+    transform: translate(1px, 2px) scale(1);
+    filter: drop-shadow(0px 0px 0px rgba(0,255,255,0)) drop-shadow(0px 0px 0px rgba(255,0,255,0));
+  }
+  100% {
+    transform: translate(0) scale(1);
+    filter: drop-shadow(0px 0px 0px rgba(0,255,255,0)) drop-shadow(0px 0px 0px rgba(255,0,255,0));
+    opacity: 1;
+  }
+}
+
+/// A mixin that applies a glitch entrance animation, useful for avatars or hero images in cyberpunk or gaming UIs.
+///
+/// @param {Time} $duration [0.6s] - The duration of the glitch animation.
+/// @param {Timing-Function} $easing [cubic-bezier(0.25, 0.46, 0.45, 0.94)] - The timing function.
+@mixin ease-glitch-avatar-mixin-ag(
+  $duration: 0.6s,
+  $easing: cubic-bezier(0.25, 0.46, 0.45, 0.94)
+) {
+  will-change: transform, filter, opacity;
+  animation: ease-glitch-avatar-keyframes-ag $duration $easing forwards;
+  
+  @media (prefers-reduced-motion: reduce) {
+    // Fallback: simple fade-in
+    animation: ease-glitch-avatar-fallback-ag 0.3s ease-out forwards !important;
+  }
+}
+
+@keyframes ease-glitch-avatar-fallback-ag {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}


### PR DESCRIPTION

# Summary
This PR resolves the `[Feature] Glitch Avatar Mixin` issue by providing an SCSS mixin that applies a dynamic "digital glitch" entrance animation, perfect for cyberpunk, gaming, or tech-focused UIs.

---

# Root Cause
Avatars or hero images often enter the screen with a basic fade or slide. In specific thematic contexts (like gaming or retro-tech), a "glitch" entrance creates a much stronger, more memorable first impression.

---

# Solution
Created the `feature-glitch-avatar-mixin-ag` in the `submissions/scss/` directory.
- `_glitch-avatar.scss`:
  - Contains the `ease-glitch-avatar-keyframes-ag` keyframes, which simulate a digital glitch using a combination of rapid `translate`, `scale`, and alternating cyan/magenta `drop-shadow` filters.
  - Exposes the `ease-glitch-avatar-mixin-ag` mixin to easily apply this entrance animation.
- **Accessibility**: 
  - Glitch effects involve rapid flashing and movement which can be harmful or uncomfortable to users with vestibular disorders or photosensitivity.
  - A strict `prefers-reduced-motion: reduce` media query completely bypasses the glitch keyframes, falling back to a smooth, simple opacity fade (`ease-glitch-avatar-fallback-ag`) to ensure accessibility is maintained without compromise.

---

# Files Changed
* `submissions/scss/feature-glitch-avatar-mixin-ag/_glitch-avatar.scss` - The SCSS mixin and keyframes.
* `submissions/scss/feature-glitch-avatar-mixin-ag/README.md` - Documentation on usage and accessibility concerns.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (Verified glitch entrance animation, filter rendering, and critical reduced-motion fallback).

---

# Impact
* Breaking changes: No (Standalone feature submission).
* Performance impact: Medium (Uses `filter: drop-shadow`, but is mitigated by a short duration and `will-change`).
* Security impact: None.
* Compatibility: Fully compatible with modern SCSS compilers.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
