### PR TITLE
feat(scss): add Jello Badge Mixin

### DIFF
--- a/submissions/scss/feature-jello-badge-mixin-as/README.md
+++ b/submissions/scss/feature-jello-badge-mixin-as/README.md
@@ -1,0 +1,32 @@
+# Jello Badge Mixin
+
+## Overview
+
+A reusable SCSS mixin that adds a smooth jello animation to interactive badge elements.
+
+## Features
+
+- Smooth jello animation
+- Reusable SCSS mixin
+- Accessible focus styles
+- Supports `prefers-reduced-motion`
+- Easy to customize
+
+## Usage
+
+```scss
+@use "ease-motion" as *;
+
+.badge {
+  @include ease-jello-badge-mixin-as(0.5s);
+}
+```
+
+## Accessibility
+
+- Includes keyboard focus styling.
+- Respects the user's `prefers-reduced-motion` setting.
+
+## Why use it?
+
+This mixin provides a lightweight interactive animation suitable for badges, labels, and status indicators while following EaseMotion CSS contribution guidelines.

--- a/submissions/scss/feature-jello-badge-mixin-as/_jello-badge.scss
+++ b/submissions/scss/feature-jello-badge-mixin-as/_jello-badge.scss
@@ -1,0 +1,65 @@
+// Jello Badge Mixin - AS
+// Unique identifiers added for GSSoC submission.
+
+@mixin ease-jello-badge-mixin-as($duration: 0.5s) {
+  animation: ease-jello-badge-as $duration both;
+  transform-origin: center;
+  will-change: transform;
+}
+
+@keyframes ease-jello-badge-as {
+  0% {
+    transform: scale3d(1, 1, 1);
+  }
+
+  30% {
+    transform: scale3d(1.25, 0.75, 1);
+  }
+
+  40% {
+    transform: scale3d(0.75, 1.25, 1);
+  }
+
+  50% {
+    transform: scale3d(1.15, 0.85, 1);
+  }
+
+  65% {
+    transform: scale3d(0.95, 1.05, 1);
+  }
+
+  75% {
+    transform: scale3d(1.05, 0.95, 1);
+  }
+
+  100% {
+    transform: scale3d(1, 1, 1);
+  }
+}
+
+.ease-jello-badge-as {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    @include ease-jello-badge-mixin-as();
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-jello-badge-as {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/submissions/scss/feature-jello-badge-mixin-as/_jello-badge.scss
+++ b/submissions/scss/feature-jello-badge-mixin-as/_jello-badge.scss
@@ -45,16 +45,16 @@
   border-radius: 999px;
   font-weight: 600;
   cursor: pointer;
+}
 
-  &:hover,
-  &:focus-visible {
-    @include ease-jello-badge-mixin-as();
-  }
+.ease-jello-badge-as:hover,
+.ease-jello-badge-as:focus-visible {
+  animation: ease-jello-badge-as 0.5s both;
+}
 
-  &:focus-visible {
-    outline: 2px solid currentColor;
-    outline-offset: 2px;
-  }
+.ease-jello-badge-as:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Pull Request Description

This PR adds a reusable **Jello Badge SCSS mixin** as a standalone submission under the `submissions/` directory. The mixin provides a smooth interactive jello animation for badge elements while following the project's SCSS contribution guidelines, including accessibility and reduced-motion support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a reusable SCSS mixin that applies a smooth jello animation to badge elements with accessibility and reduced-motion support.

**How does a developer use it?**

```scss
@use "ease-motion" as *;

.badge {
  @include ease-jello-badge-mixin-as(0.5s);
}
```

**Why does it fit EaseMotion CSS?**

It provides a lightweight, reusable animation mixin that follows the project's animation-first philosophy while maintaining readability, accessibility, and performance.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Implemented as a standalone SCSS submission following the contribution guidelines. Unique `-as` identifiers have been appended to avoid naming conflicts.

As specified in the issue, only `_jello-badge.scss` and `README.md` are required for the SCSS track, so `demo.html` and `style.css` are not included.