### PR TITLE
feat(submission): add ease-blur-entrance-saas-carousel component (#50514)

### DIFF
--- a/submissions/examples/ease-blur-entrance-saas-carousel-ksk/README.md
+++ b/submissions/examples/ease-blur-entrance-saas-carousel-ksk/README.md
@@ -1,0 +1,23 @@
+# SaaS Blur-Entrance Carousel (`ease-blur-entrance-saas-carousel-ksk`)
+
+1. What does this do?  
+An interactive 2-column SaaS feature showcase carousel. Active feature slides enter from a blurred scale state (`filter: blur(16px) scale(0.94)`) to clear full-scale size, while the right-side SVG mockup container plays a spring-loaded rise reveal. Controlled via top feature pills, side arrows, or bottom indicator dots.
+
+2. How is it used?  
+Define three radio inputs named `saas-group` (`#saas-1`, `#saas-2`, `#saas-3`) preceding `.saas-carousel-card`. Set up `<label>` elements pointing to the radio IDs for feature pills, arrows, and indicator dots. Customize transitions via CSS custom properties:
+
+```css
+.saas-carousel-card {
+  --ease-saas-blur:     16px;          /* entrance blur amount          */
+  --ease-saas-scale:    0.94;          /* entrance scale offset         */
+  --ease-saas-duration: 0.5s;          /* transition duration           */
+  --ease-saas-easing:   cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-saas-accent:   #6366f1;       /* primary theme color           */
+}
+```
+
+3. Why is it useful?  
+Designed specifically for SaaS landing pages and product feature showcases. Offers a multi-feature presentation deck with responsive two-column layouts (stacking automatically on mobile screens) and fluid spring motion—all operating 100% without JavaScript.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #50514.*

--- a/submissions/examples/ease-blur-entrance-saas-carousel-ksk/demo.html
+++ b/submissions/examples/ease-blur-entrance-saas-carousel-ksk/demo.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SaaS Blur-Entrance Carousel — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #060911;
+      background-image:
+        radial-gradient(ellipse at 20% 30%, rgba(99, 102, 241, 0.12) 0%, transparent 55%),
+        radial-gradient(ellipse at 80% 70%, rgba(168, 85, 247, 0.09) 0%, transparent 55%);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, #818cf8, #c084fc);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin: 0 0 0.4rem;
+      letter-spacing: -0.015em;
+    }
+    .page-header p {
+      color: #475569;
+      font-size: 0.88rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-header">
+    <h1>SaaS Feature Showcase Carousel</h1>
+    <p>Pure CSS carousel. Switch feature pills or use navigation arrows to experience blur-entrance transitions.</p>
+  </div>
+
+  <!-- ── Pure CSS Radio Switches (must precede the card) ── -->
+  <input type="radio" name="saas-group" id="saas-1" class="saas-radio" checked>
+  <input type="radio" name="saas-group" id="saas-2" class="saas-radio">
+  <input type="radio" name="saas-group" id="saas-3" class="saas-radio">
+
+  <!-- SaaS Carousel Container -->
+  <div class="saas-carousel-card">
+
+    <!-- Top Feature Tab Navigation Bar -->
+    <div class="saas-feature-tabs">
+      <label for="saas-1" class="saas-tab-pill pill-1">AI Analytics</label>
+      <label for="saas-2" class="saas-tab-pill pill-2">Workflows</label>
+      <label for="saas-3" class="saas-tab-pill pill-3">Security &amp; SLA</label>
+    </div>
+
+    <!-- Directional Navigation Arrows -->
+    <label for="saas-2" class="saas-arrow arrow-right arrow-to-2" role="button" aria-label="Next slide">›</label>
+
+    <label for="saas-1" class="saas-arrow arrow-left arrow-to-1" role="button" aria-label="Previous slide">‹</label>
+    <label for="saas-3" class="saas-arrow arrow-right arrow-to-3" role="button" aria-label="Next slide">›</label>
+
+    <label for="saas-2" class="saas-arrow arrow-left arrow-to-2-left" role="button" aria-label="Previous slide">‹</label>
+
+    <!-- ── Viewport containing stacked SaaS slides ── -->
+    <div class="saas-viewport">
+
+      <!-- Slide 1: AI Analytics Engine -->
+      <div class="saas-slide slide-1">
+        <div class="saas-slide-left">
+          <span class="saas-badge">✨ AI Analytics</span>
+          <h2 class="saas-title">Predictive Insights Pipeline</h2>
+          <p class="saas-desc">
+            Transform raw telemetry into real-time business decisions with automated pattern detection and instant anomaly alerts.
+          </p>
+          <div class="saas-actions">
+            <a href="#" class="saas-btn-primary">Try Demo →</a>
+            <a href="#" class="saas-btn-secondary">View Specs</a>
+          </div>
+        </div>
+
+        <div class="saas-slide-right">
+          <div class="mockup-box">
+            <!-- Data Chart SVG Mockup -->
+            <svg width="180" height="120" viewBox="0 0 180 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect width="180" height="120" rx="8" fill="#0b0f19"/>
+              <path d="M20 90 L50 60 L80 75 L120 35 L160 50" stroke="#6366f1" stroke-width="3" stroke-linecap="round"/>
+              <path d="M20 90 L50 60 L80 75 L120 35 L160 50 L160 110 L20 110 Z" fill="url(#chart-grad)" opacity="0.3"/>
+              <circle cx="120" cy="35" r="5" fill="#818cf8"/>
+              <defs>
+                <linearGradient id="chart-grad" x1="90" y1="35" x2="90" y2="110" gradientUnits="userSpaceOnUse">
+                  <stop stop-color="#6366f1"/>
+                  <stop offset="1" stop-color="#6366f1" stop-opacity="0"/>
+                </linearGradient>
+              </defs>
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      <!-- Slide 2: Automated Workflows -->
+      <div class="saas-slide slide-2" style="--ease-saas-accent: #a855f7; --ease-saas-accent-glow: rgba(168, 85, 247, 0.35);">
+        <div class="saas-slide-left">
+          <span class="saas-badge" style="background:rgba(168,85,247,0.12);border-color:rgba(168,85,247,0.25);color:#c084fc;">⚡ Automation</span>
+          <h2 class="saas-title">No-Code Trigger Pipelines</h2>
+          <p class="saas-desc">
+            Connect your stack in minutes. Build event-driven automation rules, webhook relays, and multi-step tasks without code.
+          </p>
+          <div class="saas-actions">
+            <a href="#" class="saas-btn-primary" style="background:#a855f7;box-shadow:0 4px 14px rgba(168,85,247,0.35);">Explore Workflows →</a>
+            <a href="#" class="saas-btn-secondary">Integrations</a>
+          </div>
+        </div>
+
+        <div class="saas-slide-right">
+          <div class="mockup-box">
+            <!-- Node Pipeline SVG Mockup -->
+            <svg width="180" height="120" viewBox="0 0 180 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect width="180" height="120" rx="8" fill="#0b0f19"/>
+              <rect x="25" y="45" width="30" height="30" rx="6" fill="#1e1b4b" stroke="#a855f7" stroke-width="1.5"/>
+              <rect x="75" y="45" width="30" height="30" rx="6" fill="#1e1b4b" stroke="#c084fc" stroke-width="1.5"/>
+              <rect x="125" y="45" width="30" height="30" rx="6" fill="#1e1b4b" stroke="#a855f7" stroke-width="1.5"/>
+              <path d="M55 60 L75 60" stroke="#a855f7" stroke-width="2" stroke-dasharray="3 3"/>
+              <path d="M105 60 L125 60" stroke="#a855f7" stroke-width="2" stroke-dasharray="3 3"/>
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      <!-- Slide 3: Enterprise Security & SLA -->
+      <div class="saas-slide slide-3" style="--ease-saas-accent: #10b981; --ease-saas-accent-glow: rgba(16, 185, 129, 0.35);">
+        <div class="saas-slide-left">
+          <span class="saas-badge" style="background:rgba(16,185,129,0.12);border-color:rgba(16,185,129,0.25);color:#34d399;">🔒 Security</span>
+          <h2 class="saas-title">99.99% Uptime &amp; SAML SSO</h2>
+          <p class="saas-desc">
+            Bank-grade encryption, SOC2 Type II compliance, automated audit logging, and guaranteed SLA for enterprise peace of mind.
+          </p>
+          <div class="saas-actions">
+            <a href="#" class="saas-btn-primary" style="background:#10b981;box-shadow:0 4px 14px rgba(16,185,129,0.35);">Security Portal →</a>
+            <a href="#" class="saas-btn-secondary">SOC2 Report</a>
+          </div>
+        </div>
+
+        <div class="saas-slide-right">
+          <div class="mockup-box">
+            <!-- Shield SVG Mockup -->
+            <svg width="180" height="120" viewBox="0 0 180 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect width="180" height="120" rx="8" fill="#0b0f19"/>
+              <path d="M90 30 L115 42 V68 C115 85 90 95 90 95 C90 95 65 85 65 68 V42 L90 30 Z" fill="rgba(16,185,129,0.15)" stroke="#10b981" stroke-width="2"/>
+              <path d="M82 60 L88 66 L98 54" stroke="#34d399" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Bottom Indicator Dots -->
+    <div class="saas-dots">
+      <label for="saas-1" class="saas-dot dot-1" role="button" aria-label="Go to slide 1"></label>
+      <label for="saas-2" class="saas-dot dot-2" role="button" aria-label="Go to slide 2"></label>
+      <label for="saas-3" class="saas-dot dot-3" role="button" aria-label="Go to slide 3"></label>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-blur-entrance-saas-carousel-ksk/style.css
+++ b/submissions/examples/ease-blur-entrance-saas-carousel-ksk/style.css
@@ -1,0 +1,329 @@
+/* ============================================================
+   EaseMotion CSS — Blur-Entrance Carousel (SaaS Showcase)
+   submissions/examples/ease-blur-entrance-saas-carousel-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .saas-carousel-card or any ancestor.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-saas-blur:     16px;          /* entrance blur amount          */
+  --ease-saas-scale:    0.94;          /* entrance scale offset         */
+  --ease-saas-duration: 0.5s;          /* transition duration           */
+  --ease-saas-easing:   cubic-bezier(0.34, 1.56, 0.64, 1); /* spring   */
+  --ease-saas-bg:       #090d16;
+  --ease-saas-card:     #0e1322;
+  --ease-saas-border:   rgba(255, 255, 255, 0.08);
+  --ease-saas-radius:   24px;
+  --ease-saas-accent:   #6366f1;       /* Indigo accent                 */
+  --ease-saas-accent-glow: rgba(99, 102, 241, 0.35);
+  --ease-saas-font:     system-ui, -apple-system, sans-serif;
+}
+
+/* ── Radio Switches (hidden) ────────────────────────────── */
+.saas-radio {
+  display: none;
+}
+
+/* ── SaaS Showcase Card Container ───────────────────────── */
+.saas-carousel-card {
+  width: 100%;
+  max-width: 720px;
+  background: var(--ease-saas-card);
+  border: 1px solid var(--ease-saas-border);
+  border-radius: var(--ease-saas-radius);
+  box-shadow:
+    0 30px 70px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  padding: 32px;
+  box-sizing: border-box;
+  font-family: var(--ease-saas-font);
+  color: #f8fafc;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Top Feature Tab Navigation Bar */
+.saas-feature-tabs {
+  display: flex;
+  gap: 8px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--ease-saas-border);
+  border-radius: 14px;
+  padding: 6px;
+  margin-bottom: 24px;
+  z-index: 10;
+}
+
+.saas-tab-pill {
+  flex: 1;
+  padding: 10px 14px;
+  text-align: center;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #64748b;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  user-select: none;
+}
+
+.saas-tab-pill:hover {
+  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* Active Feature Pill Highlighting */
+#saas-1:checked ~ .saas-carousel-card .pill-1,
+#saas-2:checked ~ .saas-carousel-card .pill-2,
+#saas-3:checked ~ .saas-carousel-card .pill-3 {
+  background: var(--ease-saas-accent);
+  color: #ffffff;
+  box-shadow: 0 4px 14px var(--ease-saas-accent-glow);
+}
+
+/* ── Viewport & Stacked Slides ──────────────────────────── */
+.saas-viewport {
+  position: relative;
+  min-height: 260px;
+}
+
+.saas-slide {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: center;
+  /* Blurred Starting State */
+  opacity: 0;
+  filter: blur(var(--ease-saas-blur));
+  transform: scale(var(--ease-saas-scale));
+  pointer-events: none;
+  transition:
+    opacity 0.45s ease,
+    filter 0.45s ease,
+    transform var(--ease-saas-duration) var(--ease-saas-easing);
+}
+
+/* Active Slide Revealed State */
+#saas-1:checked ~ .saas-carousel-card .slide-1,
+#saas-2:checked ~ .saas-carousel-card .slide-2,
+#saas-3:checked ~ .saas-carousel-card .slide-3 {
+  opacity: 1;
+  filter: blur(0px);
+  transform: scale(1);
+  pointer-events: auto;
+  z-index: 5;
+}
+
+/* ── Left Column: Typography & CTAs ─────────────────────── */
+.saas-slide-left {
+  display: flex;
+  flex-direction: column;
+}
+
+.saas-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 99px;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  color: #818cf8;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  width: fit-content;
+  margin-bottom: 12px;
+}
+
+.saas-title {
+  font-size: 1.45rem;
+  font-weight: 800;
+  line-height: 1.25;
+  color: #ffffff;
+  margin: 0 0 10px;
+  letter-spacing: -0.015em;
+}
+
+.saas-desc {
+  color: #94a3b8;
+  font-size: 0.84rem;
+  line-height: 1.6;
+  margin: 0 0 20px;
+}
+
+.saas-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.saas-btn-primary {
+  padding: 10px 18px;
+  border-radius: 10px;
+  background: var(--ease-saas-accent);
+  border: none;
+  color: #ffffff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 4px 14px var(--ease-saas-accent-glow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.saas-btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px var(--ease-saas-accent-glow);
+}
+
+.saas-btn-secondary {
+  color: #94a3b8;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.saas-btn-secondary:hover {
+  color: #ffffff;
+}
+
+/* ── Right Column: Interactive Mockup Illustrations ─────── */
+.saas-slide-right {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.mockup-box {
+  width: 100%;
+  height: 200px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid var(--ease-saas-border);
+  border-radius: 16px;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* SVG Mockup Child Spring Animation */
+#saas-1:checked ~ .saas-carousel-card .slide-1 .mockup-box,
+#saas-2:checked ~ .saas-carousel-card .slide-2 .mockup-box,
+#saas-3:checked ~ .saas-carousel-card .slide-3 .mockup-box {
+  animation: saas-mockup-reveal 0.6s var(--ease-saas-easing) 0.1s both;
+}
+
+/* ── Directional Navigation Arrows ──────────────────────── */
+.saas-arrow {
+  position: absolute;
+  top: 58%;
+  transform: translateY(-50%);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid var(--ease-saas-border);
+  color: #94a3b8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  font-size: 1.1rem;
+  font-weight: bold;
+  user-select: none;
+}
+
+.saas-arrow:hover {
+  background: rgba(30, 41, 59, 0.9);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.arrow-left { left: 12px; }
+.arrow-right { right: 12px; }
+
+/* Control Arrow visibility based on active checkbox state */
+.saas-arrow { display: none; }
+
+/* Slide 1 controls */
+#saas-1:checked ~ .saas-carousel-card .arrow-to-2 { display: flex; }
+
+/* Slide 2 controls */
+#saas-2:checked ~ .saas-carousel-card .arrow-to-1,
+#saas-2:checked ~ .saas-carousel-card .arrow-to-3 { display: flex; }
+
+/* Slide 3 controls */
+#saas-3:checked ~ .saas-carousel-card .arrow-to-2-left { display: flex; }
+
+/* ── Bottom Indicator Dots ──────────────────────────────── */
+.saas-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.saas-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  cursor: pointer;
+  transition: background 0.25s ease, width 0.25s ease, border-radius 0.25s ease;
+}
+
+.saas-dot:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+#saas-1:checked ~ .saas-carousel-card .dot-1,
+#saas-2:checked ~ .saas-carousel-card .dot-2,
+#saas-3:checked ~ .saas-carousel-card .dot-3 {
+  background: var(--ease-saas-accent);
+  width: 20px;
+  border-radius: 4px;
+  box-shadow: 0 0 10px var(--ease-saas-accent-glow);
+}
+
+/* ── Keyframes ───────────────────────────────────────────── */
+@keyframes saas-mockup-reveal {
+  0% {
+    opacity: 0;
+    transform: translateY(16px) scale(0.92);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── Media Queries for Responsiveness ──────────────────── */
+@media (max-width: 640px) {
+  .saas-slide {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .saas-viewport {
+    min-height: 420px;
+  }
+  .mockup-box {
+    height: 150px;
+  }
+}


### PR DESCRIPTION
Closes #50514

Adds an interactive SaaS Showcase Blur-Entrance Carousel component under `submissions/examples/ease-blur-entrance-saas-carousel-ksk/`.

#### Key Features

1. **SaaS Two-Column Showcase Layout** — Each slide features a responsive two-column grid: left side contains category pills, headlines, descriptions, and dual CTA buttons (`Try Demo` & `Specs`); right side presents an interactive vector SVG mockup (Data Charts, Node Workflows, Security Shield).
2. **Blur-Entrance & Mockup Spring Reveal** — Switching slides plays a smooth blur fade-in transition (`filter: blur(16px) scale(0.94)`) while the right-side SVG mockup container plays an independent spring rise animation (`saas-mockup-reveal`).
3. **Triple Navigation Controls** — Supports top feature pill tabs (AI Analytics, Workflows, Security), side directional arrow buttons, and bottom indicator dots.
4. **Responsive Stacking** — Automatically transforms from a two-column desktop grid to a single-column layout on mobile viewports (<640px).
5. **5 Customizable Variables** — Override `--ease-saas-blur`, `--ease-saas-scale`, `--ease-saas-duration`, `--ease-saas-easing`, and `--ease-saas-accent` inline.
6. **No JavaScript** — Operates 100% in pure CSS using standard radio button hacks and sibling selectors.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | 2-column SaaS layout grid, blur transitions, mockup spring keyframe, feature pill tab styles |
| `demo.html` | Dashboard card presenting 3 SaaS feature slides (Analytics, Automation, Security) |
| `README.md` | Integration guide and CSS variables reference table, resolving `#50514` |