### PR TITLE
feat: add rotate-click tabs for marketing landing page layouts (#50069)

### DIFF
--- a/submissions/examples/marketing-rotate-tabs-er/README.md
+++ b/submissions/examples/marketing-rotate-tabs-er/README.md
@@ -1,0 +1,65 @@
+# Marketing Rotate-Click Tabs
+
+Pure CSS tab component with rotate-click animation, designed for marketing landing page layouts.
+
+## What it is
+
+A CSS-only tab component using radio buttons for state management. Tab panels rotate in with a smooth rotateX transition when clicking tabs — designed for marketing and landing page contexts. No JavaScript is required.
+
+## How it works
+
+The tab component uses CSS `:checked` pseudo-class on hidden radio buttons to control which panel is visible. The `general sibling combinator` (`~`) selects the corresponding panel.
+
+```css
+/* Only show panel matching checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1) {
+    opacity: 1;
+    visibility: visible;
+    transform: rotateX(0deg) translateY(0) scale(1);
+}
+
+/* Rotate-click animation */
+.tabs__panel {
+    animation: ease-kf-rotate-in 0.45s ease-out forwards;
+}
+```
+
+Key techniques:
+- Hidden `<input type="radio">` controls state — fully keyboard accessible
+- `ease-kf-rotate-in` keyframe for smooth rotateX rotate-click entrance
+- Configurable `--ez-rotate-angle` for rotation depth
+- `transform-origin: top center` for natural pivot point
+- `perspective` on container for realistic 3D feel
+- `role="tabpanel"` for screen reader semantics
+- CSS custom properties for all colors, timing, and angle
+
+## Why it matters
+
+Marketing landing pages need tab components that feel dynamic and engaging. The rotate-click transition provides a tactile, physical interaction feel that draws user attention and increases engagement — all in pure CSS.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Marketing landing page with nav, hero, rotate-click tabs (Launch/Growth/Scale), and pricing |
+| `style.css` | Marketing styles, rotate-click animations, and responsive rules |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-rotate-duration` | `0.45s` | Rotate-click animation duration |
+| `--ez-rotate-angle` | `8deg` | Initial rotation angle |
+| `--ez-rotate-accent` | `#f97316` | Active tab accent color |
+| `--ez-rotate-bg` | `#ffffff` | Background color |
+| `--ez-rotate-color` | `#0f172a` | Text color |
+| `--ez-rotate-border` | `#e2e8f0` | Border color |
+
+## Keyframes
+
+- `ease-kf-rotate-in` — rotateX + translateY + scale rotate-click entrance
+- `ease-kf-badge-pop` — badge pop-in animation
+
+## Issue
+
+Closes #50069

--- a/submissions/examples/marketing-rotate-tabs-er/demo.html
+++ b/submissions/examples/marketing-rotate-tabs-er/demo.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Marketing Rotate-Click Tabs – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <nav class="nav">
+        <div class="nav__inner">
+            <a href="#" class="nav__logo">Launchpad<span class="nav__dot">.</span></a>
+            <div class="nav__links">
+                <a href="#features" class="nav__link">Features</a>
+                <a href="#pricing" class="nav__link">Pricing</a>
+                <a href="#" class="nav__link nav__link--cta">Start Free Trial</a>
+            </div>
+        </div>
+    </nav>
+
+    <header class="hero">
+        <div class="hero__inner">
+            <span class="hero__badge">Rotate-Click Tabs</span>
+            <h1 class="hero__title">Ship faster with<br><span class="highlight">rotating insights</span></h1>
+            <p class="hero__sub">Click the tabs below — panels rotate in with a smooth, tactile transition designed for marketing pages.</p>
+        </div>
+    </header>
+
+    <main class="main">
+
+        <!-- Tab Component -->
+        <section class="tab-section" id="features">
+            <div class="container">
+                <div class="tabs">
+                    <input type="radio" name="mkt-tabs" id="mtab-1" class="tabs__radio" checked>
+                    <label for="mtab-1" class="tabs__label">
+                        <span class="tabs__icon">&#128640;</span>
+                        <span class="tabs__label-text">Launch</span>
+                    </label>
+
+                    <input type="radio" name="mkt-tabs" id="mtab-2" class="tabs__radio">
+                    <label for="mtab-2" class="tabs__label">
+                        <span class="tabs__icon">&#128200;</span>
+                        <span class="tabs__label-text">Growth</span>
+                    </label>
+
+                    <input type="radio" name="mkt-tabs" id="mtab-3" class="tabs__radio">
+                    <label for="mtab-3" class="tabs__label">
+                        <span class="tabs__icon">&#127942;</span>
+                        <span class="tabs__label-text">Scale</span>
+                    </label>
+
+                    <div class="tabs__panels">
+
+                        <!-- Launch Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <div class="panel__split">
+                                <div class="panel__content">
+                                    <h3 class="panel__title">Go live in minutes</h3>
+                                    <p class="panel__desc">One-click deployments, pre-built templates, and zero-config hosting so you can focus on what matters.</p>
+                                    <ul class="panel__list">
+                                        <li>Deploy in under 60 seconds</li>
+                                        <li>50+ conversion-optimized templates</li>
+                                        <li>Custom domain with free SSL</li>
+                                        <li>Built-in analytics from day one</li>
+                                    </ul>
+                                    <a href="#" class="btn btn--primary">Get Started Free</a>
+                                </div>
+                                <div class="panel__visual">
+                                    <div class="launch-card">
+                                        <div class="launch-card__header">
+                                            <span class="launch-card__dot"></span>
+                                            <span class="launch-card__dot"></span>
+                                            <span class="launch-card__dot"></span>
+                                        </div>
+                                        <div class="launch-card__body">
+                                            <div class="launch-card__line" style="--w: 80%;"></div>
+                                            <div class="launch-card__line" style="--w: 60%;"></div>
+                                            <div class="launch-card__line" style="--w: 90%;"></div>
+                                            <div class="launch-card__badge">&#10003; Live</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Growth Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <div class="panel__split">
+                                <div class="panel__content">
+                                    <h3 class="panel__title">Accelerate your growth</h3>
+                                    <p class="panel__desc">A/B testing, heatmap analytics, and smart funnels built into every plan.</p>
+                                    <ul class="panel__list">
+                                        <li>Unlimited A/B experiments</li>
+                                        <li>Real-time conversion tracking</li>
+                                        <li>Smart audience segmentation</li>
+                                        <li>Automated email sequences</li>
+                                    </ul>
+                                    <a href="#" class="btn btn--primary">Start Growing</a>
+                                </div>
+                                <div class="panel__visual">
+                                    <div class="growth-chart">
+                                        <div class="growth-bar" style="--h: 30%;"><span>Q1</span></div>
+                                        <div class="growth-bar" style="--h: 50%;"><span>Q2</span></div>
+                                        <div class="growth-bar" style="--h: 45%;"><span>Q3</span></div>
+                                        <div class="growth-bar" style="--h: 75%;"><span>Q4</span></div>
+                                        <div class="growth-bar growth-bar--accent" style="--h: 95%;"><span>New</span></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Scale Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <div class="panel__split">
+                                <div class="panel__content">
+                                    <h3 class="panel__title">Scale without limits</h3>
+                                    <p class="panel__desc">Enterprise-grade infrastructure that auto-scales with your traffic spikes.</p>
+                                    <ul class="panel__list">
+                                        <li>Auto-scaling to millions of visits</li>
+                                        <li>Global edge network (200+ PoPs)</li>
+                                        <li>99.99% uptime guarantee</li>
+                                        <li>Dedicated success manager</li>
+                                    </ul>
+                                    <a href="#" class="btn btn--primary">Talk to Sales</a>
+                                </div>
+                                <div class="panel__visual">
+                                    <div class="scale-metrics">
+                                        <div class="scale-metric">
+                                            <span class="scale-metric__val">2.4M</span>
+                                            <span class="scale-metric__lbl">Requests / day</span>
+                                        </div>
+                                        <div class="scale-metric">
+                                            <span class="scale-metric__val">14ms</span>
+                                            <span class="scale-metric__lbl">Avg. latency</span>
+                                        </div>
+                                        <div class="scale-metric">
+                                            <span class="scale-metric__val">99.99%</span>
+                                            <span class="scale-metric__lbl">Uptime SLA</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Pricing Section -->
+        <section class="pricing-section" id="pricing">
+            <div class="container">
+                <h2 class="section-title">Simple, transparent pricing</h2>
+                <p class="section-desc">No hidden fees. Cancel anytime.</p>
+
+                <div class="pricing-grid">
+                    <div class="pricing-card">
+                        <h3 class="pricing-card__name">Starter</h3>
+                        <p class="pricing-card__desc">Perfect for side projects</p>
+                        <div class="pricing-card__price">$0<span>/mo</span></div>
+                        <ul class="pricing-card__list">
+                            <li>1 project</li>
+                            <li>1GB storage</li>
+                            <li>Community support</li>
+                        </ul>
+                        <a href="#" class="btn btn--outline">Get Started</a>
+                    </div>
+
+                    <div class="pricing-card pricing-card--featured">
+                        <span class="pricing-card__badge">Most Popular</span>
+                        <h3 class="pricing-card__name">Pro</h3>
+                        <p class="pricing-card__desc">For growing teams</p>
+                        <div class="pricing-card__price">$29<span>/mo</span></div>
+                        <ul class="pricing-card__list">
+                            <li>Unlimited projects</li>
+                            <li>100GB storage</li>
+                            <li>Priority support</li>
+                            <li>Advanced analytics</li>
+                        </ul>
+                        <a href="#" class="btn btn--primary">Get Pro</a>
+                    </div>
+
+                    <div class="pricing-card">
+                        <h3 class="pricing-card__name">Enterprise</h3>
+                        <p class="pricing-card__desc">For large organizations</p>
+                        <div class="pricing-card__price">Custom</div>
+                        <ul class="pricing-card__list">
+                            <li>Unlimited everything</li>
+                            <li>Dedicated infrastructure</li>
+                            <li>24/7 phone support</li>
+                        </ul>
+                        <a href="#" class="btn btn--outline">Contact Sales</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p>Part of <strong>EaseMotion CSS</strong> – Pure CSS animation library</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/submissions/examples/marketing-rotate-tabs-er/style.css
+++ b/submissions/examples/marketing-rotate-tabs-er/style.css
@@ -1,0 +1,654 @@
+/* =============================================
+   Marketing Rotate-Click Tabs
+   CSS-Only Tab Component
+   Pure CSS · Keyboard · ARIA
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-rotate-duration: 0.45s;
+    --ez-rotate-angle: 8deg;
+    --ez-rotate-accent: #f97316;
+    --ez-rotate-accent-hover: #ea580c;
+    --ez-rotate-accent-light: rgba(249, 115, 22, 0.08);
+    --ez-rotate-success: #22c55e;
+    --ez-rotate-bg: #ffffff;
+    --ez-rotate-page-bg: #fafafa;
+    --ez-rotate-surface: #f8fafc;
+    --ez-rotate-color: #0f172a;
+    --ez-rotate-muted: #64748b;
+    --ez-rotate-border: #e2e8f0;
+    --ez-focus-ring: 3px;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-rotate-in {
+    0% {
+        opacity: 0;
+        transform: rotateX(var(--ez-rotate-angle)) translateY(12px) scale(0.96);
+        visibility: hidden;
+    }
+    40% {
+        opacity: 0.8;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: rotateX(0deg) translateY(0) scale(1);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-badge-pop {
+    0% {
+        transform: scale(0);
+    }
+    60% {
+        transform: scale(1.15);
+    }
+    100% {
+        transform: scale(1);
+    }
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+    background: var(--ez-rotate-page-bg);
+    color: var(--ez-rotate-color);
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+/* ---------- Nav ---------- */
+.nav {
+    padding: 16px 32px;
+    background: var(--ez-rotate-bg);
+    border-bottom: 1px solid var(--ez-rotate-border);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.nav__inner {
+    max-width: 1040px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.nav__logo {
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: var(--ez-rotate-color);
+    text-decoration: none;
+}
+
+.nav__dot {
+    color: var(--ez-rotate-accent);
+}
+
+.nav__links {
+    display: flex;
+    gap: 24px;
+    align-items: center;
+}
+
+.nav__link {
+    font-size: 0.88rem;
+    color: var(--ez-rotate-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.15s ease;
+    outline: none;
+}
+
+.nav__link:hover,
+.nav__link:focus-visible {
+    color: var(--ez-rotate-color);
+}
+
+.nav__link:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(249, 115, 22, 0.3);
+    border-radius: 4px;
+}
+
+.nav__link--cta {
+    background: var(--ez-rotate-accent);
+    color: #ffffff !important;
+    padding: 8px 20px;
+    border-radius: 8px;
+    font-weight: 600;
+}
+
+.nav__link--cta:hover {
+    background: var(--ez-rotate-accent-hover);
+}
+
+/* ---------- Hero ---------- */
+.hero {
+    padding: 64px 24px 72px;
+    text-align: center;
+    background: var(--ez-rotate-bg);
+    border-bottom: 1px solid var(--ez-rotate-border);
+}
+
+.hero__badge {
+    display: inline-block;
+    padding: 5px 16px;
+    background: var(--ez-rotate-accent-light);
+    color: var(--ez-rotate-accent);
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    border-radius: 50px;
+    margin-bottom: 16px;
+}
+
+.hero__title {
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    font-weight: 800;
+    color: var(--ez-rotate-color);
+    margin-bottom: 12px;
+    letter-spacing: -0.5px;
+}
+
+.highlight {
+    color: var(--ez-rotate-accent);
+}
+
+.hero__sub {
+    font-size: 1rem;
+    color: var(--ez-rotate-muted);
+    max-width: 480px;
+    margin: 0 auto;
+}
+
+/* ---------- Main ---------- */
+.main {
+    padding: 48px 0 80px;
+}
+
+.section-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--ez-rotate-color);
+    text-align: center;
+    margin-bottom: 8px;
+}
+
+.section-desc {
+    text-align: center;
+    color: var(--ez-rotate-muted);
+    margin-bottom: 36px;
+}
+
+/* ---------- Tab Section ---------- */
+.tab-section {
+    margin-bottom: 64px;
+}
+
+/* ---------- Tabs Component ---------- */
+.tabs {
+    background: var(--ez-rotate-bg);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 16px;
+    overflow: hidden;
+    perspective: 600px;
+}
+
+.tabs__radio {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+}
+
+.tabs__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    position: relative;
+    padding: 16px 28px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--ez-rotate-muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+    outline: none;
+    user-select: none;
+}
+
+.tabs__label:hover {
+    color: var(--ez-rotate-color);
+}
+
+.tabs__label:focus-visible {
+    box-shadow: inset 0 0 0 var(--ez-focus-ring) rgba(249, 115, 22, 0.3);
+    border-radius: 8px 8px 0 0;
+}
+
+.tabs__icon {
+    font-size: 1rem;
+}
+
+/* ---------- Active Tab State ---------- */
+.tabs__radio:checked + .tabs__label {
+    color: var(--ez-rotate-accent);
+    border-bottom-color: var(--ez-rotate-accent);
+}
+
+/* ---------- Tab Panels ---------- */
+.tabs__panels {
+    position: relative;
+    min-height: 340px;
+}
+
+.tabs__panel {
+    position: absolute;
+    inset: 0;
+    padding: 36px;
+    opacity: 0;
+    visibility: hidden;
+    transform: rotateX(var(--ez-rotate-angle)) translateY(12px) scale(0.96);
+    transform-origin: top center;
+    animation: ease-kf-rotate-in var(--ez-rotate-duration) ease-out forwards;
+}
+
+/* Show only the panel matching the checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1),
+.tabs__radio:nth-of-type(2):checked ~ .tabs__panels .tabs__panel:nth-child(2),
+.tabs__radio:nth-of-type(3):checked ~ .tabs__panels .tabs__panel:nth-child(3) {
+    opacity: 1;
+    visibility: visible;
+    transform: rotateX(0deg) translateY(0) scale(1);
+    position: relative;
+}
+
+/* ---------- Panel Split Layout ---------- */
+.panel__split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 36px;
+    align-items: center;
+}
+
+.panel__title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--ez-rotate-color);
+    margin-bottom: 8px;
+}
+
+.panel__desc {
+    font-size: 0.9rem;
+    color: var(--ez-rotate-muted);
+    margin-bottom: 18px;
+}
+
+.panel__list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 24px;
+}
+
+.panel__list li {
+    font-size: 0.88rem;
+    color: var(--ez-rotate-color);
+    padding-left: 24px;
+    position: relative;
+}
+
+.panel__list li::before {
+    content: "\2713";
+    position: absolute;
+    left: 0;
+    color: var(--ez-rotate-success);
+    font-weight: 700;
+}
+
+/* ---------- Buttons ---------- */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 28px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    outline: none;
+    text-decoration: none;
+}
+
+.btn--primary {
+    background: var(--ez-rotate-accent);
+    color: #ffffff;
+}
+
+.btn--primary:hover {
+    background: var(--ez-rotate-accent-hover);
+    transform: translateY(-1px);
+}
+
+.btn--outline {
+    background: transparent;
+    color: var(--ez-rotate-accent);
+    border: 1px solid var(--ez-rotate-border);
+}
+
+.btn--outline:hover {
+    border-color: var(--ez-rotate-accent);
+    background: var(--ez-rotate-accent-light);
+}
+
+.btn:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(249, 115, 22, 0.4);
+}
+
+/* ---------- Launch Card ---------- */
+.panel__visual {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.launch-card {
+    background: var(--ez-rotate-surface);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.launch-card__header {
+    display: flex;
+    gap: 6px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--ez-rotate-border);
+    background: var(--ez-rotate-bg);
+}
+
+.launch-card__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--ez-rotate-border);
+}
+
+.launch-card__dot:first-child {
+    background: #ef4444;
+}
+
+.launch-card__dot:nth-child(2) {
+    background: #eab308;
+}
+
+.launch-card__dot:nth-child(3) {
+    background: #22c55e;
+}
+
+.launch-card__body {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.launch-card__line {
+    height: 10px;
+    width: var(--w);
+    background: var(--ez-rotate-border);
+    border-radius: 5px;
+}
+
+.launch-card__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    background: rgba(34, 197, 94, 0.1);
+    color: var(--ez-rotate-success);
+    font-size: 0.82rem;
+    font-weight: 700;
+    border-radius: 8px;
+    align-self: flex-start;
+    animation: ease-kf-badge-pop 0.4s ease-out 0.6s both;
+}
+
+/* ---------- Growth Chart ---------- */
+.growth-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+    height: 160px;
+    background: var(--ez-rotate-surface);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 12px;
+    padding: 20px;
+}
+
+.growth-bar {
+    flex: 1;
+    height: var(--h);
+    background: linear-gradient(to top, var(--ez-rotate-border), #cbd5e1);
+    border-radius: 4px 4px 0 0;
+    position: relative;
+}
+
+.growth-bar--accent {
+    background: linear-gradient(to top, var(--ez-rotate-accent), #fb923c);
+}
+
+.growth-bar span {
+    position: absolute;
+    bottom: -22px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.68rem;
+    color: var(--ez-rotate-muted);
+}
+
+/* ---------- Scale Metrics ---------- */
+.scale-metrics {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.scale-metric {
+    background: var(--ez-rotate-surface);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 12px;
+    padding: 18px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.scale-metric__val {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--ez-rotate-accent);
+}
+
+.scale-metric__lbl {
+    font-size: 0.8rem;
+    color: var(--ez-rotate-muted);
+}
+
+/* ---------- Pricing Section ---------- */
+.pricing-section {
+    margin-bottom: 60px;
+}
+
+.pricing-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.pricing-card {
+    background: var(--ez-rotate-bg);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 14px;
+    padding: 28px 24px;
+    text-align: center;
+    position: relative;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.pricing-card:hover {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+    transform: translateY(-2px);
+}
+
+.pricing-card--featured {
+    border: 2px solid var(--ez-rotate-accent);
+    box-shadow: 0 4px 24px rgba(249, 115, 22, 0.12);
+}
+
+.pricing-card__badge {
+    position: absolute;
+    top: -12px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--ez-rotate-accent);
+    color: #ffffff;
+    padding: 4px 14px;
+    border-radius: 50px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.pricing-card__name {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--ez-rotate-color);
+    margin-bottom: 4px;
+}
+
+.pricing-card__desc {
+    font-size: 0.82rem;
+    color: var(--ez-rotate-muted);
+    margin-bottom: 16px;
+}
+
+.pricing-card__price {
+    font-size: 2.2rem;
+    font-weight: 800;
+    color: var(--ez-rotate-color);
+    margin-bottom: 20px;
+}
+
+.pricing-card__price span {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--ez-rotate-muted);
+}
+
+.pricing-card__list {
+    list-style: none;
+    margin-bottom: 24px;
+    text-align: left;
+}
+
+.pricing-card__list li {
+    padding: 6px 0;
+    font-size: 0.88rem;
+    color: var(--ez-rotate-muted);
+    padding-left: 22px;
+    position: relative;
+}
+
+.pricing-card__list li::before {
+    content: "\2713";
+    position: absolute;
+    left: 0;
+    color: var(--ez-rotate-success);
+    font-weight: 700;
+}
+
+/* ---------- Footer ---------- */
+.footer {
+    text-align: center;
+    padding: 28px 24px;
+    border-top: 1px solid var(--ez-rotate-border);
+    color: var(--ez-rotate-muted);
+    font-size: 0.88rem;
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .tabs__panel {
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+    .nav__links {
+        display: none;
+    }
+
+    .hero {
+        padding: 40px 20px 50px;
+    }
+
+    .tabs__label {
+        padding: 12px 14px;
+        font-size: 0.78rem;
+    }
+
+    .tabs__icon {
+        display: none;
+    }
+
+    .tabs__panel {
+        padding: 24px 18px;
+    }
+
+    .panel__split {
+        grid-template-columns: 1fr;
+    }
+
+    .pricing-grid {
+        grid-template-columns: 1fr;
+        max-width: 360px;
+        margin: 0 auto;
+    }
+}


### PR DESCRIPTION
Closes #50069

Adds a pure CSS rotate-click tab component styled for marketing landing page layouts.

Changes:
- submissions/examples/marketing-rotate-tabs-er/demo.html — Marketing landing page with nav, hero, 3 rotate-click tabs (Launch/Growth/Scale), and pricing section
- submissions/examples/marketing-rotate-tabs-er/style.css — Marketing styles, rotate-click animations (ease-kf-rotate-in), badge pop, responsive breakpoints
- submissions/examples/marketing-rotate-tabs-er/README.md — What/How/Why documentation

Features:
- Pure CSS (no JavaScript) — radio button state management
- Rotate-click tab panels with ease-kf-rotate-in keyframes (rotateX + translateY + scale)
- perspective + transform-origin for realistic 3D feel
- Configurable --ez-rotate-angle for rotation depth
- 3 tab contexts: Launch (deploy card), Growth (bar chart), Scale (metric cards)
- Marketing layout: nav, hero, split-panel content, pricing grid
- Keyboard accessible with focus-visible states
- Respects prefers-reduced-motion
- Responsive down to 768px
- All CSS uses ease-* prefixed custom properties and keyframes