### PR TITLE
Tada FAB Mixin

### DIFF
--- a/submissions/scss/feature-tada-fab-mixin-ab/README.md
+++ b/submissions/scss/feature-tada-fab-mixin-ab/README.md
@@ -1,0 +1,139 @@
+# Tada FAB Mixin (`feature-tada-fab-mixin-ab`)
+
+Standalone **SCSS track** submission for [Issue #50775](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/50775).
+
+A beginner-friendly **tada hover effect** mixin for floating action buttons (FABs). Applies a smooth scale + rotate celebration cue on hover / focus without touching `core/` or `components/`.
+
+---
+
+## What it does
+
+- Defines unique `@keyframes tada-fab-ab` (classic tada: scale pulses + rotation)
+- Exposes `ease-tada-fab-mixin-ab` for one-line usage on any selector
+- Defaults to **hover + `:focus-visible`** so keyboard users get the same cue
+- Optional surface / extended FAB helpers for quick chrome + motion
+- Optional trigger-class generator for JS replay
+- Disables motion under `prefers-reduced-motion: reduce`
+
+---
+
+## Folder structure
+
+```
+submissions/scss/feature-tada-fab-mixin-ab/
+├── _tada-fab.scss   ← mixin + keyframes
+└── README.md        ← this file
+```
+
+---
+
+## Installation
+
+Copy `_tada-fab.scss` into your SCSS folder, then load it:
+
+```scss
+@use 'tada-fab' as *;
+// or: @import 'tada-fab';
+```
+
+---
+
+## Parameters — `ease-tada-fab-mixin-ab`
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `$duration` | Time | `0.8s` | Length of one tada cycle |
+| `$iteration` | Number / `infinite` | `1` | Plays per hover/focus |
+| `$delay` | Time | `0s` | Start delay |
+| `$easing` | String | `ease-in-out` | Timing function |
+| `$scale-grow` | Number | `1.12` | Peak scale |
+| `$scale-shrink` | Number | `0.92` | Opening dip scale |
+| `$rotate` | Angle | `8deg` | Peak rotation |
+| `$hover-only` | Boolean | `true` | Hover/focus vs play on load |
+
+---
+
+## Usage
+
+### Basic (matches issue example shape)
+
+```scss
+@use 'tada-fab' as *;
+
+.my-element {
+  @include ease-tada-fab-mixin-ab(0.5s);
+}
+```
+
+### FAB surface helper
+
+```scss
+.compose-fab-ab {
+  @include ease-tada-fab-surface-ab(0.5s);
+}
+```
+
+### Extended pill FAB
+
+```scss
+.chat-fab-ab {
+  @include ease-tada-fab-extended-ab(0.5s);
+}
+```
+
+### HTML example
+
+```html
+<button
+  type="button"
+  class="compose-fab-ab"
+  aria-label="Compose new note"
+>
+  +
+</button>
+
+<button type="button" class="chat-fab-ab" aria-label="Start chat">
+  💬 Chat
+</button>
+```
+
+Always use a real `<button>` (or link) with a clear `aria-label` when the FAB is icon-only.
+
+---
+
+## Why this is useful
+
+FABs compete with dense UI chrome. A short **tada** on hover/focus:
+
+1. Confirms the control is interactive
+2. Feels celebratory without a looping distraction
+3. Stays CSS-first via a reusable SCSS mixin
+4. Respects accessibility defaults out of the box
+
+A strong candidate for later curation into the official EaseMotion SCSS layer by the maintainer.
+
+---
+
+## Accessibility
+
+- Mixin wraps hover/focus animations in `@media (prefers-reduced-motion: reduce)` and removes them
+- Prefer semantic `<button>` elements with `aria-label` for icon-only FABs
+- `:focus-visible` is included so keyboard users receive the same tada cue
+- Avoid `$iteration: infinite` on large always-visible FABs; prefer a single play per hover
+
+---
+
+## Unique identifier
+
+All mixin names, keyframes, and CSS variables use the **`-ab`** suffix to avoid collisions with parallel submissions.
+
+---
+
+## Checklist (issue acceptance)
+
+- [x] Files live under `submissions/scss/feature-tada-fab-mixin-ab/`
+- [x] Required `_tada-fab.scss` + `README.md`
+- [x] Unique identifier on folder / mixins / keyframes
+- [x] Smooth tada hover effect
+- [x] `prefers-reduced-motion` handled
+- [x] README explains what / how / why

--- a/submissions/scss/feature-tada-fab-mixin-ab/_tada-fab.scss
+++ b/submissions/scss/feature-tada-fab-mixin-ab/_tada-fab.scss
@@ -1,0 +1,248 @@
+// ============================================================
+// Feature: Tada FAB Mixin (ab)
+// Issue: #50775 — hover tada effect for floating action buttons
+// Track: submissions/scss (SCSS)
+// ============================================================
+//
+// Usage:
+//   @use 'tada-fab' as *;
+//
+//   .my-fab {
+//     @include ease-tada-fab-mixin-ab(0.5s);
+//   }
+//
+// ============================================================
+
+/// Unique keyframe name — suffix avoids collisions with other submissions.
+$tada-fab-kf-ab: tada-fab-ab;
+
+/// Classic tada motion (scale + rotate pulses). Intensity via CSS variables.
+@keyframes #{$tada-fab-kf-ab} {
+  0% {
+    transform: scale(1) rotate(0deg);
+  }
+
+  10%,
+  20% {
+    transform: scale(var(--tada-fab-scale-shrink-ab, 0.92))
+      rotate(calc(var(--tada-fab-rotate-ab, 8deg) * -1));
+  }
+
+  30%,
+  50%,
+  70%,
+  90% {
+    transform: scale(var(--tada-fab-scale-grow-ab, 1.12))
+      rotate(var(--tada-fab-rotate-ab, 8deg));
+  }
+
+  40%,
+  60%,
+  80% {
+    transform: scale(var(--tada-fab-scale-grow-ab, 1.12))
+      rotate(calc(var(--tada-fab-rotate-ab, 8deg) * -1));
+  }
+
+  100% {
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+/// Apply a smooth tada hover effect to a FAB (or any button-like control).
+///
+/// By default the animation runs on `:hover` and `:focus-visible` so keyboard
+/// users get the same cue as pointer users.
+///
+/// @param {Time} $duration [0.8s]
+///   Length of one tada cycle. Issue example uses `0.5s` for a snappy cue.
+/// @param {Number|String} $iteration [1]
+///   How many times tada plays per hover/focus.
+/// @param {Time} $delay [0s]
+///   Delay before the animation starts.
+/// @param {String} $easing [ease-in-out]
+///   Timing function for the tada cycle.
+/// @param {Number} $scale-grow [1.12]
+///   Peak scale during celebration pulses.
+/// @param {Number} $scale-shrink [0.92]
+///   Dip scale at the start of the tada.
+/// @param {Angle} $rotate [8deg]
+///   Peak rotation angle.
+/// @param {Boolean} $hover-only [true]
+///   When true, tada runs on hover/focus-visible. When false, plays on load.
+///
+/// @example scss
+///   @use 'tada-fab' as *;
+///
+///   .my-element {
+///     @include ease-tada-fab-mixin-ab(0.5s);
+///   }
+///
+/// @example scss — stronger celebratory FAB
+///   .compose-fab-ab {
+///     @include ease-tada-fab-mixin-ab(
+///       $duration: 0.9s,
+///       $scale-grow: 1.18,
+///       $rotate: 10deg
+///     );
+///   }
+@mixin ease-tada-fab-mixin-ab(
+  $duration: 0.8s,
+  $iteration: 1,
+  $delay: 0s,
+  $easing: ease-in-out,
+  $scale-grow: 1.12,
+  $scale-shrink: 0.92,
+  $rotate: 8deg,
+  $hover-only: true
+) {
+  --tada-fab-scale-grow-ab: #{$scale-grow};
+  --tada-fab-scale-shrink-ab: #{$scale-shrink};
+  --tada-fab-rotate-ab: #{$rotate};
+
+  transform-origin: center;
+  will-change: transform;
+
+  @if $hover-only {
+    &:hover,
+    &:focus-visible {
+      animation-name: #{$tada-fab-kf-ab};
+      animation-duration: $duration;
+      animation-timing-function: $easing;
+      animation-delay: $delay;
+      animation-iteration-count: $iteration;
+      animation-fill-mode: both;
+    }
+
+    // Fine-pointer hover only; touch still gets :focus-visible / :active scale
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        animation-name: #{$tada-fab-kf-ab};
+      }
+    }
+  } @else {
+    animation-name: #{$tada-fab-kf-ab};
+    animation-duration: $duration;
+    animation-timing-function: $easing;
+    animation-delay: $delay;
+    animation-iteration-count: $iteration;
+    animation-fill-mode: both;
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  // Accessibility: disable tada for users who prefer reduced motion
+  @media (prefers-reduced-motion: reduce) {
+    animation: none !important;
+
+    &:hover,
+    &:focus-visible,
+    &:active {
+      animation: none !important;
+      transform: none !important;
+    }
+
+    will-change: auto;
+  }
+}
+
+/// Optional helper: FAB chrome + tada hover in one include.
+/// Self-contained tokens so the submission does not touch core/.
+///
+/// @param {Time} $duration [0.5s]
+/// @param {Color} $bg [#6c63ff]
+/// @param {Color} $fg [#ffffff]
+/// @param {Length} $size [3.5rem]
+///
+/// @example scss
+///   .fab-compose {
+///     @include ease-tada-fab-surface-ab(0.5s);
+///   }
+@mixin ease-tada-fab-surface-ab(
+  $duration: 0.5s,
+  $bg: #6c63ff,
+  $fg: #ffffff,
+  $size: 3.5rem
+) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: $size;
+  height: $size;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: $bg;
+  color: $fg;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow:
+    0 8px 20px rgba(15, 23, 42, 0.18),
+    0 2px 6px rgba(15, 23, 42, 0.12);
+  transition: box-shadow 160ms ease;
+
+  &:hover {
+    box-shadow:
+      0 12px 28px rgba(15, 23, 42, 0.22),
+      0 4px 10px rgba(15, 23, 42, 0.14);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.95);
+    outline-offset: 3px;
+    box-shadow:
+      0 0 0 6px rgba(108, 99, 255, 0.35),
+      0 12px 28px rgba(15, 23, 42, 0.22);
+  }
+
+  @include ease-tada-fab-mixin-ab($duration: $duration, $hover-only: true);
+}
+
+/// Extended (pill) FAB surface with label + tada hover.
+///
+/// @param {Time} $duration [0.5s]
+/// @param {Color} $bg [#6c63ff]
+/// @param {Color} $fg [#ffffff]
+///
+/// @example scss
+///   .fab-extended {
+///     @include ease-tada-fab-extended-ab(0.5s);
+///   }
+@mixin ease-tada-fab-extended-ab(
+  $duration: 0.5s,
+  $bg: #6c63ff,
+  $fg: #ffffff
+) {
+  @include ease-tada-fab-surface-ab(
+    $duration: $duration,
+    $bg: $bg,
+    $fg: $fg,
+    $size: auto
+  );
+
+  min-height: 3.1rem;
+  padding: 0 1.2rem 0 1rem;
+  gap: 0.5rem;
+}
+
+/// Utility class generator — toggle `.is-tada-fab-ab` from JS to replay tada.
+///
+/// @param {String} $class-name ['.is-tada-fab-ab']
+/// @param {Time} $duration [0.5s]
+///
+/// @example scss
+///   @include ease-tada-fab-trigger-class-ab;
+@mixin ease-tada-fab-trigger-class-ab(
+  $class-name: '.is-tada-fab-ab',
+  $duration: 0.5s
+) {
+  #{$class-name} {
+    @include ease-tada-fab-mixin-ab(
+      $duration: $duration,
+      $iteration: 1,
+      $hover-only: false
+    );
+  }
+}


### PR DESCRIPTION
# #50775 issue resolved

## Description

This PR adds a beginner-friendly **Tada FAB Mixin (Hover Effect)** under `submissions/scss/feature-tada-fab-mixin-ab/`.

## Features

- Smooth scale + rotate tada animation via SCSS mixin
- Hover and `:focus-visible` by default (keyboard-friendly)
- Optional FAB surface / extended helpers
- Respects `prefers-reduced-motion: reduce`
- Unique `-ab` suffix to avoid naming collisions