### PR TITLE
Jello Accordion Component

### DIFF
--- a/submissions/react/feature-jello-accordion-component-ab/JelloAccordion.jsx
+++ b/submissions/react/feature-jello-accordion-component-ab/JelloAccordion.jsx
@@ -1,0 +1,268 @@
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+import "./style.css";
+
+/**
+ * JelloAccordion — React accordion with a smooth jello entrance animation.
+ * Issue #50773 · submissions/react/feature-jello-accordion-component-ab
+ *
+ * Supports:
+ * 1) Simple single panel: <JelloAccordion title="FAQ">Hello</JelloAccordion>
+ * 2) Multi panel via `items` prop
+ *
+ * @param {object} props
+ * @param {React.ReactNode} [props.children] - Panel body (single-item mode)
+ * @param {string} [props.title='Details'] - Header label (single-item mode)
+ * @param {Array<{id?: string, title: string, content: React.ReactNode, defaultOpen?: boolean}>} [props.items]
+ * @param {boolean} [props.allowMultiple=false] - Allow multiple panels open
+ * @param {'soft'|'medium'|'strong'} [props.intensity='medium'] - Jello intensity
+ * @param {boolean} [props.defaultOpen=false] - Open the first/single panel by default
+ * @param {boolean} [props.enterOnMount=true] - Play entrance jello when items mount
+ * @param {string} [props.className=''] - Extra class names
+ * @param {string} [props.label] - Accessible name for the accordion region
+ */
+export default function JelloAccordion({
+  children = "Hello",
+  title = "Details",
+  items,
+  allowMultiple = false,
+  intensity = "medium",
+  defaultOpen = false,
+  enterOnMount = true,
+  className = "",
+  label = "Jello accordion",
+  ...rest
+}) {
+  const reactId = useId();
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  const panels = useMemo(() => {
+    if (Array.isArray(items) && items.length > 0) {
+      return items.map((item, index) => ({
+        id: String(item.id ?? `${reactId}-item-${index}`),
+        title: item.title,
+        content: item.content,
+        defaultOpen: Boolean(item.defaultOpen),
+      }));
+    }
+
+    return [
+      {
+        id: `${reactId}-single`,
+        title,
+        content: children,
+        defaultOpen,
+      },
+    ];
+  }, [items, children, title, defaultOpen, reactId]);
+
+  const initialOpen = useMemo(() => {
+    const openIds = panels
+      .filter((panel) => panel.defaultOpen)
+      .map((panel) => panel.id);
+    if (openIds.length > 0) return openIds;
+    if (defaultOpen && panels[0]) return [panels[0].id];
+    return [];
+  }, [panels, defaultOpen]);
+
+  const [openIds, setOpenIds] = useState(initialOpen);
+  const [jelloIds, setJelloIds] = useState([]);
+  const [mountPhase, setMountPhase] = useState(
+    enterOnMount ? "pending" : "static"
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setReducedMotion(media.matches);
+    sync();
+
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", sync);
+      return () => media.removeEventListener("change", sync);
+    }
+
+    media.addListener(sync);
+    return () => media.removeListener(sync);
+  }, []);
+
+  useEffect(() => {
+    if (reducedMotion || !enterOnMount) {
+      setMountPhase("static");
+      setJelloIds([]);
+      return;
+    }
+
+    setMountPhase("pending");
+    const frame = requestAnimationFrame(() => {
+      setMountPhase("entering");
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [enterOnMount, reducedMotion, panels.length]);
+
+  const isOpen = useCallback((id) => openIds.includes(id), [openIds]);
+
+  const toggle = useCallback(
+    (id) => {
+      const alreadyOpen = openIds.includes(id);
+
+      if (allowMultiple) {
+        if (alreadyOpen) {
+          setOpenIds((current) => current.filter((value) => value !== id));
+          setJelloIds((current) => current.filter((value) => value !== id));
+          return;
+        }
+
+        setOpenIds((current) => [...current, id]);
+        if (!reducedMotion) {
+          setJelloIds((current) => [
+            ...current.filter((value) => value !== id),
+            id,
+          ]);
+        }
+        return;
+      }
+
+      if (alreadyOpen) {
+        setOpenIds([]);
+        setJelloIds([]);
+        return;
+      }
+
+      setOpenIds([id]);
+      if (!reducedMotion) setJelloIds([id]);
+    },
+    [allowMultiple, openIds, reducedMotion]
+  );
+
+  const clearJello = useCallback((id) => {
+    setJelloIds((current) => current.filter((value) => value !== id));
+  }, []);
+
+  const onHeaderKeyDown = useCallback(
+    (event, id) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        toggle(id);
+      }
+    },
+    [toggle]
+  );
+
+  const rootClass = [
+    "jello-accordion-ab",
+    `jello-accordion-intensity-${intensity}-ab`,
+    mountPhase === "entering" ? "is-entering-ab" : "",
+    mountPhase === "static" ? "is-static-ab" : "",
+    reducedMotion ? "is-reduced-motion-ab" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={rootClass} role="region" aria-label={label} {...rest}>
+      {panels.map((panel, index) => {
+        const open = isOpen(panel.id);
+        const headerId = `${panel.id}-header`;
+        const panelId = `${panel.id}-panel`;
+        const jelloing = jelloIds.includes(panel.id);
+
+        return (
+          <div
+            key={panel.id}
+            className={[
+              "jello-accordion-item-ab",
+              open ? "is-open-ab" : "",
+              jelloing ? "is-jelloing-ab" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            style={{ "--jello-accordion-stagger-ab": `${index * 70}ms` }}
+            onAnimationEnd={(event) => {
+              if (event.target !== event.currentTarget) return;
+              if (
+                event.animationName.indexOf("jello-accordion-open-ab") === -1
+              ) {
+                return;
+              }
+              clearJello(panel.id);
+            }}
+          >
+            <h3 className="jello-accordion-heading-ab">
+              <button
+                type="button"
+                id={headerId}
+                className="jello-accordion-trigger-ab"
+                aria-expanded={open ? "true" : "false"}
+                aria-controls={panelId}
+                onClick={() => toggle(panel.id)}
+                onKeyDown={(event) => onHeaderKeyDown(event, panel.id)}
+              >
+                <span className="jello-accordion-title-ab">{panel.title}</span>
+                <span className="jello-accordion-icon-ab" aria-hidden="true">
+                  {open ? "−" : "+"}
+                </span>
+              </button>
+            </h3>
+
+            <div
+              id={panelId}
+              role="region"
+              aria-labelledby={headerId}
+              hidden={!open}
+              className="jello-accordion-panel-ab"
+            >
+              <div className="jello-accordion-panel-inner-ab">
+                {panel.content}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Optional demo helper with sample FAQ items.
+ */
+export function JelloAccordionDemoAb() {
+  return (
+    <div className="jello-accordion-demo-ab">
+      <JelloAccordion
+        allowMultiple={false}
+        intensity="medium"
+        enterOnMount
+        label="EaseMotion FAQ"
+        items={[
+          {
+            id: "what",
+            title: "What is EaseMotion CSS?",
+            content:
+              "A zero-dependency, animation-first CSS framework with human-readable class names.",
+            defaultOpen: true,
+          },
+          {
+            id: "jello",
+            title: "Why a jello accordion?",
+            content:
+              "A short jello entrance makes panels feel playful when they appear and when they open.",
+          },
+          {
+            id: "a11y",
+            title: "Is it accessible?",
+            content:
+              "Yes — real buttons, aria-expanded / aria-controls, and reduced-motion support.",
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/submissions/react/feature-jello-accordion-component-ab/README.md
+++ b/submissions/react/feature-jello-accordion-component-ab/README.md
@@ -1,0 +1,142 @@
+# Jello Accordion Component (`feature-jello-accordion-component-ab`)
+
+Standalone **React track** submission for [Issue #50773](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/50773).
+
+A beginner-friendly **Jello Accordion** with a smooth **entrance jello** animation — panels jiggle in on mount (staggered), and jello again when opened.
+
+---
+
+## What it does
+
+- Accessible accordion with real `<button>` triggers
+- Staggered jello entrance when the accordion mounts
+- Replayable jello cue each time a panel opens
+- Single-panel mode via `children` **or** multi-panel mode via `items`
+- Intensity presets: `soft` / `medium` / `strong`
+- Respects `prefers-reduced-motion` (JS + CSS)
+
+---
+
+## Folder structure
+
+```
+submissions/react/feature-jello-accordion-component-ab/
+├── JelloAccordion.jsx   ← React component (+ optional demo helper)
+├── style.css            ← jello accordion styles
+└── README.md            ← this file
+```
+
+---
+
+## Installation
+
+```jsx
+import JelloAccordion from './JelloAccordion';
+// style.css is imported inside JelloAccordion.jsx
+```
+
+---
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `children` | `ReactNode` | `"Hello"` | Panel body (single-item mode) |
+| `title` | `string` | `"Details"` | Header label (single-item mode) |
+| `items` | `Array<{id?, title, content, defaultOpen?}>` | — | Multi-panel data |
+| `allowMultiple` | `boolean` | `false` | Keep multiple panels open |
+| `intensity` | `'soft' \| 'medium' \| 'strong'` | `'medium'` | Jello strength |
+| `defaultOpen` | `boolean` | `false` | Open first/single panel on mount |
+| `enterOnMount` | `boolean` | `true` | Play staggered entrance jello |
+| `className` | `string` | `''` | Extra classes |
+| `label` | `string` | `"Jello accordion"` | `aria-label` for the region |
+
+---
+
+## Usage
+
+### Simple (matches issue example shape)
+
+```jsx
+import JelloAccordion from './JelloAccordion';
+
+export default function App() {
+  return (
+    <JelloAccordion title="Greeting" defaultOpen>
+      Hello
+    </JelloAccordion>
+  );
+}
+```
+
+### Multi-item FAQ
+
+```jsx
+<JelloAccordion
+  intensity="medium"
+  enterOnMount
+  items={[
+    {
+      id: '1',
+      title: 'What is EaseMotion?',
+      content: 'An animation-first CSS framework.',
+      defaultOpen: true,
+    },
+    {
+      id: '2',
+      title: 'Why jello?',
+      content: 'A short jello entrance feels playful without looping forever.',
+    },
+  ]}
+/>
+```
+
+### Optional demo helper
+
+```jsx
+import { JelloAccordionDemoAb } from './JelloAccordion';
+
+export default function Playground() {
+  return <JelloAccordionDemoAb />;
+}
+```
+
+---
+
+## Why this is useful
+
+Accordions often appear statically. A controlled jello entrance:
+
+1. Draws attention when the FAQ/list first lands
+2. Softly celebrates each newly opened panel
+3. Stays declarative in React (`items` or `children`)
+4. Ships with keyboard + ARIA patterns built in
+
+A strong candidate for later curation into an official EaseMotion React helper.
+
+---
+
+## Accessibility
+
+- Trigger is a real `<button>` with `aria-expanded` and `aria-controls`
+- Panels use `role="region"` + `aria-labelledby`
+- Closed panels use the `hidden` attribute
+- Enter / Space activate the trigger
+- Under `prefers-reduced-motion: reduce`, jello animations are disabled
+
+---
+
+## Unique identifier
+
+All classes, tokens, and keyframes use the **`-ab`** suffix to avoid collisions with other submissions.
+
+---
+
+## Checklist (issue acceptance)
+
+- [x] Files live under `submissions/react/feature-jello-accordion-component-ab/`
+- [x] `JelloAccordion.jsx` + `README.md` (+ `style.css`)
+- [x] Unique identifier on folder / classes
+- [x] Smooth jello entrance effect
+- [x] Accessibility + `prefers-reduced-motion` handled
+- [x] README explains what / how / why

--- a/submissions/react/feature-jello-accordion-component-ab/style.css
+++ b/submissions/react/feature-jello-accordion-component-ab/style.css
@@ -1,0 +1,273 @@
+/* ============================================================
+   Feature: Jello Accordion Component (ab)
+   Issue: #50773 — jello accordion entrance animation (React)
+   Track: submissions/react
+   ============================================================ */
+
+:root {
+  --jello-accordion-primary-ab: #6c63ff;
+  --jello-accordion-primary-dark-ab: #4b44cc;
+  --jello-accordion-surface-ab: #ffffff;
+  --jello-accordion-ink-ab: #1e293b;
+  --jello-accordion-muted-ab: #64748b;
+  --jello-accordion-border-ab: #e2e8f0;
+  --jello-accordion-bg-ab: #f8fafc;
+  --jello-accordion-radius-ab: 0.9rem;
+  --jello-accordion-speed-ab: 720ms;
+  --jello-accordion-enter-speed-ab: 780ms;
+  --jello-accordion-ease-ab: ease;
+  --jello-accordion-ease-soft-ab: cubic-bezier(0.4, 0, 0.2, 1);
+  --jello-accordion-skew-x-ab: 12.5deg;
+  --jello-accordion-skew-y-ab: 12.5deg;
+  --jello-accordion-font-ab: "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+.jello-accordion-ab {
+  display: grid;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 40rem;
+  font-family: var(--jello-accordion-font-ab);
+  color: var(--jello-accordion-ink-ab);
+}
+
+.jello-accordion-intensity-soft-ab {
+  --jello-accordion-skew-x-ab: 8deg;
+  --jello-accordion-skew-y-ab: 8deg;
+  --jello-accordion-speed-ab: 640ms;
+  --jello-accordion-enter-speed-ab: 700ms;
+}
+
+.jello-accordion-intensity-medium-ab {
+  --jello-accordion-skew-x-ab: 12.5deg;
+  --jello-accordion-skew-y-ab: 12.5deg;
+  --jello-accordion-speed-ab: 720ms;
+  --jello-accordion-enter-speed-ab: 780ms;
+}
+
+.jello-accordion-intensity-strong-ab {
+  --jello-accordion-skew-x-ab: 16deg;
+  --jello-accordion-skew-y-ab: 16deg;
+  --jello-accordion-speed-ab: 820ms;
+  --jello-accordion-enter-speed-ab: 900ms;
+}
+
+.jello-accordion-item-ab {
+  background: var(--jello-accordion-surface-ab);
+  border: 1px solid var(--jello-accordion-border-ab);
+  border-radius: var(--jello-accordion-radius-ab);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.06);
+  overflow: hidden;
+  transform-origin: center;
+  opacity: 0;
+  transform: translateY(10px);
+  transition:
+    border-color 180ms var(--jello-accordion-ease-soft-ab),
+    box-shadow 180ms var(--jello-accordion-ease-soft-ab);
+}
+
+.jello-accordion-ab.is-entering-ab .jello-accordion-item-ab {
+  animation: jello-accordion-enter-ab var(--jello-accordion-enter-speed-ab)
+    var(--jello-accordion-ease-ab) both;
+  animation-delay: var(--jello-accordion-stagger-ab, 0ms);
+}
+
+.jello-accordion-ab.is-static-ab .jello-accordion-item-ab {
+  opacity: 1;
+  transform: none;
+}
+
+.jello-accordion-item-ab.is-open-ab {
+  border-color: rgba(108, 99, 255, 0.45);
+  box-shadow:
+    0 12px 28px rgba(108, 99, 255, 0.12),
+    0 4px 12px rgba(15, 23, 42, 0.06);
+}
+
+.jello-accordion-heading-ab {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.jello-accordion-trigger-ab {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  margin: 0;
+  padding: 1rem 1.1rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+}
+
+.jello-accordion-trigger-ab:hover {
+  background: rgba(108, 99, 255, 0.04);
+}
+
+.jello-accordion-trigger-ab:focus-visible {
+  outline: 3px solid rgba(108, 99, 255, 0.4);
+  outline-offset: -3px;
+}
+
+.jello-accordion-title-ab {
+  min-width: 0;
+}
+
+.jello-accordion-icon-ab {
+  display: inline-grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: rgba(108, 99, 255, 0.12);
+  color: var(--jello-accordion-primary-dark-ab);
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: transform 180ms var(--jello-accordion-ease-soft-ab);
+}
+
+.jello-accordion-item-ab.is-open-ab .jello-accordion-icon-ab {
+  background: var(--jello-accordion-primary-ab);
+  color: #fff;
+  transform: scale(1.05);
+}
+
+.jello-accordion-panel-ab {
+  border-top: 1px solid var(--jello-accordion-border-ab);
+  background: linear-gradient(
+    180deg,
+    rgba(248, 250, 252, 0.9),
+    rgba(255, 255, 255, 0.95)
+  );
+}
+
+.jello-accordion-panel-ab[hidden] {
+  display: none;
+}
+
+.jello-accordion-panel-inner-ab {
+  padding: 1rem 1.1rem 1.15rem;
+  color: var(--jello-accordion-muted-ab);
+  line-height: 1.6;
+  transform-origin: center;
+}
+
+/* Open-panel jello (replays each expand) — beats entrance while both apply */
+.jello-accordion-ab .jello-accordion-item-ab.is-jelloing-ab {
+  animation: jello-accordion-open-ab var(--jello-accordion-speed-ab)
+    var(--jello-accordion-ease-ab) both;
+}
+
+.jello-accordion-ab .jello-accordion-item-ab.is-jelloing-ab .jello-accordion-panel-inner-ab {
+  animation: jello-accordion-content-ab
+    calc(var(--jello-accordion-speed-ab) - 80ms) var(--jello-accordion-ease-ab)
+    both;
+}
+
+@keyframes jello-accordion-enter-ab {
+  0% {
+    opacity: 0;
+    transform: translateY(10px) skewX(0deg) skewY(0deg);
+  }
+  18% {
+    opacity: 1;
+    transform: translateY(0)
+      skewX(calc(var(--jello-accordion-skew-x-ab) * -1))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * -1));
+  }
+  35% {
+    transform: skewX(var(--jello-accordion-skew-x-ab))
+      skewY(var(--jello-accordion-skew-y-ab));
+  }
+  52% {
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * -0.45))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * -0.45));
+  }
+  68% {
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * 0.28))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * 0.28));
+  }
+  84% {
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * -0.1))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * -0.1));
+  }
+  100% {
+    opacity: 1;
+    transform: skewX(0deg) skewY(0deg);
+  }
+}
+
+@keyframes jello-accordion-open-ab {
+  0%,
+  100% {
+    transform: skewX(0deg) skewY(0deg);
+  }
+  15% {
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * -1))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * -1));
+  }
+  30% {
+    transform: skewX(var(--jello-accordion-skew-x-ab))
+      skewY(var(--jello-accordion-skew-y-ab));
+  }
+  45% {
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * -0.5))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * -0.5));
+  }
+  60% {
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * 0.3))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * 0.3));
+  }
+  75% {
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * -0.12))
+      skewY(calc(var(--jello-accordion-skew-y-ab) * -0.12));
+  }
+}
+
+@keyframes jello-accordion-content-ab {
+  0% {
+    opacity: 0.35;
+    transform: skewX(calc(var(--jello-accordion-skew-x-ab) * -0.35));
+  }
+  100% {
+    opacity: 1;
+    transform: skewX(0deg);
+  }
+}
+
+.jello-accordion-demo-ab {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: var(--jello-accordion-bg-ab);
+  border: 1px dashed #cbd5e1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jello-accordion-item-ab,
+  .jello-accordion-icon-ab {
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+    animation: none !important;
+  }
+
+  .jello-accordion-ab.is-entering-ab .jello-accordion-item-ab,
+  .jello-accordion-item-ab.is-jelloing-ab,
+  .jello-accordion-item-ab.is-jelloing-ab .jello-accordion-panel-inner-ab {
+    animation: none !important;
+  }
+
+  .jello-accordion-ab.is-reduced-motion-ab .jello-accordion-item-ab,
+  .jello-accordion-ab.is-static-ab .jello-accordion-item-ab {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
# #50773 issue resolved

## Description

This PR adds a beginner-friendly **Jello Accordion Component (Entrance Animation)** under `submissions/react/feature-jello-accordion-component-ab/`.

## Features

- Smooth staggered jello entrance on mount
- Replayable jello cue when panels open
- Single-panel and multi-item accordion APIs
- Accessible triggers (`aria-expanded`, keyboard support)
- Respects `prefers-reduced-motion: reduce`
- Unique `-ab` suffix to avoid naming collisions