### PR TITLE
CSS-Only Dark/Light Theme Crossfade

### DIFF
--- a/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/README.md
+++ b/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/README.md
@@ -1,0 +1,53 @@
+# CSS-Only Dark/Light Theme Crossfade
+
+Related issue: #51872
+
+## What does this do?
+
+A light/dark theme demo where CSS custom properties on the page root crossfade background, surface, text, border, and shadow tokens when a checkbox toggle adds a `theme-dark` class. Two stacked logo layers softly crossfade opacity instead of swapping assets. Sample cards and chips show how surfaces respond to the same token set.
+
+## How is it used?
+
+Open `demo.html` in a browser.
+
+1. Use the **Dark mode** switch to toggle themes.
+2. Watch page background, cards, chips, and the dual-layer logo crossfade together.
+3. Enable **prefers-reduced-motion: reduce** in your OS to verify instant theme swaps.
+
+Minimal inline JavaScript only toggles the `theme-dark` class — all visual morphing is CSS.
+
+## Why is it useful?
+
+Design systems need theme changes that feel cohesive rather than jarring. This pattern shows how token-driven transitions plus logo opacity crossfades create polished dark mode without JavaScript color interpolation or external theme libraries.
+
+## Token overrides
+
+Light theme defaults live on `:root`. Dark theme overrides apply when `.theme-page.theme-dark` is present:
+
+| Token | Light | Dark |
+| --- | --- | --- |
+| `--bg-page` | `#f1f5f9` | `#0f172a` |
+| `--bg-surface` | `#ffffff` | `#1e293b` |
+| `--bg-elevated` | `#f8fafc` | `#334155` |
+| `--text-primary` | `#0f172a` | `#f8fafc` |
+| `--text-secondary` | `#64748b` | `#94a3b8` |
+| `--border-subtle` | `#e2e8f0` | `#475569` |
+| `--logo-light-opacity` | `1` | `0` |
+| `--logo-dark-opacity` | `0` | `1` |
+
+Shared accent tokens (`--brand-indigo`, gradients) stay consistent; soft tints like `--brand-indigo-soft` adjust per theme.
+
+## Accessibility
+
+- Toggle is a native checkbox with an accessible label.
+- Focus ring appears on keyboard focus via `:focus-visible`.
+- Under `prefers-reduced-motion: reduce`, all theme transitions are disabled for instant swaps.
+
+## Files
+
+```
+submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/
+├── demo.html
+├── style.css
+└── README.md
+```

