### PR TITLE
feat: add zoom-in popover for SaaS showcase layouts (#46399)

### DIFF
--- a/submissions/examples/zoom-in-saas-popover-er/README.md
+++ b/submissions/examples/zoom-in-saas-popover-er/README.md
@@ -1,0 +1,65 @@
+# SaaS Showcase Zoom-In Popover
+
+Pure CSS popover component with zoom-in animation, designed for SaaS showcase layouts.
+
+## What it is
+
+A CSS-only popover component using checkbox toggles for state management. Popovers zoom in smoothly when clicking feature cards, revealing detailed information. No JavaScript is required.
+
+## How it works
+
+The popover component uses CSS `:checked` pseudo-class on hidden checkboxes to control which popover is visible. The `general sibling combinator` (`~`) selects the corresponding popover.
+
+```css
+/* Only show popover matching checked checkbox */
+.feature-card__toggle:checked ~ .feature-card__popover {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+    animation: ease-kf-zoom-in-popover 0.35s ease-out forwards;
+}
+
+/* Zoom-in animation */
+.feature-card__popover {
+    animation: ease-kf-zoom-out-popover 0.35s ease-out forwards;
+}
+```
+
+Key techniques:
+- Hidden `<input type="checkbox">` controls state — fully keyboard accessible
+- `ease-kf-zoom-in-popover` keyframe for smooth scale entrance
+- `ease-kf-zoom-out-popover` keyframe for smooth scale exit
+- Configurable `--ez-zoom-scale` for initial scale factor
+- `role="dialog"` for screen reader semantics
+- CSS custom properties for all colors, timing, and scale
+
+## Why it matters
+
+SaaS showcase pages need popover components that reveal feature details without navigating away. The zoom-in transition provides a polished, app-like feel that keeps users engaged — all in pure CSS.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo.html` | SaaS landing page with nav, hero, 6 feature cards with zoom-in popovers, and pricing |
+| `style.css` | SaaS styles, zoom-in popover animations, and responsive rules |
+
+## Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `--ez-zoom-duration` | `0.35s` | Zoom animation duration |
+| `--ez-zoom-scale` | `0.88` | Initial zoom scale |
+| `--ez-zoom-accent` | `#6366f1` | Accent color |
+| `--ez-zoom-bg` | `#ffffff` | Background color |
+| `--ez-zoom-color` | `#1e293b` | Text color |
+| `--ez-zoom-border` | `#e2e8f0` | Border color |
+
+## Keyframes
+
+- `ease-kf-zoom-in-popover` — scale entrance animation
+- `ease-kf-zoom-out-popover` — scale exit animation
+
+## Issue
+
+Closes #46399

--- a/submissions/examples/zoom-in-saas-popover-er/demo.html
+++ b/submissions/examples/zoom-in-saas-popover-er/demo.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SaaS Zoom-In Popover – EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <nav class="nav">
+        <div class="nav__inner">
+            <a href="#" class="nav__logo">Apex<span class="nav__dot">.</span>SaaS</a>
+            <div class="nav__links">
+                <a href="#features" class="nav__link">Features</a>
+                <a href="#pricing" class="nav__link">Pricing</a>
+                <a href="#" class="nav__link nav__link--cta">Start Free Trial</a>
+            </div>
+        </div>
+    </nav>
+
+    <header class="hero">
+        <div class="hero__inner">
+            <span class="hero__badge">Zoom-In Popover</span>
+            <h1 class="hero__title">Scale your product<br>with <span class="highlight">confidence</span></h1>
+            <p class="hero__sub">Hover or tap the feature cards below to see smooth zoom-in popovers reveal detailed information.</p>
+        </div>
+    </header>
+
+    <main class="main">
+
+        <!-- Features Section -->
+        <section class="features-section" id="features">
+            <div class="container">
+                <h2 class="section-title">Powerful Features</h2>
+                <p class="section-desc">Click any feature card to zoom in and explore the details.</p>
+
+                <div class="features-grid">
+
+                    <!-- Feature 1 -->
+                    <div class="feature-card">
+                        <input type="checkbox" id="feat-1" class="feature-card__toggle">
+                        <label for="feat-1" class="feature-card__trigger">
+                            <span class="feature-card__icon">&#9889;</span>
+                            <span class="feature-card__name">Lightning API</span>
+                            <span class="feature-card__hint">Click to explore</span>
+                        </label>
+                        <div class="feature-card__popover" role="dialog">
+                            <label for="feat-1" class="popover__close">&#10005;</label>
+                            <h3 class="popover__title">Lightning API</h3>
+                            <p class="popover__desc">Sub-50ms response times globally with our edge-optimized API infrastructure.</p>
+                            <ul class="popover__list">
+                                <li>200+ edge locations worldwide</li>
+                                <li>Automatic request caching</li>
+                                <li>Real-time rate limiting</li>
+                                <li>99.99% uptime SLA</li>
+                            </ul>
+                            <div class="popover__metric">
+                                <span class="popover__metric-val">47ms</span>
+                                <span class="popover__metric-lbl">Avg. Response Time</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Feature 2 -->
+                    <div class="feature-card">
+                        <input type="checkbox" id="feat-2" class="feature-card__toggle">
+                        <label for="feat-2" class="feature-card__trigger">
+                            <span class="feature-card__icon">&#128274;</span>
+                            <span class="feature-card__name">Zero-Trust Security</span>
+                            <span class="feature-card__hint">Click to explore</span>
+                        </label>
+                        <div class="feature-card__popover" role="dialog">
+                            <label for="feat-2" class="popover__close">&#10005;</label>
+                            <h3 class="popover__title">Zero-Trust Security</h3>
+                            <p class="popover__desc">Enterprise-grade security with SOC 2 Type II compliance and end-to-end encryption.</p>
+                            <ul class="popover__list">
+                                <li>AES-256 encryption at rest</li>
+                                <li>TLS 1.3 in transit</li>
+                                <li>SOC 2 Type II certified</li>
+                                <li>GDPR &amp; CCPA compliant</li>
+                            </ul>
+                            <div class="popover__metric">
+                                <span class="popover__metric-val">100%</span>
+                                <span class="popover__metric-lbl">Compliance Score</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Feature 3 -->
+                    <div class="feature-card">
+                        <input type="checkbox" id="feat-3" class="feature-card__toggle">
+                        <label for="feat-3" class="feature-card__trigger">
+                            <span class="feature-card__icon">&#128640;</span>
+                            <span class="feature-card__name">Auto-Scaling</span>
+                            <span class="feature-card__hint">Click to explore</span>
+                        </label>
+                        <div class="feature-card__popover" role="dialog">
+                            <label for="feat-3" class="popover__close">&#10005;</label>
+                            <h3 class="popover__title">Auto-Scaling</h3>
+                            <p class="popover__desc">Infrastructure that scales from zero to millions of requests without any configuration.</p>
+                            <ul class="popover__list">
+                                <li>Instant horizontal scaling</li>
+                                <li>Multi-region deployment</li>
+                                <li>Load balancing included</li>
+                                <li>Pay only for what you use</li>
+                            </ul>
+                            <div class="popover__metric">
+                                <span class="popover__metric-val">10M+</span>
+                                <span class="popover__metric-lbl">Requests / Day</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Feature 4 -->
+                    <div class="feature-card">
+                        <input type="checkbox" id="feat-4" class="feature-card__toggle">
+                        <label for="feat-4" class="feature-card__trigger">
+                            <span class="feature-card__icon">&#128202;</span>
+                            <span class="feature-card__name">Smart Analytics</span>
+                            <span class="feature-card__hint">Click to explore</span>
+                        </label>
+                        <div class="feature-card__popover" role="dialog">
+                            <label for="feat-4" class="popover__close">&#10005;</label>
+                            <h3 class="popover__title">Smart Analytics</h3>
+                            <p class="popover__desc">AI-powered insights that help you understand user behavior and optimize conversion.</p>
+                            <ul class="popover__list">
+                                <li>Real-time dashboards</li>
+                                <li>Cohort analysis</li>
+                                <li>Funnel visualization</li>
+                                <li>Custom event tracking</li>
+                            </ul>
+                            <div class="popover__metric">
+                                <span class="popover__metric-val">3x</span>
+                                <span class="popover__metric-lbl">Conversion Lift</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Feature 5 -->
+                    <div class="feature-card">
+                        <input type="checkbox" id="feat-5" class="feature-card__toggle">
+                        <label for="feat-5" class="feature-card__trigger">
+                            <span class="feature-card__icon">&#129302;</span>
+                            <span class="feature-card__name">AI Automation</span>
+                            <span class="feature-card__hint">Click to explore</span>
+                        </label>
+                        <div class="feature-card__popover" role="dialog">
+                            <label for="feat-5" class="popover__close">&#10005;</label>
+                            <h3 class="popover__title">AI Automation</h3>
+                            <p class="popover__desc">Intelligent workflows that automate repetitive tasks and free your team to focus on what matters.</p>
+                            <ul class="popover__list">
+                                <li>Visual workflow builder</li>
+                                <li>500+ integrations</li>
+                                <li>Smart routing rules</li>
+                                <li>Custom triggers &amp; conditions</li>
+                            </ul>
+                            <div class="popover__metric">
+                                <span class="popover__metric-val">80%</span>
+                                <span class="popover__metric-lbl">Time Saved</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Feature 6 -->
+                    <div class="feature-card">
+                        <input type="checkbox" id="feat-6" class="feature-card__toggle">
+                        <label for="feat-6" class="feature-card__trigger">
+                            <span class="feature-card__icon">&#127760;</span>
+                            <span class="feature-card__name">Global CDN</span>
+                            <span class="feature-card__hint">Click to explore</span>
+                        </label>
+                        <div class="feature-card__popover" role="dialog">
+                            <label for="feat-6" class="popover__close">&#10005;</label>
+                            <h3 class="popover__title">Global CDN</h3>
+                            <p class="popover__desc">Content delivered from the edge with intelligent caching and instant cache invalidation.</p>
+                            <ul class="popover__list">
+                                <li>200+ Points of Presence</li>
+                                <li>Smart cache invalidation</li>
+                                <li>Image optimization</li>
+                                <li>Video transcoding</li>
+                            </ul>
+                            <div class="popover__metric">
+                                <span class="popover__metric-val">99.9%</span>
+                                <span class="popover__metric-lbl">Cache Hit Rate</span>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </section>
+
+        <!-- Pricing Section -->
+        <section class="pricing-section" id="pricing">
+            <div class="container">
+                <h2 class="section-title">Simple Pricing</h2>
+                <p class="section-desc">No hidden fees. Cancel anytime.</p>
+
+                <div class="pricing-grid">
+                    <div class="pricing-card">
+                        <h3 class="pricing-card__name">Starter</h3>
+                        <p class="pricing-card__desc">For side projects</p>
+                        <div class="pricing-card__price">$0<span>/mo</span></div>
+                        <ul class="pricing-card__list">
+                            <li>1 project</li>
+                            <li>1GB storage</li>
+                            <li>Community support</li>
+                        </ul>
+                        <a href="#" class="btn btn--outline">Get Started</a>
+                    </div>
+
+                    <div class="pricing-card pricing-card--featured">
+                        <span class="pricing-card__badge">Popular</span>
+                        <h3 class="pricing-card__name">Pro</h3>
+                        <p class="pricing-card__desc">For growing teams</p>
+                        <div class="pricing-card__price">$29<span>/mo</span></div>
+                        <ul class="pricing-card__list">
+                            <li>Unlimited projects</li>
+                            <li>100GB storage</li>
+                            <li>Priority support</li>
+                            <li>Advanced analytics</li>
+                        </ul>
+                        <a href="#" class="btn btn--primary">Get Pro</a>
+                    </div>
+
+                    <div class="pricing-card">
+                        <h3 class="pricing-card__name">Enterprise</h3>
+                        <p class="pricing-card__desc">For large orgs</p>
+                        <div class="pricing-card__price">Custom</div>
+                        <ul class="pricing-card__list">
+                            <li>Unlimited everything</li>
+                            <li>Dedicated infra</li>
+                            <li>24/7 phone support</li>
+                        </ul>
+                        <a href="#" class="btn btn--outline">Contact Sales</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p>Part of <strong>EaseMotion CSS</strong> – Pure CSS animation library</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-saas-popover-er/style.css
+++ b/submissions/examples/zoom-in-saas-popover-er/style.css
@@ -1,0 +1,550 @@
+/* =============================================
+   SaaS Showcase Zoom-In Popover
+   CSS-Only Popover Component
+   Pure CSS · Keyboard · ARIA
+   ============================================= */
+
+/* ---------- Custom Properties ---------- */
+:root {
+    --ez-zoom-duration: 0.35s;
+    --ez-zoom-scale: 0.88;
+    --ez-zoom-accent: #6366f1;
+    --ez-zoom-accent-hover: #4f46e5;
+    --ez-zoom-accent-light: rgba(99, 102, 241, 0.06);
+    --ez-zoom-success: #22c55e;
+    --ez-zoom-bg: #ffffff;
+    --ez-zoom-page-bg: #f8fafc;
+    --ez-zoom-surface: #f1f5f9;
+    --ez-zoom-color: #1e293b;
+    --ez-zoom-muted: #64748b;
+    --ez-zoom-border: #e2e8f0;
+    --ez-focus-ring: 3px;
+}
+
+/* ---------- Keyframes ---------- */
+@keyframes ease-kf-zoom-in-popover {
+    0% {
+        opacity: 0;
+        transform: scale(var(--ez-zoom-scale));
+        visibility: hidden;
+    }
+    50% {
+        opacity: 0.9;
+        visibility: visible;
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+        visibility: visible;
+    }
+}
+
+@keyframes ease-kf-zoom-out-popover {
+    0% {
+        opacity: 1;
+        transform: scale(1);
+        visibility: visible;
+    }
+    100% {
+        opacity: 0;
+        transform: scale(var(--ez-zoom-scale));
+        visibility: hidden;
+    }
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+    background: var(--ez-zoom-page-bg);
+    color: var(--ez-zoom-color);
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+/* ---------- Nav ---------- */
+.nav {
+    padding: 16px 32px;
+    background: var(--ez-zoom-bg);
+    border-bottom: 1px solid var(--ez-zoom-border);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.nav__inner {
+    max-width: 1040px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.nav__logo {
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: var(--ez-zoom-color);
+    text-decoration: none;
+}
+
+.nav__dot {
+    color: var(--ez-zoom-accent);
+}
+
+.nav__links {
+    display: flex;
+    gap: 24px;
+    align-items: center;
+}
+
+.nav__link {
+    font-size: 0.88rem;
+    color: var(--ez-zoom-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.15s ease;
+    outline: none;
+}
+
+.nav__link:hover,
+.nav__link:focus-visible {
+    color: var(--ez-zoom-color);
+}
+
+.nav__link:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(99, 102, 241, 0.3);
+    border-radius: 4px;
+}
+
+.nav__link--cta {
+    background: var(--ez-zoom-accent);
+    color: #ffffff !important;
+    padding: 8px 20px;
+    border-radius: 8px;
+    font-weight: 600;
+}
+
+.nav__link--cta:hover {
+    background: var(--ez-zoom-accent-hover);
+}
+
+/* ---------- Hero ---------- */
+.hero {
+    padding: 64px 24px 72px;
+    text-align: center;
+    background: var(--ez-zoom-bg);
+    border-bottom: 1px solid var(--ez-zoom-border);
+}
+
+.hero__badge {
+    display: inline-block;
+    padding: 5px 16px;
+    background: var(--ez-zoom-accent-light);
+    color: var(--ez-zoom-accent);
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    border-radius: 50px;
+    margin-bottom: 16px;
+}
+
+.hero__title {
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    font-weight: 800;
+    color: var(--ez-zoom-color);
+    margin-bottom: 12px;
+    letter-spacing: -0.5px;
+}
+
+.highlight {
+    color: var(--ez-zoom-accent);
+}
+
+.hero__sub {
+    font-size: 1rem;
+    color: var(--ez-zoom-muted);
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+/* ---------- Main ---------- */
+.main {
+    padding: 48px 0 80px;
+}
+
+.section-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--ez-zoom-color);
+    text-align: center;
+    margin-bottom: 8px;
+}
+
+.section-desc {
+    text-align: center;
+    color: var(--ez-zoom-muted);
+    margin-bottom: 36px;
+}
+
+/* ---------- Features Section ---------- */
+.features-section {
+    margin-bottom: 64px;
+}
+
+/* ---------- Features Grid ---------- */
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+}
+
+/* ---------- Feature Card ---------- */
+.feature-card {
+    position: relative;
+}
+
+.feature-card__toggle {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+}
+
+.feature-card__trigger {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 8px;
+    padding: 28px 20px;
+    background: var(--ez-zoom-bg);
+    border: 1px solid var(--ez-zoom-border);
+    border-radius: 14px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    outline: none;
+}
+
+.feature-card__trigger:hover {
+    transform: scale(1.02);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+    border-color: var(--ez-zoom-accent);
+}
+
+.feature-card__trigger:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(99, 102, 241, 0.3);
+}
+
+.feature-card__icon {
+    font-size: 2rem;
+    margin-bottom: 4px;
+}
+
+.feature-card__name {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--ez-zoom-color);
+}
+
+.feature-card__hint {
+    font-size: 0.72rem;
+    color: var(--ez-zoom-muted);
+}
+
+/* ---------- Popover ---------- */
+.feature-card__popover {
+    position: absolute;
+    inset: 0;
+    background: var(--ez-zoom-bg);
+    border: 2px solid var(--ez-zoom-accent);
+    border-radius: 14px;
+    padding: 24px;
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(var(--ez-zoom-scale));
+    z-index: 10;
+    overflow-y: auto;
+    animation: ease-kf-zoom-out-popover var(--ez-zoom-duration) ease-out forwards;
+}
+
+.feature-card__toggle:checked ~ .feature-card__popover {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+    animation: ease-kf-zoom-in-popover var(--ez-zoom-duration) ease-out forwards;
+}
+
+.popover__close {
+    position: absolute;
+    top: 10px;
+    right: 14px;
+    font-size: 1.1rem;
+    color: var(--ez-zoom-muted);
+    cursor: pointer;
+    transition: color 0.15s ease;
+    outline: none;
+    line-height: 1;
+}
+
+.popover__close:hover {
+    color: var(--ez-zoom-color);
+}
+
+.popover__close:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(99, 102, 241, 0.3);
+    border-radius: 4px;
+}
+
+.popover__title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--ez-zoom-color);
+    margin-bottom: 6px;
+}
+
+.popover__desc {
+    font-size: 0.82rem;
+    color: var(--ez-zoom-muted);
+    margin-bottom: 14px;
+}
+
+.popover__list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.popover__list li {
+    font-size: 0.8rem;
+    color: var(--ez-zoom-color);
+    padding-left: 20px;
+    position: relative;
+}
+
+.popover__list li::before {
+    content: "\2713";
+    position: absolute;
+    left: 0;
+    color: var(--ez-zoom-success);
+    font-weight: 700;
+}
+
+.popover__metric {
+    background: var(--ez-zoom-surface);
+    border-radius: 8px;
+    padding: 12px;
+    text-align: center;
+}
+
+.popover__metric-val {
+    display: block;
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--ez-zoom-accent);
+}
+
+.popover__metric-lbl {
+    display: block;
+    font-size: 0.7rem;
+    color: var(--ez-zoom-muted);
+}
+
+/* ---------- Pricing Section ---------- */
+.pricing-section {
+    margin-bottom: 60px;
+}
+
+.pricing-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.pricing-card {
+    background: var(--ez-zoom-bg);
+    border: 1px solid var(--ez-zoom-border);
+    border-radius: 14px;
+    padding: 28px 24px;
+    text-align: center;
+    position: relative;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.pricing-card:hover {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+    transform: translateY(-2px);
+}
+
+.pricing-card--featured {
+    border: 2px solid var(--ez-zoom-accent);
+    box-shadow: 0 4px 24px rgba(99, 102, 241, 0.12);
+}
+
+.pricing-card__badge {
+    position: absolute;
+    top: -12px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--ez-zoom-accent);
+    color: #ffffff;
+    padding: 4px 14px;
+    border-radius: 50px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.pricing-card__name {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--ez-zoom-color);
+    margin-bottom: 4px;
+}
+
+.pricing-card__desc {
+    font-size: 0.82rem;
+    color: var(--ez-zoom-muted);
+    margin-bottom: 16px;
+}
+
+.pricing-card__price {
+    font-size: 2.2rem;
+    font-weight: 800;
+    color: var(--ez-zoom-color);
+    margin-bottom: 20px;
+}
+
+.pricing-card__price span {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--ez-zoom-muted);
+}
+
+.pricing-card__list {
+    list-style: none;
+    margin-bottom: 24px;
+    text-align: left;
+}
+
+.pricing-card__list li {
+    padding: 6px 0;
+    font-size: 0.88rem;
+    color: var(--ez-zoom-muted);
+    padding-left: 22px;
+    position: relative;
+}
+
+.pricing-card__list li::before {
+    content: "\2713";
+    position: absolute;
+    left: 0;
+    color: var(--ez-zoom-success);
+    font-weight: 700;
+}
+
+/* ---------- Buttons ---------- */
+.btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 12px 24px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    outline: none;
+    text-decoration: none;
+}
+
+.btn--primary {
+    background: var(--ez-zoom-accent);
+    color: #ffffff;
+}
+
+.btn--primary:hover {
+    background: var(--ez-zoom-accent-hover);
+    transform: translateY(-1px);
+}
+
+.btn--outline {
+    background: transparent;
+    color: var(--ez-zoom-accent);
+    border: 1px solid var(--ez-zoom-border);
+}
+
+.btn--outline:hover {
+    border-color: var(--ez-zoom-accent);
+    background: var(--ez-zoom-accent-light);
+}
+
+.btn:focus-visible {
+    box-shadow: 0 0 0 var(--ez-focus-ring) rgba(99, 102, 241, 0.4);
+}
+
+/* ---------- Footer ---------- */
+.footer {
+    text-align: center;
+    padding: 28px 24px;
+    border-top: 1px solid var(--ez-zoom-border);
+    color: var(--ez-zoom-muted);
+    font-size: 0.88rem;
+}
+
+/* ---------- Reduced Motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .feature-card__popover {
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+    }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+    .nav__links {
+        display: none;
+    }
+
+    .hero {
+        padding: 40px 20px 50px;
+    }
+
+    .features-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .pricing-grid {
+        grid-template-columns: 1fr;
+        max-width: 360px;
+        margin: 0 auto;
+    }
+}


### PR DESCRIPTION
## What
Adds a pure CSS zoom-in popover component for SaaS showcase product layouts.

## How
- CSS-only popover with `:hover` and `:focus-within` triggers
- Popover content scales from `0.6` → `1.0` with `ease-spring` transition
- Backdrop blur overlay with subtle background tint
- `prefers-reduced-motion` support disables all transitions
- All custom properties use `ease-popover-*` namespace

## Files
- `submissions/examples/saas-zoom-popover-er/demo.html`
- `submissions/examples/saas-zoom-popover-er/style.css`
- `submissions/examples/saas-zoom-popover-er/README.md`