### PR TITLE
feat: add slide-up tabs component for dashboard layouts

### DIFF
--- a/submissions/examples/ease-slide-up-tabs/README.md
+++ b/submissions/examples/ease-slide-up-tabs/README.md
@@ -1,0 +1,46 @@
+# Ease Slide-Up Tabs
+
+## Description
+A pure CSS tabbed interface styled for dashboard/analytics layouts. Switching tabs slides the new panel up into view with a smooth fade, and each panel's mini bar chart animates in with staggered bars. Driven entirely by radio inputs — zero JavaScript.
+
+## Features
+- Slide-up + fade panel transition on tab switch
+- Staggered animated mini bar chart per panel
+- Active tab has a highlighted pill background with glow shadow
+- Fully keyboard accessible (native radio inputs, `role="tablist"`/`"tab"`/`"tabpanel"`)
+- Responsive (stat grid collapses to single column on small screens)
+- Fully customizable via CSS custom properties
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-tabs" role="tablist" aria-label="Dashboard tabs">
+  <input type="radio" name="dash-tab" id="tab1" class="tab-input" checked />
+  <input type="radio" name="dash-tab" id="tab2" class="tab-input" />
+
+  <div class="tab-list">
+    <label for="tab1" class="tab-label" role="tab">Overview</label>
+    <label for="tab2" class="tab-label" role="tab">Traffic</label>
+  </div>
+
+  <div class="tab-panels">
+    <div class="tab-panel panel-1" role="tabpanel">...</div>
+    <div class="tab-panel panel-2" role="tabpanel">...</div>
+  </div>
+</div>
+```
+Each `.tab-panel` needs a unique class (`panel-1`, `panel-2`, ...) matched to its radio's `id` in the CSS rule `#tabN:checked ~ .tab-panels .panel-N`.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--tabs-duration` | `0.45s` | Panel slide-up transition duration |
+| `--tabs-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Timing function |
+| `--tabs-accent` | `#38bdf8` | Active tab / chart accent color |
+| `--tabs-bg` | `#0f1420` | Outer container background |
+| `--tabs-panel-bg` | `#161c2c` | Panel content background |
+
+## Files
+- `demo.html` — live working example with 3 dashboard tabs
+- `style.css` — component styles and all animations
+- `README.md` — this file

