### PR TITLE
feat(example): add expand button example

### DIFF
--- a/submissions/examples/feature-expand-button-example-ag/README.md
+++ b/submissions/examples/feature-expand-button-example-ag/README.md
@@ -1,0 +1,13 @@
+# Expand Button Example
+
+## Description
+This is a standard HTML/CSS example demonstrating an "Expand" entrance animation for a button. On hover or focus, the button expands its width to reveal a text label alongside the icon. This is a common pattern for FABs or compact action buttons.
+
+## Files
+- `demo.html`: A pill-shaped button containing an icon and a hidden text label.
+- `style.css`: Animates `max-width` and `opacity` on the label, and `padding`/`gap` on the button, using smooth cubic-bezier transitions on hover/focus.
+
+## Accessibility
+- Provides an `aria-label` on the button so its purpose is known to screen readers even when the label is visually hidden.
+- Uses `:focus-visible` to trigger the same expand behavior for keyboard users.
+- **Reduced Motion**: Disables all transitions via `@media (prefers-reduced-motion: reduce)`. The label still becomes visible instantly on hover.

--- a/submissions/examples/feature-expand-button-example-ag/demo.html
+++ b/submissions/examples/feature-expand-button-example-ag/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Expand Button Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container-ag">
+    <button class="expand-button-ag" aria-label="Add item">
+      <span class="icon-ag">+</span>
+      <span class="label-ag">Add to Cart</span>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/feature-expand-button-example-ag/style.css
+++ b/submissions/examples/feature-expand-button-example-ag/style.css
@@ -1,0 +1,79 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.expand-button-ag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 50px;
+  padding: 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: hidden;
+  /* Width transitions create the expand effect */
+  transition: padding 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+              gap 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+              background-color 0.2s;
+}
+
+.expand-button-ag:hover,
+.expand-button-ag:focus-visible {
+  background-color: #2563eb;
+  padding: 0.75rem 1.5rem;
+  gap: 0.5rem;
+}
+
+.icon-ag {
+  font-size: 1.25rem;
+  line-height: 1;
+  display: inline-block;
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.expand-button-ag:hover .icon-ag,
+.expand-button-ag:focus-visible .icon-ag {
+  transform: rotate(180deg);
+}
+
+.label-ag {
+  max-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  opacity: 0;
+  transition: max-width 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.3s ease 0.1s;
+}
+
+.expand-button-ag:hover .label-ag,
+.expand-button-ag:focus-visible .label-ag {
+  max-width: 150px;
+  opacity: 1;
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .expand-button-ag,
+  .icon-ag,
+  .label-ag {
+    transition: none;
+  }
+
+  .expand-button-ag:hover .label-ag,
+  .expand-button-ag:focus-visible .label-ag {
+    max-width: 150px;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Resolves [Feature] Expand Button Example. Button reveals label text by expanding width on hover/focus. Reduced motion disables all transitions.