### PR TITLE
feat: add fade-in tabs for cyberpunk neon layouts (#50018)

### DIFF
--- a/submissions/examples/cyberpunk-tabs-er/README.md
+++ b/submissions/examples/cyberpunk-tabs-er/README.md
@@ -1,0 +1,64 @@
+# Cyberpunk Neon Fade-In Tabs
+
+Pure CSS tab component with fade-in animation and neon glow effects, styled for cyberpunk interfaces.
+
+## What it is
+
+A CSS-only tab component using radio buttons for state management. Tab panels fade in smoothly with a neon glow aesthetic. No JavaScript is required.
+
+## How it works
+
+The tab component uses CSS `:checked` pseudo-class on hidden radio buttons to control which panel is visible. The `general sibling combinator` (`~`) selects the corresponding panel.
+
+```css
+/* Only show panel matching checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1) {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+/* Fade-in animation */
+.tabs__panel {
+    animation: ease-kf-fade-in-tab 0.35s ease-out forwards;
+}
+```
+
+Key techniques:
+- Hidden `<input type="radio">` controls state — fully keyboard accessible
+- `ease-kf-fade-in-tab` keyframe for smooth panel entrance
+- `ease-kf-glow-pulse` keyframe for neon glow on active tab
+- `ease-kf-border-scan` for animated gradient border effect
+- CSS custom properties for all neon colors and timing
+
+## Why it matters
+
+Cyberpunk-themed interfaces need tab components that feel alive. The neon glow pulse and fade-in transitions create an immersive, futuristic feel — all in pure CSS.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Cyberpunk character profiles and weapon loadouts demo |
+| `style.css` | Tab styles, neon effects, and animations |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-tab-duration` | `0.35s` | Fade-in animation duration |
+| `--ez-tab-glow-color` | `#ff2a6d` | Active tab neon glow |
+| `--ez-tab-accent` | `#05d9e8` | Secondary accent color |
+| `--ez-tab-bg` | `#0d0221` | Background color |
+| `--ez-tab-color` | `#d1f7ff` | Text color |
+| `--ez-tab-border` | `#1a1a3e` | Border color |
+
+## Keyframes
+
+- `ease-kf-fade-in-tab` — translateY + opacity fade-in
+- `ease-kf-glow-pulse` — pulsing neon box-shadow
+- `ease-kf-border-scan` — animated gradient border sweep
+
+## Issue
+
+Closes #50018

--- a/submissions/examples/cyberpunk-tabs-er/demo.html
+++ b/submissions/examples/cyberpunk-tabs-er/demo.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Neon Fade-In Tabs – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <header class="hero">
+        <div class="hero__inner">
+            <span class="hero__badge">CSS-Only Tabs</span>
+            <h1 class="hero__title">Cyberpunk<span class="neon-text"> Neon</span> Tabs</h1>
+            <p class="hero__sub">Fade-In tabs with neon glow effects — zero JavaScript. Use keyboard arrows to navigate.</p>
+        </div>
+    </header>
+
+    <main class="main">
+
+        <section class="demo-section">
+            <div class="container">
+                <h2 class="section-title">Character Profiles</h2>
+
+                <div class="tabs">
+                    <input type="radio" name="char-tabs" id="tab-1" class="tabs__radio" checked>
+                    <label for="tab-1" class="tabs__label" tabindex="0" role="tab">
+                        <span class="tabs__label-text">Raven</span>
+                        <span class="tabs__glow"></span>
+                    </label>
+
+                    <input type="radio" name="char-tabs" id="tab-2" class="tabs__radio">
+                    <label for="tab-2" class="tabs__label" tabindex="0" role="tab">
+                        <span class="tabs__label-text">Glitch</span>
+                        <span class="tabs__glow"></span>
+                    </label>
+
+                    <input type="radio" name="char-tabs" id="tab-3" class="tabs__radio">
+                    <label for="tab-3" class="tabs__label" tabindex="0" role="tab">
+                        <span class="tabs__label-text">Nova</span>
+                        <span class="tabs__glow"></span>
+                    </label>
+
+                    <input type="radio" name="char-tabs" id="tab-4" class="tabs__radio">
+                    <label for="tab-4" class="tabs__label" tabindex="0" role="tab">
+                        <span class="tabs__label-text">Phantom</span>
+                        <span class="tabs__glow"></span>
+                    </label>
+
+                    <div class="tabs__panels">
+                        <div class="tabs__panel" role="tabpanel" id="panel-1">
+                            <div class="panel__header">
+                                <span class="panel__class">Netrunner</span>
+                                <h3 class="panel__name">Raven</h3>
+                                <span class="panel__level">LVL 42</span>
+                            </div>
+                            <div class="panel__stats">
+                                <div class="stat">
+                                    <span class="stat__label">INT</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 92%;"></span></div>
+                                    <span class="stat__val">92</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">REF</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 78%;"></span></div>
+                                    <span class="stat__val">78</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">TECH</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 85%;"></span></div>
+                                    <span class="stat__val">85</span>
+                                </div>
+                            </div>
+                            <p class="panel__bio">Elite netrunner operating in the Undernet. Known for breaching corporate firewalls that others deem impenetrable.</p>
+                        </div>
+
+                        <div class="tabs__panel" role="tabpanel" id="panel-2">
+                            <div class="panel__header">
+                                <span class="panel__class">Techie</span>
+                                <h3 class="panel__name">Glitch</h3>
+                                <span class="panel__level">LVL 38</span>
+                            </div>
+                            <div class="panel__stats">
+                                <div class="stat">
+                                    <span class="stat__label">INT</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 70%;"></span></div>
+                                    <span class="stat__val">70</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">REF</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 88%;"></span></div>
+                                    <span class="stat__val">88</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">TECH</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 96%;"></span></div>
+                                    <span class="stat__val">96</span>
+                                </div>
+                            </div>
+                            <p class="panel__bio">Weapons specialist and cyberware engineer. Can mod any piece of hardware to perform beyond its design specs.</p>
+                        </div>
+
+                        <div class="tabs__panel" role="tabpanel" id="panel-3">
+                            <div class="panel__header">
+                                <span class="panel__class">Solo</span>
+                                <h3 class="panel__name">Nova</h3>
+                                <span class="panel__level">LVL 45</span>
+                            </div>
+                            <div class="panel__stats">
+                                <div class="stat">
+                                    <span class="stat__label">INT</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 65%;"></span></div>
+                                    <span class="stat__val">65</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">REF</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 98%;"></span></div>
+                                    <span class="stat__val">98</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">TECH</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 72%;"></span></div>
+                                    <span class="stat__val">72</span>
+                                </div>
+                            </div>
+                            <p class="panel__bio">Street samurai with reflexes augmented beyond human limits. The fastest draw in Night City — never lost a duel.</p>
+                        </div>
+
+                        <div class="tabs__panel" role="tabpanel" id="panel-4">
+                            <div class="panel__header">
+                                <span class="panel__class">Fixer</span>
+                                <h3 class="panel__name">Phantom</h3>
+                                <span class="panel__level">LVL 40</span>
+                            </div>
+                            <div class="panel__stats">
+                                <div class="stat">
+                                    <span class="stat__label">INT</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 88%;"></span></div>
+                                    <span class="stat__val">88</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">REF</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 80%;"></span></div>
+                                    <span class="stat__val">80</span>
+                                </div>
+                                <div class="stat">
+                                    <span class="stat__label">TECH</span>
+                                    <div class="stat__bar"><span class="stat__fill" style="--w: 75%;"></span></div>
+                                    <span class="stat__val">75</span>
+                                </div>
+                            </div>
+                            <p class="panel__bio">Information broker and dealmaker. If you need something in Night City — legal or not — Phantom can get it.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="demo-section">
+            <div class="container">
+                <h2 class="section-title">Weapon Loadouts</h2>
+
+                <div class="tabs tabs--alt">
+                    <input type="radio" name="weapon-tabs" id="wtab-1" class="tabs__radio" checked>
+                    <label for="wtab-1" class="tabs__label" tabindex="0" role="tab">
+                        <span class="tabs__label-text">Pistols</span>
+                        <span class="tabs__glow"></span>
+                    </label>
+
+                    <input type="radio" name="weapon-tabs" id="wtab-2" class="tabs__radio">
+                    <label for="wtab-2" class="tabs__label" tabindex="0" role="tab">
+                        <span class="tabs__label-text">Rifles</span>
+                        <span class="tabs__glow"></span>
+                    </label>
+
+                    <input type="radio" name="weapon-tabs" id="wtab-3" class="tabs__radio">
+                    <label for="wtab-3" class="tabs__label" tabindex="0" role="tab">
+                        <span class="tabs__label-text">Melee</span>
+                        <span class="tabs__glow"></span>
+                    </label>
+
+                    <div class="tabs__panels">
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__name">Pistols</h3>
+                            <div class="weapon-grid">
+                                <div class="weapon">
+                                    <span class="weapon__name">Militech M-31A</span>
+                                    <span class="weapon__dmg">DMG: 45-62</span>
+                                    <span class="weapon__rarity weapon__rarity--epic">Epic</span>
+                                </div>
+                                <div class="weapon">
+                                    <span class="weapon__name">Arasaka Kensa</span>
+                                    <span class="weapon__dmg">DMG: 38-55</span>
+                                    <span class="weapon__rarity weapon__rarity--rare">Rare</span>
+                                </div>
+                                <div class="weapon">
+                                    <span class="weapon__name">Tsunami Nekomata</span>
+                                    <span class="weapon__dmg">DMG: 52-71</span>
+                                    <span class="weapon__rarity weapon__rarity--legendary">Legendary</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__name">Rifles</h3>
+                            <div class="weapon-grid">
+                                <div class="weapon">
+                                    <span class="weapon__name">Militech Ajax</span>
+                                    <span class="weapon__dmg">DMG: 55-82</span>
+                                    <span class="weapon__rarity weapon__rarity--epic">Epic</span>
+                                </div>
+                                <div class="weapon">
+                                    <span class="weapon__name">Kang Tao G-58</span>
+                                    <span class="weapon__dmg">DMG: 48-70</span>
+                                    <span class="weapon__rarity weapon__rarity--rare">Rare</span>
+                                </div>
+                                <div class="weapon">
+                                    <span class="weapon__name">Techtronika Pulsar</span>
+                                    <span class="weapon__dmg">DMG: 60-90</span>
+                                    <span class="weapon__rarity weapon__rarity--legendary">Legendary</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__name">Melee</h3>
+                            <div class="weapon-grid">
+                                <div class="weapon">
+                                    <span class="weapon__name">Mantis Blades</span>
+                                    <span class="weapon__dmg">DMG: 70-110</span>
+                                    <span class="weapon__rarity weapon__rarity--legendary">Legendary</span>
+                                </div>
+                                <div class="weapon">
+                                    <span class="weapon__name">Katana "Satori"</span>
+                                    <span class="weapon__dmg">DMG: 85-120</span>
+                                    <span class="weapon__rarity weapon__rarity--legendary">Legendary</span>
+                                </div>
+                                <div class="weapon">
+                                    <span class="weapon__name">Neurotoxin Knuckles</span>
+                                    <span class="weapon__dmg">DMG: 40-65</span>
+                                    <span class="weapon__rarity weapon__rarity--epic">Epic</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="usage-section">
+            <div class="container">
+                <h2 class="section-title">Usage</h2>
+                <pre class="code-block"><code>&lt;div class="tabs"&gt;
+    &lt;input type="radio" name="tabs" id="tab-1" class="tabs__radio" checked&gt;
+    &lt;label for="tab-1" class="tabs__label"&gt;Tab 1&lt;/label&gt;
+
+    &lt;input type="radio" name="tabs" id="tab-2" class="tabs__radio"&gt;
+    &lt;label for="tab-2" class="tabs__label"&gt;Tab 2&lt;/label&gt;
+
+    &lt;div class="tabs__panels"&gt;
+        &lt;div class="tabs__panel" role="tabpanel"&gt;Content 1&lt;/div&gt;
+        &lt;div class="tabs__panel" role="tabpanel"&gt;Content 2&lt;/div&gt;
+    &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+                <h2 class="section-title">Custom Properties</h2>
+                <div class="props-table">
+                    <div class="props-row props-row--header">
+                        <span>Property</span>
+                        <span>Default</span>
+                        <span>Description</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tab-duration</code>
+                        <code>0.35s</code>
+                        <span>Fade-in animation duration</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tab-glow-color</code>
+                        <code>#ff2a6d</code>
+                        <span>Active tab neon glow</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tab-accent</code>
+                        <code>#05d9e8</code>
+                        <span>Secondary accent color</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tab-bg</code>
+                        <code>#0d0221</code>
+                        <span>Background color</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tab-color</code>
+                        <code>#d1f7ff</code>
+                        <span>Text color</span>
+                    </div>
+                    <div class="props-row">
+                        <code>--ez-tab-border</code>
+                        <code>#1a1a3e</code>
+                        <span>Border color</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p>Part of <strong>EaseMotion CSS</strong> – Pure CSS animation library</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-tabs-er/style.css
+++ b/submissions/examples/cyberpunk-tabs-er/style.css
@@ -1,0 +1,566 @@
+/* =============================================
+   Cyberpunk Neon Fade-In Tabs
+   CSS-Only Tab Component
+   Pure CSS · Keyboard · ARIA
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-tab-duration: 0.35s;
+    --ez-tab-glow-color: #ff2a6d;
+    --ez-tab-accent: #05d9e8;
+    --ez-tab-bg: #0d0221;
+    --ez-tab-surface: #12042e;
+    --ez-tab-color: #d1f7ff;
+    --ez-tab-muted: #6b6b8d;
+    --ez-tab-border: #1a1a3e;
+    --ez-tab-glow-rgb: 255, 42, 109;
+    --ez-tab-accent-rgb: 5, 217, 232;
+    --ez-focus-ring: 3px;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-fade-in-tab {
+    0% {
+        opacity: 0;
+        transform: translateY(10px);
+        visibility: hidden;
+    }
+    50% {
+        opacity: 0.7;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-glow-pulse {
+    0%, 100% {
+        box-shadow: 0 0 8px rgba(var(--ez-tab-glow-rgb), 0.4),
+                    0 0 20px rgba(var(--ez-tab-glow-rgb), 0.2);
+    }
+    50% {
+        box-shadow: 0 0 14px rgba(var(--ez-tab-glow-rgb), 0.6),
+                    0 0 32px rgba(var(--ez-tab-glow-rgb), 0.3);
+    }
+}
+
+@keyframes ease-kf-border-scan {
+    0% { background-position: 0% 50%; }
+    100% { background-position: 200% 50%; }
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: "Courier New", "Consolas", monospace;
+    background: var(--ez-tab-bg);
+    color: var(--ez-tab-color);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.hero {
+    padding: 60px 24px 70px;
+    text-align: center;
+    border-bottom: 1px solid var(--ez-tab-border);
+    position: relative;
+    overflow: hidden;
+}
+
+.hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(ellipse at 20% 50%, rgba(var(--ez-tab-glow-rgb), 0.08) 0%, transparent 60%),
+        radial-gradient(ellipse at 80% 50%, rgba(var(--ez-tab-accent-rgb), 0.06) 0%, transparent 60%);
+    pointer-events: none;
+}
+
+.hero__badge {
+    display: inline-block;
+    padding: 5px 16px;
+    border: 1px solid var(--ez-tab-accent);
+    color: var(--ez-tab-accent);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    border-radius: 2px;
+    margin-bottom: 18px;
+    position: relative;
+}
+
+.hero__title {
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 700;
+    color: var(--ez-tab-color);
+    margin-bottom: 10px;
+    letter-spacing: -0.5px;
+    position: relative;
+}
+
+.neon-text {
+    color: var(--ez-tab-glow-color);
+    text-shadow:
+        0 0 10px rgba(var(--ez-tab-glow-rgb), 0.5),
+        0 0 30px rgba(var(--ez-tab-glow-rgb), 0.3);
+}
+
+.hero__sub {
+    font-size: 0.9rem;
+    color: var(--ez-tab-muted);
+    max-width: 480px;
+    margin: 0 auto;
+    position: relative;
+}
+
+/* ---------- Main ---------- */
+.main {
+    padding: 40px 0 80px;
+}
+
+.section-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--ez-tab-accent);
+    margin-bottom: 24px;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+}
+
+.demo-section {
+    margin-bottom: 50px;
+}
+
+/* ---------- Tabs Component ---------- */
+.tabs {
+    background: var(--ez-tab-surface);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.tabs__radio {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+}
+
+.tabs__label {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    padding: 14px 28px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ez-tab-muted);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+    outline: none;
+    user-select: none;
+}
+
+.tabs__label:hover {
+    color: var(--ez-tab-color);
+}
+
+.tabs__label:focus-visible {
+    box-shadow: inset 0 0 0 var(--ez-focus-ring) rgba(var(--ez-tab-accent-rgb), 0.4);
+    border-radius: 4px 4px 0 0;
+}
+
+.tabs__glow {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--ez-tab-glow-color);
+    opacity: 0;
+    transform: scaleX(0);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    box-shadow: 0 0 10px rgba(var(--ez-tab-glow-rgb), 0.6);
+}
+
+/* ---------- Active Tab State ---------- */
+.tabs__radio:checked + .tabs__label {
+    color: var(--ez-tab-glow-color);
+    border-bottom-color: transparent;
+}
+
+.tabs__radio:checked + .tabs__label .tabs__glow {
+    opacity: 1;
+    transform: scaleX(1);
+    animation: ease-kf-glow-pulse 2s ease-in-out infinite;
+}
+
+.tabs__radio:checked + .tabs__label::after {
+    content: "";
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--ez-tab-glow-color),
+        var(--ez-tab-accent),
+        var(--ez-tab-glow-color),
+        transparent
+    );
+    background-size: 200% 100%;
+    animation: ease-kf-border-scan 3s linear infinite;
+}
+
+/* ---------- Tab Panels ---------- */
+.tabs__panels {
+    position: relative;
+    min-height: 220px;
+}
+
+.tabs__panel {
+    position: absolute;
+    inset: 0;
+    padding: 28px;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px);
+    animation: ease-kf-fade-in-tab var(--ez-tab-duration) ease-out forwards;
+}
+
+/* Show only the panel matching the checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1),
+.tabs__radio:nth-of-type(2):checked ~ .tabs__panels .tabs__panel:nth-child(2),
+.tabs__radio:nth-of-type(3):checked ~ .tabs__panels .tabs__panel:nth-child(3),
+.tabs__radio:nth-of-type(4):checked ~ .tabs__panels .tabs__panel:nth-child(4) {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    position: relative;
+}
+
+/* ---------- Panel Content ---------- */
+.panel__header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.panel__class {
+    padding: 3px 12px;
+    background: rgba(var(--ez-tab-accent-rgb), 0.1);
+    border: 1px solid rgba(var(--ez-tab-accent-rgb), 0.3);
+    color: var(--ez-tab-accent);
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border-radius: 2px;
+}
+
+.panel__name {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--ez-tab-glow-color);
+    text-shadow: 0 0 12px rgba(var(--ez-tab-glow-rgb), 0.3);
+    flex: 1;
+}
+
+.panel__level {
+    padding: 3px 12px;
+    background: rgba(var(--ez-tab-glow-rgb), 0.1);
+    border: 1px solid rgba(var(--ez-tab-glow-rgb), 0.3);
+    color: var(--ez-tab-glow-color);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 1px;
+    border-radius: 2px;
+}
+
+.panel__bio {
+    font-size: 0.88rem;
+    color: var(--ez-tab-muted);
+    margin-top: 16px;
+    line-height: 1.6;
+}
+
+/* ---------- Stats ---------- */
+.panel__stats {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.stat {
+    display: grid;
+    grid-template-columns: 50px 1fr 36px;
+    align-items: center;
+    gap: 12px;
+}
+
+.stat__label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--ez-tab-accent);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.stat__bar {
+    height: 8px;
+    background: rgba(var(--ez-tab-glow-rgb), 0.1);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.stat__fill {
+    display: block;
+    height: 100%;
+    width: var(--w);
+    background: linear-gradient(90deg, var(--ez-tab-accent), var(--ez-tab-glow-color));
+    border-radius: 4px;
+    box-shadow: 0 0 8px rgba(var(--ez-tab-glow-rgb), 0.4);
+}
+
+.stat__val {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--ez-tab-glow-color);
+    text-align: right;
+}
+
+/* ---------- Weapon Grid ---------- */
+.weapon-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 16px;
+}
+
+.weapon {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 16px;
+    background: rgba(var(--ez-tab-glow-rgb), 0.04);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 4px;
+    transition: border-color 0.15s ease;
+}
+
+.weapon:hover {
+    border-color: rgba(var(--ez-tab-glow-rgb), 0.3);
+}
+
+.weapon__name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ez-tab-color);
+    flex: 1;
+}
+
+.weapon__dmg {
+    font-size: 0.75rem;
+    color: var(--ez-tab-muted);
+}
+
+.weapon__rarity {
+    padding: 2px 10px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-radius: 2px;
+}
+
+.weapon__rarity--rare {
+    background: rgba(var(--ez-tab-accent-rgb), 0.12);
+    color: var(--ez-tab-accent);
+    border: 1px solid rgba(var(--ez-tab-accent-rgb), 0.3);
+}
+
+.weapon__rarity--epic {
+    background: rgba(168, 85, 247, 0.12);
+    color: #a855f7;
+    border: 1px solid rgba(168, 85, 247, 0.3);
+}
+
+.weapon__rarity--legendary {
+    background: rgba(var(--ez-tab-glow-rgb), 0.12);
+    color: var(--ez-tab-glow-color);
+    border: 1px solid rgba(var(--ez-tab-glow-rgb), 0.3);
+}
+
+/* ---------- Alt Tab Variant ---------- */
+.tabs--alt .tabs__label {
+    border-bottom: 2px solid var(--ez-tab-border);
+}
+
+.tabs--alt .tabs__radio:checked + .tabs__label {
+    border-bottom-color: var(--ez-tab-accent);
+    color: var(--ez-tab-accent);
+}
+
+.tabs--alt .tabs__glow {
+    background: var(--ez-tab-accent);
+    box-shadow: 0 0 10px rgba(var(--ez-tab-accent-rgb), 0.6);
+}
+
+.tabs--alt .tabs__radio:checked + .tabs__label::after {
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--ez-tab-accent),
+        var(--ez-tab-glow-color),
+        var(--ez-tab-accent),
+        transparent
+    );
+}
+
+/* ---------- Usage Section ---------- */
+.usage-section {
+    margin-top: 50px;
+}
+
+.code-block {
+    background: var(--ez-tab-surface);
+    color: var(--ez-tab-color);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 8px;
+    padding: 20px 24px;
+    overflow-x: auto;
+    font-size: 0.8rem;
+    line-height: 1.7;
+    margin-bottom: 32px;
+    font-family: "Courier New", "Consolas", monospace;
+}
+
+.props-table {
+    background: var(--ez-tab-surface);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.props-row {
+    display: grid;
+    grid-template-columns: 200px 140px 1fr;
+    gap: 16px;
+    align-items: center;
+    padding: 10px 18px;
+    border-bottom: 1px solid var(--ez-tab-border);
+    font-size: 0.82rem;
+}
+
+.props-row:last-child {
+    border-bottom: none;
+}
+
+.props-row--header {
+    background: rgba(var(--ez-tab-accent-rgb), 0.05);
+    font-weight: 700;
+    color: var(--ez-tab-accent);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.props-row code {
+    font-family: "Courier New", "Consolas", monospace;
+    font-size: 0.78rem;
+    color: var(--ez-tab-glow-color);
+    background: rgba(var(--ez-tab-glow-rgb), 0.08);
+    padding: 3px 8px;
+    border-radius: 3px;
+}
+
+/* ---------- Footer ---------- */
+.footer {
+    text-align: center;
+    padding: 28px 24px;
+    border-top: 1px solid var(--ez-tab-border);
+    color: var(--ez-tab-muted);
+    font-size: 0.85rem;
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .tabs__panel {
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 640px) {
+    .hero {
+        padding: 40px 20px 50px;
+    }
+
+    .tabs__label {
+        padding: 12px 16px;
+        font-size: 0.75rem;
+        letter-spacing: 0.5px;
+    }
+
+    .tabs__panel {
+        padding: 20px 16px;
+    }
+
+    .stat {
+        grid-template-columns: 40px 1fr 30px;
+        gap: 8px;
+    }
+
+    .panel__header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .props-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+        padding: 8px 14px;
+    }
+
+    .props-row--header {
+        display: none;
+    }
+}


### PR DESCRIPTION
## What
Pure CSS tab component with fade-in animation and neon glow effects, designed for cyberpunk neon interfaces. Uses hidden radio buttons for state — fully keyboard accessible with zero JavaScript.

Closes #50018

## Why
Cyberpunk-themed interfaces need tab components that feel alive. The neon glow pulse and fade-in transitions create an immersive, futuristic feel — all in pure CSS.

## How
- Hidden `<input type="radio">` controls state — inherent keyboard accessibility
- `ease-kf-fade-in-tab` keyframe for smooth panel entrance (translateY + opacity)
- `ease-kf-glow-pulse` keyframe for pulsing neon box-shadow on active tab
- `ease-kf-border-scan` for animated gradient border sweep effect
- `role="tabpanel"` for screen reader semantics
- CSS custom properties for all neon colors, glow, and timing
- Two variants: default (pink glow) and alt (cyan glow)
- Responsive design with proper mobile layout

## Files (all inside submissions/)
- `submissions/examples/cyberpunk-tabs-er/demo.html`
- `submissions/examples/cyberpunk-tabs-er/style.css`
- `submissions/examples/cyberpunk-tabs-er/README.md`

## Checklist
- [x] Pure CSS, no JavaScript
- [x] Responsive (grid + media queries)
- [x] Uses `ease-*` CSS custom properties and `ease-kf-*` keyframes
- [x] Respects `prefers-reduced-motion`
- [x] Keyboard accessible (radio button navigation)
- [x] ARIA attributes (role="tabpanel")
- [x] Only new files inside `submissions/` — no other files affected