### PR TITLE
feat: add CSS spring physics tabs for responsive dashboard layouts 

### DIFF
--- a/submissions/examples/css-spring-physics-tabs-responsive-dashboard-50326/README.md
+++ b/submissions/examples/css-spring-physics-tabs-responsive-dashboard-50326/README.md
@@ -1,0 +1,56 @@
+# Spring Physics Tabs — Responsive Dashboard
+
+Closes #50326
+
+Pure CSS (no JavaScript) tabs component where the active-tab indicator and
+panel entrance both settle using a damped-spring easing curve, styled for a
+responsive dashboard UI.
+
+## Files
+
+- `demo.html` — three tabs (Overview / Revenue / Traffic), each with sample
+  dashboard stat cards that reflow to a single column on small screens
+- `style.css` — the component itself; radio-input driven tab state, no JS
+
+## How it works
+
+Tab switching is driven entirely by hidden radio inputs and the `:checked`
+sibling combinator — no JavaScript. A single pill-shaped indicator slides
+behind the active tab label (`translateX`), and the active panel enters with
+a slight scale + translateY settle. Both use a `linear()` easing function
+that approximates a damped mass-spring curve — a small overshoot past the
+resting position before settling, rather than a standard ease-out.
+
+## Custom properties
+
+All overridable per-instance on the `.sp-tabs` wrapper:
+
+| Property | Default | Purpose |
+|---|---|---|
+| `--sp-tab-count` | `3` | Number of tabs, used to size the indicator |
+| `--sp-duration` | `0.7s` | Transition duration |
+| `--sp-spring-easing` | damped-spring `linear()` curve | Transition easing |
+| `--sp-scale-from` | `0.9` | Starting scale of an entering panel |
+| `--sp-translate-y` | `10px` | Starting vertical offset of an entering panel |
+| `--sp-accent` | `#4f6df5` | Indicator / active-tab color |
+| `--sp-bg` / `--sp-panel-bg` | light neutral tones | Component/panel background |
+| `--sp-border` | `#e4e7ef` | Border color |
+| `--sp-radius` | `14px` | Corner radius |
+
+## Accessibility
+
+- Radio inputs stay in the natural tab order (visually hidden via clipping,
+  not `display: none`), so native radio-group keyboard behavior — arrow
+  keys to move between tabs, Enter/Space to activate — works out of the box.
+- Visible `:focus-visible` outline on the active tab label.
+- `@media (prefers-reduced-motion: reduce)` disables the spring transitions
+  entirely, snapping straight to the resting state.
+
+## Responsive
+
+Tabs list wraps and the stat grid inside each panel collapses from three
+columns to one under 640px. The indicator's width and position are both
+percentage-based, so it tracks the active tab correctly at any container
+width without recalculation.
+
+## Note on ARIA

