### PR TITLE
feat: add CSS blur-entrance tabs for neumorphic soft layouts (#50118)

### DIFF
--- a/submissions/examples/blur-entrance-tabs-50118/README.md
+++ b/submissions/examples/blur-entrance-tabs-50118/README.md
@@ -1,0 +1,73 @@
+# CSS Blur-Entrance Tabs - Neumorphic Soft Layouts
+
+A pure HTML/CSS tab component featuring a smooth blur-entrance transition, designed for neumorphic soft interface aesthetics.
+
+Related Issue: #50118
+
+---
+
+## Repository Standard Answers
+
+### 1. What does this do?
+It renders a CSS-only tab component where switching tabs triggers a blur-entrance animation — the new panel fades in from a blurred, scaled-down state using only CSS. Styled with neumorphic soft shadows for a tactile, raised/felt UI feel.
+
+### 2. How is it used?
+Use the radio button hack pattern: pair hidden radio inputs with labels as tab triggers, and show/hide panels via CSS sibling selectors. Apply the `.bet` class to the container.
+
+```html
+<section class="bet" aria-label="Tabs">
+  <div class="bet__list" role="tablist">
+    <input type="radio" name="demo" id="d-1" class="bet__input" checked>
+    <label for="d-1" class="bet__trigger" role="tab">Tab 1</label>
+    <input type="radio" name="demo" id="d-2" class="bet__input">
+    <label for="d-2" class="bet__trigger" role="tab">Tab 2</label>
+  </div>
+  <div class="bet__panels">
+    <div class="bet__panel" role="tabpanel"><p>Panel 1 content</p></div>
+    <div class="bet__panel" role="tabpanel"><p>Panel 2 content</p></div>
+  </div>
+</section>
+```
+
+### 3. Why is it useful?
+It provides a zero-JS tab component with a premium blur-entrance animation that feels smooth and modern. The neumorphic soft styling gives a tactile, approachable feel suitable for dashboards, settings panels, and documentation sites.
+
+---
+
+## Features
+
+- **Pure HTML + CSS**: Zero JavaScript dependencies. Uses radio button hack for tab switching.
+- **Blur-Entrance Animation**: Panel content fades in from a blurred, scaled state with a vertical slide.
+- **Neumorphic Soft Aesthetic**: Raised/inset shadows on surfaces, triggers, and panels for a tactile feel.
+- **Multiple Variants**: Default, compact, and pill styles included.
+- **Keyboard Accessible**: Tab navigation via radio inputs; focus-visible outlines.
+- **Reduced Motion**: Disables blur animation when `prefers-reduced-motion` is enabled.
+- **Responsive**: Stacks tabs vertically on small screens.
+
+---
+
+## Customization
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `--bet-duration` | Animation duration | `0.4s` |
+| `--bet-easing` | Easing curve | `cubic-bezier(0.22, 1, 0.36, 1)` |
+| `--bet-blur-from` | Starting blur amount | `8px` |
+| `--bet-scale-from` | Starting scale | `0.95` |
+| `--bet-translate-y` | Starting vertical offset | `6px` |
+| `--bet-bg` | Page background | `#e0e5ec` |
+| `--bet-surface` | Card surface | `#e0e5ec` |
+| `--bet-accent` | Active tab color | `#6366f1` |
+| `--bet-shadow-out` | Raised neumorphic shadow | `6px 6px 12px ...` |
+| `--bet-shadow-in` | Inset neumorphic shadow | `inset 4px 4px 8px ...` |
+
+---
+
+## Folder Structure
+
+```text
+submissions/examples/blur-entrance-tabs-50118/
+├── demo.html       ← Demo with 3 tab variants (default, compact, pill)
+├── style.css       ← Component styles with blur-entrance animation and CSS custom properties
+└── README.md       ← This file
+```

--- a/submissions/examples/blur-entrance-tabs-50118/demo.html
+++ b/submissions/examples/blur-entrance-tabs-50118/demo.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Blur-Entrance Tabs - Neumorphic Soft Layouts | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Blur-Entrance Tabs</h1>
+    <p>Pure CSS tabs with blur-entrance animation, styled for neumorphic soft interfaces.</p>
+  </header>
+
+  <main class="bet-grid">
+
+    <!-- Tab Component 1: Default -->
+    <section class="bet" aria-label="Analytics overview">
+      <div class="bet__list" role="tablist">
+        <input type="radio" name="tab-1" id="tab-1-1" class="bet__input" checked>
+        <label for="tab-1-1" class="bet__trigger" role="tab" tabindex="0">Overview</label>
+
+        <input type="radio" name="tab-1" id="tab-1-2" class="bet__input">
+        <label for="tab-1-2" class="bet__trigger" role="tab" tabindex="0">Revenue</label>
+
+        <input type="radio" name="tab-1" id="tab-1-3" class="bet__input">
+        <label for="tab-1-3" class="bet__trigger" role="tab" tabindex="0">Users</label>
+      </div>
+
+      <div class="bet__panels">
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">Dashboard Overview</p>
+          <p class="bet__panel-text">Active users: 1,247 | Uptime: 99.98% | Response time: 42ms avg across all regions.</p>
+        </div>
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">Revenue Metrics</p>
+          <p class="bet__panel-text">MRR: $52,400 | ARR: $628,800 | Growth rate: 14% MoM with expanding enterprise tier.</p>
+        </div>
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">User Analytics</p>
+          <p class="bet__panel-text">DAU: 3,842 | MAU: 18,200 | Retention: 78% at day-30 with 4.2 min avg session.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tab Component 2: Compact Variant -->
+    <section class="bet bet--compact" aria-label="Settings">
+      <div class="bet__list" role="tablist">
+        <input type="radio" name="tab-2" id="tab-2-1" class="bet__input" checked>
+        <label for="tab-2-1" class="bet__trigger" role="tab" tabindex="0">General</label>
+
+        <input type="radio" name="tab-2" id="tab-2-2" class="bet__input">
+        <label for="tab-2-2" class="bet__trigger" role="tab" tabindex="0">Security</label>
+
+        <input type="radio" name="tab-2" id="tab-2-3" class="bet__input">
+        <label for="tab-2-3" class="bet__trigger" role="tab" tabindex="0">Billing</label>
+      </div>
+
+      <div class="bet__panels">
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">General Settings</p>
+          <p class="bet__panel-text">Theme, language, timezone, and notification preferences for your workspace.</p>
+        </div>
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">Security Settings</p>
+          <p class="bet__panel-text">Two-factor authentication, session management, and API key rotation.</p>
+        </div>
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">Billing Settings</p>
+          <p class="bet__panel-text">Payment method, invoice history, and plan management options.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tab Component 3: Pill Variant -->
+    <section class="bet bet--pill" aria-label="Documentation">
+      <div class="bet__list" role="tablist">
+        <input type="radio" name="tab-3" id="tab-3-1" class="bet__input" checked>
+        <label for="tab-3-1" class="bet__trigger" role="tab" tabindex="0">Quick Start</label>
+
+        <input type="radio" name="tab-3" id="tab-3-2" class="bet__input">
+        <label for="tab-3-2" class="bet__trigger" role="tab" tabindex="0">API Ref</label>
+
+        <input type="radio" name="tab-3" id="tab-3-3" class="bet__input">
+        <label for="tab-3-3" class="bet__trigger" role="tab" tabindex="0">Examples</label>
+
+        <input type="radio" name="tab-3" id="tab-3-4" class="bet__input">
+        <label for="tab-3-4" class="bet__trigger" role="tab" tabindex="0">FAQ</label>
+      </div>
+
+      <div class="bet__panels">
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">Getting Started</p>
+          <p class="bet__panel-text">Install via npm, import the CSS, and add the HTML markup. Zero config required.</p>
+        </div>
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">API Reference</p>
+          <p class="bet__panel-text">All CSS custom properties, class naming conventions, and variant modifiers documented.</p>
+        </div>
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">Code Examples</p>
+          <p class="bet__panel-text">Copy-paste examples for dashboards, landing pages, and admin panels.</p>
+        </div>
+        <div class="bet__panel" role="tabpanel">
+          <p class="bet__panel-title">FAQ</p>
+          <p class="bet__panel-text">Browser support, accessibility notes, and integration guides.</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="margin-top: 3rem; color: var(--bet-text-muted); font-size: 0.75rem; text-align: center;">
+    EaseMotion-css &bull; Blur-Entrance Tabs &bull; Pure HTML + CSS
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-tabs-50118/style.css
+++ b/submissions/examples/blur-entrance-tabs-50118/style.css
@@ -1,0 +1,269 @@
+/* ==========================================================================
+   CSS Blur-Entrance Tabs - Neumorphic Soft Layouts
+   Pure CSS component for EaseMotion CSS (#50118)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design Tokens (CSS Custom Properties)
+   -------------------------------------------------------------------------- */
+:root {
+  /* Blur-Entrance Animation */
+  --bet-duration: 0.4s;
+  --bet-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --bet-blur-from: 8px;
+  --bet-blur-to: 0px;
+  --bet-scale-from: 0.95;
+  --bet-scale-to: 1;
+  --bet-translate-y: 6px;
+
+  /* Neumorphic Soft Theme */
+  --bet-bg: #e0e5ec;
+  --bet-surface: #e0e5ec;
+  --bet-text: #4a5568;
+  --bet-text-muted: #718096;
+  --bet-accent: #6366f1;
+  --bet-accent-light: #818cf8;
+
+  /* Shadows */
+  --bet-shadow-out: 6px 6px 12px rgba(163, 177, 198, 0.6), -6px -6px 12px rgba(255, 255, 255, 0.5);
+  --bet-shadow-in: inset 4px 4px 8px rgba(163, 177, 198, 0.6), inset -4px -4px 8px rgba(255, 255, 255, 0.5);
+  --bet-shadow-sm: 3px 3px 6px rgba(163, 177, 198, 0.5), -3px -3px 6px rgba(255, 255, 255, 0.4);
+
+  /* Spacing & Radii */
+  --bet-radius: 16px;
+  --bet-radius-sm: 10px;
+  --bet-padding: 1.25rem 1.5rem;
+}
+
+/* --------------------------------------------------------------------------
+   2. Base Reset & Layout
+   -------------------------------------------------------------------------- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background-color: var(--bet-bg);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: var(--bet-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Page Header */
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  max-width: 560px;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.5rem;
+  color: var(--bet-text);
+}
+
+.page-header p {
+  color: var(--bet-text-muted);
+  font-size: 1rem;
+}
+
+/* Layout Grid */
+.bet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 800px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Blur-Entrance Tabs Core
+   -------------------------------------------------------------------------- */
+
+/* Tab Container */
+.bet {
+  background-color: var(--bet-surface);
+  border-radius: var(--bet-radius);
+  box-shadow: var(--bet-shadow-out);
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+/* Tab List (Navigation) */
+.bet__list {
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0.375rem;
+  background-color: var(--bet-surface);
+  border-radius: var(--bet-radius-sm);
+  box-shadow: var(--bet-shadow-in);
+  margin-bottom: 1.25rem;
+}
+
+/* Tab Triggers */
+.bet__trigger {
+  flex: 1;
+  background: none;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--bet-text-muted);
+  cursor: pointer;
+  position: relative;
+  transition:
+    color var(--bet-duration) var(--bet-easing),
+    box-shadow var(--bet-duration) var(--bet-easing),
+    background-color var(--bet-duration) var(--bet-easing);
+}
+
+.bet__trigger:hover {
+  color: var(--bet-text);
+}
+
+/* Active tab state - uses radio button hack */
+.bet__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.bet__input:checked + .bet__trigger {
+  color: var(--bet-accent);
+  background-color: var(--bet-surface);
+  box-shadow: var(--bet-shadow-sm);
+}
+
+.bet__input:focus-visible + .bet__trigger {
+  outline: 2px solid var(--bet-accent);
+  outline-offset: 2px;
+}
+
+/* Tab Panels */
+.bet__panel {
+  display: none;
+  padding: 0.25rem 0;
+  min-height: 80px;
+}
+
+.bet__panel-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--bet-text);
+  margin-bottom: 0.5rem;
+}
+
+.bet__panel-text {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--bet-text-muted);
+}
+
+/* --------------------------------------------------------------------------
+   4. Blur-Entrance Animation on Panel Switch
+   -------------------------------------------------------------------------- */
+
+/* Show active panel with blur-entrance */
+.bet__input:nth-of-type(1):checked ~ .bet__panels .bet__panel:nth-child(1),
+.bet__input:nth-of-type(2):checked ~ .bet__panels .bet__panel:nth-child(2),
+.bet__input:nth-of-type(3):checked ~ .bet__panels .bet__panel:nth-child(3),
+.bet__input:nth-of-type(4):checked ~ .bet__panels .bet__panel:nth-child(4) {
+  display: block;
+  animation: bet-blur-in var(--bet-duration) var(--bet-easing) both;
+}
+
+@keyframes bet-blur-in {
+  0% {
+    opacity: 0;
+    filter: blur(var(--bet-blur-from));
+    transform: scale(var(--bet-scale-from)) translateY(var(--bet-translate-y));
+  }
+  100% {
+    opacity: 1;
+    filter: blur(var(--bet-blur-to));
+    transform: scale(var(--bet-scale-to)) translateY(0);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   5. Neumorphic Variants
+   -------------------------------------------------------------------------- */
+
+/* Compact variant */
+.bet--compact .bet__list {
+  margin-bottom: 1rem;
+}
+
+.bet--compact .bet__trigger {
+  padding: 0.4rem 0.6rem;
+  font-size: 0.75rem;
+}
+
+/* Pill variant */
+.bet--pill .bet__list {
+  border-radius: 24px;
+}
+
+.bet--pill .bet__trigger {
+  border-radius: 20px;
+}
+
+/* --------------------------------------------------------------------------
+   6. Accessibility
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .bet__panel {
+    animation: none !important;
+  }
+}
+
+/* Screen reader only */
+.bet-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --------------------------------------------------------------------------
+   7. Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .bet-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .bet__list {
+    flex-direction: column;
+  }
+
+  .bet__trigger {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Related Issue
Closes #50118

## Description
Adds a pure CSS Blur-Entrance Tabs component for neumorphic soft layouts. Tab panels transition in with a smooth blur-to-clear reveal using only CSS (radio button hack). Styled with soft raised/inset neumorphic shadows for a tactile feel.

## Changes
- `submissions/examples/blur-entrance-tabs-50118/style.css` — Component styles with blur-entrance keyframe, CSS custom properties, neumorphic shadows, 3 variants (default, compact, pill), and accessibility support
- `submissions/examples/blur-entrance-tabs-50118/demo.html` — Demo with 3 tab variants: Analytics Overview, Settings, and Documentation
- `submissions/examples/blur-entrance-tabs-50118/README.md` — Documentation with usage instructions and customization guide

## Features
- Pure HTML + CSS, zero JavaScript (radio button hack)
- Blur-entrance animation: panels fade in from blurred, scaled-down state
- Neumorphic soft aesthetic with raised/inset shadows
- 3 variants: default, compact, and pill
- Keyboard accessible via radio inputs with focus-visible outlines
- `prefers-reduced-motion` support
- Responsive vertical stacking on mobile
- Configurable via 10 CSS custom properties

## Checklist
- [x] Files placed only in `submissions/examples/`
- [x] No existing files modified
- [x] Demo page loads correctly
- [x] Tab switching works via keyboard
- [x] Blur animation visible on tab switch
- [x] Reduced motion preference respected