### PR TITLE
Add ease-segmented-control component

### DIFF
--- a/submissions/examples/ease-segmented-control-sh/README.md
+++ b/submissions/examples/ease-segmented-control-sh/README.md
@@ -1,0 +1,113 @@
+# Segmented Control
+
+A reusable segmented control (the iOS-settings-style toggle) with a sliding
+highlight that animates between segments. Pure CSS — zero JavaScript.
+
+## What it does
+
+- **Sliding highlight.** A single `.highlight` element moves under the
+  active segment using `transform: translateX(...)`, driven by
+  `:checked ~` sibling selectors off hidden (but focusable) radio inputs.
+- **Four variants demonstrated:**
+  - Two-option pill toggle (List / Grid — matches the original issue's
+    HTML snippet)
+  - Multi-option (4-segment) pill toggle (Day / Week / Month / Year)
+  - Flat/underline two-option (Light / Dark)
+  - Flat/underline multi-option (All / Active / Done)
+- **Free keyboard support.** Each control is a native radio group, so Tab
+  and the arrow keys move between segments automatically.
+- **Exposed custom properties** for full customization:
+  - `--segctl-highlight-bg` — highlight color/shape fill
+  - `--segctl-highlight-shadow` — highlight drop shadow (set to `none` for flat)
+  - `--segctl-radius` — corner radius (pill vs. square vs. anything between)
+  - `--segctl-duration` / `--segctl-easing` — slide timing and curve
+  - `--segctl-padding-x` / `--segctl-padding-y` — segment padding
+  - `--segctl-font-weight-active` / `--segctl-font-weight-inactive` — active vs. resting weight
+  - `--segctl-track-bg`, `--segctl-text-color`, `--segctl-text-color-active`
+
+## Files
+
+- `demo.html` — markup only, no JavaScript
+- `style.css` — all styling and all interaction logic
+- `README.md` — this file
+
+## Running it
+
+Open `demo.html` in any modern browser. No server, build step, or
+dependencies beyond a Google Fonts stylesheet link.
+
+## Using the component in your own markup
+
+The base markup is exactly the two-input shape from the original feature
+request, plus one addition — a `.highlight` span — which is what actually
+slides:
+
+```html
+<div class="ease-segmented-control" style="--segctl-count: 2;">
+  <input type="radio" name="seg" id="seg1" checked />
+  <label for="seg1">List</label>
+  <input type="radio" name="seg" id="seg2" />
+  <label for="seg2">Grid</label>
+  <span class="highlight"></span>
+</div>
+```
+
+To add more segments, add more radio/label pairs (all sharing the same
+`name`) and update `--segctl-count` to match. You'll also need one small
+CSS rule per segment mapping its `:checked` state to a `translateX`
+position and an active-label color — see the four examples in `style.css`
+for the pattern (each one is two short rule blocks).
+
+For the flat/underline look instead of the pill, add the
+`ease-segmented-control--underline` modifier class:
+
+```html
+<div class="ease-segmented-control ease-segmented-control--underline" style="--segctl-count: 2;">
+  ...
+</div>
+```
+
+To restyle any instance, override the custom properties on that specific
+container:
+
+```css
+.my-toggle {
+  --segctl-highlight-bg: #14182a;
+  --segctl-text-color-active: #ffffff;
+  --segctl-radius: 8px;
+  --segctl-duration: 200ms;
+}
+```
+
+## Design notes
+
+The visual style leans into the "familiar mobile settings toggle" framing
+from the feature request: a soft grey track, a white pill with a subtle
+shadow that looks like it's floating just above the track, and Inter as a
+clean, neutral UI typeface. The underline variant strips that down to a
+flatter, more understated look for contexts like filter chips or tab bars.
+
+## Accessibility
+
+- Radio inputs stay in the DOM, focusable and screen-reader-visible, just
+  visually hidden via a standard clip technique — this is what gives Tab
+  and arrow-key navigation for free.
+- A visible focus ring appears on the highlight when its corresponding
+  radio has keyboard focus (`:focus-visible`).
+- Label text has sufficient contrast against both the track and the
+  highlight in both variants.
+- Respects `prefers-reduced-motion` by collapsing the slide/color
+  transitions to effectively instant.
+- Fully responsive: segment padding and font size scale down at narrow
+  widths.
+
+## Known limitations
+
+- Segment count and position are driven by one small hardcoded CSS rule
+  per segment (mapping a specific `id` to a `translateX` percentage and an
+  active-label color) — the standard trade-off for a no-JavaScript,
+  radio-driven component. Each example in this demo shows the pattern so
+  it's easy to copy for a new instance.
+- `--segctl-count` must be set to match the actual number of segments in
+  that instance (used to size the highlight and the underline width); it
+  isn't inferred automatically since there's no JavaScript to count children.

