### PR TITLE
feat(example): add flip drawer example

### DIFF
--- a/submissions/examples/feature-flip-drawer-example-ag/README.md
+++ b/submissions/examples/feature-flip-drawer-example-ag/README.md
@@ -1,0 +1,20 @@
+# Flip Drawer Example
+
+## Description
+This is a standard HTML/CSS/JS example demonstrating a "Flip" entrance animation for a side drawer (sidebar). Instead of the traditional slide-in, this drawer uses CSS 3D transforms (`rotateY`) and `perspective` to swing open like a door hinged on the right edge of the screen.
+
+## Files
+- `demo.html`: Contains the layout, the drawer markup, and vanilla JS to toggle ARIA attributes and the `.is-open-ag` class.
+- `style.css`: Contains the perspective wrapper and the 3D flip transition applied to the `.flip-drawer-ag`.
+
+## How It Works
+1. A `.drawer-container-ag` wraps the drawer and provides `perspective: 1000px` to establish 3D space.
+2. The `.flip-drawer-ag` defaults to `transform: rotateY(90deg)` with `transform-origin: right center`. This makes the drawer sit completely edge-on and invisible.
+3. When the `.is-open-ag` class is added, the drawer transitions to `rotateY(0deg)`, swinging open smoothly.
+4. JS toggles this class along with ARIA attributes.
+
+## Accessibility Considerations
+- Toggles `aria-expanded` on the trigger button.
+- Updates `aria-hidden` on the drawer to correctly manage screen reader visibility.
+- Note: In a full implementation, focus trapping should be added.
+- **Reduced Motion**: Disables the 3D `rotateY` transform via `@media (prefers-reduced-motion: reduce)`. The drawer gracefully falls back to a simple opacity fade-in, toggling `display: none` to `flex`.

--- a/submissions/examples/feature-flip-drawer-example-ag/demo.html
+++ b/submissions/examples/feature-flip-drawer-example-ag/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flip Drawer Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="app-layout-ag">
+    <main class="main-content-ag">
+      <h2>Drawer Navigation</h2>
+      <button onclick="toggleDrawer()" class="toggle-btn-ag" aria-expanded="false" aria-controls="side-drawer">
+        Toggle Flip Drawer
+      </button>
+    </main>
+    
+    <!-- The perspective container is needed for the 3D flip effect -->
+    <div class="drawer-container-ag">
+      <aside id="side-drawer" class="flip-drawer-ag" aria-hidden="true">
+        <div class="drawer-header-ag">
+          <h3>Menu</h3>
+          <button onclick="toggleDrawer()" class="close-btn-ag" aria-label="Close menu">&times;</button>
+        </div>
+        <nav class="drawer-nav-ag">
+          <a href="#">Dashboard</a>
+          <a href="#">Profile</a>
+          <a href="#">Settings</a>
+          <a href="#">Logout</a>
+        </nav>
+      </aside>
+    </div>
+  </div>
+
+  <script>
+    function toggleDrawer() {
+      const drawer = document.getElementById('side-drawer');
+      const toggleBtn = document.querySelector('.toggle-btn-ag');
+      const isHidden = drawer.getAttribute('aria-hidden') === 'true';
+      
+      if (isHidden) {
+        drawer.setAttribute('aria-hidden', 'false');
+        toggleBtn.setAttribute('aria-expanded', 'true');
+        drawer.classList.add('is-open-ag');
+      } else {
+        drawer.setAttribute('aria-hidden', 'true');
+        toggleBtn.setAttribute('aria-expanded', 'false');
+        drawer.classList.remove('is-open-ag');
+      }
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/feature-flip-drawer-example-ag/style.css
+++ b/submissions/examples/feature-flip-drawer-example-ag/style.css
@@ -1,0 +1,129 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  margin: 0;
+  background-color: #f8fafc;
+}
+
+.app-layout-ag {
+  display: flex;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden; /* contain the drawer */
+}
+
+.main-content-ag {
+  flex: 1;
+  padding: 2rem;
+}
+
+h2 {
+  color: #0f172a;
+  margin-top: 0;
+}
+
+.toggle-btn-ag, .close-btn-ag {
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.toggle-btn-ag:hover, .close-btn-ag:hover {
+  background-color: #2563eb;
+}
+
+.close-btn-ag {
+  padding: 0.25rem 0.75rem;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+/* Perspective container for 3D flip */
+.drawer-container-ag {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  perspective: 1000px;
+  pointer-events: none; /* Let clicks pass through when closed */
+  z-index: 40;
+}
+
+/* The Drawer */
+.flip-drawer-ag {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 100%;
+  background-color: white;
+  box-shadow: -4px 0 15px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  pointer-events: auto;
+  
+  /* Initial hidden state: rotated 90deg on Y axis so it's edge-on and invisible */
+  opacity: 0;
+  transform: rotateY(90deg);
+  transform-origin: right center; /* Hinge on the right edge */
+  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.5s ease;
+}
+
+/* Open state */
+.flip-drawer-ag.is-open-ag {
+  opacity: 1;
+  transform: rotateY(0deg);
+}
+
+.drawer-header-ag {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.drawer-header-ag h3 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.drawer-nav-ag {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0;
+}
+
+.drawer-nav-ag a {
+  padding: 1rem 1.5rem;
+  color: #475569;
+  text-decoration: none;
+  font-weight: 500;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.drawer-nav-ag a:hover {
+  background-color: #f1f5f9;
+  color: #0f172a;
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .flip-drawer-ag {
+    transition: opacity 0.3s ease;
+    /* Instead of rotating, just keep it flat and hidden */
+    transform: none;
+    display: none;
+  }
+  
+  .flip-drawer-ag.is-open-ag {
+    display: flex;
+    transform: none;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Flip Drawer Example` issue. Provides a standard HTML/CSS/JS example demonstrating a "Flip" entrance animation for a side drawer.

# Solution
- `demo.html`: Drawer markup with vanilla JS to toggle ARIA attributes and classes.
- `style.css`: Applies `perspective` to a container and transitions `rotateY` on the drawer from 90deg to 0deg to create a swinging door effect.
- `prefers-reduced-motion` replaces the 3D flip with a simple opacity fade-in.

# Files Changed
* `submissions/examples/feature-flip-drawer-example-ag/demo.html`
* `submissions/examples/feature-flip-drawer-example-ag/style.css`
* `submissions/examples/feature-flip-drawer-example-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (aria-expanded, aria-hidden)
* [x] No unrelated changes
* [x] Ready for review