--- a/submissions/examples/ease-slide-up-tabs/demo.html
+++ b/submissions/examples/ease-slide-up-tabs/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Slide-Up Tabs — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #05070d;
+      padding: 30px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-tabs" role="tablist" aria-label="Analytics dashboard tabs">
+    <input type="radio" name="dash-tab" id="tab1" class="tab-input" checked />
+    <input type="radio" name="dash-tab" id="tab2" class="tab-input" />
+    <input type="radio" name="dash-tab" id="tab3" class="tab-input" />
+
+    <div class="tab-list">
+      <label for="tab1" class="tab-label" role="tab">Overview</label>
+      <label for="tab2" class="tab-label" role="tab">Traffic</label>
+      <label for="tab3" class="tab-label" role="tab">Revenue</label>
+    </div>
+
+    <div class="tab-panels">
+      <div class="tab-panel panel-1" role="tabpanel">
+        <h3 class="panel-title">Overview</h3>
+        <p class="panel-subtitle">Last 30 days summary</p>
+        <div class="stat-grid">
+          <div class="stat-box">
+            <div class="stat-value">12.4k</div>
+            <div class="stat-label">Active Users</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-value">98.2%</div>
+            <div class="stat-label">Uptime</div>
+          </div>
+        </div>
+        <div class="mini-bar-chart">
+          <span></span><span></span><span></span><span></span><span></span><span></span>
+        </div>
+      </div>
+
+      <div class="tab-panel panel-2" role="tabpanel">
+        <h3 class="panel-title">Traffic</h3>
+        <p class="panel-subtitle">Sessions by source</p>
+        <div class="stat-grid">
+          <div class="stat-box">
+            <div class="stat-value">8.1k</div>
+            <div class="stat-label">Organic</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-value">3.6k</div>
+            <div class="stat-label">Referral</div>
+          </div>
+        </div>
+        <div class="mini-bar-chart">
+          <span></span><span></span><span></span><span></span><span></span><span></span>
+        </div>
+      </div>
+
+      <div class="tab-panel panel-3" role="tabpanel">
+        <h3 class="panel-title">Revenue</h3>
+        <p class="panel-subtitle">Monthly recurring revenue</p>
+        <div class="stat-grid">
+          <div class="stat-box">
+            <div class="stat-value">$24.8k</div>
+            <div class="stat-label">MRR</div>
+          </div>
+          <div class="stat-box">
+            <div class="stat-value">+12%</div>
+            <div class="stat-label">Growth</div>
+          </div>
+        </div>
+        <div class="mini-bar-chart">
+          <span></span><span></span><span></span><span></span><span></span><span></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-slide-up-tabs/style.css
+++ b/submissions/examples/ease-slide-up-tabs/style.css
@@ -1,0 +1,184 @@
+/* Ease Slide-Up Tabs — pure CSS, dashboard analytics style, zero JS */
+
+.ease-tabs {
+  --tabs-bg: #0f1420;
+  --tabs-panel-bg: #161c2c;
+  --tabs-border: #232a3d;
+  --tabs-accent: #38bdf8;
+  --tabs-fg: #f5f7fa;
+  --tabs-muted: #94a3b8;
+  --tabs-duration: 0.45s;
+  --tabs-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tabs-radius: 16px;
+
+  width: min(480px, 92vw);
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  padding: 6px;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-tabs .tab-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+}
+
+.ease-tabs .tab-list {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.ease-tabs .tab-label {
+  flex: 1;
+  text-align: center;
+  padding: 11px 12px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--tabs-muted);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background var(--tabs-duration) ease, color var(--tabs-duration) ease;
+  user-select: none;
+}
+
+.ease-tabs .tab-label:hover {
+  color: var(--tabs-fg);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.ease-tabs .tab-input:focus-visible + .tab-label {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: -2px;
+}
+
+.ease-tabs .tab-input:checked + .tab-label {
+  color: #0b0f19;
+  background: var(--tabs-accent);
+  box-shadow: 0 4px 14px rgba(56, 189, 248, 0.35);
+}
+
+/* ---- panels ---- */
+.ease-tabs .tab-panels {
+  position: relative;
+  background: var(--tabs-panel-bg);
+  border-radius: 12px;
+  min-height: 220px;
+  overflow: hidden;
+}
+
+.ease-tabs .tab-panel {
+  position: absolute;
+  inset: 0;
+  padding: 22px;
+  color: var(--tabs-fg);
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(28px);
+  transition:
+    opacity var(--tabs-duration) var(--tabs-easing),
+    transform var(--tabs-duration) var(--tabs-easing),
+    visibility var(--tabs-duration);
+  pointer-events: none;
+}
+
+/* Each panel shows only when its matching radio is checked.
+   Using :checked + label + ... + panel via general sibling since
+   panels come after all labels in the DOM order. */
+#tab1:checked ~ .tab-panels .panel-1,
+#tab2:checked ~ .tab-panels .panel-2,
+#tab3:checked ~ .tab-panels .panel-3 {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.ease-tabs .panel-title {
+  margin: 0 0 6px;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.ease-tabs .panel-subtitle {
+  margin: 0 0 18px;
+  font-size: 0.78rem;
+  color: var(--tabs-muted);
+}
+
+.ease-tabs .stat-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.ease-tabs .stat-box {
+  background: rgba(56, 189, 248, 0.06);
+  border: 1px solid rgba(56, 189, 248, 0.15);
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.ease-tabs .stat-value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--tabs-accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.ease-tabs .stat-label {
+  font-size: 0.72rem;
+  color: var(--tabs-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+.ease-tabs .mini-bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 60px;
+  margin-top: 16px;
+}
+
+.ease-tabs .mini-bar-chart span {
+  flex: 1;
+  background: linear-gradient(180deg, var(--tabs-accent), #a78bfa);
+  border-radius: 4px 4px 0 0;
+  transform: scaleY(0);
+  transform-origin: bottom;
+  transition: transform 0.5s var(--tabs-easing);
+}
+
+#tab1:checked ~ .tab-panels .panel-1 .mini-bar-chart span,
+#tab2:checked ~ .tab-panels .panel-2 .mini-bar-chart span,
+#tab3:checked ~ .tab-panels .panel-3 .mini-bar-chart span {
+  transform: scaleY(1);
+}
+
+.ease-tabs .mini-bar-chart span:nth-child(1) { height: 40%; transition-delay: 0.1s; }
+.ease-tabs .mini-bar-chart span:nth-child(2) { height: 70%; transition-delay: 0.15s; }
+.ease-tabs .mini-bar-chart span:nth-child(3) { height: 55%; transition-delay: 0.2s; }
+.ease-tabs .mini-bar-chart span:nth-child(4) { height: 90%; transition-delay: 0.25s; }
+.ease-tabs .mini-bar-chart span:nth-child(5) { height: 65%; transition-delay: 0.3s; }
+.ease-tabs .mini-bar-chart span:nth-child(6) { height: 45%; transition-delay: 0.35s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs .tab-panel,
+  .ease-tabs .mini-bar-chart span,
+  .ease-tabs .tab-label {
+    transition: opacity 0.2s ease;
+    transform: none !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .ease-tabs .stat-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Closes #50025

## Pull Request Description
Adds a pure CSS tabbed component styled for dashboard/analytics layouts. Switching tabs slides the new panel up into view with a smooth fade, and each panel's mini bar chart animates in with staggered bars. Driven entirely by radio inputs — zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-slide-up-tabs-savni/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A tabbed dashboard component (`ease-tabs`) where switching tabs triggers a slide-up + fade transition on the panel, with each panel's mini bar chart animating in with staggered bar heights.

**How does a developer use it?**
```html
<div class="ease-tabs" role="tablist" aria-label="Dashboard tabs">
  <input type="radio" name="dash-tab" id="tab1" class="tab-input" checked />
  <input type="radio" name="dash-tab" id="tab2" class="tab-input" />

  <div class="tab-list">
    <label for="tab1" class="tab-label" role="tab">Overview</label>
    <label for="tab2" class="tab-label" role="tab">Traffic</label>
  </div>

  <div class="tab-panels">
    <div class="tab-panel panel-1" role="tabpanel">...</div>
    <div class="tab-panel panel-2" role="tabpanel">...</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Fully pure-CSS, zero-JavaScript state management using the classic hidden-radio + `:checked` sibling-selector pattern, with slide-up/fade panel transitions and staggered bar-chart animations fully controllable via CSS custom properties (`--tabs-duration`, `--tabs-easing`, `--tabs-accent`, etc.) without touching core rules — consistent with the framework's animation-first, zero-dependency philosophy. Built with `role="tablist"`/`"tab"`/`"tabpanel"` semantics on native, keyboard-operable radio inputs, and respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` — 3-tab dashboard example: Overview, Traffic, Revenue)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Panel visibility uses `#tabN:checked ~ .tab-panels .panel-N` per-panel rules since all panels share a common parent after the tab list in the DOM — each panel needs a numbered class matching its corresponding radio input's `id`.