### PR TITLE
feat: add matching exit animations (slide-down, slide-out-left)

### DIFF
--- a/easemotion/slide.css
+++ b/easemotion/slide.css
@@ -235,3 +235,20 @@
   }
 }
 }
+
+/* Exit animations */
+@keyframes ease-kf-slide-down {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(20px); opacity: 0; }
+}
+.ease-slide-down {
+  animation: ease-kf-slide-down var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4,0,0.2,1)) both;
+}
+
+@keyframes ease-kf-slide-out-left {
+  from { opacity: 1; transform: translateX(0); }
+  to { opacity: 0; transform: translateX(-100%); }
+}
+.ease-slide-out-left {
+  animation: ease-kf-slide-out-left var(--ease-speed-medium, 300ms) var(--ease-ease, cubic-bezier(0.4,0,0.2,1)) both;
+}


### PR DESCRIPTION
Closes #52042

## What this adds
- `ease-slide-down` — pairs with the existing `ease-slide-up` entrance animation
- `ease-slide-out-left` — pairs with the existing slide-in-left entrance animation

## Why
The Motion Library only had entrance animations for slide effects, with no matching exit counterparts. This makes it hard to animate elements both in and out symmetrically (e.g. for dismissible items, list removal, drawers).

## Implementation
- Added to `easemotion/slide.css`, following the existing `ease-kf-*` keyframe naming convention
- Uses the existing `--ease-speed-medium` and `--ease-ease` custom properties for consistent timing across the library

## Testing
- [ ] Verified visually in the demo page
- [ ] Checked `prefers-reduced-motion` behavior