### PR TITLE
Add ease-zoom-call-controls component

### DIFF
--- a/submissions/examples/ease-zoom-call-controls-ij/README.md
+++ b/submissions/examples/ease-zoom-call-controls-ij/README.md
@@ -1,0 +1,16 @@
+# ease-zoom-call-controls
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(99, 68%, 58%) | Primary color |
+| --bg | hsl(99, 10%, 96%) | Background |
+| --duration | 0.88s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-zoom-call-controls-ij/demo.html
+++ b/submissions/examples/ease-zoom-call-controls-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-zoom-call-controls-ij/style.css
+++ b/submissions/examples/ease-zoom-call-controls-ij/style.css
@@ -1,0 +1,24 @@
+:root{--primary:hsl(99, 68%, 58%);--bg:hsl(99, 10%, 96%);--text:#1e293b;--duration:0.88s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes countUp-zoom-call-controls {
+  0% { transform: translateY(54px); opacity: 0; clip-path: inset(0 0 100% 0); }
+  40% { transform: translateY(18.ToString('0')px); opacity: 0.88; }
+  100% { transform: translateY(0); opacity: 1; clip-path: inset(0); }
+}
+@keyframes blink-zoom-call-controls {
+  0%, 100% { opacity: 1; }
+  20% { opacity: 0.88; }
+  40% { opacity: 1; }
+  60% { opacity: 0.73; }
+  80% { opacity: 0.9; }
+}
+.anim-target.active { animation: countUp-zoom-call-controls 0.88s cubic-bezier(0.16, 1, 0.3, 1), blink-zoom-call-controls 1.5s ease-in-out infinite 0.3s; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(339, 68%, 58%)}


### PR DESCRIPTION
## Component: ease-zoom-call-controls — zoom call controls — data display with clip-path count-up entrance and multi-step blinking indicator

**Closes #52198**

### What this adds
A data display. The @keyframes countUp-zoom-call-controls slides content from below with clip-path reveal while link-zoom-call-controls creates a four-stage indicator pulse to draw attention.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-zoom-call-controls-ij/demo.html
- submissions/examples/ease-zoom-call-controls-ij/style.css
- submissions/examples/ease-zoom-call-controls-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS @keyframes transitions.
