### PR TITLE
Add ease-wobble-card-hover component

### DIFF
--- a/submissions/examples/ease-wobble-card-hover-sh/README.md
+++ b/submissions/examples/ease-wobble-card-hover-sh/README.md
@@ -1,0 +1,57 @@
+# Wobble Card Hover
+
+A grid of gummy, sticker-style feature cards that lean toward the cursor as
+you move over them, then spring back with a little overshoot "wobble" when
+the cursor leaves.
+
+## What it does
+
+- **Cursor-following tilt** — each card rotates on its X/Y axis based on
+  where the cursor is over it, with the icon/title/text lifted slightly for
+  a subtle 3D pop.
+- **Springy settle** — on mouse leave, the card eases back to flat using a
+  cubic-bezier curve with overshoot, giving it a soft "wobble" rather than a
+  linear snap.
+- **Keyboard accessible** — tabbing to a card triggers the same lift/settle
+  effect on focus/blur, so keyboard users get the interaction too.
+- **Motion toggle** — a checkbox lets anyone turn the tilt animation off
+  entirely (box-shadow hover feedback still works). Also automatically
+  disabled if the OS-level "reduce motion" preference is set.
+
+## Files
+
+- `demo.html` — markup + logic (vanilla JS, no build step, no frameworks)
+- `style.css` — all styling, sticker-card visual theme
+- `README.md` — this file
+
+## Running it
+
+Just open `demo.html` in any modern browser. No server, build step, or
+dependencies beyond a Google Fonts stylesheet link.
+
+## Design notes
+
+The visual concept is a set of thick-outlined, sticker-like cards on a dotted
+corkboard background — bold flat colors, chunky rounded typography (Baloo 2
+for headings, Nunito for body), and an offset drop shadow that grows on
+hover to reinforce the "lifting toward you" feel.
+
+## Accessibility
+
+- Cards are focusable (`tabindex="0"`) and respond to keyboard focus/blur
+  the same way they respond to mouse enter/leave.
+- Respects `prefers-reduced-motion` automatically, and also exposes an
+  in-page toggle so anyone can turn the tilt off regardless of OS setting.
+- Color contrast on card text was chosen against each pastel background for
+  readability.
+- Fully responsive down to narrow mobile widths (grid collapses to a single
+  column).
+
+## Known limitations
+
+- Tilt is calculated from raw mouse position, so on touch devices there's no
+  hover/tilt — cards just show their resting state, which is an acceptable
+  and common trade-off for a hover-driven effect.
+- The 3D effect relies on `perspective` and `transform-style: preserve-3d`;
+  it degrades gracefully (cards just stay flat) in any environment that
+  doesn't support these, since they're a progressive enhancement here.

