### PR TITLE
feat(scss): add swing badge mixin

### DIFF
--- a/submissions/scss/feature-swing-badge-mixin-ag/README.md
+++ b/submissions/scss/feature-swing-badge-mixin-ag/README.md
@@ -1,0 +1,35 @@
+# Swing Badge Mixin
+
+## Description
+The `ease-swing-badge-mixin-ag` is an SCSS mixin that applies a pendulum-like swing animation to badge elements. The element pivots from its top-center, swaying back and forth like a hanging tag. This is perfect for drawing attention to notification badges, sale labels, or new feature tags.
+
+## Installation & Usage
+
+```scss
+@import 'path/to/feature-swing-badge-mixin-ag/swing-badge';
+
+.notification-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background: #ef4444;
+  color: white;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+
+  @include ease-swing-badge-mixin-ag(0.8s, ease-in-out, 2);
+}
+```
+
+## Parameters
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$duration` | Time | `0.8s` | Duration of one full swing cycle. |
+| `$easing` | Timing-Function | `ease-in-out` | Timing function. |
+| `$iterations` | Number | `1` | Number of iterations. Use `infinite` for continuous swinging. |
+
+## How It Works
+The keyframes rotate the element through decreasing angles (15° → -10° → 5° → -5° → 2° → 0°), creating a natural damped oscillation. Setting `transform-origin: top center` makes the element swing from its top edge, simulating a pendulum.
+
+## Accessibility Considerations
+- **Reduced Motion**: A `@media (prefers-reduced-motion: reduce)` block disables the animation entirely. The badge remains static — no swing, no rotation — ensuring a safe experience for users with vestibular sensitivities.

--- a/submissions/scss/feature-swing-badge-mixin-ag/_swing-badge.scss
+++ b/submissions/scss/feature-swing-badge-mixin-ag/_swing-badge.scss
@@ -1,0 +1,46 @@
+// _swing-badge.scss
+
+@keyframes ease-swing-badge-attention-ag {
+  0% {
+    transform: rotate(0deg);
+  }
+  15% {
+    transform: rotate(15deg);
+  }
+  30% {
+    transform: rotate(-10deg);
+  }
+  45% {
+    transform: rotate(5deg);
+  }
+  60% {
+    transform: rotate(-5deg);
+  }
+  75% {
+    transform: rotate(2deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+/// A mixin that applies a pendulum-like swing animation to badge elements.
+/// The element pivots from its top-center, creating a swaying "hanging tag" effect.
+///
+/// @param {Time} $duration [0.8s] - The duration of one swing cycle.
+/// @param {Timing-Function} $easing [ease-in-out] - The timing function.
+/// @param {Number} $iterations [1] - Number of times the animation plays. Use `infinite` for continuous.
+@mixin ease-swing-badge-mixin-ag(
+  $duration: 0.8s,
+  $easing: ease-in-out,
+  $iterations: 1
+) {
+  transform-origin: top center;
+  will-change: transform;
+  animation: ease-swing-badge-attention-ag $duration $easing $iterations;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Swing Badge Mixin` issue. Provides an SCSS mixin for a pendulum-like swing animation for badge/tag elements.

# Solution
- `_swing-badge.scss`: Keyframes rotate through decreasing angles (15°→-10°→5°→-5°→2°→0°) for natural damped oscillation. Uses `transform-origin: top center` for pendulum pivot.
- Configurable duration, easing, and iteration count.
- `prefers-reduced-motion` disables all animation.

# Files Changed
* `submissions/scss/feature-swing-badge-mixin-ag/_swing-badge.scss`
* `submissions/scss/feature-swing-badge-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled
* [x] No unrelated changes
* [x] Ready for review