### PR TITLE
Add Blur-Entrance carousel component for checkout layouts (blur-entra…

### DIFF
--- a/submissions/examples/blur-entrance-carousel-hr18/README.md
+++ b/submissions/examples/blur-entrance-carousel-hr18/README.md
@@ -1,0 +1,100 @@
+# Blur-Entrance Carousel (`blur-entrance-carousel-hr18`)
+
+A pure-CSS animated carousel with a "Blur-Entrance" slide transition,
+styled for e-commerce checkout layouts, built for issue
+[#50512](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/50512).
+
+## What it does
+
+A single-item-at-a-time carousel — framed as a "You might also like" upsell
+strip on a checkout review step — where each incoming slide sharpens into
+view from a soft blur, slightly scaled down and transparent, rather than
+cutting in abruptly. The **entrance animation itself is 100% CSS**
+(`@keyframes ease-blur-carousel-in-hr18`, driven entirely by custom
+properties); JavaScript only tracks which slide is active, toggles the
+entrance class, and keeps the dot indicators and screen-reader status in
+sync — there's no animation logic in JavaScript.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<div class="ease-carousel-blur-hr18" role="region" aria-roledescription="carousel" aria-label="You might also like" tabindex="0">
+  <div class="bec-slide-track-hr18">
+    <div class="bec-slide-hr18 is-active-hr18" data-index="0">
+      <!-- slide content -->
+    </div>
+    <div class="bec-slide-hr18" data-index="1">
+      <!-- slide content -->
+    </div>
+  </div>
+  <!-- prev/next buttons + dots, see demo.html -->
+</div>
+```
+
+Only one `.bec-slide-hr18` should carry `.is-active-hr18` at a time. When
+navigating to a new slide, the script:
+
+1. Removes `.is-active-hr18`/`.is-entering-hr18` from the current slide
+2. Adds `.is-active-hr18` to the target slide
+3. Forces a reflow, then adds `.is-entering-hr18` — which plays the
+   blur-entrance keyframe every time, even on a slide that's been shown
+   before
+
+### Tuning the animation
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-blur-carousel-duration-hr18` | `420ms` | How long each slide's sharpen-in takes |
+| `--ease-blur-carousel-easing-hr18` | `cubic-bezier(0.22, 1, 0.36, 1)` | The easing curve for the entrance |
+| `--ease-blur-carousel-amount-hr18` | `12px` | Starting blur radius — higher looks softer/further away |
+| `--ease-blur-carousel-scale-hr18` | `0.95` | Starting scale, so each slide also grows slightly into place |
+
+```css
+.ease-carousel-blur-hr18.dramatic {
+  --ease-blur-carousel-amount-hr18: 22px;
+  --ease-blur-carousel-duration-hr18: 600ms;
+}
+```
+
+## Accessibility notes
+
+- The carousel container uses `role="region"`,
+  `aria-roledescription="carousel"`, and a descriptive `aria-label`, and is
+  itself focusable (`tabindex="0"`) so keyboard users can reach it and use
+  `←`/`→` to navigate without needing to tab to the arrow buttons first.
+- Prev/next controls are native `<button>` elements with `aria-label`s
+  ("Previous item" / "Next item"), not icon-only with no text alternative.
+- Dot indicators use `aria-current="true"` on the active dot and a
+  descriptive `aria-label` per dot ("Item 1 of 3"), so their state and
+  position are both announced.
+- A visually-hidden `role="status"` / `aria-live="polite"` region
+  announces which item is now showing on every navigation, so screen
+  reader users get the same "you moved to a new slide" feedback sighted
+  users get visually.
+- The blur/scale entrance respects
+  `@media (prefers-reduced-motion: reduce)` and slides appear instantly at
+  full clarity instead.
+
+## Responsiveness
+
+Slides stack into a centered, vertical layout (thumbnail above text)
+under a `480px` viewport width instead of staying side-by-side in a
+cramped row.
+
+## Why this fits EaseMotion CSS
+
+It's a self-contained, reusable interaction pattern with a distinct named
+animation (`ease-blur-carousel-in`) exposed entirely through custom
+properties — matching the issue's ask for zero JavaScript animation
+overhead and tunable timing/easing/blur/scale — while remaining fully
+keyboard accessible and screen-reader friendly.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/blur-entrance-carousel-hr18/demo.html
+++ b/submissions/examples/blur-entrance-carousel-hr18/demo.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Blur-Entrance Carousel — checkout demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="bec-hr18">
+  <div class="bec-wrap-hr18">
+
+    <header class="bec-header-hr18">
+      <span class="bec-eyebrow-hr18">EaseMotion-css · component</span>
+      <h1>Complete your order</h1>
+      <p>Browse a few more items before you check out. Each slide sharpens
+        into view from a soft blur instead of cutting in abruptly.</p>
+    </header>
+
+    <div class="bec-checkout-strip-hr18">
+      <span class="bec-checkout-step-hr18">Step 2 of 3 &middot; <strong>Review order</strong></span>
+      <span class="bec-checkout-total-hr18">Subtotal: $86.00</span>
+    </div>
+
+    <div
+      class="ease-carousel-blur-hr18"
+      id="becCarousel"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="You might also like"
+      tabindex="0"
+    >
+      <h2 class="bec-carousel-heading-hr18">You might also like</h2>
+
+      <div class="bec-slide-track-hr18">
+        <p class="bec-sr-status-hr18" id="becSrStatus" role="status" aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;"></p>
+
+        <div class="bec-slide-hr18 is-active-hr18" data-index="0">
+          <div class="bec-slide-thumb-hr18 c1" aria-hidden="true">01</div>
+          <div class="bec-slide-info-hr18">
+            <h3>Insulated Water Bottle</h3>
+            <p>Keeps drinks cold for 24 hours.</p>
+            <div class="bec-slide-price-row-hr18">
+              <span class="bec-slide-price-hr18">$18</span>
+              <button type="button" class="bec-add-btn-hr18">Add to order</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="bec-slide-hr18" data-index="1">
+          <div class="bec-slide-thumb-hr18 c2" aria-hidden="true">02</div>
+          <div class="bec-slide-info-hr18">
+            <h3>Leather Card Wallet</h3>
+            <p>Slim profile, holds up to 6 cards.</p>
+            <div class="bec-slide-price-row-hr18">
+              <span class="bec-slide-price-hr18">$32</span>
+              <button type="button" class="bec-add-btn-hr18">Add to order</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="bec-slide-hr18" data-index="2">
+          <div class="bec-slide-thumb-hr18 c3" aria-hidden="true">03</div>
+          <div class="bec-slide-info-hr18">
+            <h3>Travel Packing Cubes</h3>
+            <p>Set of 4, compression zippers.</p>
+            <div class="bec-slide-price-row-hr18">
+              <span class="bec-slide-price-hr18">$24</span>
+              <button type="button" class="bec-add-btn-hr18">Add to order</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bec-controls-hr18">
+        <button type="button" class="bec-arrow-btn-hr18" id="becPrevBtn" aria-label="Previous item">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        </button>
+        <div class="bec-dots-hr18" role="tablist" aria-label="Slides">
+          <button type="button" class="bec-dot-hr18" data-index="0" aria-current="true" aria-label="Item 1 of 3"></button>
+          <button type="button" class="bec-dot-hr18" data-index="1" aria-current="false" aria-label="Item 2 of 3"></button>
+          <button type="button" class="bec-dot-hr18" data-index="2" aria-current="false" aria-label="Item 3 of 3"></button>
+        </div>
+        <button type="button" class="bec-arrow-btn-hr18" id="becNextBtn" aria-label="Next item">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="bec-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-blur-carousel-duration-hr18</code></td><td><code>420ms</code></td><td>How long each slide's sharpen-in takes.</td></tr>
+          <tr><td><code>--ease-blur-carousel-easing-hr18</code></td><td><code>cubic-bezier(0.22, 1, 0.36, 1)</code></td><td>The easing curve for the entrance.</td></tr>
+          <tr><td><code>--ease-blur-carousel-amount-hr18</code></td><td><code>12px</code></td><td>Starting blur radius &mdash; higher looks softer/further away.</td></tr>
+          <tr><td><code>--ease-blur-carousel-scale-hr18</code></td><td><code>0.95</code></td><td>Starting scale, so each slide also grows slightly into place.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="bec-footnote-hr18">submissions/examples/blur-entrance-carousel-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var carousel = document.getElementById("becCarousel");
+  var slides = Array.prototype.slice.call(carousel.querySelectorAll(".bec-slide-hr18"));
+  var dots = Array.prototype.slice.call(carousel.querySelectorAll(".bec-dot-hr18"));
+  var prevBtn = document.getElementById("becPrevBtn");
+  var nextBtn = document.getElementById("becNextBtn");
+  var srStatus = document.getElementById("becSrStatus");
+  var current = 0;
+
+  function goTo(index) {
+    var next = (index + slides.length) % slides.length;
+    if (next === current) return;
+
+    var currentSlide = slides[current];
+    var nextSlide = slides[next];
+
+    currentSlide.classList.remove("is-active-hr18", "is-entering-hr18");
+    nextSlide.classList.add("is-active-hr18");
+
+    // Force a reflow so the entrance animation restarts every time,
+    // even if this slide has played it before.
+    void nextSlide.offsetWidth;
+    nextSlide.classList.add("is-entering-hr18");
+
+    dots.forEach(function (dot, i) {
+      dot.setAttribute("aria-current", String(i === next));
+    });
+
+    var title = nextSlide.querySelector("h3");
+    srStatus.textContent = (next + 1) + " of " + slides.length + ": " + (title ? title.textContent : "");
+
+    current = next;
+  }
+
+  prevBtn.addEventListener("click", function () {
+    goTo(current - 1);
+  });
+
+  nextBtn.addEventListener("click", function () {
+    goTo(current + 1);
+  });
+
+  dots.forEach(function (dot) {
+    dot.addEventListener("click", function () {
+      goTo(parseInt(dot.getAttribute("data-index"), 10));
+    });
+  });
+
+  // Arrow-key navigation when the carousel region itself has focus.
+  carousel.addEventListener("keydown", function (e) {
+    if (e.target !== carousel) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      goTo(current + 1);
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      goTo(current - 1);
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/blur-entrance-carousel-hr18/style.css
+++ b/submissions/examples/blur-entrance-carousel-hr18/style.css
@@ -1,0 +1,333 @@
+/* ==========================================================================
+   blur-entrance-carousel-hr18 — style.css
+   CSS Blur-Entrance Carousel for E-Commerce Checkout layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.bec-hr18 {
+  --bg-hr18: #f7f8f6;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e0e4dd;
+  --text-hr18: #16181b;
+  --text-muted-hr18: #666b62;
+  --accent-hr18: #1f8a4c;
+  --accent-soft-hr18: #e5f5ec;
+  --radius-hr18: 14px;
+
+  /* Exposed animation parameters. */
+  --ease-blur-carousel-duration-hr18: 420ms;
+  --ease-blur-carousel-easing-hr18: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-blur-carousel-amount-hr18: 12px;
+  --ease-blur-carousel-scale-hr18: 0.95;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  padding: 3rem 1.5rem 4.5rem;
+  min-height: 100%;
+}
+
+.bec-hr18 * {
+  box-sizing: border-box;
+}
+
+.bec-hr18 h1,
+.bec-hr18 h2,
+.bec-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.bec-wrap-hr18 {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+/* ---- Header ------------------------------------------------------------------ */
+.bec-header-hr18 {
+  margin-bottom: 1.75rem;
+}
+
+.bec-eyebrow-hr18 {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent-hr18);
+  margin-bottom: 0.6rem;
+  font-weight: 600;
+  font-family: var(--font-mono-hr18);
+}
+
+.bec-header-hr18 h1 {
+  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+}
+
+.bec-header-hr18 p {
+  margin: 0.6rem 0 0;
+  color: var(--text-muted-hr18);
+  max-width: 58ch;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+/* ---- Checkout context strip ----------------------------------------------------- */
+.bec-checkout-strip-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 0.85rem 1.1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.82rem;
+}
+
+.bec-checkout-step-hr18 {
+  color: var(--text-muted-hr18);
+}
+
+.bec-checkout-step-hr18 strong {
+  color: var(--accent-hr18);
+}
+
+.bec-checkout-total-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-weight: 600;
+}
+
+/* ---- The reusable carousel component ---------------------------------------------
+   Drop-in markup: a .ease-carousel-blur-hr18 container with a
+   .bec-slide-hr18 per item (only one un-hidden at a time) and prev/next +
+   dot controls. Whenever the active slide changes, the script adds
+   .is-entering-hr18 to the newly visible slide, which plays the
+   blur-entrance keyframe — 100% CSS, driven by the custom properties
+   declared above. */
+.ease-carousel-blur-hr18 {
+  position: relative;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.5rem;
+  box-shadow: 0 1px 2px rgba(10, 20, 10, 0.03), 0 12px 28px rgba(10, 20, 10, 0.05);
+}
+
+.bec-carousel-heading-hr18 {
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+}
+
+.bec-slide-track-hr18 {
+  position: relative;
+  min-height: 160px;
+}
+
+.bec-slide-hr18 {
+  display: none;
+  align-items: center;
+  gap: 1.1rem;
+}
+
+.bec-slide-hr18.is-active-hr18 {
+  display: flex;
+}
+
+.bec-slide-hr18.is-entering-hr18 {
+  animation: ease-blur-carousel-in-hr18 var(--ease-blur-carousel-duration-hr18) var(--ease-blur-carousel-easing-hr18) both;
+}
+
+/* The blur entrance: starts soft, slightly scaled down, and transparent;
+   sharpens and settles to full size and opacity. Amount and scale are
+   both tunable. */
+@keyframes ease-blur-carousel-in-hr18 {
+  0% {
+    opacity: 0;
+    filter: blur(var(--ease-blur-carousel-amount-hr18));
+    transform: scale(var(--ease-blur-carousel-scale-hr18));
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+  }
+}
+
+.bec-slide-thumb-hr18 {
+  width: 84px;
+  height: 84px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display-hr18);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: rgba(0, 0, 0, 0.4);
+}
+
+.bec-slide-thumb-hr18.c1 { background: linear-gradient(135deg, #cfe8d8, #9ed4b3); }
+.bec-slide-thumb-hr18.c2 { background: linear-gradient(135deg, #f4dfc4, #e8bd8a); }
+.bec-slide-thumb-hr18.c3 { background: linear-gradient(135deg, #d8e0f4, #a9bcec); }
+
+.bec-slide-info-hr18 h3 {
+  font-size: 0.95rem;
+}
+
+.bec-slide-info-hr18 p {
+  margin: 0.3rem 0 0.6rem;
+  font-size: 0.8rem;
+  color: var(--text-muted-hr18);
+}
+
+.bec-slide-price-row-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.bec-slide-price-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-weight: 600;
+  color: var(--accent-hr18);
+}
+
+.bec-add-btn-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.76rem;
+  font-weight: 600;
+  border: 1px solid var(--accent-hr18);
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.bec-add-btn-hr18:hover {
+  background: var(--accent-hr18);
+  color: #fff;
+}
+
+/* ---- Controls ------------------------------------------------------------------------ */
+.bec-controls-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1.25rem;
+}
+
+.bec-arrow-btn-hr18 {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  color: var(--text-hr18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.bec-arrow-btn-hr18:hover {
+  border-color: var(--accent-hr18);
+  color: var(--accent-hr18);
+}
+
+.bec-dots-hr18 {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.bec-dot-hr18 {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--border-hr18);
+  cursor: pointer;
+  padding: 0;
+}
+
+.bec-dot-hr18[aria-current="true"] {
+  background: var(--accent-hr18);
+  width: 20px;
+  border-radius: 999px;
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.bec-tuning-hr18 {
+  margin-top: 2rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: var(--radius-hr18);
+  padding: 1.25rem 1.4rem;
+}
+
+.bec-tuning-hr18 h2 {
+  font-size: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.bec-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.bec-tuning-hr18 th,
+.bec-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.bec-tuning-hr18 th {
+  color: var(--text-muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.bec-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+}
+
+.bec-footnote-hr18 {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--text-muted-hr18);
+}
+
+/* ---- Responsive ---------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .bec-slide-hr18 {
+    flex-direction: column;
+    text-align: center;
+  }
+  .bec-slide-price-row-hr18 {
+    justify-content: center;
+  }
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.bec-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bec-slide-hr18.is-entering-hr18 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Carousel with a "Blur-Entrance" slide
transition, styled for e-commerce checkout layouts — framed as a "You
might also like" upsell strip on a checkout review step. Each incoming
slide sharpens into view from a soft blur, slightly scaled down and
transparent, instead of cutting in abruptly. The entrance animation
itself is 100% CSS, driven by exposed custom properties for duration,
easing, blur amount, and scale; JavaScript only tracks the active slide,
toggles the entrance class, and keeps dot indicators + a screen-reader
status region in sync.

Resolves #50512

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/blur-entrance-carousel-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS blur-entrance carousel with tunable timing/blur/scale
via custom properties, plus full keyboard and screen-reader support.

**How does a developer use it?**
```html
<div class="ease-carousel-blur-hr18" role="region" aria-roledescription="carousel" aria-label="You might also like" tabindex="0">
  <div class="bec-slide-track-hr18">
    <div class="bec-slide-hr18 is-active-hr18" data-index="0">...</div>
    <div class="bec-slide-hr18" data-index="1">...</div>
  </div>
  <!-- prev/next + dots -->
</div>
```

**Why does it fit EaseMotion CSS?**
A self-contained interaction with a distinct named animation
(`ease-blur-carousel-in`) exposed entirely through custom properties, per
the issue's ask for zero JS animation overhead — while being genuinely
keyboard accessible (arrow-key navigation on the focused region) and
screen-reader friendly (live status region on slide change).

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18` suffix.
Tested keyboard navigation (Tab to the region, arrow keys to move between
slides, Tab further to reach dots/buttons/Add-to-order links) and the
aria-live announcement in Chrome; haven't checked other browsers yet.