### PR TITLE
feat(submission): add ease-blur-entrance-carousel component (#50515)

### DIFF
--- a/submissions/examples/ease-blur-entrance-carousel-ksk/README.md
+++ b/submissions/examples/ease-blur-entrance-carousel-ksk/README.md
@@ -1,0 +1,23 @@
+# Blur-Entrance Carousel (`ease-blur-entrance-carousel-ksk`)
+
+1. What does this do?  
+An interactive stacked carousel where slides transition in from a blurred, scaled-down state (`filter: blur(18px) scale(0.92)`) to clear full-scale size, matching frosted glassmorphic card designs. Directional arrow labels and dot indicator pills navigate through the deck.
+
+2. How is it used?  
+Define three radio inputs named `carousel-group` (`#carousel-1`, `#carousel-2`, `#carousel-3`) immediately before the card `.carousel-card`. Set up `<label>` elements pointing to the radio IDs for arrows and dots. Customize transition properties using variables:
+
+```css
+.carousel-card {
+  --ease-carousel-blur:     18px;          /* initial blur distance   */
+  --ease-carousel-scale:    0.92;          /* initial scale offset    */
+  --ease-carousel-duration: 0.55s;         /* speed of transition     */
+  --ease-carousel-easing:   cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-carousel-accent:   #3b82f6;       /* category theme color    */
+}
+```
+
+3. Why is it useful?  
+Instead of traditional slide-in translations, the blur-entrance transition creates a clean focal fade effect. Perfect for glassmorphic product highlights, portfolio decks, features spotlights, and Spatial UI mockups. Fully responsive and operates 100% without JavaScript.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #50515.*

--- a/submissions/examples/ease-blur-entrance-carousel-ksk/demo.html
+++ b/submissions/examples/ease-blur-entrance-carousel-ksk/demo.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blur-Entrance Carousel — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #070913;
+      /* Vivid colourful background to showcase glassmorphism */
+      background-image:
+        radial-gradient(circle at 10% 20%, #4f46e5 0%, transparent 40%),
+        radial-gradient(circle at 90% 80%, #db2777 0%, transparent 45%),
+        radial-gradient(circle at 50% 50%, #0891b2 0%, transparent 50%);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 3rem;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-header h1 {
+      font-size: 1.85rem;
+      font-weight: 800;
+      color: #ffffff;
+      margin: 0 0 0.4rem;
+      letter-spacing: -0.02em;
+      text-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    }
+    .page-header p {
+      color: rgba(255, 255, 255, 0.5);
+      font-size: 0.88rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-header">
+    <h1>Blur-Entrance Carousel</h1>
+    <p>Pure CSS carousel. Active slides fade in from blur and scale up using spring transitions.</p>
+  </div>
+
+  <!-- ── Pure CSS Radio Switches (must precede the card) ── -->
+  <input type="radio" name="carousel-group" id="carousel-1" class="carousel-radio" checked>
+  <input type="radio" name="carousel-group" id="carousel-2" class="carousel-radio">
+  <input type="radio" name="carousel-group" id="carousel-3" class="carousel-radio">
+
+  <!-- Carousel Card Container -->
+  <div class="carousel-card">
+
+    <!-- ── Directional Navigation Arrows ── -->
+    <!-- Slide 1 arrows -->
+    <label for="carousel-2" class="carousel-arrow arrow-right arrow-to-2" role="button" aria-label="Next slide">›</label>
+
+    <!-- Slide 2 arrows -->
+    <label for="carousel-1" class="carousel-arrow arrow-left arrow-to-1" role="button" aria-label="Previous slide">‹</label>
+    <label for="carousel-3" class="carousel-arrow arrow-right arrow-to-3" role="button" aria-label="Next slide">›</label>
+
+    <!-- Slide 3 arrows -->
+    <label for="carousel-2" class="carousel-arrow arrow-left arrow-to-2-left" role="button" aria-label="Previous slide">‹</label>
+
+    <!-- ── Viewport containing stacked slides ── -->
+    <div class="carousel-viewport">
+
+      <!-- Slide 1 -->
+      <div class="carousel-slide slide-1">
+        <div>
+          <div class="slide-category">Design System</div>
+          <h2 class="slide-title">Glassmorphic Interfaces</h2>
+          <p class="slide-desc">
+            Explore the aesthetics of frosted glass overlays, layered depths, and vivid background refraction tokens.
+          </p>
+        </div>
+        <a href="#" class="slide-cta">
+          Learn More
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="9 18 15 12 9 6"/></svg>
+        </a>
+      </div>
+
+      <!-- Slide 2 -->
+      <div class="carousel-slide slide-2" style="--ease-carousel-accent: #06b6d4; --ease-carousel-accent-glow: rgba(6, 182, 212, 0.35);">
+        <div>
+          <div class="slide-category" style="color:var(--ease-carousel-accent);">Spatial UI</div>
+          <h2 class="slide-title">Spatial Computing Layouts</h2>
+          <p class="slide-desc">
+            Designing digital canvas spaces that blend seamlessly with physical surroundings using environmental lighting.
+          </p>
+        </div>
+        <a href="#" class="slide-cta">
+          Explore Labs
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="9 18 15 12 9 6"/></svg>
+        </a>
+      </div>
+
+      <!-- Slide 3 -->
+      <div class="carousel-slide slide-3" style="--ease-carousel-accent: #ec4899; --ease-carousel-accent-glow: rgba(236, 72, 153, 0.35);">
+        <div>
+          <div class="slide-category" style="color:var(--ease-carousel-accent);">Performance</div>
+          <h2 class="slide-title">Immersive Motion Graphics</h2>
+          <p class="slide-desc">
+            Ultra-performance, hardware-accelerated animations running completely in CSS with zero script overhead.
+          </p>
+        </div>
+        <a href="#" class="slide-cta">
+          View Gallery
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="9 18 15 12 9 6"/></svg>
+        </a>
+      </div>
+
+    </div>
+
+    <!-- ── Bottom Navigation Indicator Pills ── -->
+    <div class="carousel-dots">
+      <label for="carousel-1" class="carousel-dot dot-1" role="button" aria-label="Go to slide 1"></label>
+      <label for="carousel-2" class="carousel-dot dot-2" role="button" aria-label="Go to slide 2"></label>
+      <label for="carousel-3" class="carousel-dot dot-3" role="button" aria-label="Go to slide 3"></label>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-blur-entrance-carousel-ksk/style.css
+++ b/submissions/examples/ease-blur-entrance-carousel-ksk/style.css
@@ -1,0 +1,212 @@
+/* ============================================================
+   EaseMotion CSS — Blur-Entrance Carousel (Glassmorphism)
+   submissions/examples/ease-blur-entrance-carousel-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .carousel-card or any ancestor to tune.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-carousel-blur:     18px;          /* initial entrance blur         */
+  --ease-carousel-scale:    0.92;          /* initial entrance scale        */
+  --ease-carousel-duration: 0.55s;         /* transition duration           */
+  --ease-carousel-easing:   cubic-bezier(0.34, 1.56, 0.64, 1); /* spring   */
+  --ease-carousel-radius:   24px;
+  --ease-carousel-font:     system-ui, -apple-system, sans-serif;
+  --ease-carousel-accent:   #3b82f6;
+  --ease-carousel-accent-glow: rgba(59, 130, 246, 0.35);
+}
+
+/* ── Radio Switches (hidden) ────────────────────────────── */
+.carousel-radio {
+  display: none;
+}
+
+/* ── Glassmorphism Carousel Card ────────────────────────── */
+.carousel-card {
+  width: 100%;
+  max-width: 500px;
+  height: 380px;
+  /* Frosted Glass details */
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: var(--ease-carousel-radius);
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  padding: 24px;
+  box-sizing: border-box;
+  font-family: var(--ease-carousel-font);
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Viewport & Stacked Slides ──────────────────────────── */
+.carousel-viewport {
+  flex: 1;
+  position: relative;
+}
+
+.carousel-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-sizing: border-box;
+  padding-bottom: 20px;
+  /* Hidden / Blurred starting state */
+  opacity: 0;
+  filter: blur(var(--ease-carousel-blur));
+  transform: scale(var(--ease-carousel-scale));
+  pointer-events: none;
+  transition:
+    opacity var(--ease-carousel-duration) ease,
+    filter var(--ease-carousel-duration) ease,
+    transform var(--ease-carousel-duration) var(--ease-carousel-easing);
+}
+
+/* Active checked states: clear and scale up */
+#carousel-1:checked ~ .carousel-card .slide-1,
+#carousel-2:checked ~ .carousel-card .slide-2,
+#carousel-3:checked ~ .carousel-card .slide-3 {
+  opacity: 1;
+  filter: blur(0px);
+  transform: scale(1);
+  pointer-events: auto;
+  z-index: 5;
+}
+
+/* ── Slide Contents ─────────────────────────────────────── */
+.slide-category {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ease-carousel-accent);
+  text-shadow: 0 0 10px var(--ease-carousel-accent-glow);
+  margin-bottom: 8px;
+}
+
+.slide-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1.3;
+  margin: 0 0 12px;
+  letter-spacing: -0.015em;
+  background: linear-gradient(135deg, #fff 60%, rgba(255,255,255,0.6));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.slide-desc {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.88rem;
+  line-height: 1.6;
+  margin: 0 0 24px;
+}
+
+/* Glass CTA button */
+.slide-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  width: fit-content;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s var(--ease-carousel-easing);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.slide-cta:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+/* ── Navigation Arrows ──────────────────────────────────── */
+.carousel-arrow {
+  position: absolute;
+  top: 55%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255,255,255,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  font-size: 1.15rem;
+  font-weight: bold;
+}
+
+.carousel-arrow:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+.arrow-left { left: 16px; }
+.arrow-right { right: 16px; }
+
+/* Control Arrow visibility based on active checkbox state */
+.carousel-arrow {
+  display: none;
+}
+
+/* Slide 1 controls */
+#carousel-1:checked ~ .carousel-card .arrow-to-2 { display: flex; }
+
+/* Slide 2 controls */
+#carousel-2:checked ~ .carousel-card .arrow-to-1,
+#carousel-2:checked ~ .carousel-card .arrow-to-3 { display: flex; }
+
+/* Slide 3 controls */
+#carousel-3:checked ~ .carousel-card .arrow-to-2-left { display: flex; }
+
+/* ── Indicator Dots ─────────────────────────────────────── */
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.carousel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.carousel-dot:hover {
+  background: rgba(255, 255, 255, 0.45);
+}
+
+/* Active dot expansion */
+#carousel-1:checked ~ .carousel-card .dot-1,
+#carousel-2:checked ~ .carousel-card .dot-2,
+#carousel-3:checked ~ .carousel-card .dot-3 {
+  background: #fff;
+  width: 22px;
+  border-radius: 4px;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.4);
+}


