### PR TITLE
feat: add CSS shimmer sweep popover for SaaS showcase layouts (#49999)

### DIFF
--- a/submissions/examples/shimmer-sweep-popover-49999/README.md
+++ b/submissions/examples/shimmer-sweep-popover-49999/README.md
@@ -1,0 +1,67 @@
+# CSS Shimmer Sweep Popover - SaaS Showcase Layouts
+
+A pure HTML/CSS popover component featuring a smooth shimmer sweep light animation, designed for modern SaaS showcase interfaces.
+
+Related Issue: #49999
+
+---
+
+## Repository Standard Answers
+
+### 1. What does this do?
+It renders a CSS-driven popover overlay with a shimmer sweep light effect that glides across the panel on hover or keyboard focus. Designed for clean, modern SaaS showcase layouts with gradient accents and soft shadows.
+
+### 2. How is it used?
+Wrap a trigger element and popover container inside a `.ssp` parent wrapper and apply direction classes (`ssp--top`, `ssp--bottom`, `ssp--left`, `ssp--right`).
+
+```html
+<span class="ssp ssp--top">
+  <a href="#" class="ssp__trigger" tabindex="0" aria-describedby="pop-1">Trigger</a>
+  <span class="ssp__popover" role="tooltip" id="pop-1">
+    <p class="ssp__popover-title">Title</p>
+    <p class="ssp__popover-body">Description text.</p>
+  </span>
+</span>
+```
+
+### 3. Why is it useful?
+It provides a polished, zero-JS popover with a premium shimmer sweep animation that adds visual depth and motion feedback. Ideal for SaaS landing pages, product showcases, and marketing sites where subtle animation elevates the user experience.
+
+---
+
+## Features
+
+- **Pure HTML + CSS**: Zero JavaScript dependencies.
+- **Shimmer Sweep Animation**: A translucent light bar glides across the popover and trigger on hover, creating a premium feel.
+- **SaaS Aesthetic**: Clean white surfaces, gradient accents, soft shadows, and modern typography.
+- **Directional Support**: Top, Bottom, Left, and Right positioning with matching arrows.
+- **Keyboard Accessible**: Triggers are focusable; popovers appear on `:focus-within` for full keyboard navigation.
+- **Reduced Motion**: Disables shimmer animation when `prefers-reduced-motion` is enabled.
+- **Responsive**: Single-column layout on small screens.
+
+---
+
+## Customization
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `--ssp-duration` | Popover transition duration | `0.4s` |
+| `--ssp-easing` | Transition easing curve | `cubic-bezier(0.22, 1, 0.36, 1)` |
+| `--ssp-shimmer-speed` | Shimmer sweep animation speed | `1.2s` |
+| `--ssp-shimmer-color` | Shimmer highlight color | `rgba(255, 255, 255, 0.15)` |
+| `--ssp-shimmer-width` | Width of the shimmer bar | `60px` |
+| `--ssp-bg` | Page background | `#f4f6fb` |
+| `--ssp-surface` | Card/popover background | `#ffffff` |
+| `--ssp-accent` | Primary accent color | `#6366f1` |
+| `--ssp-gradient` | Icon gradient | `linear-gradient(135deg, #6366f1, #8b5cf6, #a78bfa)` |
+
+---
+
+## Folder Structure
+
+```text
+submissions/examples/shimmer-sweep-popover-49999/
+├── demo.html       ← SaaS showcase demo with Analytics, Team, and Deploy cards
+├── style.css       ← Component styles with shimmer sweep animation and CSS custom properties
+└── README.md       ← This file
+```

--- a/submissions/examples/shimmer-sweep-popover-49999/demo.html
+++ b/submissions/examples/shimmer-sweep-popover-49999/demo.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Shimmer Sweep Popover - SaaS Showcase Layouts | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Shimmer Sweep Popover</h1>
+    <p>Pure CSS popover with smooth shimmer sweep transition, built for modern SaaS showcase interfaces.</p>
+  </header>
+
+  <main class="ssp-grid">
+
+    <!-- Card 1: Analytics Dashboard -->
+    <section class="ssp-card" aria-labelledby="analytics-title">
+      <div class="ssp-card__icon" aria-hidden="true">&#9632;</div>
+      <h2 id="analytics-title" class="ssp-card__title">Analytics</h2>
+      <p class="ssp-card__desc">Real-time insights for your product metrics</p>
+
+      <div class="ssp-card__actions">
+        <span class="ssp ssp--top">
+          <a href="#" class="ssp__trigger" tabindex="0" aria-describedby="pop-mrr">
+            MRR
+            <span class="ssp-sr-only">View monthly recurring revenue</span>
+          </a>
+          <span class="ssp__popover" role="tooltip" id="pop-mrr">
+            <p class="ssp__popover-title">Monthly Revenue</p>
+            <p class="ssp__popover-body">$48,200 MRR with 12% month-over-month growth across all plan tiers.</p>
+          </span>
+        </span>
+
+        <span class="ssp ssp--bottom">
+          <a href="#" class="ssp__trigger" tabindex="0" aria-describedby="pop-churn">
+            Churn
+            <span class="ssp-sr-only">View churn rate</span>
+          </a>
+          <span class="ssp__popover" role="tooltip" id="pop-churn">
+            <p class="ssp__popover-title">Churn Rate</p>
+            <p class="ssp__popover-body">2.1% monthly churn. Net retention at 118% with expansion revenue.</p>
+          </span>
+        </span>
+      </div>
+    </section>
+
+    <!-- Card 2: Team Management -->
+    <section class="ssp-card" aria-labelledby="team-title">
+      <div class="ssp-card__icon" aria-hidden="true">&#9641;</div>
+      <h2 id="team-title" class="ssp-card__title">Team</h2>
+      <p class="ssp-card__desc">Collaborate across your organization</p>
+
+      <div class="ssp-card__actions">
+        <span class="ssp ssp--left">
+          <a href="#" class="ssp__trigger" tabindex="0" aria-describedby="pop-members">
+            Members
+            <span class="ssp-sr-only">View team members</span>
+          </a>
+          <span class="ssp__popover" role="tooltip" id="pop-members">
+            <p class="ssp__popover-title">Active Seats</p>
+            <p class="ssp__popover-body">24 active members across 5 teams. 3 pending invitations.</p>
+          </span>
+        </span>
+
+        <span class="ssp ssp--right">
+          <a href="#" class="ssp__trigger" tabindex="0" aria-describedby="pop-roles">
+            Roles
+            <span class="ssp-sr-only">View team roles</span>
+          </a>
+          <span class="ssp__popover" role="tooltip" id="pop-roles">
+            <p class="ssp__popover-title">Role Distribution</p>
+            <p class="ssp__popover-body">8 admins, 12 editors, 4 viewers. Custom roles available on Enterprise.</p>
+          </span>
+        </span>
+      </div>
+    </section>
+
+    <!-- Card 3: Deploy Pipeline -->
+    <section class="ssp-card" aria-labelledby="deploy-title">
+      <div class="ssp-card__icon" aria-hidden="true">&#9654;</div>
+      <h2 id="deploy-title" class="ssp-card__title">Deploy</h2>
+      <p class="ssp-card__desc">Ship with confidence every time</p>
+
+      <div class="ssp-card__actions">
+        <span class="ssp ssp--top">
+          <a href="#" class="ssp__trigger" tabindex="0" aria-describedby="pop-uptime">
+            Uptime
+            <span class="ssp-sr-only">View uptime status</span>
+          </a>
+          <span class="ssp__popover" role="tooltip" id="pop-uptime">
+            <p class="ssp__popover-title">SLA Status</p>
+            <p class="ssp__popover-body">99.99% uptime over the last 90 days. Zero incidents this quarter.</p>
+          </span>
+        </span>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="margin-top: 3rem; color: var(--ssp-text-muted); font-size: 0.75rem; text-align: center;">
+    EaseMotion-css &bull; Shimmer Sweep Popover &bull; Pure HTML + CSS
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/shimmer-sweep-popover-49999/style.css
+++ b/submissions/examples/shimmer-sweep-popover-49999/style.css
@@ -1,0 +1,463 @@
+/* ==========================================================================
+   CSS Shimmer Sweep Popover - SaaS Showcase Layouts
+   Pure CSS component for EaseMotion CSS (#49999)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design Tokens (CSS Custom Properties)
+   -------------------------------------------------------------------------- */
+:root {
+  /* Animation Timing */
+  --ssp-duration: 0.4s;
+  --ssp-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --ssp-shimmer-speed: 1.2s;
+
+  /* Shimmer Sweep Gradient */
+  --ssp-shimmer-color: rgba(255, 255, 255, 0.15);
+  --ssp-shimmer-width: 60px;
+
+  /* SaaS Theme Colors */
+  --ssp-bg: #f4f6fb;
+  --ssp-surface: #ffffff;
+  --ssp-text: #1a1d2e;
+  --ssp-text-muted: #6b7280;
+  --ssp-accent: #6366f1;
+  --ssp-accent-light: #818cf8;
+  --ssp-border: #e5e7eb;
+  --ssp-gradient: linear-gradient(135deg, #6366f1, #8b5cf6, #a78bfa);
+
+  /* Radii & Padding */
+  --ssp-radius-trigger: 10px;
+  --ssp-radius-popover: 14px;
+  --ssp-padding: 1.125rem 1.375rem;
+  --ssp-font-size: 0.8125rem;
+  --ssp-max-width: 280px;
+  --ssp-arrow-size: 8px;
+
+  /* Shadows */
+  --ssp-shadow-trigger: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --ssp-shadow-trigger-hover: 0 4px 12px rgba(99, 102, 241, 0.15), 0 2px 4px rgba(0, 0, 0, 0.06);
+  --ssp-shadow-popover: 0 12px 40px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+/* --------------------------------------------------------------------------
+   2. Base Reset & Layout
+   -------------------------------------------------------------------------- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background-color: var(--ssp-bg);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: var(--ssp-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Page Header */
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  max-width: 560px;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.5rem;
+  background: var(--ssp-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-header p {
+  color: var(--ssp-text-muted);
+  font-size: 1rem;
+}
+
+/* Showcase Grid */
+.ssp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+/* SaaS Card */
+.ssp-card {
+  background-color: var(--ssp-surface);
+  border: 1px solid var(--ssp-border);
+  border-radius: 16px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.ssp-card:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+  border-color: rgba(99, 102, 241, 0.2);
+}
+
+.ssp-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: var(--ssp-gradient);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  color: #fff;
+  margin-bottom: 0.25rem;
+}
+
+.ssp-card__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ssp-text);
+}
+
+.ssp-card__desc {
+  font-size: 0.8125rem;
+  color: var(--ssp-text-muted);
+  max-width: 240px;
+}
+
+.ssp-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+  width: 100%;
+}
+
+/* --------------------------------------------------------------------------
+   3. Shimmer Sweep Popover Core
+   -------------------------------------------------------------------------- */
+.ssp {
+  position: relative;
+  display: inline-block;
+}
+
+/* ---- Trigger Button ---- */
+.ssp__trigger {
+  background-color: var(--ssp-surface);
+  border: 1px solid var(--ssp-border);
+  border-radius: var(--ssp-radius-trigger);
+  color: var(--ssp-text);
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  user-select: none;
+  position: relative;
+  overflow: hidden;
+  transition:
+    box-shadow var(--ssp-duration) var(--ssp-easing),
+    border-color var(--ssp-duration) var(--ssp-easing),
+    color var(--ssp-duration) var(--ssp-easing);
+}
+
+/* Shimmer sweep overlay on trigger */
+.ssp__trigger::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: var(--ssp-shimmer-width);
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--ssp-shimmer-color),
+    transparent
+  );
+  transition: none;
+  pointer-events: none;
+}
+
+.ssp:hover .ssp__trigger::before,
+.ssp:focus-within .ssp__trigger::before {
+  animation: ssp-sweep var(--ssp-shimmer-speed) ease-in-out;
+}
+
+/* Trigger hover/focus states */
+.ssp:hover .ssp__trigger,
+.ssp:focus-within .ssp__trigger {
+  border-color: var(--ssp-accent-light);
+  box-shadow: var(--ssp-shadow-trigger-hover);
+  color: var(--ssp-accent);
+}
+
+.ssp__trigger:active {
+  transform: scale(0.97);
+}
+
+/* ---- Popover Panel ---- */
+.ssp__popover {
+  position: absolute;
+  z-index: 100;
+  padding: var(--ssp-padding);
+  background-color: var(--ssp-surface);
+  color: var(--ssp-text);
+  font-size: var(--ssp-font-size);
+  font-family: inherit;
+  border-radius: var(--ssp-radius-popover);
+  border: 1px solid var(--ssp-border);
+  box-shadow: var(--ssp-shadow-popover);
+  max-width: var(--ssp-max-width);
+  width: max-content;
+  pointer-events: none;
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    opacity var(--ssp-duration) var(--ssp-easing),
+    transform var(--ssp-duration) var(--ssp-easing);
+}
+
+/* Shimmer sweep overlay on popover */
+.ssp__popover::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: var(--ssp-shimmer-width);
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--ssp-shimmer-color),
+    transparent
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+.ssp:hover .ssp__popover::before,
+.ssp:focus-within .ssp__popover::before {
+  animation: ssp-sweep var(--ssp-shimmer-speed) ease-in-out 0.1s;
+}
+
+/* Popover Content */
+.ssp__popover-title {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ssp-accent);
+  margin-bottom: 0.3rem;
+  position: relative;
+  z-index: 2;
+}
+
+.ssp__popover-body {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--ssp-text-muted);
+  position: relative;
+  z-index: 2;
+}
+
+/* Popover Arrow */
+.ssp__popover::after {
+  content: '';
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  z-index: 0;
+}
+
+/* --------------------------------------------------------------------------
+   4. Shimmer Sweep Keyframe
+   -------------------------------------------------------------------------- */
+@keyframes ssp-sweep {
+  0% {
+    left: -100%;
+  }
+  100% {
+    left: calc(100% + var(--ssp-shimmer-width));
+  }
+}
+
+/* --------------------------------------------------------------------------
+   5. Directional Positions and Arrows
+   -------------------------------------------------------------------------- */
+
+/* TOP */
+.ssp--top .ssp__popover {
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform-origin: bottom center;
+  transform: translateX(-50%) translateY(6px);
+}
+
+.ssp--top .ssp__popover::after {
+  bottom: calc(-1 * var(--ssp-arrow-size));
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: var(--ssp-arrow-size) var(--ssp-arrow-size) 0 var(--ssp-arrow-size);
+  border-color: var(--ssp-surface) transparent transparent transparent;
+}
+
+.ssp--top:hover .ssp__popover,
+.ssp--top:focus-within .ssp__popover {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* BOTTOM */
+.ssp--bottom .ssp__popover {
+  top: calc(100% + 12px);
+  left: 50%;
+  transform-origin: top center;
+  transform: translateX(-50%) translateY(-6px);
+}
+
+.ssp--bottom .ssp__popover::after {
+  top: calc(-1 * var(--ssp-arrow-size));
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0 var(--ssp-arrow-size) var(--ssp-arrow-size) var(--ssp-arrow-size);
+  border-color: transparent transparent var(--ssp-surface) transparent;
+}
+
+.ssp--bottom:hover .ssp__popover,
+.ssp--bottom:focus-within .ssp__popover {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* LEFT */
+.ssp--left .ssp__popover {
+  right: calc(100% + 12px);
+  top: 50%;
+  transform-origin: right center;
+  transform: translateY(-50%) translateX(6px);
+}
+
+.ssp--left .ssp__popover::after {
+  right: calc(-1 * var(--ssp-arrow-size));
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: var(--ssp-arrow-size) 0 var(--ssp-arrow-size) var(--ssp-arrow-size);
+  border-color: transparent transparent transparent var(--ssp-surface);
+}
+
+.ssp--left:hover .ssp__popover,
+.ssp--left:focus-within .ssp__popover {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%) translateX(0);
+}
+
+/* RIGHT */
+.ssp--right .ssp__popover {
+  left: calc(100% + 12px);
+  top: 50%;
+  transform-origin: left center;
+  transform: translateY(-50%) translateX(-6px);
+}
+
+.ssp--right .ssp__popover::after {
+  left: calc(-1 * var(--ssp-arrow-size));
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: var(--ssp-arrow-size) var(--ssp-arrow-size) var(--ssp-arrow-size) 0;
+  border-color: transparent var(--ssp-surface) transparent transparent;
+}
+
+.ssp--right:hover .ssp__popover,
+.ssp--right:focus-within .ssp__popover {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%) translateX(0);
+}
+
+/* --------------------------------------------------------------------------
+   6. Accessibility
+   -------------------------------------------------------------------------- */
+.ssp__trigger:focus-visible {
+  outline: 2px solid var(--ssp-accent);
+  outline-offset: 3px;
+}
+
+.ssp-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .ssp__popover,
+  .ssp__trigger {
+    transition: opacity 0.05s linear;
+  }
+
+  .ssp__trigger::before,
+  .ssp__popover::before {
+    animation: none !important;
+  }
+
+  .ssp:hover .ssp__popover,
+  .ssp:focus-within .ssp__popover {
+    transform: translateX(-50%) !important;
+  }
+
+  .ssp--left:hover .ssp__popover,
+  .ssp--left:focus-within .ssp__popover,
+  .ssp--right:hover .ssp__popover,
+  .ssp--right:focus-within .ssp__popover {
+    transform: translateY(-50%) !important;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   7. Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 600px) {
+  .ssp-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .ssp__popover {
+    max-width: 220px;
+  }
+}


