### PR TITLE
feat(scss): add glow image mixin

### DIFF
--- a/submissions/scss/feature-glow-image-mixin-ag/README.md
+++ b/submissions/scss/feature-glow-image-mixin-ag/README.md
@@ -1,0 +1,21 @@
+# Glow Image SCSS Mixin
+
+## Description
+This SCSS mixin provides a visually striking "Glow Entrance" animation. Designed specifically for images (especially transparent PNGs or SVGs), it fades the image in while scaling it up slightly and emitting a bright, pulsating drop-shadow glow that settles into a soft ambient glow.
+
+## Usage
+
+```scss
+@use 'glow-image' as *;
+
+.my-hero-illustration {
+  @include ease-glow-image-mixin-ag(rgba(16, 185, 129, 0.7), 1.2s);
+}
+```
+
+## Parameters
+- `$glow-color`: The color of the drop-shadow glow (default: `rgba(59, 130, 246, 0.6)`).
+- `$duration`: The length of the entrance animation (default: `1s`).
+
+## Accessibility
+- Respects `prefers-reduced-motion: reduce` by replacing the scale and pulsating glow animation with a simple opacity fade-in. It maintains the final static drop-shadow for design consistency.

--- a/submissions/scss/feature-glow-image-mixin-ag/_glow-image.scss
+++ b/submissions/scss/feature-glow-image-mixin-ag/_glow-image.scss
@@ -1,0 +1,39 @@
+// _glow-image.scss
+
+@mixin ease-glow-image-mixin-ag($glow-color: rgba(59, 130, 246, 0.6), $duration: 1s) {
+  animation: ease-glow-image-enter-ag $duration ease-out forwards;
+  /* Use a CSS variable to pass the color into the keyframes */
+  --ease-glow-color-ag: #{$glow-color};
+}
+
+@keyframes ease-glow-image-enter-ag {
+  0% {
+    opacity: 0;
+    filter: drop-shadow(0 0 0 transparent);
+    transform: scale(0.95);
+  }
+  50% {
+    filter: drop-shadow(0 0 20px var(--ease-glow-color-ag));
+  }
+  100% {
+    opacity: 1;
+    filter: drop-shadow(0 0 10px var(--ease-glow-color-ag));
+    transform: scale(1);
+  }
+}
+
+// Reduced Motion Fallback
+@media (prefers-reduced-motion: reduce) {
+  @keyframes ease-glow-image-enter-ag {
+    from {
+      opacity: 0;
+      filter: none;
+      transform: none;
+    }
+    to {
+      opacity: 1;
+      filter: drop-shadow(0 0 10px var(--ease-glow-color-ag));
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Glow Image Mixin` issue. Provides an SCSS mixin for a "Glow Entrance" animation, commonly used on hero images or badges.

# Solution
- `_glow-image.scss`: Contains the mixin `ease-glow-image-mixin-ag` which animates an element scaling up while emitting a bright, pulsating `drop-shadow` glow that settles into a soft ambient glow.
- `prefers-reduced-motion` suppresses the scale and pulse, applying a simple opacity fade-in to the final glowing state.

# Files Changed
* `submissions/scss/feature-glow-image-mixin-ag/_glow-image.scss`
* `submissions/scss/feature-glow-image-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Reduced motion)
* [x] No unrelated changes
* [x] Ready for review