### PR TITLE
Add CSS-only dark/light theme crossfade demo

### DIFF
--- a/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/README.md
+++ b/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/README.md
@@ -1,0 +1,163 @@
+# 🌾 Smart Farmer AI
+
+> An AI-powered crop recommendation web app for Indian farmers — predicts the best crops for any city using real-time weather, NASA soil data, ICAR soil database, and Groq LLM for fertilizer, irrigation, and mandi price advice.
+
+![Python](https://img.shields.io/badge/Python-3.10+-blue?style=flat&logo=python)
+![Flask](https://img.shields.io/badge/Flask-3.x-black?style=flat&logo=flask)
+![XGBoost](https://img.shields.io/badge/XGBoost-ML-orange?style=flat)
+![NASA API](https://img.shields.io/badge/NASA-POWER_API-blue?style=flat)
+![Groq LLM](https://img.shields.io/badge/Groq-LLaMA_3.3-purple?style=flat)
+![License](https://img.shields.io/badge/License-MIT-green?style=flat)
+
+---
+
+## 🚀 Features
+
+- 🌱 **Crop Prediction** — XGBoost ML model trained on 22+ crops with real soil & weather inputs
+- 🌤️ **Live Weather Integration** — OpenWeatherMap API for real-time temperature, humidity & wind
+- 🛰️ **NASA POWER API** — Daily rainfall and soil moisture data from satellite
+- 🧪 **ICAR Soil Database** — City-specific N, P, K, pH values for 100+ Indian cities
+- 🤖 **Groq LLM Advice** — AI-generated fertilizer schedules, irrigation plans & mandi prices
+- 🍃 **Leaf Disease Detection** — Upload a leaf image for instant AI disease diagnosis
+- 📅 **12-Month Crop Calendar** — Month-wise farming activity planner
+- 🏪 **Mandi Price Search** — Real-time market price analysis with 30-day forecast
+- 🌐 **Multilingual Support** — English, Telugu, and Hindi
+- 🗺️ **50+ Extended Crops** — Region + climate based recommendations beyond ML model
+
+---
+
+## 🛠️ Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | Python, Flask |
+| ML Model | XGBoost, Scikit-learn |
+| AI / LLM | Groq API (LLaMA 3.3 70B + LLaMA 4 Scout Vision) |
+| Weather | OpenWeatherMap API |
+| Soil & Rain | NASA POWER API |
+| Geocoding | Geopy (Nominatim) |
+| Frontend | HTML, CSS, JavaScript, Jinja2 |
+| Data | ICAR Soil DB, Custom Rainfall DB (120+ cities) |
+
+---
+
+## 📁 Project Structure
+
+```
+Smart_Farmer_AI/
+├── templates/              # HTML templates (Jinja2)
+├── app.py                  # Main Flask application
+├── shc_engine.py           # Soil Health Card scraper engine
+├── train_model.py          # XGBoost model training script
+├── xgb_model.pkl           # Trained XGBoost model
+├── encoder.pkl             # Label encoder for crop classes
+├── class_names.json        # Crop class names
+├── Crop_recommendation.csv # Training dataset
+├── requirements.txt        # Python dependencies
+├── .gitignore              # Git ignore rules
+└── README.md               # Project documentation
+```
+
+---
+
+## ⚙️ Setup & Installation
+
+### 1. Clone the repository
+```bash
+git clone https://github.com/GeethaBurigalla/Smart_Farmer_AI.git
+cd Smart_Farmer_AI
+```
+
+### 2. Install dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Set up environment variables
+
+Create a `.env` file in the root directory:
+```
+GROQ_API_KEY=your_groq_api_key_here
+WEATHER_API_KEY=your_openweathermap_api_key_here
+```
+
+> 🔑 Get your free API keys:
+> - Groq: https://console.groq.com
+> - OpenWeatherMap: https://openweathermap.org/api
+
+### 4. Run the application
+```bash
+python app.py
+```
+
+Visit `http://127.0.0.1:5000` in your browser.
+
+---
+
+## 🌍 How It Works
+
+```
+User enters city name
+        ↓
+Geocoding (Geopy) → lat/lon
+        ↓
+┌─────────────────────────────────┐
+│  NASA POWER API → daily rain    │
+│  OpenWeatherMap → temp, humidity│
+│  ICAR Soil DB   → N, P, K, pH  │
+│  Annual Rain DB → annual mm     │
+└─────────────────────────────────┘
+        ↓
+XGBoost ML Model → Top 5 crop predictions
+        ↓
+Region + Climate Engine → 8 extended crops
+        ↓
+Groq LLM → Fertilizer / Irrigation / Mandi advice
+        ↓
+Result displayed in selected language
+```
+
+---
+
+## 📊 ML Model Details
+
+- **Algorithm:** XGBoost Classifier
+- **Dataset:** Crop Recommendation Dataset (Kaggle)
+- **Features:** N, P, K, Temperature, Humidity, pH, Rainfall
+- **Classes:** 22 crops (Rice, Maize, Chickpea, Mango, Coconut, Coffee, etc.)
+- **Extended:** 50+ crops via region + climate scoring engine
+
+---
+
+## 🌐 Supported Cities
+
+100+ Indian cities across all states including Hyderabad, Bengaluru, Mumbai, Delhi, Chennai, Kolkata, and more — each with curated ICAR soil data and annual rainfall values.
+
+---
+
+## 👥 Contributors
+
+| Name | GitHub |
+|------|--------|
+| Geetha Burigalla | [@GeethaBurigalla](https://github.com/GeethaBurigalla) |
+| Hruthika | [@hruthika18](https://github.com/hruthika18) |
+
+---
+
+## 📄 License
+
+This project is licensed under the MIT License.
+
+---
+
+## 🙏 Acknowledgements
+
+- [NASA POWER API](https://power.larc.nasa.gov/) for satellite-based soil & weather data
+- [ICAR](https://icar.org.in/) for soil health reference data
+- [Groq](https://groq.com/) for blazing-fast LLM inference
+- [OpenWeatherMap](https://openweathermap.org/) for live weather data
+- [Kaggle Crop Recommendation Dataset](https://www.kaggle.com/datasets/atharvaingle/crop-recommendation-dataset)
+
+---
+
+<p align="center">Made with ❤️ for Indian Farmers 🇮🇳</p>

--- a/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/demo.html
+++ b/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS-Only Dark/Light Theme Crossfade</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- CSS-only toggle driver. Must be the first element so ~ sibling selectors can reach everything below it. -->
+  <input type="checkbox" id="theme-toggle" class="theme-toggle-input">
+
+  <div class="page">
+
+    <header class="site-header">
+      <div class="logo-wrap" aria-hidden="false">
+        <span class="logo logo--light">EaseMotion</span>
+        <span class="logo logo--dark">EaseMotion</span>
+      </div>
+
+      <label for="theme-toggle" class="toggle-switch" aria-label="Toggle dark and light theme">
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
+        <span class="toggle-text toggle-text--light">Light</span>
+        <span class="toggle-text toggle-text--dark">Dark</span>
+      </label>
+    </header>
+
+    <main class="content">
+      <section class="card">
+        <h1>Theme Crossfade Demo</h1>
+        <p>
+          Flip the switch above. Background, surface, and text tokens morph
+          smoothly instead of hard-switching, and the logo mark crossfades
+          between its light and dark variants.
+        </p>
+        <button class="btn btn--primary" type="button">Primary action</button>
+        <button class="btn btn--ghost" type="button">Secondary action</button>
+      </section>
+
+      <section class="card card--muted">
+        <h2>Sample surface</h2>
+        <p>
+          This second surface uses the <code>--surface</code> token so you
+          can see it morph independently from the page background.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>CSS-only crossfade &middot; respects <code>prefers-reduced-motion</code></p>
+    </footer>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/style.css
+++ b/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/style.css
@@ -1,0 +1,551 @@
+/* ============ RESET & BASE ============ */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --bg: #0a0e17;
+  --bg-card: #131826;
+  --bg-card-2: #1a2133;
+  --border: #252e44;
+  --text: #e8ecf5;
+  --text-dim: #8b95ab;
+  --accent: #6c5ce7;
+  --accent-2: #00d9b5;
+  --accent-3: #ff6b9d;
+  --warn: #ffb454;
+  --radius: 16px;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+}
+
+h1, h2, h3 { font-family: 'Space Grotesk', sans-serif; }
+
+/* ============ BACKGROUND GLOW ============ */
+.bg-glow {
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.25;
+  pointer-events: none;
+  z-index: 0;
+}
+.bg-glow-1 {
+  width: 500px; height: 500px;
+  background: var(--accent);
+  top: -150px; left: -100px;
+}
+.bg-glow-2 {
+  width: 400px; height: 400px;
+  background: var(--accent-2);
+  bottom: -100px; right: -100px;
+}
+
+/* ============ SCREENS ============ */
+.screen {
+  display: none;
+  min-height: 100vh;
+  position: relative;
+  z-index: 1;
+}
+.screen.active { display: block; }
+
+.container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+/* ============ HERO ============ */
+.hero { text-align: center; margin-bottom: 36px; }
+
+.badge {
+  display: inline-block;
+  background: rgba(108, 92, 231, 0.15);
+  border: 1px solid rgba(108, 92, 231, 0.4);
+  color: #b8a9ff;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: 999px;
+  margin-bottom: 18px;
+}
+
+.hero h1 {
+  font-size: 48px;
+  font-weight: 700;
+  letter-spacing: -1px;
+}
+.accent { color: var(--accent-2); }
+
+.subtitle {
+  color: var(--text-dim);
+  font-size: 16px;
+  margin-top: 10px;
+}
+
+/* ============ CARD ============ */
+.card {
+  background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-card-2) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+  margin-bottom: 20px;
+}
+
+.form-card { padding: 32px; }
+
+/* ============ FORM FIELDS ============ */
+.field-group { margin-bottom: 24px; }
+
+label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 10px;
+}
+
+select, input[type="text"] {
+  width: 100%;
+  background: #0e1320;
+  border: 1.5px solid var(--border);
+  color: var(--text);
+  font-family: 'Inter', sans-serif;
+  font-size: 15px;
+  padding: 13px 16px;
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+select:focus, input[type="text"]:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(108, 92, 231, 0.15);
+}
+
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1L6 6L11 1' stroke='%238b95ab' stroke-width='1.5' fill='none'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+}
+
+/* ============ AUTOSUGGEST ============ */
+.autosuggest-wrap { position: relative; }
+
+.suggestions-list {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0; right: 0;
+  background: #131826;
+  border: 1.5px solid var(--accent);
+  border-radius: 10px;
+  list-style: none;
+  max-height: 220px;
+  overflow-y: auto;
+  z-index: 10;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.5);
+  display: none;
+}
+.suggestions-list.show { display: block; }
+
+.suggestions-list li {
+  padding: 11px 16px;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.15s;
+}
+.suggestions-list li:last-child { border-bottom: none; }
+.suggestions-list li:hover, .suggestions-list li.highlighted {
+  background: rgba(108, 92, 231, 0.15);
+}
+.suggestions-list li .tag {
+  font-size: 11px;
+  color: var(--text-dim);
+  background: rgba(255,255,255,0.05);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.suggestions-list li.empty {
+  color: var(--text-dim);
+  cursor: default;
+}
+.suggestions-list li.empty:hover { background: transparent; }
+
+/* ============ CHIPS ============ */
+.chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+  min-height: 0;
+}
+
+.chip {
+  background: rgba(0, 217, 181, 0.12);
+  border: 1px solid rgba(0, 217, 181, 0.4);
+  color: var(--accent-2);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 7px 10px 7px 14px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  animation: chipIn 0.25s ease;
+}
+
+@keyframes chipIn {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.chip button {
+  background: none;
+  border: none;
+  color: var(--accent-2);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.7;
+  padding: 0;
+}
+.chip button:hover { opacity: 1; }
+
+.hint {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 8px;
+  text-transform: none;
+}
+
+/* ============ ENGINE TOGGLE ============ */
+.toggle-label { margin-bottom: 10px; }
+
+.engine-toggle {
+  display: flex;
+  gap: 8px;
+  background: #0e1320;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 4px;
+}
+
+.engine-btn {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.engine-btn.active {
+  background: var(--accent);
+  color: white;
+}
+
+.engine-hint { margin-top: 8px; }
+
+/* ============ BUTTONS ============ */
+.btn-primary {
+  width: 100%;
+  background: linear-gradient(135deg, var(--accent) 0%, #5849c4 100%);
+  color: white;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 16px;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.15s, opacity 0.2s, box-shadow 0.2s;
+  box-shadow: 0 8px 24px rgba(108, 92, 231, 0.3);
+}
+.btn-primary:hover:not(:disabled) { transform: translateY(-2px); box-shadow: 0 12px 28px rgba(108, 92, 231, 0.4); }
+.btn-primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-secondary {
+  width: 100%;
+  background: var(--bg-card-2);
+  border: 1.5px solid var(--border);
+  color: var(--text);
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: border-color 0.2s, background 0.2s;
+}
+.btn-secondary:hover { border-color: var(--accent); background: var(--bg-card); }
+
+.btn-ghost {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 14px;
+  cursor: pointer;
+  margin-bottom: 20px;
+  padding: 8px 0;
+}
+.btn-ghost:hover { color: var(--text); }
+
+/* ============ SCANNING SCREEN ============ */
+#screen-scanning {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+#screen-scanning.active { display: flex; }
+
+.scanning-box {
+  text-align: center;
+}
+
+.scan-ring {
+  width: 110px; height: 110px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  margin: 0 auto 32px;
+  animation: spin 1.1s linear infinite;
+  position: relative;
+}
+.scan-ring-inner {
+  position: absolute;
+  inset: 14px;
+  border: 3px solid var(--border);
+  border-bottom-color: var(--accent-2);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite reverse;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.scan-text {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 18px;
+  font-weight: 500;
+  margin-bottom: 24px;
+  min-height: 24px;
+}
+
+.scan-progress {
+  width: 280px;
+  height: 6px;
+  background: var(--bg-card-2);
+  border-radius: 999px;
+  overflow: hidden;
+  margin: 0 auto;
+}
+.scan-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+/* ============ RESULTS SCREEN ============ */
+.results-container { max-width: 680px; }
+
+.persona-card {
+  text-align: center;
+  background: linear-gradient(160deg, rgba(108,92,231,0.18), rgba(0,217,181,0.1));
+  border: 1.5px solid rgba(108, 92, 231, 0.4);
+  animation: revealIn 0.5s ease;
+}
+
+@keyframes revealIn {
+  from { opacity: 0; transform: translateY(16px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.persona-emoji {
+  font-size: 56px;
+  margin-bottom: 8px;
+  animation: bounceIn 0.6s ease;
+}
+@keyframes bounceIn {
+  0% { transform: scale(0); }
+  60% { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+.persona-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  color: var(--accent-2);
+  margin-bottom: 8px;
+}
+
+.persona-card h2 {
+  font-size: 28px;
+  margin-bottom: 10px;
+}
+
+.persona-card p {
+  color: var(--text-dim);
+  font-size: 15px;
+  max-width: 440px;
+  margin: 0 auto;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+/* ============ ROADMAP TRACK ============ */
+.roadmap-track {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.roadmap-stage {
+  display: flex;
+  gap: 16px;
+  opacity: 0;
+  animation: slideIn 0.4s ease forwards;
+}
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(-12px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.stage-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.stage-dot {
+  width: 40px; height: 40px;
+  background: var(--bg-card-2);
+  border: 2px solid var(--accent);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  z-index: 1;
+}
+
+.stage-line {
+  width: 2px;
+  flex: 1;
+  background: linear-gradient(180deg, var(--accent), var(--border));
+  min-height: 36px;
+}
+
+.roadmap-stage:last-child .stage-line { display: none; }
+
+.stage-content { padding-bottom: 28px; flex: 1; }
+
+.stage-title {
+  font-weight: 600;
+  font-size: 15px;
+  margin-bottom: 4px;
+}
+
+.stage-when {
+  font-size: 11px;
+  color: var(--accent-2);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+
+.stage-desc {
+  font-size: 13.5px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+/* ============ SKILL GAP ============ */
+.skillgap-bars { display: flex; flex-direction: column; gap: 16px; }
+
+.skillgap-row { width: 100%; }
+
+.skillgap-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+.skillgap-label .skill-name { font-weight: 500; }
+.skillgap-label .skill-pct { color: var(--text-dim); }
+
+.skillgap-track {
+  height: 10px;
+  background: var(--bg-card-2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.skillgap-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: 999px;
+  transition: width 0.8s ease;
+}
+.skillgap-fill.have { background: linear-gradient(90deg, var(--accent-2), #00b89a); }
+.skillgap-fill.need { background: linear-gradient(90deg, var(--accent-3), #d6447d); }
+
+/* ============ RESOURCES ============ */
+.resources-list { display: flex; flex-direction: column; gap: 10px; }
+
+.resource-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--bg-card-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color 0.2s, transform 0.15s;
+}
+.resource-item:hover { border-color: var(--accent); transform: translateX(2px); }
+
+.resource-icon { font-size: 18px; }
+.resource-text { flex: 1; font-size: 13.5px; }
+.resource-text .resource-stage { display: block; font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+
+/* ============ RESPONSIVE ============ */
+@media (max-width: 480px) {
+  .hero h1 { font-size: 36px; }
+  .container { padding: 32px 16px 60px; }
+  .card { padding: 20px; }
+  .engine-toggle { flex-direction: column; }
+}


### PR DESCRIPTION
Adds a CSS-only dark/light theme crossfade demo. Instead of hard-switching colors, background/surface/text tokens morph smoothly on toggle, and the logo mark softly crossfades between light/dark variants. Solves the gap flagged in #51872 — no existing EaseMotion demo documents a token-morph theme transition.
Type of Change

 ✨ New animation / hover effect
 🧩 New component

Submission Checklist

 All changes are inside submissions/ (submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)

Feature Description
What does this add?
A CSS-only theme toggle that crossfades design tokens and a logo mark between light and dark, instead of snapping instantly.
How does a developer use it?
html<input type="checkbox" id="theme-toggle" class="theme-toggle-input">
<div class="page">
  <!-- your content — tokens like --bg, --surface, --text
       automatically morph when the checkbox is checked -->
</div>
Why does it fit EaseMotion CSS?
It's zero-JS and driven entirely by native CSS (:checked + sibling selectors + transitioned custom properties), matching EaseMotion's animation-first, human-readable philosophy. It also respects prefers-reduced-motion, which keeps it accessible by default.
Demo

 Demo added (demo.html works by opening directly in a browser)

Browser Testing

 Chrome
 Firefox
 Edge
 Safari

Notes for Maintainer
Transition duration is set to 600ms — happy to tune faster/slower if you'd prefer a snappier or more dramatic crossfade. Opened as a draft while I do a final pass across browsers.
Closes #51872