### PR TITLE
Expand Accordion SCSS mixin

### DIFF
--- a/submissions/scss/feature-expand-accordion-mixin-sp/README.md
+++ b/submissions/scss/feature-expand-accordion-mixin-sp/README.md
@@ -1,0 +1,81 @@
+# Expand Accordion Mixin
+
+## Description
+
+`ease-expand-accordion-mixin-sp` is a beginner-friendly SCSS mixin that adds a smooth expand / collapse animation to accordion panels. It uses CSS Grid (`0fr` → `1fr`) for accurate height transitions, plus a light scale-and-fade motion for polish. An optional exit class supports collapse animations when a panel closes.
+
+## Why it is useful
+
+- Smooth expand without guessing `max-height` values
+- Works with semantic `<details>` / `aria-expanded` patterns
+- One `@include` for reusable accordion motion across a project
+- Built-in `prefers-reduced-motion` support
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `$duration` | Time | `0.5s` | Length of the expand / exit animation |
+| `$easing` | Timing-Function | `cubic-bezier(0.4, 0, 0.2, 1)` | Motion easing curve |
+
+## Usage
+
+```scss
+@use 'path/to/expand-accordion' as *;
+
+.my-element {
+  @include ease-expand-accordion-mixin-sp(0.5s);
+}
+```
+
+### HTML (accessible pattern)
+
+```html
+<details class="ease-expand-accordion-item-sp">
+  <summary>Section title</summary>
+  <div class="my-element">
+    <div>
+      Accordion body content goes here.
+    </div>
+  </div>
+</details>
+```
+
+Or toggle with classes / ARIA:
+
+```html
+<button type="button" aria-expanded="false" aria-controls="panel-1">Toggle</button>
+<div
+  id="panel-1"
+  class="my-element"
+  role="region"
+  aria-labelledby="heading-1"
+>
+  <div>Panel content</div>
+</div>
+```
+
+```js
+// Open
+panel.classList.add('ease-expand-accordion-open-sp');
+button.setAttribute('aria-expanded', 'true');
+
+// Exit / collapse
+panel.classList.remove('ease-expand-accordion-open-sp');
+panel.classList.add('ease-expand-accordion-exiting-sp');
+button.setAttribute('aria-expanded', 'false');
+```
+
+## Accessibility
+
+- Prefer semantic markup (`<details>` / `<summary>`, or `button` + `aria-expanded` + `aria-controls`)
+- Keep focusable controls keyboard-operable
+- Under `prefers-reduced-motion: reduce`, animations and transitions are disabled; the panel still opens and closes instantly so content remains usable
+
+## Files
+
+```
+submissions/scss/feature-expand-accordion-mixin-sp/
+├── _expand-accordion.scss
+└── README.md
+```

--- a/submissions/scss/feature-expand-accordion-mixin-sp/_expand-accordion.scss
+++ b/submissions/scss/feature-expand-accordion-mixin-sp/_expand-accordion.scss
@@ -1,0 +1,100 @@
+// _expand-accordion.scss
+// Expand Accordion Mixin — smooth expand / collapse for accordion panels
+// Unique suffix: -sp (avoids naming collisions with other submissions)
+
+/// Keyframes for a gentle expand entrance (height + opacity).
+@keyframes easeExpandAccordionInSp {
+  from {
+    opacity: 0;
+    transform: scaleY(0.92);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+/// Keyframes for a soft expand-panel exit (collapse + fade).
+@keyframes easeExpandAccordionOutSp {
+  from {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: scaleY(0.92);
+  }
+}
+
+/// Applies a smooth expand accordion panel transition.
+/// Use on the collapsible content region. Toggle open/closed with
+/// `.ease-expand-accordion-open-sp` or `[aria-expanded="true"]` on a parent,
+/// or add `.ease-expand-accordion-exiting-sp` for the exit animation.
+///
+/// @param {Time} $duration [0.5s] - Length of the expand / exit motion.
+/// @param {Timing-Function} $easing [cubic-bezier(0.4, 0, 0.2, 1)] - Easing curve.
+///
+/// @example
+///   .my-element {
+///     @include ease-expand-accordion-mixin-sp(0.5s);
+///   }
+@mixin ease-expand-accordion-mixin-sp(
+  $duration: 0.5s,
+  $easing: cubic-bezier(0.4, 0, 0.2, 1)
+) {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transform-origin: top center;
+  overflow: hidden;
+  transition:
+    grid-template-rows $duration $easing,
+    opacity $duration $easing;
+  will-change: grid-template-rows, opacity;
+
+  > * {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  // Expanded / open state
+  &.ease-expand-accordion-open-sp,
+  &[aria-expanded="true"],
+  .ease-expand-accordion-item-sp[open] &,
+  .ease-expand-accordion-item-sp[aria-expanded="true"] & {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    animation: easeExpandAccordionInSp $duration $easing both;
+  }
+
+  // Exit animation (collapse)
+  &.ease-expand-accordion-exiting-sp {
+    grid-template-rows: 0fr;
+    opacity: 0;
+    animation: easeExpandAccordionOutSp $duration $easing both;
+  }
+
+  // Accessibility: respect reduced motion preference
+  @media (prefers-reduced-motion: reduce) {
+    transition: none !important;
+    animation: none !important;
+    will-change: auto;
+
+    &.ease-expand-accordion-open-sp,
+    &[aria-expanded="true"],
+    .ease-expand-accordion-item-sp[open] &,
+    .ease-expand-accordion-item-sp[aria-expanded="true"] & {
+      grid-template-rows: 1fr;
+      opacity: 1;
+      transform: none;
+    }
+
+    &.ease-expand-accordion-exiting-sp {
+      grid-template-rows: 0fr;
+      opacity: 0;
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
# #50769 issue resolved

## Description

This PR adds a beginner-friendly Expand Accordion SCSS mixin under `submissions/scss/feature-expand-accordion-mixin-sp`.

## Features

- Smooth expand/collapse accordion motion via CSS Grid (`0fr` → `1fr`)
- Reusable `@include ease-expand-accordion-mixin-sp(0.5s)` mixin
- Exit animation support with `.ease-expand-accordion-exiting-sp`
- Works with semantic HTML and `aria-expanded`
- Respects `prefers-reduced-motion: reduce`