--- a/submissions/examples/ease-segmented-control-sh/demo.html
+++ b/submissions/examples/ease-segmented-control-sh/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Segmented Control</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="page-header">
+      <h1>Segmented Control</h1>
+      <p>Pure CSS, zero JavaScript. Click a segment, or Tab in and use the arrow keys.</p>
+    </header>
+
+    <section class="panel">
+      <h2>Two-option pill toggle</h2>
+      <p class="panel-desc">View mode switcher — the smallest, most common case.</p>
+      <div class="ease-segmented-control" style="--segctl-count: 2;">
+        <input type="radio" name="seg" id="seg1" checked />
+        <label for="seg1">List</label>
+        <input type="radio" name="seg" id="seg2" />
+        <label for="seg2">Grid</label>
+        <span class="highlight"></span>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Multi-option pill toggle</h2>
+      <p class="panel-desc">Four segments — same component, wider track.</p>
+      <div class="ease-segmented-control" style="--segctl-count: 4;">
+        <input type="radio" name="period" id="day1" checked />
+        <label for="day1">Day</label>
+        <input type="radio" name="period" id="day2" />
+        <label for="day2">Week</label>
+        <input type="radio" name="period" id="day3" />
+        <label for="day3">Month</label>
+        <input type="radio" name="period" id="day4" />
+        <label for="day4">Year</label>
+        <span class="highlight"></span>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Flat / underline style</h2>
+      <p class="panel-desc">Light/dark mode switch — sliding underline instead of a pill.</p>
+      <div class="ease-segmented-control ease-segmented-control--underline" style="--segctl-count: 2;">
+        <input type="radio" name="theme-mode" id="theme1" checked />
+        <label for="theme1">Light</label>
+        <input type="radio" name="theme-mode" id="theme2" />
+        <label for="theme2">Dark</label>
+        <span class="highlight"></span>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Underline, multi-option</h2>
+      <p class="panel-desc">Filter category selector with three segments.</p>
+      <div class="ease-segmented-control ease-segmented-control--underline" style="--segctl-count: 3;">
+        <input type="radio" name="filter" id="filter1" checked />
+        <label for="filter1">All</label>
+        <input type="radio" name="filter" id="filter2" />
+        <label for="filter2">Active</label>
+        <input type="radio" name="filter" id="filter3" />
+        <label for="filter3">Done</label>
+        <span class="highlight"></span>
+      </div>
+    </section>
+
+    <footer>
+      <p style="text-align:center; font-size:12px; color:#8a93a3; margin-top: 26px;">
+        Zero JavaScript. Tunable via <code>--segctl-highlight-bg</code>,
+        <code>--segctl-radius</code>, <code>--segctl-duration</code>,
+        <code>--segctl-easing</code>, <code>--segctl-padding-x</code>,
+        <code>--segctl-padding-y</code>, and <code>--segctl-font-weight-active</code>.
+      </p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-segmented-control-sh/style.css
+++ b/submissions/examples/ease-segmented-control-sh/style.css
@@ -1,0 +1,242 @@
+/* ==========================================================================
+   Ease Segmented Control
+   Pure CSS (zero JavaScript). Radio inputs drive which segment is active;
+   a single ".highlight" element slides underneath using CSS transforms,
+   driven entirely by :checked ~ sibling selectors.
+   ========================================================================== */
+
+:root {
+  /* -- Exposed tuning knobs, override per-instance or globally ---------- */
+  --segctl-track-bg: #e4e7ee;
+  --segctl-highlight-bg: #ffffff;
+  --segctl-highlight-shadow: 0 1px 3px rgba(20, 24, 38, 0.18), 0 1px 1px rgba(20, 24, 38, 0.1);
+  --segctl-radius: 12px;
+  --segctl-duration: 320ms;
+  --segctl-easing: cubic-bezier(0.32, 0.72, 0, 1);
+  --segctl-padding-x: 16px;
+  --segctl-padding-y: 8px;
+  --segctl-font-weight-inactive: 500;
+  --segctl-font-weight-active: 700;
+  --segctl-text-color: #5b6472;
+  --segctl-text-color-active: #14182a;
+
+  --font-body: "Inter", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: #f4f5f8;
+  color: #14182a;
+  font-family: var(--font-body);
+  min-height: 100vh;
+  padding: 40px 18px 60px;
+}
+
+.page {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.page-header h1 {
+  font-size: 24px;
+  margin: 0 0 6px;
+  font-weight: 700;
+}
+
+.page-header p {
+  margin: 0;
+  font-size: 14px;
+  color: #6b7280;
+}
+
+/* -- Example panels -------------------------------------------------------- */
+
+.panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px 22px 24px;
+  box-shadow: 0 1px 2px rgba(20, 24, 38, 0.06), 0 8px 24px rgba(20, 24, 38, 0.05);
+  margin-bottom: 18px;
+}
+
+.panel h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.panel .panel-desc {
+  font-size: 12.5px;
+  color: #6b7280;
+  margin: 0 0 16px;
+}
+
+/* -- Core component ---------------------------------------------------------- */
+
+.ease-segmented-control {
+  position: relative;
+  display: inline-flex;
+  width: 100%;
+  background: var(--segctl-track-bg);
+  border-radius: var(--segctl-radius);
+  padding: 4px;
+}
+
+/* Visually hidden but focusable + keyboard-operable: native radio-group
+   Tab / arrow-key behavior gives full keyboard support for free. */
+.ease-segmented-control input[type="radio"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-segmented-control label {
+  position: relative;
+  z-index: 2;
+  flex: 1;
+  text-align: center;
+  padding: var(--segctl-padding-y) var(--segctl-padding-x);
+  font-size: 14px;
+  font-weight: var(--segctl-font-weight-inactive);
+  color: var(--segctl-text-color);
+  cursor: pointer;
+  user-select: none;
+  border-radius: calc(var(--segctl-radius) - 4px);
+  transition: color var(--segctl-duration) var(--segctl-easing),
+    font-weight 0.15s ease;
+}
+
+.ease-segmented-control label:hover {
+  color: var(--segctl-text-color-active);
+}
+
+/* The sliding highlight. Width = one segment's share of the track, based
+   on --segctl-count (set inline per instance, e.g. style="--segctl-count:4"). */
+.ease-segmented-control .highlight {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: calc((100% - 8px) / var(--segctl-count, 2));
+  background: var(--segctl-highlight-bg);
+  border-radius: calc(var(--segctl-radius) - 4px);
+  box-shadow: var(--segctl-highlight-shadow);
+  transition: transform var(--segctl-duration) var(--segctl-easing);
+  z-index: 1;
+  pointer-events: none;
+}
+
+/* Visible focus ring on whichever label corresponds to the focused radio */
+.ease-segmented-control input:focus-visible ~ .highlight {
+  outline: 2px solid #2f6fed;
+  outline-offset: 2px;
+}
+
+/* -- Underline / flat variant -------------------------------------------------- */
+
+.ease-segmented-control--underline {
+  --segctl-highlight-bg: #2f6fed;
+  --segctl-highlight-shadow: none;
+  --segctl-text-color-active: #2f6fed;
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  border-bottom: 2px solid var(--segctl-track-bg);
+}
+
+.ease-segmented-control--underline label {
+  border-radius: 0;
+  padding: 10px 18px;
+}
+
+.ease-segmented-control--underline .highlight {
+  top: auto;
+  bottom: -2px;
+  left: 0;
+  height: 3px;
+  width: calc(100% / var(--segctl-count, 2));
+  border-radius: 3px 3px 0 0;
+}
+
+/* -- Two-option pill toggle: List / Grid (ids from the original snippet) ------- */
+
+#seg1:checked ~ .highlight { transform: translateX(0%); }
+#seg2:checked ~ .highlight { transform: translateX(100%); }
+#seg1:checked ~ label[for="seg1"],
+#seg2:checked ~ label[for="seg2"] {
+  color: var(--segctl-text-color-active);
+  font-weight: var(--segctl-font-weight-active);
+}
+
+/* -- Multi-option (4) pill toggle: Day / Week / Month / Year ------------------- */
+
+#day1:checked ~ .highlight { transform: translateX(0%); }
+#day2:checked ~ .highlight { transform: translateX(100%); }
+#day3:checked ~ .highlight { transform: translateX(200%); }
+#day4:checked ~ .highlight { transform: translateX(300%); }
+#day1:checked ~ label[for="day1"],
+#day2:checked ~ label[for="day2"],
+#day3:checked ~ label[for="day3"],
+#day4:checked ~ label[for="day4"] {
+  color: var(--segctl-text-color-active);
+  font-weight: var(--segctl-font-weight-active);
+}
+
+/* -- Underline two-option: Light / Dark ---------------------------------------- */
+
+#theme1:checked ~ .highlight { transform: translateX(0%); }
+#theme2:checked ~ .highlight { transform: translateX(100%); }
+#theme1:checked ~ label[for="theme1"],
+#theme2:checked ~ label[for="theme2"] {
+  color: var(--segctl-text-color-active);
+  font-weight: var(--segctl-font-weight-active);
+}
+
+/* -- Underline multi-option (3): All / Active / Done --------------------------- */
+
+#filter1:checked ~ .highlight { transform: translateX(0%); }
+#filter2:checked ~ .highlight { transform: translateX(100%); }
+#filter3:checked ~ .highlight { transform: translateX(200%); }
+#filter1:checked ~ label[for="filter1"],
+#filter2:checked ~ label[for="filter2"],
+#filter3:checked ~ label[for="filter3"] {
+  color: var(--segctl-text-color-active);
+  font-weight: var(--segctl-font-weight-active);
+}
+
+/* -- Reduced motion ------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-segmented-control .highlight,
+  .ease-segmented-control label {
+    transition-duration: 1ms;
+  }
+}
+
+/* -- Responsive ------------------------------------------------------------------ */
+
+@media (max-width: 420px) {
+  .ease-segmented-control label {
+    padding: 8px 10px;
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #51350 

### Type of Change
- [x] New component/example submission
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

### Submission Checklist
- [x] Component lives in `submissions/examples/ease-segmented-control-sh/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Demo runs standalone by opening `demo.html` directly (no build step)
- [x] Zero JavaScript — pure CSS component
- [x] Tested in at least one browser
- [x] Keyboard accessible (native radio-group Tab/arrow-key navigation, visible focus states)
- [x] Responsive down to mobile widths
- [x] No console errors on load or interaction

### Feature Description
A reusable segmented control with a sliding highlight, matching the
original feature request's markup shape (radio + label pairs, plus one
added `.highlight` element that does the sliding). Demonstrates all four
requested variants: two-option pill, multi-option (4-segment) pill,
flat/underline two-option, and flat/underline multi-option (3-segment).
Highlight color/shape, slide duration/easing, segment padding, and active
font-weight are all exposed as CSS custom properties. Fully keyboard
accessible for free via native radio-group behavior.

### Demo
Open `submissions/examples/ease-segmented-control-sh/demo.html` in any
modern browser. No build step, no dependencies beyond a Google Fonts link,
and zero JavaScript.

<img width="1920" height="1020" alt="ease-segmented-control" src="https://github.com/user-attachments/assets/b2229774-e35f-43f3-9993-16333bbbd78c" />

### Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Notes for Maintainer
- Genuinely zero JavaScript — verified no `<script>` tags in `demo.html`.
- Segment position/count is driven by one small hardcoded CSS rule per
  segment (documented in the README as the standard trade-off for a
  no-JS, radio-driven approach), plus a `--segctl-count` custom property
  consumers must set to match their segment count.
- Complements the existing pill-tabs component with a distinct
  "settings toggle" interaction, per the original feature request.