### PR TITLE
feat: add tabs focus indicator example

### DIFF
--- a/submissions/examples/tabs-focus-indicator/README.md
+++ b/submissions/examples/tabs-focus-indicator/README.md
@@ -1,0 +1,15 @@
+# Tabs Focus Indicator
+
+This example adds a tab group with a sliding focus and hover indicator.
+
+## Files
+
+- `demo.html` contains the tablist and tab buttons.
+- `style.css` defines the sliding indicator, focus states, responsive fallback, and reduced-motion behavior.
+
+## Highlights
+
+- Uses `role="tablist"` and `role="tab"` for the demo structure.
+- Keeps tab button dimensions stable while the indicator moves.
+- Supports hover and keyboard focus states.
+- Removes indicator transition timing for reduced-motion users.

--- a/submissions/examples/tabs-focus-indicator/demo.html
+++ b/submissions/examples/tabs-focus-indicator/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tabs Focus Indicator</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="tabs-stage" aria-label="Tabs focus indicator animation demo">
+      <div class="tabs" role="tablist" aria-label="Dashboard views">
+        <button type="button" role="tab">Overview</button>
+        <button type="button" role="tab" aria-selected="true">Activity</button>
+        <button type="button" role="tab">Reports</button>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/tabs-focus-indicator/style.css
+++ b/submissions/examples/tabs-focus-indicator/style.css
@@ -1,0 +1,95 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #172033;
+  --muted: #64748b;
+  --panel: #ffffff;
+  --accent: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #f5f3ff, #f8fafc);
+  color: var(--ink);
+}
+
+.tabs-stage {
+  width: min(92vw, 36rem);
+  padding: 2rem;
+}
+
+.tabs {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 1.5rem 3rem rgba(124, 58, 237, 0.14);
+}
+
+.tabs::before {
+  content: "";
+  position: absolute;
+  top: 0.35rem;
+  bottom: 0.35rem;
+  left: calc(33.333% + 0.12rem);
+  width: calc(33.333% - 0.24rem);
+  border-radius: 8px;
+  background: #ede9fe;
+  transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tabs:hover::before,
+.tabs:focus-within::before {
+  transform: translateX(100%);
+}
+
+button {
+  position: relative;
+  z-index: 1;
+  min-height: 3rem;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+[aria-selected="true"],
+button:hover,
+button:focus-visible {
+  color: var(--ink);
+  outline: none;
+}
+
+button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.24);
+}
+
+@media (max-width: 32rem) {
+  .tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .tabs::before {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a tabs focus indicator animation example
- include tablist markup and keyboard focus states
- document reduced-motion support

## Verification
- git diff --cached --check