### PR TITLE
Notification Permission Prompt Mock

### DIFF
--- a/submissions/examples/feature-notification-permission-prompt-mock-sum/README.md
+++ b/submissions/examples/feature-notification-permission-prompt-mock-sum/README.md
@@ -1,0 +1,36 @@
+# Notification Permission Prompt Mock
+
+Related issue: #51873
+
+## What does this do?
+
+A browser-style notification permission dialog mock with three motion states: spring entrance when shown, horizontal slide-out on Block/dismiss, and a success pulse when Allow is clicked. Demo controls drive the UI only — the page never calls the real `Notification` API or triggers OS permission prompts.
+
+## How is it used?
+
+Open `demo.html` in a browser.
+
+1. Click **Show prompt** to animate the mock dialog into the stage.
+2. Click **Allow** to play the success pulse, or **Block** to slide the dialog out.
+3. Click **Reset** to return to the idle state.
+
+All motion is CSS-driven with minimal inline JavaScript for state toggling.
+
+## Why is it useful?
+
+Permission prompts are sensitive UX moments. This mock lets designers and contributors prototype entrance, dismissal, and confirmation motion in isolation — without spamming real notification requests during reviews, recordings, or GSSoC demos.
+
+## Accessibility
+
+- The dialog uses `role="dialog"`, `aria-modal`, and labelled title text.
+- Status updates use `aria-live="polite"`.
+- Animations are removed under `prefers-reduced-motion: reduce` for instant state changes.
+
+## Files
+
+```
+submissions/examples/feature-notification-permission-prompt-mock-sum/
+├── demo.html
+├── style.css
+└── README.md
+```

