### PR TITLE
docs: add css scale-hover tabs for portfolio layouts (#50093)

### DIFF
--- a/submissions/examples/ease-tabs-portfolio-pp/README.md
+++ b/submissions/examples/ease-tabs-portfolio-pp/README.md
@@ -1,0 +1,45 @@
+# CSS Scale-Hover Tabs for Creative Portfolio Layouts
+
+A pure CSS animated Tabs component utilizing scale-hover label interactions and sliding active highlights, styled to complement creative design portfolios.
+
+---
+
+## 1. What does this do?
+This showcase presents a pure CSS sliding active highlight navigation tabs layout, featuring vertical slide-fade animations on grid contents and custom parameters sliders.
+
+---
+
+## 2. How is it used?
+Configure standard `<input type="radio">` hooks and declare matching label indicators inside your layout wrappers:
+
+```html
+<!-- Main tabs container wrapper -->
+<div class="ease-portfolio-container">
+  <input type="radio" id="tab-1" name="my-tabs" class="ease-tab-radio" checked />
+  <!-- Navigation labels trigger -->
+  <div class="ease-tabs-nav">
+    <label for="tab-1" class="ease-tab-label" tabindex="0">Portfolio Item</label>
+    <!-- Sliding highlight bubble backer -->
+    <div class="ease-tab-bubble"></div>
+  </div>
+</div>
+```
+
+---
+
+## 3. Why is it useful?
+It demonstrates how to configure complex interactive components with zero JavaScript runtime overhead, guarantees screen reader accessibility through standard focus states, and enables theme adjustments via CSS variables.
+
+---
+
+## Technical Specifications & Suffix
+
+- **Folder Path:** `submissions/examples/ease-tabs-portfolio-pp/`
+- **Contributor Suffix:** `pp` (Pratyush Panda)
+- **Resolved Ticket:** [Issue #50093](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/50093)
+
+### Included Layout Features:
+1. **Interactive Tabs Playground Board:** Showcase grid containing beautiful creative agency cards (photography, design, motion).
+2. **Parameters Customizer:** Sliders to adjust scale factors, transition speed rates, easing presets, and active bubble colors.
+3. **Accessibility Integration:** Tab-index support and Enter key trigger behaviors.
+4. **Interactive Quiz:** In-app quiz on CSS selectors and accessibility rules.

--- a/submissions/examples/ease-tabs-portfolio-pp/demo.html
+++ b/submissions/examples/ease-tabs-portfolio-pp/demo.html
@@ -1,0 +1,586 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scale-Hover Tabs for Creative Portfolio Layouts</title>
+  
+  <!-- SEO & Accessibility Metadata -->
+  <meta name="description" content="An interactive showcase demonstrating pure CSS scale-hover active portfolio tabs, visual card layouts, custom variables config, and keyboard accessibility." />
+  <meta name="author" content="Pratyush Panda (pp)" />
+  
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  
+  <!-- EaseMotion CSS from CDN -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+  
+  <!-- Local Styles -->
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+
+  <!-- Theme Toggle Button -->
+  <button class="pp-theme-toggle" id="themeToggleBtn" aria-label="Toggle Dark/Light Mode">
+    <!-- Sun Icon (shown in dark mode) -->
+    <svg id="sunIcon" style="display:none;" viewBox="0 0 24 24">
+      <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0s-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41l-1.06-1.06zm1.06-12.37c-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.38.39-1.02 0-1.41zM5.99 18.01l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06c.39-.39.39-1.03 0-1.41z"/>
+    </svg>
+    <!-- Moon Icon (shown in light mode) -->
+    <svg id="moonIcon" viewBox="0 0 24 24">
+      <path d="M9.37 5.51c-.18-.64-.86-1.02-1.5-.84-2.32.63-4.13 2.5-4.7 4.88-.66 2.76.62 5.57 3.03 6.77.34.17.65.41.9.7l1.06 1.18c1.3 1.45 3.39 1.83 5.09 1 .73-.36 1.34-.9 1.81-1.57.4-.57.19-1.35-.47-1.63-3.64-1.55-5.91-5.32-5.46-9.45.08-.75-.5-1.4-1.26-1.07z"/>
+    </svg>
+  </button>
+
+  <header class="pp-header">
+    <div class="pp-container">
+      <span class="pp-eyebrow">Creative Portfolio Sandbox</span>
+      <h1>CSS Scale-Hover Portfolio Tabs</h1>
+      <p class="pp-subtitle">
+        Explore a pure CSS layout tabs pattern utilizing scale-hover label variables and radio input bindings. 
+        Tweak active sliders, customize speed variables, and inspect the keyboard-friendly HTML structure.
+      </p>
+      <div class="pp-meta-badge">
+        <span>Resolves</span> Issue #50093
+      </div>
+    </div>
+  </header>
+
+  <main class="pp-container pp-main-grid">
+
+    <!-- Section: The Playground -->
+    <section class="pp-card pp-card-primary" aria-labelledby="playground-heading">
+      <h2 class="pp-card-title" id="playground-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line><line x1="15" y1="3" x2="15" y2="21"></line><line x1="3" y1="9" x2="21" y2="9"></line><line x1="3" y1="15" x2="21" y2="15"></line></svg>
+        Tactile Studio Board
+      </h2>
+      <p class="pp-card-desc">
+        Click on the navigation tab list below to switch active portfolios. Tweak the variables parameters in the side drawer.
+      </p>
+
+      <div class="pp-playground-grid" id="tabsSandbox">
+        <!-- The Tabs shell structure -->
+        <div class="ease-portfolio-container">
+          <!-- Hidden inputs for pure CSS state mapping -->
+          <input type="radio" id="tab-photo" name="portfolio-tabs" class="ease-tab-radio" checked />
+          <input type="radio" id="tab-design" name="portfolio-tabs" class="ease-tab-radio" />
+          <input type="radio" id="tab-motion" name="portfolio-tabs" class="ease-tab-radio" />
+
+          <!-- Nav labels container -->
+          <div class="ease-tabs-nav">
+            <label for="tab-photo" class="ease-tab-label" tabindex="0" role="tab" aria-controls="panel-photo" aria-selected="true">Photography</label>
+            <label for="tab-design" class="ease-tab-label" tabindex="0" role="tab" aria-controls="panel-design" aria-selected="false">UI Design</label>
+            <label for="tab-motion" class="ease-tab-label" tabindex="0" role="tab" aria-controls="panel-motion" aria-selected="false">3D Motion</label>
+            <div class="ease-tab-bubble" id="activeBubble"></div>
+          </div>
+
+          <!-- Content Panels -->
+          <div class="ease-tab-contents">
+            
+            <!-- Panel 1: Photo -->
+            <div class="ease-tab-panel panel-photo" id="panel-photo" role="tabpanel" aria-labelledby="tab-photo">
+              <div class="pp-portfolio-grid">
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">📸</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">Photography</span>
+                    <h3 class="pp-card-name">Silent Streets</h3>
+                    <p style="font-size:0.8rem;">Monochrome captures of empty midnight urban corners.</p>
+                  </div>
+                </div>
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">🏔️</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">Photography</span>
+                    <h3 class="pp-card-name">Glacier Peaks</h3>
+                    <p style="font-size:0.8rem;">High contrast nature photography on high altitude ridges.</p>
+                  </div>
+                </div>
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">👁️</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">Photography</span>
+                    <h3 class="pp-card-name">Macro Details</h3>
+                    <p style="font-size:0.8rem;">Intricate details of butterfly wings and rain textures.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Panel 2: Design -->
+            <div class="ease-tab-panel panel-design" id="panel-design" role="tabpanel" aria-labelledby="tab-design">
+              <div class="pp-portfolio-grid">
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">🎨</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">UI Design</span>
+                    <h3 class="pp-card-name">Neumorph Kit</h3>
+                    <p style="font-size:0.8rem;">Tactile design components library for landing screens.</p>
+                  </div>
+                </div>
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">🌐</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">UI Design</span>
+                    <h3 class="pp-card-name">Crypto Portal</h3>
+                    <p style="font-size:0.8rem;">Glassmorphic dashboard tracking live token transactions.</p>
+                  </div>
+                </div>
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">📱</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">UI Design</span>
+                    <h3 class="pp-card-name">Fitness Tracker</h3>
+                    <p style="font-size:0.8rem;">Minimalist dark-mode fitness tracking UI screens.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Panel 3: Motion -->
+            <div class="ease-tab-panel panel-motion" id="panel-motion" role="tabpanel" aria-labelledby="tab-motion">
+              <div class="pp-portfolio-grid">
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">🌀</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">3D Motion</span>
+                    <h3 class="pp-card-name">Fluid Swirls</h3>
+                    <p style="font-size:0.8rem;">Dynamic canvas simulation of colorful vector waves.</p>
+                  </div>
+                </div>
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">🧊</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">3D Motion</span>
+                    <h3 class="pp-card-name">Glass Cubes</h3>
+                    <p style="font-size:0.8rem;">Looping animation of glass objects refracting light grids.</p>
+                  </div>
+                </div>
+                <div class="pp-portfolio-card">
+                  <div class="pp-card-media">⚙️</div>
+                  <div class="pp-card-info">
+                    <span class="pp-card-category">3D Motion</span>
+                    <h3 class="pp-card-name">Kinetic Engine</h3>
+                    <p style="font-size:0.8rem;">Mechanical rotation loop modeling physical forces.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+        <!-- Controls panel -->
+        <div class="pp-controls-panel">
+          <div class="pp-control-row">
+            <label for="scaleSlider">Hover Scale Factor (--tab-scale)</label>
+            <div class="pp-slider-row">
+              <input type="range" id="scaleSlider" class="pp-slider" min="100" max="125" value="108" step="1" />
+              <span class="pp-slider-val" id="scaleVal">1.08</span>
+            </div>
+          </div>
+
+          <div class="pp-control-row">
+            <label for="speedSlider">Transition Rate (--tab-speed)</label>
+            <div class="pp-slider-row">
+              <input type="range" id="speedSlider" class="pp-slider" min="100" max="1000" value="280" step="20" />
+              <span class="pp-slider-val" id="speedVal">280ms</span>
+            </div>
+          </div>
+
+          <div class="pp-control-row">
+            <label for="easingSelect">Transition Easing (--tab-easing)</label>
+            <select id="easingSelect" class="pp-state-select">
+              <option value="backOut">Back Out Sweep (cubic-bezier(0.34, 1.56, 0.64, 1))</option>
+              <option value="linear">Linear Transition (cubic-bezier(0, 0, 1, 1))</option>
+              <option value="smooth">Smooth Ease (cubic-bezier(0.4, 0, 0.2, 1))</option>
+              <option value="bounce">Bounce Out (cubic-bezier(0.175, 0.885, 0.32, 1.275))</option>
+            </select>
+          </div>
+
+          <div class="pp-control-row">
+            <label>Active Theme color</label>
+            <div class="pp-color-picker" id="accentPicker">
+              <div class="pp-color-dot active" data-color="indigo" style="background:#6366f1;"></div>
+              <div class="pp-color-dot" data-color="pink" style="background:#d946ef;"></div>
+              <div class="pp-color-dot" data-color="cyan" style="background:#0ea5e9;"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Accessibility & Specification checklist -->
+    <section class="pp-card pp-card-secondary" aria-labelledby="checklist-heading">
+      <h2 class="pp-card-title" id="checklist-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--secondary);"><polyline points="9 11 12 14 22 4"></polyline><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg>
+        Accessibility &amp; Semantic Guidelines
+      </h2>
+      <p class="pp-card-desc">
+        How the Scale-Hover tab component guarantees keyboard navigation and responsive styling.
+      </p>
+
+      <ul class="pp-check-list">
+        <li class="pp-check-item">
+          <div class="pp-check-bullet ok">&checkmark;</div>
+          <div>
+            <strong>Keyboard Enter Triggers:</strong>
+            Tab navigation index values mapped on labels enable keyboard navigation. JavaScript listeners check Enter keys and automatically toggle radio values.
+          </div>
+        </li>
+        <li class="pp-check-item">
+          <div class="pp-check-bullet ok">&checkmark;</div>
+          <div>
+            <strong>Scale-Hover boundaries:</strong>
+            Hover scales are limited inside safe boundaries (<code>1.08</code>) to prevent overlaps and text-clipping issues on compact tablets.
+          </div>
+        </li>
+        <li class="pp-check-item">
+          <div class="pp-check-bullet ok">&checkmark;</div>
+          <div>
+            <strong>Fade-Slide Animations:</strong>
+            Switching panels triggers a smooth CSS vertical scale and fade, preventing abrupt content flashes.
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Section: Interactive Quiz -->
+    <section class="pp-card pp-card-accent" aria-labelledby="quiz-heading">
+      <h2 class="pp-card-title" id="quiz-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent);"><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line><circle cx="12" cy="12" r="10"></circle></svg>
+        Selector Literacy Quiz
+      </h2>
+      <p class="pp-card-desc">
+        Verify your knowledge of layout selectors and transitions.
+      </p>
+
+      <div class="pp-quiz-card">
+        <div class="pp-quiz-question" id="quizQuestion">Loading question...</div>
+        <div class="pp-quiz-options" id="quizOptions"></div>
+        <div class="pp-quiz-feedback" id="quizFeedback"></div>
+        <button type="button" class="pp-quiz-next" id="quizNextBtn">Next Question</button>
+      </div>
+    </section>
+
+    <!-- Section: Code Snippets -->
+    <section class="pp-card" id="snippets" aria-labelledby="snippets-heading">
+      <h2 class="pp-card-title" id="snippets-heading">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary);"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Production Code Snippets
+      </h2>
+      <p class="pp-card-desc">
+        Copy this clean CSS structure to apply sliding active highlights.
+      </p>
+
+      <div class="pp-snippets">
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">HTML Structure</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetHtml">Copy HTML</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetHtml">&lt;!-- pure CSS tabs --&gt;
+&lt;div class="ease-portfolio-container"&gt;
+  &lt;input type="radio" id="t-1" name="tabs" class="ease-tab-radio" checked /&gt;
+  &lt;input type="radio" id="t-2" name="tabs" class="ease-tab-radio" /&gt;
+  &lt;div class="ease-tabs-nav"&gt;
+    &lt;label for="t-1" class="ease-tab-label" tabindex="0"&gt;Photo&lt;/label&gt;
+    &lt;label for="t-2" class="ease-tab-label" tabindex="0"&gt;Design&lt;/label&gt;
+    &lt;div class="ease-tab-bubble"&gt;&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</pre>
+        </div>
+
+        <div class="pp-snippet-card">
+          <div class="pp-snippet-header">
+            <span class="pp-snippet-title">CSS Active Bubble offsets</span>
+            <button type="button" class="pp-copy-btn" data-code-id="snippetCss">Copy CSS</button>
+          </div>
+          <pre class="pp-snippet-pre" id="snippetCss">/* Translate bubble according to radio check */
+#t-1:checked ~ .ease-tabs-nav .ease-tab-bubble {
+  transform: translateX(0px);
+}
+#t-2:checked ~ .ease-tabs-nav .ease-tab-bubble {
+  transform: translateX(124px);
+}</pre>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Toast Notification -->
+  <div class="pp-toast" id="copyToast" role="status" aria-live="polite">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--success);"><polyline points="20 6 9 17 4 12"></polyline></svg>
+    Snippet copied to clipboard!
+  </div>
+
+  <footer class="pp-footer">
+    <div class="pp-container">
+      <div class="pp-footer-links">
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+        <span>&bull;</span>
+        <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/50093" target="_blank" rel="noopener noreferrer">Issue Ticket</a>
+      </div>
+      <p>&copy; 2026 EaseMotion CSS. Creative Portfolio design guidelines.</p>
+    </div>
+  </footer>
+
+  <!-- Interactivity Scripts -->
+  <script>
+    (function() {
+      "use strict";
+
+      // --- Dark Theme Toggle ---
+      const themeToggleBtn = document.getElementById('themeToggleBtn');
+      const sunIcon = document.getElementById('sunIcon');
+      const moonIcon = document.getElementById('moonIcon');
+      const rootHtml = document.documentElement;
+
+      const savedTheme = localStorage.getItem('pp-theme') || 'light';
+      rootHtml.setAttribute('data-theme', savedTheme);
+      updateThemeIcons(savedTheme);
+
+      themeToggleBtn.addEventListener('click', () => {
+        const currentTheme = rootHtml.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        rootHtml.setAttribute('data-theme', newTheme);
+        localStorage.setItem('pp-theme', newTheme);
+        updateThemeIcons(newTheme);
+      });
+
+      function updateThemeIcons(theme) {
+        if (theme === 'dark') {
+          sunIcon.style.display = 'block';
+          moonIcon.style.display = 'none';
+        } else {
+          sunIcon.style.display = 'none';
+          moonIcon.style.display = 'block';
+        }
+      }
+
+      // --- Slider Parameters & Style updates ---
+      const scaleSlider = document.getElementById('scaleSlider');
+      const scaleVal = document.getElementById('scaleVal');
+      const speedSlider = document.getElementById('speedSlider');
+      const speedVal = document.getElementById('speedVal');
+      const easingSelect = document.getElementById('easingSelect');
+      const accentPicker = document.getElementById('accentPicker');
+      
+      const tabsSandbox = document.getElementById('tabsSandbox');
+      const activeBubble = document.getElementById('activeBubble');
+
+      const easingMap = {
+        backOut: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+        linear: "cubic-bezier(0, 0, 1, 1)",
+        smooth: "cubic-bezier(0.4, 0, 0.2, 1)",
+        bounce: "cubic-bezier(0.175, 0.885, 0.32, 1.275)"
+      };
+
+      const colorMap = {
+        indigo: "#6366f1",
+        pink: "#d946ef",
+        cyan: "#0ea5e9"
+      };
+
+      function updateParameters() {
+        const scale = scaleSlider.value / 100;
+        const speed = speedSlider.value;
+        const easingKey = easingSelect.value;
+
+        scaleVal.textContent = scale;
+        speedVal.textContent = `${speed}ms`;
+
+        // Apply variables on root container wrapper
+        tabsSandbox.style.setProperty('--tab-scale', scale);
+        tabsSandbox.style.setProperty('--tab-speed', `${speed}ms`);
+        tabsSandbox.style.setProperty('--tab-easing', easingMap[easingKey]);
+      }
+
+      scaleSlider.addEventListener('input', updateParameters);
+      speedSlider.addEventListener('input', updateParameters);
+      easingSelect.addEventListener('change', updateParameters);
+
+      accentPicker.addEventListener('click', (e) => {
+        const dot = e.target.closest('[data-color]');
+        if (!dot) return;
+
+        accentPicker.querySelectorAll('.pp-color-dot').forEach(d => d.classList.remove('active'));
+        dot.classList.add('active');
+
+        const colorVal = colorMap[dot.dataset.color];
+        tabsSandbox.style.setProperty('--tab-accent', colorVal);
+        tabsSandbox.style.setProperty('--tab-accent-hover', colorVal);
+        
+        // Update bubble drop shadow color to match accent
+        activeBubble.style.boxShadow = `0 4px 10px ${colorVal}4d`;
+      });
+
+      // Default init
+      updateParameters();
+
+      // --- Keyboard Enter listener to select tabs ---
+      const labels = document.querySelectorAll('.ease-tab-label');
+      labels.forEach(lbl => {
+        lbl.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            const targetId = lbl.getAttribute('for');
+            const radio = document.getElementById(targetId);
+            if (radio) {
+              radio.checked = true;
+              
+              // Force trigger visual checked animations by dispatching a change event
+              radio.dispatchEvent(new Event('change', { bubbles: true }));
+              
+              // Update aria values
+              updateAriaSelected(targetId);
+            }
+          }
+        });
+      });
+
+      // Maintain aria attributes on radio click
+      const radios = document.querySelectorAll('.ease-tab-radio');
+      radios.forEach(rad => {
+        rad.addEventListener('change', () => {
+          updateAriaSelected(rad.id);
+        });
+      });
+
+      function updateAriaSelected(activeId) {
+        labels.forEach(lbl => {
+          if (lbl.getAttribute('for') === activeId) {
+            lbl.setAttribute('aria-selected', 'true');
+          } else {
+            lbl.setAttribute('aria-selected', 'false');
+          }
+        });
+      }
+
+      // --- Selector Literacy Quiz ---
+      const quizQuestions = [
+        {
+          question: "How do pure CSS tab components toggle panel visibility without JavaScript engines?",
+          options: [
+            "Using :hover hooks on body margins",
+            "Pairing hidden <input type='radio'> tags with adjacent sibling selectors (~)",
+            "Nesting multiple z-index grids",
+            "Setting pointer-events variables to auto"
+          ],
+          correct: 1,
+          explanation: "Radio button checked state (:checked) paired with adjacent sibling selectors (e.g. #tab:checked ~ .panel) is the standard CSS selector mechanism for layout state toggles."
+        },
+        {
+          question: "What CSS property ensures smooth translations of sliding highlighting tabs backgrounds?",
+          options: [
+            "transform: translateX() transition",
+            "margin-left margin-right auto override",
+            "display: block transition",
+            "width height scale animation loops"
+          ],
+          correct: 0,
+          explanation: "Transitioning transform translations utilizes GPU composite layers, preventing layout repaints and jank."
+        }
+      ];
+
+      let quizIdx = 0;
+      const quizQuestion = document.getElementById('quizQuestion');
+      const quizOptions = document.getElementById('quizOptions');
+      const quizFeedback = document.getElementById('quizFeedback');
+      const quizNextBtn = document.getElementById('quizNextBtn');
+
+      function loadQuiz() {
+        const data = quizQuestions[quizIdx];
+        quizQuestion.textContent = `Question ${quizIdx + 1}: ${data.question}`;
+        quizOptions.innerHTML = '';
+        quizFeedback.style.display = 'none';
+        quizFeedback.className = 'pp-quiz-feedback';
+        quizNextBtn.style.display = 'none';
+
+        data.options.forEach((opt, idx) => {
+          const optBtn = document.createElement('button');
+          optBtn.type = 'button';
+          optBtn.className = 'pp-quiz-option';
+          optBtn.innerHTML = `<span class="pp-option-index">${String.fromCharCode(65 + idx)}</span> <span>${opt}</span>`;
+          optBtn.addEventListener('click', () => selectQuiz(idx));
+          quizOptions.appendChild(optBtn);
+        });
+      }
+
+      function selectQuiz(selIdx) {
+        const data = quizQuestions[quizIdx];
+        const buttons = quizOptions.querySelectorAll('.pp-quiz-option');
+        buttons.forEach(btn => btn.disabled = true);
+
+        if (selIdx === data.correct) {
+          buttons[selIdx].classList.add('correct');
+          quizFeedback.textContent = `Correct! ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback success';
+        } else {
+          buttons[selIdx].classList.add('incorrect');
+          buttons[data.correct].classList.add('correct');
+          quizFeedback.textContent = `Incorrect. ${data.explanation}`;
+          quizFeedback.className = 'pp-quiz-feedback error';
+        }
+        quizNextBtn.style.display = 'inline-block';
+      }
+
+      quizNextBtn.addEventListener('click', () => {
+        quizIdx++;
+        if (quizIdx < quizQuestions.length) {
+          loadQuiz();
+        } else {
+          quizQuestion.textContent = 'Diagnostic Complete!';
+          quizOptions.innerHTML = '<p class="pp-text-center pp-mt-4">Excellent! You are now fully literate in advanced CSS layouts selectors.</p>';
+          quizFeedback.style.display = 'none';
+          quizNextBtn.style.display = 'none';
+        }
+      });
+
+      loadQuiz();
+
+      // --- Snippet Copy System ---
+      const copyBtns = document.querySelectorAll('.pp-copy-btn');
+      const toastEl = document.getElementById('copyToast');
+
+      copyBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const preId = btn.dataset.codeId;
+          const preEl = document.getElementById(preId);
+          if (!preEl) return;
+
+          const text = preEl.textContent.trim();
+
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(() => showToast(btn));
+          } else {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            showToast(btn);
+          }
+        });
+      });
+
+      function showToast(btn) {
+        btn.classList.add('copied');
+        btn.textContent = 'Copied!';
+        toastEl.classList.add('show');
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.textContent = btn.dataset.codeId === 'snippetHtml' ? 'Copy HTML' : 'Copy CSS';
+          toastEl.classList.remove('show');
+        }, 2000);
+      }
+
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tabs-portfolio-pp/style.css
+++ b/submissions/examples/ease-tabs-portfolio-pp/style.css
@@ -1,0 +1,783 @@
+/* ==========================================================================
+   EaseMotion CSS - Creative Portfolio Tabs
+   Component: Pure CSS Scale-Hover Tabs
+   File: style.css
+   Author: Pratyush Panda (pp)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design System & CSS Variables
+   -------------------------------------------------------------------------- */
+:root {
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+
+  /* App Theme - Light default */
+  --bg-app: #f1f5f9;
+  --bg-card: #ffffff;
+  --border-color: #e2e8f0;
+  
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  
+  --primary: #6366f1;
+  --primary-hover: #4f46e5;
+  --primary-glow: rgba(99, 102, 241, 0.12);
+  
+  --secondary: #0ea5e9;
+  --accent: #d946ef;
+  --accent-glow: rgba(217, 70, 239, 0.12);
+  
+  --success: #10b981;
+  --success-bg: #d1fae5;
+  --error: #ef4444;
+  --error-bg: #fee2e2;
+
+  /* Custom Parameters */
+  --tab-speed: 280ms;
+  --tab-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* backOut */
+  --tab-scale: 1.08;
+  --tab-accent: var(--primary);
+  --tab-accent-hover: var(--primary-hover);
+
+  /* Border Radii */
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 24px;
+  --radius-full: 9999px;
+  
+  /* Shadow Elevators */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+/* Dark Theme Variables Override */
+[data-theme="dark"] {
+  --bg-app: #090d16;
+  --bg-card: #0f172a;
+  --border-color: #1e293b;
+  
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #64748b;
+  
+  --primary: #818cf8;
+  --primary-hover: #6366f1;
+  --primary-glow: rgba(129, 140, 248, 0.25);
+  
+  --secondary: #38bdf8;
+  --accent: #f472b6;
+  --accent-glow: rgba(244, 114, 182, 0.2);
+}
+
+/* --------------------------------------------------------------------------
+   2. Reset & Core Base Styles
+   -------------------------------------------------------------------------- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  background-color: var(--bg-app);
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg-app);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 5px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+code, pre {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  border-radius: 4px;
+}
+
+code {
+  background-color: var(--bg-app);
+  padding: 0.2em 0.4em;
+  color: var(--accent);
+  border: 1px solid var(--border-color);
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+/* Layout container */
+.pp-container {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   3. Header & Hero Section
+   -------------------------------------------------------------------------- */
+.pp-header {
+  padding: 3rem 0 2rem;
+  text-align: center;
+}
+
+.pp-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+  display: inline-block;
+  background: var(--primary-glow);
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-full);
+}
+
+.pp-header h1 {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, var(--text-primary) 30%, var(--primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.pp-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.15rem);
+  max-width: 68ch;
+  margin: 0 auto 1.5rem;
+}
+
+.pp-meta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.pp-meta-badge span {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* Theme Toggle Widget */
+.pp-theme-toggle {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.75rem;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xl);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition-normal);
+}
+.pp-theme-toggle:hover {
+  transform: scale(1.1);
+}
+.pp-theme-toggle svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: var(--text-secondary);
+}
+
+/* Grid Layout */
+.pp-main-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* --------------------------------------------------------------------------
+   4. Cards & Component Panels
+   -------------------------------------------------------------------------- */
+.pp-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+.pp-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: var(--border-color);
+}
+.pp-card.pp-card-primary::before { background: var(--primary); }
+.pp-card.pp-card-secondary::before { background: var(--secondary); }
+.pp-card.pp-card-accent::before { background: var(--accent); }
+
+.pp-card-title {
+  font-size: 1.35rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pp-card-desc {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   5. Pure CSS Scale-Hover Portfolio Tabs Engine
+   -------------------------------------------------------------------------- */
+.ease-portfolio-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Hide native inputs completely but keep accessible */
+.ease-tab-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Tabs Navigation shell */
+.ease-tabs-nav {
+  display: inline-flex;
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem;
+  border-radius: var(--radius-full);
+  margin: 0 auto;
+  position: relative;
+  gap: 0.25rem;
+}
+
+/* Accessible hover tab labels */
+.ease-tab-label {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  padding: 0.6rem 1.5rem;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  position: relative;
+  z-index: 10;
+  transition: transform var(--tab-speed) var(--tab-easing),
+              color var(--tab-speed) var(--tab-easing);
+  outline: none;
+}
+
+/* Scale-Hover Interaction */
+.ease-tab-label:hover {
+  transform: scale(var(--tab-scale));
+  color: var(--tab-accent-hover);
+}
+
+/* Focused indicators */
+.ease-tab-radio:focus-visible + .ease-tab-label {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
+/* Active Highlight mechanics inside navigation */
+/* In pure CSS, we map label colors when their corresponding input is checked */
+#tab-photo:checked ~ .ease-tabs-nav label[for="tab-photo"],
+#tab-design:checked ~ .ease-tabs-nav label[for="tab-design"],
+#tab-motion:checked ~ .ease-tabs-nav label[for="tab-motion"] {
+  color: white;
+}
+
+/* CSS Active slider bubble */
+.ease-tab-bubble {
+  position: absolute;
+  top: 0.4rem;
+  bottom: 0.4rem;
+  left: 0.4rem;
+  width: 120px; /* will adjust dynamically or via JS, or pure CSS steps */
+  background: var(--tab-accent);
+  border-radius: var(--radius-full);
+  z-index: 5;
+  transition: transform var(--tab-speed) var(--tab-easing),
+              width var(--tab-speed) var(--tab-easing),
+              background-color var(--tab-speed) var(--tab-easing);
+  box-shadow: 0 4px 10px rgba(99, 102, 241, 0.3);
+}
+
+/* Bubble sliding positions depending on checked radio button */
+#tab-photo:checked ~ .ease-tabs-nav .ease-tab-bubble {
+  transform: translateX(0px);
+  width: 120px;
+}
+
+#tab-design:checked ~ .ease-tabs-nav .ease-tab-bubble {
+  transform: translateX(124px);
+  width: 120px;
+}
+
+#tab-motion:checked ~ .ease-tabs-nav .ease-tab-bubble {
+  transform: translateX(248px);
+  width: 120px;
+}
+
+/* Content panels */
+.ease-tab-contents {
+  width: 100%;
+}
+
+.ease-tab-panel {
+  display: none;
+  width: 100%;
+}
+
+/* Show active panel in pure CSS */
+#tab-photo:checked ~ .ease-tab-contents .panel-photo,
+#tab-design:checked ~ .ease-tab-contents .panel-design,
+#tab-motion:checked ~ .ease-tab-contents .panel-motion {
+  display: block;
+  animation: ease-fade-slide var(--tab-speed) var(--tab-easing) forwards;
+}
+
+@keyframes ease-fade-slide {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   6. Creative Portfolio Visual Grid
+   -------------------------------------------------------------------------- */
+.pp-portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-portfolio-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .pp-portfolio-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-portfolio-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.3s ease;
+}
+
+.pp-portfolio-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-xl);
+}
+
+.pp-card-media {
+  height: 180px;
+  background: linear-gradient(135deg, var(--bg-app) 0%, var(--border-color) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  position: relative;
+}
+
+.pp-card-media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, transparent 40%, rgba(0,0,0,0.05));
+}
+
+.pp-card-info {
+  padding: 1.25rem;
+}
+
+.pp-card-category {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin-bottom: 0.25rem;
+  display: block;
+}
+
+.pp-card-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   7. Interactive Playground Controls
+   -------------------------------------------------------------------------- */
+.pp-playground-grid {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .pp-playground-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-controls-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  background: var(--bg-app);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+}
+
+.pp-control-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pp-control-row label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.pp-state-select {
+  padding: 0.6rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  outline: none;
+  font-family: var(--font-sans);
+}
+
+/* Slider Controls */
+.pp-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.pp-slider {
+  flex-grow: 1;
+  height: 6px;
+  background: var(--border-color);
+  border-radius: 3px;
+  outline: none;
+}
+.pp-slider-val {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  min-width: 50px;
+  text-align: right;
+}
+
+/* Color dot selector */
+.pp-color-picker {
+  display: flex;
+  gap: 0.75rem;
+}
+.pp-color-dot {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: transform 0.2s ease;
+}
+.pp-color-dot:hover {
+  transform: scale(1.15);
+}
+.pp-color-dot.active {
+  transform: scale(1.15);
+  border-color: var(--text-primary);
+}
+
+/* --------------------------------------------------------------------------
+   8. Interactive Quiz System
+   -------------------------------------------------------------------------- */
+.pp-quiz-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  background: var(--bg-app);
+  margin-top: 1rem;
+}
+
+.pp-quiz-question {
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+  color: var(--text-primary);
+}
+
+.pp-quiz-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.pp-quiz-option {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: left;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.pp-quiz-option:hover {
+  background-color: var(--bg-card-hover);
+  border-color: var(--primary);
+}
+.pp-quiz-option.correct {
+  border-color: var(--success);
+  background-color: var(--success-bg);
+  color: var(--success);
+}
+.pp-quiz-option.incorrect {
+  border-color: var(--error);
+  background-color: var(--error-bg);
+  color: var(--error);
+}
+
+.pp-option-index {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-app);
+  border: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+.pp-quiz-option.correct .pp-option-index {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+.pp-quiz-option.incorrect .pp-option-index {
+  background: var(--error);
+  color: white;
+  border-color: var(--error);
+}
+
+.pp-quiz-feedback {
+  font-size: 0.88rem;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  margin-top: 1rem;
+  display: none;
+}
+.pp-quiz-feedback.success {
+  background: var(--success-bg);
+  color: var(--success);
+  border: 1px solid var(--success);
+  display: block;
+}
+.pp-quiz-feedback.error {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error);
+  display: block;
+}
+
+.pp-quiz-next {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+}
+.pp-quiz-next:hover {
+  background: var(--primary-hover);
+}
+
+/* --------------------------------------------------------------------------
+   9. Code Snippets & Copy System
+   -------------------------------------------------------------------------- */
+.pp-snippets {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .pp-snippets {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pp-snippet-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-app);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.pp-snippet-header {
+  padding: 0.75rem 1rem;
+  background: rgba(0,0,0,0.03);
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pp-snippet-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.pp-snippet-pre {
+  margin: 0;
+  padding: 1.25rem 1rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.pp-copy-btn {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.pp-copy-btn:hover {
+  background-color: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+.pp-copy-btn.copied {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+
+.pp-toast {
+  position: fixed;
+  bottom: 2.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(100px);
+  background: var(--text-primary);
+  color: var(--bg-card);
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-full);
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-xl);
+  opacity: 0;
+  transition: transform var(--transition-bounce), opacity var(--transition-fast);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.pp-toast.show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+/* --------------------------------------------------------------------------
+   10. Footer Section
+   -------------------------------------------------------------------------- */
+.pp-footer {
+  margin-top: 4rem;
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.pp-footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
- Closes #50093
- Adds an interactive scale-hover tabs lab inside `submissions/examples/ease-tabs-portfolio-pp/` detailing pure CSS radio-button toggles and active highlight animations.
- Includes a creative agency grid panel, parameter customizer sliders, keyboard triggers, and a selector quiz.
- Fully self-contained and responsive, with support for local light/dark mode toggling.