### PR TITLE
feat(examples): add tada checkbox example

### DIFF
--- a/submissions/examples/feature-tada-checkbox-example-ag/README.md
+++ b/submissions/examples/feature-tada-checkbox-example-ag/README.md
@@ -1,0 +1,32 @@
+# Tada Checkbox Example
+
+## Description
+This example provides a custom, accessible checkbox that performs a celebratory "tada" animation when it is checked. The animation scales and wiggles the checkbox, adding a micro-interaction that rewards the user for completing an action (like subscribing to a newsletter or finishing a to-do list item).
+
+## Files
+- `demo.html`: The HTML structure for the custom checkbox with an embedded SVG checkmark.
+- `style.css`: The CSS styling and the `@keyframes` for the tada animation.
+
+## Usage
+Simply open `demo.html` in any modern web browser.
+
+The setup relies on a visually hidden standard `<input type="checkbox">` connected to a `<label>`. 
+
+```html
+<label class="tada-checkbox-label-ag" for="subscribe-checkbox">
+    <input type="checkbox" id="subscribe-checkbox" class="tada-checkbox-input-ag" aria-checked="false">
+    <span class="tada-checkbox-box-ag" aria-hidden="true">
+        <!-- SVG Checkmark -->
+        ...
+    </span>
+    <span class="label-text-ag">Subscribe to Newsletter</span>
+</label>
+```
+
+When the hidden input's state becomes `:checked`, CSS sibling selectors (`+`) trigger the animation on the custom box.
+
+## Accessibility Considerations
+- **Visually Hidden Input**: The native checkbox is hidden visually but remains accessible to assistive technologies and keyboard focus via CSS clipping.
+- **Keyboard Navigation**: Native focus states are preserved and styled using `:focus-visible` with an `outline` to ensure clear keyboard navigation.
+- **ARIA Attributes**: `aria-checked` is synchronized with the input's state via JavaScript to properly announce state changes to screen readers.
+- **Reduced Motion**: The "tada" animation is disabled for users who prefer reduced motion using a `@media (prefers-reduced-motion: reduce)` query. The checkmark simply appears without any movement, maintaining a comfortable user experience.

