### PR TITLE
Expand Icon Mixin

### DIFF
--- a/submissions/scss/feature-expand-icon-mixin-sum/README.md
+++ b/submissions/scss/feature-expand-icon-mixin-sum/README.md
@@ -1,0 +1,42 @@
+# Expand Icon Mixin
+
+## What does this do?
+
+An SCSS mixin that expands an icon smoothly on hover and keyboard focus.
+
+## How is it used?
+
+```scss
+@use 'expand-icon' as *;
+
+.my-element {
+  @include expand-icon-mixin-sum(0.5s);
+}
+```
+
+### Parameters
+
+| Param | Default | Description |
+| --- | --- | --- |
+| `$duration` | `0.5s` | Transition length |
+| `$scale` | `1.18` | Peak expand scale |
+| `$easing` | spring cubic-bezier | Motion curve |
+
+## Why is it useful?
+
+Expand-on-hover icons give clear interactive feedback for toolbars, FABs, and action buttons without writing one-off CSS each time.
+
+## Accessibility
+
+- Works with `:focus-visible` for keyboard users
+- Under `prefers-reduced-motion: reduce`, scaling is disabled and a static outline cue is used instead
+
+## Files
+
+```
+submissions/scss/feature-expand-icon-mixin-sum/
+├── _expand-icon.scss
+└── README.md
+```
+
+Related issue: #50759

--- a/submissions/scss/feature-expand-icon-mixin-sum/_expand-icon.scss
+++ b/submissions/scss/feature-expand-icon-mixin-sum/_expand-icon.scss
@@ -1,0 +1,39 @@
+// _expand-icon.scss
+// Expand Icon — hover expand effect mixin
+
+/// Applies a smooth expand (scale-up) effect on hover and focus-visible.
+///
+/// @param {Time} $duration [0.5s] - Transition duration
+/// @param {Number} $scale [1.18] - Peak scale on hover/focus
+/// @param {Timing-Function} $easing [cubic-bezier(0.34, 1.56, 0.64, 1)] - Spring-like easing
+@mixin expand-icon-mixin-sum(
+  $duration: 0.5s,
+  $scale: 1.18,
+  $easing: cubic-bezier(0.34, 1.56, 0.64, 1)
+) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform: scale(1);
+  transform-origin: center;
+  transition: transform $duration $easing;
+  will-change: transform;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    transform: scale($scale);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none !important;
+
+    &:hover,
+    &:focus-visible {
+      transform: none !important;
+      /* Static cue without scaling */
+      outline: 2px solid currentColor;
+      outline-offset: 3px;
+    }
+  }
+}


### PR DESCRIPTION
# #50759 issue resolved

## Description

This PR adds a beginner-friendly Expand Icon SCSS mixin under `submissions/scss`.

## Features

- Smooth expand (scale) on hover and `:focus-visible`
- Configurable duration, scale, and easing
- Respects `prefers-reduced-motion: reduce` with a static outline cue