### PR TITLE
feat: add rotate-click tabs for creative portfolio layouts (#50079)

### DIFF
--- a/submissions/examples/portfolio-rotate-tabs-er/README.md
+++ b/submissions/examples/portfolio-rotate-tabs-er/README.md
@@ -1,0 +1,66 @@
+# Creative Portfolio Rotate-Click Tabs
+
+Pure CSS tab component with rotate-click animation, designed for creative portfolio layouts.
+
+## What it is
+
+A CSS-only tab component using radio buttons for state management. Tab panels rotate in with a smooth rotateX transition when clicking tabs — designed for creative portfolio and personal site contexts. No JavaScript is required.
+
+## How it works
+
+The tab component uses CSS `:checked` pseudo-class on hidden radio buttons to control which panel is visible. The `general sibling combinator` (`~`) selects the corresponding panel.
+
+```css
+/* Only show panel matching checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1) {
+    opacity: 1;
+    visibility: visible;
+    transform: rotateX(0deg) translateY(0) scale(1);
+}
+
+/* Rotate-click animation */
+.tabs__panel {
+    animation: ease-kf-rotate-in 0.45s ease-out forwards;
+}
+```
+
+Key techniques:
+- Hidden `<input type="radio">` controls state — fully keyboard accessible
+- `ease-kf-rotate-in` keyframe for smooth rotateX rotate-click entrance
+- Configurable `--ez-rotate-angle` for rotation depth
+- `transform-origin: top center` for natural pivot point
+- `perspective` on container for realistic 3D feel
+- `role="tabpanel"` for screen reader semantics
+- CSS custom properties for all colors, timing, and angle
+
+## Why it matters
+
+Creative portfolio sites need tab components that feel dynamic and expressive. The rotate-click transition provides a tactile, physical interaction feel that showcases projects and skills with polish — all in pure CSS.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | Portfolio layout with sidebar, topbar, and 3 rotate-click tabs (Projects, Skills, About) |
+| `style.css` | Portfolio layout, sidebar, rotate-click animations, and responsive rules |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-rotate-duration` | `0.45s` | Rotate-click animation duration |
+| `--ez-rotate-angle` | `10deg` | Initial rotation angle |
+| `--ez-rotate-accent` | `#8b5cf6` | Active tab accent color |
+| `--ez-rotate-bg` | `#ffffff` | Background color |
+| `--ez-rotate-color` | `#18181b` | Text color |
+| `--ez-rotate-border` | `#e4e4e7` | Border color |
+| `--ez-rotate-sidebar-bg` | `#18181b` | Sidebar background |
+
+## Keyframes
+
+- `ease-kf-rotate-in` — rotateX + translateY + scale rotate-click entrance
+- `ease-kf-card-reveal` — staggered card reveal animation
+
+## Issue
+
+Closes #50079

--- a/submissions/examples/portfolio-rotate-tabs-er/demo.html
+++ b/submissions/examples/portfolio-rotate-tabs-er/demo.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Creative Portfolio Rotate-Click Tabs – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="portfolio">
+
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar__brand">
+                <span class="sidebar__avatar">AK</span>
+                <div>
+                    <span class="sidebar__name">Alex Kim</span>
+                    <span class="sidebar__role">Creative Developer</span>
+                </div>
+            </div>
+            <nav class="sidebar__nav">
+                <a href="#" class="sidebar__link sidebar__link--active">Work</a>
+                <a href="#" class="sidebar__link">About</a>
+                <a href="#" class="sidebar__link">Contact</a>
+            </nav>
+            <div class="sidebar__social">
+                <a href="#" class="sidebar__social-link">Dribbble</a>
+                <a href="#" class="sidebar__social-link">GitHub</a>
+                <a href="#" class="sidebar__social-link">LinkedIn</a>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <div class="content">
+
+            <header class="topbar">
+                <h1 class="topbar__title">Selected Work</h1>
+                <span class="topbar__badge">Rotate-Click Tabs</span>
+            </header>
+
+            <!-- Tab Component -->
+            <section class="tab-section">
+                <div class="tabs">
+                    <input type="radio" name="port-tabs" id="ptab-1" class="tabs__radio" checked>
+                    <label for="ptab-1" class="tabs__label">
+                        <span class="tabs__label-text">Projects</span>
+                    </label>
+
+                    <input type="radio" name="port-tabs" id="ptab-2" class="tabs__radio">
+                    <label for="ptab-2" class="tabs__label">
+                        <span class="tabs__label-text">Skills</span>
+                    </label>
+
+                    <input type="radio" name="port-tabs" id="ptab-3" class="tabs__radio">
+                    <label for="ptab-3" class="tabs__label">
+                        <span class="tabs__label-text">About</span>
+                    </label>
+
+                    <div class="tabs__panels">
+
+                        <!-- Projects Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__title">Featured Projects</h3>
+                            <p class="panel__desc">A curated selection of recent work across branding, web, and motion design.</p>
+                            <div class="project-grid">
+                                <div class="project-card">
+                                    <div class="project-card__thumb" style="background: linear-gradient(135deg, #6366f1, #a855f7);">
+                                        <span class="project-card__number">01</span>
+                                    </div>
+                                    <div class="project-card__info">
+                                        <span class="project-card__name">Nebula Branding</span>
+                                        <span class="project-card__cat">Brand Identity</span>
+                                    </div>
+                                </div>
+                                <div class="project-card">
+                                    <div class="project-card__thumb" style="background: linear-gradient(135deg, #f97316, #ef4444);">
+                                        <span class="project-card__number">02</span>
+                                    </div>
+                                    <div class="project-card__info">
+                                        <span class="project-card__name">Pulse Dashboard</span>
+                                        <span class="project-card__cat">UI/UX Design</span>
+                                    </div>
+                                </div>
+                                <div class="project-card">
+                                    <div class="project-card__thumb" style="background: linear-gradient(135deg, #22c55e, #06b6d4);">
+                                        <span class="project-card__number">03</span>
+                                    </div>
+                                    <div class="project-card__info">
+                                        <span class="project-card__name">Verde E-Commerce</span>
+                                        <span class="project-card__cat">Web Development</span>
+                                    </div>
+                                </div>
+                                <div class="project-card">
+                                    <div class="project-card__thumb" style="background: linear-gradient(135deg, #ec4899, #8b5cf6);">
+                                        <span class="project-card__number">04</span>
+                                    </div>
+                                    <div class="project-card__info">
+                                        <span class="project-card__name">Flux Motion</span>
+                                        <span class="project-card__cat">Motion Design</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Skills Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__title">Expertise &amp; Skills</h3>
+                            <p class="panel__desc">Technologies and tools I use to bring ideas to life.</p>
+                            <div class="skills-grid">
+                                <div class="skill-group">
+                                    <h4 class="skill-group__title">Design</h4>
+                                    <div class="skill-tags">
+                                        <span class="skill-tag">Figma</span>
+                                        <span class="skill-tag">Sketch</span>
+                                        <span class="skill-tag">Adobe XD</span>
+                                        <span class="skill-tag">Illustrator</span>
+                                        <span class="skill-tag">Photoshop</span>
+                                    </div>
+                                </div>
+                                <div class="skill-group">
+                                    <h4 class="skill-group__title">Development</h4>
+                                    <div class="skill-tags">
+                                        <span class="skill-tag">HTML/CSS</span>
+                                        <span class="skill-tag">JavaScript</span>
+                                        <span class="skill-tag">React</span>
+                                        <span class="skill-tag">Vue</span>
+                                        <span class="skill-tag">TypeScript</span>
+                                    </div>
+                                </div>
+                                <div class="skill-group">
+                                    <h4 class="skill-group__title">Motion</h4>
+                                    <div class="skill-tags">
+                                        <span class="skill-tag">After Effects</span>
+                                        <span class="skill-tag">Lottie</span>
+                                        <span class="skill-tag">GSAP</span>
+                                        <span class="skill-tag">CSS Animations</span>
+                                    </div>
+                                </div>
+                                <div class="skill-group">
+                                    <h4 class="skill-group__title">Other</h4>
+                                    <div class="skill-tags">
+                                        <span class="skill-tag">Blender</span>
+                                        <span class="skill-tag">Notion</span>
+                                        <span class="skill-tag">Git</span>
+                                        <span class="skill-tag">Framer</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- About Panel -->
+                        <div class="tabs__panel" role="tabpanel">
+                            <h3 class="panel__title">About Me</h3>
+                            <p class="panel__desc">A creative developer passionate about building beautiful, interactive experiences.</p>
+                            <div class="about-layout">
+                                <div class="about-text">
+                                    <p>I'm a multi-disciplinary designer and developer with 8+ years of experience crafting digital products. I specialize in the intersection of design and code — building interfaces that are both visually stunning and technically robust.</p>
+                                    <p>Currently available for freelance projects and creative collaborations.</p>
+                                    <div class="about-stats">
+                                        <div class="about-stat">
+                                            <span class="about-stat__val">120+</span>
+                                            <span class="about-stat__lbl">Projects</span>
+                                        </div>
+                                        <div class="about-stat">
+                                            <span class="about-stat__val">8+</span>
+                                            <span class="about-stat__lbl">Years</span>
+                                        </div>
+                                        <div class="about-stat">
+                                            <span class="about-stat__val">45+</span>
+                                            <span class="about-stat__lbl">Clients</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="about-contact">
+                                    <div class="contact-card">
+                                        <span class="contact-card__icon">&#9993;</span>
+                                        <span class="contact-card__label">Email</span>
+                                        <span class="contact-card__value">hello@alexkim.dev</span>
+                                    </div>
+                                    <div class="contact-card">
+                                        <span class="contact-card__icon">&#9742;</span>
+                                        <span class="contact-card__label">Phone</span>
+                                        <span class="contact-card__value">+1 (555) 123-4567</span>
+                                    </div>
+                                    <div class="contact-card">
+                                        <span class="contact-card__icon">&#9873;</span>
+                                        <span class="contact-card__label">Location</span>
+                                        <span class="contact-card__value">San Francisco, CA</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </section>
+
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/portfolio-rotate-tabs-er/style.css
+++ b/submissions/examples/portfolio-rotate-tabs-er/style.css
@@ -1,0 +1,556 @@
+/* =============================================
+   Creative Portfolio Rotate-Click Tabs
+   CSS-Only Tab Component
+   Pure CSS · Keyboard · ARIA
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-rotate-duration: 0.45s;
+    --ez-rotate-angle: 10deg;
+    --ez-rotate-accent: #8b5cf6;
+    --ez-rotate-accent-hover: #7c3aed;
+    --ez-rotate-accent-light: rgba(139, 92, 246, 0.08);
+    --ez-rotate-success: #22c55e;
+    --ez-rotate-bg: #ffffff;
+    --ez-rotate-page-bg: #fafafa;
+    --ez-rotate-surface: #f4f4f5;
+    --ez-rotate-color: #18181b;
+    --ez-rotate-muted: #71717a;
+    --ez-rotate-border: #e4e4e7;
+    --ez-rotate-sidebar-bg: #18181b;
+    --ez-rotate-sidebar-color: #a1a1aa;
+    --ez-focus-ring: 3px;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-rotate-in {
+    0% {
+        opacity: 0;
+        transform: rotateX(var(--ez-rotate-angle)) translateY(14px) scale(0.95);
+        visibility: hidden;
+    }
+    40% {
+        opacity: 0.8;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: rotateX(0deg) translateY(0) scale(1);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-card-reveal {
+    0% {
+        opacity: 0;
+        transform: translateY(20px) scale(0.95);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+    background: var(--ez-rotate-page-bg);
+    color: var(--ez-rotate-color);
+    line-height: 1.6;
+}
+
+/* ---------- Portfolio Layout ---------- */
+.portfolio {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    min-height: 100vh;
+}
+
+/* ---------- Sidebar ---------- */
+.sidebar {
+    background: var(--ez-rotate-sidebar-bg);
+    color: var(--ez-rotate-sidebar-color);
+    display: flex;
+    flex-direction: column;
+    padding: 32px 24px;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+}
+
+.sidebar__brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 32px;
+}
+
+.sidebar__avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--ez-rotate-accent), #ec4899);
+    color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.sidebar__name {
+    display: block;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #f4f4f5;
+}
+
+.sidebar__role {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--ez-rotate-sidebar-color);
+}
+
+.sidebar__nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+}
+
+.sidebar__link {
+    display: block;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: var(--ez-rotate-sidebar-color);
+    text-decoration: none;
+    transition: background 0.15s ease, color 0.15s ease;
+    outline: none;
+}
+
+.sidebar__link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: #f4f4f5;
+}
+
+.sidebar__link:focus-visible {
+    box-shadow: inset 0 0 0 var(--ez-focus-ring) rgba(139, 92, 246, 0.4);
+}
+
+.sidebar__link--active {
+    background: rgba(139, 92, 246, 0.12);
+    color: var(--ez-rotate-accent);
+}
+
+.sidebar__social {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 24px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sidebar__social-link {
+    font-size: 0.8rem;
+    color: var(--ez-rotate-sidebar-color);
+    text-decoration: none;
+    transition: color 0.15s ease;
+    outline: none;
+}
+
+.sidebar__social-link:hover {
+    color: var(--ez-rotate-accent);
+}
+
+.sidebar__social-link:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(139, 92, 246, 0.3);
+    border-radius: 4px;
+}
+
+/* ---------- Content Area ---------- */
+.content {
+    padding: 24px 32px;
+    overflow-y: auto;
+}
+
+/* ---------- Topbar ---------- */
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.topbar__title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--ez-rotate-color);
+}
+
+.topbar__badge {
+    display: inline-block;
+    padding: 5px 14px;
+    background: var(--ez-rotate-accent-light);
+    color: var(--ez-rotate-accent);
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border-radius: 50px;
+}
+
+/* ---------- Tab Section ---------- */
+.tab-section {
+    margin-top: 4px;
+}
+
+/* ---------- Tabs Component ---------- */
+.tabs {
+    background: var(--ez-rotate-bg);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 16px;
+    overflow: hidden;
+    perspective: 600px;
+}
+
+.tabs__radio {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+}
+
+.tabs__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    position: relative;
+    padding: 16px 28px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--ez-rotate-muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+    outline: none;
+    user-select: none;
+}
+
+.tabs__label:hover {
+    color: var(--ez-rotate-color);
+}
+
+.tabs__label:focus-visible {
+    box-shadow: inset 0 0 0 var(--ez-focus-ring) rgba(139, 92, 246, 0.3);
+    border-radius: 8px 8px 0 0;
+}
+
+/* ---------- Active Tab State ---------- */
+.tabs__radio:checked + .tabs__label {
+    color: var(--ez-rotate-accent);
+    border-bottom-color: var(--ez-rotate-accent);
+}
+
+/* ---------- Tab Panels ---------- */
+.tabs__panels {
+    position: relative;
+    min-height: 420px;
+}
+
+.tabs__panel {
+    position: absolute;
+    inset: 0;
+    padding: 36px;
+    opacity: 0;
+    visibility: hidden;
+    transform: rotateX(var(--ez-rotate-angle)) translateY(14px) scale(0.95);
+    transform-origin: top center;
+    animation: ease-kf-rotate-in var(--ez-rotate-duration) ease-out forwards;
+}
+
+/* Show only the panel matching the checked radio */
+.tabs__radio:nth-of-type(1):checked ~ .tabs__panels .tabs__panel:nth-child(1),
+.tabs__radio:nth-of-type(2):checked ~ .tabs__panels .tabs__panel:nth-child(2),
+.tabs__radio:nth-of-type(3):checked ~ .tabs__panels .tabs__panel:nth-child(3) {
+    opacity: 1;
+    visibility: visible;
+    transform: rotateX(0deg) translateY(0) scale(1);
+    position: relative;
+}
+
+/* ---------- Panel Styles ---------- */
+.panel__title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--ez-rotate-color);
+    margin-bottom: 4px;
+}
+
+.panel__desc {
+    font-size: 0.88rem;
+    color: var(--ez-rotate-muted);
+    margin-bottom: 28px;
+}
+
+/* ---------- Project Grid ---------- */
+.project-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+}
+
+.project-card {
+    background: var(--ez-rotate-surface);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 14px;
+    overflow: hidden;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    animation: ease-kf-card-reveal 0.5s ease-out both;
+}
+
+.project-card:nth-child(2) { animation-delay: 0.08s; }
+.project-card:nth-child(3) { animation-delay: 0.16s; }
+.project-card:nth-child(4) { animation-delay: 0.24s; }
+
+.project-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.08);
+}
+
+.project-card__thumb {
+    height: 120px;
+    display: flex;
+    align-items: flex-end;
+    padding: 14px;
+}
+
+.project-card__number {
+    font-size: 2rem;
+    font-weight: 800;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.project-card__info {
+    padding: 14px 16px;
+}
+
+.project-card__name {
+    display: block;
+    font-size: 0.92rem;
+    font-weight: 700;
+    color: var(--ez-rotate-color);
+    margin-bottom: 2px;
+}
+
+.project-card__cat {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--ez-rotate-muted);
+}
+
+/* ---------- Skills Grid ---------- */
+.skills-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+}
+
+.skill-group {
+    background: var(--ez-rotate-surface);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 12px;
+    padding: 20px;
+}
+
+.skill-group__title {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--ez-rotate-color);
+    margin-bottom: 12px;
+}
+
+.skill-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.skill-tag {
+    display: inline-block;
+    padding: 5px 12px;
+    background: var(--ez-rotate-bg);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 6px;
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--ez-rotate-muted);
+    transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.skill-tag:hover {
+    border-color: var(--ez-rotate-accent);
+    color: var(--ez-rotate-accent);
+}
+
+/* ---------- About Layout ---------- */
+.about-layout {
+    display: grid;
+    grid-template-columns: 1.2fr 1fr;
+    gap: 24px;
+    align-items: start;
+}
+
+.about-text p {
+    font-size: 0.9rem;
+    color: var(--ez-rotate-muted);
+    margin-bottom: 14px;
+}
+
+.about-stats {
+    display: flex;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.about-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: var(--ez-rotate-surface);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 12px;
+    padding: 16px 24px;
+    flex: 1;
+}
+
+.about-stat__val {
+    font-size: 1.6rem;
+    font-weight: 800;
+    color: var(--ez-rotate-accent);
+}
+
+.about-stat__lbl {
+    font-size: 0.72rem;
+    color: var(--ez-rotate-muted);
+}
+
+.about-contact {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.contact-card {
+    background: var(--ez-rotate-surface);
+    border: 1px solid var(--ez-rotate-border);
+    border-radius: 12px;
+    padding: 16px 18px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    transition: border-color 0.15s ease;
+}
+
+.contact-card:hover {
+    border-color: var(--ez-rotate-accent);
+}
+
+.contact-card__icon {
+    font-size: 1.2rem;
+}
+
+.contact-card__label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--ez-rotate-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.contact-card__value {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ez-rotate-color);
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .tabs__panel {
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1024px) {
+    .project-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .skills-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .about-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .portfolio {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        display: none;
+    }
+
+    .content {
+        padding: 16px;
+    }
+
+    .topbar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .tabs__label {
+        padding: 12px 14px;
+        font-size: 0.78rem;
+    }
+
+    .tabs__panel {
+        padding: 24px 18px;
+    }
+
+    .about-stats {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
Closes #50079

Adds a pure CSS rotate-click tab component styled for creative portfolio layouts.

Changes:
- submissions/examples/portfolio-rotate-tabs-er/demo.html — Portfolio layout with sidebar, topbar, and 3 rotate-click tabs (Projects, Skills, About)
- submissions/examples/portfolio-rotate-tabs-er/style.css — Portfolio layout, sidebar, rotate-click animations (ease-kf-rotate-in), card reveals, responsive breakpoints
- submissions/examples/portfolio-rotate-tabs-er/README.md — What/How/Why documentation

Features:
- Pure CSS (no JavaScript) — radio button state management
- Rotate-click tab panels with ease-kf-rotate-in keyframes (rotateX + translateY + scale)
- perspective + transform-origin for realistic 3D feel
- Configurable --ez-rotate-angle for rotation depth
- 3 tab contexts: Projects (gradient cards), Skills (tag groups), About (stats + contact)
- Portfolio layout with sidebar navigation and social links
- Keyboard accessible with focus-visible states
- Respects prefers-reduced-motion
- Responsive down to 768px (sidebar collapses)
- All CSS uses ease-* prefixed custom properties and keyframes