### PR TITLE
feat(example): add wiggle modal example

### DIFF
--- a/submissions/examples/feature-wiggle-modal-example-ag/README.md
+++ b/submissions/examples/feature-wiggle-modal-example-ag/README.md
@@ -1,0 +1,12 @@
+# Wiggle Modal Example
+
+## Description
+This is a standard HTML/CSS/JS example demonstrating a "Wiggle" attention-seeker animation applied to a modal. When the modal is triggered (e.g., simulating an error or incorrect password), it rapidly wiggles back and forth, visually communicating rejection or grabbing immediate attention.
+
+## Files
+- `demo.html`: Contains the modal layout and basic JavaScript to toggle visibility and restart the animation when opened.
+- `style.css`: Uses keyframes animating `rotate` back and forth at decreasing intervals to create a natural, diminishing wiggle effect.
+
+## Accessibility
+- Uses standard ARIA attributes (`role="dialog"`, `aria-modal`, `aria-hidden`) for screen readers.
+- **Reduced Motion**: Disables the wiggle animation entirely via `@media (prefers-reduced-motion: reduce)`. The modal will simply appear without shaking.

--- a/submissions/examples/feature-wiggle-modal-example-ag/demo.html
+++ b/submissions/examples/feature-wiggle-modal-example-ag/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wiggle Modal Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container-ag">
+    <button onclick="showModal()" class="trigger-btn-ag">Show Modal</button>
+  </div>
+
+  <div id="modal-overlay" class="modal-overlay-ag" aria-hidden="true">
+    <div class="wiggle-modal-ag" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+      <h3 id="modal-title">Incorrect Password</h3>
+      <p>The password you entered is incorrect. Please try again.</p>
+      <button onclick="hideModal()" class="close-btn-ag">Try Again</button>
+    </div>
+  </div>
+
+  <script>
+    function showModal() {
+      const overlay = document.getElementById('modal-overlay');
+      overlay.setAttribute('aria-hidden', 'false');
+      overlay.classList.add('is-visible-ag');
+      
+      const modal = overlay.querySelector('.wiggle-modal-ag');
+      // Remove class then force reflow to restart animation
+      modal.classList.remove('play-animation-ag');
+      void modal.offsetWidth; 
+      modal.classList.add('play-animation-ag');
+    }
+
+    function hideModal() {
+      const overlay = document.getElementById('modal-overlay');
+      overlay.setAttribute('aria-hidden', 'true');
+      overlay.classList.remove('is-visible-ag');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/feature-wiggle-modal-example-ag/style.css
+++ b/submissions/examples/feature-wiggle-modal-example-ag/style.css
@@ -1,0 +1,73 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+.trigger-btn-ag, .close-btn-ag {
+  background-color: #ef4444;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.modal-overlay-ag {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.modal-overlay-ag.is-visible-ag {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.wiggle-modal-ag {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.wiggle-modal-ag h3 {
+  margin-top: 0;
+  color: #b91c1c;
+}
+
+/* Wiggle animation */
+.play-animation-ag {
+  animation: wiggle-anim-ag 0.6s ease-in-out;
+}
+
+@keyframes wiggle-anim-ag {
+  0%, 100% { transform: rotate(0deg); }
+  15% { transform: rotate(-5deg); }
+  30% { transform: rotate(4deg); }
+  45% { transform: rotate(-3deg); }
+  60% { transform: rotate(2deg); }
+  75% { transform: rotate(-1deg); }
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .play-animation-ag {
+    animation: none;
+  }
+}


### PR DESCRIPTION
# Summary
Resolves the `[Feature] Wiggle Modal Example` issue. Provides a standard HTML/CSS/JS example demonstrating a "Wiggle" attention-seeker animation on a modal.

# Solution
- `demo.html`: Modal with ARIA attributes and JS that re-triggers the wiggle animation each time the modal opens.
- `style.css`: Keyframes animate `rotate` back and forth at decreasing intervals to create a natural, diminishing shake effect.
- `prefers-reduced-motion` disables the wiggle animation entirely.

# Files Changed
* `submissions/examples/feature-wiggle-modal-example-ag/demo.html`
* `submissions/examples/feature-wiggle-modal-example-ag/style.css`
* `submissions/examples/feature-wiggle-modal-example-ag/README.md`

# Checklist
* [x] Issue solved
* [x] Accessibility handled (ARIA, Reduced motion)
* [x] No unrelated changes
* [x] Ready for review