### PR TITLE
feat(scss): add rotate input mixin

### DIFF
--- a/submissions/scss/feature-rotate-input-mixin-ag/README.md
+++ b/submissions/scss/feature-rotate-input-mixin-ag/README.md
@@ -1,0 +1,21 @@
+# Rotate Input SCSS Mixin
+
+## Description
+This SCSS mixin provides a dynamic "Rotate Entrance" animation. When applied to an input field (or any element) as it enters the DOM, the element fades in, scales up slightly, and rotates from an angle into its final resting position, using a bouncy spring-like easing curve.
+
+## Usage
+
+```scss
+@use 'rotate-input' as *;
+
+.my-fancy-input {
+  @include ease-rotate-input-mixin-ag(0.6s);
+}
+```
+
+## Parameters
+- `$duration`: The length of the entrance animation (default: `0.6s`).
+- `$timing-function`: The easing function. Defaults to a bouncy cubic-bezier (`cubic-bezier(0.175, 0.885, 0.32, 1.275)`).
+
+## Accessibility
+- Respects `prefers-reduced-motion: reduce` by replacing the scale and rotation with a simple opacity fade-in to avoid triggering motion sickness.

--- a/submissions/scss/feature-rotate-input-mixin-ag/_rotate-input.scss
+++ b/submissions/scss/feature-rotate-input-mixin-ag/_rotate-input.scss
@@ -1,0 +1,34 @@
+// _rotate-input.scss
+
+@mixin ease-rotate-input-mixin-ag($duration: 0.6s, $timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.275)) {
+  /* Requires perspective on a parent container if 3D rotate is desired, 
+     but we'll use a 2D rotate and scale to ensure it works globally */
+  animation: ease-rotate-input-enter-ag $duration $timing-function forwards;
+  opacity: 0;
+  transform: rotate(-15deg) scale(0.8);
+}
+
+@keyframes ease-rotate-input-enter-ag {
+  0% {
+    opacity: 0;
+    transform: rotate(-15deg) scale(0.8);
+  }
+  100% {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+// Reduced Motion Fallback
+@media (prefers-reduced-motion: reduce) {
+  @keyframes ease-rotate-input-enter-ag {
+    from {
+      opacity: 0;
+      transform: none;
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Rotate Input Mixin` issue. Provides an SCSS mixin for a dynamic "Rotate Entrance" animation.

# Solution
- `_rotate-input.scss`: Contains the mixin `ease-rotate-input-mixin-ag` and keyframes that scale up and rotate an element from an angle into its final resting position.
- `prefers-reduced-motion` replaces the scale and rotation with a simple opacity fade-in.

# Files Changed
* `submissions/scss/feature-rotate-input-mixin-ag/_rotate-input.scss`
* `submissions/scss/feature-rotate-input-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Reduced motion)
* [x] No unrelated changes
* [x] Ready for review