### PR TITLE
fix(accordion): implement smooth height transition using grid

### DIFF
--- a/submissions/docs/accordion-content-jump-jp/README.md
+++ b/submissions/docs/accordion-content-jump-jp/README.md
@@ -1,0 +1,23 @@
+# Accordion Content Jump Fix
+
+Fixes the abrupt layout jumping when opening and closing `.ease-accordion` items.
+
+**What does this do?**
+Standard CSS cannot transition smoothly to `height: auto`. This fix leverages modern CSS Grid (`grid-template-rows: 0fr` transitioning to `1fr`) to allow the accordion body to smoothly animate to its intrinsic content height.
+
+**How is it used?**
+Ensure your accordion HTML uses the wrapper elements:
+```html
+<div class="ease-accordion is-open">
+  <button class="ease-accordion-header">Title</button>
+  <div class="ease-accordion-body">
+    <div class="ease-accordion-content">
+      Content goes here.
+    </div>
+  </div>
+</div>
+```
+When the `.is-open` class is applied, the grid row seamlessly expands.
+
+**Why is it useful?**
+It provides a premium, smooth opening animation that drastically improves the feel of the component compared to the default instant-snap behavior.

--- a/submissions/docs/accordion-content-jump-jp/demo.html
+++ b/submissions/docs/accordion-content-jump-jp/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accordion Content Jump Fix Demo</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      padding: 3rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f1f5f9;
+      color: #334155;
+    }
+    
+    .ease-accordion {
+      max-width: 500px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+      overflow: hidden;
+    }
+    
+    .ease-accordion-header {
+      width: 100%;
+      text-align: left;
+      padding: 1rem 1.5rem;
+      font-size: 1.125rem;
+      font-weight: 600;
+      background: #fff;
+      border: none;
+      border-bottom: 1px solid #e2e8f0;
+      cursor: pointer;
+    }
+    
+    .ease-accordion-content {
+      padding: 1.5rem;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  
+  <div class="ease-accordion" id="accordion">
+    <button class="ease-accordion-header" onclick="document.getElementById('accordion').classList.toggle('is-open')">
+      Click to toggle smooth expansion
+    </button>
+    <div class="ease-accordion-body">
+      <div class="ease-accordion-content">
+        This content uses CSS Grid (`grid-template-rows: 0fr` to `1fr`) to smoothly animate its height from 0 to its natural, intrinsic height. Before this fix, the content would instantly snap open because standard CSS cannot animate to `height: auto`.
+      </div>
+    </div>
+  </div>
+  
+</body>
+</html>

--- a/submissions/docs/accordion-content-jump-jp/style.css
+++ b/submissions/docs/accordion-content-jump-jp/style.css
@@ -1,0 +1,17 @@
+/* Accordion height transition fix using CSS Grid */
+
+.ease-accordion-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease-in-out;
+}
+
+.ease-accordion-content {
+  overflow: hidden;
+}
+
+/* When the accordion is open, expand the grid to 1fr (its natural height) */
+.ease-accordion.is-open .ease-accordion-body,
+.ease-accordion-body.is-open {
+  grid-template-rows: 1fr;
+}


### PR DESCRIPTION
Closes #51262

# Description

## 🐛 What was broken? / What is added?
Opening or closing an `.ease-accordion` item caused the content to expand or collapse instantly. This snap effect felt unpolished because native CSS `height` transitions cannot animate to `height: auto`.

## ✅ What was changed?
- Created `style.css` which leverages CSS Grid to transition `grid-template-rows` from `0fr` to `1fr`, allowing smooth animation to natural intrinsic height.
- Set `overflow: hidden` on the inner `.ease-accordion-content` to prevent content from spilling during the transition.
- Included `demo.html` to showcase the smooth opening animation.
- Added `README.md` to document the usage and integration of the fix.

## 🔗 Related Issue
Fixes #51262 

## Pull Request Description

This PR fixes a major layout jump issue in accordions by implementing a modern CSS Grid hack to smoothly animate to intrinsic `auto` heights.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Uses modern CSS Grid `0fr` to `1fr` transitions to enable smooth accordion height animations.

**How does a developer use it?**
Wrap accordion content inside an `.ease-accordion-body` and `.ease-accordion-content` structure, and toggle `.is-open` on the wrapper.

**Why does it fit EaseMotion CSS?**
It provides a purely CSS-based solution to a notoriously difficult animation problem (animating to `height: auto`), avoiding heavy JavaScript measurement calculations.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari (iOS)

---

## Notes for Maintainer

This fix is fully contained within `submissions/docs/accordion-content-jump-jp/` to adhere to the repository's strict no-overwrite policy.
