### PR TITLE
feat: add CSS slide-up tabs for creative portfolio layouts 

### DIFF
--- a/submissions/examples/css-slide-up-tabs-creative-portfolio-50036/README.md
+++ b/submissions/examples/css-slide-up-tabs-creative-portfolio-50036/README.md
@@ -1,0 +1,56 @@
+# Slide-Up Tabs — Creative Portfolio
+
+Closes #50036
+
+Pure CSS (no JavaScript) tabs component with a slide-up panel transition,
+styled for a creative portfolio / editorial layout — an underline-style nav
+with italic serif type instead of boxed tab buttons, and a project-tile
+grid rather than dashboard stat cards.
+
+## Files
+
+- `demo.html` — three tabs (Selected Work / Editorial / About), each with a
+  sample project-tile grid
+- `style.css` — the component itself; radio-input driven tab state, no JS
+
+## How it works
+
+Tab switching is driven entirely by hidden radio inputs and the `:checked`
+sibling combinator — no JavaScript. The active tab is marked by an
+underline (`::after`, `scaleX` growing from 0 to 1) rather than a
+background/box change. The active panel slides up into place
+(`translateY(--su-slide-distance)` to `0`) combined with an opacity fade.
+
+## Custom properties
+
+All overridable per-instance on the `.su-tabs` wrapper:
+
+| Property | Default | Purpose |
+|---|---|---|
+| `--su-duration` | `0.55s` | Transition duration |
+| `--su-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Transition easing |
+| `--su-slide-distance` | `32px` | How far the panel travels on entrance |
+| `--su-bg` / `--su-panel-bg` | warm off-white / white | Backgrounds |
+| `--su-text` / `--su-text-muted` | near-black / warm gray | Text colors |
+| `--su-accent` | `#d94f2b` | Underline color |
+| `--su-border` | `#e6e5df` | Tab-list divider color |
+| `--su-radius` | `4px` | Corner radius (kept small — editorial layouts read cleaner with sharp-ish corners) |
+| `--su-font-display` | `Georgia, "Times New Roman", serif` | Heading/tab typeface |
+
+## Accessibility
+
+- Radio inputs stay in the natural tab order (visually hidden via clipping,
+  not `display: none`), so native radio-group keyboard behavior — arrow
+  keys to move between tabs, Enter/Space to activate — works out of the box.
+- Visible `:focus-visible` outline on the active tab label.
+- `@media (prefers-reduced-motion: reduce)` disables the slide/underline
+  transitions entirely.
+
+## Responsive
+
+Tab list wraps and the project-tile grid collapses from three columns to
+one under 640px.
+
+## Note on ARIA
+
+This uses native radio/label semantics rather than the ARIA tabs pattern

