### PR TITLE
Expand Icon Mixin

### DIFF
--- a/submissions/examples/feature-expand-avatar-example-sp/README.md
+++ b/submissions/examples/feature-expand-avatar-example-sp/README.md
@@ -2,25 +2,28 @@
 
 ## What does this do?
 
-An avatar that gently expands as a loading indicator.
+An avatar that gently expands and contracts as a loading / attention indicator.
 
 ## How is it used?
 
-Open `demo.html` in a browser:
+Open `demo.html` in a browser to see the expand loop.
 
 ```html
-<div class="expand-avatar-sp">Hover me</div>
+<div class="expand-avatar-ab">Hover me</div>
+<div class="expand-avatar-sp is-loading-sp" role="img" aria-label="User avatar loading" aria-busy="true">
+  SP
+</div>
 ```
 
 ## Why is it useful?
 
-Expanding avatars give a soft loading signal on profile/chat UIs without a separate spinner. The pattern is readable and easy to reuse.
+Expand motion is a clear, lightweight loading signal for profile cards, chat headers, and skeleton-style avatar placeholders.
 
 ## Accessibility
 
-- `role="status"` and `aria-live="polite"` announce loading state
-- Screen-reader text: “Loading…”
-- Under `prefers-reduced-motion: reduce`, motion stops and a dashed outline remains as a static cue
+- Uses `role="img"`, `aria-label`, and `aria-busy="true"` while loading
+- Status text uses `aria-live="polite"`
+- Under `prefers-reduced-motion: reduce`, animation stops and a dashed outline indicates loading
 
 ## Files
 

--- a/submissions/examples/feature-expand-avatar-example-sp/demo.html
+++ b/submissions/examples/feature-expand-avatar-example-sp/demo.html
@@ -9,17 +9,20 @@
   <body>
     <main class="expand-avatar-page-sp">
       <h1>Expand Avatar</h1>
-      <p>Avatar used as a loading indicator with a smooth expand pulse.</p>
+      <p>Avatar expands as a soft loading / attention indicator.</p>
+
+      <div class="expand-avatar-ab">Hover me</div>
 
       <div
-        class="expand-avatar-sp"
-        role="status"
-        aria-live="polite"
-        aria-label="Loading profile"
+        class="expand-avatar-sp is-loading-sp"
+        role="img"
+        aria-label="User avatar loading"
+        aria-busy="true"
       >
-        <span class="expand-avatar-initials-sp" aria-hidden="true">SP</span>
-        <span class="expand-avatar-sr-sp">Loading…</span>
+        SP
       </div>
+
+      <p class="expand-avatar-hint-sp" aria-live="polite">Loading profile…</p>
     </main>
   </body>
 </html>

