### PR TITLE
feat: add zoom-in carousel for glassmorphism UI layouts (issue #50441)

### DIFF
--- a/submissions/examples/zoom-in-carousel-glassmorphism-ag/README.md
+++ b/submissions/examples/zoom-in-carousel-glassmorphism-ag/README.md
@@ -1,0 +1,42 @@
+# Zoom-In Carousel — Glassmorphism
+
+A pure CSS carousel using a smooth zoom-in transition, styled for
+glassmorphism UI layouts (frosted blur, translucent layering, soft
+gradient backdrop). Built with radio inputs and the `:checked`
+selector — zero JavaScript.
+
+## Files
+- `demo.html` — carousel markup (radio-driven slides + dot navigation)
+- `style.css` — zoom-in transition, glass effect, dot indicators
+
+## Usage
+Open `demo.html` in a browser. Click a dot, or tab to the carousel
+and use arrow keys (native radio group behavior) to switch slides —
+no mouse required.
+
+## Customization
+Exposed via CSS custom properties on `.zig-carousel`:
+- `--zig-duration` — transition duration (default `0.5s`)
+- `--zig-easing` — transition easing curve (default `cubic-bezier(.22,1,.36,1)`)
+- `--zig-scale-from` — starting scale for the zoom-in effect (default `0.85`)
+
+Example:
+```css
+.zig-carousel {
+  --zig-duration: 0.8s;
+  --zig-easing: ease-out;
+  --zig-scale-from: 0.7;
+}
+```
+
+## Accessibility
+- Navigation uses native `<input type="radio">` elements, so slides
+  are reachable and switchable via keyboard (Tab + Arrow keys) without
+  any JavaScript or `tabindex` workarounds
+- Dot labels include `aria-label` for screen reader context
+- Respects `prefers-reduced-motion` by disabling the zoom/opacity transition
+
+## Notes
+`backdrop-filter` requires a modern browser (Safari, Chrome, Firefox
+103+, Edge). A fallback translucent background is applied via
+`rgba()` so the carousel still looks reasonable where blur isn't supported.

--- a/submissions/examples/zoom-in-carousel-glassmorphism-ag/demo.html
+++ b/submissions/examples/zoom-in-carousel-glassmorphism-ag/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Zoom-In Carousel — Glassmorphism</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="zig-carousel" style="--zig-duration: 0.5s; --zig-easing: cubic-bezier(.22,1,.36,1); --zig-scale-from: 0.85;">
+
+    <input type="radio" name="zig-slide" id="zig-slide-1" class="zig-radio" checked>
+    <input type="radio" name="zig-slide" id="zig-slide-2" class="zig-radio">
+    <input type="radio" name="zig-slide" id="zig-slide-3" class="zig-radio">
+    <input type="radio" name="zig-slide" id="zig-slide-4" class="zig-radio">
+
+    <div class="zig-track">
+
+      <article class="zig-slide" id="zig-panel-1">
+        <div class="zig-card">
+          <div class="zig-media">✨</div>
+          <h3 class="zig-title">Aurora Theme</h3>
+          <p class="zig-desc">Soft gradients with frosted depth</p>
+        </div>
+      </article>
+
+      <article class="zig-slide" id="zig-panel-2">
+        <div class="zig-card">
+          <div class="zig-media">🌊</div>
+          <h3 class="zig-title">Ocean Glass</h3>
+          <p class="zig-desc">Cool tones, translucent layers</p>
+        </div>
+      </article>
+
+      <article class="zig-slide" id="zig-panel-3">
+        <div class="zig-card">
+          <div class="zig-media">🌙</div>
+          <h3 class="zig-title">Midnight Blur</h3>
+          <p class="zig-desc">Dark glass with subtle glow</p>
+        </div>
+      </article>
+
+      <article class="zig-slide" id="zig-panel-4">
+        <div class="zig-card">
+          <div class="zig-media">🔮</div>
+          <h3 class="zig-title">Prism Frost</h3>
+          <p class="zig-desc">Iridescent highlights on glass</p>
+        </div>
+      </article>
+
+    </div>
+
+    <div class="zig-dots">
+      <label for="zig-slide-1" class="zig-dot" aria-label="Show slide 1"></label>
+      <label for="zig-slide-2" class="zig-dot" aria-label="Show slide 2"></label>
+      <label for="zig-slide-3" class="zig-dot" aria-label="Show slide 3"></label>
+      <label for="zig-slide-4" class="zig-dot" aria-label="Show slide 4"></label>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/zoom-in-carousel-glassmorphism-ag/style.css
+++ b/submissions/examples/zoom-in-carousel-glassmorphism-ag/style.css
@@ -1,0 +1,138 @@
+:root {
+  --zig-duration: 0.5s;
+  --zig-easing: cubic-bezier(.22, 1, .36, 1);
+  --zig-scale-from: 0.85;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #4338ca, #db2777 60%, #f59e0b);
+  font-family: system-ui, sans-serif;
+}
+
+.zig-carousel {
+  position: relative;
+  width: min(90vw, 420px);
+  aspect-ratio: 4 / 3;
+}
+
+.zig-radio {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.zig-track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25),
+              inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.zig-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(var(--zig-scale-from));
+  transition: opacity var(--zig-duration) var(--zig-easing),
+              transform var(--zig-duration) var(--zig-easing);
+  pointer-events: none;
+}
+
+#zig-slide-1:checked ~ .zig-track #zig-panel-1,
+#zig-slide-2:checked ~ .zig-track #zig-panel-2,
+#zig-slide-3:checked ~ .zig-track #zig-panel-3,
+#zig-slide-4:checked ~ .zig-track #zig-panel-4 {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.zig-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  color: #fff;
+  padding: 28px;
+}
+
+.zig-media {
+  font-size: 56px;
+  line-height: 1;
+  filter: drop-shadow(0 6px 14px rgba(0,0,0,0.3));
+}
+
+.zig-title {
+  margin: 8px 0 0;
+  font-size: 19px;
+  font-weight: 600;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.2);
+}
+
+.zig-desc {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.zig-dots {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.zig-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+  display: inline-block;
+}
+
+.zig-dot:hover {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+#zig-slide-1:checked ~ .zig-dots label[for="zig-slide-1"],
+#zig-slide-2:checked ~ .zig-dots label[for="zig-slide-2"],
+#zig-slide-3:checked ~ .zig-dots label[for="zig-slide-3"],
+#zig-slide-4:checked ~ .zig-dots label[for="zig-slide-4"] {
+  background: #fff;
+  transform: scale(1.3);
+}
+
+.zig-radio:focus-visible ~ .zig-track .zig-slide {
+  outline: 2px solid #fff;
+  outline-offset: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zig-slide {
+    transition: opacity 0.01ms;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS zoom-in carousel styled for glassmorphism UI layouts,
as requested in #50441.

## Changes
- New folder: `submissions/examples/zoom-in-carousel-glassmorphism-ag/`
- `demo.html` — radio-driven carousel markup with dot navigation
- `style.css` — zoom-in transition, frosted glass styling, custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Zero JavaScript — pure CSS via radio inputs + `:checked`
- Keyboard accessible (native radio group Tab/Arrow key navigation)
- Custom properties for duration, easing, and zoom scale
- Frosted glass effect via `backdrop-filter` with translucent fallback
- `prefers-reduced-motion` support

## Notes
No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #50441