### PR TITLE
feat: add stats card hover example

### DIFF
--- a/submissions/examples/stats-card-hover/README.md
+++ b/submissions/examples/stats-card-hover/README.md
@@ -1,0 +1,15 @@
+# Stats Card Hover
+
+This example adds a metrics card that lifts and strengthens its shadow on hover or keyboard focus.
+
+## Files
+
+- `demo.html` contains the focusable stats card markup.
+- `style.css` defines the hover lift, focus state, and reduced-motion fallback.
+
+## Highlights
+
+- Keeps the card dimensions stable while animating with transforms.
+- Supports hover and keyboard focus interactions.
+- Uses clear metric hierarchy and status color.
+- Removes motion when reduced motion is requested.

--- a/submissions/examples/stats-card-hover/demo.html
+++ b/submissions/examples/stats-card-hover/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stats Card Hover</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stats-stage" aria-label="Stats card hover animation demo">
+      <article class="stats-card" tabindex="0">
+        <span>Revenue</span>
+        <strong>$24.8k</strong>
+        <p>Up 18% this week</p>
+      </article>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/stats-card-hover/style.css
+++ b/submissions/examples/stats-card-hover/style.css
@@ -1,0 +1,74 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: #172033;
+  --muted: #64748b;
+  --panel: #ffffff;
+  --accent: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #f0fdf4, #f8fafc);
+  color: var(--ink);
+}
+
+.stats-stage {
+  width: min(92vw, 26rem);
+  padding: 2rem;
+}
+
+.stats-card {
+  min-height: 14rem;
+  display: grid;
+  align-content: center;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 1.5rem 3rem rgba(22, 163, 74, 0.14);
+  transition: transform 240ms ease, border-color 240ms ease, box-shadow 240ms ease;
+}
+
+.stats-card:hover,
+.stats-card:focus-visible {
+  transform: translateY(-0.35rem);
+  border-color: rgba(22, 163, 74, 0.45);
+  box-shadow: 0 2rem 3.5rem rgba(22, 163, 74, 0.2);
+  outline: none;
+}
+
+span {
+  color: var(--muted);
+  font-weight: 850;
+}
+
+strong {
+  font-size: 2.8rem;
+  line-height: 1;
+}
+
+p {
+  margin: 0;
+  color: var(--accent);
+  font-weight: 850;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stats-card {
+    transition: none;
+  }
+
+  .stats-card:hover,
+  .stats-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a stats card hover animation example
- include keyboard focus and reduced-motion states

## Verification
- git diff --cached --check