--- a/submissions/examples/feature-tada-checkbox-example-ag/demo.html
+++ b/submissions/examples/feature-tada-checkbox-example-ag/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tada Checkbox Example</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="container-ag">
+        <h1>Tada Checkbox</h1>
+        <p>A fun checkbox that performs a celebratory "tada" animation when checked.</p>
+        
+        <div class="checkbox-wrapper-ag">
+            <label class="tada-checkbox-label-ag" for="subscribe-checkbox">
+                <input type="checkbox" id="subscribe-checkbox" class="tada-checkbox-input-ag" aria-checked="false">
+                <span class="tada-checkbox-box-ag" aria-hidden="true">
+                    <!-- SVG Checkmark -->
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="20 6 9 17 4 12"></polyline>
+                    </svg>
+                </span>
+                <span class="label-text-ag">Subscribe to Newsletter</span>
+            </label>
+        </div>
+    </main>
+    
+    <script>
+        const checkbox = document.getElementById('subscribe-checkbox');
+        checkbox.addEventListener('change', (e) => {
+            e.target.setAttribute('aria-checked', e.target.checked);
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/feature-tada-checkbox-example-ag/style.css
+++ b/submissions/examples/feature-tada-checkbox-example-ag/style.css
@@ -1,0 +1,122 @@
+/* style.css */
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+    background-color: #f8fafc;
+    color: #334155;
+}
+
+.container-ag {
+    background: white;
+    padding: 2.5rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    max-width: 400px;
+}
+
+.checkbox-wrapper-ag {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+/* Hide default checkbox visually */
+.tada-checkbox-input-ag {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+.tada-checkbox-label-ag {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    user-select: none;
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
+/* Custom Checkbox Box */
+.tada-checkbox-box-ag {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 28px;
+    height: 28px;
+    background-color: #e2e8f0;
+    border: 2px solid #cbd5e1;
+    border-radius: 6px;
+    transition: background-color 0.2s, border-color 0.2s;
+    will-change: transform;
+}
+
+/* SVG Checkmark styling */
+.tada-checkbox-box-ag svg {
+    width: 18px;
+    height: 18px;
+    color: white;
+    opacity: 0;
+    transform: scale(0.5);
+    transition: opacity 0.2s, transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Checked State */
+.tada-checkbox-input-ag:checked + .tada-checkbox-box-ag {
+    background-color: #10b981; /* Emerald green */
+    border-color: #10b981;
+    animation: ease-tada-ag 1s ease-in-out;
+}
+
+.tada-checkbox-input-ag:checked + .tada-checkbox-box-ag svg {
+    opacity: 1;
+    transform: scale(1);
+}
+
+/* Hover States */
+.tada-checkbox-label-ag:hover .tada-checkbox-box-ag {
+    border-color: #94a3b8;
+}
+
+.tada-checkbox-label-ag:hover .tada-checkbox-input-ag:checked + .tada-checkbox-box-ag {
+    background-color: #059669;
+    border-color: #059669;
+}
+
+/* Focus State */
+.tada-checkbox-input-ag:focus-visible + .tada-checkbox-box-ag {
+    outline: 3px solid rgba(16, 185, 129, 0.5);
+    outline-offset: 2px;
+}
+
+/* Tada Keyframes */
+@keyframes ease-tada-ag {
+    0% { transform: scale(1); }
+    10%, 20% { transform: scale(0.9) rotate(-3deg); }
+    30%, 50%, 70%, 90% { transform: scale(1.1) rotate(3deg); }
+    40%, 60%, 80% { transform: scale(1.1) rotate(-3deg); }
+    100% { transform: scale(1) rotate(0); }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .tada-checkbox-input-ag:checked + .tada-checkbox-box-ag {
+        animation: none;
+    }
+    .tada-checkbox-box-ag svg {
+        transition: opacity 0.1s;
+        transform: scale(1);
+    }
+}


### PR DESCRIPTION

# Summary
This PR resolves the `[Feature] Tada Checkbox Example` issue by providing a standard HTML/CSS implementation of a custom checkbox that performs a celebratory "tada" scale and rotation animation when checked.

---

# Root Cause
Checking off items (like subscribing or completing tasks) is a positive action for the user. A standard checkbox provides minimal feedback. Adding a micro-interaction like a "tada" wiggle rewards the user and makes the UI feel more playful and responsive.

---

# Solution
Created the `feature-tada-checkbox-example-ag` in the `submissions/examples/` directory.
- `demo.html`: Uses a visually hidden native `<input type="checkbox">` coupled with a custom visual box and an inline SVG checkmark, all wrapped in a `<label>`.
- `style.css`:
  - Styles the custom box.
  - Implements the `ease-tada-ag` keyframes, which slightly scale down, rotate left/right, and scale up the box before settling back to normal.
  - Animates the SVG checkmark scaling and fading in simultaneously.
- **Accessibility**: 
  - The native checkbox handles state and keyboard interactions.
  - Uses `:focus-visible` to apply a clear outline to the custom box for keyboard users.
  - A `prefers-reduced-motion: reduce` media query disables the tada animation and relies only on a simple opacity fade for the checkmark, preventing discomfort for sensitive users.

---

# Files Changed
* `submissions/examples/feature-tada-checkbox-example-ag/demo.html` - The HTML structure.
* `submissions/examples/feature-tada-checkbox-example-ag/style.css` - The CSS styles and tada animation.
* `submissions/examples/feature-tada-checkbox-example-ag/README.md` - Documentation on structure and accessibility.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (Verified tada animation, checkmark scaling, keyboard focus, and reduced-motion fallback).

---

# Impact
* Breaking changes: No (Standalone feature submission).
* Performance impact: Low (Uses `transform` with `will-change`).
* Security impact: None.
* Compatibility: Fully compatible with modern browsers.

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
