### PR TITLE
feat: add CSS zoom-in tabs for neumorphic soft layouts

### DIFF
--- a/submissions/examples/css-zoom-in-tabs-neumorphic-soft-50047/README.md
+++ b/submissions/examples/css-zoom-in-tabs-neumorphic-soft-50047/README.md
@@ -1,0 +1,56 @@
+# Zoom-In Tabs — Neumorphic Soft
+
+Closes #50047
+
+Pure CSS (no JavaScript) tabs component with a zoom-in panel transition,
+styled in a neumorphic ("soft UI") aesthetic — elements read as carved into
+or raised off a single-color background via paired light/dark shadows,
+rather than bordered cards.
+
+## Files
+
+- `demo.html` — three tabs (Overview / Revenue / Traffic), each with sample
+  dashboard stat tiles styled as inset neumorphic "wells"
+- `style.css` — the component itself; radio-input driven tab state, no JS
+
+## How it works
+
+Tab switching is driven entirely by hidden radio inputs and the `:checked`
+sibling combinator — no JavaScript. Inactive tabs sit flush with the
+background using a raised dual-shadow (light top-left, dark bottom-right);
+the active tab flips to an inset shadow, reading as physically pressed in.
+The active panel enters with a zoom-in scale from `--zt-zoom-from` to `1`,
+combined with an opacity fade.
+
+## Custom properties
+
+All overridable per-instance on the `.zt-tabs` wrapper:
+
+| Property | Default | Purpose |
+|---|---|---|
+| `--zt-duration` | `0.45s` | Transition duration |
+| `--zt-easing` | `cubic-bezier(0.22, 1, 0.36, 1)` | Transition easing |
+| `--zt-zoom-from` | `0.85` | Starting scale of an entering panel |
+| `--zt-bg` | `#e6e9ef` | Shared background the neumorphic shadows are built on |
+| `--zt-text` / `--zt-text-muted` | dark slate tones | Text colors |
+| `--zt-accent` | `#5b6ee8` | Active-tab text color |
+| `--zt-shadow-light` / `--zt-shadow-dark` | white / soft gray | The two shadow colors that create the raised/inset effect |
+| `--zt-radius` | `20px` | Corner radius |
+
+## Accessibility
+
+- Radio inputs stay in the natural tab order (visually hidden via clipping,
+  not `display: none`), so native radio-group keyboard behavior — arrow
+  keys to move between tabs, Enter/Space to activate — works out of the box.
+- Visible `:focus-visible` outline on the active tab label.
+- Tabs use a `min-width`/`min-height` of `44px` to meet WCAG's minimum
+  touch-target size, since neumorphic shadows alone don't always give a
+  strong visual affordance for interactive edges.
+- `@media (prefers-reduced-motion: reduce)` disables the zoom/scale
+  transitions entirely.
+
+## Responsive
+
+Tabs wrap onto multiple lines and the stat grid collapses from three
+columns to one under 640px.
+

