### PR TITLE
feat: add flash loader animation (issue #51848)

### DIFF
--- a/submissions/examples/flash-focus-ag/README.md
+++ b/submissions/examples/flash-focus-ag/README.md
@@ -1,0 +1,18 @@
+# Flash Loader
+
+A looping "flash" animation used as a loading indicator. Three dots pulse
+in sequence with a staggered delay, creating a flashing/blinking effect.
+
+## Files
+- `demo.html` — minimal markup to preview the loader
+- `style.css` — the flash animation and dot styling
+
+## Usage
+Open `demo.html` in a browser to see the loader in action. Copy the
+`.flash-loader` markup and CSS into your project and drop it wherever
+you need a loading indicator.
+
+## Customization
+- Change `background` on `.flash-dot` to match your theme color
+- Adjust `animation-delay` values to speed up/slow down the stagger
+- Tweak `1.2s` in the `animation` shorthand to change the flash speed

--- a/submissions/examples/flash-focus-ag/demo.html
+++ b/submissions/examples/flash-focus-ag/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Flash Loader</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="flash-loader" role="status" aria-label="Loading">
+    <span class="flash-dot"></span>
+    <span class="flash-dot"></span>
+    <span class="flash-dot"></span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/flash-focus-ag/style.css
+++ b/submissions/examples/flash-focus-ag/style.css
@@ -1,0 +1,41 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  background: #0f0f10;
+}
+
+.flash-loader {
+  display: flex;
+  gap: 10px;
+}
+
+.flash-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ffcc00;
+  animation: flash 1.2s ease-in-out infinite;
+}
+
+.flash-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.flash-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes flash {
+  0%, 100% {
+    opacity: 0.2;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+    box-shadow: 0 0 8px 2px rgba(255, 204, 0, 0.6);
+  }
+}


### PR DESCRIPTION
## Description
Adds a looping "flash" loading indicator as requested in #51848.

## Changes
- New folder: `submissions/examples/flash-focus-ag/`
- `demo.html` — preview markup for the loader
- `style.css` — flash animation (staggered pulsing dots)
- `README.md` — usage and customization notes

## Notes
No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #51848