### PR TITLE
Wiggle Icon Mixin

### DIFF
--- a/submissions/scss/feature-wiggle-icon-mixin-sum/README.md
+++ b/submissions/scss/feature-wiggle-icon-mixin-sum/README.md
@@ -1,0 +1,34 @@
+# Wiggle Icon Mixin
+
+## What does this do?
+
+An SCSS mixin that wiggles an icon on hover and keyboard focus to seek attention.
+
+## How is it used?
+
+```scss
+@use 'wiggle-icon' as *;
+
+.my-element {
+  @include wiggle-icon-mixin-sum(0.5s);
+}
+```
+
+## Why is it useful?
+
+Wiggle icons highlight notifications and actions in toolbars without writing one-off keyframes each time.
+
+## Accessibility
+
+- Triggers on `:focus-visible` for keyboard users
+- Under `prefers-reduced-motion: reduce`, wiggle is disabled and a static outline cue is used
+
+## Files
+
+```
+submissions/scss/feature-wiggle-icon-mixin-sum/
+├── _wiggle-icon.scss
+└── README.md
+```
+
+Related issue: #50750

--- a/submissions/scss/feature-wiggle-icon-mixin-sum/_wiggle-icon.scss
+++ b/submissions/scss/feature-wiggle-icon-mixin-sum/_wiggle-icon.scss
@@ -1,0 +1,57 @@
+// _wiggle-icon.scss
+// Wiggle Icon — attention seeker
+
+@keyframes wiggle-icon-sum {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  15% {
+    transform: rotate(-12deg);
+  }
+  30% {
+    transform: rotate(10deg);
+  }
+  45% {
+    transform: rotate(-8deg);
+  }
+  60% {
+    transform: rotate(6deg);
+  }
+  75% {
+    transform: rotate(-3deg);
+  }
+  90% {
+    transform: rotate(2deg);
+  }
+}
+
+/// Applies a wiggle attention animation on hover and focus-visible.
+///
+/// @param {Time} $duration [0.5s] - Wiggle duration
+/// @param {Timing-Function} $easing [ease-in-out] - Timing function
+@mixin wiggle-icon-mixin-sum(
+  $duration: 0.5s,
+  $easing: ease-in-out
+) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform-origin: center;
+  will-change: transform;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    animation: wiggle-icon-sum $duration $easing;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &:hover,
+    &:focus-visible {
+      animation: none !important;
+      outline: 2px solid currentColor;
+      outline-offset: 3px;
+    }
+  }
+}


### PR DESCRIPTION
# #50750 issue resolved

## Description

This PR adds a beginner-friendly Wiggle Icon SCSS mixin under `submissions/scss`.

## Features

- Smooth wiggle on hover and `:focus-visible`
- Configurable duration and easing
- Respects `prefers-reduced-motion: reduce` with a static outline