### PR TITLE
feat(example): add wiggle image example

### DIFF
--- a/submissions/examples/feature-wiggle-image-example-ag/README.md
+++ b/submissions/examples/feature-wiggle-image-example-ag/README.md
@@ -1,0 +1,17 @@
+# Wiggle Image Example
+
+## Description
+This is a standard HTML/CSS example demonstrating a "Wiggle" attention-seeker animation applied to an image. The image remains still for the majority of the animation cycle, but periodically wiggles rapidly side-to-side to draw the user's eye, making it ideal for promotional content or important graphics.
+
+## Files
+- `demo.html`: Contains a simple promotional card layout with an `<img>` tag holding the `.wiggle-image-ag` class.
+- `style.css`: Contains the basic layout styling and the `@keyframes ease-wiggle-attention-ag` animation logic.
+
+## How It Works
+1. The `.wiggle-image-ag` class applies a 3-second infinite animation (`ease-wiggle-attention-ag`).
+2. The keyframes dictate that from 0% to 80% of the duration, the image stays completely still (`rotate(0deg)`).
+3. From 80% to 100% (the last ~600ms of the 3s loop), the image rapidly rotates back and forth (`3deg`, `-3deg`, `2deg`, `-1deg`), producing the wiggle effect before settling back to 0.
+
+## Accessibility Considerations
+- The `<img>` tag includes a descriptive `alt` attribute for screen readers.
+- **Reduced Motion**: Disables the periodic wiggle animation entirely via `@media (prefers-reduced-motion: reduce)`, respecting users who are sensitive to sudden movements.

--- a/submissions/examples/feature-wiggle-image-example-ag/demo.html
+++ b/submissions/examples/feature-wiggle-image-example-ag/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wiggle Image Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="container-ag">
+    <h2>Special Offer</h2>
+    <p>Check out our new premium features.</p>
+    
+    <div class="image-wrapper-ag">
+      <!-- Dummy image placeholder using a colored div or actual img -->
+      <img 
+        src="https://via.placeholder.com/300x200/3b82f6/ffffff?text=Premium+Feature" 
+        alt="Premium Feature Promotion" 
+        class="wiggle-image-ag" 
+      />
+    </div>
+    
+    <button class="cta-button-ag">Learn More</button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/feature-wiggle-image-example-ag/style.css
+++ b/submissions/examples/feature-wiggle-image-example-ag/style.css
@@ -1,0 +1,87 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #f8fafc;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container-ag {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  max-width: 400px;
+}
+
+h2 {
+  color: #0f172a;
+  margin-top: 0;
+}
+
+p {
+  color: #64748b;
+  margin-bottom: 2rem;
+}
+
+.image-wrapper-ag {
+  margin-bottom: 2rem;
+  overflow: hidden; /* optional: depends on if we want the image to break out */
+  border-radius: 8px;
+}
+
+/* Wiggle Image Animation */
+.wiggle-image-ag {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  /* Animate continuously to draw attention */
+  animation: ease-wiggle-attention-ag 3s ease-in-out infinite;
+  transform-origin: center;
+}
+
+@keyframes ease-wiggle-attention-ag {
+  0%, 80%, 100% {
+    transform: rotate(0deg);
+  }
+  82% {
+    transform: rotate(3deg);
+  }
+  86% {
+    transform: rotate(-3deg);
+  }
+  90% {
+    transform: rotate(2deg);
+  }
+  94% {
+    transform: rotate(-1deg);
+  }
+}
+
+.cta-button-ag {
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.cta-button-ag:hover {
+  background-color: #2563eb;
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .wiggle-image-ag {
+    animation: none;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Wiggle Image Example` issue. Provides a standard HTML/CSS example demonstrating a "Wiggle" attention-seeker animation applied to an image.

# Solution
- `demo.html`: Promotional card layout with a wiggle image.
- `style.css`: Keyframes apply a subtle, rapid rotation wiggle every 3 seconds to draw attention.
- `prefers-reduced-motion` replaces the periodic wiggle with a static image.

# Files Changed
* `submissions/examples/feature-wiggle-image-example-ag/demo.html`
* `submissions/examples/feature-wiggle-image-example-ag/style.css`
* `submissions/examples/feature-wiggle-image-example-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Reduced motion)
* [x] No unrelated changes
* [x] Ready for review