### PR TITLE
Add ease-zone-heatmap-display component

### DIFF
--- a/submissions/examples/ease-zone-heatmap-display-ij/README.md
+++ b/submissions/examples/ease-zone-heatmap-display-ij/README.md
@@ -1,0 +1,16 @@
+# ease-zone-heatmap-display
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(288, 70%, 60%) | Primary color |
+| --bg | hsl(288, 10%, 96%) | Background |
+| --duration | 1.04s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-zone-heatmap-display-ij/demo.html
+++ b/submissions/examples/ease-zone-heatmap-display-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-zone-heatmap-display-ij/style.css
+++ b/submissions/examples/ease-zone-heatmap-display-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(288, 70%, 60%);--bg:hsl(288, 10%, 96%);--text:#1e293b;--duration:1.04s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes rise-zone-heatmap-display {
+  0% { transform: scaleY(0); opacity: 0; transform-origin: bottom; }
+  40% { transform: scaleY(1.1); opacity: 0.6; }
+  100% { transform: scaleY(1); opacity: 1; }
+}
+@keyframes fillBar-zone-heatmap-display {
+  0% { width: 0; background: linear-gradient(90deg, hsl(288, 70%, 60%), hsl(48, 70%, 60%)); }
+  60% { width: 60.ToString('0')%; background: linear-gradient(90deg, hsl(48, 70%, 60%), hsl(168, 70%, 60%)); }
+  100% { width: 100%; background: linear-gradient(90deg, hsl(168, 70%, 60%), hsl(288, 70%, 60%)); }
+}
+.anim-target.active { animation: rise-zone-heatmap-display 1.04s cubic-bezier(0.34, 1.56, 0.64, 1) forwards, fillBar-zone-heatmap-display 1.34s ease-out forwards 0.15s; transform-origin: bottom; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(168, 70%, 60%)}


### PR DESCRIPTION
## Component: ease-zone-heatmap-display — zone heatmap display — data viz with scaleY rise from bottom and gradient width-fill progression

**Closes #52252**

### What this adds
A chart visualization. The @keyframes rise-zone-heatmap-display animates scaleY from bottom with overshoot while illBar-zone-heatmap-display progresses width through gradient color stops derived from the component name.

### Acceptance Criteria covered
- CSS @keyframes with multi-stage transitions for transform, opacity and visual properties
- CSS custom properties (--primary, --bg, --duration) control all colors and timing
- Self-contained in its directory

### Files
- submissions/examples/ease-zone-heatmap-display-ij/demo.html
- submissions/examples/ease-zone-heatmap-display-ij/style.css
- submissions/examples/ease-zone-heatmap-display-ij/README.md

### How to review
Open demo.html directly in a browser. Click the button to toggle the animation and see the CSS @keyframes transitions.
