### PR TITLE
feat(example): add blur text hover animation

### DIFF
--- a/submissions/examples/feature-blur-text-example-ag/README.md
+++ b/submissions/examples/feature-blur-text-example-ag/README.md
@@ -1,0 +1,19 @@
+# Blur Text Example
+
+## Description
+This is a standard HTML/CSS example demonstrating a "blur text" hover effect. The text is initially hidden using a heavy `text-shadow` with a transparent font color. When the user hovers or focuses the element, the blur smoothly transitions away to reveal the clear text underneath.
+
+## Files
+- `demo.html`: Contains the structural markup.
+- `style.css`: Contains the blur styling using `text-shadow` and the transition rules for the hover state.
+
+## How It Works
+1. The `.blur-text-ag` element initially has `color: transparent` and `text-shadow: 0 0 12px rgba(...)`. This creates a frosted/blurred appearance that obscures the actual letters.
+2. The `user-select: none` property prevents users from accidentally highlighting and copying the text while it's supposed to be hidden.
+3. On `:hover` or `:focus-visible`, the `text-shadow` blur radius is animated to `0px`, and the `color` transitions to a solid color, bringing the text into focus. `user-select: auto` is restored.
+
+## Accessibility Considerations
+- `tabindex="0"` allows keyboard users to focus the element to reveal the text.
+- An explicit `:focus-visible` outline is provided.
+- An `aria-label` is included to inform screen reader users of the interaction required (though screen readers will read the text normally anyway, which is often desired for accessibility of hidden content).
+- **Reduced Motion**: Disables the CSS transition. The blur is removed instantly upon hover/focus for users who prefer reduced motion.

--- a/submissions/examples/feature-blur-text-example-ag/demo.html
+++ b/submissions/examples/feature-blur-text-example-ag/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blur Text Hover Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="container-ag">
+    <h2>Secret Information</h2>
+    <p class="description-ag">Hover over the redacted text below to reveal its contents.</p>
+
+    <!-- Blur Text Element -->
+    <div class="blur-text-ag" tabindex="0" aria-label="Hover to reveal secret text">
+      Project Phoenix launches in Q4 with a revolutionary new UI architecture.
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/feature-blur-text-example-ag/style.css
+++ b/submissions/examples/feature-blur-text-example-ag/style.css
@@ -1,0 +1,71 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.container-ag {
+  width: 100%;
+  max-width: 600px;
+  text-align: center;
+}
+
+h2 {
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.description-ag {
+  color: #94a3b8;
+  margin-bottom: 3rem;
+}
+
+/* Blur Text Hover Effect */
+.blur-text-ag {
+  display: inline-block;
+  padding: 1rem 1.5rem;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  background-color: #1e293b;
+  border-radius: 8px;
+  
+  /* Initial state: blurred and slightly transparent text to hide contents */
+  color: transparent;
+  text-shadow: 0 0 12px rgba(248, 250, 252, 0.8);
+  
+  /* Smooth transition for hover */
+  transition: text-shadow 0.4s ease-out, color 0.4s ease-out, background-color 0.4s ease;
+  cursor: pointer;
+  user-select: none; /* Prevent selection while blurred */
+}
+
+.blur-text-ag:hover,
+.blur-text-ag:focus-visible {
+  /* Hover state: reveal text */
+  color: #f8fafc;
+  text-shadow: 0 0 0 rgba(248, 250, 252, 0);
+  background-color: #334155;
+  outline: none;
+  user-select: auto; /* Allow selection once revealed */
+}
+
+/* Focus ring for accessibility */
+.blur-text-ag:focus-visible {
+  box-shadow: 0 0 0 2px #0f172a, 0 0 0 4px #3b82f6;
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .blur-text-ag {
+    /* Instantly reveal without transition */
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Blur Text Example` issue. Provides a standard HTML/CSS example of text that is blurred initially and revealed clearly on hover.

# Solution
- `demo.html`: Container with text to blur.
- `style.css`: Uses `color: transparent` and a heavy `text-shadow` to blur the text, then transitions `text-shadow` to 0 and `color` to a solid value on hover.
- `prefers-reduced-motion` removes the transition duration, snapping instantly to clear text on hover.

# Files Changed
* `submissions/examples/feature-blur-text-example-ag/demo.html`
* `submissions/examples/feature-blur-text-example-ag/style.css`
* `submissions/examples/feature-blur-text-example-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (tabindex, focus-visible)
* [x] No unrelated changes
* [x] Ready for review