### PR TITLE
feat: add smudge stick smoke animation (issue #51920)

### DIFF
--- a/submissions/examples/smudge-stick-smoke-ag/README.md
+++ b/submissions/examples/smudge-stick-smoke-ag/README.md
@@ -1,0 +1,36 @@
+# Smudge Stick Smoke
+
+A calming visualization of a burning sage smudge stick, with smoke
+particles and trails rising in organic, swirling patterns. Pure CSS,
+zero JavaScript.
+
+## Files
+- `demo.html` — sage stick, ember, smoke particles/trails, and controls
+- `style.css` — smoke rise/sway animations, ember glow, density variants
+
+## Usage
+Open `demo.html` in a browser.
+- **Toggle Burn** — starts/stops the ember glow and rising smoke
+- **Light Smoke** / **Thick Smoke** — switches particle size and opacity
+
+## Details
+- 30 smoke particles rise with staggered delays and individual sway
+  offsets (via a `--sway` custom property per particle) for an organic,
+  non-repetitive look
+- 6 flowing smoke trails move independently, wider and slower than particles
+- Ember tip flickers continuously while burning; ambient glow pulses behind the stick
+
+## Customization
+CSS custom properties on `.smudge-stage` / `:root`:
+- `--smoke-color` — particle/trail color (default sage-green translucent)
+- `--ember-color` — glow tip color (default warm orange)
+- `--smoke-speed` — multiplier for animation speed (default `1`; e.g. `1.5` for faster drift)
+
+## Notes on scope
+This is a pure CSS/HTML implementation. Live speed sliders and
+free-form density control require JavaScript; here, density is
+offered as two fixed presets (Light / Thick) via radio buttons, and
+speed can be adjusted by editing the `--smoke-speed` custom property.
+
+Respects `prefers-reduced-motion` by disabling animations while
+keeping the ember visibly lit when burning is active.

--- a/submissions/examples/smudge-stick-smoke-ag/demo.html
+++ b/submissions/examples/smudge-stick-smoke-ag/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Smudge Stick Smoke</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="smudge-stage">
+
+    <input type="checkbox" id="burn-toggle" class="burn-input" checked>
+    <input type="radio" name="density" id="density-light" class="density-input" checked>
+    <input type="radio" name="density" id="density-thick" class="density-input">
+
+    <div class="smudge-scene">
+      <div class="ember-glow"></div>
+
+      <div class="sage-stick">
+        <div class="sage-bundle"></div>
+        <div class="sage-wrap"></div>
+        <div class="ember-tip"></div>
+      </div>
+
+      <div class="smoke-particles">
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span></span><span></span><span></span><span></span><span></span>
+      </div>
+
+      <div class="smoke-trails">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+      </div>
+    </div>
+
+    <div class="smudge-controls">
+      <label for="burn-toggle" class="btn btn-primary">Toggle Burn</label>
+      <label for="density-light" class="btn">Light Smoke</label>
+      <label for="density-thick" class="btn">Thick Smoke</label>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/submissions/examples/smudge-stick-smoke-ag/style.css
+++ b/submissions/examples/smudge-stick-smoke-ag/style.css
@@ -1,0 +1,266 @@
+:root {
+  --smoke-color: rgba(168, 197, 168, 0.5);
+  --ember-color: #ff7a3c;
+  --smoke-speed: 1;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 50% 60%, #1a1f1a, #06070a);
+  font-family: system-ui, sans-serif;
+}
+
+.smudge-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 40px;
+}
+
+.burn-input, .density-input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.smudge-scene {
+  position: relative;
+  width: 220px;
+  height: 320px;
+}
+
+.ember-glow {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255,122,60,0.35), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  animation: glow-pulse 2.4s ease-in-out infinite;
+}
+
+.burn-input:checked ~ .smudge-scene .ember-glow {
+  opacity: 1;
+}
+
+@keyframes glow-pulse {
+  0%, 100% { transform: translateX(-50%) scale(1); }
+  50%      { transform: translateX(-50%) scale(1.15); }
+}
+
+.sage-stick {
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 22px;
+  height: 130px;
+}
+
+.sage-bundle {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 10px 10px 4px 4px;
+  background: linear-gradient(to right, #6b7b4f, #8a9c63, #6b7b4f);
+}
+
+.sage-wrap {
+  position: absolute;
+  bottom: 20px;
+  width: 100%;
+  height: 6px;
+  background: repeating-linear-gradient(
+    45deg, #a8895c, #a8895c 4px, #8a6d42 4px, #8a6d42 8px
+  );
+}
+
+.sage-wrap::before,
+.sage-wrap::after {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 6px;
+  background: inherit;
+}
+
+.sage-wrap::before { top: 30px; }
+.sage-wrap::after { top: 60px; }
+
+.ember-tip {
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--ember-color);
+  box-shadow: 0 0 8px 2px rgba(255, 122, 60, 0.6);
+  opacity: 0.3;
+  transition: opacity 0.6s ease;
+}
+
+.burn-input:checked ~ .smudge-scene .ember-tip {
+  opacity: 1;
+  animation: ember-flicker 1.8s ease-in-out infinite;
+}
+
+@keyframes ember-flicker {
+  0%, 100% { box-shadow: 0 0 8px 2px rgba(255, 122, 60, 0.6); }
+  50%      { box-shadow: 0 0 14px 4px rgba(255, 122, 60, 0.9); }
+}
+
+.smoke-particles { position: absolute; inset: 0; }
+
+.smoke-particles span {
+  position: absolute;
+  bottom: 150px;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--smoke-color);
+  filter: blur(1px);
+  opacity: 0;
+}
+
+.burn-input:checked ~ .smudge-scene .smoke-particles span {
+  animation: smoke-rise calc(5s / var(--smoke-speed)) ease-out infinite;
+}
+
+.smoke-particles span:nth-child(1)  { animation-delay: 0.0s;  --sway: 12px;  }
+.smoke-particles span:nth-child(2)  { animation-delay: 0.15s; --sway: -18px; }
+.smoke-particles span:nth-child(3)  { animation-delay: 0.3s;  --sway: 20px;  }
+.smoke-particles span:nth-child(4)  { animation-delay: 0.45s; --sway: -10px; }
+.smoke-particles span:nth-child(5)  { animation-delay: 0.6s;  --sway: 16px;  }
+.smoke-particles span:nth-child(6)  { animation-delay: 0.75s; --sway: -22px; }
+.smoke-particles span:nth-child(7)  { animation-delay: 0.9s;  --sway: 8px;   }
+.smoke-particles span:nth-child(8)  { animation-delay: 1.05s; --sway: -14px; }
+.smoke-particles span:nth-child(9)  { animation-delay: 1.2s;  --sway: 18px;  }
+.smoke-particles span:nth-child(10) { animation-delay: 1.35s; --sway: -8px;  }
+.smoke-particles span:nth-child(11) { animation-delay: 1.5s;  --sway: 22px;  }
+.smoke-particles span:nth-child(12) { animation-delay: 1.65s; --sway: -16px; }
+.smoke-particles span:nth-child(13) { animation-delay: 1.8s;  --sway: 10px;  }
+.smoke-particles span:nth-child(14) { animation-delay: 1.95s; --sway: -20px; }
+.smoke-particles span:nth-child(15) { animation-delay: 2.1s;  --sway: 14px;  }
+.smoke-particles span:nth-child(16) { animation-delay: 2.25s; --sway: -12px; }
+.smoke-particles span:nth-child(17) { animation-delay: 2.4s;  --sway: 18px;  }
+.smoke-particles span:nth-child(18) { animation-delay: 2.55s; --sway: -6px;  }
+.smoke-particles span:nth-child(19) { animation-delay: 2.7s;  --sway: 20px;  }
+.smoke-particles span:nth-child(20) { animation-delay: 2.85s; --sway: -18px; }
+.smoke-particles span:nth-child(21) { animation-delay: 3.0s;  --sway: 12px;  }
+.smoke-particles span:nth-child(22) { animation-delay: 3.15s; --sway: -10px; }
+.smoke-particles span:nth-child(23) { animation-delay: 3.3s;  --sway: 16px;  }
+.smoke-particles span:nth-child(24) { animation-delay: 3.45s; --sway: -22px; }
+.smoke-particles span:nth-child(25) { animation-delay: 3.6s;  --sway: 8px;   }
+.smoke-particles span:nth-child(26) { animation-delay: 3.75s; --sway: -14px; }
+.smoke-particles span:nth-child(27) { animation-delay: 3.9s;  --sway: 20px;  }
+.smoke-particles span:nth-child(28) { animation-delay: 4.05s; --sway: -8px;  }
+.smoke-particles span:nth-child(29) { animation-delay: 4.2s;  --sway: 22px;  }
+.smoke-particles span:nth-child(30) { animation-delay: 4.35s; --sway: -16px; }
+
+@keyframes smoke-rise {
+  0%   { transform: translate(-50%, 0) scale(0.6); opacity: 0; }
+  10%  { opacity: 0.7; }
+  50%  { transform: translate(calc(-50% + var(--sway)), -110px) scale(1.4); }
+  90%  { opacity: 0.15; }
+  100% { transform: translate(calc(-50% + var(--sway) * 1.6), -220px) scale(2); opacity: 0; }
+}
+
+.density-thick:checked ~ .smudge-scene .smoke-particles span {
+  width: 10px;
+  height: 10px;
+  background: rgba(168, 197, 168, 0.75);
+}
+
+.smoke-trails { position: absolute; inset: 0; }
+
+.smoke-trails span {
+  position: absolute;
+  bottom: 150px;
+  left: 50%;
+  width: 3px;
+  height: 60px;
+  background: linear-gradient(to top, var(--smoke-color), transparent);
+  border-radius: 50%;
+  filter: blur(2px);
+  opacity: 0;
+}
+
+.burn-input:checked ~ .smudge-scene .smoke-trails span {
+  animation: trail-flow calc(4s / var(--smoke-speed)) ease-in infinite;
+}
+
+.smoke-trails span:nth-child(1) { animation-delay: 0s;    --tsway: 20px;  }
+.smoke-trails span:nth-child(2) { animation-delay: 0.6s;  --tsway: -24px; }
+.smoke-trails span:nth-child(3) { animation-delay: 1.2s;  --tsway: 16px;  }
+.smoke-trails span:nth-child(4) { animation-delay: 1.8s;  --tsway: -18px; }
+.smoke-trails span:nth-child(5) { animation-delay: 2.4s;  --tsway: 22px;  }
+.smoke-trails span:nth-child(6) { animation-delay: 3.0s;  --tsway: -14px; }
+
+@keyframes trail-flow {
+  0%   { transform: translate(-50%, 0) scaleX(1); opacity: 0; }
+  20%  { opacity: 0.5; }
+  100% { transform: translate(calc(-50% + var(--tsway)), -200px) scaleX(2.4); opacity: 0; }
+}
+
+.density-thick:checked ~ .smudge-scene .smoke-trails span {
+  width: 5px;
+  opacity: 0.7;
+}
+
+.smudge-controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(168, 197, 168, 0.35);
+  background: rgba(168, 197, 168, 0.08);
+  color: #cfe0cf;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.2s ease;
+  user-select: none;
+  display: inline-block;
+}
+
+.btn:hover { background: rgba(168, 197, 168, 0.18); }
+
+.btn-primary {
+  background: rgba(255, 122, 60, 0.15);
+  border-color: rgba(255, 122, 60, 0.4);
+  color: #ffcba8;
+}
+
+.density-light:checked ~ .smudge-controls label[for="density-light"],
+.density-thick:checked ~ .smudge-controls label[for="density-thick"] {
+  background: rgba(168, 197, 168, 0.3);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .smoke-particles span, .smoke-trails span, .ember-tip, .ember-glow {
+    animation: none !important;
+    transition: none !important;
+  }
+  .burn-input:checked ~ .smudge-scene .ember-tip { opacity: 1; }
+}


### PR DESCRIPTION
## Description
Adds a "Smudge Stick Smoke" component — a burning sage stick with
rising, swirling smoke particles and trails, as requested in #51920.

## Changes
- New folder: `submissions/examples/smudge-stick-smoke-ag/`
- `demo.html` — sage stick, ember, particles/trails, controls
- `style.css` — smoke rise/sway keyframes, ember glow, density variants
- `README.md` — usage, customization, and scope notes

## Features
- 30 smoke particles with staggered timing and individual sway offsets
- 6 independent flowing smoke trails
- Pulsing ember glow and ambient light
- Light/Thick density presets
- `--smoke-speed` custom property for animation speed tuning
- `prefers-reduced-motion` support
- Zero JavaScript — pure CSS/HTML

## Notes
Per the Standard (HTML/CSS) track, this omits JS-dependent features
mentioned in the original issue description (live speed slider,
free-form density control) in favor of fixed density presets and a
CSS custom property for speed — documented in the README.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #51920