### PR TITLE
feat: add ease-input-float-label animated floating label form input (…

### DIFF
--- a/submissions/examples/ease-input-float-label-v1/README.md
+++ b/submissions/examples/ease-input-float-label-v1/README.md
@@ -1,0 +1,94 @@
+# ease-input-float-label
+
+Submission for Issue #51346
+
+## What this adds
+
+A reusable animated floating label form input component where
+the placeholder label animates upward and shrinks on focus or
+when the field is filled. Pure CSS via `:focus` and
+`:not(:placeholder-shown)` — zero JavaScript required.
+
+## How It Works
+
+```css
+/* Label floats up when focused OR when field has value */
+.ease-input-float-label input:focus ~ label,
+.ease-input-float-label input:not(:placeholder-shown) ~ label {
+  top: 0.55rem;
+  transform: translateY(0) scale(0.82);
+  color: var(--float-color-focus);
+}
+```
+
+The key trick: `placeholder=" "` (a single space) on the
+input makes `:placeholder-shown` work correctly — the label
+stays floated when the field has real content.
+
+## HTML Structure
+
+```html
+<div class="ease-input-float-label">
+  <input type="text" id="name" placeholder=" " />
+  <label for="name">Full Name</label>
+</div>
+```
+
+**Note:** `placeholder=" "` (single space) is required.
+Label must come **after** the input in the DOM.
+
+## Classes
+
+### Input Styles
+| Class | Description |
+|---|---|
+| `ease-input-float-label` | Default bordered style |
+| `ease-input-float-label--underline` | Underline only with sweep animation |
+| `ease-input-float-label--outlined` | Rounded border with label on border |
+| `ease-input-float-label--filled` | Filled background, bottom border only |
+
+### Validation States
+| Class | Description |
+|---|---|
+| `ease-input-float-label--error` | Red border + label |
+| `ease-input-float-label--success` | Green border + label |
+
+### Modifiers
+| Class | Description |
+|---|---|
+| `ease-input-float-label--icon` | Adds left padding for icon |
+| `ease-input-float-label--sm` | Smaller padding + font |
+| `ease-input-float-label--lg` | Larger padding + font |
+
+### Focus Color Variants
+| Class | Color |
+|---|---|
+| default | Green (#4ade80) |
+| `--blue` | Blue (#60a5fa) |
+| `--purple` | Purple (#a78bfa) |
+| `--pink` | Pink (#f472b6) |
+
+### Helper Element
+```html
+<div class="ease-input-float-label__helper">Helper text here</div>
+```
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--float-color-focus` | #4ade80 | Label + border color on focus |
+| `--float-border-default` | #334155 | Default border color |
+| `--float-duration` | 0.22s | Animation speed |
+| `--float-bg` | #1e293b | Input background |
+
+## Accessibility
+
+- Semantic `<label for="id">` linked to input — screen reader friendly
+- `:focus-visible` styles preserved
+- `aria-describedby` can be added for helper text
+- Respects `prefers-reduced-motion` — all transitions disabled
+
+## Theme Support
+
+Supports `data-theme="neon"`, `data-theme="dracula"`, `data-theme="dark"`.

--- a/submissions/examples/ease-input-float-label-v1/demo.html
+++ b/submissions/examples/ease-input-float-label-v1/demo.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-input-float-label — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      background: #0f172a;
+      font-family: sans-serif;
+      color: #e2e8f0;
+      padding: 2rem;
+      max-width: 560px;
+    }
+    h2 {
+      margin-top: 2.5rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #64748b;
+      margin-bottom: 1.25rem;
+    }
+    p.desc { color: #64748b; font-size: 0.85rem; margin: 0.25rem 0 1.5rem; }
+    .form-group { margin-bottom: 1.25rem; }
+    .form-row { display: flex; gap: 1rem; margin-bottom: 1.25rem; }
+    .form-row .ease-input-float-label { flex: 1; }
+    .controls {
+      display: flex;
+      gap: 0.75rem;
+      margin: 1.5rem 0;
+      flex-wrap: wrap;
+    }
+    button {
+      padding: 6px 14px;
+      cursor: pointer;
+      background: #1e293b;
+      color: #e2e8f0;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      font-size: 0.8rem;
+    }
+    button:hover { background: #334155; }
+    .submit-btn {
+      width: 100%;
+      padding: 0.75rem;
+      background: linear-gradient(135deg, #4ade80, #22d3ee);
+      color: #052e16;
+      border: none;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      font-weight: 700;
+      cursor: pointer;
+      font-family: sans-serif;
+      margin-top: 0.5rem;
+      transition: opacity 0.2s ease;
+    }
+    .submit-btn:hover { opacity: 0.9; }
+    hr { border: none; border-top: 1px solid #1e293b; margin: 2rem 0; }
+  </style>
+</head>
+<body>
+
+<h1>🏷️ ease-input-float-label</h1>
+<p class="desc">Animated floating label form inputs — pure CSS via :focus and :placeholder-shown. Zero JavaScript.</p>
+
+<!-- DEFAULT OUTLINED -->
+<h2>Default (Outlined Border)</h2>
+<div class="form-group">
+  <div class="ease-input-float-label">
+    <input type="text" id="name1" placeholder=" " autocomplete="off" />
+    <label for="name1">Full Name</label>
+  </div>
+</div>
+<div class="form-group">
+  <div class="ease-input-float-label">
+    <input type="email" id="email1" placeholder=" " autocomplete="off" />
+    <label for="email1">Email Address</label>
+  </div>
+</div>
+
+<!-- UNDERLINE STYLE -->
+<h2>Underline Style</h2>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--underline">
+    <input type="text" id="name2" placeholder=" " autocomplete="off" />
+    <label for="name2">Full Name</label>
+  </div>
+</div>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--underline">
+    <input type="email" id="email2" placeholder=" " autocomplete="off" />
+    <label for="email2">Email Address</label>
+  </div>
+</div>
+
+<!-- OUTLINED STYLE -->
+<h2>Outlined Style</h2>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--outlined">
+    <input type="text" id="name3" placeholder=" " autocomplete="off" />
+    <label for="name3">Username</label>
+  </div>
+</div>
+
+<!-- FILLED STYLE -->
+<h2>Filled Style</h2>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--filled">
+    <input type="text" id="name4" placeholder=" " autocomplete="off" />
+    <label for="name4">Full Name</label>
+  </div>
+</div>
+
+<!-- WITH ICONS -->
+<h2>With Icons</h2>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--icon">
+    <span class="ease-input-float-label__icon">👤</span>
+    <input type="text" id="name5" placeholder=" " autocomplete="off" />
+    <label for="name5">Full Name</label>
+  </div>
+</div>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--icon">
+    <span class="ease-input-float-label__icon">📧</span>
+    <input type="email" id="email5" placeholder=" " autocomplete="off" />
+    <label for="email5">Email Address</label>
+  </div>
+</div>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--icon">
+    <span class="ease-input-float-label__icon">🔒</span>
+    <input type="password" id="pass5" placeholder=" " autocomplete="off" />
+    <label for="pass5">Password</label>
+  </div>
+</div>
+
+<!-- VALIDATION STATES -->
+<h2>Validation States</h2>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--error">
+    <input type="email" id="email-err" placeholder=" " value="invalid@" />
+    <label for="email-err">Email Address</label>
+  </div>
+  <div class="ease-input-float-label__helper">Please enter a valid email address.</div>
+</div>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--success">
+    <input type="text" id="name-ok" placeholder=" " value="John Doe" />
+    <label for="name-ok">Full Name</label>
+  </div>
+  <div class="ease-input-float-label__helper">Looks great!</div>
+</div>
+
+<!-- TEXTAREA -->
+<h2>Textarea</h2>
+<div class="form-group">
+  <div class="ease-input-float-label">
+    <textarea id="msg" placeholder=" "></textarea>
+    <label for="msg">Message</label>
+  </div>
+</div>
+
+<!-- COLOR VARIANTS -->
+<h2>Color Variants</h2>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--blue">
+    <input type="text" id="c-blue" placeholder=" " autocomplete="off" />
+    <label for="c-blue">Blue Focus</label>
+  </div>
+</div>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--purple">
+    <input type="text" id="c-purple" placeholder=" " autocomplete="off" />
+    <label for="c-purple">Purple Focus</label>
+  </div>
+</div>
+<div class="form-group">
+  <div class="ease-input-float-label ease-input-float-label--pink">
+    <input type="text" id="c-pink" placeholder=" " autocomplete="off" />
+    <label for="c-pink">Pink Focus</label>
+  </div>
+</div>
+
+<!-- FULL FORM EXAMPLE -->
+<h2>Full Sign-Up Form</h2>
+<form onsubmit="return false" style="background:#1e293b;border:1px solid #334155;border-radius:12px;padding:1.5rem">
+  <div class="form-row">
+    <div class="ease-input-float-label">
+      <input type="text" id="f-first" placeholder=" " autocomplete="off" />
+      <label for="f-first">First Name</label>
+    </div>
+    <div class="ease-input-float-label">
+      <input type="text" id="f-last" placeholder=" " autocomplete="off" />
+      <label for="f-last">Last Name</label>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="ease-input-float-label ease-input-float-label--icon">
+      <span class="ease-input-float-label__icon">📧</span>
+      <input type="email" id="f-email" placeholder=" " autocomplete="off" />
+      <label for="f-email">Email Address</label>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="ease-input-float-label ease-input-float-label--icon">
+      <span class="ease-input-float-label__icon">🔒</span>
+      <input type="password" id="f-pass" placeholder=" " autocomplete="off" />
+      <label for="f-pass">Password</label>
+    </div>
+  </div>
+  <button class="submit-btn" type="submit">Create Account</button>
+</form>
+
+<!-- THEMES -->
+<h2>Themes</h2>
+<div class="controls">
+  <button onclick="setTheme('')">Default</button>
+  <button onclick="setTheme('neon')">Neon</button>
+  <button onclick="setTheme('dracula')">Dracula</button>
+  <button onclick="setTheme('dark')">Dark</button>
+</div>
+<div id="theme-demo" style="background:#1e293b;border:1px solid #334155;border-radius:12px;padding:1.25rem">
+  <div class="form-group">
+    <div class="ease-input-float-label">
+      <input type="text" id="t-name" placeholder=" " autocomplete="off" />
+      <label for="t-name">Full Name</label>
+    </div>
+  </div>
+  <div class="form-group" style="margin-bottom:0">
+    <div class="ease-input-float-label">
+      <input type="email" id="t-email" placeholder=" " autocomplete="off" />
+      <label for="t-email">Email Address</label>
+    </div>
+  </div>
+</div>
+
+<script>
+  function setTheme(t) {
+    document.getElementById('theme-demo').dataset.theme = t;
+  }
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-input-float-label-v1/style.css
+++ b/submissions/examples/ease-input-float-label-v1/style.css
@@ -1,0 +1,365 @@
+/* =============================================
+   ease-input-float-label
+   Animated Floating Label Form Input
+   Zero JavaScript | :focus + :placeholder-shown
+   ============================================= */
+
+/* =====================
+   CSS VARIABLES
+   ===================== */
+.ease-input-float-label {
+  --float-color-default:  #64748b;
+  --float-color-focus:    #4ade80;
+  --float-color-error:    #f87171;
+  --float-color-success:  #4ade80;
+  --float-border-default: #334155;
+  --float-border-focus:   #4ade80;
+  --float-bg:             #1e293b;
+  --float-text:           #e2e8f0;
+  --float-duration:       0.22s;
+  --float-label-size:     0.85rem;
+  --float-label-float-size: 0.68rem;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+/* =====================
+   BASE INPUT
+   ===================== */
+.ease-input-float-label input,
+.ease-input-float-label textarea,
+.ease-input-float-label select {
+  width: 100%;
+  padding: 1.25rem 1rem 0.5rem;
+  background: var(--float-bg);
+  border: 1.5px solid var(--float-border-default);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-family: sans-serif;
+  color: var(--float-text);
+  outline: none;
+  transition:
+    border-color var(--float-duration) ease,
+    box-shadow   var(--float-duration) ease;
+  box-sizing: border-box;
+  caret-color: var(--float-color-focus);
+}
+
+.ease-input-float-label input::placeholder,
+.ease-input-float-label textarea::placeholder {
+  color: transparent;
+}
+
+/* Focus state */
+.ease-input-float-label input:focus,
+.ease-input-float-label textarea:focus,
+.ease-input-float-label select:focus {
+  border-color: var(--float-border-focus);
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.12);
+}
+
+/* =====================
+   FLOATING LABEL
+   ===================== */
+.ease-input-float-label label {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: var(--float-label-size);
+  font-family: sans-serif;
+  color: var(--float-color-default);
+  pointer-events: none;
+  transition:
+    top              var(--float-duration) cubic-bezier(0.22, 1, 0.36, 1),
+    font-size        var(--float-duration) cubic-bezier(0.22, 1, 0.36, 1),
+    color            var(--float-duration) ease,
+    transform        var(--float-duration) cubic-bezier(0.22, 1, 0.36, 1);
+  background: transparent;
+  padding: 0 2px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Float label up: on focus OR when not placeholder-shown (filled) */
+.ease-input-float-label input:focus ~ label,
+.ease-input-float-label input:not(:placeholder-shown) ~ label,
+.ease-input-float-label textarea:focus ~ label,
+.ease-input-float-label textarea:not(:placeholder-shown) ~ label,
+.ease-input-float-label select:focus ~ label,
+.ease-input-float-label select:not([value=""]) ~ label {
+  top: 0.55rem;
+  transform: translateY(0) scale(0.82);
+  transform-origin: left;
+  font-size: var(--float-label-float-size);
+}
+
+/* Label color on focus */
+.ease-input-float-label input:focus ~ label,
+.ease-input-float-label textarea:focus ~ label,
+.ease-input-float-label select:focus ~ label {
+  color: var(--float-color-focus);
+}
+
+/* =====================
+   UNDERLINE STYLE
+   ===================== */
+.ease-input-float-label--underline input,
+.ease-input-float-label--underline textarea {
+  border: none;
+  border-bottom: 1.5px solid var(--float-border-default);
+  border-radius: 0;
+  background: transparent;
+  padding: 1.25rem 0 0.5rem;
+}
+
+.ease-input-float-label--underline label {
+  left: 0;
+}
+
+.ease-input-float-label--underline input:focus,
+.ease-input-float-label--underline textarea:focus {
+  border-bottom-color: var(--float-border-focus);
+  box-shadow: 0 2px 0 0 rgba(74, 222, 128, 0.4);
+}
+
+/* Animated underline sweep */
+.ease-input-float-label--underline::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--float-border-focus);
+  transition: width var(--float-duration) cubic-bezier(0.22, 1, 0.36, 1);
+  border-radius: 1px;
+}
+
+.ease-input-float-label--underline:focus-within::after {
+  width: 100%;
+}
+
+/* =====================
+   OUTLINED STYLE
+   ===================== */
+.ease-input-float-label--outlined input,
+.ease-input-float-label--outlined textarea {
+  border-radius: 12px;
+  padding: 1.4rem 1rem 0.6rem;
+}
+
+.ease-input-float-label--outlined input:focus,
+.ease-input-float-label--outlined textarea:focus {
+  box-shadow: 0 0 0 2px var(--float-border-focus);
+}
+
+/* Outlined label sits on border */
+.ease-input-float-label--outlined label {
+  top: 50%;
+  background: var(--float-bg);
+}
+
+.ease-input-float-label--outlined input:focus ~ label,
+.ease-input-float-label--outlined input:not(:placeholder-shown) ~ label,
+.ease-input-float-label--outlined textarea:focus ~ label,
+.ease-input-float-label--outlined textarea:not(:placeholder-shown) ~ label {
+  top: 0;
+  background: var(--float-bg);
+  padding: 0 4px;
+}
+
+/* =====================
+   FILLED STYLE
+   ===================== */
+.ease-input-float-label--filled input,
+.ease-input-float-label--filled textarea {
+  background: #273548;
+  border: 1.5px solid transparent;
+  border-radius: 8px 8px 0 0;
+  border-bottom: 1.5px solid var(--float-border-default);
+}
+
+.ease-input-float-label--filled input:focus,
+.ease-input-float-label--filled textarea:focus {
+  border-bottom-color: var(--float-border-focus);
+  box-shadow: none;
+  background: #2d3e52;
+}
+
+/* =====================
+   VALIDATION STATES
+   ===================== */
+
+/* Error */
+.ease-input-float-label--error input,
+.ease-input-float-label--error textarea {
+  border-color: var(--float-color-error);
+}
+
+.ease-input-float-label--error input:focus,
+.ease-input-float-label--error textarea:focus {
+  border-color: var(--float-color-error);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.12);
+}
+
+.ease-input-float-label--error label {
+  color: var(--float-color-error);
+}
+
+.ease-input-float-label--error input:focus ~ label,
+.ease-input-float-label--error input:not(:placeholder-shown) ~ label {
+  color: var(--float-color-error);
+}
+
+/* Success */
+.ease-input-float-label--success input,
+.ease-input-float-label--success textarea {
+  border-color: #4ade80;
+}
+
+.ease-input-float-label--success input:focus ~ label,
+.ease-input-float-label--success input:not(:placeholder-shown) ~ label {
+  color: #4ade80;
+}
+
+/* =====================
+   HELPER / ERROR TEXT
+   ===================== */
+.ease-input-float-label__helper {
+  font-size: 0.72rem;
+  font-family: sans-serif;
+  color: #64748b;
+  margin-top: 0.3rem;
+  padding-left: 0.25rem;
+  transition: color var(--float-duration) ease;
+}
+
+.ease-input-float-label--error .ease-input-float-label__helper {
+  color: var(--float-color-error);
+}
+
+.ease-input-float-label--success .ease-input-float-label__helper {
+  color: #4ade80;
+}
+
+/* =====================
+   ICON SUPPORT
+   ===================== */
+.ease-input-float-label--icon input {
+  padding-left: 2.75rem;
+}
+
+.ease-input-float-label--icon label {
+  left: 2.75rem;
+}
+
+.ease-input-float-label__icon {
+  position: absolute;
+  left: 0.9rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #64748b;
+  font-size: 1rem;
+  pointer-events: none;
+  transition: color var(--float-duration) ease;
+  line-height: 1;
+}
+
+.ease-input-float-label:focus-within .ease-input-float-label__icon {
+  color: var(--float-color-focus);
+}
+
+/* =====================
+   TEXTAREA VARIANT
+   ===================== */
+.ease-input-float-label textarea {
+  resize: vertical;
+  min-height: 100px;
+  padding-top: 1.5rem;
+}
+
+.ease-input-float-label textarea ~ label {
+  top: 1.1rem;
+  transform: none;
+}
+
+.ease-input-float-label textarea:focus ~ label,
+.ease-input-float-label textarea:not(:placeholder-shown) ~ label {
+  top: 0.45rem;
+  transform: scale(0.82);
+  transform-origin: left;
+}
+
+/* =====================
+   SIZE VARIANTS
+   ===================== */
+.ease-input-float-label--sm input,
+.ease-input-float-label--sm textarea {
+  padding: 1rem 0.75rem 0.35rem;
+  font-size: 0.8rem;
+}
+
+.ease-input-float-label--lg input,
+.ease-input-float-label--lg textarea {
+  padding: 1.5rem 1.25rem 0.65rem;
+  font-size: 1rem;
+}
+
+/* =====================
+   COLOR VARIANTS
+   ===================== */
+.ease-input-float-label--blue {
+  --float-color-focus:   #60a5fa;
+  --float-border-focus:  #60a5fa;
+}
+
+.ease-input-float-label--purple {
+  --float-color-focus:  #a78bfa;
+  --float-border-focus: #a78bfa;
+}
+
+.ease-input-float-label--pink {
+  --float-color-focus:  #f472b6;
+  --float-border-focus: #f472b6;
+}
+
+/* =====================
+   THEME OVERRIDES
+   ===================== */
+[data-theme="neon"] .ease-input-float-label {
+  --float-bg:             #0d0d1a;
+  --float-border-default: rgba(240,171,252,0.2);
+  --float-border-focus:   #f0abfc;
+  --float-color-focus:    #f0abfc;
+  --float-text:           #f0abfc;
+}
+
+[data-theme="dracula"] .ease-input-float-label {
+  --float-bg:             #282a36;
+  --float-border-default: #44475a;
+  --float-border-focus:   #bd93f9;
+  --float-color-focus:    #bd93f9;
+}
+
+[data-theme="dark"] .ease-input-float-label {
+  --float-bg:             #111827;
+  --float-border-default: #1f2937;
+  --float-border-focus:   #34d399;
+  --float-color-focus:    #34d399;
+}
+
+/* =====================
+   REDUCED MOTION
+   ===================== */
+@media (prefers-reduced-motion: reduce) {
+  .ease-input-float-label label,
+  .ease-input-float-label input,
+  .ease-input-float-label textarea,
+  .ease-input-float-label::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds `ease-input-float-label`, a reusable animated floating label form input component. The label smoothly animates upward and shrinks on focus or when the field is filled — built entirely with CSS (`:focus` + `:not(:placeholder-shown)`), no JavaScript required. Closes #51346

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/ease-input-float-label-v1/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An animated floating label input where the label shrinks and moves above the field on focus/fill, using pure CSS pseudo-classes — no JS.

**How does a developer use it?**
```html
<div class="ease-input-float-label">
  <input type="text" id="name" placeholder=" " autocomplete="off" />
  <label for="name">Full Name</label>
</div>
```
Add modifier classes for variants, e.g. `ease-input-float-label--underline`, `--outlined`, `--filled`, `--error`, `--success`, `--icon`, `--sm`, `--lg`, `--blue`, `--purple`, `--pink`.

**Why does it fit EaseMotion CSS?**
It's a common, practical UI pattern implemented with readable, well-commented CSS and no dependencies — in line with EaseMotion's human-readable, animation-first, zero-JS philosophy. It also respects `prefers-reduced-motion` for accessibility.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
`placeholder=" "` (a single space) is required on inputs for `:placeholder-shown` to work correctly — noted in the README. Open to feedback on the default color/timing choices if they don't match the design system.