--- a/submissions/examples/css-zoom-in-tabs-neumorphic-soft-50047/demo.html
+++ b/submissions/examples/css-zoom-in-tabs-neumorphic-soft-50047/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zoom-In Tabs — Neumorphic Soft Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #e6e9ef;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  .demo-shell { width: min(560px, 92vw); }
+  .stat__label {
+    font-size: 0.7rem;
+    color: #7b8399;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.35rem;
+  }
+  .stat__value { font-size: 1.15rem; font-weight: 700; color: #3b4252; }
+  .panel-title { margin: 0 0 1rem; font-size: 1rem; }
+</style>
+</head>
+<body>
+
+<div class="demo-shell">
+  <div class="zt-tabs">
+    <input type="radio" id="zt-tab-1" name="zt-tabs" class="zt-tabs__radio" checked>
+    <label for="zt-tab-1" class="zt-tabs__tab">Overview</label>
+    <input type="radio" id="zt-tab-2" name="zt-tabs" class="zt-tabs__radio">
+    <label for="zt-tab-2" class="zt-tabs__tab">Revenue</label>
+    <input type="radio" id="zt-tab-3" name="zt-tabs" class="zt-tabs__radio">
+    <label for="zt-tab-3" class="zt-tabs__tab">Traffic</label>
+
+    <div class="zt-tabs__panels">
+
+      <section class="zt-tabs__panel" data-panel="1">
+        <h3 class="panel-title">Overview</h3>
+        <div class="zt-tabs__stats">
+          <div class="zt-well">
+            <div class="stat__label">Active Users</div>
+            <div class="stat__value">8,942</div>
+          </div>
+          <div class="zt-well">
+            <div class="stat__label">Sessions</div>
+            <div class="stat__value">21,038</div>
+          </div>
+          <div class="zt-well">
+            <div class="stat__label">Avg. Time</div>
+            <div class="stat__value">3m 42s</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="zt-tabs__panel" data-panel="2">
+        <h3 class="panel-title">Revenue</h3>
+        <div class="zt-tabs__stats">
+          <div class="zt-well">
+            <div class="stat__label">This Month</div>
+            <div class="stat__value">$128.4K</div>
+          </div>
+          <div class="zt-well">
+            <div class="stat__label">Refunds</div>
+            <div class="stat__value">$2.1K</div>
+          </div>
+          <div class="zt-well">
+            <div class="stat__label">MRR</div>
+            <div class="stat__value">$41.9K</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="zt-tabs__panel" data-panel="3">
+        <h3 class="panel-title">Traffic</h3>
+        <div class="zt-tabs__stats">
+          <div class="zt-well">
+            <div class="stat__label">Conversion</div>
+            <div class="stat__value">4.8%</div>
+          </div>
+          <div class="zt-well">
+            <div class="stat__label">Bounce Rate</div>
+            <div class="stat__value">38.2%</div>
+          </div>
+          <div class="zt-well">
+            <div class="stat__label">New Visitors</div>
+            <div class="stat__value">62%</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-zoom-in-tabs-neumorphic-soft-50047/style.css
+++ b/submissions/examples/css-zoom-in-tabs-neumorphic-soft-50047/style.css
@@ -1,0 +1,156 @@
+/* =============================================================================
+   Zoom-In Tabs — pure CSS, no JavaScript
+   Tabs component with a zoom-in panel transition, styled in a neumorphic
+   ("soft UI") aesthetic — elements are carved from or raised off a single
+   background color using paired light/dark shadows, rather than bordered
+   cards.
+   ============================================================================= */
+
+.zt-tabs {
+  /* Public, overridable API */
+  --zt-duration: 0.45s;
+  --zt-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --zt-zoom-from: 0.85;
+  --zt-bg: #e6e9ef;
+  --zt-text: #3b4252;
+  --zt-text-muted: #7b8399;
+  --zt-accent: #5b6ee8;
+  --zt-shadow-light: #ffffff;
+  --zt-shadow-dark: #b9c0d1;
+  --zt-radius: 20px;
+
+  display: grid;
+  gap: 1.5rem;
+  background: var(--zt-bg);
+  padding: 1.75rem;
+  border-radius: var(--zt-radius);
+  color: var(--zt-text);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Visually hide the native radios but keep them keyboard-focusable —
+   never display:none, that removes them from the tab order. */
+.zt-tabs__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.zt-tabs__list {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Inactive tabs sit flush ("flat") with the background.
+   Active tab looks pressed INTO the surface (inset shadow) — the
+   signature neumorphic "pushed button" state. */
+.zt-tabs__tab {
+  cursor: pointer;
+  user-select: none;
+  flex: 1 1 auto;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.1rem;
+  border-radius: calc(var(--zt-radius) - 8px);
+  background: var(--zt-bg);
+  color: var(--zt-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow:
+    6px 6px 12px var(--zt-shadow-dark),
+    -6px -6px 12px var(--zt-shadow-light);
+  transition:
+    box-shadow var(--zt-duration) var(--zt-easing),
+    color var(--zt-duration) var(--zt-easing),
+    transform var(--zt-duration) var(--zt-easing);
+}
+
+.zt-tabs__tab:hover {
+  color: var(--zt-text);
+}
+
+.zt-tabs__radio:focus-visible + .zt-tabs__tab {
+  outline: 2px solid var(--zt-accent);
+  outline-offset: 3px;
+}
+
+.zt-tabs__radio:checked + .zt-tabs__tab {
+  color: var(--zt-accent);
+  transform: scale(0.98);
+  box-shadow:
+    inset 4px 4px 8px var(--zt-shadow-dark),
+    inset -4px -4px 8px var(--zt-shadow-light);
+}
+
+/* Panels stack in one grid cell so the wrapper height always matches the
+   tallest panel — no JS measuring needed. */
+.zt-tabs__panels {
+  position: relative;
+  display: grid;
+  grid-template-areas: "stack";
+}
+
+.zt-tabs__panel {
+  grid-area: stack;
+  background: var(--zt-bg);
+  border-radius: var(--zt-radius);
+  padding: 1.75rem;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(var(--zt-zoom-from));
+  box-shadow:
+    8px 8px 16px var(--zt-shadow-dark),
+    -8px -8px 16px var(--zt-shadow-light);
+  transition:
+    transform var(--zt-duration) var(--zt-easing),
+    opacity var(--zt-duration) var(--zt-easing);
+}
+
+#zt-tab-1:checked ~ .zt-tabs__panels [data-panel="1"],
+#zt-tab-2:checked ~ .zt-tabs__panels [data-panel="2"],
+#zt-tab-3:checked ~ .zt-tabs__panels [data-panel="3"] {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 2;
+  transform: scale(1);
+}
+
+/* Neumorphic "well" used by the demo for stat tiles — same soft-inset look */
+.zt-tabs__stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.zt-well {
+  border-radius: calc(var(--zt-radius) - 6px);
+  padding: 1rem;
+  box-shadow:
+    inset 4px 4px 8px var(--zt-shadow-dark),
+    inset -4px -4px 8px var(--zt-shadow-light);
+}
+
+@media (max-width: 640px) {
+  .zt-tabs { padding: 1.1rem; }
+  .zt-tabs__stats { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zt-tabs__tab,
+  .zt-tabs__panel {
+    transition: none;
+  }
+  .zt-tabs__panel { transform: none; }
+  .zt-tabs__radio:checked + .zt-tabs__tab { transform: none; }
+}


### PR DESCRIPTION
Closes #50047

## What this adds

A pure CSS/HTML tabs component (`submissions/examples/css-zoom-in-tabs-neumorphic-soft-50047/`)
with a zoom-in panel transition, styled in a neumorphic ("soft UI")
aesthetic — elements are carved into or raised off a single-color
background using paired light/dark shadows rather than bordered cards.

## Contents

- `demo.html` = three tabs (Overview / Revenue / Traffic), each with sample
  dashboard stat tiles styled as inset neumorphic "wells"
- `style.css` =  pure CSS, radio-input driven tab state (no JavaScript)
- `README.md` = component description, custom properties, usage

## Notes

- No core files touched =  submission-only, under `submissions/examples/`.
- Custom properties exposed for duration, easing, zoom-from scale, and all
  neumorphic colors (background, text, accent, both shadow tones, radius).
- Keyboard accessible: radios stay focusable (visually hidden via clip, not
  `display: none`), with a visible `:focus-visible` outline; tabs meet the
  44px WCAG minimum touch-target size.
- Responsive: tabs wrap and the stat grid collapses to one column under
  640px.
- Respects `prefers-reduced-motion`, snapping to the resting state instead
  of animating.
- Flags a known neumorphism weak point in the README: low shadow contrast
  can be an accessibility concern, so any retheme should be contrast-checked
  against the chosen background before shipping.