### PR TITLE
feat: add 3D perspective tilt tabs for dashboard analytics layouts

### DIFF
--- a/submissions-example/Readme.md
+++ b/submissions-example/Readme.md
@@ -1,0 +1,43 @@
+# CSS 3D Perspective Tilt Tabs - Dashboard Analytics Aesthetic
+
+A pure CSS tab component that uses `perspective` and 3D transforms (`rotateX`, `rotateY`, `translateZ`) to give tab navigation a spatial, premium feel — styled for a dark, data-dense analytics dashboard.
+
+Closes #50347.
+
+## Features
+
+- **3D Perspective Tilt Interaction**:
+  - **On Hover**: Tabs tilt and lift toward the user in 3D space, with a directional drop shadow to reinforce depth.
+  - **On Transition**: Panels animate in with a combined 3D tilt + scale entrance (`@keyframes panelTiltIn`).
+  - **Internal Depth**: Stat cards, the revenue highlight card, and list rows use `translateZ` so they visually sit above the panel surface.
+- **Dashboard Analytics Content**: Three realistic panels — Overview (stat cards + bar chart), Revenue (highlight card + plan breakdown), Traffic (source list with proportional bars) — so the component reads as a real dashboard, not just a placeholder.
+- **Pure CSS State Management**: Active tab/panel state is handled entirely with visually hidden radio inputs and the `:checked` selector — no JavaScript.
+- **Accessible**:
+  - Radio inputs are hidden with the standard clip-based visually-hidden pattern (not `display: none`), so they stay keyboard- and screen-reader-reachable.
+  - A visible `:focus-visible` outline is provided for keyboard navigation.
+  - Decorative icons are marked `aria-hidden="true"`; the bar chart has a descriptive `aria-label`.
+  - Respects `prefers-reduced-motion`: transitions and the panel entrance animation are disabled for users who have requested reduced motion at the OS level, per this repo's [accessibility-reduced-motion guide](../../../docs/accessibility-reduced-motion.md).
+- **Responsive**: Tabs stack into full-width rows and stat/list layouts collapse to a single column below 600px.
+
+## Custom Properties
+
+Fine-tune the 3D physics and the analytics color palette via the CSS variables in `:root` in `style.css`:
+
+```css
+:root {
+  /* 3D Tilt Parameters */
+  --tilt-duration: 0.55s;
+  --tilt-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275); /* Springy bounce effect */
+  --tilt-perspective: 1200px; /* Adjust the 3D viewing distance */
+
+  /* Dashboard Analytics Palette */
+  --panel-bg: #101728;
+  --accent-blue: #38bdf8;
+  --accent-green: #34d399;
+  /* ...see style.css for the full list */
+}
+```
+
+## Usage
+
+Open `demo.html` in a browser. Hover over "Overview", "Revenue", or "Traffic" to see the 3D tilt, and click (or use `Tab` + arrow/space) to switch panels and trigger the 3D entrance animation.

