### PR TITLE
Zoom Skeleton Mixin

### DIFF
--- a/submissions/scss/feature-zoom-skeleton-mixin-sum/README.md
+++ b/submissions/scss/feature-zoom-skeleton-mixin-sum/README.md
@@ -1,0 +1,35 @@
+# Zoom Skeleton Mixin
+
+## What does this do?
+
+An SCSS mixin that applies a smooth zoom pulse to skeleton loading placeholders.
+
+## How is it used?
+
+```scss
+@use 'zoom-skeleton' as *;
+
+.my-element {
+  @include zoom-skeleton-mixin-sum(0.5s);
+  width: 100%;
+  height: 1rem;
+}
+```
+
+## Why is it useful?
+
+Zooming skeletons keep loading states visually alive without heavy shimmer libraries — simple and readable.
+
+## Accessibility
+
+- Under `prefers-reduced-motion: reduce`, zoom stops and a static opacity remains
+
+## Files
+
+```
+submissions/scss/feature-zoom-skeleton-mixin-sum/
+├── _zoom-skeleton.scss
+└── README.md
+```
+
+Related issue: #50752

--- a/submissions/scss/feature-zoom-skeleton-mixin-sum/_zoom-skeleton.scss
+++ b/submissions/scss/feature-zoom-skeleton-mixin-sum/_zoom-skeleton.scss
@@ -1,0 +1,45 @@
+// _zoom-skeleton.scss
+// Zoom Skeleton — interactive loading placeholder
+
+@keyframes zoom-skeleton-pulse-sum {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+}
+
+@keyframes zoom-skeleton-static-sum {
+  from {
+    opacity: 0.75;
+  }
+  to {
+    opacity: 0.75;
+  }
+}
+
+/// Applies a gentle zoom pulse to skeleton placeholders.
+///
+/// @param {Time} $duration [0.5s] - Pulse cycle duration (doubled internally for a softer loop)
+/// @param {Color} $base-color [#e2e8f0] - Skeleton fill color
+@mixin zoom-skeleton-mixin-sum(
+  $duration: 0.5s,
+  $base-color: #e2e8f0
+) {
+  display: block;
+  background: $base-color;
+  border-radius: 0.5rem;
+  transform-origin: center;
+  will-change: transform, opacity;
+  animation: zoom-skeleton-pulse-sum ($duration * 2) ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: zoom-skeleton-static-sum 0.01ms linear both !important;
+    opacity: 0.75;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
# #50752 issue resolved

## Description

This PR adds a beginner-friendly Zoom Skeleton SCSS mixin under `submissions/scss`.

## Features

- Smooth zoom pulse for skeleton placeholders
- Configurable duration and base color
- Respects `prefers-reduced-motion: reduce` with a static state