### PR TITLE
feat(scss): add swing fab mixin

### DIFF
--- a/submissions/scss/feature-swing-fab-mixin-ag/README.md
+++ b/submissions/scss/feature-swing-fab-mixin-ag/README.md
@@ -1,0 +1,22 @@
+# Swing FAB SCSS Mixin
+
+## Description
+This SCSS mixin provides a subtle, pendulum-like "Swing" animation. It is designed specifically for Floating Action Buttons (FABs) or icons to periodically draw attention without being overly distracting.
+
+## Usage
+
+```scss
+@use 'swing-fab' as *;
+
+.my-floating-button {
+  /* Set transform origin to top center for a pendulum effect */
+  @include ease-swing-fab-mixin-ag(2s, top center);
+}
+```
+
+## Parameters
+- `$duration`: The length of one complete swing cycle (default: `2s`).
+- `$transform-origin`: The point around which the element swings (default: `top center`).
+
+## Accessibility
+- Respects `prefers-reduced-motion: reduce` by overriding the keyframes to apply no transform at all, completely disabling the continuous motion to prevent distractions for users with cognitive or vestibular disorders.

--- a/submissions/scss/feature-swing-fab-mixin-ag/_swing-fab.scss
+++ b/submissions/scss/feature-swing-fab-mixin-ag/_swing-fab.scss
@@ -1,0 +1,22 @@
+// _swing-fab.scss
+
+@mixin ease-swing-fab-mixin-ag($duration: 2s, $transform-origin: top center) {
+  transform-origin: $transform-origin;
+  animation: ease-swing-fab-ag $duration ease-in-out infinite;
+}
+
+@keyframes ease-swing-fab-ag {
+  0% { transform: rotate(0deg); }
+  20% { transform: rotate(15deg); }
+  40% { transform: rotate(-10deg); }
+  60% { transform: rotate(5deg); }
+  80% { transform: rotate(-5deg); }
+  100% { transform: rotate(0deg); }
+}
+
+// Reduced Motion Fallback
+@media (prefers-reduced-motion: reduce) {
+  @keyframes ease-swing-fab-ag {
+    from, to { transform: none; }
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Swing FAB Mixin` issue. Provides an SCSS mixin for a "Swing" attention-seeker animation, specifically designed for Floating Action Buttons (FABs).

# Solution
- `_swing-fab.scss`: Contains the mixin `ease-swing-fab-mixin-ag` which animates a pendulum-like rotation back and forth.
- `prefers-reduced-motion` completely disables the continuous motion to prevent distractions for users with cognitive or vestibular disorders.

# Files Changed
* `submissions/scss/feature-swing-fab-mixin-ag/_swing-fab.scss`
* `submissions/scss/feature-swing-fab-mixin-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (Reduced motion)
* [x] No unrelated changes
* [x] Ready for review