### PR TITLE
Add Fade-In Popover for Cyberpunk Neon layouts

### DIFF
--- a/submissions/examples/fade-in-popover-sj/README.md
+++ b/submissions/examples/fade-in-popover-sj/README.md
@@ -1,0 +1,49 @@
+# Fade-In Popover (Cyberpunk Neon)
+
+A pure CSS animated popover featuring a smooth fade-in transition with a cyberpunk neon-inspired design. The component is responsive, keyboard accessible, and customizable using CSS custom properties.
+
+## Features
+
+- Pure HTML & CSS
+- Smooth fade-in animation
+- Cyberpunk neon theme
+- Responsive layout
+- Keyboard accessible (`:focus-visible`)
+- Customizable with CSS variables
+- No JavaScript required
+
+## Files
+
+- `demo.html` – Demonstration of the popover component
+- `style.css` – Styling, animations, and CSS custom properties
+- `README.md` – Documentation
+
+## Customization
+
+You can modify the following CSS custom properties:
+
+```css
+--bg-color
+--popover-bg
+--text-color
+--accent
+--accent-secondary
+--button-bg
+--button-hover
+--radius
+--duration
+--easing
+--shadow
+```
+
+## Usage
+
+1. Open `demo.html` in a browser.
+2. Hover over or focus the button to display the popover.
+3. Customize the appearance by editing the CSS variables.
+
+## Accessibility
+
+- Keyboard accessible using `:focus-visible`
+- Semantic HTML elements
+- Responsive across different screen sizes

--- a/submissions/examples/fade-in-popover-sj/demo.html
+++ b/submissions/examples/fade-in-popover-sj/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fade-In Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+
+    <button class="popover-btn" aria-describedby="popover-card">
+        Open Popover
+
+        <div class="popover-card" id="popover-card" role="dialog">
+
+            <h2>Cyberpunk Neon</h2>
+
+            <p>
+                A futuristic CSS popover with a smooth fade-in effect and glowing neon accents.
+            </p>
+
+            <a href="#" class="explore-btn">
+                Explore
+            </a>
+
+        </div>
+    </button>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-popover-sj/style.css
+++ b/submissions/examples/fade-in-popover-sj/style.css
@@ -1,0 +1,124 @@
+:root {
+    --bg-color: #0b0f1a;
+    --popover-bg: #151a2d;
+    --text-color: #ffffff;
+    --accent: #00f7ff;
+    --accent-secondary: #ff00d4;
+    --button-bg: #111827;
+    --button-hover: #1f2937;
+    --radius: 14px;
+    --duration: 0.4s;
+    --easing: ease;
+    --shadow: 0 0 15px rgba(0, 247, 255, 0.5);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: var(--bg-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 20px;
+}
+
+.container {
+    position: relative;
+}
+
+.popover-btn {
+    position: relative;
+    padding: 14px 28px;
+    border: 2px solid var(--accent);
+    border-radius: var(--radius);
+    background: var(--button-bg);
+    color: var(--text-color);
+    font-size: 16px;
+    cursor: pointer;
+    transition: background var(--duration) var(--easing),
+                box-shadow var(--duration) var(--easing);
+}
+
+.popover-btn:hover,
+.popover-btn:focus-visible {
+    background: var(--button-hover);
+    box-shadow: var(--shadow);
+    outline: none;
+}
+
+.popover-card {
+    position: absolute;
+    top: calc(100% + 16px);
+    left: 50%;
+    transform: translateX(-50%) translateY(10px);
+
+    width: 300px;
+    background: var(--popover-bg);
+    color: var(--text-color);
+    border: 2px solid var(--accent);
+    border-radius: var(--radius);
+    padding: 20px;
+    box-shadow: 0 0 20px rgba(0,247,255,0.35);
+
+    opacity: 0;
+    visibility: hidden;
+
+    transition:
+        opacity var(--duration) var(--easing),
+        transform var(--duration) var(--easing),
+        visibility var(--duration) var(--easing);
+}
+
+.popover-card h2 {
+    color: var(--accent);
+    margin-bottom: 10px;
+    font-size: 22px;
+    text-shadow: 0 0 8px var(--accent);
+}
+
+.popover-card p {
+    font-size: 15px;
+    line-height: 1.6;
+    margin-bottom: 18px;
+}
+
+.explore-btn {
+    display: inline-block;
+    text-decoration: none;
+    padding: 10px 18px;
+    border-radius: 8px;
+    background: var(--accent);
+    color: #000;
+    font-weight: bold;
+    transition: all var(--duration) var(--easing);
+}
+
+.explore-btn:hover {
+    background: var(--accent-secondary);
+    color: #fff;
+    box-shadow: 0 0 15px var(--accent-secondary);
+}
+
+.popover-btn:hover .popover-card,
+.popover-btn:focus-visible .popover-card {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0);
+}
+
+@media (max-width: 480px) {
+    .popover-card {
+        width: 260px;
+        padding: 16px;
+    }
+
+    .popover-btn {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new **Fade-In Popover** component with a Cyberpunk Neon theme built using pure HTML and CSS.

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

### What does this add?

A responsive cyberpunk-themed popover with a smooth fade-in animation using only HTML and CSS.

### How does a developer use it?

Open `demo.html` in a browser and hover over or focus the button to display the popover.

### Why does it fit EaseMotion CSS?

It provides a reusable animated UI component that matches the project's collection of CSS interaction examples.

## Demo

- [x] Demo added (`demo.html`)

## Browser Testing

- [x] Chrome

## Notes for Maintainer

Closes #46374