### PR TITLE
Add ease-yeast-thermometer component

### DIFF
--- a/submissions/examples/ease-yeast-thermometer-ij/README.md
+++ b/submissions/examples/ease-yeast-thermometer-ij/README.md
@@ -1,0 +1,16 @@
+# ease-yeast-thermometer
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(231, 67%, 57%) | Primary color |
+| --bg | hsl(231, 10%, 96%) | Background |
+| --duration | 0.80s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-yeast-thermometer-ij/demo.html
+++ b/submissions/examples/ease-yeast-thermometer-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-yeast-thermometer-ij/style.css
+++ b/submissions/examples/ease-yeast-thermometer-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(231, 67%, 57%);--bg:hsl(231, 10%, 96%);--text:#1e293b;--duration:0.80s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes rotate-yeast-thermometer {
+  0% { transform: rotate(0deg) scale(1); }
+  33% { transform: rotate(107.666666666667deg) scale(1.05); border-radius: 40%; }
+  66% { transform: rotate(215.333333333333deg) scale(1.45); border-radius: 20%; }
+  100% { transform: rotate(323deg) scale(1); border-radius: 50%; }
+}
+@keyframes pulse-yeast-thermometer {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 hsl(231, 67%, 57%)60; }
+  50% { opacity: 0.77; box-shadow: 0 0 25px 10px hsl(351, 67%, 57%)30; }
+}
+.anim-target.active { animation: rotate-yeast-thermometer 0.80s ease-in-out infinite, pulse-yeast-thermometer 2s ease-in-out infinite; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(111, 67%, 57%)}


### PR DESCRIPTION
## Component: ease-yeast-thermometer — yeast thermometer — CSS rotation and pulse keyframes drive a loading indicator, timing set via custom property

**Closes #52110**

### What this adds
A loading indicator. CSS @keyframes rotate-yeast-thermometer rotates the element through four stages while pulse-yeast-thermometer varies opacity and box-shadow for a breathing glow. Both keyframes loop infinitely.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-yeast-thermometer-ij/demo.html
- submissions/examples/ease-yeast-thermometer-ij/style.css
- submissions/examples/ease-yeast-thermometer-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS @keyframes transitions.
