### PR TITLE
Add Zoom-Out tooltip component for product catalog layouts (zoom-out-…

### DIFF
--- a/submissions/examples/zoom-out-tooltip-hr18/README.md
+++ b/submissions/examples/zoom-out-tooltip-hr18/README.md
@@ -1,0 +1,90 @@
+# Zoom-Out Tooltip (`zoom-out-tooltip-hr18`)
+
+A pure-CSS animated tooltip with a "Zoom-Out" entrance, styled for product
+catalog layouts, built for issue
+[#46243](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/46243).
+
+## What it does
+
+Hovering — or tabbing to, with a keyboard — a color swatch or info icon
+reveals a tooltip that starts noticeably larger than its resting size and
+shrinks down into place, rather than growing up from small — the inverse of
+a typical zoom-in tooltip. Both the **show/hide behavior and the zoom-out
+animation are pure CSS**, driven by `:hover`/`:focus-within` plus
+`@keyframes ease-zoomout-hr18` — no JavaScript is required for the core
+interaction. A few lines of optional script only add `Escape`-to-dismiss.
+
+The demo applies it to a two-product catalog grid, each product with
+color-swatch tooltips (naming the color) and a care-instructions info icon.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Wrap a trigger and a tooltip bubble in the component markup:
+
+```html
+<span class="zot-tooltip-wrap-hr18">
+  <button type="button" class="zot-swatch-hr18" style="background: #7a5c3e" aria-describedby="myTip"></button>
+  <span class="ease-tooltip-zoomout-hr18" id="myTip" role="tooltip">Walnut</span>
+</span>
+```
+
+That's the entire component — no JavaScript wiring is needed per instance.
+
+### Tuning the animation
+
+Every timing/scale value is a CSS custom property, overridable per instance
+or globally:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-zoomout-duration-hr18` | `260ms` | How long the shrink-into-place takes |
+| `--ease-zoomout-easing-hr18` | `cubic-bezier(0.22, 1, 0.36, 1)` | The easing curve for the entrance |
+| `--ease-zoomout-start-scale-hr18` | `1.6` | How much larger than rest the tooltip starts — higher feels punchier |
+| `--ease-zoomout-delay-hr18` | `0ms` | Delay before the animation starts |
+
+```css
+.zot-tooltip-wrap-hr18.subtle .ease-tooltip-zoomout-hr18 {
+  --ease-zoomout-start-scale-hr18: 1.2;
+  --ease-zoomout-duration-hr18: 180ms;
+}
+```
+
+## Accessibility notes
+
+- Both trigger types (color swatches and the info icon) are native
+  `<button>` elements, reachable and triggerable by keyboard without any
+  extra scripting.
+- The tooltip shows on `:focus-within` as well as `:hover`, so keyboard-only
+  users see the same content sighted mouse users do.
+- Each trigger and its tooltip are connected with `aria-describedby`, and
+  the tooltip carries `role="tooltip"`.
+- The tooltip contains only short text — no interactive content — matching
+  the WAI-ARIA tooltip pattern's expectations.
+- Color swatches are named in their tooltip text ("Walnut", "Forest",
+  "Onyx"), so color choice is never communicated by color alone.
+- `Escape` blurs the trigger (via the small optional script) to dismiss the
+  tooltip early without needing to tab away.
+- The zoom-out animation respects `@media (prefers-reduced-motion: reduce)`
+  and appears instantly at rest instead.
+
+## Responsiveness
+
+The two-product grid collapses from two columns to one under a `620px`
+viewport width.
+
+## Why this fits EaseMotion CSS
+
+The entire interaction runs on plain CSS selectors and a single
+`@keyframes` block, matching the issue's explicit ask for zero JavaScript
+overhead, while exposing every timing/scale value as a tunable custom
+property and remaining keyboard accessible via `:focus-within`.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/zoom-out-tooltip-hr18/demo.html
+++ b/submissions/examples/zoom-out-tooltip-hr18/demo.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Zoom-Out Tooltip — product catalog demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="zot-hr18">
+  <div class="zot-wrap-hr18">
+
+    <header class="zot-header-hr18">
+      <span class="zot-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Shop the collection</h1>
+      <p>Hover or tab to any swatch or info icon &mdash; its tooltip starts
+        noticeably larger than rest and shrinks into place, the inverse of
+        a typical zoom-in.</p>
+    </header>
+
+    <section class="zot-grid-hr18">
+
+      <!-- Product 1 -->
+      <article class="zot-card-hr18">
+        <div class="zot-card-top-hr18">
+          <h3>Canvas Field Jacket</h3>
+          <span class="zot-price-hr18">$128</span>
+        </div>
+        <p class="zot-card-sub-hr18">Waxed cotton canvas, brass hardware</p>
+        <div class="zot-swatch-row-hr18">
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-swatch-hr18 s1" aria-describedby="zotTip1"></button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip1" role="tooltip">Walnut</span>
+          </span>
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-swatch-hr18 s2" aria-describedby="zotTip2"></button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip2" role="tooltip">Forest</span>
+          </span>
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-swatch-hr18 s4" aria-describedby="zotTip3"></button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip3" role="tooltip">Onyx</span>
+          </span>
+        </div>
+        <div class="zot-care-row-hr18">
+          <span>Care instructions</span>
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-info-trigger-hr18" aria-describedby="zotTip4">i</button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip4" role="tooltip">Machine wash cold, hang dry</span>
+          </span>
+        </div>
+      </article>
+
+      <!-- Product 2 -->
+      <article class="zot-card-hr18">
+        <div class="zot-card-top-hr18">
+          <h3>Ridge Wool Scarf</h3>
+          <span class="zot-price-hr18">$54</span>
+        </div>
+        <p class="zot-card-sub-hr18">Merino wool blend, fringe edge</p>
+        <div class="zot-swatch-row-hr18">
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-swatch-hr18 s3" aria-describedby="zotTip5"></button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip5" role="tooltip">Wheat</span>
+          </span>
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-swatch-hr18 s2" aria-describedby="zotTip6"></button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip6" role="tooltip">Forest</span>
+          </span>
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-swatch-hr18 s1" aria-describedby="zotTip7"></button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip7" role="tooltip">Walnut</span>
+          </span>
+        </div>
+        <div class="zot-care-row-hr18">
+          <span>Care instructions</span>
+          <span class="zot-tooltip-wrap-hr18">
+            <button type="button" class="zot-info-trigger-hr18" aria-describedby="zotTip8">i</button>
+            <span class="ease-tooltip-zoomout-hr18" id="zotTip8" role="tooltip">Dry clean only</span>
+          </span>
+        </div>
+      </article>
+
+    </section>
+
+    <div class="zot-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-zoomout-duration-hr18</code></td><td><code>260ms</code></td><td>How long the shrink-into-place takes.</td></tr>
+          <tr><td><code>--ease-zoomout-easing-hr18</code></td><td><code>cubic-bezier(0.22, 1, 0.36, 1)</code></td><td>The easing curve for the entrance.</td></tr>
+          <tr><td><code>--ease-zoomout-start-scale-hr18</code></td><td><code>1.6</code></td><td>How much larger than rest the tooltip starts &mdash; higher feels punchier.</td></tr>
+          <tr><td><code>--ease-zoomout-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the animation starts.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="zot-footnote-hr18">submissions/examples/zoom-out-tooltip-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // The core show/hide and zoom-out animation are pure CSS (:hover /
+  // :focus-within) — no JavaScript is required for them to work. This
+  // script only adds one convenience: pressing Escape while a tooltip is
+  // showing via keyboard focus blurs the trigger, which naturally hides
+  // the tooltip since it's no longer within a :focus-within wrapper.
+  document.addEventListener("keydown", function (e) {
+    if (e.key !== "Escape") return;
+    var active = document.activeElement;
+    if (
+      active &&
+      (active.classList.contains("zot-swatch-hr18") ||
+        active.classList.contains("zot-info-trigger-hr18"))
+    ) {
+      active.blur();
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/zoom-out-tooltip-hr18/style.css
+++ b/submissions/examples/zoom-out-tooltip-hr18/style.css
@@ -1,0 +1,300 @@
+/* ==========================================================================
+   zoom-out-tooltip-hr18 — style.css
+   CSS Zoom-Out Tooltip for Product Catalog layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.zot-hr18 {
+  --bg-hr18: #faf8f5;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e5ddd0;
+  --text-hr18: #201d18;
+  --text-muted-hr18: #766f62;
+  --accent-hr18: #b8552f;
+  --accent-soft-hr18: #f6e4d8;
+  --radius-hr18: 14px;
+
+  /* Exposed animation parameters. */
+  --ease-zoomout-duration-hr18: 260ms;
+  --ease-zoomout-easing-hr18: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-zoomout-start-scale-hr18: 1.6;
+  --ease-zoomout-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4.5rem;
+  min-height: 100%;
+}
+
+.zot-hr18 * {
+  box-sizing: border-box;
+}
+
+.zot-hr18 h1,
+.zot-hr18 h2,
+.zot-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.zot-wrap-hr18 {
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+/* ---- Header ------------------------------------------------------------------ */
+.zot-header-hr18 {
+  margin-bottom: 2.25rem;
+}
+
+.zot-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.zot-header-hr18 h1 {
+  font-size: clamp(1.6rem, 2.6vw, 2.2rem);
+}
+
+.zot-header-hr18 p {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 60ch;
+  font-size: 0.96rem;
+  line-height: 1.6;
+}
+
+/* ---- Product grid --------------------------------------------------------------- */
+.zot-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+
+@media (max-width: 620px) {
+  .zot-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.zot-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgba(30, 20, 10, 0.03), 0 10px 24px rgba(30, 20, 10, 0.05);
+}
+
+.zot-card-top-hr18 {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.zot-card-hr18 h3 {
+  font-size: 0.98rem;
+}
+
+.zot-price-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-weight: 600;
+  color: var(--accent-hr18);
+  font-size: 0.95rem;
+}
+
+.zot-card-sub-hr18 {
+  margin: 0.2rem 0 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Swatch row ------------------------------------------------------------------- */
+.zot-swatch-row-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.9rem;
+}
+
+.zot-swatch-hr18 {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid var(--panel-hr18);
+  outline: 1px solid var(--border-hr18);
+  cursor: pointer;
+  padding: 0;
+}
+
+.zot-swatch-hr18.s1 { background: #7a5c3e; }
+.zot-swatch-hr18.s2 { background: #2f4a3e; }
+.zot-swatch-hr18.s3 { background: #c9a15a; }
+.zot-swatch-hr18.s4 { background: #26262b; }
+
+.zot-swatch-hr18:hover,
+.zot-swatch-hr18:focus-visible {
+  outline: 2px solid var(--accent-hr18);
+}
+
+/* ---- The reusable tooltip component ---------------------------------------------
+   Drop-in markup: a .zot-tooltip-wrap-hr18 containing a trigger and a
+   .ease-tooltip-zoomout-hr18 bubble. Visibility and the zoom-out
+   animation are both driven purely by :hover / :focus-within — no
+   JavaScript is required for the core interaction. */
+.zot-tooltip-wrap-hr18 {
+  position: relative;
+  display: inline-flex;
+}
+
+.ease-tooltip-zoomout-hr18 {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  background: var(--text-hr18);
+  color: #fff;
+  font-size: 0.76rem;
+  font-weight: 600;
+  padding: 0.4rem 0.7rem;
+  border-radius: 8px;
+  white-space: nowrap;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 20;
+  transform: translateX(-50%);
+  transform-origin: bottom center;
+}
+
+.ease-tooltip-zoomout-hr18::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--text-hr18);
+}
+
+.zot-tooltip-wrap-hr18:hover .ease-tooltip-zoomout-hr18,
+.zot-tooltip-wrap-hr18:focus-within .ease-tooltip-zoomout-hr18 {
+  visibility: visible;
+  opacity: 1;
+  animation: ease-zoomout-hr18 var(--ease-zoomout-duration-hr18) var(--ease-zoomout-easing-hr18) var(--ease-zoomout-delay-hr18) both;
+}
+
+/* The zoom-out entrance: starts noticeably larger than rest and shrinks
+   down into place, rather than growing up from small — the inverse of a
+   typical zoom-in tooltip. Starting scale is tunable. */
+@keyframes ease-zoomout-hr18 {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) scale(var(--ease-zoomout-start-scale-hr18));
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+  }
+}
+
+/* ---- Info icon trigger (care instructions example) --------------------------------- */
+.zot-info-trigger-hr18 {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1px solid var(--border-hr18);
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+  font-family: var(--font-display-hr18);
+  font-weight: 700;
+  font-size: 0.68rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zot-info-trigger-hr18:hover,
+.zot-info-trigger-hr18:focus-visible {
+  border-color: var(--accent-hr18);
+}
+
+.zot-care-row-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.zot-tuning-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.zot-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.zot-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.zot-tuning-hr18 th,
+.zot-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.zot-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.zot-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+}
+
+.zot-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.zot-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zot-tooltip-wrap-hr18:hover .ease-tooltip-zoomout-hr18,
+  .zot-tooltip-wrap-hr18:focus-within .ease-tooltip-zoomout-hr18 {
+    animation: none;
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Tooltip with a "Zoom-Out" entrance, styled for
product catalog layouts. Hovering — or tabbing to, with a keyboard — a
color swatch or info icon reveals a tooltip that starts noticeably larger
than its resting size and shrinks down into place, the inverse of a
typical zoom-in tooltip. Both the show/hide behavior and the animation are
pure CSS (:hover/:focus-within + one @keyframes block) — no JavaScript
required for the core interaction. Demo applies it to a 2-product catalog
grid with named color swatches and care-instruction info icons.

Resolves #46243

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-out-tooltip-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS zoom-out tooltip with tunable timing/starting-scale
via custom properties.

**How does a developer use it?**
```html
<span class="zot-tooltip-wrap-hr18">
  <button type="button" class="zot-swatch-hr18" style="background: #7a5c3e" aria-describedby="myTip"></button>
  <span class="ease-tooltip-zoomout-hr18" id="myTip" role="tooltip">Walnut</span>
</span>
```

**Why does it fit EaseMotion CSS?**
The entire interaction runs on plain CSS selectors and one `@keyframes`
block, matching the issue's ask for zero JS overhead, while exposing every
timing/scale value as a tunable custom property and staying keyboard
accessible via `:focus-within`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
Color swatches are also named in their tooltip text, so color choice isn't
communicated by color alone. Show/hide and the zoom-out itself need zero
JS; the only script adds Escape-to-dismiss. Tested keyboard flow in
Chrome; haven't checked other browsers yet.