### PR TITLE
feat(example): add blur checkbox example

### DIFF
--- a/submissions/examples/feature-blur-checkbox-example-ag/README.md
+++ b/submissions/examples/feature-blur-checkbox-example-ag/README.md
@@ -1,0 +1,20 @@
+# Blur Checkbox Hover Example
+
+## Description
+This is a standard HTML/CSS example demonstrating a custom checkbox design that employs a subtle "blur" hover effect. When the user hovers over the label or checkbox, the checkbox outline softens and glows slightly via a CSS filter, providing modern, tactile feedback.
+
+## Files
+- `demo.html`: Contains standard, accessible markup tying a hidden `<input type="checkbox">` to a `<label>` using the `for` attribute.
+- `style.css`: Hides the default checkbox and recreates it using the `::before` pseudo-element on the label. Applies the hover blur effect and manages the checked state.
+
+## How It Works
+1. The default checkbox is hidden visually but remains in the DOM for keyboard access.
+2. The `::before` pseudo-element on `.blur-checkbox-label-ag` acts as the visual box.
+3. On hover (`.blur-checkbox-label-ag:hover::before`), a CSS `filter: blur(1px)` and a box-shadow are applied. The transition makes the blur fade in smoothly, softening the edges of the box.
+4. When checked (`:checked + label::before`), the background color turns blue and an SVG checkmark is applied via `background-image`.
+
+## Accessibility Considerations
+- Fully semantic `<input type="checkbox">` linked to a `<label>`.
+- The native checkbox is hidden via `opacity: 0` and `width: 0` rather than `display: none` so it remains keyboard focusable.
+- A `:focus-visible` outline is provided.
+- **Reduced Motion**: Disables the blur and glow transitions via `@media (prefers-reduced-motion: reduce)`. The hover state safely falls back to a simple, instant border color change.

--- a/submissions/examples/feature-blur-checkbox-example-ag/demo.html
+++ b/submissions/examples/feature-blur-checkbox-example-ag/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blur Checkbox Hover Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="container-ag">
+    <h2>Privacy Settings</h2>
+    
+    <div class="checkbox-wrapper-ag">
+      <input type="checkbox" id="tracking" class="custom-checkbox-ag" />
+      <label for="tracking" class="blur-checkbox-label-ag">
+        Allow anonymous usage tracking
+      </label>
+    </div>
+
+    <div class="checkbox-wrapper-ag">
+      <input type="checkbox" id="marketing" class="custom-checkbox-ag" />
+      <label for="marketing" class="blur-checkbox-label-ag">
+        Receive marketing emails
+      </label>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/feature-blur-checkbox-example-ag/style.css
+++ b/submissions/examples/feature-blur-checkbox-example-ag/style.css
@@ -1,0 +1,108 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #f1f5f9;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container-ag {
+  background: white;
+  padding: 2rem 3rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+h2 {
+  color: #1e293b;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 0.75rem;
+}
+
+.checkbox-wrapper-ag {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+/* Hide standard checkbox visually but keep it accessible */
+.custom-checkbox-ag {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Custom Checkbox Label */
+.blur-checkbox-label-ag {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: #475569;
+  font-size: 1rem;
+  user-select: none;
+  transition: color 0.3s ease;
+}
+
+/* Custom Checkbox Box */
+.blur-checkbox-label-ag::before {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-right: 12px;
+  border: 2px solid #cbd5e1;
+  border-radius: 4px;
+  background-color: white;
+  /* Setup transition for hover effect */
+  transition: filter 0.3s ease, border-color 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* Hover Effect: The Blur */
+.blur-checkbox-label-ag:hover::before {
+  border-color: #3b82f6;
+  filter: blur(1px); /* Slight blur on hover to soften the edge */
+  box-shadow: 0 0 8px rgba(59, 130, 246, 0.4);
+}
+
+/* Focus state */
+.custom-checkbox-ag:focus-visible + .blur-checkbox-label-ag::before {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
+}
+
+/* Checked State */
+.custom-checkbox-ag:checked + .blur-checkbox-label-ag::before {
+  background-color: #3b82f6;
+  border-color: #3b82f6;
+  /* A simple checkmark using background image */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  background-size: 14px;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+/* Keep blur strong on hover even when checked */
+.custom-checkbox-ag:checked + .blur-checkbox-label-ag:hover::before {
+  filter: blur(1px);
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .blur-checkbox-label-ag::before {
+    transition: none;
+  }
+  
+  .blur-checkbox-label-ag:hover::before {
+    filter: none; /* Disable blur */
+    box-shadow: none; /* Disable shadow animation */
+    /* Just a simple color change for hover */
+    border-color: #3b82f6;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Blur Checkbox Example` issue. Provides a standard HTML/CSS example demonstrating a custom checkbox design with a subtle blur hover effect.

# Solution
- `demo.html`: Checkbox markup using visually hidden input and semantic label.
- `style.css`: Applies a CSS `filter: blur(1px)` and `box-shadow` to the label's pseudo-element on hover.
- `prefers-reduced-motion` disables the blur transition for an instant color change.

# Files Changed
* `submissions/examples/feature-blur-checkbox-example-ag/demo.html`
* `submissions/examples/feature-blur-checkbox-example-ag/style.css`
* `submissions/examples/feature-blur-checkbox-example-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Visually hidden native checkbox)
* [x] No unrelated changes
* [x] Ready for review