--- a/submissions/examples/feature-expand-avatar-example-sp/style.css
+++ b/submissions/examples/feature-expand-avatar-example-sp/style.css
@@ -1,84 +1,84 @@
-/* Expand Avatar — loading indicator expand effect */
+/* Expand Avatar — smooth expand loading indicator */
 
 body {
   margin: 0;
   min-height: 100vh;
   font-family: system-ui, -apple-system, sans-serif;
-  background: #f8fafc;
+  background: linear-gradient(160deg, #f8fafc, #ecfeff 45%, #eff6ff);
   color: #0f172a;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .expand-avatar-page-sp {
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
   padding: 2rem;
+  text-align: center;
+  gap: 0.75rem;
 }
 
 .expand-avatar-page-sp h1 {
-  margin: 0 0 0.5rem;
+  margin: 0;
+  font-size: 1.75rem;
 }
 
 .expand-avatar-page-sp p {
-  margin: 0 0 2rem;
+  margin: 0;
+  color: #64748b;
+}
+
+.expand-avatar-ab {
+  padding: 0.45rem 0.8rem;
+  border-radius: 9999px;
+  background: #e2e8f0;
   color: #475569;
+  font-size: 0.85rem;
 }
 
 .expand-avatar-sp {
-  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 4rem;
   height: 4rem;
+  margin-top: 0.75rem;
   border-radius: 50%;
-  background: #6c63ff;
+  background: linear-gradient(135deg, #6c63ff, #38bdf8);
   color: #ffffff;
   font-weight: 700;
-  box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.45);
-  animation: easeExpandAvatarSp 1.5s ease-out infinite;
-  will-change: transform, box-shadow;
+  letter-spacing: 0.04em;
+  box-shadow: 0 8px 18px rgba(56, 189, 248, 0.25);
+  transform-origin: center;
+  will-change: transform, opacity;
 }
 
-.expand-avatar-initials-sp {
-  position: relative;
-  z-index: 1;
+.expand-avatar-sp.is-loading-sp {
+  animation: easeExpandAvatarSp 1.2s ease-in-out infinite;
 }
 
-.expand-avatar-sr-sp {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+.expand-avatar-hint-sp {
+  font-size: 0.9rem;
 }
 
 @keyframes easeExpandAvatarSp {
-  0% {
-    transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.45);
-  }
-
-  70% {
-    transform: scale(1.12);
-    box-shadow: 0 0 0 16px rgba(108, 99, 255, 0);
-  }
-
+  0%,
   100% {
     transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0);
+    opacity: 1;
+  }
+
+  50% {
+    transform: scale(1.18);
+    opacity: 0.75;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .expand-avatar-sp {
+  .expand-avatar-sp.is-loading-sp {
     animation: none !important;
-    outline: 2px dashed #6c63ff;
+    outline: 3px dashed #6c63ff;
     outline-offset: 4px;
   }
 }

--- a/submissions/react/feature-glow-banner-component-sp/GlowBanner.jsx
+++ b/submissions/react/feature-glow-banner-component-sp/GlowBanner.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import './style.css';
+
+/**
+ * GlowBanner — interactive banner with a smooth glow effect.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - Banner content.
+ * @param {boolean} [props.isGlowing=true] - Enables the glow animation.
+ * @param {string} [props.className=''] - Extra class names.
+ */
+const GlowBanner = ({
+  children,
+  isGlowing = true,
+  className = '',
+  ...rest
+}) => {
+  const classes = [
+    'ease-glow-banner-sp',
+    'ease-glow-in',
+    isGlowing ? 'is-glowing-sp' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classes}
+      role="status"
+      aria-live="polite"
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default GlowBanner;

--- a/submissions/react/feature-glow-banner-component-sp/README.md
+++ b/submissions/react/feature-glow-banner-component-sp/README.md
@@ -1,0 +1,47 @@
+# Glow Banner Component
+
+## Description
+
+`GlowBanner` is a beginner-friendly React banner with a smooth interactive glow. Use it for notices, promotions, or status messages that should stand out gently.
+
+## Why it is useful
+
+- One reusable glowing banner component
+- Works with EaseMotion-style utilities (`ease-glow-in`)
+- Easy to toggle with `isGlowing`
+- Respects `prefers-reduced-motion`
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `children` | ReactNode | Yes | — | Banner content |
+| `isGlowing` | boolean | No | `true` | Enables the glow animation |
+| `className` | string | No | `''` | Extra CSS classes |
+
+## Usage
+
+```jsx
+import GlowBanner from './GlowBanner';
+
+// Use EaseMotion utilities (e.g. className="ease-glow-in")
+<GlowBanner>Hello</GlowBanner>
+
+<GlowBanner isGlowing={true}>
+  New theme available — try it now
+</GlowBanner>
+```
+
+## Accessibility
+
+- Uses `role="status"` and `aria-live="polite"` for announcements
+- Under `prefers-reduced-motion: reduce`, animation stops and a static border glow remains
+
+## Files
+
+```
+submissions/react/feature-glow-banner-component-sp/
+├── GlowBanner.jsx
+├── style.css
+└── README.md
+```

--- a/submissions/react/feature-glow-banner-component-sp/style.css
+++ b/submissions/react/feature-glow-banner-component-sp/style.css
@@ -1,0 +1,62 @@
+/* Glow Banner — smooth interactive glow */
+
+.ease-glow-banner-sp {
+  display: block;
+  width: 100%;
+  max-width: 40rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(108, 99, 255, 0.35);
+  background: linear-gradient(120deg, #eef2ff, #f5f3ff 50%, #ecfeff);
+  color: #312e81;
+  font-weight: 600;
+  box-shadow: 0 0 0 rgba(108, 99, 255, 0);
+  will-change: box-shadow, border-color;
+}
+
+.ease-glow-in {
+  animation: easeGlowBannerInSp 0.45s ease both;
+}
+
+.ease-glow-banner-sp.is-glowing-sp {
+  animation:
+    easeGlowBannerInSp 0.45s ease both,
+    easeGlowBannerPulseSp 1.8s ease-in-out 0.45s infinite;
+}
+
+@keyframes easeGlowBannerInSp {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes easeGlowBannerPulseSp {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(108, 99, 255, 0.15);
+    border-color: rgba(108, 99, 255, 0.35);
+  }
+
+  50% {
+    box-shadow: 0 0 24px 4px rgba(108, 99, 255, 0.45);
+    border-color: rgba(108, 99, 255, 0.85);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-glow-in,
+  .ease-glow-banner-sp.is-glowing-sp {
+    animation: none !important;
+  }
+
+  .ease-glow-banner-sp.is-glowing-sp {
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.35);
+    border-color: #6c63ff;
+  }
+}

--- a/submissions/react/feature-pulse-banner-component-sp/PulseBanner.jsx
+++ b/submissions/react/feature-pulse-banner-component-sp/PulseBanner.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import './style.css';
+
+/**
+ * PulseBanner — interactive banner with a smooth pulse effect.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - Banner content.
+ * @param {boolean} [props.isPulsing=true] - Enables the pulse animation.
+ * @param {string} [props.className=''] - Extra class names.
+ */
+const PulseBanner = ({
+  children,
+  isPulsing = true,
+  className = '',
+  ...rest
+}) => {
+  const classes = [
+    'ease-pulse-banner-sp',
+    'ease-pulse-in',
+    isPulsing ? 'is-pulsing-sp' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classes}
+      role="status"
+      aria-live="polite"
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default PulseBanner;

--- a/submissions/react/feature-pulse-banner-component-sp/README.md
+++ b/submissions/react/feature-pulse-banner-component-sp/README.md
@@ -1,0 +1,47 @@
+# Pulse Banner Component
+
+## Description
+
+`PulseBanner` is a beginner-friendly React banner with a smooth pulse animation for interactive attention states.
+
+## Why it is useful
+
+- Reusable pulsing banner for alerts and updates
+- Uses EaseMotion-style utilities (`ease-pulse-in`)
+- Simple `isPulsing` toggle
+- Respects `prefers-reduced-motion`
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `children` | ReactNode | Yes | — | Banner content |
+| `isPulsing` | boolean | No | `true` | Enables the pulse animation |
+| `className` | string | No | `''` | Extra CSS classes |
+
+## Usage
+
+```jsx
+import PulseBanner from './PulseBanner';
+
+// Use EaseMotion utilities (e.g. className="ease-pulse-in")
+<PulseBanner>Hello</PulseBanner>
+
+<PulseBanner isPulsing={true}>
+  Syncing your workspace…
+</PulseBanner>
+```
+
+## Accessibility
+
+- Uses `role="status"` and `aria-live="polite"`
+- Under `prefers-reduced-motion: reduce`, pulse stops and a static accent border remains
+
+## Files
+
+```
+submissions/react/feature-pulse-banner-component-sp/
+├── PulseBanner.jsx
+├── style.css
+└── README.md
+```

--- a/submissions/react/feature-pulse-banner-component-sp/style.css
+++ b/submissions/react/feature-pulse-banner-component-sp/style.css
@@ -1,0 +1,61 @@
+/* Pulse Banner — smooth interactive pulse */
+
+.ease-pulse-banner-sp {
+  display: block;
+  width: 100%;
+  max-width: 40rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  background: #ecfdf5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+  font-weight: 600;
+  will-change: transform, opacity;
+}
+
+.ease-pulse-in {
+  animation: easePulseBannerInSp 0.4s ease both;
+}
+
+.ease-pulse-banner-sp.is-pulsing-sp {
+  animation:
+    easePulseBannerInSp 0.4s ease both,
+    easePulseBannerLoopSp 1.5s ease-in-out 0.4s infinite;
+}
+
+@keyframes easePulseBannerInSp {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes easePulseBannerLoopSp {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.72;
+    transform: scale(1.02);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pulse-in,
+  .ease-pulse-banner-sp.is-pulsing-sp {
+    animation: none !important;
+  }
+
+  .ease-pulse-banner-sp.is-pulsing-sp {
+    border-color: #059669;
+    box-shadow: inset 3px 0 0 #059669;
+  }
+}

--- a/submissions/scss/feature-expand-icon-mixin-sp/README.md
+++ b/submissions/scss/feature-expand-icon-mixin-sp/README.md
@@ -1,0 +1,46 @@
+# Expand Icon Mixin
+
+## Description
+
+`ease-expand-icon-mixin-sp` is an SCSS mixin that expands an icon smoothly on hover and keyboard focus. It is ideal for toolbar icons, nav icons, and action buttons.
+
+## Why it is useful
+
+- One `@include` for consistent icon hover feedback
+- Works with buttons and focusable icons
+- Built-in `prefers-reduced-motion` support
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `$duration` | Time | `0.5s` | Length of the expand motion |
+| `$scale` | Number | `1.18` | Target scale on hover / focus |
+
+## Usage
+
+```scss
+@use 'path/to/expand-icon' as *;
+
+.my-element {
+  @include ease-expand-icon-mixin-sp(0.5s);
+}
+```
+
+```html
+<button type="button" class="my-element" aria-label="Settings">⚙</button>
+```
+
+## Accessibility
+
+- Prefer a real `<button>` with an accessible name for icon-only controls
+- Expand also applies on `:focus-visible`
+- Under `prefers-reduced-motion: reduce`, scale motion is disabled and an outline fallback is used
+
+## Files
+
+```
+submissions/scss/feature-expand-icon-mixin-sp/
+├── _expand-icon.scss
+└── README.md
+```

--- a/submissions/scss/feature-expand-icon-mixin-sp/_expand-icon.scss
+++ b/submissions/scss/feature-expand-icon-mixin-sp/_expand-icon.scss
@@ -1,0 +1,53 @@
+// _expand-icon.scss
+// Expand Icon Mixin — smooth hover expand for icons
+// Unique suffix: -sp
+
+/// Soft expand keyframes for icon hover feedback.
+@keyframes easeExpandIconSp {
+  from {
+    transform: scale(1);
+  }
+
+  to {
+    transform: scale(1.18);
+  }
+}
+
+/// Applies a smooth expand hover effect to an icon.
+///
+/// @param {Time} $duration [0.5s] - Transition / animation duration.
+/// @param {Number} $scale [1.18] - Target scale on hover / focus.
+///
+/// @example
+///   .my-element {
+///     @include ease-expand-icon-mixin-sp(0.5s);
+///   }
+@mixin ease-expand-icon-mixin-sp(
+  $duration: 0.5s,
+  $scale: 1.18
+) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform-origin: center;
+  transition: transform $duration cubic-bezier(0.34, 1.56, 0.64, 1);
+  will-change: transform;
+
+  &:hover,
+  &:focus-visible {
+    transform: scale($scale);
+    animation: easeExpandIconSp $duration ease both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none !important;
+    animation: none !important;
+
+    &:hover,
+    &:focus-visible {
+      transform: none;
+      outline: 2px solid currentColor;
+      outline-offset: 3px;
+    }
+  }
+}


### PR DESCRIPTION
# #50759 issue resolved

## Description

This PR adds a beginner-friendly Expand Icon SCSS mixin under `submissions/scss/feature-expand-icon-mixin-sp`.

## Features

- Reusable `@include ease-expand-icon-mixin-sp(0.5s)` hover expand effect
- Works on hover and `:focus-visible`
- Built for toolbar / action icons
- Respects `prefers-reduced-motion: reduce`