### PR TITLE
fix(modal): update backdrop to use 100dvh for mobile toolbars

### DIFF
--- a/submissions/docs/modal-backdrop-mobile-jp/README.md
+++ b/submissions/docs/modal-backdrop-mobile-jp/README.md
@@ -1,0 +1,18 @@
+# Modal Backdrop Mobile Fix
+
+Fixes the issue where modal backdrop overlays (`.ease-modal-backdrop`) fail to cover the full viewport on mobile devices when browser toolbars dynamically hide.
+
+**What does this do?**
+It updates the `.ease-modal-backdrop` to use `bottom: 0` alongside modern `height: 100dvh` (Dynamic Viewport Height). This ensures the overlay strictly adheres to the exact visible edges of the screen, dynamically responding to UI changes like scrolling.
+
+**How is it used?**
+The styling applies automatically to the `.ease-modal-backdrop` element.
+
+```html
+<div class="ease-modal-backdrop">
+  <!-- Modal Content -->
+</div>
+```
+
+**Why is it useful?**
+It prevents the UI from looking broken (displaying a gap at the bottom of the screen) when users scroll to view long modal content on mobile devices.

--- a/submissions/docs/modal-backdrop-mobile-jp/demo.html
+++ b/submissions/docs/modal-backdrop-mobile-jp/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Backdrop Mobile Fix Demo</title>
+  <link rel="stylesheet" href="../../easemotion.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      padding: 2rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      /* Extra tall body to allow scrolling and hiding of mobile toolbars */
+      min-height: 200vh;
+      margin: 0;
+    }
+    
+    .ease-modal-backdrop {
+      background: rgba(15, 23, 42, 0.7);
+      z-index: 50;
+      /* The fix is applied via style.css */
+    }
+    
+    .demo-content {
+      position: relative;
+      z-index: 10;
+    }
+  </style>
+</head>
+<body>
+  
+  <div class="demo-content">
+    <h2>Modal Backdrop Fix</h2>
+    <p>Scroll down on a mobile device (or in mobile emulator mode) to hide the browser toolbar. The dark backdrop overlay will remain perfectly flush against the bottom of the screen without leaving a gap.</p>
+  </div>
+
+  <!-- The backdrop with the fix applied -->
+  <div class="ease-modal-backdrop"></div>
+  
+</body>
+</html>

--- a/submissions/docs/modal-backdrop-mobile-jp/style.css
+++ b/submissions/docs/modal-backdrop-mobile-jp/style.css
@@ -1,0 +1,12 @@
+/* Fix for mobile modal backdrop gap */
+
+.ease-modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* Instead of height: 100vh, we pin it to all 4 corners */
+  bottom: 0;
+  /* Modern fallback for dynamic viewport height */
+  height: 100dvh;
+}


### PR DESCRIPTION

# Description

## 🐛 What was broken? / What is added?
On mobile browsers (like iOS Safari), scrolling dynamically hides toolbars. The `.ease-modal-backdrop` overlay failed to adapt, resulting in a visible gap at the bottom of the viewport because it was hardcoded to `100vh` rather than anchoring properly.

## ✅ What was changed?
- Created `style.css` which anchors the backdrop using `bottom: 0` and modern `100dvh` to ensure it resizes perfectly alongside the dynamic browser UI.
- Included `demo.html` to showcase the fix in a scrollable view.
- Added `README.md` to document the usage and integration of the fix.

## 🔗 Related Issue
Fixes #51269

## Pull Request Description

This PR fixes a glaring visual gap that appears at the bottom of modal backdrops on mobile browsers due to dynamic toolbars.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Modern `dvh` (Dynamic Viewport Height) support and a `bottom: 0` anchor for the modal backdrop.

**How does a developer use it?**
No changes needed. It automatically applies to `.ease-modal-backdrop`.

**Why does it fit EaseMotion CSS?**
It fixes a common layout bug natively via CSS, ensuring high-end polish on all devices.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari (iOS)

---

## Notes for Maintainer

This fix is fully contained within `submissions/docs/modal-backdrop-mobile-jp/` to adhere to the repository's strict no-overwrite policy.