--- a/submissions-example/demo.html
+++ b/submissions-example/demo.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 3D Perspective Tilt Tabs - Dashboard Analytics</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+  <main class="dash-container">
+    <div class="tabs-wrapper">
+
+      <!-- Accessible visually hidden radio inputs for state management -->
+      <input type="radio" id="tab-overview" name="dashtabs" class="tab-input" checked>
+      <input type="radio" id="tab-revenue" name="dashtabs" class="tab-input">
+      <input type="radio" id="tab-traffic" name="dashtabs" class="tab-input">
+
+      <!-- Navigation Tabs with 3D Perspective Tilt -->
+      <nav class="tabs-nav" aria-label="Analytics Dashboard Sections">
+        <label for="tab-overview" class="tab-label">
+          <span class="icon" aria-hidden="true">📊</span>
+          <span class="label-text">Overview</span>
+        </label>
+
+        <label for="tab-revenue" class="tab-label">
+          <span class="icon" aria-hidden="true">💰</span>
+          <span class="label-text">Revenue</span>
+        </label>
+
+        <label for="tab-traffic" class="tab-label">
+          <span class="icon" aria-hidden="true">🌐</span>
+          <span class="label-text">Traffic</span>
+        </label>
+      </nav>
+
+      <!-- Dashboard Analytics Tab Panels with 3D Entrance Animation -->
+      <div class="tabs-panels">
+
+        <!-- Panel 1: Overview -->
+        <article class="tab-panel" id="panel-overview">
+          <div class="panel-content">
+            <h2>Analytics Overview</h2>
+            <p>A snapshot of your key metrics this month. Tilt into the tabs above to explore each section in 3D space.</p>
+
+            <div class="stat-grid">
+              <div class="stat-card">
+                <h4>Active Users</h4>
+                <div class="value">24,809</div>
+                <div class="delta up">▲ 8.2%</div>
+              </div>
+              <div class="stat-card">
+                <h4>Conversion Rate</h4>
+                <div class="value">3.42%</div>
+                <div class="delta up">▲ 1.1%</div>
+              </div>
+              <div class="stat-card">
+                <h4>Bounce Rate</h4>
+                <div class="value">27.6%</div>
+                <div class="delta down">▼ 2.4%</div>
+              </div>
+            </div>
+
+            <div class="mini-chart" role="img" aria-label="Bar chart showing weekly active users trending upward">
+              <span style="--h: 40%"></span>
+              <span style="--h: 55%"></span>
+              <span style="--h: 48%"></span>
+              <span style="--h: 70%"></span>
+              <span style="--h: 62%"></span>
+              <span style="--h: 85%"></span>
+              <span style="--h: 96%"></span>
+            </div>
+          </div>
+        </article>
+
+        <!-- Panel 2: Revenue -->
+        <article class="tab-panel" id="panel-revenue">
+          <div class="panel-content">
+            <h2>Revenue Breakdown</h2>
+            <p>Monthly recurring revenue continues to trend upward across all plans.</p>
+
+            <div class="revenue-card">
+              <div class="revenue-label">Total Revenue (MTD)</div>
+              <div class="revenue-value">$48,230.00</div>
+              <div class="revenue-sub">+12.8% vs last month</div>
+            </div>
+
+            <ul class="plan-list">
+              <li>
+                <span>Enterprise Plan</span>
+                <span class="plan-amount">$28,400</span>
+              </li>
+              <li>
+                <span>Pro Plan</span>
+                <span class="plan-amount">$15,120</span>
+              </li>
+              <li>
+                <span>Starter Plan</span>
+                <span class="plan-amount">$4,710</span>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <!-- Panel 3: Traffic -->
+        <article class="tab-panel" id="panel-traffic">
+          <div class="panel-content">
+            <h2>Traffic Sources</h2>
+            <p>Where your visitors are coming from this week.</p>
+
+            <ul class="source-list">
+              <li>
+                <span class="source-name">Organic Search</span>
+                <div class="source-bar"><span style="--w: 62%"></span></div>
+                <span class="source-pct">62%</span>
+              </li>
+              <li>
+                <span class="source-name">Direct</span>
+                <div class="source-bar"><span style="--w: 21%"></span></div>
+                <span class="source-pct">21%</span>
+              </li>
+              <li>
+                <span class="source-name">Referral</span>
+                <div class="source-bar"><span style="--w: 11%"></span></div>
+                <span class="source-pct">11%</span>
+              </li>
+              <li>
+                <span class="source-name">Social</span>
+                <div class="source-bar"><span style="--w: 6%"></span></div>
+                <span class="source-pct">6%</span>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions-example/style.css
+++ b/submissions-example/style.css
@@ -1,0 +1,382 @@
+:root {
+  /* 3D Tilt Parameters */
+  --tilt-duration: 0.55s;
+  --tilt-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275); /* Springy bounce effect */
+  --tilt-perspective: 1200px;
+
+  /* Dashboard Analytics Theme Parameters */
+  --panel-bg: #101728;
+  --panel-bg-hover: #16213a;
+  --panel-bg-active: #1b2a4a;
+  --panel-border: rgba(148, 163, 184, 0.18);
+  --panel-border-active: #38bdf8;
+  --shadow-color: rgba(0, 0, 0, 0.45);
+
+  --accent-blue: #38bdf8;
+  --accent-green: #34d399;
+  --accent-red: #f87171;
+  --accent-amber: #fbbf24;
+
+  /* Text & Accessibility */
+  --text-main: #f1f5f9;
+  --text-muted: #94a3b8;
+  --focus-ring: #38bdf8;
+
+  /* Radii */
+  --radius-tab: 14px;
+  --radius-panel: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, #131c33 0%, #0a0f1c 60%, #05070d 100%);
+  font-family: 'Inter', -apple-system, sans-serif;
+  color: var(--text-main);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 20px;
+}
+
+.dash-container {
+  width: 100%;
+  max-width: 780px;
+}
+
+.tabs-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Visually hide radio inputs while keeping them keyboard-accessible */
+.tab-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Tabs Navigation Area */
+.tabs-nav {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  perspective: var(--tilt-perspective); /* Establish 3D space for children tabs */
+}
+
+/* 3D Perspective Tilt on Tabs */
+.tab-label {
+  flex: 1;
+  max-width: 190px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 18px 16px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-tab);
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: 1rem;
+  cursor: pointer;
+  user-select: none;
+
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+
+  /* 3D Transform Setup */
+  transform-style: preserve-3d;
+  transform: rotateX(0) rotateY(0) translateZ(0);
+  transition: transform 0.35s ease-out,
+              background 0.3s ease,
+              color 0.3s ease,
+              border-color 0.3s ease,
+              box-shadow 0.3s ease;
+}
+
+.tab-label .icon {
+  font-size: 1.7rem;
+  transition: transform 0.3s ease;
+}
+
+/* The Tilt-Hover Interaction */
+.tab-label:hover {
+  background: var(--panel-bg-hover);
+  color: var(--text-main);
+  transform: rotateX(12deg) rotateY(-8deg) translateZ(10px);
+  box-shadow: -6px 16px 26px rgba(0, 0, 0, 0.4);
+}
+
+.tab-label:active {
+  transform: rotateX(5deg) rotateY(-3deg) translateZ(2px);
+}
+
+/* Active Tab State */
+#tab-overview:checked ~ .tabs-nav label[for="tab-overview"],
+#tab-revenue:checked ~ .tabs-nav label[for="tab-revenue"],
+#tab-traffic:checked ~ .tabs-nav label[for="tab-traffic"] {
+  background: var(--panel-bg-active);
+  border-color: var(--panel-border-active);
+  color: var(--text-main);
+  box-shadow: 0 12px 30px var(--shadow-color);
+  transform: rotateX(0) rotateY(0) translateZ(5px);
+}
+
+#tab-overview:checked ~ .tabs-nav label[for="tab-overview"] .icon,
+#tab-revenue:checked ~ .tabs-nav label[for="tab-revenue"] .icon,
+#tab-traffic:checked ~ .tabs-nav label[for="tab-traffic"] .icon {
+  transform: scale(1.15) translateZ(20px);
+}
+
+/* Focus Ring for Keyboard Navigation */
+#tab-overview:focus-visible ~ .tabs-nav label[for="tab-overview"],
+#tab-revenue:focus-visible ~ .tabs-nav label[for="tab-revenue"],
+#tab-traffic:focus-visible ~ .tabs-nav label[for="tab-traffic"] {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 4px;
+}
+
+/* Tabs Content Panels */
+.tabs-panels {
+  position: relative;
+  min-height: 380px;
+  perspective: var(--tilt-perspective);
+}
+
+.tab-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 36px;
+  box-sizing: border-box;
+
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-panel);
+  box-shadow: 0 20px 45px var(--shadow-color);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transform-style: preserve-3d;
+}
+
+/* Panel Entrance 3D Perspective Tilt Animation */
+@keyframes panelTiltIn {
+  0% {
+    opacity: 0;
+    transform: rotateX(-15deg) rotateY(10deg) translateZ(-50px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: rotateX(0) rotateY(0) translateZ(0) scale(1);
+  }
+}
+
+#tab-overview:checked ~ .tabs-panels #panel-overview,
+#tab-revenue:checked ~ .tabs-panels #panel-revenue,
+#tab-traffic:checked ~ .tabs-panels #panel-traffic {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  animation: panelTiltIn var(--tilt-duration) var(--tilt-easing) forwards;
+}
+
+/* --- Internal Content Styling --- */
+.panel-content h2 {
+  margin-top: 0;
+  font-size: 1.7rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.panel-content p {
+  font-size: 1rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin-bottom: 28px;
+}
+
+/* Stat Grid (Overview panel) */
+.stat-grid {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+.stat-card {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--panel-border);
+  padding: 18px;
+  border-radius: 14px;
+  transform: translateZ(15px); /* Add 3D depth to elements inside the panel */
+}
+.stat-card h4 {
+  margin: 0 0 8px 0;
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+.stat-card .value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.delta {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+.delta.up { color: var(--accent-green); }
+.delta.down { color: var(--accent-red); }
+
+/* Mini Bar Chart */
+.mini-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  height: 100px;
+  transform: translateZ(10px);
+}
+.mini-chart span {
+  flex: 1;
+  height: var(--h);
+  background: linear-gradient(180deg, var(--accent-blue), rgba(56, 189, 248, 0.15));
+  border-radius: 6px 6px 2px 2px;
+}
+
+/* Revenue Card (Revenue panel) */
+.revenue-card {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(52, 211, 153, 0.08));
+  border: 1px solid var(--panel-border-active);
+  border-radius: 16px;
+  padding: 24px;
+  margin-bottom: 24px;
+  transform: translateZ(25px) rotateY(-3deg);
+}
+.revenue-label {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+}
+.revenue-value {
+  font-size: 2rem;
+  font-weight: 700;
+}
+.revenue-sub {
+  color: var(--accent-green);
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-top: 6px;
+}
+
+.plan-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transform: translateZ(10px);
+}
+.plan-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 14px 18px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+}
+.plan-amount {
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+/* Traffic Source List (Traffic panel) */
+.source-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transform: translateZ(10px);
+}
+.source-list li {
+  display: grid;
+  grid-template-columns: 110px 1fr 46px;
+  align-items: center;
+  gap: 12px;
+}
+.source-name {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+.source-bar {
+  height: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.source-bar span {
+  display: block;
+  height: 100%;
+  width: var(--w);
+  background: linear-gradient(90deg, var(--accent-blue), var(--accent-green));
+  border-radius: 8px;
+}
+.source-pct {
+  text-align: right;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+/* Respect users who have requested reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tab-label,
+  .tab-label .icon,
+  .tab-panel {
+    transition-duration: 0.01ms !important;
+  }
+  @keyframes panelTiltIn {
+    0%, 100% {
+      opacity: 1;
+      transform: none;
+    }
+  }
+}
+
+/* Responsive Overrides */
+@media (max-width: 600px) {
+  .tabs-nav {
+    flex-wrap: wrap;
+  }
+  .tab-label {
+    max-width: 100%;
+    flex-direction: row;
+    padding: 14px;
+  }
+  .tab-label .icon {
+    font-size: 1.4rem;
+  }
+  .stat-grid {
+    flex-direction: column;
+  }
+  .source-list li {
+    grid-template-columns: 90px 1fr 40px;
+  }
+}


### PR DESCRIPTION
Closes #50347

## What this adds
A pure CSS/HTML tabs component (`submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/`) using perspective and 3D transforms (`rotateX`, `rotateY`, `translateZ`) for a tilt-on-hover interaction and a 3D tilt+scale panel entrance animation, styled as a dark analytics dashboard.

## Contents
- `demo.html` — three tabs (Overview / Revenue / Traffic), each with realistic dashboard content (stat cards with up/down deltas, a mini CSS bar chart, a revenue highlight card, a traffic source breakdown)
- `style.css` — pure CSS, radio-input driven tab state (no JavaScript)
- `README.md` — component description, custom properties, usage

## Notes
- No core files were touched (submission-only, per the current contribution freeze).
- Includes `prefers-reduced-motion` support per the repo's accessibility guide, disabling the tilt transitions and panel entrance animation for users who've requested reduced motion.
- Focus-visible outline included for keyboard navigation; decorative icons are `aria-hidden`; the chart has a descriptive `aria-label`.