--- a/submissions/examples/feature-notification-permission-prompt-mock-sum/demo.html
+++ b/submissions/examples/feature-notification-permission-prompt-mock-sum/demo.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notification Permission Prompt Mock</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="notify-page">
+      <header class="notify-header">
+        <h1>Notification Permission Prompt Mock</h1>
+        <p>
+          A browser-style permission dialog with spring entrance, dismiss slide-out, and Allow success
+          pulse. Demo controls only — no real Notification API calls.
+        </p>
+      </header>
+
+      <div class="notify-controls">
+        <button type="button" class="notify-btn notify-btn--primary" id="show-prompt">Show prompt</button>
+        <button type="button" class="notify-btn" id="reset-demo">Reset</button>
+      </div>
+
+      <div class="notify-stage" id="stage">
+        <p class="notify-stage-hint" id="stage-hint">Click “Show prompt” to preview the mock dialog.</p>
+
+        <div
+          class="notify-dialog"
+          id="dialog"
+          data-state="hidden"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="dialog-title"
+          aria-hidden="true"
+          hidden
+        >
+          <div class="notify-dialog-header">
+            <span class="notify-site-icon" aria-hidden="true">E</span>
+            <h2 class="notify-dialog-title" id="dialog-title">ease-motion.dev wants to</h2>
+          </div>
+          <p class="notify-dialog-body">Show notifications for motion tips and release notes.</p>
+          <div class="notify-dialog-actions">
+            <button type="button" class="notify-action notify-action--block" id="block-btn">Block</button>
+            <button type="button" class="notify-action notify-action--allow" id="allow-btn">Allow</button>
+          </div>
+        </div>
+      </div>
+
+      <p class="notify-status" id="status" aria-live="polite">
+        Status: idle — this demo never requests real browser notification permission.
+      </p>
+    </main>
+
+    <script>
+      (function () {
+        var dialog = document.getElementById("dialog");
+        var stageHint = document.getElementById("stage-hint");
+        var statusEl = document.getElementById("status");
+        var showBtn = document.getElementById("show-prompt");
+        var resetBtn = document.getElementById("reset-demo");
+        var blockBtn = document.getElementById("block-btn");
+        var allowBtn = document.getElementById("allow-btn");
+        var animating = false;
+
+        function setStatus(text) {
+          statusEl.textContent = "Status: " + text;
+        }
+
+        function hideDialog() {
+          dialog.setAttribute("data-state", "hidden");
+          dialog.setAttribute("aria-hidden", "true");
+          dialog.hidden = true;
+          stageHint.hidden = false;
+          animating = false;
+        }
+
+        function showDialog() {
+          if (animating) return;
+          stageHint.hidden = true;
+          dialog.hidden = false;
+          dialog.setAttribute("aria-hidden", "false");
+          dialog.setAttribute("data-state", "enter");
+          animating = true;
+          setStatus("prompt visible — choose Block or Allow");
+          window.setTimeout(function () {
+            dialog.setAttribute("data-state", "visible");
+            animating = false;
+          }, 560);
+        }
+
+        function dismissDialog(label) {
+          if (animating || dialog.hidden) return;
+          animating = true;
+          dialog.setAttribute("data-state", "exit");
+          setStatus(label);
+          window.setTimeout(hideDialog, 380);
+        }
+
+        function allowDialog() {
+          if (animating || dialog.hidden) return;
+          animating = true;
+          dialog.setAttribute("data-state", "success");
+          setStatus("allowed (mock) — success pulse played");
+          window.setTimeout(function () {
+            hideDialog();
+            setStatus("idle — mock permission stored in demo state only");
+          }, 900);
+        }
+
+        showBtn.addEventListener("click", showDialog);
+        resetBtn.addEventListener("click", function () {
+          hideDialog();
+          setStatus("idle — this demo never requests real browser notification permission.");
+        });
+        blockBtn.addEventListener("click", function () {
+          dismissDialog("blocked (mock) — dialog slid out");
+        });
+        allowBtn.addEventListener("click", allowDialog);
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/feature-notification-permission-prompt-mock-sum/style.css
+++ b/submissions/examples/feature-notification-permission-prompt-mock-sum/style.css
@@ -1,0 +1,240 @@
+/* Notification Permission Prompt Mock */
+
+:root {
+  --brand-indigo: #5b4fcf;
+  --brand-indigo-dark: #4338a8;
+  --brand-indigo-soft: rgba(91, 79, 207, 0.12);
+  --slate-50: #f8fafc;
+  --slate-100: #f1f5f9;
+  --slate-200: #e2e8f0;
+  --slate-400: #94a3b8;
+  --slate-500: #64748b;
+  --slate-700: #334155;
+  --slate-900: #0f172a;
+  --spring-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --slide-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --motion-speed: 0.45s;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--slate-100);
+  color: var(--slate-900);
+  line-height: 1.5;
+}
+
+.notify-page {
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.notify-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.45rem, 3vw, 1.85rem);
+  color: var(--brand-indigo-dark);
+}
+
+.notify-header p {
+  margin: 0 0 1.5rem;
+  color: var(--slate-500);
+}
+
+.notify-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-bottom: 1.5rem;
+}
+
+.notify-btn {
+  appearance: none;
+  border: 1px solid var(--slate-200);
+  border-radius: 0.6rem;
+  padding: 0.55rem 0.95rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  background: #fff;
+  color: var(--slate-700);
+  transition: border-color var(--motion-speed) ease, background var(--motion-speed) ease;
+}
+
+.notify-btn:focus-visible {
+  outline: 2px solid var(--brand-indigo);
+  outline-offset: 2px;
+}
+
+.notify-btn--primary {
+  background: var(--brand-indigo);
+  border-color: var(--brand-indigo);
+  color: #fff;
+}
+
+.notify-stage {
+  position: relative;
+  min-height: 14rem;
+  border-radius: 1rem;
+  border: 1px solid var(--slate-200);
+  background: linear-gradient(160deg, #fff, var(--slate-50));
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  overflow: hidden;
+}
+
+.notify-stage-hint {
+  color: var(--slate-400);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.notify-dialog {
+  width: min(22rem, 100%);
+  border-radius: 0.85rem;
+  background: #fff;
+  border: 1px solid var(--slate-200);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.14);
+  padding: 1rem 1.1rem 0.85rem;
+  transform-origin: center top;
+}
+
+.notify-dialog[data-state="hidden"] {
+  display: none;
+}
+
+.notify-dialog[data-state="enter"] {
+  animation: notifySpringIn 0.55s var(--spring-ease) both;
+}
+
+.notify-dialog[data-state="exit"] {
+  animation: notifySlideOut 0.38s var(--slide-ease) forwards;
+}
+
+.notify-dialog[data-state="success"] {
+  animation: notifySuccessPulse 0.65s ease both;
+}
+
+.notify-dialog-header {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.65rem;
+}
+
+.notify-site-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 0.3rem;
+  background: var(--brand-indigo);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.notify-dialog-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.notify-dialog-body {
+  margin: 0 0 0.85rem;
+  font-size: 0.875rem;
+  color: var(--slate-500);
+}
+
+.notify-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.notify-action {
+  appearance: none;
+  border-radius: 0.45rem;
+  padding: 0.4rem 0.85rem;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.notify-action--block {
+  background: var(--slate-100);
+  border-color: var(--slate-200);
+  color: var(--slate-700);
+}
+
+.notify-action--allow {
+  background: var(--brand-indigo);
+  color: #fff;
+}
+
+.notify-action:focus-visible {
+  outline: 2px solid var(--brand-indigo);
+  outline-offset: 2px;
+}
+
+.notify-status {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.65rem;
+  background: #fff;
+  border: 1px solid var(--slate-200);
+  font-size: 0.875rem;
+  color: var(--slate-500);
+}
+
+@keyframes notifySpringIn {
+  0% {
+    opacity: 0;
+    transform: translateY(-18px) scale(0.92);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes notifySlideOut {
+  to {
+    opacity: 0;
+    transform: translateX(110%);
+  }
+}
+
+@keyframes notifySuccessPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(91, 79, 207, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(91, 79, 207, 0);
+  }
+  100% {
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.14);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notify-dialog[data-state="enter"],
+  .notify-dialog[data-state="exit"],
+  .notify-dialog[data-state="success"] {
+    animation: none !important;
+  }
+
+  .notify-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
# #51873 issue resolved

## Description
This PR adds a Notification Permission Prompt Mock under submissions/examples.

## Features
- Browser-style permission dialog mock
- Spring entrance, dismiss slide-out, allow success pulse
- Demo-only (no real Notification API)