### PR TITLE
feat: add rune activation animation (issue #51892)

### DIFF
--- a/submissions/examples/rune-activation-ag/README.md
+++ b/submissions/examples/rune-activation-ag/README.md
@@ -1,0 +1,39 @@
+# Rune Activation
+
+A mystical circle of 12 Elder Futhark runes that light up with a
+warm golden glow — either individually on click, or all in sequence
+via the "Activate Circle" control. Pure CSS, zero JavaScript.
+
+## Files
+- `demo.html` — the 12-rune circle, center Algiz symbol, and controls
+- `style.css` — circular layout, glow/ring animations, particles, connection rings
+
+## Usage
+Open `demo.html` in a browser.
+- Click any individual rune glyph to activate it on its own
+- Click **Activate Circle** to trigger all 12 runes in sequence,
+  followed by expanding connection rings from the center
+
+## Details
+- Runes are positioned around the circle using `transform: rotate() translate() rotate()`
+  driven by a `--i` custom property per node (no JS needed for layout)
+- Sequential "Activate Circle" timing uses staggered `animation-delay`
+  based on each rune's `--i` index
+- 8 floating particles drift around the circle using a rotating
+  `translate` keyframe animation
+- The center Algiz (ᛉ) rune pulses continuously as an ambient anchor
+
+## Customization
+CSS custom properties on `.rune-stage` / `:root`:
+- `--rune-glow` — glow color (default `#e8b64c`, warm gold)
+- `--rune-duration` — per-rune activation transition length (default `0.6s`)
+
+## Notes on scope
+This is a pure CSS/HTML implementation. Because true randomization,
+live speed/intensity sliders, and fully independent async timers
+require JavaScript, this version uses a fixed sequential activation
+order and static timing instead — individual runes remain freely
+and independently clickable via checkboxes.
+
+Respects `prefers-reduced-motion` by disabling animations while still
+reflecting activated state instantly.

--- a/submissions/examples/rune-activation-ag/demo.html
+++ b/submissions/examples/rune-activation-ag/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rune Activation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="rune-stage">
+
+    <input type="checkbox" id="activate-all" class="rune-master-toggle">
+
+    <div class="rune-circle">
+      <div class="rune-center" aria-hidden="true">ᛉ</div>
+
+      <label class="rune-node" style="--i:0"  for="rune-1"><input type="checkbox" id="rune-1" class="rune-toggle"><span class="rune-glyph">ᚠ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:1"  for="rune-2"><input type="checkbox" id="rune-2" class="rune-toggle"><span class="rune-glyph">ᚢ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:2"  for="rune-3"><input type="checkbox" id="rune-3" class="rune-toggle"><span class="rune-glyph">ᚦ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:3"  for="rune-4"><input type="checkbox" id="rune-4" class="rune-toggle"><span class="rune-glyph">ᚨ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:4"  for="rune-5"><input type="checkbox" id="rune-5" class="rune-toggle"><span class="rune-glyph">ᚱ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:5"  for="rune-6"><input type="checkbox" id="rune-6" class="rune-toggle"><span class="rune-glyph">ᚲ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:6"  for="rune-7"><input type="checkbox" id="rune-7" class="rune-toggle"><span class="rune-glyph">ᚷ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:7"  for="rune-8"><input type="checkbox" id="rune-8" class="rune-toggle"><span class="rune-glyph">ᚹ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:8"  for="rune-9"><input type="checkbox" id="rune-9" class="rune-toggle"><span class="rune-glyph">ᚺ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:9"  for="rune-10"><input type="checkbox" id="rune-10" class="rune-toggle"><span class="rune-glyph">ᚾ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:10" for="rune-11"><input type="checkbox" id="rune-11" class="rune-toggle"><span class="rune-glyph">ᛁ</span><span class="rune-ring"></span></label>
+      <label class="rune-node" style="--i:11" for="rune-12"><input type="checkbox" id="rune-12" class="rune-toggle"><span class="rune-glyph">ᛃ</span><span class="rune-ring"></span></label>
+
+      <span class="particle" style="--p:0"></span>
+      <span class="particle" style="--p:1"></span>
+      <span class="particle" style="--p:2"></span>
+      <span class="particle" style="--p:3"></span>
+      <span class="particle" style="--p:4"></span>
+      <span class="particle" style="--p:5"></span>
+      <span class="particle" style="--p:6"></span>
+      <span class="particle" style="--p:7"></span>
+    </div>
+
+    <div class="rune-controls">
+      <label for="activate-all" class="btn btn-primary">Activate Circle</label>
+      <span class="rune-status">Click a rune, or activate the full circle</span>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/rune-activation-ag/style.css
+++ b/submissions/examples/rune-activation-ag/style.css
@@ -1,0 +1,222 @@
+:root {
+  --rune-glow: #e8b64c;
+  --rune-duration: 0.6s;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 50% 40%, #1c1710, #08070a);
+  font-family: system-ui, sans-serif;
+}
+
+.rune-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 40px;
+}
+
+.rune-master-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.rune-circle {
+  position: relative;
+  width: 320px;
+  height: 320px;
+}
+
+.rune-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 40px;
+  color: var(--rune-glow);
+  text-shadow: 0 0 12px var(--rune-glow);
+  animation: center-pulse 3s ease-in-out infinite;
+}
+
+@keyframes center-pulse {
+  0%, 100% { opacity: 0.6; text-shadow: 0 0 8px var(--rune-glow); }
+  50%      { opacity: 1;   text-shadow: 0 0 20px var(--rune-glow); }
+}
+
+.rune-node {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  margin: -22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(calc(var(--i) * 30deg)) translate(140px) rotate(calc(var(--i) * -30deg));
+  cursor: pointer;
+}
+
+.rune-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.rune-glyph {
+  position: relative;
+  z-index: 2;
+  font-size: 26px;
+  color: #6b5d47;
+  transition: color 0.4s ease, text-shadow 0.4s ease;
+}
+
+.rune-ring {
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  transition: border-color 0.4s ease, box-shadow 0.4s ease, transform 0.4s ease;
+}
+
+.rune-toggle:checked ~ .rune-glyph {
+  color: var(--rune-glow);
+  text-shadow: 0 0 10px var(--rune-glow);
+}
+
+.rune-toggle:checked ~ .rune-ring {
+  border-color: var(--rune-glow);
+  box-shadow: 0 0 14px var(--rune-glow);
+  transform: scale(1.15);
+}
+
+.rune-master-toggle:checked ~ .rune-circle .rune-node .rune-glyph {
+  animation: rune-awaken var(--rune-duration) ease forwards;
+  animation-delay: calc(var(--i) * 0.18s);
+}
+
+.rune-master-toggle:checked ~ .rune-circle .rune-node .rune-ring {
+  animation: ring-awaken var(--rune-duration) ease forwards;
+  animation-delay: calc(var(--i) * 0.18s);
+}
+
+@keyframes rune-awaken {
+  0%   { color: #6b5d47; text-shadow: none; }
+  100% { color: var(--rune-glow); text-shadow: 0 0 12px var(--rune-glow); }
+}
+
+@keyframes ring-awaken {
+  0%   { border-color: transparent; box-shadow: none; transform: scale(1); }
+  60%  { transform: scale(1.3); }
+  100% { border-color: var(--rune-glow); box-shadow: 0 0 14px var(--rune-glow); transform: scale(1.15); }
+}
+
+.rune-circle::before,
+.rune-circle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border: 1px solid var(--rune-glow);
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rune-master-toggle:checked ~ .rune-circle::before {
+  width: 100%;
+  height: 100%;
+  animation: ring-expand 1.6s ease-out 1.2s forwards;
+}
+
+.rune-master-toggle:checked ~ .rune-circle::after {
+  width: 70%;
+  height: 70%;
+  animation: ring-expand 1.6s ease-out 1.6s forwards;
+}
+
+@keyframes ring-expand {
+  0%   { transform: translate(-50%, -50%) scale(0.3); opacity: 0.6; }
+  100% { transform: translate(-50%, -50%) scale(1); opacity: 0; }
+}
+
+.particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--rune-glow);
+  box-shadow: 0 0 6px var(--rune-glow);
+  opacity: 0;
+  animation: particle-drift 6s ease-in-out infinite;
+  animation-delay: calc(var(--p) * 0.7s);
+}
+
+@keyframes particle-drift {
+  0%   { transform: translate(-50%, -50%) rotate(calc(var(--p) * 45deg)) translate(170px) rotate(0deg); opacity: 0; }
+  15%  { opacity: 0.8; }
+  85%  { opacity: 0.4; }
+  100% { transform: translate(-50%, -50%) rotate(calc(var(--p) * 45deg + 40deg)) translate(150px) rotate(0deg); opacity: 0; }
+}
+
+.rune-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.btn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: 1px solid rgba(232, 182, 76, 0.4);
+  background: rgba(232, 182, 76, 0.1);
+  color: var(--rune-glow);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: background 0.2s ease;
+  user-select: none;
+  display: inline-block;
+}
+
+.btn:hover {
+  background: rgba(232, 182, 76, 0.2);
+}
+
+.rune-master-toggle:checked ~ .rune-controls .btn-primary {
+  background: rgba(232, 182, 76, 0.3);
+}
+
+.rune-status {
+  font-size: 13px;
+  color: #8a7d63;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rune-glyph, .rune-ring, .rune-center, .particle,
+  .rune-circle::before, .rune-circle::after {
+    animation: none !important;
+    transition: none !important;
+  }
+  .rune-toggle:checked ~ .rune-glyph,
+  .rune-master-toggle:checked ~ .rune-circle .rune-node .rune-glyph {
+    color: var(--rune-glow);
+  }
+}


### PR DESCRIPTION
## Description
Adds a "Rune Activation" component — a circle of 12 Elder Futhark
runes that glow individually on click or activate in sequence, as
requested in #51892.

## Changes
- New folder: `submissions/examples/rune-activation-ag/`
- `demo.html` — 12-rune circle, center Algiz symbol, activation control
- `style.css` — circular positioning, glow/ring animations, particles, connection rings
- `README.md` — usage, customization, and scope notes

## Features
- 12 Elder Futhark runes arranged in a circle via CSS transforms
- Individually clickable runes (checkbox-driven, independent toggles)
- "Activate Circle" triggers a staggered sequential glow across all runes
- Expanding connection rings on full activation
- 8 drifting energy particles
- Center Algiz rune with continuous ambient pulse
- `prefers-reduced-motion` support
- Zero JavaScript — pure CSS/HTML

## Notes
Per the Standard (HTML/CSS) track, this omits JS-dependent features
mentioned in the original issue description (true randomized order,
live speed/intensity sliders) in favor of a fixed sequential
animation and static timing — documented in the README.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #51892