### PR DESCRIPTION
## Related Issue
Closes #49999

## Description
Adds a pure CSS Shimmer Sweep Popover component for SaaS showcase layouts. A translucent light bar glides across the popover and trigger element on hover or keyboard focus, creating a polished shimmer sweep animation with zero JavaScript.

## Changes
- `submissions/examples/shimmer-sweep-popover-49999/style.css` — Component styles with shimmer sweep keyframe, CSS custom properties, SaaS theme, directional positioning, and accessibility support
- `submissions/examples/shimmer-sweep-popover-49999/demo.html` — SaaS showcase demo featuring Analytics, Team, and Deploy cards
- `submissions/examples/shimmer-sweep-popover-49999/README.md` — Documentation with usage instructions and customization guide

## Features
- Pure HTML + CSS, zero JavaScript
- Shimmer sweep light animation across trigger and popover
- SaaS showcase aesthetic with gradient accents and soft shadows
- Full directional support (top, bottom, left, right)
- Keyboard accessible via `:focus-within` and `tabindex`
- `prefers-reduced-motion` support
- Responsive single-column layout on mobile
- Configurable via 9 CSS custom properties

## Checklist
- [x] Files placed only in `submissions/examples/`
- [x] No existing files modified
- [x] Demo page loads correctly
- [x] Keyboard navigation works
- [x] Shimmer animation visible on hover
- [x] Reduced motion preference respected