### PR TITLE
Pulse Checkbox Mixin

### DIFF
--- a/submissions/scss/feature-pulse-checkbox-mixin-ab/README.md
+++ b/submissions/scss/feature-pulse-checkbox-mixin-ab/README.md
@@ -1,0 +1,126 @@
+# Pulse Checkbox Mixin (`feature-pulse-checkbox-mixin-ab`)
+
+Standalone **SCSS track** submission for [Issue #50770](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/50770).
+
+A beginner-friendly **Pulse Checkbox (Attention Seeker)** mixin — gently scales (and optionally rings) a checkbox to draw attention without touching `core/` or `components/`.
+
+---
+
+## What it does
+
+- Defines unique pulse `@keyframes` (scale + optional expanding ring)
+- Exposes `ease-pulse-checkbox-mixin-ab` for one-line usage
+- Optional `ease-pulse-checkbox-surface-ab` for a styled native checkbox host
+- Optional unchecked-only + trigger-class helpers
+- Pauses while `:focus-visible` and disables under `prefers-reduced-motion`
+
+---
+
+## Folder structure
+
+```
+submissions/scss/feature-pulse-checkbox-mixin-ab/
+├── _pulse-checkbox.scss   ← mixin + keyframes
+└── README.md              ← this file
+```
+
+---
+
+## Installation
+
+```scss
+@use 'pulse-checkbox' as *;
+// or: @import 'pulse-checkbox';
+```
+
+---
+
+## Parameters — `ease-pulse-checkbox-mixin-ab`
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `$duration` | Time | `1.2s` | Length of one pulse cycle |
+| `$iteration` | Number / `infinite` | `infinite` | How many times it pulses |
+| `$delay` | Time | `0s` | Start delay |
+| `$easing` | String | `ease-in-out` | Timing function |
+| `$scale` | Number | `1.12` | Peak scale |
+| `$ring` | Boolean | `true` | Soft expanding ring via `::after` |
+
+---
+
+## Usage
+
+### Basic (matches issue example shape)
+
+```scss
+@use 'pulse-checkbox' as *;
+
+.my-element {
+  @include ease-pulse-checkbox-mixin-ab(0.5s);
+}
+```
+
+### Styled checkbox surface + attention class
+
+```scss
+.pulse-check-ab {
+  @include ease-pulse-checkbox-surface-ab(0.5s, 3);
+}
+```
+
+```html
+<label class="pulse-check-ab is-attention-ab">
+  <input type="checkbox" name="terms" required />
+  <span>I agree to the terms</span>
+</label>
+```
+
+Add `is-attention-ab` when you need the unchecked box to pulse (e.g. form validation). The pulse stops once the box is checked.
+
+### Unchecked-only pulse on the input
+
+```scss
+.terms-check input[type='checkbox'] {
+  @include ease-pulse-checkbox-unchecked-ab(0.5s, 3);
+}
+```
+
+---
+
+## Why this is useful
+
+Required checkboxes are easy to miss. A short pulse cue:
+
+1. Draws attention to “accept terms” / required options
+2. Stops naturally when checked (with the surface / unchecked helpers)
+3. Stays CSS-first via a reusable SCSS mixin
+4. Respects focus and reduced-motion preferences
+
+A strong candidate for later curation into the official EaseMotion SCSS layer.
+
+---
+
+## Accessibility
+
+- Always use a native `<input type="checkbox">` associated with a `<label>`
+- Do not replace checkboxes with non-focusable `<div>`s
+- Mixin pauses on `:focus-visible` so keyboard users aren’t distracted while focusing
+- Under `prefers-reduced-motion: reduce`, pulse + ring are disabled
+- Prefer finite `$iteration` (e.g. `3`) over infinite for photosensitive comfort
+
+---
+
+## Unique identifier
+
+All mixin names, keyframes, and CSS variables use the **`-ab`** suffix to avoid collisions with parallel submissions.
+
+---
+
+## Checklist (issue acceptance)
+
+- [x] Files live under `submissions/scss/feature-pulse-checkbox-mixin-ab/`
+- [x] Required `_pulse-checkbox.scss` + `README.md`
+- [x] Unique identifier on folder / mixins / keyframes
+- [x] Smooth pulse attention effect
+- [x] `prefers-reduced-motion` handled
+- [x] README explains what / how / why

--- a/submissions/scss/feature-pulse-checkbox-mixin-ab/_pulse-checkbox.scss
+++ b/submissions/scss/feature-pulse-checkbox-mixin-ab/_pulse-checkbox.scss
@@ -1,0 +1,284 @@
+// ============================================================
+// Feature: Pulse Checkbox Mixin (ab)
+// Issue: #50770 — Pulse Checkbox (Attention Seeker)
+// Track: submissions/scss (SCSS)
+// ============================================================
+//
+// Usage:
+//   @use 'pulse-checkbox' as *;
+//
+//   .my-element {
+//     @include ease-pulse-checkbox-mixin-ab(0.5s);
+//   }
+//
+// ============================================================
+
+/// Unique keyframe names — suffix avoids collisions with other submissions.
+$pulse-checkbox-kf-ab: pulse-checkbox-ab;
+$pulse-checkbox-ring-kf-ab: pulse-checkbox-ring-ab;
+
+/// Soft scale pulse for checkbox attention.
+@keyframes #{$pulse-checkbox-kf-ab} {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(var(--pulse-checkbox-scale-ab, 1.12));
+  }
+}
+
+/// Expanding ring pulse around the control (attention seeker).
+@keyframes #{$pulse-checkbox-ring-kf-ab} {
+  0% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+
+  70% {
+    transform: scale(var(--pulse-checkbox-ring-scale-ab, 1.55));
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(var(--pulse-checkbox-ring-scale-ab, 1.55));
+    opacity: 0;
+  }
+}
+
+/// Apply a smooth pulse attention-seeker animation to a checkbox (or host).
+///
+/// @param {Time} $duration [1.2s]
+///   Length of one pulse cycle. Issue example uses `0.5s` for a snappy cue.
+/// @param {Number|String} $iteration [infinite]
+///   How many times it pulses. Use `1`–`3` for a short entrance cue.
+/// @param {Time} $delay [0s]
+///   Delay before the animation starts.
+/// @param {String} $easing [ease-in-out]
+///   Timing function for the pulse.
+/// @param {Number} $scale [1.12]
+///   Peak scale of the checkbox control.
+/// @param {Boolean} $ring [true]
+///   When true, also emits a soft expanding ring via `::after`.
+///
+/// @example scss
+///   @use 'pulse-checkbox' as *;
+///
+///   .my-element {
+///     @include ease-pulse-checkbox-mixin-ab(0.5s);
+///   }
+@mixin ease-pulse-checkbox-mixin-ab(
+  $duration: 1.2s,
+  $iteration: infinite,
+  $delay: 0s,
+  $easing: ease-in-out,
+  $scale: 1.12,
+  $ring: true
+) {
+  --pulse-checkbox-scale-ab: #{$scale};
+  --pulse-checkbox-ring-scale-ab: 1.55;
+
+  position: relative;
+  transform-origin: center;
+  will-change: transform;
+
+  animation-name: #{$pulse-checkbox-kf-ab};
+  animation-duration: $duration;
+  animation-timing-function: $easing;
+  animation-delay: $delay;
+  animation-iteration-count: $iteration;
+  animation-fill-mode: both;
+
+  @if $ring {
+    &::after {
+      content: "";
+      position: absolute;
+      inset: -0.2rem;
+      border-radius: inherit;
+      border: 2px solid currentColor;
+      pointer-events: none;
+      opacity: 0;
+      animation: #{$pulse-checkbox-ring-kf-ab} $duration $easing $delay
+        $iteration;
+    }
+  }
+
+  // Pause attention pulse while focused so keyboard users stay steady
+  &:focus-visible {
+    animation-play-state: paused;
+
+    &::after {
+      animation-play-state: paused;
+      opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none !important;
+    transform: none !important;
+    will-change: auto;
+
+    &::after {
+      content: none !important;
+      animation: none !important;
+    }
+  }
+}
+
+/// Styled checkbox host + optional pulse attention seeker.
+/// Works with a native `<input type="checkbox">` inside a label.
+///
+/// Markup:
+///   <label class="pulse-check-ab">
+///     <input type="checkbox" />
+///     <span>Remember me</span>
+///   </label>
+///
+/// @param {Time} $duration [1.2s]
+/// @param {Number|String} $iteration [infinite]
+/// @param {Color} $accent [#6c63ff]
+/// @param {Length} $size [1.15rem]
+/// @param {Boolean} $pulse [true]
+///   When true, unchecked required/attention state can pulse via `.is-attention-ab`.
+///
+/// @example scss
+///   .pulse-check-ab {
+///     @include ease-pulse-checkbox-surface-ab(0.5s);
+///   }
+@mixin ease-pulse-checkbox-surface-ab(
+  $duration: 1.2s,
+  $iteration: infinite,
+  $accent: #6c63ff,
+  $size: 1.15rem,
+  $pulse: true
+) {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  user-select: none;
+  color: #1e293b;
+  font: inherit;
+  line-height: 1.4;
+
+  input[type='checkbox'] {
+    appearance: none;
+    -webkit-appearance: none;
+    position: relative;
+    flex-shrink: 0;
+    width: $size;
+    height: $size;
+    margin: 0;
+    border: 2px solid #94a3b8;
+    border-radius: 0.3rem;
+    background: #fff;
+    color: $accent;
+    cursor: pointer;
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease,
+      box-shadow 150ms ease;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: no-repeat center / 70% 70%
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23ffffff' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3.5 8.5 6.5 11.5 12.5 4.5'/%3E%3C/svg%3E");
+      opacity: 0;
+      transform: scale(0.7);
+      transition:
+        opacity 140ms ease,
+        transform 140ms ease;
+    }
+
+    &:checked {
+      background: $accent;
+      border-color: $accent;
+    }
+
+    &:checked::before {
+      opacity: 1;
+      transform: scale(1);
+    }
+
+    &:focus-visible {
+      outline: 3px solid rgba($accent, 0.35);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  @if $pulse {
+    &.is-attention-ab input[type='checkbox']:not(:checked):not(:disabled) {
+      @include ease-pulse-checkbox-mixin-ab(
+        $duration: $duration,
+        $iteration: $iteration,
+        $scale: 1.1
+      );
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    input[type='checkbox'],
+    input[type='checkbox']::before {
+      transition: none !important;
+    }
+  }
+}
+
+/// Pulse only while the checkbox is unchecked (common “please accept” cue).
+///
+/// @param {Time} $duration [0.5s]
+/// @param {Number|String} $iteration [3]
+///
+/// @example scss
+///   .terms-check input {
+///     @include ease-pulse-checkbox-unchecked-ab(0.5s, 3);
+///   }
+@mixin ease-pulse-checkbox-unchecked-ab(
+  $duration: 0.5s,
+  $iteration: 3
+) {
+  &:not(:checked):not(:disabled) {
+    @include ease-pulse-checkbox-mixin-ab(
+      $duration: $duration,
+      $iteration: $iteration
+    );
+  }
+
+  &:checked {
+    animation: none !important;
+
+    &::after {
+      content: none !important;
+      animation: none !important;
+    }
+  }
+}
+
+/// Utility class generator — toggle `.is-pulse-checkbox-ab` from JS to replay.
+///
+/// @param {String} $class-name ['.is-pulse-checkbox-ab']
+/// @param {Time} $duration [0.5s]
+/// @param {Number|String} $iteration [3]
+///
+/// @example scss
+///   @include ease-pulse-checkbox-trigger-class-ab;
+@mixin ease-pulse-checkbox-trigger-class-ab(
+  $class-name: '.is-pulse-checkbox-ab',
+  $duration: 0.5s,
+  $iteration: 3
+) {
+  #{$class-name} {
+    @include ease-pulse-checkbox-mixin-ab(
+      $duration: $duration,
+      $iteration: $iteration
+    );
+  }
+}


### PR DESCRIPTION
# #50770 issue resolved

## Description

This PR adds a beginner-friendly **Pulse Checkbox Mixin (Attention Seeker)** under `submissions/scss/feature-pulse-checkbox-mixin-ab/`.

## Features

- Smooth scale pulse + optional expanding ring
- Optional styled checkbox surface with attention class
- Unchecked-only helper for required/terms cues
- Respects `prefers-reduced-motion: reduce`
- Unique `-ab` suffix to avoid naming collisions