### PR TITLE
feat(example): add rotate image exit animation

### DIFF
--- a/submissions/examples/feature-rotate-image-example-ag/README.md
+++ b/submissions/examples/feature-rotate-image-example-ag/README.md
@@ -1,0 +1,21 @@
+# Rotate Image Exit Animation Example
+
+## Description
+This example demonstrates a **rotate exit animation** for image elements. When dismissed, the image rotates 90 degrees while shrinking and fading out, creating an elegant "spinning away" departure effect. This pattern is useful for photo galleries, dismissible cards, or media viewers.
+
+## Usage
+Open `demo.html` in a browser. Click **Dismiss Image** to trigger the rotate exit animation. Click **Reset** to bring the image back.
+
+## How It Works
+- The `ease-rotate-image-exit-ag` keyframes animate:
+  - `rotate(0deg) → rotate(90deg)` — the image spins.
+  - `scale(1) → scale(0.6)` — the image shrinks.
+  - `opacity: 1 → 0` — the image fades out.
+- On `animationend`, the image's `visibility` is set to `hidden` to remove it from interactive flow.
+- The **Reset** button removes the `exiting-ag` class and restores visibility.
+
+## Accessibility Considerations
+- **Reduced Motion**: The `@media (prefers-reduced-motion: reduce)` query disables the rotation animation entirely. The image simply fades out with a quick opacity transition.
+- Buttons include descriptive `aria-label` attributes.
+- Semantic HTML is used throughout (`<h1>`, `<p>`, `<button>`).
+- Focus-visible outlines are provided on buttons for keyboard navigation.

--- a/submissions/examples/feature-rotate-image-example-ag/demo.html
+++ b/submissions/examples/feature-rotate-image-example-ag/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rotate Image Exit Animation Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container-ag">
+    <h1>Rotate Image Exit Animation</h1>
+    <p>Click the button to dismiss the image with a rotating exit animation.</p>
+
+    <div class="image-stage-ag">
+      <img
+        id="rotate-exit-image-ag"
+        src="https://picsum.photos/seed/rotate-exit/320/240"
+        alt="Sample landscape photo used for the rotate exit demo"
+        class="rotate-image-ag"
+      />
+    </div>
+
+    <div class="controls-ag">
+      <button id="dismiss-btn-ag" class="btn-ag" aria-label="Dismiss image with rotation">
+        Dismiss Image
+      </button>
+      <button id="reset-btn-ag" class="btn-ag btn-secondary-ag" aria-label="Reset the image back to view">
+        Reset
+      </button>
+    </div>
+  </div>
+
+  <script>
+    const image = document.getElementById('rotate-exit-image-ag');
+    const dismissBtn = document.getElementById('dismiss-btn-ag');
+    const resetBtn = document.getElementById('reset-btn-ag');
+
+    dismissBtn.addEventListener('click', () => {
+      image.classList.add('exiting-ag');
+      // After animation ends, hide the element
+      image.addEventListener('animationend', () => {
+        image.style.visibility = 'hidden';
+      }, { once: true });
+    });
+
+    resetBtn.addEventListener('click', () => {
+      image.classList.remove('exiting-ag');
+      image.style.visibility = 'visible';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/feature-rotate-image-example-ag/style.css
+++ b/submissions/examples/feature-rotate-image-example-ag/style.css
@@ -1,0 +1,113 @@
+/* style.css */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #f1f5f9;
+}
+
+.demo-container-ag {
+  text-align: center;
+  padding: 2rem;
+}
+
+.demo-container-ag h1 {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo-container-ag p {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+}
+
+.image-stage-ag {
+  width: 320px;
+  height: 240px;
+  margin: 0 auto 2rem;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.rotate-image-ag {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: visibility 0s;
+}
+
+/* Exit animation keyframes */
+@keyframes ease-rotate-image-exit-ag {
+  0% {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(90deg) scale(0.6);
+  }
+}
+
+.rotate-image-ag.exiting-ag {
+  animation: ease-rotate-image-exit-ag 0.6s ease-in forwards;
+  will-change: transform, opacity;
+}
+
+/* Controls */
+.controls-ag {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.btn-ag {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: #3b82f6;
+  color: white;
+  transition: background 0.2s ease;
+}
+
+.btn-ag:hover {
+  background: #2563eb;
+}
+
+.btn-ag:focus-visible {
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.btn-secondary-ag {
+  background: #475569;
+}
+
+.btn-secondary-ag:hover {
+  background: #64748b;
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .rotate-image-ag.exiting-ag {
+    animation: none !important;
+    opacity: 0;
+    transition: opacity 0.3s ease-in;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Rotate Image Example` issue. Provides a standard HTML/CSS example of a rotate exit animation for images.

# Solution
- `demo.html`: Interactive demo with Dismiss/Reset buttons. Image rotates 90° while shrinking and fading out.
- `style.css`: Contains `ease-rotate-image-exit-ag` keyframes (`rotate + scale + opacity`).
- `prefers-reduced-motion` replaces rotation with a simple opacity fade.

# Files Changed
* `submissions/examples/feature-rotate-image-example-ag/demo.html`
* `submissions/examples/feature-rotate-image-example-ag/style.css`
* `submissions/examples/feature-rotate-image-example-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled
* [x] No unrelated changes
* [x] Ready for review