### PR TITLE
feat: add 3D perspective tilt tabs for dashboard analytics layouts 

### DIFF
--- a/submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/README.md
+++ b/submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/README.md
@@ -1,0 +1,56 @@
+# 3D Perspective Tilt Tabs — Dashboard Analytics
+
+Closes #50347
+
+Pure CSS (no JavaScript) tabs component with a 3D perspective tilt interaction,
+styled for a dark dashboard-analytics UI.
+
+## Files
+
+- `demo.html` — three tabs (Overview / Revenue / Traffic), each with sample
+  dashboard content (stat cards with up/down deltas, a mini CSS bar chart)
+- `style.css` — the component itself; radio-input driven tab state, no JS
+
+## How it works
+
+Tab switching is driven entirely by hidden radio inputs and the `:checked`
+sibling combinator — no JavaScript is used. The inactive panel sits tilted
+in 3D space (`rotateY` + `scale`, via `perspective`) and animates flat when
+its tab is selected. The tab buttons themselves also tilt slightly in 3D on
+hover/focus/active for a consistent visual language.
+
+## Custom properties
+
+All overridable per-instance on the `.tt-tabs` wrapper:
+
+| Property | Default | Purpose |
+|---|---|---|
+| `--tt-duration` | `0.6s` | Transition duration |
+| `--tt-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Transition easing |
+| `--tt-tilt-angle` | `18deg` | How far the inactive panel is tilted |
+| `--tt-tilt-scale` | `0.92` | How much the inactive panel is scaled down |
+| `--tt-perspective` | `1200px` | 3D perspective depth |
+| `--tt-accent` | `#7c9cff` | Active-tab accent color |
+| `--tt-bg` / `--tt-panel-bg` | dark navy tones | Component/panel background |
+| `--tt-radius` | `14px` | Corner radius |
+
+## Accessibility
+
+- Radio inputs stay in the natural tab order (visually hidden via clipping,
+  not `display: none`), so native radio-group keyboard behavior — arrow
+  keys to move between tabs, Enter/Space to activate — works out of the box.
+- Visible `:focus-visible` outline on the active tab label.
+- `@media (prefers-reduced-motion: reduce)` disables the tilt/scale
+  transitions entirely.
+
+## Responsive
+
+Under 600px, tabs grow to fill the row equally and the tilt angle is reduced
+(`8deg`) so the 3D effect stays comfortable on small/touch screens.
+
+## Note on ARIA
+
+This uses native radio/label semantics rather than the ARIA tabs pattern
+(`role="tablist"` + `aria-selected` toggled via JS), since the goal is zero
+JavaScript. Screen readers will announce it as a radio group rather than a
+tab list — a deliberate tradeoff for a pure-CSS implementation.

