### PR TITLE
feat(example): add bounce checkbox example

### DIFF
--- a/submissions/examples/feature-bounce-checkbox-example-ag/README.md
+++ b/submissions/examples/feature-bounce-checkbox-example-ag/README.md
@@ -1,0 +1,13 @@
+# Bounce Checkbox Example
+
+## Description
+A standard HTML/CSS example demonstrating a "Bounce" interactive state animation for a custom checkbox. When checked, the checkbox dips down slightly before bouncing back to its normal scale, giving satisfying tactile feedback, while the checkmark SVG draws itself.
+
+## Files
+- `demo.html`: Structure hiding the native checkbox while pairing it with a styled SVG container.
+- `style.css`: Uses a `scale()` keyframe animation on the checked state to create the bounce, and animates `stroke-dashoffset` for the checkmark.
+
+## Accessibility
+- Wraps the native `<input type="checkbox">` in a `<label>` to retain standard keyboard interaction, screen reader semantics, and focus management.
+- Exposes `:focus-visible` styles to indicate keyboard focus.
+- **Reduced Motion**: Disables the scale bounce and SVG drawing animation via `@media (prefers-reduced-motion: reduce)`.

--- a/submissions/examples/feature-bounce-checkbox-example-ag/demo.html
+++ b/submissions/examples/feature-bounce-checkbox-example-ag/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bounce Checkbox Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container-ag">
+    <label class="bounce-checkbox-label-ag">
+      <input type="checkbox" class="bounce-checkbox-input-ag" aria-label="Accept terms">
+      <span class="bounce-checkbox-custom-ag" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="20 6 9 17 4 12"></polyline>
+        </svg>
+      </span>
+      Accept Terms and Conditions
+    </label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/feature-bounce-checkbox-example-ag/style.css
+++ b/submissions/examples/feature-bounce-checkbox-example-ag/style.css
@@ -1,0 +1,82 @@
+/* style.css */
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.bounce-checkbox-label-ag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+  font-size: 1rem;
+  color: #334155;
+}
+
+.bounce-checkbox-input-ag {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.bounce-checkbox-custom-ag {
+  width: 24px;
+  height: 24px;
+  border: 2px solid #cbd5e1;
+  border-radius: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: white;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.bounce-checkbox-custom-ag svg {
+  width: 14px;
+  height: 14px;
+  color: white;
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  transition: stroke-dashoffset 0.3s ease-out;
+}
+
+/* Checked State */
+.bounce-checkbox-input-ag:checked + .bounce-checkbox-custom-ag {
+  background: #10b981;
+  border-color: #10b981;
+  animation: bounce-check-ag 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
+}
+
+.bounce-checkbox-input-ag:checked + .bounce-checkbox-custom-ag svg {
+  stroke-dashoffset: 0;
+}
+
+/* Focus Indicator for Accessibility */
+.bounce-checkbox-input-ag:focus-visible + .bounce-checkbox-custom-ag {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+@keyframes bounce-check-ag {
+  0% { transform: scale(1); }
+  40% { transform: scale(0.8); }
+  100% { transform: scale(1); }
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .bounce-checkbox-input-ag:checked + .bounce-checkbox-custom-ag {
+    animation: none;
+  }
+  .bounce-checkbox-custom-ag svg {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Resolves [Feature] Bounce Checkbox Example. Checkbox shrinks then scales back to 1 on check for tactile feel. Reduced motion disables animations.