### PR TITLE
feat: add slide-right tabs component with cyberpunk neon styling

### DIFF
--- a/submissions/examples/ease-slide-right-tabs/README.md
+++ b/submissions/examples/ease-slide-right-tabs/README.md
@@ -1,0 +1,46 @@
+# Ease Slide-Right Tabs
+
+## Description
+A pure CSS tabbed interface with a vertical tab list styled for a cyberpunk/neon aesthetic — monospace type, glowing accent bar, and neon-tagged panel content. Switching tabs slides the new panel in horizontally from the right with a fade. Driven entirely by radio inputs — zero JavaScript.
+
+## Features
+- Slide-right + fade panel transition on tab switch
+- Vertical tab list with an animated glowing accent bar on the active tab
+- Staggered tag entrance animation inside each panel
+- Fully keyboard accessible (native radio inputs, `role="tablist"`/`"tab"`/`"tabpanel"`)
+- Responsive — collapses to a horizontal top tab bar on small screens
+- Fully customizable via CSS custom properties
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-tabs-neon" role="tablist" aria-label="System panels">
+  <input type="radio" name="neon-tab" id="ntab1" class="tab-input" checked />
+  <input type="radio" name="neon-tab" id="ntab2" class="tab-input" />
+
+  <div class="tab-list">
+    <label for="ntab1" class="tab-label" role="tab">&gt; SYSTEM</label>
+    <label for="ntab2" class="tab-label" role="tab">&gt; NETWORK</label>
+  </div>
+
+  <div class="tab-panels">
+    <div class="tab-panel panel-1" role="tabpanel">...</div>
+    <div class="tab-panel panel-2" role="tabpanel">...</div>
+  </div>
+</div>
+```
+Each `.tab-panel` needs a unique class (`panel-1`, `panel-2`, ...) matched to its radio's `id` in the CSS rule `#ntabN:checked ~ .tab-panels .panel-N`.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--tabs-duration` | `0.5s` | Panel slide-right transition duration |
+| `--tabs-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Timing function |
+| `--neon-primary` | `#00f0ff` | Active tab / title accent (cyan) |
+| `--neon-secondary` | `#ff00c8` | Tag border/text color (magenta) |
+| `--neon-tertiary` | `#a3ff00` | Focus outline color (lime) |
+
+## Files
+- `demo.html` — live working example with 3 system panels
+- `style.css` — component styles and all animations
+- `README.md` — this file