--- a/submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/demo.html
+++ b/submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/demo.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Tilt Tabs — Dashboard Analytics Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: radial-gradient(circle at 20% 20%, #1a1f3a 0%, #0a0c16 60%);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  .demo-shell {
+    width: min(560px, 92vw);
+  }
+  .stat-row {
+    display: flex;
+    gap: 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .stat {
+    flex: 1;
+  }
+  .stat__label {
+    font-size: 0.75rem;
+    color: #9198b8;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.25rem;
+  }
+  .stat__value {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #fff;
+  }
+  .stat__delta {
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+  .stat__delta--up { color: #4ade80; }
+  .stat__delta--down { color: #f87171; }
+  .bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.4rem;
+    height: 90px;
+  }
+  .bars span {
+    flex: 1;
+    background: linear-gradient(180deg, #7c9cff, rgba(124,156,255,0.15));
+    border-radius: 4px 4px 0 0;
+  }
+  .panel-title {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+    color: #e7e9f5;
+  }
+</style>
+</head>
+<body>
+
+<div class="demo-shell">
+  <div class="tt-tabs">
+    <input type="radio" id="tt-tab-1" name="tt-tabs" class="tt-tabs__radio" checked>
+    <label for="tt-tab-1" class="tt-tabs__tab">Overview</label>
+
+    <input type="radio" id="tt-tab-2" name="tt-tabs" class="tt-tabs__radio">
+    <label for="tt-tab-2" class="tt-tabs__tab">Revenue</label>
+
+    <input type="radio" id="tt-tab-3" name="tt-tabs" class="tt-tabs__radio">
+    <label for="tt-tab-3" class="tt-tabs__tab">Traffic</label>
+
+    <div class="tt-tabs__panels">
+
+      <section class="tt-tabs__panel" data-panel="1">
+        <h3 class="panel-title">Overview</h3>
+        <div class="stat-row">
+          <div class="stat">
+            <div class="stat__label">Active Users</div>
+            <div class="stat__value">8,942</div>
+            <div class="stat__delta stat__delta--up">▲ 12.4%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">Sessions</div>
+            <div class="stat__value">21,038</div>
+            <div class="stat__delta stat__delta--up">▲ 4.1%</div>
+          </div>
+        </div>
+        <div class="bars">
+          <span style="height:40%"></span><span style="height:65%"></span>
+          <span style="height:50%"></span><span style="height:85%"></span>
+          <span style="height:60%"></span><span style="height:95%"></span>
+          <span style="height:70%"></span>
+        </div>
+      </section>
+
+      <section class="tt-tabs__panel" data-panel="2">
+        <h3 class="panel-title">Revenue</h3>
+        <div class="stat-row">
+          <div class="stat">
+            <div class="stat__label">This Month</div>
+            <div class="stat__value">$128.4K</div>
+            <div class="stat__delta stat__delta--up">▲ 8.2%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">Refunds</div>
+            <div class="stat__value">$2.1K</div>
+            <div class="stat__delta stat__delta--down">▼ 1.3%</div>
+          </div>
+        </div>
+        <div class="bars">
+          <span style="height:55%"></span><span style="height:45%"></span>
+          <span style="height:80%"></span><span style="height:60%"></span>
+          <span style="height:90%"></span><span style="height:70%"></span>
+          <span style="height:100%"></span>
+        </div>
+      </section>
+
+      <section class="tt-tabs__panel" data-panel="3">
+        <h3 class="panel-title">Traffic</h3>
+        <div class="stat-row">
+          <div class="stat">
+            <div class="stat__label">Conversion</div>
+            <div class="stat__value">4.8%</div>
+            <div class="stat__delta stat__delta--up">▲ 0.6%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">Bounce Rate</div>
+            <div class="stat__value">38.2%</div>
+            <div class="stat__delta stat__delta--down">▼ 2.9%</div>
+          </div>
+        </div>
+        <div class="bars">
+          <span style="height:30%"></span><span style="height:55%"></span>
+          <span style="height:40%"></span><span style="height:75%"></span>
+          <span style="height:45%"></span><span style="height:65%"></span>
+          <span style="height:50%"></span>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/style.css
+++ b/submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/style.css
@@ -1,0 +1,152 @@
+/* =============================================================================
+   EASEMOTION CSS - 3D PERSPECTIVE TILT TABS SYSTEM SPECIFICATION
+   =============================================================================
+   Core Issue Target Tracking System Identifier: #50347
+   Design Paradigm: Pure CSS Asymmetrical 3D Matrix Transformation Pipeline
+   Zero Scripting Engine. High Performance Hardware Layer Composition Layout.
+   ============================================================================= */
+
+/* =============================================================================
+   1. GLOBAL SYSTEM ARCHITECTURE CUSTOM DESIGN VARIABLES & TOKENS
+   ============================================================================= */
+
+.tt-tabs {
+  /* Public, overridable API */
+  --tt-duration: 0.6s;
+  --tt-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tt-tilt-angle: 18deg;
+  --tt-tilt-scale: 0.92;
+  --tt-perspective: 1200px;
+  --tt-accent: #7c9cff;
+  --tt-accent-soft: rgba(124, 156, 255, 0.16);
+  --tt-bg: #0f1220;
+  --tt-panel-bg: #151934;
+  --tt-text: #e7e9f5;
+  --tt-text-muted: #9198b8;
+  --tt-radius: 14px;
+
+  display: grid;
+  gap: 1.25rem;
+  background: var(--tt-bg);
+  padding: 1.5rem;
+  border-radius: var(--tt-radius);
+  color: var(--tt-text);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Visually hide the native radios but keep them in the tab order and
+   operable — do NOT use display:none, it removes keyboard focusability. */
+.tt-tabs__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tt-tabs__tab {
+  display: inline-block;
+  cursor: pointer;
+  user-select: none;
+  padding: 0.65rem 1.1rem;
+  margin-right: 0.5rem;
+  border-radius: calc(var(--tt-radius) - 6px);
+  background: transparent;
+  color: var(--tt-text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transform-style: preserve-3d;
+  transition:
+    transform var(--tt-duration) var(--tt-easing),
+    color var(--tt-duration) var(--tt-easing),
+    background var(--tt-duration) var(--tt-easing),
+    box-shadow var(--tt-duration) var(--tt-easing);
+}
+
+.tt-tabs__tab:hover {
+  color: var(--tt-text);
+  transform: perspective(var(--tt-perspective)) rotateX(-10deg) translateY(-2px);
+}
+
+/* Focus ring on the label when its (visually hidden) radio has keyboard focus */
+.tt-tabs__radio:focus-visible + .tt-tabs__tab {
+  outline: 2px solid var(--tt-accent);
+  outline-offset: 3px;
+}
+
+.tt-tabs__radio:checked + .tt-tabs__tab {
+  color: #fff;
+  background: var(--tt-accent-soft);
+  box-shadow: 0 6px 16px -6px var(--tt-accent);
+  transform: perspective(var(--tt-perspective)) rotateX(-6deg) translateY(-3px) scale(1.03);
+}
+
+/* Panels are stacked in the same grid cell so the wrapper's height always
+   matches the tallest panel, with no JS measuring required. */
+.tt-tabs__panels {
+  position: relative;
+  display: grid;
+  grid-template-areas: "stack";
+  perspective: var(--tt-perspective);
+}
+
+.tt-tabs__panel {
+  grid-area: stack;
+  background: var(--tt-panel-bg);
+  border-radius: var(--tt-radius);
+  padding: 1.5rem;
+  opacity: 0;
+  pointer-events: none;
+  transform-style: preserve-3d;
+  transform: perspective(var(--tt-perspective)) rotateY(var(--tt-tilt-angle)) scale(var(--tt-tilt-scale));
+  transition:
+    transform var(--tt-duration) var(--tt-easing),
+    opacity var(--tt-duration) var(--tt-easing);
+}
+
+/* Wire each radio to its matching panel (extend this block per extra tab) */
+#tt-tab-1:checked ~ .tt-tabs__panels [data-panel="1"],
+#tt-tab-2:checked ~ .tt-tabs__panels [data-panel="2"],
+#tt-tab-3:checked ~ .tt-tabs__panels [data-panel="3"] {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 2;
+  transform: perspective(var(--tt-perspective)) rotateY(0deg) scale(1);
+}
+
+/* Responsive: full-width equal tabs on small screens, subtler tilt so the
+   3D effect doesn't feel disorienting on touch devices */
+@media (max-width: 600px) {
+  .tt-tabs {
+    --tt-tilt-angle: 8deg;
+    padding: 1rem;
+  }
+  .tt-tabs__tablist {
+    flex-wrap: wrap;
+  }
+  .tt-tabs__tab {
+    flex: 1 1 auto;
+    text-align: center;
+    margin-right: 0;
+  }
+}
+
+/* Respect reduced-motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .tt-tabs__tab,
+  .tt-tabs__panel {
+    transition: none;
+  }
+  .tt-tabs__tab:hover,
+  .tt-tabs__radio:checked + .tt-tabs__tab {
+    transform: none;
+  }
+  .tt-tabs__panel {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #50347

## What this adds

A pure CSS/HTML tabs component (`submissions/examples/3d-perspective-tilt-tabs-dashboard-analytics-50347/`)
using perspective and 3D transforms (`rotateX`, `rotateY`, `scale`) for a
tilt-on-hover tab interaction and a 3D tilt+scale panel entrance animation,
styled as a dark analytics dashboard.

## Contents

- `demo.html` = three tabs (Overview / Revenue / Traffic), each with sample
  dashboard content (stat cards with up/down deltas, a mini CSS bar chart)
- `style.css` = pure CSS, radio-input driven tab state (no JavaScript)
- `README.md` = component description, custom properties, usage

## Notes

- No core files touched = submission-only, under `submissions/examples/`.
- Custom properties exposed for timing, easing, tilt angle/scale, and colors.
- Keyboard accessible: radios stay focusable (visually hidden via clip, not
  `display: none`), with a visible `:focus-visible` outline.
- Responsive: tabs go full-width and tilt angle reduces under 600px.
- Respects `prefers-reduced-motion`.