### PR TITLE
Jello Icon

### DIFF
--- a/submissions/react/feature-jello-icon-component-sum/JelloIcon.jsx
+++ b/submissions/react/feature-jello-icon-component-sum/JelloIcon.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import './style.css';
+
+/**
+ * JelloIcon — entrance animation with a jello wobble.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - Icon content (emoji, SVG, or text)
+ * @param {string} [props.className=""] - Extra class names
+ * @param {string} [props.label="Icon"] - Accessible name
+ */
+const JelloIcon = ({ children, className = '', label = 'Icon', ...rest }) => {
+  return (
+    <span
+      className={`jello-icon-sum ${className}`.trim()}
+      role="img"
+      aria-label={label}
+      {...rest}
+    >
+      <span className="jello-icon-sum__inner" aria-hidden="true">
+        {children}
+      </span>
+    </span>
+  );
+};
+
+export default JelloIcon;

--- a/submissions/react/feature-jello-icon-component-sum/README.md
+++ b/submissions/react/feature-jello-icon-component-sum/README.md
@@ -1,0 +1,33 @@
+# Jello Icon Component
+
+## What does this do?
+
+A React icon that enters with a smooth jello wobble animation.
+
+## How is it used?
+
+```jsx
+import JelloIcon from './JelloIcon';
+
+<JelloIcon label="Success">★</JelloIcon>
+```
+
+## Why is it useful?
+
+Jello entrances draw soft attention to status icons without a heavy motion library — fitting EaseMotion’s readable, animation-first style.
+
+## Accessibility
+
+- `role="img"` with `aria-label`
+- Under `prefers-reduced-motion: reduce`, jello skew is replaced by a simple fade
+
+## Files
+
+```
+submissions/react/feature-jello-icon-component-sum/
+├── JelloIcon.jsx
+├── style.css
+└── README.md
+```
+
+Related issue: #50757

--- a/submissions/react/feature-jello-icon-component-sum/style.css
+++ b/submissions/react/feature-jello-icon-component-sum/style.css
@@ -1,0 +1,70 @@
+/* Jello Icon — entrance animation */
+
+.jello-icon-sum {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  background: #6c63ff;
+  color: #ffffff;
+  font-size: 1.35rem;
+  will-change: transform;
+  animation: jelloIconEntranceSum 0.9s both;
+}
+
+.jello-icon-sum__inner {
+  display: inline-flex;
+  line-height: 1;
+}
+
+@keyframes jelloIconEntranceSum {
+  0% {
+    transform: scale3d(1, 1, 1);
+    opacity: 0;
+  }
+  11.1% {
+    opacity: 1;
+  }
+  22.2% {
+    transform: skewX(-12.5deg) skewY(-12.5deg);
+  }
+  33.3% {
+    transform: skewX(6.25deg) skewY(6.25deg);
+  }
+  44.4% {
+    transform: skewX(-3.125deg) skewY(-3.125deg);
+  }
+  55.5% {
+    transform: skewX(1.5625deg) skewY(1.5625deg);
+  }
+  66.6% {
+    transform: skewX(-0.78125deg) skewY(-0.78125deg);
+  }
+  77.7% {
+    transform: skewX(0.390625deg) skewY(0.390625deg);
+  }
+  88.8% {
+    transform: skewX(-0.1953125deg) skewY(-0.1953125deg);
+  }
+  100% {
+    transform: scale3d(1, 1, 1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jello-icon-sum {
+    animation: jelloIconFadeSum 0.25s ease both !important;
+  }
+}
+
+@keyframes jelloIconFadeSum {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
# #50757 issue resolved

## Description

This PR adds a beginner-friendly Jello Icon React component under `submissions/react`.

## Features

- Smooth jello entrance animation for icons
- Accessible `role="img"` with `aria-label`
- Respects `prefers-reduced-motion: reduce` with a simple fade