### PR TITLE
feat(react): add jello toggle component

### DIFF
--- a/submissions/react/feature-jello-toggle-component-ag/JelloToggle.jsx
+++ b/submissions/react/feature-jello-toggle-component-ag/JelloToggle.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import './style.css';
+
+/**
+ * JelloToggle
+ * 
+ * A toggle switch component that plays a jello wobble animation
+ * on the knob when toggled, creating a playful, bouncy effect.
+ */
+const JelloToggle = ({
+  label,
+  initialValue = false,
+  onChange,
+}) => {
+  const [isOn, setIsOn] = useState(initialValue);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const handleToggle = () => {
+    const newValue = !isOn;
+    setIsOn(newValue);
+    setIsAnimating(true);
+    if (onChange) onChange(newValue);
+  };
+
+  const handleAnimationEnd = () => {
+    setIsAnimating(false);
+  };
+
+  return (
+    <div className="jello-toggle-wrapper-ag">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isOn}
+        aria-label={label || 'Toggle switch'}
+        className={`jello-toggle-track-ag ${isOn ? 'is-on-ag' : ''}`}
+        onClick={handleToggle}
+      >
+        <span
+          className={`jello-toggle-knob-ag ${isAnimating ? 'jello-ag' : ''}`}
+          onAnimationEnd={handleAnimationEnd}
+          aria-hidden="true"
+        />
+      </button>
+      {label && <span className="jello-toggle-label-ag">{label}</span>}
+    </div>
+  );
+};
+
+export default JelloToggle;

--- a/submissions/react/feature-jello-toggle-component-ag/README.md
+++ b/submissions/react/feature-jello-toggle-component-ag/README.md
@@ -1,0 +1,41 @@
+# Jello Toggle Component
+
+## Description
+The `JelloToggle` is a React toggle switch component that applies a playful jello wobble animation to the knob whenever the user toggles it. The skew-based jello effect creates a bouncy, organic feel that makes the interaction delightful.
+
+## Installation & Usage
+
+```jsx
+import JelloToggle from './JelloToggle';
+
+function App() {
+  return (
+    <div>
+      <JelloToggle
+        label="Dark mode"
+        initialValue={false}
+        onChange={(isOn) => console.log('Toggle:', isOn)}
+      />
+    </div>
+  );
+}
+```
+
+## Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | — | Label text displayed next to the toggle. |
+| `initialValue` | `boolean` | `false` | Initial on/off state. |
+| `onChange` | `function` | — | Callback fired with the new boolean value on toggle. |
+
+## How It Works
+- The component uses `role="switch"` and `aria-checked` for accessible toggle semantics.
+- On click, the `jello-ag` class is added to the knob, triggering the `ease-jello-toggle-ag` keyframes.
+- The keyframes use decreasing `skewX`/`skewY` values (12.5° → 6.25° → 3.125° → ...) to create natural damped wobble.
+- A CSS variable `--knob-x-ag` coordinates the jello animation with the knob's translated position.
+
+## Accessibility Considerations
+- **ARIA**: Uses `role="switch"` with `aria-checked` for proper switch semantics.
+- **Keyboard**: Fully accessible via keyboard (Space/Enter to toggle).
+- **Focus**: `focus-visible` outline on the track for keyboard navigation.
+- **Reduced Motion**: The `@media (prefers-reduced-motion: reduce)` query disables the jello wobble entirely. The knob slides smoothly without any skew deformation.

--- a/submissions/react/feature-jello-toggle-component-ag/style.css
+++ b/submissions/react/feature-jello-toggle-component-ag/style.css
@@ -1,0 +1,100 @@
+/* style.css */
+
+.jello-toggle-wrapper-ag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.jello-toggle-track-ag {
+  position: relative;
+  width: 52px;
+  height: 28px;
+  border-radius: 9999px;
+  border: none;
+  background-color: #d1d5db;
+  cursor: pointer;
+  padding: 2px;
+  transition: background-color 0.25s ease;
+}
+
+.jello-toggle-track-ag:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.jello-toggle-track-ag.is-on-ag {
+  background-color: #3b82f6;
+}
+
+.jello-toggle-knob-ag {
+  display: block;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.25s ease;
+}
+
+.jello-toggle-track-ag.is-on-ag .jello-toggle-knob-ag {
+  transform: translateX(24px);
+}
+
+/* Jello Animation */
+@keyframes ease-jello-toggle-ag {
+  0% {
+    transform: translateX(var(--knob-x-ag, 0)) scale(1, 1);
+  }
+  22.2% {
+    transform: translateX(var(--knob-x-ag, 0)) skewX(-12.5deg) skewY(-12.5deg);
+  }
+  33.3% {
+    transform: translateX(var(--knob-x-ag, 0)) skewX(6.25deg) skewY(6.25deg);
+  }
+  44.4% {
+    transform: translateX(var(--knob-x-ag, 0)) skewX(-3.125deg) skewY(-3.125deg);
+  }
+  55.5% {
+    transform: translateX(var(--knob-x-ag, 0)) skewX(1.5625deg) skewY(1.5625deg);
+  }
+  66.6% {
+    transform: translateX(var(--knob-x-ag, 0)) skewX(-0.78125deg) skewY(-0.78125deg);
+  }
+  77.7% {
+    transform: translateX(var(--knob-x-ag, 0)) skewX(0.390625deg) skewY(0.390625deg);
+  }
+  100% {
+    transform: translateX(var(--knob-x-ag, 0)) scale(1, 1);
+  }
+}
+
+/* Apply jello on the knob in OFF state (translateX = 0) */
+.jello-toggle-knob-ag.jello-ag {
+  --knob-x-ag: 0px;
+  animation: ease-jello-toggle-ag 0.7s ease forwards;
+  will-change: transform;
+}
+
+/* Apply jello on the knob in ON state (translateX = 24px) */
+.jello-toggle-track-ag.is-on-ag .jello-toggle-knob-ag.jello-ag {
+  --knob-x-ag: 24px;
+}
+
+.jello-toggle-label-ag {
+  color: #374151;
+  font-size: 0.9375rem;
+  user-select: none;
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .jello-toggle-knob-ag.jello-ag {
+    animation: none !important;
+  }
+
+  .jello-toggle-knob-ag {
+    transition: transform 0.15s ease;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Jello Toggle Component` issue. Provides a React toggle switch component that applies a playful jello wobble animation to the knob when toggled.

# Solution
- `JelloToggle.jsx`: React component with `isOn` and `isAnimating` state. Triggers `ease-jello-toggle-ag` keyframes on state change.
- `style.css`: The keyframes use decreasing `skewX`/`skewY` values to create natural damped wobble. Uses CSS variables for position tracking.
- `prefers-reduced-motion` disables the jello wobble entirely.

# Files Changed
* `submissions/react/feature-jello-toggle-component-ag/JelloToggle.jsx`
* `submissions/react/feature-jello-toggle-component-ag/style.css`
* `submissions/react/feature-jello-toggle-component-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled
* [x] No unrelated changes
* [x] Ready for review