### PR TITLE
Add ease-wizard-step-navigation component

### DIFF
--- a/submissions/examples/ease-wizard-step-navigation-ij/README.md
+++ b/submissions/examples/ease-wizard-step-navigation-ij/README.md
@@ -1,0 +1,16 @@
+# ease-wizard-step-navigation
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(283, 72%, 62%) | Primary color |
+| --bg | hsl(283, 10%, 96%) | Background |
+| --duration | 1.20s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-wizard-step-navigation-ij/demo.html
+++ b/submissions/examples/ease-wizard-step-navigation-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-wizard-step-navigation-ij/style.css
+++ b/submissions/examples/ease-wizard-step-navigation-ij/style.css
@@ -1,0 +1,21 @@
+:root{--primary:hsl(283, 72%, 62%);--bg:hsl(283, 10%, 96%);--text:#1e293b;--duration:1.20s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes slideIn-wizard-step-navigation {
+  0% { transform: translateX(-28px); opacity: 0; clip-path: inset(0 100% 0 0); }
+  60% { transform: translateX(-2.4.ToString('0'))px; opacity: 0.82; }
+  100% { transform: translateX(0); opacity: 1; clip-path: inset(0 0 0 0); }
+}
+@keyframes expand-wizard-step-navigation {
+  0% { max-height: 0; opacity: 0; transform: scaleY(0); }
+  100% { max-height: 250px; opacity: 1; transform: scaleY(1); }
+}
+.anim-target.active { animation: slideIn-wizard-step-navigation 1.20s cubic-bezier(0.22, 1, 0.36, 1) forwards, expand-wizard-step-navigation 1.50s ease-out; overflow: hidden; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(163, 72%, 62%)}


### PR DESCRIPTION
## Component: ease-wizard-step-navigation — wizard step navigation — navigation panel with slideIn translateX entrance and expand clip-path reveal

**Closes #51177**

### What this adds
A navigation panel. The @keyframes slideIn-wizard-step-navigation moves the element from off-screen with opacity fade and clip-path reveal. expand-wizard-step-navigation animates max-height and scaleY for progressive disclosure.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-wizard-step-navigation-ij/demo.html
- submissions/examples/ease-wizard-step-navigation-ij/style.css
- submissions/examples/ease-wizard-step-navigation-ij/README.md

### How to review
Open demo.html directly in a browser. Click to trigger the slide-in and expand animation sequence.
