### PR TITLE
feat: add float radio mixin

### DIFF
--- a/submissions/scss/feature-float-radio-mixin-mixin-varsha/README.md
+++ b/submissions/scss/feature-float-radio-mixin-mixin-varsha/README.md
@@ -1,0 +1,35 @@
+# Float Radio Mixin
+
+## What does this do?
+An SCSS mixin, `ease-float-radio-mixin-mixin($duration, $distance)`, that applies a gentle
+floating/bobbing "attention seeker" animation to a radio button's custom indicator when it
+becomes checked — drawing the user's eye to the newly selected option.
+
+## How is it used?
+```scss
+@use 'ease-motion' as *;
+
+.radio-label {
+  @include ease-float-radio-mixin-mixin(0.5s);
+}
+```
+
+```html
+<label class="radio-label">
+  <input type="radio" name="plan" />
+  <span class="radio-indicator"></span>
+  Basic Plan
+</label>
+```
+
+The mixin targets the sibling element immediately after a `input[type="radio"]:checked`,
+so apply it to the visual indicator/label element that follows the radio input in your markup.
+
+Parameters:
+- `$duration` (default `0.5s`) — how long one float cycle takes
+- `$distance` (default `6px`) — how far the element floats up before returning
+
+## Why is it useful?
+Radio buttons are easy to miss in dense forms. A brief, repeating float animation on the
+selected option gives lightweight visual feedback without being as jarring as a full bounce
+or color flash, and it stops entirely under `prefers-reduced-motion: reduce`.

--- a/submissions/scss/feature-float-radio-mixin-mixin-varsha/_float-radio-mixin.scss
+++ b/submissions/scss/feature-float-radio-mixin-mixin-varsha/_float-radio-mixin.scss
@@ -1,0 +1,27 @@
+// Float Radio Mixin — by vbarik317-droid
+// Applies a gentle floating/bobbing "attention seeker" animation to a
+// checked radio input, to draw the user's eye toward it.
+
+@mixin ease-float-radio-mixin-mixin($duration: 0.5s, $distance: 6px) {
+  transition: transform 0.2s ease;
+
+  input[type='radio']:checked + & {
+    animation: ease-float-radio-varsha #{$duration} ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    input[type='radio']:checked + & {
+      animation: none;
+    }
+  }
+}
+
+@keyframes ease-float-radio-varsha {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}


### PR DESCRIPTION
Closes #52632

SCSS mixin that applies a gentle floating attention-seeker animation to a checked radio button's indicator. Respects prefers-reduced-motion.

Submission: submissions/scss/feature-float-radio-mixin-mixin-varsha/