### PR TITLE
Add Skeleton-to-Content Morph Swap demo

### DIFF
--- a/submissions/examples/feature-skeleton-to-content-morph-swap-sum/README.md
+++ b/submissions/examples/feature-skeleton-to-content-morph-swap-sum/README.md
@@ -1,0 +1,24 @@
+# Skeleton-to-Content Morph Swap
+
+## 1. What does this do?
+
+A replayable morph-swap demo that transitions skeleton placeholders into real card content using blur→sharp, scale, and clip-path choreography.
+
+## 2. How is it used?
+
+Open `demo.html` in a browser. Wait for the automatic handoff, or press **Replay morph** to watch skeletons dissolve into content again.
+
+```html
+<article class="card" data-state="ready">
+  <div class="layer skeleton-layer">...</div>
+  <div class="layer content-layer">...</div>
+</article>
+```
+
+## 3. Why is it useful?
+
+Most skeleton demos only pulse forever. This shows a clear loading→ready motion pattern that matches EaseMotion’s readable, purposeful interaction style.
+
+## Issue
+
+Resolves #51866

--- a/submissions/examples/feature-skeleton-to-content-morph-swap-sum/demo.html
+++ b/submissions/examples/feature-skeleton-to-content-morph-swap-sum/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Skeleton-to-Content Morph Swap</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="intro">
+      <p class="eyebrow">Morph swap</p>
+      <h1>Skeleton → content handoff</h1>
+      <p class="lede">
+        Skeletons dissolve into real content with blur→sharp, scale, and clip-path cues —
+        not another endless pulse loop.
+      </p>
+      <button type="button" class="replay-btn" id="replay-btn">Replay morph</button>
+    </header>
+
+    <article class="card" id="morph-card" data-state="loading" aria-busy="true">
+      <div class="layer skeleton-layer" aria-hidden="true">
+        <div class="sk-media"></div>
+        <div class="sk-body">
+          <div class="sk-line sk-title"></div>
+          <div class="sk-line"></div>
+          <div class="sk-line sk-short"></div>
+          <div class="sk-meta">
+            <div class="sk-avatar"></div>
+            <div class="sk-line sk-name"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="layer content-layer">
+        <div class="media" role="img" aria-label="Warm studio photo placeholder"></div>
+        <div class="body">
+          <h2>Studio session notes</h2>
+          <p>
+            Soft light, clean frames, and a paced reveal that teaches the handoff from
+            placeholder geometry to readable content.
+          </p>
+          <div class="meta">
+            <span class="avatar" aria-hidden="true">EM</span>
+            <div>
+              <strong>EaseMotion Lab</strong>
+              <span>Content ready</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <p class="status" id="status" role="status" aria-live="polite">Loading placeholders…</p>
+  </main>
+
+  <script>
+    (function () {
+      const card = document.getElementById('morph-card');
+      const btn = document.getElementById('replay-btn');
+      const status = document.getElementById('status');
+      const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      let timer;
+
+      function setLoading() {
+        card.dataset.state = 'loading';
+        card.setAttribute('aria-busy', 'true');
+        status.textContent = 'Loading placeholders…';
+      }
+
+      function setReady() {
+        card.dataset.state = reduced ? 'ready-instant' : 'ready';
+        card.setAttribute('aria-busy', 'false');
+        status.textContent = 'Content morph complete.';
+      }
+
+      function run() {
+        clearTimeout(timer);
+        setLoading();
+        timer = window.setTimeout(setReady, reduced ? 120 : 1400);
+      }
+
+      btn.addEventListener('click', run);
+      run();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/feature-skeleton-to-content-morph-swap-sum/style.css
+++ b/submissions/examples/feature-skeleton-to-content-morph-swap-sum/style.css
@@ -1,0 +1,280 @@
+/* Skeleton-to-Content Morph Swap — local demo styles */
+
+:root {
+  --ink: #1c1917;
+  --muted: #78716c;
+  --bg: #f5f1eb;
+  --card: #fffaf3;
+  --line: #e7e0d5;
+  --bone: #e8e0d4;
+  --bone-shine: #f4eee4;
+  --accent: #b45309;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --spring: cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", "Avenir Next", system-ui, sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 12% 10%, #fde8c8 0%, transparent 36%),
+    radial-gradient(circle at 90% 80%, #e8efe4 0%, transparent 40%),
+    var(--bg);
+}
+
+.page {
+  width: min(520px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 3rem 0 4rem;
+}
+
+.intro {
+  margin-bottom: 1.4rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.45rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+h1 {
+  margin: 0 0 0.55rem;
+  font-size: clamp(1.7rem, 4vw, 2.15rem);
+  line-height: 1.15;
+}
+
+.lede {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.replay-btn {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem 1.1rem;
+  background: var(--ink);
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 160ms var(--ease), background 160ms var(--ease);
+}
+
+.replay-btn:hover {
+  transform: translateY(-1px);
+}
+
+.replay-btn:active {
+  transform: scale(0.98);
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 22px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  box-shadow: 0 18px 40px rgba(28, 25, 23, 0.08);
+  min-height: 420px;
+}
+
+.layer {
+  inset: 0;
+}
+
+.skeleton-layer {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  transition:
+    opacity 520ms var(--ease),
+    filter 620ms var(--ease),
+    transform 620ms var(--spring),
+    clip-path 680ms var(--ease);
+  clip-path: inset(0 0 0 0 round 22px);
+}
+
+.content-layer {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  opacity: 0;
+  filter: blur(10px);
+  transform: scale(0.96);
+  transition:
+    opacity 540ms var(--ease),
+    filter 640ms var(--ease),
+    transform 640ms var(--spring);
+}
+
+.sk-media,
+.media {
+  aspect-ratio: 16 / 10;
+  border-radius: 16px;
+}
+
+.sk-media,
+.sk-line,
+.sk-avatar {
+  background: linear-gradient(90deg, var(--bone) 20%, var(--bone-shine) 50%, var(--bone) 80%);
+  background-size: 200% 100%;
+  animation: shimmer 1.3s linear infinite;
+}
+
+.sk-media {
+  width: 100%;
+}
+
+.sk-body {
+  display: grid;
+  gap: 0.7rem;
+  padding: 0.25rem 0.35rem 0.5rem;
+}
+
+.sk-line {
+  height: 0.85rem;
+  border-radius: 999px;
+  width: 100%;
+}
+
+.sk-title {
+  height: 1.15rem;
+  width: 68%;
+}
+
+.sk-short {
+  width: 54%;
+}
+
+.sk-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 0.55rem;
+}
+
+.sk-avatar {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.sk-name {
+  width: 42%;
+}
+
+.media {
+  background:
+    linear-gradient(145deg, rgba(28, 25, 23, 0.18), transparent 42%),
+    linear-gradient(180deg, #f6c98b, #d97706 55%, #92400e);
+}
+
+.body h2 {
+  margin: 0.2rem 0 0.55rem;
+  font-size: 1.35rem;
+}
+
+.body p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.1rem;
+}
+
+.meta strong,
+.meta span {
+  display: block;
+}
+
+.meta span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.avatar {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #292524;
+  color: #fef3c7;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.status {
+  margin: 1rem 0 0;
+  min-height: 1.25rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.card[data-state='ready'] .skeleton-layer {
+  opacity: 0;
+  filter: blur(12px);
+  transform: scale(1.04);
+  clip-path: inset(8% 6% 10% 6% round 28px);
+  pointer-events: none;
+}
+
+.card[data-state='ready'] .content-layer,
+.card[data-state='ready-instant'] .content-layer {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+}
+
+.card[data-state='ready-instant'] .skeleton-layer {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@keyframes shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .sk-media,
+  .sk-line,
+  .sk-avatar {
+    animation: none;
+  }
+}


### PR DESCRIPTION
# #51866 issue resolved

## Description

This PR adds a Skeleton-to-Content Morph Swap demo under `submissions/examples`.

## Features

- Skeleton placeholders that morph into real content
- Blur→sharp, scale, and clip-path choreography
- Replay / reload button
- Card-style content reveal
- Respects `prefers-reduced-motion`