### PR DESCRIPTION
Closes #50515

Adds an interactive Blur-Entrance Carousel component under `submissions/examples/ease-blur-entrance-carousel-ksk/`.

#### Key Features

1. **Blur-Entrance Transition** — Stacked slides transition in from a blurred, scaled-down starting state (`filter: blur(18px) scale(0.92)`) to fully clear, full-scale sizes using standard CSS transitions.
2. **Glassmorphism Styling** — Nested in a premium frosted glass card utilizing heavy backdrops (`backdrop-filter: blur(20px)`), subtle translucent border frames (`rgba(255,255,255,0.09)`), and deep layout drop shadows.
3. **Pure CSS Controls** — Includes direction arrow overlays (labels) and indicator dot navigation pills matching active radio states.
4. **Vivid Backdrop Demo** — Pre-configured with a colorful, multi-layered background gradient mesh that showcases the refraction and frosted glass blurring in real time.
5. **5 Customizable Variables** — Easily configure `--ease-carousel-blur`, `--ease-carousel-scale`, `--ease-carousel-duration`, `--ease-carousel-easing`, and `--ease-carousel-accent` values inline.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Frosted glass backdrops, blur keyframe scales, arrow overlaps, and indicators dot states |
| `demo.html` | Dashboard layout showcasing three stacked, themed slides (Design Systems, Spatial Computing, Motion Graphics) |
| `README.md` | Installation directions and variables guides, resolving `#50515` |