--- a/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/demo.html
+++ b/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS-Only Dark/Light Theme Crossfade</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="theme-page" id="theme-root">
+      <header class="theme-header">
+        <div class="theme-brand">
+          <div class="theme-logo-wrap" aria-hidden="true">
+            <span class="theme-logo theme-logo--light">EM</span>
+            <span class="theme-logo theme-logo--dark">EM</span>
+          </div>
+          <div>
+            <h1>EaseMotion</h1>
+            <p>Theme crossfade via CSS custom properties</p>
+          </div>
+        </div>
+
+        <label class="theme-toggle">
+          <span>Dark mode</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle dark mode" />
+          <span class="theme-toggle-track" aria-hidden="true">
+            <span class="theme-toggle-thumb"></span>
+          </span>
+        </label>
+      </header>
+
+      <div class="theme-grid">
+        <section class="theme-card">
+          <h2>Surface card</h2>
+          <p>
+            Background, border, text, and shadow tokens morph together when the theme class toggles on
+            the page root.
+          </p>
+          <div class="theme-chip-row">
+            <span class="theme-chip">motion</span>
+            <span class="theme-chip">tokens</span>
+            <span class="theme-chip">crossfade</span>
+          </div>
+        </section>
+
+        <section class="theme-card">
+          <h2>Progress surface</h2>
+          <p>Elevated track color adapts while the indigo accent bar stays recognizable.</p>
+          <div class="theme-stat-bar" aria-hidden="true">
+            <div class="theme-stat-fill"></div>
+          </div>
+        </section>
+      </div>
+
+      <p class="theme-note">
+        Toggle the switch to crossfade themes. Under <code>prefers-reduced-motion: reduce</code>, token
+        swaps are instant with no transition delay.
+      </p>
+    </main>
+
+    <script>
+      (function () {
+        var root = document.getElementById("theme-root");
+        var toggle = document.getElementById("theme-toggle");
+
+        function applyTheme(isDark) {
+          root.classList.toggle("theme-dark", isDark);
+          toggle.checked = isDark;
+        }
+
+        toggle.addEventListener("change", function () {
+          applyTheme(toggle.checked);
+        });
+
+        applyTheme(false);
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/style.css
+++ b/submissions/examples/feature-css-only-dark-light-theme-crossfade-sum/style.css
@@ -1,0 +1,244 @@
+/* CSS-Only Dark/Light Theme Crossfade */
+
+:root {
+  --brand-indigo: #5b4fcf;
+  --brand-indigo-dark: #4338a8;
+  --brand-indigo-soft: rgba(91, 79, 207, 0.12);
+
+  --bg-page: #f1f5f9;
+  --bg-surface: #ffffff;
+  --bg-elevated: #f8fafc;
+  --text-primary: #0f172a;
+  --text-secondary: #64748b;
+  --border-subtle: #e2e8f0;
+  --shadow-soft: 0 12px 30px rgba(15, 23, 42, 0.08);
+
+  --logo-light-opacity: 1;
+  --logo-dark-opacity: 0;
+
+  --theme-speed: 0.55s;
+  --theme-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.theme-page.theme-dark {
+  --bg-page: #0f172a;
+  --bg-surface: #1e293b;
+  --bg-elevated: #334155;
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --border-subtle: #475569;
+  --shadow-soft: 0 12px 30px rgba(0, 0, 0, 0.35);
+  --brand-indigo-soft: rgba(139, 124, 247, 0.18);
+
+  --logo-light-opacity: 0;
+  --logo-dark-opacity: 1;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--bg-page);
+  color: var(--text-primary);
+  line-height: 1.5;
+  transition: background var(--theme-speed) var(--theme-ease), color var(--theme-speed) var(--theme-ease);
+}
+
+.theme-page {
+  max-width: 44rem;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.theme-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.theme-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.theme-logo-wrap {
+  position: relative;
+  width: 2.75rem;
+  height: 2.75rem;
+}
+
+.theme-logo {
+  position: absolute;
+  inset: 0;
+  border-radius: 0.65rem;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 1rem;
+  transition: opacity var(--theme-speed) var(--theme-ease);
+}
+
+.theme-logo--light {
+  background: linear-gradient(135deg, #8b7cf7, var(--brand-indigo));
+  color: #fff;
+  opacity: var(--logo-light-opacity);
+}
+
+.theme-logo--dark {
+  background: linear-gradient(135deg, #312e81, #1e1b4b);
+  color: #c4b5fd;
+  opacity: var(--logo-dark-opacity);
+}
+
+.theme-header h1 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.theme-header p {
+  margin: 0.15rem 0 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.theme-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.theme-toggle-track {
+  width: 2.75rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--border-subtle);
+  position: relative;
+  transition: background var(--theme-speed) var(--theme-ease);
+}
+
+.theme-toggle-thumb {
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: var(--brand-indigo);
+  transition: transform var(--theme-speed) var(--theme-ease), background var(--theme-speed) var(--theme-ease);
+}
+
+.theme-toggle input:checked + .theme-toggle-track .theme-toggle-thumb {
+  transform: translateX(1.25rem);
+  background: #c4b5fd;
+}
+
+.theme-toggle input:focus-visible + .theme-toggle-track {
+  outline: 2px solid var(--brand-indigo);
+  outline-offset: 2px;
+}
+
+.theme-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.theme-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.85rem;
+  padding: 1rem 1.1rem;
+  box-shadow: var(--shadow-soft);
+  transition: background var(--theme-speed) var(--theme-ease), border-color var(--theme-speed) var(--theme-ease),
+    box-shadow var(--theme-speed) var(--theme-ease);
+}
+
+.theme-card h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.theme-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.theme-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+}
+
+.theme-chip {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: var(--brand-indigo-soft);
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  transition: background var(--theme-speed) var(--theme-ease), color var(--theme-speed) var(--theme-ease);
+}
+
+.theme-stat-bar {
+  margin-top: 0.75rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  overflow: hidden;
+  transition: background var(--theme-speed) var(--theme-ease);
+}
+
+.theme-stat-fill {
+  width: 68%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--brand-indigo), #8b7cf7);
+  transition: background var(--theme-speed) var(--theme-ease);
+}
+
+.theme-note {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.65rem;
+  border: 1px dashed var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  transition: border-color var(--theme-speed) var(--theme-ease), color var(--theme-speed) var(--theme-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body,
+  .theme-logo,
+  .theme-card,
+  .theme-chip,
+  .theme-stat-bar,
+  .theme-stat-fill,
+  .theme-note,
+  .theme-toggle-track,
+  .theme-toggle-thumb {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
# #51872 issue resolved

## Description
This PR adds a CSS-Only Dark/Light Theme Crossfade under submissions/examples.

## Features
- Theme toggle with token morphing
- Soft logo crossfade
- Documented token overrides in README