--- a/submissions/examples/css-spring-physics-tabs-responsive-dashboard-50326/demo.html
+++ b/submissions/examples/css-spring-physics-tabs-responsive-dashboard-50326/demo.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Spring Physics Tabs — Responsive Dashboard Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #e9ecf5;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  .demo-shell { width: min(560px, 92vw); }
+  .stat__label {
+    font-size: 0.72rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.25rem;
+  }
+  .stat__value { font-size: 1.25rem; font-weight: 700; color: #1c2130; }
+  .stat__delta { font-size: 0.75rem; font-weight: 600; }
+  .stat__delta--up { color: #16a34a; }
+  .stat__delta--down { color: #dc2626; }
+  .panel-title { margin: 0 0 1rem; font-size: 1rem; }
+</style>
+</head>
+<body>
+
+<div class="demo-shell">
+  <div class="sp-tabs">
+    <input type="radio" id="sp-tab-1" name="sp-tabs" class="sp-tabs__radio" checked>
+    <input type="radio" id="sp-tab-2" name="sp-tabs" class="sp-tabs__radio">
+    <input type="radio" id="sp-tab-3" name="sp-tabs" class="sp-tabs__radio">
+
+    <div class="sp-tabs__list">
+      <label for="sp-tab-1" class="sp-tabs__tab">Overview</label>
+      <label for="sp-tab-2" class="sp-tabs__tab">Revenue</label>
+      <label for="sp-tab-3" class="sp-tabs__tab">Traffic</label>
+      <span class="sp-tabs__indicator" aria-hidden="true"></span>
+    </div>
+
+    <div class="sp-tabs__panels">
+
+      <section class="sp-tabs__panel" data-panel="1">
+        <h3 class="panel-title">Overview</h3>
+        <div class="sp-tabs__stats">
+          <div class="stat">
+            <div class="stat__label">Active Users</div>
+            <div class="stat__value">8,942</div>
+            <div class="stat__delta stat__delta--up">▲ 12.4%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">Sessions</div>
+            <div class="stat__value">21,038</div>
+            <div class="stat__delta stat__delta--up">▲ 4.1%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">Avg. Time</div>
+            <div class="stat__value">3m 42s</div>
+            <div class="stat__delta stat__delta--down">▼ 0.6%</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="sp-tabs__panel" data-panel="2">
+        <h3 class="panel-title">Revenue</h3>
+        <div class="sp-tabs__stats">
+          <div class="stat">
+            <div class="stat__label">This Month</div>
+            <div class="stat__value">$128.4K</div>
+            <div class="stat__delta stat__delta--up">▲ 8.2%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">Refunds</div>
+            <div class="stat__value">$2.1K</div>
+            <div class="stat__delta stat__delta--down">▼ 1.3%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">MRR</div>
+            <div class="stat__value">$41.9K</div>
+            <div class="stat__delta stat__delta--up">▲ 5.5%</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="sp-tabs__panel" data-panel="3">
+        <h3 class="panel-title">Traffic</h3>
+        <div class="sp-tabs__stats">
+          <div class="stat">
+            <div class="stat__label">Conversion</div>
+            <div class="stat__value">4.8%</div>
+            <div class="stat__delta stat__delta--up">▲ 0.6%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">Bounce Rate</div>
+            <div class="stat__value">38.2%</div>
+            <div class="stat__delta stat__delta--down">▼ 2.9%</div>
+          </div>
+          <div class="stat">
+            <div class="stat__label">New Visitors</div>
+            <div class="stat__value">62%</div>
+            <div class="stat__delta stat__delta--up">▲ 1.8%</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-spring-physics-tabs-responsive-dashboard-50326/style.css
+++ b/submissions/examples/css-spring-physics-tabs-responsive-dashboard-50326/style.css
@@ -1,0 +1,166 @@
+/* =============================================================================
+   Spring Physics Tabs — pure CSS, no JavaScript
+   A tab component styled for responsive dashboard layouts, with a sliding
+   indicator and panel entrance that both settle using a damped-spring
+   easing curve instead of a standard ease/linear transition.
+   ============================================================================= */
+
+.sp-tabs {
+  /* Public, overridable API */
+  --sp-tab-count: 3;
+  --sp-duration: 0.7s;
+  /* Approximates a damped mass-spring curve (slight overshoot, settles by 1) */
+  --sp-spring-easing: linear(
+    0, 0.29 8.1%, 0.986 20.3%, 1.153 26.1%, 1.208 29.5%,
+    1.198 32.4%, 1.129 36.9%, 1.019 44.6%, 0.976 49.7%,
+    0.953 55.5%, 0.949 61.7%, 0.965 69.4%, 0.996 82.2%, 1
+  );
+  --sp-scale-from: 0.9;
+  --sp-translate-y: 10px;
+  --sp-accent: #4f6df5;
+  --sp-bg: #f4f6fb;
+  --sp-panel-bg: #ffffff;
+  --sp-text: #1c2130;
+  --sp-text-muted: #6b7280;
+  --sp-border: #e4e7ef;
+  --sp-radius: 14px;
+
+  display: grid;
+  gap: 1.25rem;
+  background: var(--sp-bg);
+  padding: 1.5rem;
+  border-radius: var(--sp-radius);
+  color: var(--sp-text);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Visually hide the native radios but keep them keyboard-focusable —
+   never display:none, that removes them from the tab order. */
+.sp-tabs__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sp-tabs__list {
+  position: relative;
+  display: flex;
+  background: var(--sp-panel-bg);
+  border: 1px solid var(--sp-border);
+  border-radius: calc(var(--sp-radius) - 4px);
+  padding: 0.35rem;
+}
+
+.sp-tabs__tab {
+  position: relative;
+  z-index: 2;
+  flex: 1 1 0;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  padding: 0.6rem 0.75rem;
+  border-radius: calc(var(--sp-radius) - 8px);
+  color: var(--sp-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: color var(--sp-duration) var(--sp-spring-easing);
+}
+
+.sp-tabs__radio:focus-visible + .sp-tabs__tab {
+  outline: 2px solid var(--sp-accent);
+  outline-offset: 2px;
+}
+
+.sp-tabs__radio:checked + .sp-tabs__tab {
+  color: #fff;
+}
+
+/* Sliding indicator — one pill that moves behind the active tab.
+   Width is 1/N of the tablist; position driven by which radio is checked. */
+.sp-tabs__indicator {
+  position: absolute;
+  z-index: 1;
+  top: 0.35rem;
+  bottom: 0.35rem;
+  left: 0.35rem;
+  width: calc((100% - 0.7rem) / var(--sp-tab-count));
+  background: var(--sp-accent);
+  border-radius: calc(var(--sp-radius) - 8px);
+  transition: transform var(--sp-duration) var(--sp-spring-easing);
+}
+
+#sp-tab-1:checked ~ .sp-tabs__list .sp-tabs__indicator { transform: translateX(0%); }
+#sp-tab-2:checked ~ .sp-tabs__list .sp-tabs__indicator { transform: translateX(100%); }
+#sp-tab-3:checked ~ .sp-tabs__list .sp-tabs__indicator { transform: translateX(200%); }
+
+/* Panels stack in one grid cell so the wrapper height always matches the
+   tallest panel — no JS measuring needed. */
+.sp-tabs__panels {
+  position: relative;
+  display: grid;
+  grid-template-areas: "stack";
+}
+
+.sp-tabs__panel {
+  grid-area: stack;
+  background: var(--sp-panel-bg);
+  border: 1px solid var(--sp-border);
+  border-radius: var(--sp-radius);
+  padding: 1.5rem;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(var(--sp-translate-y)) scale(var(--sp-scale-from));
+  transition:
+    transform var(--sp-duration) var(--sp-spring-easing),
+    opacity calc(var(--sp-duration) * 0.6) ease-out;
+}
+
+#sp-tab-1:checked ~ .sp-tabs__panels [data-panel="1"],
+#sp-tab-2:checked ~ .sp-tabs__panels [data-panel="2"],
+#sp-tab-3:checked ~ .sp-tabs__panels [data-panel="3"] {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 2;
+  transform: translateY(0) scale(1);
+}
+
+/* Stat grid inside panels, used by the demo — reflows for small screens */
+.sp-tabs__stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .sp-tabs {
+    padding: 1rem;
+  }
+  .sp-tabs__list {
+    flex-wrap: wrap;
+  }
+  .sp-tabs__tab {
+    font-size: 0.8rem;
+    padding: 0.55rem 0.5rem;
+  }
+  .sp-tabs__stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sp-tabs__tab,
+  .sp-tabs__indicator,
+  .sp-tabs__panel {
+    transition: none;
+  }
+  .sp-tabs__panel {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #50326

## What this adds

A pure CSS/HTML tabs component (`submissions/examples/css-spring-physics-tabs-responsive-dashboard-50326/`)
where the active-tab indicator and panel entrance both settle using a
damped-spring easing curve (`linear()` approximating a mass-spring-damper
overshoot), styled for a responsive dashboard UI.

## Contents

- `demo.html` — three tabs (Overview / Revenue / Traffic), each with sample
  dashboard stat cards that reflow from a 3-column to 1-column grid on
  small screens
- `style.css` — pure CSS, radio-input driven tab state (no JavaScript)
- `README.md` — component description, custom properties, usage

## Notes

- No core files touched — submission-only, under `submissions/examples/`.
- Custom properties exposed for tab count, duration, spring easing, panel
  entrance offset/scale, and colors.
- Keyboard accessible: radios stay focusable (visually hidden via clip, not
  `display: none`), with a visible `:focus-visible` outline.
- Responsive: tab list wraps and the stat grid collapses to one column
  under 640px; the sliding indicator is percentage-based so it tracks the
  active tab correctly at any width.
- Respects `prefers-reduced-motion`, snapping to the resting state instead
  of animating.