### PR TITLE
Add ease-wire-transfer-form component

### DIFF
--- a/submissions/examples/ease-wire-transfer-form-ij/README.md
+++ b/submissions/examples/ease-wire-transfer-form-ij/README.md
@@ -1,0 +1,16 @@
+# ease-wire-transfer-form
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(94, 68%, 58%) | Primary color |
+| --bg | hsl(94, 10%, 96%) | Background |
+| --duration | 0.88s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-wire-transfer-form-ij/demo.html
+++ b/submissions/examples/ease-wire-transfer-form-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-wire-transfer-form-ij/style.css
+++ b/submissions/examples/ease-wire-transfer-form-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(94, 68%, 58%);--bg:hsl(94, 10%, 96%);--text:#1e293b;--duration:0.88s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes focusRing-wire-transfer-form {
+  0%, 100% { border-color: hsl(94, 68%, 58%); box-shadow: 0 0 0 2px hsl(94, 68%, 58%)30, 0 0 0 0 hsl(214, 68%, 58%)20; }
+  33% { border-color: hsl(214, 68%, 58%); box-shadow: 0 0 0 4px hsl(214, 68%, 58%)30, 0 0 8px hsl(214, 68%, 58%)20; }
+  66% { border-color: hsl(334, 68%, 58%); box-shadow: 0 0 0 3px hsl(334, 68%, 58%)30, 0 0 12px hsl(334, 68%, 58%)20; }
+}
+@keyframes check-wire-transfer-form {
+  0% { clip-path: polygon(0 0, 0 0, 0 0, 0 0); }
+  50% { clip-path: polygon(0 50%, 30% 80%, 60% 30%, 100% 0); }
+  100% { clip-path: polygon(0 50%, 30% 80%, 60% 100%, 100% 20%); }
+}
+.anim-target.active { animation: focusRing-wire-transfer-form 0.88s ease-in-out, check-wire-transfer-form 0.5s ease-in-out; border: 2px solid; border-radius: 10px; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(334, 68%, 58%)}


### PR DESCRIPTION
## Component: ease-wire-transfer-form — wire transfer form — form control with cycling focus ring through three hue stops and clip-path checkmark

**Closes #51165**

### What this adds
A form control. The @keyframes focusRing-wire-transfer-form cycles border-color and box-shadow through three hue stops while check-wire-transfer-form uses clip-path for a checkmark reveal animation.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-wire-transfer-form-ij/demo.html
- submissions/examples/ease-wire-transfer-form-ij/style.css
- submissions/examples/ease-wire-transfer-form-ij/README.md

### How to review
Open demo.html directly in a browser. Click to trigger the focus ring and checkmark reveal animation.
