### PR TITLE
feat(scss): add swing dropdown mixin

### DIFF
--- a/submissions/scss/feature-swing-dropdown-mixin-ag/README.md
+++ b/submissions/scss/feature-swing-dropdown-mixin-ag/README.md
@@ -1,0 +1,22 @@
+# Swing Dropdown SCSS Mixin
+
+## Description
+This SCSS mixin provides a dynamic 3D "Swing" animation. It is ideal for dropdown menus, tooltip arrows, or loading indicators that need to swing down into view as if hinged from the top.
+
+## Usage
+
+```scss
+@use 'swing-dropdown' as *;
+
+.my-dropdown-menu {
+  /* Set perspective on the parent wrapper (e.g. perspective: 1000px) */
+  @include ease-swing-dropdown-mixin-ag(0.6s);
+}
+```
+
+## Parameters
+- `$duration`: The length of the entrance animation (default: `0.6s`).
+- `$transform-origin`: The hinge point. For a dropdown, `top center` is recommended so it swings down from the trigger (default: `top center`).
+
+## Accessibility
+- Respects `prefers-reduced-motion: reduce` by overriding the keyframes to a standard opacity fade-in, disabling the 3D rotation entirely.

--- a/submissions/scss/feature-swing-dropdown-mixin-ag/_swing-dropdown.scss
+++ b/submissions/scss/feature-swing-dropdown-mixin-ag/_swing-dropdown.scss
@@ -1,0 +1,40 @@
+// _swing-dropdown.scss
+
+@mixin ease-swing-dropdown-mixin-ag($duration: 0.6s, $transform-origin: top center) {
+  transform-origin: $transform-origin;
+  animation: ease-swing-dropdown-ag $duration ease-out forwards;
+}
+
+@keyframes ease-swing-dropdown-ag {
+  0% {
+    opacity: 0;
+    transform: rotateX(-90deg);
+  }
+  40% {
+    transform: rotateX(20deg);
+  }
+  60% {
+    transform: rotateX(-10deg);
+  }
+  80% {
+    transform: rotateX(5deg);
+  }
+  100% {
+    opacity: 1;
+    transform: rotateX(0deg);
+  }
+}
+
+// Reduced Motion Fallback
+@media (prefers-reduced-motion: reduce) {
+  @keyframes ease-swing-dropdown-ag {
+    from {
+      opacity: 0;
+      transform: none;
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Swing Dropdown Mixin` issue. Provides an SCSS mixin for a 3D "Swing" entrance animation, useful for dropdown menus or tooltips.

# Solution
- `_swing-dropdown.scss`: Contains the mixin `ease-swing-dropdown-mixin-ag` which uses `rotateX` around a `top center` transform origin to create a swinging hinge effect.
- `prefers-reduced-motion` replaces the 3D swing with a simple opacity fade-in.

# Files Changed
* `submissions/scss/feature-swing-dropdown-mixin-ag/_swing-dropdown.scss`
* `submissions/scss/feature-swing-dropdown-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Reduced motion)
* [x] No unrelated changes
* [x] Ready for review