### PR TITLE
Feature ease chip

### DIFF
--- a/submissions/examples/ease-chip-print-friendly-ag/README.md
+++ b/submissions/examples/ease-chip-print-friendly-ag/README.md
@@ -1,0 +1,70 @@
+# Print-Friendly Chip Component
+
+A standard CSS-only select chip component optimized for paper printouts, stripping away heavy background colors and box-shadows to conserve printer ink.
+
+## What does this do?
+
+This component provides a lightweight select chip group that functions identically to standard checkboxes/pills on screen, but automatically formats itself for printing:
+
+- **Backgrounds & Gradients**: Stripped to `transparent` to avoid waste.
+- **Colors**: Forced to pure black (`#000000`) for high contrast on white paper.
+- **Shadows & Transitions**: Disabled entirely to prevent muddy halftone dots.
+- **State Recognition**: Checked inputs get a solid black border, bold typography, and a distinct black checkmark (`✓`) to maintain readability on paper.
+- **Disabled States**: Set to a dashed border and reduced opacity to show they are inactive.
+
+## How is it used?
+
+Structure the chip elements within a label and input wrapper:
+
+```html
+<div class="ease-chip-group-ag">
+  <!-- Checked State -->
+  <label>
+    <input type="checkbox" name="skills" value="html" checked />
+    <span class="ease-chip-ag">HTML</span>
+  </label>
+
+  <!-- Unchecked State -->
+  <label>
+    <input type="checkbox" name="skills" value="js" />
+    <span class="ease-chip-ag">JavaScript</span>
+  </label>
+
+  <!-- Disabled State -->
+  <label>
+    <input type="checkbox" name="skills" value="css" disabled />
+    <span class="ease-chip-ag">CSS</span>
+  </label>
+</div>
+```
+
+### Size Modifiers
+
+- **Small**: `.ease-chip-sm-ag`
+- **Large**: `.ease-chip-lg-ag`
+
+## Why is it useful?
+
+Forms, resumes, search filters, and data summaries are frequently printed or exported to PDF by users. Standard styled chips contain heavy solid backgrounds (like indigo or grey) and drop shadows that look unprofessional and consume excessive ink when printed. The print-friendly version solves this by ensuring clean, black-and-white grid lines.
+
+## Print Overrides Code Reference
+
+The following `@media print` block is incorporated to handle the conversions:
+
+```css
+@media print {
+  .ease-chip-ag {
+    background: transparent !important;
+    color: #000000 !important;
+    border: 1.5px solid #000000 !important;
+    box-shadow: none !important;
+    transition: none !important;
+  }
+
+  .ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag {
+    border-color: #000000 !important;
+    color: #000000 !important;
+    font-weight: 700 !important;
+  }
+}
+```

