### PR TITLE
feat(example): add jello card example

### DIFF
--- a/submissions/examples/feature-jello-card-example-ag/README.md
+++ b/submissions/examples/feature-jello-card-example-ag/README.md
@@ -1,0 +1,12 @@
+# Jello Card Example
+
+## Description
+This is a standard HTML/CSS example demonstrating a "Jello" interactive state animation. When a user hovers over or focuses on the card, it squishes and wobbles like jello. This is a playful effect that can add character to pricing cards, feature highlights, or game UI.
+
+## Files
+- `demo.html`: Contains the card markup. Uses `tabindex="0"` to make the card focusable for testing.
+- `style.css`: Applies the jello keyframes on `:hover` and `:focus-visible`. The animation utilizes `scale3d` to distort the element proportionally without changing its layout flow.
+
+## Accessibility
+- Uses `:focus-visible` to trigger the animation for keyboard users and provides a clear focus ring.
+- **Reduced Motion**: Disables the complex scaling wobble via `@media (prefers-reduced-motion: reduce)`. It gracefully falls back to a simple, static `scale(1.02)` transform on hover.

--- a/submissions/examples/feature-jello-card-example-ag/demo.html
+++ b/submissions/examples/feature-jello-card-example-ag/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jello Card Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container-ag">
+    <div class="jello-card-ag" tabindex="0">
+      <h3>Hover or Focus Me</h3>
+      <p>This card jiggles like jello to provide a playful interactive state.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/feature-jello-card-example-ag/style.css
+++ b/submissions/examples/feature-jello-card-example-ag/style.css
@@ -1,0 +1,65 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #f1f5f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.jello-card-ag {
+  background-color: white;
+  border-radius: 12px;
+  padding: 2rem;
+  width: 300px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  cursor: pointer;
+  transition: box-shadow 0.3s;
+  outline: none; /* Removed default outline for custom focus state */
+}
+
+.jello-card-ag h3 {
+  margin-top: 0;
+  color: #0f172a;
+}
+
+.jello-card-ag p {
+  color: #475569;
+  margin-bottom: 0;
+  line-height: 1.5;
+}
+
+/* Hover and Focus States trigger the Jello animation */
+.jello-card-ag:hover,
+.jello-card-ag:focus-visible {
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  animation: jello-anim-ag 0.9s both;
+}
+
+/* Accessibility for focus */
+.jello-card-ag:focus-visible {
+  box-shadow: 0 0 0 3px #93c5fd, 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+@keyframes jello-anim-ag {
+  0% { transform: scale3d(1, 1, 1); }
+  30% { transform: scale3d(1.25, 0.75, 1); }
+  40% { transform: scale3d(0.75, 1.25, 1); }
+  50% { transform: scale3d(1.15, 0.85, 1); }
+  65% { transform: scale3d(0.95, 1.05, 1); }
+  75% { transform: scale3d(1.05, 0.95, 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .jello-card-ag:hover,
+  .jello-card-ag:focus-visible {
+    animation: none;
+    transform: scale(1.02); /* Simple slight scale instead of jello wobble */
+    transition: transform 0.2s ease;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Jello Card Example` issue. Provides a standard HTML/CSS example demonstrating a "Jello" interactive state animation on a card.

# Solution
- `demo.html`: Card layout with `tabindex="0"` for focusability.
- `style.css`: Applies keyframes on `:hover` and `:focus-visible` that scale the element along X and Y axes asynchronously to create a jello-like wobble.
- `prefers-reduced-motion` replaces the wobble with a subtle static scale.

# Files Changed
* `submissions/examples/feature-jello-card-example-ag/demo.html`
* `submissions/examples/feature-jello-card-example-ag/style.css`
* `submissions/examples/feature-jello-card-example-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Reduced motion, focus ring)
* [x] No unrelated changes
* [x] Ready for review