### PR TITLE
Add ease-yield-curve-chart component

### DIFF
--- a/submissions/examples/ease-yield-curve-chart-ij/README.md
+++ b/submissions/examples/ease-yield-curve-chart-ij/README.md
@@ -1,0 +1,16 @@
+# ease-yield-curve-chart
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(144, 67%, 57%) | Primary color |
+| --bg | hsl(144, 10%, 96%) | Background |
+| --duration | 0.80s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-yield-curve-chart-ij/demo.html
+++ b/submissions/examples/ease-yield-curve-chart-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-yield-curve-chart-ij/style.css
+++ b/submissions/examples/ease-yield-curve-chart-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(144, 67%, 57%);--bg:hsl(144, 10%, 96%);--text:#1e293b;--duration:0.80s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes rise-yield-curve-chart {
+  0% { transform: scaleY(0); opacity: 0; transform-origin: bottom; }
+  40% { transform: scaleY(1.05); opacity: 0.77; }
+  100% { transform: scaleY(1); opacity: 1; }
+}
+@keyframes fillBar-yield-curve-chart {
+  0% { width: 0; background: linear-gradient(90deg, hsl(144, 67%, 57%), hsl(264, 67%, 57%)); }
+  60% { width: 63.ToString('0')%; background: linear-gradient(90deg, hsl(264, 67%, 57%), hsl(24, 67%, 57%)); }
+  100% { width: 100%; background: linear-gradient(90deg, hsl(24, 67%, 57%), hsl(144, 67%, 57%)); }
+}
+.anim-target.active { animation: rise-yield-curve-chart 0.80s cubic-bezier(0.34, 1.56, 0.64, 1) forwards, fillBar-yield-curve-chart 1.10s ease-out forwards 0.15s; transform-origin: bottom; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(24, 67%, 57%)}


### PR DESCRIPTION
## Component: ease-yield-curve-chart — yield curve chart — data viz with scaleY rise from bottom and gradient width-fill progression

**Closes #52126**

### What this adds
A chart visualization. The @keyframes rise-yield-curve-chart animates scaleY from bottom with overshoot while illBar-yield-curve-chart progresses width through gradient color stops derived from the component name.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-yield-curve-chart-ij/demo.html
- submissions/examples/ease-yield-curve-chart-ij/style.css
- submissions/examples/ease-yield-curve-chart-ij/README.md

### How to review
Open demo.html directly in a browser. Click to trigger the rise and fill animation showing data progression.