--- a/submissions/examples/ease-wobble-card-hover-sh/demo.html
+++ b/submissions/examples/ease-wobble-card-hover-sh/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Wobble Card Hover</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600;700&family=Nunito:wght@400;600&display=swap"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="board">
+    <header class="board-header">
+      <h1>Wobble Card Hover</h1>
+      <p>Move your cursor over a card — it leans toward you, then springs back when you leave.</p>
+    </header>
+
+    <div class="card-grid" id="card-grid">
+      <div class="wobble-card" data-color="yellow" tabindex="0">
+        <span class="icon">⚡</span>
+        <h2>Fast</h2>
+        <p>Loads in a blink. No spinners, no waiting around.</p>
+      </div>
+      <div class="wobble-card" data-color="pink" tabindex="0">
+        <span class="icon">🔒</span>
+        <h2>Secure</h2>
+        <p>Locked down by default, so you don't have to think about it.</p>
+      </div>
+      <div class="wobble-card" data-color="mint" tabindex="0">
+        <span class="icon">🧩</span>
+        <h2>Simple</h2>
+        <p>Drop it in, wire up your data, done.</p>
+      </div>
+      <div class="wobble-card" data-color="sky" tabindex="0">
+        <span class="icon">🎈</span>
+        <h2>Playful</h2>
+        <p>Little bits of delight, right where people are looking.</p>
+      </div>
+    </div>
+
+    <div class="controls">
+      <label class="motion-toggle">
+        <input type="checkbox" id="motion-checkbox" checked />
+        Tilt animation
+      </label>
+    </div>
+
+    <footer>
+      Tilt strength follows your cursor position over each card; the spring-back
+      uses a slight overshoot curve for the "wobble" feel. Fully keyboard
+      accessible — tab to a card to see the wobble on focus too.
+    </footer>
+  </div>
+
+  <script>
+    const cards = document.querySelectorAll('.wobble-card');
+    const motionCheckbox = document.getElementById('motion-checkbox');
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const MAX_TILT = 14; // degrees
+    const LIFT = 14; // px translateZ on hover
+
+    function motionEnabled() {
+      return motionCheckbox.checked && !prefersReducedMotion;
+    }
+
+    function handleMove(e, card) {
+      if (!motionEnabled()) return;
+      const rect = card.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+
+      const px = x / rect.width - 0.5; // -0.5 .. 0.5
+      const py = y / rect.height - 0.5;
+
+      const rotateY = px * MAX_TILT * 2;
+      const rotateX = -py * MAX_TILT * 2;
+
+      card.style.transition = 'box-shadow 0.25s ease';
+      card.style.transform = `translateZ(${LIFT}px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(1.04)`;
+    }
+
+    function handleLeave(card) {
+      // Restore the springy overshoot transition defined in CSS, then clear
+      // the inline transform so it eases back to resting position.
+      card.style.transition = '';
+      card.style.transform = '';
+    }
+
+    function handleEnter(card) {
+      if (!motionEnabled()) return;
+      card.style.transition = 'box-shadow 0.25s ease';
+    }
+
+    cards.forEach((card) => {
+      card.addEventListener('mouseenter', () => handleEnter(card));
+      card.addEventListener('mousemove', (e) => handleMove(e, card));
+      card.addEventListener('mouseleave', () => handleLeave(card));
+
+      // Keyboard users get the same wobble-in / wobble-out on focus.
+      card.addEventListener('focus', () => {
+        if (!motionEnabled()) return;
+        card.style.transition = '';
+        card.style.transform = `translateZ(${LIFT}px) scale(1.05)`;
+      });
+      card.addEventListener('blur', () => handleLeave(card));
+    });
+
+    motionCheckbox.addEventListener('change', () => {
+      document.body.setAttribute('data-motion', motionCheckbox.checked ? 'on' : 'off');
+      if (!motionCheckbox.checked) {
+        cards.forEach((card) => {
+          card.style.transition = '';
+          card.style.transform = '';
+        });
+      }
+    });
+
+    if (prefersReducedMotion) {
+      motionCheckbox.checked = false;
+      document.body.setAttribute('data-motion', 'off');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-wobble-card-hover-sh/style.css
+++ b/submissions/examples/ease-wobble-card-hover-sh/style.css
@@ -1,0 +1,175 @@
+/* ==========================================================================
+   Ease Wobble Card Hover
+   Visual concept: gummy/sticker feature cards that tilt toward the cursor
+   and give a springy little wobble-overshoot when the cursor leaves.
+   ========================================================================== */
+
+:root {
+  --bg: #fdf3e7;
+  --ink: #241c15;
+  --card-yellow: #ffd166;
+  --card-pink: #ff8fa3;
+  --card-mint: #7bd8b0;
+  --card-sky: #7cb8ff;
+  --outline: #241c15;
+  --shadow-color: rgba(36, 28, 21, 0.35);
+  --font-display: "Baloo 2", "Comic Sans MS", sans-serif;
+  --font-body: "Nunito", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  background-image: radial-gradient(rgba(36, 28, 21, 0.05) 1.5px, transparent 1.5px);
+  background-size: 18px 18px;
+  color: var(--ink);
+  font-family: var(--font-body);
+  min-height: 100vh;
+  padding: 36px 20px 56px;
+}
+
+.board {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+/* -- Header ---------------------------------------------------------------- */
+
+.board-header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.board-header h1 {
+  font-family: var(--font-display);
+  font-size: 30px;
+  margin: 0 0 6px;
+}
+
+.board-header p {
+  margin: 0;
+  color: #6b5c48;
+  font-size: 14px;
+}
+
+/* -- Card grid --------------------------------------------------------------- */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 22px;
+  perspective: 900px;
+}
+
+.wobble-card {
+  position: relative;
+  border: 3px solid var(--outline);
+  border-radius: 18px;
+  padding: 22px 18px 20px;
+  background: var(--card-color, var(--card-yellow));
+  box-shadow: 6px 6px 0 var(--shadow-color);
+  transform-style: preserve-3d;
+  will-change: transform;
+  cursor: pointer;
+  transition: transform 0.55s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.25s ease;
+}
+
+.wobble-card:hover,
+.wobble-card:focus-visible {
+  box-shadow: 10px 12px 0 var(--shadow-color);
+}
+
+.wobble-card:focus-visible {
+  outline: 3px solid var(--ink);
+  outline-offset: 4px;
+}
+
+.wobble-card .icon {
+  font-size: 34px;
+  display: inline-block;
+  transform: translateZ(30px);
+  margin-bottom: 10px;
+}
+
+.wobble-card h2 {
+  font-family: var(--font-display);
+  font-size: 19px;
+  margin: 0 0 6px;
+  transform: translateZ(20px);
+}
+
+.wobble-card p {
+  font-size: 13px;
+  margin: 0;
+  line-height: 1.4;
+  color: #3a2f22;
+  transform: translateZ(14px);
+}
+
+.wobble-card[data-color="pink"] { --card-color: var(--card-pink); }
+.wobble-card[data-color="mint"] { --card-color: var(--card-mint); }
+.wobble-card[data-color="sky"]  { --card-color: var(--card-sky); }
+
+/* -- Controls ----------------------------------------------------------------- */
+
+.controls {
+  display: flex;
+  justify-content: center;
+  margin-top: 28px;
+}
+
+.motion-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  background: #fff;
+  border: 2px solid var(--outline);
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.motion-toggle input {
+  accent-color: var(--ink);
+}
+
+/* -- Footer -------------------------------------------------------------------- */
+
+footer {
+  margin-top: 30px;
+  text-align: center;
+  font-size: 12px;
+  color: #8a7a63;
+}
+
+/* -- Reduced motion, both system preference and in-app toggle ------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .wobble-card {
+    transition: box-shadow 0.2s ease;
+    transform: none !important;
+  }
+}
+
+body[data-motion="off"] .wobble-card {
+  transition: box-shadow 0.2s ease;
+  transform: none !important;
+}
+
+/* -- Responsive ------------------------------------------------------------------ */
+
+@media (max-width: 480px) {
+  .board-header h1 {
+    font-size: 24px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes  #51185

### Type of Change
- [x] New component/example submission
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

### Submission Checklist
- [x] Component lives in `submissions/examples/ease-wobble-card-hover-sh/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Demo runs standalone by opening `demo.html` directly (no build step)
- [x] Tested in at least one browser
- [x] Keyboard accessible (visible focus states, no keyboard traps)
- [x] Responsive down to mobile widths
- [x] No console errors on load or interaction

### Feature Description
A grid of sticker-style feature cards with a cursor-following 3D tilt effect
that springs back with an overshoot "wobble" on mouse-leave. Cards are
keyboard-focusable and trigger the same lift/settle on focus/blur. Includes
a motion toggle checkbox and automatic `prefers-reduced-motion` support.

### Demo
Open `submissions/examples/ease-wobble-card-hover-sh/demo.html` in any
modern browser. No build step or dependencies beyond a Google Fonts link.

<img width="1920" height="1020" alt="ease-wobble-card-hover" src="https://github.com/user-attachments/assets/82ea902c-e088-4480-8e3d-1c3304328dc4" />

### Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Notes for Maintainer
- No external JS dependencies; only Google Fonts loaded via CDN link tags.
- Tilt effect is a progressive enhancement — degrades gracefully to a flat
  card with hover shadow on touch devices or if `prefers-reduced-motion`
  is set.