### PR TITLE
feat: add dark mode variants for cards and buttons

### DIFF
--- a/submissions/examples/dark-mode-cards-buttons-varsha/README.md
+++ b/submissions/examples/dark-mode-cards-buttons-varsha/README.md
@@ -1,0 +1,17 @@
+# Dark Mode Cards & Buttons
+
+## What does this do?
+Adds automatic dark-mode styling for card and button components using `prefers-color-scheme: dark`.
+
+## How is it used?
+```html
+<div class="card-varsha card-shadow-varsha">
+  <button class="btn-primary-varsha">Primary</button>
+  <button class="btn-outline-varsha">Outline</button>
+  <button class="btn-ghost-varsha">Ghost</button>
+</div>
+```
+No extra class needed — styling switches automatically based on the user's OS/browser theme preference.
+
+## Why is it useful?
+EaseMotion's card and button components currently only ship light-theme styling. Many users browse with dark mode enabled system-wide, and without this, cards/buttons look inconsistent or harsh against a dark page background.

--- a/submissions/examples/dark-mode-cards-buttons-varsha/demo.html
+++ b/submissions/examples/dark-mode-cards-buttons-varsha/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Dark Mode Cards & Buttons Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; padding: 3rem; background: #f8fafc; }
+  @media (prefers-color-scheme: dark) { body { background: #0f172a; } }
+  .row { display: flex; gap: 1rem; margin-top: 1rem; }
+</style>
+</head>
+<body>
+  <h1>Dark Mode Demo</h1>
+  <p>Toggle your OS/browser color scheme to see this switch automatically.</p>
+
+  <div class="card-varsha card-shadow-varsha">
+    <h3>Sample Card</h3>
+    <p>This card adapts to light/dark mode using prefers-color-scheme.</p>
+    <div class="row">
+      <button class="btn-primary-varsha">Primary</button>
+      <button class="btn-outline-varsha">Outline</button>
+      <button class="btn-ghost-varsha">Ghost</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dark-mode-cards-buttons-varsha/style.css
+++ b/submissions/examples/dark-mode-cards-buttons-varsha/style.css
@@ -1,0 +1,75 @@
+/* Dark mode variants for cards & buttons - by vbarik317-droid */
+
+@media (prefers-color-scheme: dark) {
+  .card-varsha {
+    background: #1e293b;
+    color: #f1f5f9;
+    border-color: #334155;
+  }
+
+  .card-shadow-varsha {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+
+  .btn-primary-varsha {
+    background: #6366f1;
+    color: #fff;
+  }
+
+  .btn-outline-varsha {
+    background: transparent;
+    color: #f1f5f9;
+    border: 1px solid #475569;
+  }
+
+  .btn-ghost-varsha {
+    background: transparent;
+    color: #cbd5e1;
+  }
+
+  .btn-ghost-varsha:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+}
+
+/* Base (light) styles so demo.html works standalone */
+.card-varsha {
+  background: #fff;
+  color: #1e293b;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.card-shadow-varsha {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.btn-primary-varsha,
+.btn-outline-varsha,
+.btn-ghost-varsha {
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn-primary-varsha {
+  background: #6366f1;
+  color: #fff;
+  border: none;
+}
+
+.btn-outline-varsha {
+  background: transparent;
+  color: #1e293b;
+  border: 1px solid #cbd5e1;
+}
+
+.btn-ghost-varsha {
+  background: transparent;
+  color: #475569;
+  border: none;
+}


### PR DESCRIPTION
Closes #52046

Adds prefers-color-scheme dark mode support for card and button components, following the standard submission track in submissions/examples/dark-mode-cards-buttons-varsha/.