### PR TITLE
add animated macos style dock

### DIFF
--- a/submissions/examples/animated-macos-style-dock/README.md
+++ b/submissions/examples/animated-macos-style-dock/README.md
@@ -1,0 +1,31 @@
+# Interactive macOS-Style Dock Animation
+
+A macOS-inspired dock where icons smoothly magnify as the cursor hovers over them, including a "sympathy" magnification effect on neighboring icons. Pure HTML and CSS — no JavaScript required.
+
+## Features
+
+- 🔍 Hovered icon lifts and scales up smoothly
+- 🌊 Neighboring icons on either side also grow slightly, approximating macOS's distance-based magnification using the CSS `:has()` selector and adjacent sibling combinator
+- 💬 Tooltip label fades in above each icon on hover
+- 🟢 Optional "running app" indicator dot
+- 📱 Responsive — scales down icon size and spacing on small screens
+- ♿ Accessible structure: semantic `<ul>`/`<li>` list, `tabindex="0"` for keyboard focus, and `aria-label` on every icon
+- ♿ Respects `prefers-reduced-motion`
+- 🧩 Pure HTML + CSS — no JavaScript dependencies
+
+## Usage
+
+Include `style.css` and build the dock as an unordered list, giving each icon a unique color modifier class:
+
+```html
+<ul class="dock">
+  <li class="dock-icon dock-icon--1 is-running" tabindex="0" aria-label="Messages">
+    💬
+    <span class="dock-label">Messages</span>
+  </li>
+  <li class="dock-icon dock-icon--2" tabindex="0" aria-label="Mail">
+    ✉️
+    <span class="dock-label">Mail</span>
+  </li>
+  <!-- add as many icons as you need -->
+</ul>

--- a/submissions/examples/animated-macos-style-dock/demo.html
+++ b/submissions/examples/animated-macos-style-dock/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Interactive macOS-Style Dock — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-title">Hover over the dock icons (pure CSS)</p>
+
+  <!--
+    Semantic list structure keeps this accessible: each icon is a
+    focusable, labeled list item. Hovering (or tab-focusing, since
+    :hover styles also trigger via :focus-visible in modern browsers
+    that support :has()) magnifies the icon and its neighbors.
+  -->
+  <ul class="dock">
+    <li class="dock-icon dock-icon--1 is-running" tabindex="0" aria-label="Messages">
+      💬
+      <span class="dock-label">Messages</span>
+    </li>
+    <li class="dock-icon dock-icon--2 is-running" tabindex="0" aria-label="Mail">
+      ✉️
+      <span class="dock-label">Mail</span>
+    </li>
+    <li class="dock-icon dock-icon--3" tabindex="0" aria-label="Music">
+      🎵
+      <span class="dock-label">Music</span>
+    </li>
+    <li class="dock-icon dock-icon--4 is-running" tabindex="0" aria-label="Photos">
+      🖼️
+      <span class="dock-label">Photos</span>
+    </li>
+    <li class="dock-icon dock-icon--5" tabindex="0" aria-label="Calendar">
+      📅
+      <span class="dock-label">Calendar</span>
+    </li>
+    <li class="dock-icon dock-icon--6" tabindex="0" aria-label="Settings">
+      ⚙️
+      <span class="dock-label">Settings</span>
+    </li>
+  </ul>
+
+</body>
+</html>

--- a/submissions/examples/animated-macos-style-dock/style.css
+++ b/submissions/examples/animated-macos-style-dock/style.css
@@ -1,0 +1,164 @@
+/* ============================================
+   Interactive macOS-Style Dock Animation
+   Pure CSS — no JavaScript required
+   ============================================ */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  background: linear-gradient(160deg, #1e3c72, #2a5298);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.demo-title {
+  position: fixed;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: center;
+  opacity: 0.9;
+}
+
+/* ---------- Dock container ---------- */
+.dock {
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+  list-style: none;
+  margin: 0;
+  padding: 12px 18px;
+  border-radius: 20px;
+
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+/* ---------- Dock icon ---------- */
+.dock-icon {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  cursor: pointer;
+
+  transform-origin: bottom center;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.25s ease;
+}
+
+/* Magnify the icon directly under the cursor */
+.dock-icon:hover {
+  transform: translateY(-14px) scale(1.5);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
+  z-index: 2;
+}
+
+/* "Sympathy" magnification: immediate neighbors on either side
+   scale up a little too, approximating macOS's magnify-by-distance
+   effect using only sibling combinators (no JS). */
+.dock-icon:hover + .dock-icon,
+.dock-icon:has(+ .dock-icon:hover) {
+  transform: translateY(-8px) scale(1.25);
+  z-index: 1;
+}
+
+/* ---------- Tooltip label ---------- */
+.dock-label {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+  margin-bottom: 10px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: rgba(30, 30, 30, 0.9);
+  color: #fff;
+  font-size: 0.7rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.dock-icon:hover .dock-label {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ---------- "Running app" indicator dot ---------- */
+.dock-icon.is-running::after {
+  content: "";
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #fff;
+  opacity: 0.85;
+}
+
+/* ---------- Individual icon colors ---------- */
+.dock-icon--1 { background: linear-gradient(135deg, #ff7675, #d63031); }
+.dock-icon--2 { background: linear-gradient(135deg, #74b9ff, #0984e3); }
+.dock-icon--3 { background: linear-gradient(135deg, #55efc4, #00b894); }
+.dock-icon--4 { background: linear-gradient(135deg, #ffeaa7, #fdcb6e); }
+.dock-icon--5 { background: linear-gradient(135deg, #a29bfe, #6c5ce7); }
+.dock-icon--6 { background: linear-gradient(135deg, #fab1a0, #e17055); }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 480px) {
+  .dock {
+    gap: 8px;
+    padding: 10px 12px;
+  }
+
+  .dock-icon {
+    width: 44px;
+    height: 44px;
+    font-size: 1.2rem;
+    border-radius: 12px;
+  }
+
+  .dock-icon:hover {
+    transform: translateY(-10px) scale(1.35);
+  }
+
+  .dock-icon:hover + .dock-icon,
+  .dock-icon:has(+ .dock-icon:hover) {
+    transform: translateY(-6px) scale(1.15);
+  }
+}
+
+/* ---------- Reduced motion / no-hover devices ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .dock-icon,
+  .dock-label {
+    transition: none;
+  }
+
+  .dock-icon:hover,
+  .dock-icon:hover + .dock-icon,
+  .dock-icon:has(+ .dock-icon:hover) {
+    transform: none;
+  }
+}


### PR DESCRIPTION
**PR Description**
```markdown
## Pull Request Description

Adds an interactive macOS-inspired dock where icons smoothly magnify on hover, with a sympathy magnification effect on neighboring icons, built with pure HTML and CSS. Closes #50553.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/macos-dock/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A macOS-style dock where the hovered icon lifts and magnifies, and its immediate neighbors get a smaller "sympathy" magnification, approximating the real dock's distance-based scaling effect.

**How does a developer use it?**

```html
<ul class="dock">
  <li class="dock-icon dock-icon--1 is-running" tabindex="0" aria-label="Messages">
    💬
    <span class="dock-label">Messages</span>
  </li>
  <li class="dock-icon dock-icon--2" tabindex="0" aria-label="Mail">
    ✉️
    <span class="dock-label">Mail</span>
  </li>
</ul>