### PR TITLE
Feat fade fab

### DIFF
--- a/submissions/scss/feature-fade-fab-mixin-nv/README.md
+++ b/submissions/scss/feature-fade-fab-mixin-nv/README.md
@@ -1,0 +1,23 @@
+# Fade FAB (Exit Animation) Mixin
+
+A clean, accessible SCSS mixin engineered for Floating Action Buttons (FAB) that triggers a smooth fade and scaling drop exit transition sequence.
+
+## What It Does
+This mixin provides a fluid fade-out transition while subtly shrinking and lowering the element. It natively binds to the custom exit trigger state class (`.exit-active-nv`) or structural ARIA states (`[aria-hidden="true"]`) to keep scripts minimal.
+
+## How to Use It
+Import and include the mixin inside your component files, supplying your desired transition speed layout configuration:
+
+```scss
+@use 'fade-fab' as *;
+
+.fab-button-nv {
+  // Pass customized duration if needed (defaults to 0.3s)
+  @include fade-fab-mixin-nv(0.4s);
+}
+```
+
+## Why it is Useful
+* **SCSS Compliant Layout:** Keeps styling variables modular without polluting global namespaces.
+* **Semantic ARIA Binding:** Automatically hides visual structures when accessibility profiles hook onto `aria-hidden="true"`.
+* **Motion Guard:** Safely cleans out scaling movement rules under `prefers-reduced-motion: reduce` bounds.

--- a/submissions/scss/feature-fade-fab-mixin-nv/_fade-fab.scss
+++ b/submissions/scss/feature-fade-fab-mixin-nv/_fade-fab.scss
@@ -1,0 +1,26 @@
+// Custom Mixin for Floating Action Button (FAB) Fade Exit Animation
+// Unique identifier Suffix (-nv) applied to prevent collision
+@mixin fade-fab-mixin-nv($duration: 0.3s, $curve: cubic-bezier(0.4, 0, 0.2, 1)) {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+  transition: 
+    opacity #{$duration} #{$curve}, 
+    transform #{$duration} #{$curve};
+
+  // Target class or state representing the hidden/dismissed state
+  &.exit-active-nv,
+  &[aria-hidden="true"] {
+    opacity: 0;
+    transform: scale(0.8) translateY(8px); // Subtle scale-down and drop exit effect
+  }
+
+  // Handle system motion constraints automatically for accessibility
+  @media (prefers-reduced-motion: reduce) {
+    transition: opacity #{$duration} linear;
+    
+    &.exit-active-nv,
+    &[aria-hidden="true"] {
+      transform: none !important; // Stop spatial motion entirely
+    }
+  }
+}


### PR DESCRIPTION
Closes #50631

### 📋 Description
This PR addresses issue #50631 by implementing a reusable, beginner-friendly **Fade FAB (Exit Animation) Mixin** inside the scoped `submissions/scss/` namespace.

It provides developers with a modular SCSS mixin that generates performant fade and scale-drop transition sequences for Floating Action Buttons during an exit lifecycle phase.

---

### 🛠️ Changes Proposed
All additions are strictly separated to respect repository code boundaries:
* **`submissions/scss/feature-fade-fab-mixin-nv/_fade-fab.scss`**: Built the SCSS `@mixin` with customizable parameters. It handles fade styling triggers via state classes or ARIA states (`aria-hidden`) while supporting motion overrides.
* **`submissions/scss/feature-fade-fab-mixin-nv/README.md`**: Outlined installation steps, dynamic compilation overrides, and the layout philosophy.

---

### 🔍 Checklist
- [x] All submission files are contained strictly inside the `submissions/scss/` directory.
- [x] Appended the unique identifier suffix (`-nv`) to the mixin name, folder, and utility states.
- [x] Implemented a smooth, configurable timing profile.
- [x] Linked styling properties with standard semantic HTML accessibility features (`aria-hidden`).
- [x] Handled motion constraints explicitly using `@media (prefers-reduced-motion: reduce)`.
- [x] Documented practical syntax implementation steps inside the README.md file.
