### PR TITLE
feat: add zoom-in carousel for neumorphic soft layouts (issue #50444)

### DIFF
--- a/submissions/examples/zoom-in-carousel-neumorphic-ag/README.md
+++ b/submissions/examples/zoom-in-carousel-neumorphic-ag/README.md
@@ -1,0 +1,42 @@
+# Zoom-In Carousel — Neumorphic Soft
+
+A pure CSS carousel using a smooth zoom-in transition, styled for
+neumorphic ("soft UI") layouts — raised and inset shadows on a
+monochrome background. Built with radio inputs and the `:checked`
+selector — zero JavaScript.
+
+## Files
+- `demo.html` — carousel markup (radio-driven slides + dot navigation)
+- `style.css` — zoom-in transition, neumorphic shadows, dot indicators
+
+## Usage
+Open `demo.html` in a browser. Click a dot, or tab to the carousel
+and use arrow keys (native radio group behavior) to switch slides —
+no mouse required.
+
+## Customization
+Exposed via CSS custom properties on `.zin-carousel`:
+- `--zin-duration` — transition duration (default `0.5s`)
+- `--zin-easing` — transition easing curve (default `cubic-bezier(.22,1,.36,1)`)
+- `--zin-scale-from` — starting scale for the zoom-in effect (default `0.85`)
+
+Example:
+```css
+.zin-carousel {
+  --zin-duration: 0.8s;
+  --zin-easing: ease-out;
+  --zin-scale-from: 0.7;
+}
+```
+
+## Accessibility
+- Navigation uses native `<input type="radio">` elements, so slides
+  are reachable and switchable via keyboard (Tab + Arrow keys) without
+  any JavaScript or `tabindex` workarounds
+- Dot labels include `aria-label` for screen reader context
+- Respects `prefers-reduced-motion` by disabling the zoom/opacity transition
+
+## Notes
+Neumorphic shadows rely on a light, low-contrast background (`#e0e5ec`
+here). If embedding into a page with a different background color,
+adjust the shadow colors in `style.css` to match for the effect to read correctly.

--- a/submissions/examples/zoom-in-carousel-neumorphic-ag/demo.html
+++ b/submissions/examples/zoom-in-carousel-neumorphic-ag/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Zoom-In Carousel — Neumorphic Soft</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="zin-carousel" style="--zin-duration: 0.5s; --zin-easing: cubic-bezier(.22,1,.36,1); --zin-scale-from: 0.85;">
+
+    <input type="radio" name="zin-slide" id="zin-slide-1" class="zin-radio" checked>
+    <input type="radio" name="zin-slide" id="zin-slide-2" class="zin-radio">
+    <input type="radio" name="zin-slide" id="zin-slide-3" class="zin-radio">
+    <input type="radio" name="zin-slide" id="zin-slide-4" class="zin-radio">
+
+    <div class="zin-track">
+
+      <article class="zin-slide" id="zin-panel-1">
+        <div class="zin-card">
+          <div class="zin-media">🧘</div>
+          <h3 class="zin-title">Calm Focus</h3>
+          <p class="zin-desc">Soft shadows, gentle depth</p>
+        </div>
+      </article>
+
+      <article class="zin-slide" id="zin-panel-2">
+        <div class="zin-card">
+          <div class="zin-media">☁️</div>
+          <h3 class="zin-title">Cloud Layer</h3>
+          <p class="zin-desc">Muted tones, subtle relief</p>
+        </div>
+      </article>
+
+      <article class="zin-slide" id="zin-panel-3">
+        <div class="zin-card">
+          <div class="zin-media">🪶</div>
+          <h3 class="zin-title">Feather Light</h3>
+          <p class="zin-desc">Minimal contrast, soft edges</p>
+        </div>
+      </article>
+
+      <article class="zin-slide" id="zin-panel-4">
+        <div class="zin-card">
+          <div class="zin-media">🌾</div>
+          <h3 class="zin-title">Warm Neutral</h3>
+          <p class="zin-desc">Cozy, understated glow</p>
+        </div>
+      </article>
+
+    </div>
+
+    <div class="zin-dots">
+      <label for="zin-slide-1" class="zin-dot" aria-label="Show slide 1"></label>
+      <label for="zin-slide-2" class="zin-dot" aria-label="Show slide 2"></label>
+      <label for="zin-slide-3" class="zin-dot" aria-label="Show slide 3"></label>
+      <label for="zin-slide-4" class="zin-dot" aria-label="Show slide 4"></label>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/zoom-in-carousel-neumorphic-ag/style.css
+++ b/submissions/examples/zoom-in-carousel-neumorphic-ag/style.css
@@ -1,0 +1,142 @@
+:root {
+  --zin-duration: 0.5s;
+  --zin-easing: cubic-bezier(.22, 1, .36, 1);
+  --zin-scale-from: 0.85;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e0e5ec;
+  font-family: system-ui, sans-serif;
+}
+
+.zin-carousel {
+  position: relative;
+  width: min(90vw, 420px);
+  aspect-ratio: 4 / 3;
+}
+
+.zin-radio {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.zin-track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 24px;
+  overflow: hidden;
+  background: #e0e5ec;
+  box-shadow: 9px 9px 18px #b8bec7,
+              -9px -9px 18px #ffffff;
+}
+
+.zin-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(var(--zin-scale-from));
+  transition: opacity var(--zin-duration) var(--zin-easing),
+              transform var(--zin-duration) var(--zin-easing);
+  pointer-events: none;
+}
+
+#zin-slide-1:checked ~ .zin-track #zin-panel-1,
+#zin-slide-2:checked ~ .zin-track #zin-panel-2,
+#zin-slide-3:checked ~ .zin-track #zin-panel-3,
+#zin-slide-4:checked ~ .zin-track #zin-panel-4 {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.zin-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  text-align: center;
+  color: #4a5568;
+  padding: 28px;
+}
+
+.zin-media {
+  width: 76px;
+  height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 34px;
+  border-radius: 50%;
+  background: #e0e5ec;
+  box-shadow: 6px 6px 12px #b8bec7,
+              -6px -6px 12px #ffffff;
+}
+
+.zin-title {
+  margin: 4px 0 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.zin-desc {
+  margin: 0;
+  font-size: 14px;
+  color: #8892a0;
+}
+
+.zin-dots {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.zin-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #e0e5ec;
+  box-shadow: 3px 3px 6px #b8bec7,
+              -3px -3px 6px #ffffff;
+  cursor: pointer;
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
+  display: inline-block;
+}
+
+.zin-dot:hover {
+  transform: scale(1.1);
+}
+
+#zin-slide-1:checked ~ .zin-dots label[for="zin-slide-1"],
+#zin-slide-2:checked ~ .zin-dots label[for="zin-slide-2"],
+#zin-slide-3:checked ~ .zin-dots label[for="zin-slide-3"],
+#zin-slide-4:checked ~ .zin-dots label[for="zin-slide-4"] {
+  box-shadow: inset 3px 3px 6px #b8bec7,
+              inset -3px -3px 6px #ffffff;
+}
+
+.zin-radio:focus-visible ~ .zin-track .zin-slide {
+  outline: 2px solid #8892a0;
+  outline-offset: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zin-slide {
+    transition: opacity 0.01ms;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS zoom-in carousel styled for neumorphic (soft UI)
layouts, as requested in #50444.

## Changes
- New folder: `submissions/examples/zoom-in-carousel-neumorphic-ag/`
- `demo.html` — radio-driven carousel markup with dot navigation
- `style.css` — zoom-in transition, neumorphic shadow styling, custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Zero JavaScript — pure CSS via radio inputs + `:checked`
- Keyboard accessible (native radio group Tab/Arrow key navigation)
- Custom properties for duration, easing, and zoom scale
- Neumorphic raised/inset shadow styling
- `prefers-reduced-motion` support

## Notes
No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #50444