### PR TITLE
Add spin focus example

### DIFF
--- a/submissions/examples/spin-focus-vk/README.md
+++ b/submissions/examples/spin-focus-vk/README.md
@@ -1,0 +1,40 @@
+# Spin Focus Example
+
+A lightweight CSS-only focus animation that spins a button when it receives keyboard focus. The effect is accessible, beginner-friendly, and respects users who prefer reduced motion.
+
+---
+
+## Features
+
+- Pure HTML and CSS
+- Smooth spin animation on focus
+- Keyboard accessible using `:focus-visible`
+- Uses a semantic `<button>`
+- Supports `prefers-reduced-motion`
+- Self-contained example with no dependencies
+
+---
+
+## Usage
+
+Open `demo.html` in a browser.
+
+Press **Tab** to move focus to the button and watch the spin animation.
+
+---
+
+## Accessibility
+
+- Uses `:focus-visible` to avoid unnecessary animations for mouse users.
+- Includes a visible focus ring.
+- Respects reduced-motion user preferences.
+
+---
+
+## Use Cases
+
+- Buttons
+- Forms
+- Navigation menus
+- Interactive cards
+- Accessible UI components

--- a/submissions/examples/spin-focus-vk/demo.html
+++ b/submissions/examples/spin-focus-vk/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Spin Focus Example</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <button class="spin-focus-vk" aria-label="Focusable Button">
+        Press Tab to Focus
+    </button>
+
+</body>
+</html>

--- a/submissions/examples/spin-focus-vk/style.css
+++ b/submissions/examples/spin-focus-vk/style.css
@@ -1,0 +1,61 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #f5f5f5;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.spin-focus-vk {
+    padding: 14px 30px;
+    border: none;
+    border-radius: 12px;
+    background: #2563eb;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    outline: none;
+    transition:
+        transform 0.6s ease,
+        box-shadow 0.3s ease,
+        background-color 0.3s ease;
+}
+
+.spin-focus-vk:hover {
+    background: #1d4ed8;
+}
+
+.spin-focus-vk:focus-visible {
+    animation: spinFocusVK 0.7s ease;
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.35);
+}
+
+@keyframes spinFocusVK {
+    0% {
+        transform: rotate(0deg) scale(1);
+    }
+
+    50% {
+        transform: rotate(180deg) scale(1.08);
+    }
+
+    100% {
+        transform: rotate(360deg) scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .spin-focus-vk,
+    .spin-focus-vk:focus-visible {
+        animation: none;
+        transition: none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a new **Spin Focus Example** under the `submissions/examples/` directory. It demonstrates a lightweight CSS-only spin animation that is triggered when an element receives keyboard focus. The implementation is fully self-contained, beginner-friendly, accessible, and respects users who prefer reduced motion.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a CSS-only spin focus animation that provides clear visual feedback when an interactive element receives keyboard focus.

**How does a developer use it?**

```html
<button class="spin-focus-vk">
    Press Tab to Focus
</button>
```

**Why does it fit EaseMotion CSS?**

This example is lightweight, reusable, dependency-free, and accessibility-focused. It demonstrates a simple focus animation using pure HTML and CSS, making it easy to integrate into interactive UI components.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Edge

---

## Notes for Maintainer

The example is self-contained, uses semantic HTML, includes a visible focus indicator, and respects users who prefer reduced motion.

---

Closes #51474