### PR TITLE
feat(scss): add tada modal mixin

### DIFF
--- a/submissions/scss/feature-tada-modal-mixin-ag/README.md
+++ b/submissions/scss/feature-tada-modal-mixin-ag/README.md
@@ -1,0 +1,20 @@
+# Tada Modal SCSS Mixin
+
+## Description
+This SCSS mixin provides a classic "Tada" attention-seeker animation. It scales the element down slightly, then scales it up while alternating rotation to create a joyful, springy pop effect. It is often used on success modals, achievement badges, or important notifications.
+
+## Usage
+
+```scss
+@use 'tada-modal' as *;
+
+.my-success-modal {
+  @include ease-tada-modal-mixin-ag(1s);
+}
+```
+
+## Parameters
+- `$duration`: The length of the animation (default: `1s`).
+
+## Accessibility
+- Respects `prefers-reduced-motion: reduce` by overriding the keyframes to apply no transform at all, suppressing the flashing/shaking animation entirely to prevent triggering vestibular issues.

--- a/submissions/scss/feature-tada-modal-mixin-ag/_tada-modal.scss
+++ b/submissions/scss/feature-tada-modal-mixin-ag/_tada-modal.scss
@@ -1,0 +1,32 @@
+// _tada-modal.scss
+
+@mixin ease-tada-modal-mixin-ag($duration: 1s) {
+  animation: ease-tada-modal-ag $duration both;
+}
+
+@keyframes ease-tada-modal-ag {
+  0% {
+    transform: scale(1);
+  }
+  10%, 20% {
+    transform: scale(0.9) rotate(-3deg);
+  }
+  30%, 50%, 70%, 90% {
+    transform: scale(1.1) rotate(3deg);
+  }
+  40%, 60%, 80% {
+    transform: scale(1.1) rotate(-3deg);
+  }
+  100% {
+    transform: scale(1) rotate(0);
+  }
+}
+
+// Reduced Motion Fallback
+@media (prefers-reduced-motion: reduce) {
+  @keyframes ease-tada-modal-ag {
+    from, to {
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Tada Modal Mixin` issue. Provides an SCSS mixin for a "Tada" attention-seeker animation, commonly used on success modals or badges.

# Solution
- `_tada-modal.scss`: Contains the mixin `ease-tada-modal-mixin-ag` which uses alternating rotations and scaling to create a springy, celebratory pop effect.
- `prefers-reduced-motion` disables the animation entirely (transform: none) to prevent vestibular triggering.

# Files Changed
* `submissions/scss/feature-tada-modal-mixin-ag/_tada-modal.scss`
* `submissions/scss/feature-tada-modal-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Reduced motion)
* [x] No unrelated changes
* [x] Ready for review