### PR TITLE
Add ease-ytd-earnings-chart component

### DIFF
--- a/submissions/examples/ease-ytd-earnings-chart-ij/README.md
+++ b/submissions/examples/ease-ytd-earnings-chart-ij/README.md
@@ -1,0 +1,16 @@
+# ease-ytd-earnings-chart
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(102, 68%, 58%) | Primary color |
+| --bg | hsl(102, 10%, 96%) | Background |
+| --duration | 0.88s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-ytd-earnings-chart-ij/demo.html
+++ b/submissions/examples/ease-ytd-earnings-chart-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-ytd-earnings-chart-ij/style.css
+++ b/submissions/examples/ease-ytd-earnings-chart-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(102, 68%, 58%);--bg:hsl(102, 10%, 96%);--text:#1e293b;--duration:0.88s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes rise-ytd-earnings-chart {
+  0% { transform: scaleY(0); opacity: 0; transform-origin: bottom; }
+  40% { transform: scaleY(1.05); opacity: 0.88; }
+  100% { transform: scaleY(1); opacity: 1; }
+}
+@keyframes fillBar-ytd-earnings-chart {
+  0% { width: 0; background: linear-gradient(90deg, hsl(102, 68%, 58%), hsl(222, 68%, 58%)); }
+  60% { width: 62.ToString('0')%; background: linear-gradient(90deg, hsl(222, 68%, 58%), hsl(342, 68%, 58%)); }
+  100% { width: 100%; background: linear-gradient(90deg, hsl(342, 68%, 58%), hsl(102, 68%, 58%)); }
+}
+.anim-target.active { animation: rise-ytd-earnings-chart 0.88s cubic-bezier(0.34, 1.56, 0.64, 1) forwards, fillBar-ytd-earnings-chart 1.18s ease-out forwards 0.15s; transform-origin: bottom; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(342, 68%, 58%)}


### PR DESCRIPTION
## Component: ease-ytd-earnings-chart — ytd earnings chart — data viz with scaleY rise from bottom and gradient width-fill progression

**Closes #52138**

### What this adds
A chart visualization. The @keyframes rise-ytd-earnings-chart animates scaleY from bottom with overshoot while illBar-ytd-earnings-chart progresses width through gradient color stops derived from the component name.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-ytd-earnings-chart-ij/demo.html
- submissions/examples/ease-ytd-earnings-chart-ij/style.css
- submissions/examples/ease-ytd-earnings-chart-ij/README.md

### How to review
Open demo.html directly in a browser. Click to trigger the rise and fill animation showing data progression.
