### PR TITLE
feat(scss): add Glide Textarea mixin (Exit Animation) — closes #52626

### DIFF
--- a/submissions/scss/feature-glide-textarea-mixin-mixin-XX/README.md
+++ b/submissions/scss/feature-glide-textarea-mixin-mixin-XX/README.md
@@ -1,0 +1,63 @@
+# Glide Textarea Mixin (feature-glide-textarea-mixin-mixin-XX)
+
+## What it does
+A SCSS mixin that gives a `<textarea>` (or its wrapper) a smooth
+**glide-out exit animation** — a gentle downward slide combined with
+a fade and slight scale-down. Ideal for dismissible comment boxes,
+inline edit fields, or feedback forms that disappear after submission
+or cancellation.
+
+## How to use
+```scss
+@use 'ease-motion' as *;
+
+.my-textarea-wrapper {
+  @include ease-glide-textarea-mixin-XX(0.5s);
+}
+```
+
+Toggle the `.is-exiting` class (e.g. via JS) right before removing the
+element from the DOM, then remove the node once the animation ends:
+
+```js
+const el = document.querySelector('.my-textarea-wrapper');
+el.classList.add('is-exiting');
+el.addEventListener('animationend', () => el.remove(), { once: true });
+```
+
+### Parameters
+
+| Parameter   | Type      | Default                       | Description                              |
+|-------------|-----------|--------------------------------|--------------------------------------------|
+| `$duration` | time      | `0.5s`                         | How long the glide-out animation takes     |
+| `$distance` | length    | `40px`                         | How far the element travels downward       |
+| `$easing`   | timing fn | `cubic-bezier(0.4, 0, 0.2, 1)` | Easing curve for the glide                 |
+
+### Example markup
+```html
+<div class="my-textarea-wrapper">
+  <label for="feedback">Feedback</label>
+  <textarea id="feedback" rows="4"></textarea>
+  <button type="button" id="cancel-btn">Cancel</button>
+</div>
+```
+
+## Why it's useful
+- **Purposeful feedback**: an exit animation signals removal instead
+  of an abrupt disappearance, reducing layout jank surprise.
+- **Configurable**: duration, distance, and easing are adjustable per use.
+- **Trigger-based**: driven by a single `.is-exiting` class, so it's
+  easy to hook into any framework's state/lifecycle logic.
+- **Accessible**:
+  - Works with a properly labeled `<textarea>` (`<label for>` pairing).
+  - Fully respects `prefers-reduced-motion: reduce` — the element
+    fades out immediately without translation/scale for users who
+    prefer reduced motion.
+- **Lightweight**: pure CSS animation, no dependencies, no JS animation logic.
+
+## Accessibility notes
+- Always pair the textarea with a `<label>` (visible or `aria-label`)
+  so its purpose is announced by assistive tech before it exits.
+- If the textarea's removal is a significant state change (e.g. after
+  a successful submit), consider announcing that via an `aria-live`
+  region elsewhere in the UI rather than relying on the animation alone.

--- a/submissions/scss/feature-glide-textarea-mixin-mixin-XX/_glide-textarea-mixin.scss
+++ b/submissions/scss/feature-glide-textarea-mixin-mixin-XX/_glide-textarea-mixin.scss
@@ -1,0 +1,38 @@
+// ============================================================
+// Glide Textarea Mixin (Exit Animation) — EaseMotion CSS
+// Submission by: XX
+// A textarea that glides smoothly out of view when dismissed
+// (e.g. on submit, cancel, or removal from the DOM flow).
+// Respects prefers-reduced-motion.
+// ============================================================
+
+@mixin ease-glide-textarea-mixin-XX(
+  $duration: 0.5s,
+  $distance: 40px,
+  $easing: cubic-bezier(0.4, 0, 0.2, 1)
+) {
+  transform-origin: center;
+  will-change: transform, opacity;
+
+  &.is-exiting {
+    animation: ease-glide-out-XX #{$duration} #{$easing} forwards;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &.is-exiting {
+      animation: none;
+      opacity: 0;
+    }
+  }
+
+  @keyframes ease-glide-out-XX {
+    0% {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(#{$distance}) scale(0.97);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a standalone SCSS mixin implementing a **Glide Textarea** (Exit Animation)
as requested in #52626. The mixin animates a textarea (or its wrapper) gliding
smoothly out of view — sliding down, fading, and slightly scaling down — when
an `.is-exiting` class is applied.

## Changes
- `submissions/scss/feature-glide-textarea-mixin-mixin-XX/_glide-textarea-mixin.scss` —
  the `ease-glide-textarea-mixin-XX` mixin and `ease-glide-out-XX` keyframes
- `submissions/scss/feature-glide-textarea-mixin-mixin-XX/README.md` —
  usage docs, parameter table, and accessibility notes

## Details
- Pure CSS keyframe animation, no JS animation dependencies
- Configurable `$duration`, `$distance`, and `$easing` parameters
- Driven by a single `.is-exiting` trigger class for easy integration
  with any framework's dismiss/removal logic
- Unique `XX` suffix applied to folder name, mixin name, and keyframes
  to avoid conflicts with other submissions, per contribution policy

## Accessibility
- Intended for use with a properly labeled `<textarea>`
- Fully respects `prefers-reduced-motion: reduce` — animation is
  disabled and the element fades out immediately with no motion

## Scope
- Only files added inside `submissions/scss/feature-glide-textarea-mixin-mixin-XX/`
- No changes to `core/`, `components/`, `docs/`, or `examples/`

Closes #52626