--- a/submissions/examples/ease-slide-right-tabs/demo.html
+++ b/submissions/examples/ease-slide-right-tabs/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Slide-Right Tabs — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at 50% 20%, #10101f 0%, #05050a 70%);
+      padding: 30px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-tabs-neon" role="tablist" aria-label="System panels">
+    <input type="radio" name="neon-tab" id="ntab1" class="tab-input" checked />
+    <input type="radio" name="neon-tab" id="ntab2" class="tab-input" />
+    <input type="radio" name="neon-tab" id="ntab3" class="tab-input" />
+
+    <div class="tab-list">
+      <label for="ntab1" class="tab-label" role="tab">&gt; SYSTEM</label>
+      <label for="ntab2" class="tab-label" role="tab">&gt; NETWORK</label>
+      <label for="ntab3" class="tab-label" role="tab">&gt; SECURITY</label>
+    </div>
+
+    <div class="tab-panels">
+      <div class="tab-panel panel-1" role="tabpanel">
+        <h3 class="panel-title">SYSTEM STATUS</h3>
+        <p class="panel-subtitle">Core diagnostics</p>
+        <p class="panel-body">
+          All primary subsystems operating within normal parameters.
+          CPU load: 34%. Memory: 6.2GB / 16GB allocated.
+        </p>
+        <div class="panel-tags">
+          <span class="panel-tag">ONLINE</span>
+          <span class="panel-tag">STABLE</span>
+        </div>
+      </div>
+
+      <div class="tab-panel panel-2" role="tabpanel">
+        <h3 class="panel-title">NETWORK TRAFFIC</h3>
+        <p class="panel-subtitle">Live connections</p>
+        <p class="panel-body">
+          482 active connections across 12 nodes. Latency averaging 14ms.
+          No anomalies detected in the last 24 hours.
+        </p>
+        <div class="panel-tags">
+          <span class="panel-tag">LOW LATENCY</span>
+          <span class="panel-tag">ENCRYPTED</span>
+        </div>
+      </div>
+
+      <div class="tab-panel panel-3" role="tabpanel">
+        <h3 class="panel-title">SECURITY SCAN</h3>
+        <p class="panel-subtitle">Threat monitoring</p>
+        <p class="panel-body">
+          Last scan completed 3 minutes ago. Zero threats detected.
+          Firewall rules: 128 active. Intrusion attempts blocked: 7.
+        </p>
+        <div class="panel-tags">
+          <span class="panel-tag">SECURE</span>
+          <span class="panel-tag">MONITORED</span>
+          <span class="panel-tag">7 BLOCKED</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-slide-right-tabs/style.css
+++ b/submissions/examples/ease-slide-right-tabs/style.css
@@ -1,0 +1,198 @@
+/* Ease Slide-Right Tabs — pure CSS, cyberpunk neon style, zero JS */
+
+.ease-tabs-neon {
+  --neon-primary: #00f0ff;
+  --neon-secondary: #ff00c8;
+  --neon-tertiary: #a3ff00;
+  --tabs-bg: #0a0a12;
+  --tabs-panel-bg: #10101c;
+  --tabs-border: #1e1e2e;
+  --tabs-fg: #eaf9ff;
+  --tabs-muted: #6b7a90;
+  --tabs-duration: 0.5s;
+  --tabs-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tabs-radius: 16px;
+
+  display: flex;
+  width: min(560px, 92vw);
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  overflow: hidden;
+  font-family: 'Courier New', monospace;
+}
+
+.ease-tabs-neon .tab-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+}
+
+.ease-tabs-neon .tab-list {
+  display: flex;
+  flex-direction: column;
+  width: 140px;
+  flex-shrink: 0;
+  padding: 14px 8px;
+  gap: 4px;
+  border-right: 1px solid var(--tabs-border);
+  background: linear-gradient(180deg, #0d0d18, #0a0a12);
+}
+
+.ease-tabs-neon .tab-label {
+  position: relative;
+  padding: 12px 14px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--tabs-muted);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: color var(--tabs-duration) ease, background var(--tabs-duration) ease;
+  user-select: none;
+  overflow: hidden;
+}
+
+.ease-tabs-neon .tab-label::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: var(--neon-primary);
+  transform: scaleY(0);
+  transition: transform var(--tabs-duration) var(--tabs-easing);
+  box-shadow: 0 0 10px var(--neon-primary);
+}
+
+.ease-tabs-neon .tab-label:hover {
+  color: var(--tabs-fg);
+  background: rgba(0, 240, 255, 0.05);
+}
+
+.ease-tabs-neon .tab-input:focus-visible + .tab-label {
+  outline: 2px solid var(--neon-tertiary);
+  outline-offset: -2px;
+}
+
+.ease-tabs-neon .tab-input:checked + .tab-label {
+  color: var(--neon-primary);
+  background: rgba(0, 240, 255, 0.08);
+  text-shadow: 0 0 8px rgba(0, 240, 255, 0.6);
+}
+
+.ease-tabs-neon .tab-input:checked + .tab-label::before {
+  transform: scaleY(1);
+}
+
+/* ---- panels: slide in from the right ---- */
+.ease-tabs-neon .tab-panels {
+  position: relative;
+  flex: 1;
+  background: var(--tabs-panel-bg);
+  min-height: 260px;
+  overflow: hidden;
+}
+
+.ease-tabs-neon .tab-panel {
+  position: absolute;
+  inset: 0;
+  padding: 24px;
+  color: var(--tabs-fg);
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(40px);
+  transition:
+    opacity var(--tabs-duration) var(--tabs-easing),
+    transform var(--tabs-duration) var(--tabs-easing),
+    visibility var(--tabs-duration);
+  pointer-events: none;
+}
+
+#ntab1:checked ~ .tab-panels .panel-1,
+#ntab2:checked ~ .tab-panels .panel-2,
+#ntab3:checked ~ .tab-panels .panel-3 {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.ease-tabs-neon .panel-title {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: var(--neon-primary);
+  text-shadow: 0 0 12px rgba(0, 240, 255, 0.5);
+  letter-spacing: 0.03em;
+}
+
+.ease-tabs-neon .panel-subtitle {
+  margin: 0 0 18px;
+  font-size: 0.75rem;
+  color: var(--tabs-muted);
+}
+
+.ease-tabs-neon .panel-body {
+  font-size: 0.82rem;
+  line-height: 1.7;
+  color: #b8c5d6;
+}
+
+.ease-tabs-neon .panel-tags {
+  display: flex;
+  gap: 8px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+
+.ease-tabs-neon .panel-tag {
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 5px 11px;
+  border-radius: 999px;
+  border: 1px solid var(--neon-secondary);
+  color: var(--neon-secondary);
+  text-shadow: 0 0 6px rgba(255, 0, 200, 0.5);
+
+  opacity: 0;
+  transform: translateX(15px);
+  transition: opacity var(--tabs-duration) ease, transform var(--tabs-duration) var(--tabs-easing);
+}
+
+#ntab1:checked ~ .tab-panels .panel-1 .panel-tag,
+#ntab2:checked ~ .tab-panels .panel-2 .panel-tag,
+#ntab3:checked ~ .tab-panels .panel-3 .panel-tag {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.ease-tabs-neon .panel-tag:nth-child(1) { transition-delay: 0.1s; }
+.ease-tabs-neon .panel-tag:nth-child(2) { transition-delay: 0.18s; }
+.ease-tabs-neon .panel-tag:nth-child(3) { transition-delay: 0.26s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-neon .tab-panel,
+  .ease-tabs-neon .panel-tag,
+  .ease-tabs-neon .tab-label::before {
+    transition: opacity 0.2s ease;
+    transform: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .ease-tabs-neon {
+    flex-direction: column;
+  }
+  .ease-tabs-neon .tab-list {
+    flex-direction: row;
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--tabs-border);
+  }
+  .ease-tabs-neon .tab-label::before {
+    left: 0; right: 0; top: auto; bottom: 0;
+    width: auto; height: 3px;
+  }
+}


### PR DESCRIPTION
Closes #50251

## Pull Request Description
Adds a pure CSS tabbed component with a vertical tab list styled for a cyberpunk/neon aesthetic. Switching tabs slides the new panel in horizontally from the right with a fade, and tag elements inside each panel animate in staggered. Driven entirely by radio inputs — zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-slide-right-tabs-savni/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A vertical-tab-list dashboard component (`ease-tabs-neon`) styled with a cyberpunk/neon aesthetic — monospace type, glowing accent bar on the active tab, and neon-outlined tag pills — where switching tabs slides the panel in from the right with a fade and staggered tag entrance.

**How does a developer use it?**
```html
<div class="ease-tabs-neon" role="tablist" aria-label="System panels">
  <input type="radio" name="neon-tab" id="ntab1" class="tab-input" checked />
  <input type="radio" name="neon-tab" id="ntab2" class="tab-input" />

  <div class="tab-list">
    <label for="ntab1" class="tab-label" role="tab">&gt; SYSTEM</label>
    <label for="ntab2" class="tab-label" role="tab">&gt; NETWORK</label>
  </div>

  <div class="tab-panels">
    <div class="tab-panel panel-1" role="tabpanel">...</div>
    <div class="tab-panel panel-2" role="tabpanel">...</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Fully pure-CSS, zero-JavaScript state management using the hidden-radio + `:checked` sibling-selector pattern, with slide-right/fade panel transitions and staggered tag animations fully controllable via CSS custom properties (`--tabs-duration`, `--tabs-easing`, `--neon-primary/secondary/tertiary`, etc.) without touching core rules — consistent with the framework's animation-first, zero-dependency philosophy. Built with `role="tablist"`/`"tab"`/`"tabpanel"` semantics on native, keyboard-operable radio inputs, collapses responsively to a horizontal tab bar on small screens, and respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` — 3-panel system dashboard: System, Network, Security)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Panel visibility uses `#ntabN:checked ~ .tab-panels .panel-N` per-panel rules since all panels share a common parent after the tab list in the DOM — each panel needs a numbered class matching its corresponding radio input's `id`. This pairs with the earlier `ease-slide-up-tabs` (#50025) submission as a companion "slide direction" variant.