--- a/submissions/examples/css-slide-up-tabs-creative-portfolio-50036/demo.html
+++ b/submissions/examples/css-slide-up-tabs-creative-portfolio-50036/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Slide-Up Tabs — Creative Portfolio Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f1f0eb;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  .demo-shell { width: min(680px, 92vw); }
+  .section-heading {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 1.4rem;
+    margin: 0 0 1rem;
+  }
+  .section-sub {
+    color: #8a8a85;
+    font-size: 0.85rem;
+    margin: 0 0 1.5rem;
+    max-width: 40ch;
+  }
+</style>
+</head>
+<body>
+
+<div class="demo-shell">
+  <div class="su-tabs">
+    <input type="radio" id="su-tab-1" name="su-tabs" class="su-tabs__radio" checked>
+    <input type="radio" id="su-tab-2" name="su-tabs" class="su-tabs__radio">
+    <input type="radio" id="su-tab-3" name="su-tabs" class="su-tabs__radio">
+
+    <div class="su-tabs__list">
+      <label for="su-tab-1" class="su-tabs__tab">Selected Work</label>
+      <label for="su-tab-2" class="su-tabs__tab">Editorial</label>
+      <label for="su-tab-3" class="su-tabs__tab">About</label>
+    </div>
+
+    <div class="su-tabs__panels">
+
+      <section class="su-tabs__panel" data-panel="1">
+        <h2 class="section-heading">Selected Work</h2>
+        <p class="section-sub">A small collection of recent projects, spanning brand identity, print, and digital design.</p>
+        <div class="su-tabs__grid">
+          <div class="su-tile" style="background: linear-gradient(160deg, #d94f2b, #7a2a15);">Wayfare — Identity</div>
+          <div class="su-tile" style="background: linear-gradient(160deg, #2b4b8f, #16244a);">Lumen — Web</div>
+          <div class="su-tile" style="background: linear-gradient(160deg, #3f7a54, #1e3d29);">Fernweh — Print</div>
+        </div>
+      </section>
+
+      <section class="su-tabs__panel" data-panel="2">
+        <h2 class="section-heading">Editorial</h2>
+        <p class="section-sub">Writing and features on process, craft, and the studio's ongoing experiments.</p>
+        <div class="su-tabs__grid">
+          <div class="su-tile" style="background: linear-gradient(160deg, #8a6d3b, #3e2f14);">On Restraint</div>
+          <div class="su-tile" style="background: linear-gradient(160deg, #6b3f8f, #33204a);">Field Notes</div>
+          <div class="su-tile" style="background: linear-gradient(160deg, #2b7a8f, #163c46);">Type &amp; Texture</div>
+        </div>
+      </section>
+
+      <section class="su-tabs__panel" data-panel="3">
+        <h2 class="section-heading">About</h2>
+        <p class="section-sub">An independent design studio working across brand, editorial, and interactive projects since 2019.</p>
+        <div class="su-tabs__grid">
+          <div class="su-tile" style="background: linear-gradient(160deg, #17181c, #3a3b40);">Studio</div>
+          <div class="su-tile" style="background: linear-gradient(160deg, #d94f2b, #a63a1f);">Contact</div>
+          <div class="su-tile" style="background: linear-gradient(160deg, #4b4b45, #232320);">Process</div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-slide-up-tabs-creative-portfolio-50036/style.css
+++ b/submissions/examples/css-slide-up-tabs-creative-portfolio-50036/style.css
@@ -1,0 +1,156 @@
+/* =============================================================================
+   Slide-Up Tabs — pure CSS, no JavaScript
+   Tabs component with a slide-up panel transition, styled for a creative
+   portfolio / editorial layout — bold serif display type, an underline-style
+   nav instead of boxed tabs, and generous whitespace.
+   ============================================================================= */
+
+.su-tabs {
+  /* Public, overridable API */
+  --su-duration: 0.55s;
+  --su-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --su-slide-distance: 32px;
+  --su-bg: #fafaf7;
+  --su-panel-bg: #ffffff;
+  --su-text: #17181c;
+  --su-text-muted: #8a8a85;
+  --su-accent: #d94f2b;
+  --su-border: #e6e5df;
+  --su-radius: 4px;
+  --su-font-display: Georgia, "Times New Roman", serif;
+
+  display: grid;
+  gap: 2rem;
+  background: var(--su-bg);
+  padding: 2rem;
+  border-radius: var(--su-radius);
+  color: var(--su-text);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Visually hide the native radios but keep them keyboard-focusable —
+   never display:none, that removes them from the tab order. */
+.su-tabs__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.su-tabs__list {
+  display: flex;
+  gap: 2rem;
+  border-bottom: 1px solid var(--su-border);
+  flex-wrap: wrap;
+}
+
+/* Editorial-style nav: no box around the tab, just type + an underline
+   that grows in on the active tab. */
+.su-tabs__tab {
+  position: relative;
+  cursor: pointer;
+  user-select: none;
+  padding: 0.5rem 0.1rem 1rem;
+  font-family: var(--su-font-display);
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--su-text-muted);
+  transition: color var(--su-duration) var(--su-easing);
+}
+
+.su-tabs__tab::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--su-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--su-duration) var(--su-easing);
+}
+
+.su-tabs__tab:hover {
+  color: var(--su-text);
+}
+
+.su-tabs__radio:focus-visible + .su-tabs__tab {
+  outline: 2px solid var(--su-accent);
+  outline-offset: 4px;
+}
+
+.su-tabs__radio:checked + .su-tabs__tab {
+  color: var(--su-text);
+}
+
+.su-tabs__radio:checked + .su-tabs__tab::after {
+  transform: scaleX(1);
+}
+
+/* Panels stack in one grid cell so the wrapper height always matches the
+   tallest panel — no JS measuring needed. */
+.su-tabs__panels {
+  position: relative;
+  display: grid;
+  grid-template-areas: "stack";
+  overflow: hidden;
+}
+
+.su-tabs__panel {
+  grid-area: stack;
+  padding: 0.5rem 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(var(--su-slide-distance));
+  transition:
+    transform var(--su-duration) var(--su-easing),
+    opacity var(--su-duration) var(--su-easing);
+}
+
+#su-tab-1:checked ~ .su-tabs__panels [data-panel="1"],
+#su-tab-2:checked ~ .su-tabs__panels [data-panel="2"],
+#su-tab-3:checked ~ .su-tabs__panels [data-panel="3"] {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 2;
+  transform: translateY(0);
+}
+
+/* Portfolio-style project grid used by the demo */
+.su-tabs__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.su-tile {
+  aspect-ratio: 4 / 3;
+  border-radius: var(--su-radius);
+  display: flex;
+  align-items: flex-end;
+  padding: 0.75rem;
+  color: #fff;
+  font-family: var(--su-font-display);
+  font-style: italic;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  .su-tabs { padding: 1.25rem; gap: 1.5rem; }
+  .su-tabs__list { gap: 1.25rem; }
+  .su-tabs__grid { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .su-tabs__tab::after,
+  .su-tabs__panel {
+    transition: none;
+  }
+  .su-tabs__panel { transform: none; }
+}


### PR DESCRIPTION
Closes #50036

## What this adds

A pure CSS/HTML tabs component (`submissions/examples/css-slide-up-tabs-creative-portfolio-50036/`)
with a slide-up panel transition, styled for a creative portfolio /
editorial layout  = an underline-style nav with italic serif type instead of
boxed tab buttons, and a project-tile grid rather than dashboard stat cards.

## Contents

- `demo.html` = three tabs (Selected Work / Editorial / About), each with a
  sample project-tile grid
- `style.css` =  pure CSS, radio-input driven tab state (no JavaScript)
- `README.md` = component description, custom properties, usage

## Notes

- No core files touched =  submission-only, under `submissions/examples/`.
- Custom properties exposed for duration, easing, slide distance, colors,
  border, radius, and display typeface.
- Keyboard accessible: radios stay focusable (visually hidden via clip, not
  `display: none`), with a visible `:focus-visible` outline.
- Responsive: tab list wraps and the project grid collapses to one column
  under 640px.
- Respects `prefers-reduced-motion`, snapping to the resting state instead
  of animating.