### PR TITLE
feat: add zoom-in tabs for responsive dashboard layouts (#50048)

### DIFF
--- a/submissions/examples/dashboard-tabs-er/README.md
+++ b/submissions/examples/dashboard-tabs-er/README.md
@@ -1,0 +1,63 @@
+# Responsive Dashboard Zoom-In Tabs
+
+Pure CSS tab component with zoom-in animation, designed for responsive dashboard interfaces.
+
+## What it is
+
+A CSS-only tab component using radio buttons for state management. Tab panels zoom in smoothly when switching between content — ideal for dashboard analytics, reports, and settings views. No JavaScript is required.
+
+## How it works
+
+The tab component uses CSS `:checked` pseudo-class on hidden radio buttons to control which panel is visible. The `general sibling combinator` (`~`) selects the corresponding panel.
+
+```css
+/* Only show panel matching checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1) {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+}
+
+/* Zoom-in animation */
+.tabs__panel {
+    animation: ease-kf-zoom-in-panel 0.35s ease-out forwards;
+}
+```
+
+Key techniques:
+- Hidden `<input type="radio">` controls state — fully keyboard accessible
+- `ease-kf-zoom-in-panel` keyframe for smooth panel zoom entrance
+- Configurable `--ez-tab-scale` for zoom factor
+- `role="tabpanel"` for screen reader semantics
+- CSS custom properties for all colors, timing, and scale
+
+## Why it matters
+
+Dashboard interfaces need tab components that feel responsive and polished. The zoom-in transition provides an app-like feel that helps users track content changes — all in pure CSS with zero JavaScript.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Full dashboard layout with sidebar, stats cards, and zoom-in tabs |
+| `style.css` | Dashboard layout, tab styles, zoom-in animations, and responsive rules |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-tab-duration` | `0.35s` | Zoom-in animation duration |
+| `--ez-tab-scale` | `0.9` | Initial zoom scale |
+| `--ez-tab-accent` | `#3b82f6` | Active tab accent color |
+| `--ez-tab-bg` | `#ffffff` | Background color |
+| `--ez-tab-color` | `#0f172a` | Text color |
+| `--ez-tab-border` | `#e2e8f0` | Border color |
+| `--ez-tab-sidebar-bg` | `#0f172a` | Sidebar background |
+
+## Keyframes
+
+- `ease-kf-zoom-in-panel` — scale + opacity zoom-in entrance
+
+## Issue
+
+Closes #50048

--- a/submissions/examples/dashboard-tabs-er/demo.html
+++ b/submissions/examples/dashboard-tabs-er/demo.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard Zoom-In Tabs – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="dashboard">
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar__brand">
+                <span class="sidebar__logo">&#9670;</span>
+                <span class="sidebar__name">DashBoard</span>
+            </div>
+            <nav class="sidebar__nav">
+                <a href="#" class="sidebar__link sidebar__link--active">
+                    <span class="sidebar__icon">&#9632;</span> Overview
+                </a>
+                <a href="#" class="sidebar__link">
+                    <span class="sidebar__icon">&#9651;</span> Analytics
+                </a>
+                <a href="#" class="sidebar__link">
+                    <span class="sidebar__icon">&#9776;</span> Reports
+                </a>
+                <a href="#" class="sidebar__link">
+                    <span class="sidebar__icon">&#9881;</span> Settings
+                </a>
+            </nav>
+            <div class="sidebar__footer">
+                <span class="sidebar__avatar">JD</span>
+                <span class="sidebar__user">Jane Doe</span>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <div class="content">
+
+            <!-- Topbar -->
+            <header class="topbar">
+                <h1 class="topbar__title">Dashboard Overview</h1>
+                <div class="topbar__actions">
+                    <span class="topbar__badge">Zoom-In Tabs</span>
+                    <span class="topbar__date">Jul 2026</span>
+                </div>
+            </header>
+
+            <!-- Stats Cards -->
+            <div class="stats-row">
+                <div class="stat-card">
+                    <span class="stat-card__value">12,847</span>
+                    <span class="stat-card__label">Total Users</span>
+                    <span class="stat-card__change stat-card__change--up">+12.5%</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-card__value">$48.2K</span>
+                    <span class="stat-card__label">Revenue</span>
+                    <span class="stat-card__change stat-card__change--up">+8.1%</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-card__value">3,421</span>
+                    <span class="stat-card__label">Orders</span>
+                    <span class="stat-card__change stat-card__change--down">-2.3%</span>
+                </div>
+                <div class="stat-card">
+                    <span class="stat-card__value">99.8%</span>
+                    <span class="stat-card__label">Uptime</span>
+                    <span class="stat-card__change stat-card__change--up">+0.1%</span>
+                </div>
+            </div>
+
+            <!-- Tab Component -->
+            <section class="tabs-section">
+                <div class="tabs">
+                    <input type="radio" name="dash-tabs" id="dtab-1" class="tabs__radio" checked>
+                    <label for="dtab-1" class="tabs__label">
+                        <span class="tabs__icon">&#9632;</span>
+                        <span class="tabs__label-text">Analytics</span>
+                    </label>
+
+                    <input type="radio" name="dash-tabs" id="dtab-2" class="tabs__radio">
+                    <label for="dtab-2" class="tabs__label">
+                        <span class="tabs__icon">&#9776;</span>
+                        <span class="tabs__label-text">Reports</span>
+                    </label>
+
+                    <input type="radio" name="dash-tabs" id="dtab-3" class="tabs__radio">
+                    <label for="dtab-3" class="tabs__label">
+                        <span class="tabs__icon">&#9881;</span>
+                        <span class="tabs__label-text">Settings</span>
+                    </label>
+
+                    <div class="tabs__panels">
+
+                        <!-- Analytics Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__title">Traffic Analytics</h3>
+                            <p class="panel__desc">Monitor your site traffic and user engagement metrics.</p>
+                            <div class="chart-area">
+                                <div class="bar-chart">
+                                    <div class="bar-chart__bar" style="--h: 65%;"><span>Mon</span></div>
+                                    <div class="bar-chart__bar" style="--h: 80%;"><span>Tue</span></div>
+                                    <div class="bar-chart__bar" style="--h: 55%;"><span>Wed</span></div>
+                                    <div class="bar-chart__bar" style="--h: 90%;"><span>Thu</span></div>
+                                    <div class="bar-chart__bar" style="--h: 75%;"><span>Fri</span></div>
+                                    <div class="bar-chart__bar" style="--h: 45%;"><span>Sat</span></div>
+                                    <div class="bar-chart__bar" style="--h: 60%;"><span>Sun</span></div>
+                                </div>
+                            </div>
+                            <div class="panel__metrics">
+                                <div class="panel__metric">
+                                    <span class="panel__metric-val">45.2K</span>
+                                    <span class="panel__metric-lbl">Page Views</span>
+                                </div>
+                                <div class="panel__metric">
+                                    <span class="panel__metric-val">2m 34s</span>
+                                    <span class="panel__metric-lbl">Avg. Duration</span>
+                                </div>
+                                <div class="panel__metric">
+                                    <span class="panel__metric-val">68.4%</span>
+                                    <span class="panel__metric-lbl">Bounce Rate</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Reports Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__title">Sales Reports</h3>
+                            <p class="panel__desc">View detailed breakdowns of your monthly sales performance.</p>
+                            <div class="report-table">
+                                <div class="report-row report-row--header">
+                                    <span>Month</span>
+                                    <span>Revenue</span>
+                                    <span>Orders</span>
+                                    <span>Growth</span>
+                                </div>
+                                <div class="report-row">
+                                    <span>January</span>
+                                    <span>$12,400</span>
+                                    <span>890</span>
+                                    <span class="report-row__change report-row__change--up">+15%</span>
+                                </div>
+                                <div class="report-row">
+                                    <span>February</span>
+                                    <span>$15,800</span>
+                                    <span>1,024</span>
+                                    <span class="report-row__change report-row__change--up">+27%</span>
+                                </div>
+                                <div class="report-row">
+                                    <span>March</span>
+                                    <span>$14,200</span>
+                                    <span>978</span>
+                                    <span class="report-row__change report-row__change--down">-10%</span>
+                                </div>
+                                <div class="report-row">
+                                    <span>April</span>
+                                    <span>$18,900</span>
+                                    <span>1,340</span>
+                                    <span class="report-row__change report-row__change--up">+33%</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Settings Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__title">Dashboard Settings</h3>
+                            <p class="panel__desc">Configure your dashboard preferences and integrations.</p>
+                            <div class="settings-grid">
+                                <div class="setting-card">
+                                    <span class="setting-card__icon">&#128276;</span>
+                                    <span class="setting-card__title">Notifications</span>
+                                    <span class="setting-card__desc">Manage email and push notifications</span>
+                                    <span class="setting-card__status setting-card__status--on">Enabled</span>
+                                </div>
+                                <div class="setting-card">
+                                    <span class="setting-card__icon">&#128274;</span>
+                                    <span class="setting-card__title">Two-Factor Auth</span>
+                                    <span class="setting-card__desc">Add an extra layer of security</span>
+                                    <span class="setting-card__status setting-card__status--on">Active</span>
+                                </div>
+                                <div class="setting-card">
+                                    <span class="setting-card__icon">&#128187;</span>
+                                    <span class="setting-card__title">API Access</span>
+                                    <span class="setting-card__desc">Manage your API keys and tokens</span>
+                                    <span class="setting-card__status">Configure</span>
+                                </div>
+                                <div class="setting-card">
+                                    <span class="setting-card__icon">&#128230;</span>
+                                    <span class="setting-card__title">Integrations</span>
+                                    <span class="setting-card__desc">Connect third-party services</span>
+                                    <span class="setting-card__status">Setup</span>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </section>
+
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/dashboard-tabs-er/style.css
+++ b/submissions/examples/dashboard-tabs-er/style.css
@@ -1,0 +1,600 @@
+/* =============================================
+   Responsive Dashboard Zoom-In Tabs
+   CSS-Only Tab Component
+   Pure CSS · Keyboard · ARIA
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-tab-duration: 0.35s;
+    --ez-tab-scale: 0.9;
+    --ez-tab-accent: #3b82f6;
+    --ez-tab-accent-hover: #2563eb;
+    --ez-tab-accent-light: rgba(59, 130, 246, 0.08);
+    --ez-tab-success: #22c55e;
+    --ez-tab-danger: #ef4444;
+    --ez-tab-bg: #ffffff;
+    --ez-tab-page-bg: #f1f5f9;
+    --ez-tab-surface: #f8fafc;
+    --ez-tab-color: #0f172a;
+    --ez-tab-muted: #64748b;
+    --ez-tab-border: #e2e8f0;
+    --ez-tab-sidebar-bg: #0f172a;
+    --ez-tab-sidebar-color: #94a3b8;
+    --ez-tab-sidebar-active: #3b82f6;
+    --ez-focus-ring: 3px;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-zoom-in-panel {
+    0% {
+        opacity: 0;
+        transform: scale(var(--ez-tab-scale));
+        visibility: hidden;
+    }
+    50% {
+        opacity: 0.85;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+        visibility: visible;
+    }
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+    background: var(--ez-tab-page-bg);
+    color: var(--ez-tab-color);
+    line-height: 1.6;
+}
+
+/* ---------- Dashboard Layout ---------- */
+.dashboard {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    min-height: 100vh;
+}
+
+/* ---------- Sidebar ---------- */
+.sidebar {
+    background: var(--ez-tab-sidebar-bg);
+    color: var(--ez-tab-sidebar-color);
+    display: flex;
+    flex-direction: column;
+    padding: 24px 0;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+}
+
+.sidebar__brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 20px 24px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    margin-bottom: 16px;
+}
+
+.sidebar__logo {
+    font-size: 1.4rem;
+    color: var(--ez-tab-accent);
+}
+
+.sidebar__name {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #f8fafc;
+}
+
+.sidebar__nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 0 12px;
+    flex: 1;
+}
+
+.sidebar__link {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: var(--ez-tab-sidebar-color);
+    text-decoration: none;
+    transition: background 0.15s ease, color 0.15s ease;
+    outline: none;
+}
+
+.sidebar__link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: #f8fafc;
+}
+
+.sidebar__link:focus-visible {
+    box-shadow: inset 0 0 0 var(--ez-focus-ring) rgba(59, 130, 246, 0.4);
+}
+
+.sidebar__link--active {
+    background: rgba(59, 130, 246, 0.12);
+    color: var(--ez-tab-sidebar-active);
+}
+
+.sidebar__icon {
+    font-size: 0.9rem;
+    width: 20px;
+    text-align: center;
+}
+
+.sidebar__footer {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 16px 20px 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    margin-top: 16px;
+}
+
+.sidebar__avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--ez-tab-accent);
+    color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.sidebar__user {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #f8fafc;
+}
+
+/* ---------- Content Area ---------- */
+.content {
+    padding: 24px 32px;
+    overflow-y: auto;
+}
+
+/* ---------- Topbar ---------- */
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.topbar__title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--ez-tab-color);
+}
+
+.topbar__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.topbar__badge {
+    display: inline-block;
+    padding: 5px 14px;
+    background: var(--ez-tab-accent-light);
+    color: var(--ez-tab-accent);
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border-radius: 50px;
+}
+
+.topbar__date {
+    font-size: 0.85rem;
+    color: var(--ez-tab-muted);
+}
+
+/* ---------- Stats Row ---------- */
+.stats-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    margin-bottom: 28px;
+}
+
+.stat-card {
+    background: var(--ez-tab-bg);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+}
+
+.stat-card__value {
+    font-size: 1.6rem;
+    font-weight: 800;
+    color: var(--ez-tab-color);
+    margin-bottom: 2px;
+}
+
+.stat-card__label {
+    font-size: 0.78rem;
+    color: var(--ez-tab-muted);
+    margin-bottom: 8px;
+}
+
+.stat-card__change {
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.stat-card__change--up {
+    color: var(--ez-tab-success);
+}
+
+.stat-card__change--down {
+    color: var(--ez-tab-danger);
+}
+
+/* ---------- Tabs Section ---------- */
+.tabs-section {
+    margin-top: 4px;
+}
+
+/* ---------- Tabs Component ---------- */
+.tabs {
+    background: var(--ez-tab-bg);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 14px;
+    overflow: hidden;
+}
+
+.tabs__radio {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+}
+
+.tabs__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    position: relative;
+    padding: 16px 24px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--ez-tab-muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+    outline: none;
+    user-select: none;
+}
+
+.tabs__label:hover {
+    color: var(--ez-tab-color);
+}
+
+.tabs__label:focus-visible {
+    box-shadow: inset 0 0 0 var(--ez-focus-ring) rgba(59, 130, 246, 0.3);
+    border-radius: 8px 8px 0 0;
+}
+
+.tabs__icon {
+    font-size: 0.9rem;
+}
+
+/* ---------- Active Tab State ---------- */
+.tabs__radio:checked + .tabs__label {
+    color: var(--ez-tab-accent);
+    border-bottom-color: var(--ez-tab-accent);
+}
+
+/* ---------- Tab Panels ---------- */
+.tabs__panels {
+    position: relative;
+    min-height: 340px;
+}
+
+.tabs__panel {
+    position: absolute;
+    inset: 0;
+    padding: 32px;
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(var(--ez-tab-scale));
+    animation: ease-kf-zoom-in-panel var(--ez-tab-duration) ease-out forwards;
+}
+
+/* Show only the panel matching the checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1),
+.tabs__radio:nth-of-type(2):checked ~ .tabs__panels .tabs__panel:nth-child(2),
+.tabs__radio:nth-of-type(3):checked ~ .tabs__panels .tabs__panel:nth-child(3) {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+    position: relative;
+}
+
+/* ---------- Panel Styles ---------- */
+.panel__title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--ez-tab-color);
+    margin-bottom: 6px;
+}
+
+.panel__desc {
+    font-size: 0.88rem;
+    color: var(--ez-tab-muted);
+    margin-bottom: 24px;
+}
+
+/* ---------- Bar Chart ---------- */
+.chart-area {
+    margin-bottom: 24px;
+}
+
+.bar-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+    height: 160px;
+    background: var(--ez-tab-surface);
+    border-radius: 12px;
+    padding: 20px;
+    border: 1px solid var(--ez-tab-border);
+}
+
+.bar-chart__bar {
+    flex: 1;
+    height: var(--h);
+    background: linear-gradient(to top, var(--ez-tab-accent), #60a5fa);
+    border-radius: 4px 4px 0 0;
+    position: relative;
+    transition: opacity 0.2s ease;
+}
+
+.bar-chart__bar:hover {
+    opacity: 0.8;
+}
+
+.bar-chart__bar span {
+    position: absolute;
+    bottom: -22px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.68rem;
+    color: var(--ez-tab-muted);
+}
+
+/* ---------- Panel Metrics ---------- */
+.panel__metrics {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+}
+
+.panel__metric {
+    background: var(--ez-tab-surface);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 10px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.panel__metric-val {
+    font-size: 1.3rem;
+    font-weight: 800;
+    color: var(--ez-tab-accent);
+}
+
+.panel__metric-lbl {
+    font-size: 0.72rem;
+    color: var(--ez-tab-muted);
+    margin-top: 2px;
+}
+
+/* ---------- Report Table ---------- */
+.report-table {
+    background: var(--ez-tab-surface);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.report-row {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr 1fr 1fr;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--ez-tab-border);
+    font-size: 0.85rem;
+    color: var(--ez-tab-color);
+    align-items: center;
+}
+
+.report-row:last-child {
+    border-bottom: none;
+}
+
+.report-row--header {
+    background: var(--ez-tab-bg);
+    font-weight: 700;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--ez-tab-muted);
+}
+
+.report-row__change--up {
+    color: var(--ez-tab-success);
+    font-weight: 600;
+}
+
+.report-row__change--down {
+    color: var(--ez-tab-danger);
+    font-weight: 600;
+}
+
+/* ---------- Settings Grid ---------- */
+.settings-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+}
+
+.setting-card {
+    background: var(--ez-tab-surface);
+    border: 1px solid var(--ez-tab-border);
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.setting-card:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+    transform: translateY(-2px);
+}
+
+.setting-card__icon {
+    font-size: 1.4rem;
+    margin-bottom: 4px;
+}
+
+.setting-card__title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--ez-tab-color);
+}
+
+.setting-card__desc {
+    font-size: 0.78rem;
+    color: var(--ez-tab-muted);
+    margin-bottom: 8px;
+}
+
+.setting-card__status {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    background: var(--ez-tab-accent-light);
+    color: var(--ez-tab-accent);
+    align-self: flex-start;
+}
+
+.setting-card__status--on {
+    background: rgba(34, 197, 94, 0.1);
+    color: var(--ez-tab-success);
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .tabs__panel {
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1024px) {
+    .stats-row {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .panel__metrics {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .dashboard {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        display: none;
+    }
+
+    .content {
+        padding: 16px;
+    }
+
+    .topbar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .stats-row {
+        grid-template-columns: 1fr;
+    }
+
+    .tabs__label {
+        padding: 12px 14px;
+        font-size: 0.78rem;
+    }
+
+    .tabs__icon {
+        display: none;
+    }
+
+    .tabs__panel {
+        padding: 20px 16px;
+    }
+
+    .panel__metrics {
+        grid-template-columns: 1fr;
+    }
+
+    .report-row {
+        grid-template-columns: 1fr 1fr;
+        gap: 4px;
+    }
+
+    .report-row--header {
+        display: none;
+    }
+
+    .settings-grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
Closes #50048

Adds a pure CSS zoom-in tab component styled for responsive dashboard analytics layouts.

Changes:
- submissions/examples/dashboard-tabs-er/demo.html — Full dashboard layout with sidebar, stats row, and 3 tab panels (Analytics, Reports, Settings)
- submissions/examples/dashboard-tabs-er/style.css — Dashboard grid, sidebar, tab zoom-in animations (ease-kf-zoom-in-panel), and responsive breakpoints
- submissions/examples/dashboard-tabs-er/README.md — What/How/Why documentation

Features:
- Pure CSS (no JavaScript) — radio button state management
- Zoom-in tab panels with ease-kf-zoom-in-panel keyframes
- Dashboard layout with sidebar, topbar, and stats cards
- 3 tab contexts: Analytics (bar chart + metrics), Reports (data table), Settings (config cards)
- Keyboard accessible with focus-visible states
- Respects prefers-reduced-motion
- Responsive down to 768px (sidebar collapses)
- All CSS uses ease-* prefixed custom properties and keyframes