### PR TITLE
Add ease-cyberpunk-skew-carousel component

### DIFF
--- a/submissions/examples/ease-cyberpunk-skew-carousel-sh/README.md
+++ b/submissions/examples/ease-cyberpunk-skew-carousel-sh/README.md
@@ -1,0 +1,92 @@
+# Cyberpunk Skew Carousel
+
+A pure CSS carousel — zero JavaScript. Slides transition with a smooth
+skew-and-settle motion, styled as a neon cyberpunk interface panel.
+
+## What it does
+
+- **Pure CSS state machine.** Hidden (but focusable) radio inputs drive
+  which slide is active, using the sibling combinator (`~`) to show the
+  matching slide, highlight the matching dot, and reveal the matching
+  prev/next arrow. There is no `<script>` tag anywhere in `demo.html`.
+- **Skew-active transition.** Inactive slides sit skewed, shifted, and
+  scaled down with `opacity: 0`; the active slide animates back to a flat,
+  full-opacity, full-scale resting state.
+- **Free keyboard support.** Because slide selection is backed by a native
+  `<input type="radio">` group, Tab and the arrow keys move between slides
+  automatically — no custom key handling needed.
+- **Exposed custom properties** for consumers to override:
+  - `--carousel-duration` — transition length
+  - `--carousel-easing` — transition timing function
+  - `--carousel-skew` — skew angle for inactive slides
+  - `--carousel-travel` — horizontal offset for inactive slides
+  - `--carousel-scale-inactive` — scale factor for inactive slides
+- **Live speed presets** (Fast / Normal / Slow) — also pure CSS, using the
+  same radio + sibling-combinator technique to override the properties
+  above on the fly, so you can feel the difference the custom properties
+  make without touching a stylesheet.
+
+## Files
+
+- `demo.html` — markup only, no JavaScript
+- `style.css` — all styling and all interaction logic
+- `README.md` — this file
+
+## Running it
+
+Open `demo.html` in any modern browser. No server, build step, or
+dependencies beyond a Google Fonts stylesheet link.
+
+## Design notes
+
+The visual theme is a cyberpunk "uplink" terminal: a near-black background
+with a faint cyan grid, glowing neon borders and text-shadow, and a
+condensed, wide-tracking display font (Orbitron) paired with Rajdhani for
+body copy. Each slide has its own accent color (cyan, magenta, yellow,
+green) carried through its heading glow and eyebrow label.
+
+## How the pure-CSS mechanics work
+
+- Four radio inputs (`#s1`–`#s4`, one `name` group) are visually hidden with
+  a standard clip-based technique that keeps them in the accessibility tree
+  and the tab order.
+- Each slide's default (inactive) state is skewed/offset/scaled/hidden.
+  A rule like `#s1:checked ~ .viewport .slide-1 { ...flat, visible... }`
+  overrides that only for the slide matching the checked radio.
+- Dots and arrows are `<label for="...">` elements pointing at a specific
+  radio, so clicking them is just a native label-click — no JS needed to
+  "jump" to a slide. Because there's one prev/next label pair per possible
+  current slide, the correct pair is revealed with the same
+  `:checked ~ selector` pattern and all others stay hidden/non-interactive.
+- The speed-preset radios sit as earlier siblings of `.carousel` in the
+  DOM, so their `:checked` state can override `.carousel`'s custom
+  properties the same way — demonstrating the exposed API without any JS.
+
+## Accessibility
+
+- The slide radios remain focusable and screen-reader-visible even though
+  hidden visually; each has a descriptive `aria-label` (e.g. "Slide 2 of 4:
+  Grid Runner").
+- The carousel container uses `role="group"` and
+  `aria-roledescription="carousel"` with a descriptive `aria-label`.
+- Dots and arrows are marked `aria-hidden="true"` since they're mouse/touch
+  conveniences that duplicate the native radio-group keyboard behavior;
+  this avoids screen readers announcing eight extra, sparsely-labeled
+  controls on top of the four properly-labeled radios.
+- A visible focus ring appears on the dot matching whichever radio currently
+  has keyboard focus (`:focus-visible`).
+- Respects `prefers-reduced-motion` by collapsing the skew/scale transition
+  down to a quick opacity fade.
+- Fully responsive: the viewport's aspect ratio and padding adjust at
+  narrow widths.
+
+## Known limitations
+
+- The number of slides (4) is currently hardcoded into the CSS selectors
+  (one rule per slide/dot/arrow pair), which is the standard trade-off for
+  a no-JavaScript, radio-driven carousel — adding a 5th slide means adding
+  one more radio, one more slide rule, one more dot rule, and one more
+  prev/next arrow pair.
+- There's no autoplay, since a "zero JavaScript overhead" carousel has no
+  timer mechanism to drive one; this can be added later as an optional,
+  separate JS-enhanced variant if the project wants one.

--- a/submissions/examples/ease-cyberpunk-skew-carousel-sh/demo.html
+++ b/submissions/examples/ease-cyberpunk-skew-carousel-sh/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Cyberpunk Skew Carousel</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;700&family=Rajdhani:wght@400;600&display=swap"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="stage">
+    <header class="stage-header">
+      <h1>Cyberpunk Skew Carousel</h1>
+      <p>Pure CSS — no JavaScript. Click a dot/arrow, or Tab in and use the arrow keys.</p>
+    </header>
+
+    <!-- Speed presets: pure-CSS radios that override the carousel's exposed
+         custom properties via the sibling combinator. Must stay before
+         .carousel in source order for the CSS selectors below to work. -->
+    <input type="radio" name="speed" id="speed-fast" />
+    <input type="radio" name="speed" id="speed-normal" checked />
+    <input type="radio" name="speed" id="speed-slow" />
+    <div class="speed-toggle">
+      <label for="speed-fast">Fast</label>
+      <label for="speed-normal">Normal</label>
+      <label for="speed-slow">Slow</label>
+    </div>
+
+    <div class="carousel" role="group" aria-roledescription="carousel" aria-label="Featured showcase slides">
+      <input type="radio" name="carousel-slide" id="s1" checked aria-label="Slide 1 of 4: Neon Grid" />
+      <input type="radio" name="carousel-slide" id="s2" aria-label="Slide 2 of 4: Grid Runner" />
+      <input type="radio" name="carousel-slide" id="s3" aria-label="Slide 3 of 4: Synth Wave" />
+      <input type="radio" name="carousel-slide" id="s4" aria-label="Slide 4 of 4: Chrome Pulse" />
+
+      <div class="viewport">
+        <div class="track">
+          <div class="slide slide-1">
+            <span class="eyebrow">01 // Uplink</span>
+            <h2>Neon Grid</h2>
+            <p>A skewed pane of light slides into place — pure transform and opacity, no script required.</p>
+          </div>
+          <div class="slide slide-2">
+            <span class="eyebrow">02 // Uplink</span>
+            <h2>Grid Runner</h2>
+            <p>Every transition timing, easing curve, and skew angle is a CSS custom property you can override.</p>
+          </div>
+          <div class="slide slide-3">
+            <span class="eyebrow">03 // Uplink</span>
+            <h2>Synth Wave</h2>
+            <p>Radio inputs drive the whole thing, so the native keyboard behavior of a radio group comes for free.</p>
+          </div>
+          <div class="slide slide-4">
+            <span class="eyebrow">04 // Uplink</span>
+            <h2>Chrome Pulse</h2>
+            <p>Try the speed presets above — same markup, three completely different transition feels.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="arrows" aria-hidden="true">
+        <label class="arrow prev prev-1" for="s4">&#8249;</label>
+        <label class="arrow prev prev-2" for="s1">&#8249;</label>
+        <label class="arrow prev prev-3" for="s2">&#8249;</label>
+        <label class="arrow prev prev-4" for="s3">&#8249;</label>
+        <label class="arrow next next-1" for="s2">&#8250;</label>
+        <label class="arrow next next-2" for="s3">&#8250;</label>
+        <label class="arrow next next-3" for="s4">&#8250;</label>
+        <label class="arrow next next-4" for="s1">&#8250;</label>
+      </div>
+
+      <div class="dots" aria-hidden="true">
+        <label for="s1"></label>
+        <label for="s2"></label>
+        <label for="s3"></label>
+        <label for="s4"></label>
+      </div>
+    </div>
+
+    <footer>
+      Fully CSS-driven: slide state, dot highlighting, arrow visibility, focus rings,
+      and speed presets are all handled with radio inputs and sibling selectors.
+      Tunable via <code>--carousel-duration</code>, <code>--carousel-easing</code>,
+      <code>--carousel-skew</code>, <code>--carousel-travel</code>, and
+      <code>--carousel-scale-inactive</code>.
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-cyberpunk-skew-carousel-sh/style.css
+++ b/submissions/examples/ease-cyberpunk-skew-carousel-sh/style.css
@@ -1,0 +1,356 @@
+/* ==========================================================================
+   Ease Cyberpunk Skew Carousel
+   Pure CSS carousel (zero JavaScript). Radio inputs + the checkbox-hack
+   drive which slide is active; native radio-group keyboard behavior
+   (arrow keys, Tab) gives full keyboard access for free.
+   ========================================================================== */
+
+:root {
+  /* -- Exposed tuning knobs -------------------------------------------- */
+  --carousel-duration: 650ms;
+  --carousel-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --carousel-skew: 22deg;
+  --carousel-travel: 46px;
+  --carousel-scale-inactive: 0.86;
+  --carousel-opacity-inactive: 0;
+
+  --neon-cyan: #2ef8ff;
+  --neon-magenta: #ff2ee6;
+  --neon-yellow: #f9f871;
+  --neon-green: #39ff9d;
+  --bg-void: #0a0014;
+  --bg-panel: #150a24;
+  --grid-line: rgba(46, 248, 255, 0.08);
+  --font-display: "Orbitron", "Segoe UI", sans-serif;
+  --font-body: "Rajdhani", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg-void);
+  background-image:
+    linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 34px 34px;
+  color: #eaf6ff;
+  font-family: var(--font-body);
+  min-height: 100vh;
+  padding: 36px 16px 56px;
+}
+
+.stage {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.stage-header {
+  text-align: center;
+  margin-bottom: 26px;
+}
+
+.stage-header h1 {
+  font-family: var(--font-display);
+  font-size: 26px;
+  letter-spacing: 0.06em;
+  margin: 0 0 8px;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 6px rgba(46, 248, 255, 0.6), 0 0 22px rgba(46, 248, 255, 0.25);
+}
+
+.stage-header p {
+  margin: 0;
+  font-size: 14px;
+  color: #9fb4c9;
+}
+
+/* -- Carousel shell -------------------------------------------------------- */
+
+.carousel {
+  position: relative;
+}
+
+/* Visually hidden but still focusable + keyboard-operable (native radio
+   group arrow-key navigation works because these stay in the a11y tree). */
+.carousel input[type="radio"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.viewport {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--bg-panel);
+  border: 1px solid rgba(46, 248, 255, 0.25);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4), 0 20px 50px rgba(0, 0, 0, 0.5);
+}
+
+.track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 8px;
+  padding: 34px 40px;
+  opacity: var(--carousel-opacity-inactive);
+  transform: skewX(var(--carousel-skew)) translateX(var(--carousel-travel))
+    scale(var(--carousel-scale-inactive));
+  transform-origin: left center;
+  transition: opacity var(--carousel-duration) var(--carousel-easing),
+    transform var(--carousel-duration) var(--carousel-easing);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.slide .eyebrow {
+  font-family: var(--font-display);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--slide-accent, var(--neon-cyan));
+  opacity: 0.85;
+}
+
+.slide h2 {
+  font-family: var(--font-display);
+  font-size: 30px;
+  margin: 2px 0 4px;
+  color: #fff;
+  text-shadow: 0 0 10px var(--slide-accent, var(--neon-cyan));
+}
+
+.slide p {
+  max-width: 320px;
+  margin: 0;
+  font-size: 15px;
+  color: #c7d6e6;
+}
+
+.slide-1 { --slide-accent: var(--neon-cyan); }
+.slide-2 { --slide-accent: var(--neon-magenta); }
+.slide-3 { --slide-accent: var(--neon-yellow); }
+.slide-4 { --slide-accent: var(--neon-green); }
+
+/* Active slide: flat, full opacity, on top */
+#s1:checked ~ .viewport .slide-1,
+#s2:checked ~ .viewport .slide-2,
+#s3:checked ~ .viewport .slide-3,
+#s4:checked ~ .viewport .slide-4 {
+  opacity: 1;
+  transform: skewX(0deg) translateX(0) scale(1);
+  pointer-events: auto;
+  z-index: 2;
+}
+
+/* -- Dots ------------------------------------------------------------------- */
+
+.dots {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.dots label {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 2px solid rgba(234, 246, 255, 0.35);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.dots label:hover {
+  border-color: var(--neon-cyan);
+}
+
+#s1:checked ~ .dots label[for="s1"],
+#s2:checked ~ .dots label[for="s2"],
+#s3:checked ~ .dots label[for="s3"],
+#s4:checked ~ .dots label[for="s4"] {
+  background: var(--neon-cyan);
+  border-color: var(--neon-cyan);
+  box-shadow: 0 0 10px var(--neon-cyan);
+}
+
+/* Visible focus ring on the dot matching the currently focused radio */
+#s1:focus-visible ~ .dots label[for="s1"],
+#s2:focus-visible ~ .dots label[for="s2"],
+#s3:focus-visible ~ .dots label[for="s3"],
+#s4:focus-visible ~ .dots label[for="s4"] {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+/* -- Prev / next arrows ------------------------------------------------------- */
+/* One label per (current -> target) transition, all stacked in the same
+   spot; only the pair matching the checked radio is shown/interactive. */
+
+.arrows .arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(10, 0, 20, 0.55);
+  border: 1px solid rgba(46, 248, 255, 0.35);
+  color: var(--neon-cyan);
+  font-family: var(--font-display);
+  font-size: 16px;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, box-shadow 0.2s ease;
+  z-index: 3;
+}
+
+.arrows .arrow:hover {
+  box-shadow: 0 0 12px var(--neon-cyan);
+}
+
+.arrow.prev { left: 12px; }
+.arrow.next { right: 12px; }
+
+#s1:checked ~ .arrows .prev-1,
+#s2:checked ~ .arrows .prev-2,
+#s3:checked ~ .arrows .prev-3,
+#s4:checked ~ .arrows .prev-4,
+#s1:checked ~ .arrows .next-1,
+#s2:checked ~ .arrows .next-2,
+#s3:checked ~ .arrows .next-3,
+#s4:checked ~ .arrows .next-4 {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* -- Speed preset toggle ---------------------------------------------------- */
+/* Pure CSS: these radios sit before .carousel in the DOM, so :checked can
+   override the carousel's custom properties via the sibling combinator —
+   no JavaScript involved in tuning the transition. */
+
+.speed-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 14px;
+  font-size: 12px;
+}
+
+input[name="speed"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.speed-toggle label {
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(234, 246, 255, 0.3);
+  color: #9fb4c9;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.speed-toggle label:hover {
+  border-color: var(--neon-cyan);
+  color: var(--neon-cyan);
+}
+
+#speed-fast:checked ~ .speed-toggle label[for="speed-fast"],
+#speed-normal:checked ~ .speed-toggle label[for="speed-normal"],
+#speed-slow:checked ~ .speed-toggle label[for="speed-slow"] {
+  border-color: var(--neon-cyan);
+  color: var(--neon-cyan);
+  box-shadow: 0 0 8px rgba(46, 248, 255, 0.5);
+}
+
+#speed-fast:focus-visible ~ .speed-toggle label[for="speed-fast"],
+#speed-normal:focus-visible ~ .speed-toggle label[for="speed-normal"],
+#speed-slow:focus-visible ~ .speed-toggle label[for="speed-slow"] {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+#speed-fast:checked ~ .carousel {
+  --carousel-duration: 280ms;
+  --carousel-skew: 14deg;
+  --carousel-travel: 24px;
+}
+
+#speed-slow:checked ~ .carousel {
+  --carousel-duration: 1100ms;
+  --carousel-skew: 30deg;
+  --carousel-travel: 64px;
+}
+
+/* -- Footer -------------------------------------------------------------------- */
+
+footer {
+  margin-top: 26px;
+  text-align: center;
+  font-size: 11.5px;
+  color: #63748a;
+}
+
+/* -- Reduced motion -------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .slide {
+    transition: opacity 0.15s linear;
+    transform: none !important;
+  }
+}
+
+/* -- Responsive ------------------------------------------------------------------- */
+
+@media (max-width: 560px) {
+  .viewport {
+    aspect-ratio: 4 / 5;
+  }
+  .slide {
+    padding: 26px 24px;
+  }
+  .slide h2 {
+    font-size: 24px;
+  }
+  .arrows .arrow {
+    width: 32px;
+    height: 32px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #50502 

### Type of Change
- [x] New component/example submission
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

### Submission Checklist
- [x] Component lives in `submissions/examples/ease-cyberpunk-skew-carousel-sh/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Demo runs standalone by opening `demo.html` directly (no build step)
- [x] Zero JavaScript — pure CSS carousel
- [x] Tested in at least one browser
- [x] Keyboard accessible (native radio-group Tab/arrow-key navigation, visible focus states)
- [x] Responsive down to mobile widths
- [x] No console errors on load or interaction

### Feature Description
A pure CSS carousel with a smooth skew-active transition, styled to a
cyberpunk neon aesthetic. Hidden (but focusable) radio inputs drive slide
state via CSS sibling selectors — no JavaScript anywhere. Exposes
`--carousel-duration`, `--carousel-easing`, `--carousel-skew`,
`--carousel-travel`, and `--carousel-scale-inactive` as custom properties,
demonstrated live via a pure-CSS Fast/Normal/Slow speed-preset toggle.
Fully keyboard accessible for free, since it's backed by a native radio
group.

### Demo
Open `submissions/examples/ease-cyberpunk-skew-carousel-sh/demo.html` in
any modern browser. No build step, no dependencies beyond a Google Fonts
link, and zero JavaScript.

<img width="1920" height="1020" alt="ease-cyberpunk-skew-carousel" src="https://github.com/user-attachments/assets/4c0caf18-3970-4cdf-a416-6a7495aae910" />

### Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Notes for Maintainer
- Genuinely zero JavaScript — verified no `<script>` tags in `demo.html`.
- Slide count (4) is currently hardcoded into the CSS selector set, per the
  README's "Known limitations" — a common trade-off for radio-driven,
  no-JS carousels.
- No autoplay, for the same zero-JS reason (no timer mechanism available).