### PR TITLE
feat(scss): add flip checkbox mixin

### DIFF
--- a/submissions/scss/feature-flip-checkbox-mixin-ag/README.md
+++ b/submissions/scss/feature-flip-checkbox-mixin-ag/README.md
@@ -1,0 +1,45 @@
+# Flip Checkbox Mixin
+
+## Description
+The `ease-flip-checkbox-mixin-ag` is an SCSS mixin that transforms a standard HTML checkbox into a custom, accessible checkbox with a fun 3D flip animation when toggled. When the user checks the box, it flips 180 degrees along the Y-axis to reveal the checkmark.
+
+## Installation & Usage
+
+```scss
+@import 'path/to/feature-flip-checkbox-mixin-ag/flip-checkbox';
+
+.my-flip-checkbox {
+  @include ease-flip-checkbox-mixin-ag(0.5s, ease);
+  color: #3b82f6; // Uses currentColor for border and focus
+  
+  // Customizing colors for the checked state
+  input[type="checkbox"]:checked + .checkbox-visual {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+  }
+}
+```
+
+```html
+<label class="my-flip-checkbox">
+  <input type="checkbox" aria-label="Subscribe to newsletter" />
+  <span class="checkbox-visual"></span>
+  <span class="checkbox-label">Subscribe</span>
+</label>
+```
+
+## Parameters
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$duration` | Time | `0.4s` | Duration of the flip animation. |
+| `$easing` | Timing-Function | `cubic-bezier(0.4, 0, 0.2, 1)` | Timing function for the 3D rotation. |
+
+## How It Works
+The mixin relies on a specific HTML structure (`<label>` wrapping a hidden `<input type="checkbox">` and a visible `<span class="checkbox-visual">`). 
+It uses CSS `perspective` and `transform-style: preserve-3d` to give depth to the flip.
+When the hidden input is `:checked`, the sibling selector (`+`) targets `.checkbox-visual` and applies `transform: rotateY(180deg)`. The checkmark inside is already rotated 180 degrees with `backface-visibility: hidden`, so it appears correctly upright when the box flips.
+
+## Accessibility Considerations
+- The native checkbox is hidden visually but remains in the DOM, ensuring full screen reader support and keyboard navigation.
+- The `:focus-visible` pseudo-class is applied to the visible box when the hidden input receives focus.
+- **Reduced Motion**: Disables the 3D flip entirely via `@media (prefers-reduced-motion: reduce)`. The checkmark will instead appear instantly when checked.

--- a/submissions/scss/feature-flip-checkbox-mixin-ag/_flip-checkbox.scss
+++ b/submissions/scss/feature-flip-checkbox-mixin-ag/_flip-checkbox.scss
@@ -1,0 +1,79 @@
+// _flip-checkbox.scss
+
+/// A mixin that creates a 3D flip animation for a custom checkbox upon checking.
+/// When the checkbox is checked, it flips around the Y-axis.
+///
+/// @param {Time} $duration [0.4s] - The duration of the flip animation.
+/// @param {Timing-Function} $easing [cubic-bezier(0.4, 0, 0.2, 1)] - The timing function for the flip.
+@mixin ease-flip-checkbox-mixin-ag(
+  $duration: 0.4s,
+  $easing: cubic-bezier(0.4, 0, 0.2, 1)
+) {
+  // Base setup for 3D transforms
+  perspective: 400px;
+  display: inline-block;
+  cursor: pointer;
+  position: relative;
+
+  // Hide the actual native checkbox visually, but keep it accessible
+  input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  // The visual box
+  .checkbox-visual {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border: 2px solid currentColor;
+    border-radius: 4px;
+    transition: transform $duration $easing, background-color $duration $easing, border-color $duration $easing;
+    transform-style: preserve-3d;
+  }
+
+  // Focus ring on the visual box when the hidden input is focused
+  input[type="checkbox"]:focus-visible + .checkbox-visual {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+
+  // When checked, trigger the flip
+  input[type="checkbox"]:checked + .checkbox-visual {
+    transform: rotateY(180deg);
+  }
+
+  // Checkmark icon (only visible when flipped to the 'checked' side)
+  // We use backface-visibility and rotate it 180deg so it's upright when the box is flipped 180deg.
+  .checkbox-visual::after {
+    content: "✓";
+    position: absolute;
+    font-size: 14px;
+    font-weight: bold;
+    transform: rotateY(180deg);
+    backface-visibility: hidden;
+    color: white; // Assuming a colored background when checked
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .checkbox-visual {
+      transition: background-color 0.1s ease, border-color 0.1s ease !important;
+    }
+    input[type="checkbox"]:checked + .checkbox-visual {
+      transform: none !important; // Disable the flip
+    }
+    .checkbox-visual::after {
+      transform: none !important; // Keep it upright
+      display: none;
+    }
+    input[type="checkbox"]:checked + .checkbox-visual::after {
+      display: block; // Just show it instantly instead of flipping
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Flip Checkbox Mixin` issue. Provides an SCSS mixin for a 3D flip animation on checkboxes.

# Solution
- `_flip-checkbox.scss`: Uses `rotateY(180deg)` and `backface-visibility` for a smooth 3D flip when toggled. Replaces the native checkbox with a stylized visual box for better animation control.
- `prefers-reduced-motion` replaces the 3D flip with a simple instant toggle.

# Files Changed
* `submissions/scss/feature-flip-checkbox-mixin-ag/_flip-checkbox.scss`
* `submissions/scss/feature-flip-checkbox-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Visually hidden native input)
* [x] No unrelated changes
* [x] Ready for review