### PR TITLE
feat(scss): add zoom text exit mixin

### DIFF
--- a/submissions/scss/feature-zoom-text-mixin-ag/README.md
+++ b/submissions/scss/feature-zoom-text-mixin-ag/README.md
@@ -1,0 +1,33 @@
+# Zoom Text Mixin
+
+## Description
+The `ease-zoom-text-mixin-ag` is an SCSS mixin that applies a zoom-out exit animation to text elements. The text scales up dramatically while fading out and blurring, creating a cinematic "exploding away" dismissal effect ideal for toast messages, alerts, or transitional headings.
+
+## Installation & Usage
+
+```scss
+@import 'path/to/feature-zoom-text-mixin-ag/zoom-text';
+
+.toast-message-dismissing {
+  @include ease-zoom-text-mixin-ag(0.5s, ease-in);
+  @include ease-zoom-text-reduced-motion-ag();
+}
+```
+
+## Parameters
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$duration` | Time | `0.5s` | Duration of the exit animation. |
+| `$easing` | Timing-Function | `ease-in` | Timing function for the animation curve. |
+
+## How It Works
+The keyframes animate three properties simultaneously:
+- `transform: scale(1) → scale(2.5)` — the text zooms outward.
+- `opacity: 1 → 0` — the text fades out.
+- `filter: blur(0) → blur(4px)` — the text softens as it disappears.
+
+The result is a text element that appears to "zoom past" the viewer and vanish.
+
+## Accessibility Considerations
+- **Reduced Motion**: The `ease-zoom-text-reduced-motion-ag` companion mixin provides a `prefers-reduced-motion` fallback. When active, the scaling and blur are completely disabled. The text simply fades out with a shorter duration, preventing any vestibular discomfort.
+- Always call both mixins together to ensure full accessibility coverage.

--- a/submissions/scss/feature-zoom-text-mixin-ag/_zoom-text.scss
+++ b/submissions/scss/feature-zoom-text-mixin-ag/_zoom-text.scss
@@ -1,0 +1,45 @@
+// _zoom-text.scss
+
+@keyframes ease-zoom-text-exit-ag {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(2.5);
+    filter: blur(4px);
+  }
+}
+
+/// A mixin that applies a zoom-out exit animation to text elements.
+/// The text scales up while fading out and blurring, creating a dramatic "exploding away" dismissal.
+///
+/// @param {Time} $duration [0.5s] - The duration of the zoom exit.
+/// @param {Timing-Function} $easing [ease-in] - The timing function.
+@mixin ease-zoom-text-mixin-ag(
+  $duration: 0.5s,
+  $easing: ease-in
+) {
+  will-change: transform, opacity, filter;
+  animation: ease-zoom-text-exit-ag $duration $easing forwards;
+}
+
+// Reduced motion fallback — simple fade without scale/blur
+@keyframes ease-zoom-text-exit-fallback-ag {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@mixin ease-zoom-text-reduced-motion-ag() {
+  @media (prefers-reduced-motion: reduce) {
+    animation: ease-zoom-text-exit-fallback-ag 0.3s ease-in forwards !important;
+    transform: none !important;
+    filter: none !important;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Zoom Text Mixin` issue. Provides an SCSS mixin for a dramatic text exit animation using scale, opacity, and blur.

# Solution
- `_zoom-text.scss`: Keyframes animate `scale(1→2.5)`, `opacity(1→0)`, and `blur(0→4px)` simultaneously.
- Companion `ease-zoom-text-reduced-motion-ag` mixin provides a safe fade-only fallback.

# Files Changed
* `submissions/scss/feature-zoom-text-mixin-ag/_zoom-text.scss`
* `submissions/scss/feature-zoom-text-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled
* [x] No unrelated changes
* [x] Ready for review