--- a/submissions/examples/ease-chip-print-friendly-ag/demo.html
+++ b/submissions/examples/ease-chip-print-friendly-ag/demo.html
@@ -1,0 +1,397 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>Print-Friendly Chip Component - EaseMotion CSS</title>
+
+    <!-- Link to Component CSS -->
+    <link rel="stylesheet" href="style.css" />
+
+    <!-- Google Fonts: Outfit for premium typography -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+
+    <style>
+      /* Demo-specific layout */
+      body {
+        background-color: #0b0f19;
+        color: #f8fafc;
+        font-family: "Outfit", sans-serif;
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        transition:
+          background-color 0.4s ease,
+          color 0.4s ease;
+      }
+
+      .demo-header {
+        text-align: center;
+        max-width: 600px;
+        padding: 0 1.5rem;
+        margin-bottom: 2.5rem;
+      }
+
+      .demo-header h1 {
+        font-size: clamp(2rem, 5vw, 3rem);
+        font-weight: 800;
+        background: linear-gradient(135deg, #a78bfa, #8b5cf6, #3b82f6);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        margin: 0 0 12px 0;
+        letter-spacing: -0.02em;
+      }
+
+      .demo-header p {
+        color: #94a3b8;
+        font-size: 1.05rem;
+        line-height: 1.6;
+        margin: 0;
+      }
+
+      .showcase-card {
+        width: 100%;
+        max-width: 750px;
+        background: rgba(15, 23, 42, 0.45);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        border-radius: 24px;
+        padding: 3rem;
+        backdrop-filter: blur(16px);
+        -webkit-backdrop-filter: blur(16px);
+        box-shadow: 0 25px 60px rgba(0, 0, 0, 0.4);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        position: relative;
+        transition: all 0.4s ease;
+      }
+
+      .showcase-card::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 4px;
+        background: linear-gradient(90deg, #6c63ff, #8b5cf6, #3b82f6);
+      }
+
+      .showcase-card__subtitle {
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: #a78bfa;
+        letter-spacing: 0.15em;
+        margin-bottom: 2.5rem;
+      }
+
+      /* Actions row */
+      .controls-row {
+        display: flex;
+        gap: 1rem;
+        margin-top: 3rem;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      /* Buttons */
+      .btn-ag {
+        padding: 10px 22px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        border-radius: 8px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        transition: all 0.3s ease;
+        outline: none;
+      }
+
+      .btn-primary-ag {
+        background: linear-gradient(135deg, #6c63ff, #8b5cf6);
+        border: none;
+        color: #ffffff;
+        box-shadow: 0 4px 14px rgba(108, 99, 255, 0.3);
+      }
+
+      .btn-primary-ag:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 6px 20px rgba(108, 99, 255, 0.4);
+      }
+
+      .btn-secondary-ag {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        color: #f3f4f6;
+      }
+
+      .btn-secondary-ag:hover {
+        background: rgba(255, 255, 255, 0.08);
+        color: #ffffff;
+        border-color: rgba(255, 255, 255, 0.2);
+      }
+
+      .btn-ag svg {
+        width: 16px;
+        height: 16px;
+        fill: currentColor;
+      }
+
+      .btn-ag:focus-visible {
+        outline: 2px solid #8b5cf6;
+        outline-offset: 3px;
+      }
+
+      /* Chip sizes section */
+      .size-section {
+        width: 100%;
+        margin-bottom: 2rem;
+      }
+
+      .size-section h3 {
+        font-size: 0.875rem;
+        font-weight: 700;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-bottom: 1rem;
+        margin-top: 0;
+        text-align: center;
+      }
+
+      .chip-container {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+      }
+
+      /* ── Print Simulation Mode (Screen Preview) ────────────────── */
+      .simulate-print-active {
+        background: #ffffff !important;
+        color: #000000 !important;
+      }
+
+      .simulate-print-active .demo-header h1 {
+        background: none !important;
+        -webkit-text-fill-color: initial !important;
+        color: #000000 !important;
+      }
+
+      .simulate-print-active .demo-header p {
+        color: #333333 !important;
+      }
+
+      .simulate-print-active .showcase-card {
+        background: #ffffff !important;
+        border: 1px dashed #cccccc !important;
+        box-shadow: none !important;
+        color: #000000 !important;
+      }
+
+      .simulate-print-active .showcase-card::before {
+        display: none;
+      }
+
+      .simulate-print-active .showcase-card__subtitle {
+        color: #555555 !important;
+      }
+
+      .simulate-print-active .size-section h3 {
+        color: #444444 !important;
+      }
+
+      /* Force the print CSS variables & styles to apply on screen during simulation */
+      .simulate-print-active .ease-chip-ag {
+        background: transparent !important;
+        background-color: transparent !important;
+        color: #000000 !important;
+        border: 1.5px solid #000000 !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+        transition: none !important;
+        transform: none !important;
+      }
+
+      .simulate-print-active
+        .ease-chip-group-ag
+        input[type="checkbox"]:checked
+        + .ease-chip-ag {
+        background: transparent !important;
+        background-color: transparent !important;
+        border-color: #000000 !important;
+        color: #000000 !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+        font-weight: 700 !important;
+      }
+
+      .simulate-print-active
+        .ease-chip-group-ag
+        input[type="checkbox"]:checked
+        + .ease-chip-ag::before {
+        color: #000000 !important;
+        font-weight: 700 !important;
+      }
+
+      .simulate-print-active
+        .ease-chip-group-ag
+        input[type="checkbox"]:disabled
+        + .ease-chip-ag {
+        opacity: 0.35 !important;
+        border-style: dashed !important;
+        color: #555555 !important;
+      }
+
+      /* ── Print Styles (Real Print Mode) ────────────────────────── */
+      @media print {
+        /* Hide demo controls and headings when printing */
+        .demo-header,
+        .showcase-card__subtitle,
+        .controls-row {
+          display: none !important;
+        }
+
+        body {
+          background: #ffffff !important;
+          color: #000000 !important;
+          padding: 0 !important;
+        }
+
+        .showcase-card {
+          background: transparent !important;
+          border: none !important;
+          box-shadow: none !important;
+          padding: 0 !important;
+        }
+
+        .showcase-card::before {
+          display: none !important;
+        }
+      }
+    </style>
+  </head>
+  <body id="demo-body">
+    <div class="demo-header">
+      <h1>Print-Friendly Chips</h1>
+      <p>
+        A CSS-only select chip component optimized for paper output. Strips away
+        heavy background fills, drop shadows, and scale transitions when printed
+        to conserve ink.
+      </p>
+    </div>
+
+    <div class="showcase-card">
+      <div class="showcase-card__subtitle">Interactive Select Grid</div>
+
+      <!-- Standard Chips Showcase -->
+      <div class="size-section">
+        <h3>Standard Size</h3>
+        <div class="chip-container">
+          <div class="ease-chip-group-ag">
+            <label>
+              <input type="checkbox" name="skills" value="html" checked />
+              <span class="ease-chip-ag">HTML</span>
+            </label>
+
+            <label>
+              <input type="checkbox" name="skills" value="css" checked />
+              <span class="ease-chip-ag">CSS</span>
+            </label>
+
+            <label>
+              <input type="checkbox" name="skills" value="js" />
+              <span class="ease-chip-ag">JavaScript</span>
+            </label>
+
+            <label>
+              <input type="checkbox" name="skills" value="scss" />
+              <span class="ease-chip-ag">SCSS Mixins</span>
+            </label>
+
+            <label>
+              <input type="checkbox" name="skills" value="a11y" disabled />
+              <span class="ease-chip-ag">Disabled Category</span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <!-- Small & Large Variations -->
+      <div class="size-section">
+        <h3>Size Variants</h3>
+        <div
+          class="chip-container"
+          style="flex-direction: column; align-items: center; gap: 1rem"
+        >
+          <!-- Small -->
+          <div class="ease-chip-group-ag">
+            <label>
+              <input type="checkbox" name="small-tags" value="tag1" checked />
+              <span class="ease-chip-ag ease-chip-sm-ag">Small Tag</span>
+            </label>
+            <label>
+              <input type="checkbox" name="small-tags" value="tag2" />
+              <span class="ease-chip-ag ease-chip-sm-ag">Mini Label</span>
+            </label>
+          </div>
+
+          <!-- Large -->
+          <div class="ease-chip-group-ag">
+            <label>
+              <input type="checkbox" name="large-tags" value="tag3" checked />
+              <span class="ease-chip-ag ease-chip-lg-ag">Large Selection</span>
+            </label>
+            <label>
+              <input type="checkbox" name="large-tags" value="tag4" />
+              <span class="ease-chip-ag ease-chip-lg-ag">Extended Pill</span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <!-- Action Trigger Controls -->
+      <div class="controls-row">
+        <!-- Simulate print preview directly on screen -->
+        <button
+          class="btn-ag btn-secondary-ag"
+          id="sim-btn"
+          onclick="
+            document
+              .getElementById('demo-body')
+              .classList.toggle('simulate-print-active');
+            const isActive = document
+              .getElementById('demo-body')
+              .classList.contains('simulate-print-active');
+            this.innerHTML = isActive
+              ? 'Show Screen Styles'
+              : 'Simulate Print Styles';
+          "
+        >
+          Simulate Print Styles
+        </button>
+
+        <!-- Real Print Trigger -->
+        <button class="btn-ag btn-primary-ag" onclick="window.print()">
+          <svg viewBox="0 0 24 24">
+            <path
+              d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"
+            />
+          </svg>
+          Print Page
+        </button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-chip-print-friendly-ag/style.css
+++ b/submissions/examples/ease-chip-print-friendly-ag/style.css
@@ -1,0 +1,196 @@
+/* ============================================================
+   EaseMotion CSS — ease-chip-print-friendly-ag
+   Print-Friendly Chip Component Styles & Print Overrides
+   ============================================================ */
+
+/* ── Chip Group Wrapper ─────────────────────────────────────── */
+.ease-chip-group-ag {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* ── Hide native checkbox ───────────────────────────────────── */
+.ease-chip-group-ag input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── Focus visible state ────────────────────────────────────── */
+.ease-chip-group-ag input[type="checkbox"]:focus-visible + .ease-chip-ag {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+/* ── Base Chip ─────────────────────────────────────────────── */
+.ease-chip-ag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid var(--ease-color-neutral-300, #d1d5db);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-700, #374151);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition:
+    background var(--ease-speed-fast, 150ms)
+      var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color var(--ease-speed-fast, 150ms)
+      var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    color var(--ease-speed-fast, 150ms)
+      var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+    transform var(--ease-speed-fast, 150ms)
+      var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+    box-shadow var(--ease-speed-fast, 150ms)
+      var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.ease-chip-ag:hover {
+  border-color: var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-neutral-200, #e5e7eb);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+/* ── Checkmark icon ────────────────────────────────────────── */
+.ease-chip-ag::before {
+  content: "";
+  display: inline-block;
+  width: 0;
+  height: 14px;
+  overflow: hidden;
+  transition: width var(--ease-speed-fast, 150ms)
+    var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/* ── Selected state ────────────────────────────────────────── */
+.ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag {
+  background: var(--ease-color-primary, #6366f1);
+  border-color: var(--ease-color-primary, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.35);
+}
+
+.ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag::before {
+  content: "✓";
+  width: 14px;
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 14px;
+}
+
+/* ── Disabled state ─────────────────────────────────────────── */
+.ease-chip-group-ag input[type="checkbox"]:disabled + .ease-chip-ag {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ── Size variants ──────────────────────────────────────────── */
+.ease-chip-sm-ag {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+}
+
+.ease-chip-lg-ag {
+  padding: 0.5rem 1.125rem;
+  font-size: 0.9rem;
+}
+
+/* ── Dark Mode ───────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .ease-chip-ag {
+    background: var(--ease-color-neutral-700, #374151);
+    border-color: var(--ease-color-neutral-600, #4b5563);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-chip-ag:hover {
+    background: var(--ease-color-neutral-600, #4b5563);
+    border-color: var(--ease-color-primary, #6366f1);
+  }
+
+  .ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag {
+    background: var(--ease-color-primary, #6366f1);
+    border-color: var(--ease-color-primary, #6366f1);
+    color: #ffffff;
+    box-shadow: 0 4px 12px rgba(99, 102, 241, 0.55);
+  }
+}
+
+/* ── Reduced Motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-chip-ag {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
+/* ── Windows High Contrast Mode ──────────────────────────────── */
+@media (forced-colors: active) {
+  .ease-chip-ag {
+    outline: 1px solid CanvasText;
+    outline-offset: 1px;
+  }
+
+  .ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag {
+    background-color: Highlight;
+    border-color: Highlight;
+    color: HighlightText;
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  .ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag::before {
+    color: HighlightText;
+  }
+}
+
+/* ============================================================
+   @media print Query Ink-Saving Overrides
+   ============================================================ */
+@media print {
+  /* Strip heavy colors, shadows, gradients, and transitions to save ink */
+  .ease-chip-ag {
+    background: transparent !important;
+    background-color: transparent !important;
+    color: #000000 !important;
+    border: 1.5px solid #000000 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    transition: none !important;
+    transform: none !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag {
+    background: transparent !important;
+    background-color: transparent !important;
+    border-color: #000000 !important;
+    color: #000000 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    font-weight: 700 !important; /* Bold text for clear distinction of checked state */
+  }
+
+  .ease-chip-group-ag input[type="checkbox"]:checked + .ease-chip-ag::before {
+    color: #000000 !important;
+    font-weight: 700 !important;
+  }
+
+  .ease-chip-group-ag input[type="checkbox"]:disabled + .ease-chip-ag {
+    opacity: 0.35 !important;
+    border-style: dashed !important; /* Dashed outline for disabled chips on print */
+    color: #555555 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Submits a print-friendly styling optimization for the `ease-chip` component, stripping all heavy colors, gradients, drop shadows, and scale transitions during printing to save paper ink while keeping checked states readable.
---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  * Print stylesheet optimization for the chip component
---
## Submission Checklist
- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
A `@media print` query implementation for the EaseMotion chip component that removes heavy fills and box-shadows on printed media. Checked and disabled states are represented using simple ink-saving outlines, bold weights, and checkmarks.
**How does a developer use it?**
```html
<!-- Default markup structure stays the same; the print media overrides apply automatically -->
<div class="ease-chip-group-ag">
  <label>
    <input type="checkbox" name="skills" value="html" checked>
    <span class="ease-chip-ag">HTML</span>
  </label>
</div>
Why does it fit EaseMotion CSS?

It improves framework utility by ensuring that components remain practical, professional, and readable when pages containing them are printed or exported to PDF, without requiring developer-written overrides.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari
Notes for Maintainer
The demo.html includes a "Simulate Print Styles" toggle that dynamically injects the print styling variables on the screen so developers can preview print rendering without opening their system print dialog.
Suffix -ag has been appended to the folder structure and custom selector names to avoid conflicts.