### PR TITLE
feat: add sway select mixin example

### DIFF
--- a/submissions/scss/feature-sway-select-mixin-mixin-sb/README.md
+++ b/submissions/scss/feature-sway-select-mixin-mixin-sb/README.md
@@ -1,0 +1,34 @@
+# Feature Sway Select Mixin (SB)
+
+## Overview
+
+A reusable SCSS mixin that applies a subtle sway animation when a `<select>` element gains keyboard or mouse focus.
+
+## Features
+
+- Reusable SCSS mixin
+- Customizable animation duration
+- Smooth sway animation
+- Accessible focus styling
+- Supports `prefers-reduced-motion`
+
+## Usage
+
+```scss
+@use "ease-motion" as *;
+
+.my-select {
+  @include feature-sway-select-mixin-mixin-sb(0.5s);
+}
+```
+
+## Accessibility
+
+- Uses `:focus` and `:focus-visible`
+- Honors `prefers-reduced-motion: reduce`
+- Includes a visible focus ring
+
+## Files
+
+- `_sway-select-mixin.scss`
+- `README.md`

--- a/submissions/scss/feature-sway-select-mixin-mixin-sb/_sway-select-mixin.scss
+++ b/submissions/scss/feature-sway-select-mixin-mixin-sb/_sway-select-mixin.scss
@@ -1,0 +1,46 @@
+/// Sway Select Mixin - SB
+/// Adds a gentle sway animation when a select element receives focus.
+/// Duration is customizable.
+
+@mixin feature-sway-select-mixin-mixin-sb($duration: 0.5s) {
+  transition: transform $duration ease, box-shadow $duration ease;
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+    animation: feature-sway-select-sb $duration ease;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:focus,
+    &:focus-visible {
+      animation: none;
+      transform: none;
+    }
+  }
+}
+
+@keyframes feature-sway-select-sb {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  25% {
+    transform: rotate(-2deg);
+  }
+
+  50% {
+    transform: rotate(2deg);
+  }
+
+  75% {
+    transform: rotate(-1deg);
+  }
+
+  100% {
+    transform: rotate(0deg);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new self-contained **Sway Select Mixin** under:

`submissions/scss/feature-sway-select-mixin-mixin-sb/`

### Features

- Reusable SCSS mixin for select focus animation
- Smooth sway effect on `:focus` and `:focus-visible`
- Customizable animation duration
- Visible focus ring for better accessibility
- Supports `prefers-reduced-motion`
- Beginner-friendly and easy to integrate
- Does not modify any core framework files

### Files Included

- `_sway-select-mixin.scss`
- `README.md`

Closes #52630