### PR TITLE
feat(scss): add glow banner mixin

### DIFF
--- a/submissions/scss/feature-glow-banner-mixin-ag/README.md
+++ b/submissions/scss/feature-glow-banner-mixin-ag/README.md
@@ -1,0 +1,50 @@
+# Glow Banner Mixin
+
+## Description
+The `ease-glow-banner-mixin-ag` is an SCSS mixin designed for banners, alerts, or notifications that are being dismissed. Instead of simply fading out, the banner briefly flashes a bright glow and slightly expands before dissipating. This creates a satisfying, energetic exit effect indicating that an action (like "accepting" or "dismissing") was successfully registered.
+
+## Installation & Usage
+Import the `_glow-banner.scss` file into your styles.
+
+```scss
+@import 'path/to/feature-glow-banner-mixin-ag/glow-banner';
+
+.my-alert-banner {
+  /* Basic banner styling */
+  background-color: #1e293b;
+  color: white;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  
+  /* Include the mixin */
+  @include ease-glow-banner-mixin-ag(0.6s);
+  
+  /* Optionally override the default glow color using the CSS variable */
+  --glow-color-ag: rgba(16, 185, 129, 0.6); /* emerald green glow */
+}
+```
+
+Trigger the exit animation by adding the `.exiting-ag` class, typically via JavaScript when the close button is clicked, before removing the element from the DOM.
+
+```javascript
+const banner = document.querySelector('.my-alert-banner');
+const closeBtn = banner.querySelector('.close-btn');
+
+closeBtn.addEventListener('click', () => {
+  banner.classList.add('exiting-ag');
+  banner.addEventListener('animationend', () => {
+    banner.remove();
+  });
+});
+```
+
+## Parameters
+The mixin accepts the following optional parameters:
+- `$duration`: How long the exit animation lasts. Default is `0.6s`.
+- `$easing`: The timing function. Default is `ease-in-out`.
+
+You can also customize the color of the glow dynamically by setting the `--glow-color-ag` CSS variable on the element.
+
+## Accessibility Considerations
+- **Pointer Events**: Applies `pointer-events: none` during the exit animation to prevent accidental clicks while the element is disappearing.
+- **Reduced Motion**: The glow effect and scaling can be distracting. A `@media (prefers-reduced-motion: reduce)` media query overrides the complex animation and replaces it with a simple, fast opacity fade (`ease-glow-banner-fallback-ag`), ensuring a calm and accessible experience for sensitive users.

--- a/submissions/scss/feature-glow-banner-mixin-ag/_glow-banner.scss
+++ b/submissions/scss/feature-glow-banner-mixin-ag/_glow-banner.scss
@@ -1,0 +1,49 @@
+// _glow-banner.scss
+
+@keyframes ease-glow-banner-exit-keyframes-ag {
+  0% {
+    opacity: 1;
+    box-shadow: 0 0 0 rgba(255, 255, 255, 0);
+    transform: scale(1);
+  }
+  40% {
+    opacity: 1;
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.8), 0 0 40px var(--glow-color-ag, rgba(59, 130, 246, 0.6));
+    transform: scale(1.02);
+  }
+  100% {
+    opacity: 0;
+    box-shadow: 0 0 60px rgba(255, 255, 255, 0), 0 0 80px var(--glow-color-ag, rgba(59, 130, 246, 0));
+    transform: scale(0.95);
+  }
+}
+
+/// A mixin that applies an exiting glow animation, useful for banners or alerts being dismissed.
+/// It flashes a glow before fading out and scaling down slightly.
+///
+/// @param {Time} $duration [0.6s] - The duration of the exit animation.
+/// @param {Timing-Function} $easing [ease-in-out] - The timing function.
+/// @param {Color} $glow-color [rgba(59, 130, 246, 0.6)] - Optional custom glow color, can be passed as a CSS variable `--glow-color-ag`.
+@mixin ease-glow-banner-mixin-ag(
+  $duration: 0.6s,
+  $easing: ease-in-out
+) {
+  will-change: transform, opacity, box-shadow;
+  
+  &.exiting-ag {
+    animation: ease-glow-banner-exit-keyframes-ag $duration $easing forwards;
+    pointer-events: none;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    &.exiting-ag {
+      // Fallback: simple fade-out without the intense glow or scaling
+      animation: ease-glow-banner-fallback-ag 0.3s linear forwards !important;
+    }
+  }
+}
+
+@keyframes ease-glow-banner-fallback-ag {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}


### PR DESCRIPTION

# Summary
This PR resolves the `[Feature] Glow Banner Mixin` issue by providing an SCSS mixin for an exit animation that flashes a bright glow and slightly expands before fading out, ideal for acknowledging dismissals of banners or alerts.

---

# Root Cause
When dismissing banners or alerts, a simple fade-out can sometimes feel unacknowledged by the system. Adding a "glow" burst before the fade provides a satisfying, energetic exit effect indicating that the action (like "accepting" or "dismissing") was successfully registered.

---

# Solution
Created the `feature-glow-banner-mixin-ag` in the `submissions/scss/` directory.
- `_glow-banner.scss`:
  - Contains the `ease-glow-banner-exit-keyframes-ag` keyframes, which animate `box-shadow` (to create the glow), `scale`, and `opacity`.
  - Exposes the `ease-glow-banner-mixin-ag` mixin.
  - Allows customization of the glow color via a CSS variable `--glow-color-ag`.
  - Applies `pointer-events: none` during the exit phase.
- **Accessibility**: 
  - A `prefers-reduced-motion: reduce` media query disables the scale and intense glow, falling back to a simple `opacity` fade (`ease-glow-banner-fallback-ag`) to prevent distraction or discomfort.

---

# Files Changed
* `submissions/scss/feature-glow-banner-mixin-ag/_glow-banner.scss` - The SCSS mixin and keyframes.
* `submissions/scss/feature-glow-banner-mixin-ag/README.md` - Documentation on usage, customization, and accessibility.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (Verified glow exit animation, CSS variable customization, pointer events, and reduced-motion fallback).

---

# Impact
* Breaking changes: No (Standalone feature submission).
* Performance impact: Medium (Uses `box-shadow`, but is mitigated by `will-change: box-shadow` and a short duration).
* Security impact: None.
* Compatibility: Fully compatible with modern SCSS compilers.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
