### PR TITLE
feat: add zoom-in carousel for product catalog layouts (issue #50438)

### DIFF
--- a/submissions/examples/zoom-in-carousel-product-catalog-ag/README.md
+++ b/submissions/examples/zoom-in-carousel-product-catalog-ag/README.md
@@ -1,0 +1,36 @@
+# Zoom-In Carousel — Product Catalog
+
+A pure CSS carousel using a smooth zoom-in transition, styled for
+product catalog layouts. Built with radio inputs and the `:checked`
+selector — zero JavaScript.
+
+## Files
+- `demo.html` — carousel markup (radio-driven slides + dot navigation)
+- `style.css` — zoom-in transition, dot indicators, responsive layout
+
+## Usage
+Open `demo.html` in a browser. Click a dot, or tab to the carousel
+and use arrow keys (native radio group behavior) to switch slides —
+no mouse required.
+
+## Customization
+Exposed via CSS custom properties on `.zic-carousel`:
+- `--zic-duration` — transition duration (default `0.5s`)
+- `--zic-easing` — transition easing curve (default `cubic-bezier(.22,1,.36,1)`)
+- `--zic-scale-from` — starting scale for the zoom-in effect (default `0.85`)
+
+Example:
+```css
+.zic-carousel {
+  --zic-duration: 0.8s;
+  --zic-easing: ease-out;
+  --zic-scale-from: 0.7;
+}
+```
+
+## Accessibility
+- Navigation uses native `<input type="radio">` elements, so slides
+  are reachable and switchable via keyboard (Tab + Arrow keys) without
+  any JavaScript or `tabindex` workarounds
+- Dot labels include `aria-label` for screen reader context
+- Respects `prefers-reduced-motion` by disabling the zoom/opacity transition

--- a/submissions/examples/zoom-in-carousel-product-catalog-ag/demo.html
+++ b/submissions/examples/zoom-in-carousel-product-catalog-ag/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Zoom-In Carousel — Product Catalog</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="zic-carousel" style="--zic-duration: 0.5s; --zic-easing: cubic-bezier(.22,1,.36,1); --zic-scale-from: 0.85;">
+
+    <input type="radio" name="zic-slide" id="zic-slide-1" class="zic-radio" checked>
+    <input type="radio" name="zic-slide" id="zic-slide-2" class="zic-radio">
+    <input type="radio" name="zic-slide" id="zic-slide-3" class="zic-radio">
+    <input type="radio" name="zic-slide" id="zic-slide-4" class="zic-radio">
+
+    <div class="zic-track">
+
+      <article class="zic-slide" id="zic-panel-1">
+        <div class="zic-card">
+          <div class="zic-media">🎧</div>
+          <h3 class="zic-title">Wireless Headphones</h3>
+          <p class="zic-price">$79.99</p>
+        </div>
+      </article>
+
+      <article class="zic-slide" id="zic-panel-2">
+        <div class="zic-card">
+          <div class="zic-media">⌚</div>
+          <h3 class="zic-title">Smart Watch</h3>
+          <p class="zic-price">$129.99</p>
+        </div>
+      </article>
+
+      <article class="zic-slide" id="zic-panel-3">
+        <div class="zic-card">
+          <div class="zic-media">👜</div>
+          <h3 class="zic-title">Leather Backpack</h3>
+          <p class="zic-price">$59.99</p>
+        </div>
+      </article>
+
+      <article class="zic-slide" id="zic-panel-4">
+        <div class="zic-card">
+          <div class="zic-media">🕶️</div>
+          <h3 class="zic-title">Sunglasses</h3>
+          <p class="zic-price">$34.99</p>
+        </div>
+      </article>
+
+    </div>
+
+    <div class="zic-dots">
+      <label for="zic-slide-1" class="zic-dot" aria-label="Show slide 1"></label>
+      <label for="zic-slide-2" class="zic-dot" aria-label="Show slide 2"></label>
+      <label for="zic-slide-3" class="zic-dot" aria-label="Show slide 3"></label>
+      <label for="zic-slide-4" class="zic-dot" aria-label="Show slide 4"></label>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/zoom-in-carousel-product-catalog-ag/style.css
+++ b/submissions/examples/zoom-in-carousel-product-catalog-ag/style.css
@@ -1,0 +1,136 @@
+:root {
+  --zic-duration: 0.5s;
+  --zic-easing: cubic-bezier(.22, 1, .36, 1);
+  --zic-scale-from: 0.85;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f1115;
+  font-family: system-ui, sans-serif;
+}
+
+.zic-carousel {
+  position: relative;
+  width: min(90vw, 420px);
+  aspect-ratio: 4 / 3;
+}
+
+.zic-radio {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.zic-radio:focus-visible ~ .zic-dots label {
+  outline: none;
+}
+
+.zic-track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #1a1d24;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.4);
+}
+
+.zic-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(var(--zic-scale-from));
+  transition: opacity var(--zic-duration) var(--zic-easing),
+              transform var(--zic-duration) var(--zic-easing);
+  pointer-events: none;
+}
+
+#zic-slide-1:checked ~ .zic-track #zic-panel-1,
+#zic-slide-2:checked ~ .zic-track #zic-panel-2,
+#zic-slide-3:checked ~ .zic-track #zic-panel-3,
+#zic-slide-4:checked ~ .zic-track #zic-panel-4 {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.zic-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  color: #f4f4f5;
+  padding: 24px;
+}
+
+.zic-media {
+  font-size: 64px;
+  line-height: 1;
+  filter: drop-shadow(0 6px 14px rgba(0,0,0,0.4));
+}
+
+.zic-title {
+  margin: 6px 0 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.zic-price {
+  margin: 0;
+  font-size: 15px;
+  color: #a1a1aa;
+}
+
+.zic-dots {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.zic-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #3f3f46;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+  display: inline-block;
+}
+
+.zic-dot:hover {
+  background: #71717a;
+}
+
+#zic-slide-1:checked ~ .zic-dots label[for="zic-slide-1"],
+#zic-slide-2:checked ~ .zic-dots label[for="zic-slide-2"],
+#zic-slide-3:checked ~ .zic-dots label[for="zic-slide-3"],
+#zic-slide-4:checked ~ .zic-dots label[for="zic-slide-4"] {
+  background: #f4f4f5;
+  transform: scale(1.3);
+}
+
+.zic-radio:focus-visible ~ .zic-track .zic-slide {
+  outline: 2px solid #f4f4f5;
+  outline-offset: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zic-slide {
+    transition: opacity 0.01ms;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS zoom-in carousel styled for product catalog layouts,
as requested in #50438.

## Changes
- New folder: `submissions/examples/zoom-in-carousel-product-catalog-ag/`
- `demo.html` — radio-driven carousel markup with dot navigation
- `style.css` — zoom-in transition, responsive layout, custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Zero JavaScript — pure CSS via radio inputs + `:checked`
- Keyboard accessible (native radio group Tab/Arrow key navigation)
- Custom properties for duration, easing, and zoom scale
- Responsive sizing (`min(90vw, 420px)`)
- `prefers-reduced-motion` support

## Notes
No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #50438