### PR TITLE
feat: add empty cart bounce example

### DIFF
--- a/submissions/examples/empty-cart-bounce/README.md
+++ b/submissions/examples/empty-cart-bounce/README.md
@@ -1,0 +1,15 @@
+# Empty Cart Bounce
+
+This example adds an empty cart state with a subtle bouncing icon and clear call to action.
+
+## Files
+
+- `demo.html` contains the empty cart message and CTA.
+- `style.css` defines the card layout, icon bounce, focus state, and reduced-motion fallback.
+
+## Highlights
+
+- Keeps the empty-state card dimensions stable.
+- Uses a lightweight icon bounce for visual emphasis.
+- Includes a keyboard-focusable call-to-action button.
+- Disables the bounce when reduced motion is requested.

--- a/submissions/examples/empty-cart-bounce/demo.html
+++ b/submissions/examples/empty-cart-bounce/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Empty Cart Bounce</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="cart-stage" aria-label="Empty cart bounce animation demo">
+      <section class="empty-cart">
+        <span aria-hidden="true">□</span>
+        <h1>Your cart is empty</h1>
+        <p>Add items to start a checkout.</p>
+        <button type="button">Browse products</button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/empty-cart-bounce/style.css
+++ b/submissions/examples/empty-cart-bounce/style.css
@@ -1,0 +1,102 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #172033;
+  --muted: #64748b;
+  --panel: #ffffff;
+  --accent: #ef4444;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #fef2f2, #f8fafc);
+  color: var(--ink);
+}
+
+.cart-stage {
+  width: min(92vw, 28rem);
+  padding: 2rem;
+}
+
+.empty-cart {
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+  min-height: 22rem;
+  padding: 2rem;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(239, 68, 68, 0.12);
+}
+
+.empty-cart > span {
+  width: 4.6rem;
+  height: 4.6rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #fee2e2;
+  color: var(--accent);
+  font-size: 2.4rem;
+  font-weight: 900;
+  animation: cart-bounce 1.6s ease-in-out infinite;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  margin-top: 0.4rem;
+  font-size: 1.6rem;
+}
+
+p {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+button {
+  min-height: 3rem;
+  margin-top: 0.8rem;
+  padding: 0 1rem;
+  border: 0;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(239, 68, 68, 0.28);
+  outline-offset: 4px;
+}
+
+@keyframes cart-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-0.35rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .empty-cart > span {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add an empty cart bounce animation example
- include stable empty-state card and CTA focus state
- document reduced-motion support

## Verification
- git diff --cached --check