### PR TITLE
Wiggle Input Mixin

### DIFF
--- a/submissions/scss/feature-wiggle-input-mixin-sum/README.md
+++ b/submissions/scss/feature-wiggle-input-mixin-sum/README.md
@@ -1,0 +1,36 @@
+# Wiggle Input Mixin
+
+## What does this do?
+
+An SCSS mixin that wiggles an input as an exit / error attention cue.
+
+## How is it used?
+
+```scss
+@use 'wiggle-input' as *;
+
+.my-element {
+  @include wiggle-input-mixin-sum(0.5s);
+}
+
+/* Trigger with: */
+/* <input class="my-element is-exiting-sum" /> */
+```
+
+## Why is it useful?
+
+Wiggle feedback makes validation errors obvious without custom JS animation code — readable and reusable.
+
+## Accessibility
+
+- Under `prefers-reduced-motion: reduce`, wiggle is replaced by a gentle opacity fade
+
+## Files
+
+```
+submissions/scss/feature-wiggle-input-mixin-sum/
+├── _wiggle-input.scss
+└── README.md
+```
+
+Related issue: #50754

--- a/submissions/scss/feature-wiggle-input-mixin-sum/_wiggle-input.scss
+++ b/submissions/scss/feature-wiggle-input-mixin-sum/_wiggle-input.scss
@@ -1,0 +1,57 @@
+// _wiggle-input.scss
+// Wiggle Input — exit / error attention animation
+
+@keyframes wiggle-input-exit-sum {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  15% {
+    transform: translateX(-8px);
+  }
+  30% {
+    transform: translateX(8px);
+  }
+  45% {
+    transform: translateX(-6px);
+  }
+  60% {
+    transform: translateX(6px);
+  }
+  75% {
+    transform: translateX(-3px);
+  }
+  90% {
+    transform: translateX(3px);
+  }
+}
+
+@keyframes wiggle-input-fade-sum {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0.55;
+  }
+}
+
+/// Applies a wiggle exit/error animation when `.is-exiting-sum` (or custom class) is added.
+///
+/// @param {Time} $duration [0.5s] - Animation duration
+/// @param {Timing-Function} $easing [ease-in-out] - Timing function
+@mixin wiggle-input-mixin-sum(
+  $duration: 0.5s,
+  $easing: ease-in-out
+) {
+  will-change: transform;
+
+  &.is-exiting-sum {
+    animation: wiggle-input-exit-sum $duration $easing both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &.is-exiting-sum {
+      animation: wiggle-input-fade-sum 0.25s ease both !important;
+    }
+  }
+}


### PR DESCRIPTION
# #50754 issue resolved

## Description

This PR adds a beginner-friendly Wiggle Input SCSS mixin under `submissions/scss`.

## Features

- Smooth wiggle exit/error animation for inputs
- Triggered via `.is-exiting-sum` class
- Respects `prefers-reduced-motion: reduce` with a gentle fade