### PR TITLE
Add ease-weather-dashboard-grid component

### DIFF
--- a/submissions/examples/ease-weather-dashboard-grid-ij/README.md
+++ b/submissions/examples/ease-weather-dashboard-grid-ij/README.md
@@ -1,0 +1,16 @@
+# ease-weather-dashboard-grid
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(160, 72%, 62%) | Primary color |
+| --bg | hsl(160, 10%, 96%) | Background |
+| --duration | 1.20s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-weather-dashboard-grid-ij/demo.html
+++ b/submissions/examples/ease-weather-dashboard-grid-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-weather-dashboard-grid-ij/style.css
+++ b/submissions/examples/ease-weather-dashboard-grid-ij/style.css
@@ -1,0 +1,23 @@
+:root{--primary:hsl(160, 72%, 62%);--bg:hsl(160, 10%, 96%);--text:#1e293b;--duration:1.20s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes enter-weather-dashboard-grid {
+  0% { transform: translateY(-14px) scale(0.9); opacity: 0; filter: blur(4px); }
+  50% { transform: translateY(-3px) scale(1.03); filter: blur(0); }
+  100% { transform: translateY(0) scale(1); opacity: 1; filter: blur(0); }
+}
+@keyframes borderGlow-weather-dashboard-grid {
+  0%, 100% { border-color: hsl(160, 72%, 62%); }
+  25% { border-color: hsl(280, 72%, 62%); box-shadow: 0 0 8px hsl(280, 72%, 62%)40; }
+  50% { border-color: hsl(40, 72%, 62%); }
+  75% { border-color: hsl(280, 72%, 62%); box-shadow: 0 0 12px hsl(40, 72%, 62%)40; }
+}
+.anim-target.active { animation: enter-weather-dashboard-grid 1.20s cubic-bezier(0.16, 1, 0.3, 1) forwards, borderGlow-weather-dashboard-grid 2.5s ease-in-out infinite; border: 2px solid; border-radius: 14px; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(40, 72%, 62%)}


### PR DESCRIPTION
## Component: ease-weather-dashboard-grid — weather dashboard grid — layout container with blur-in translateY entrance and cycling border glow

**Closes #51059**

### What this adds
A layout container. The @keyframes enter-weather-dashboard-grid rises from below with blur-in entrance while orderGlow-weather-dashboard-grid transitions through three color stops with inner shadow for visual depth.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-weather-dashboard-grid-ij/demo.html
- submissions/examples/ease-weather-dashboard-grid-ij/style.css
- submissions/examples/ease-weather-dashboard-grid-ij/README.md

### How to review
Open demo.html directly in a browser. Click to see the blur-in entrance and border glow cycling animation.
