### PR TITLE
feat: add search result fade example

### DIFF
--- a/submissions/examples/search-result-fade/README.md
+++ b/submissions/examples/search-result-fade/README.md
@@ -1,0 +1,15 @@
+# Search Result Fade
+
+This example adds a search results panel where result rows fade into place with a short stagger.
+
+## Files
+
+- `demo.html` contains the results panel and result links.
+- `style.css` defines the staggered fade, hover and focus states, and reduced-motion fallback.
+
+## Highlights
+
+- Uses real links for result rows.
+- Keeps row height stable while animating with transforms.
+- Supports hover and keyboard focus states.
+- Shows static results when reduced motion is requested.

--- a/submissions/examples/search-result-fade/demo.html
+++ b/submissions/examples/search-result-fade/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Search Result Fade</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="results-stage" aria-label="Search result fade animation demo">
+      <section class="results-card">
+        <h1>Search results</h1>
+        <a href="#" style="--delay: 0ms">
+          <strong>Motion utilities</strong>
+          <span>Reusable CSS animation patterns</span>
+        </a>
+        <a href="#" style="--delay: 120ms">
+          <strong>Component examples</strong>
+          <span>Small demos for common UI states</span>
+        </a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/search-result-fade/style.css
+++ b/submissions/examples/search-result-fade/style.css
@@ -1,0 +1,100 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #f8fafc;
+  --muted: #a8b3c7;
+  --panel: #111827;
+  --accent: #f59e0b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #111827, #451a03);
+  color: var(--ink);
+}
+
+.results-stage {
+  width: min(92vw, 34rem);
+  padding: 2rem;
+}
+
+.results-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(17, 24, 39, 0.94);
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.5rem;
+}
+
+a {
+  min-height: 5rem;
+  display: grid;
+  align-content: center;
+  gap: 0.25rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--ink);
+  text-decoration: none;
+  opacity: 0;
+  transform: translateY(0.75rem);
+  animation: result-fade 560ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: var(--delay);
+  transition: border-color 180ms ease, transform 180ms ease;
+}
+
+a:hover,
+a:focus-visible {
+  border-color: rgba(245, 158, 11, 0.5);
+  transform: translateY(-0.16rem);
+  outline: none;
+}
+
+a:focus-visible {
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.24);
+}
+
+strong {
+  font-size: 1.05rem;
+}
+
+span {
+  color: var(--muted);
+  font-weight: 650;
+}
+
+@keyframes result-fade {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  a {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  a:hover,
+  a:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a search result fade animation example
- include staggered result links with hover and focus states
- document reduced-motion support

## Verification
- git diff --cached --check