### PR TITLE
Add CSS Fade-In Carousel for Neumorphic Soft Layouts

### DIFF
--- a/submissions/examples/Add CSS Fade-In Carousel for Neumorphic Soft Layouts #50414/README.md
+++ b/submissions/examples/Add CSS Fade-In Carousel for Neumorphic Soft Layouts #50414/README.md
@@ -1,0 +1,34 @@
+# CSS Fade-In Carousel (Neumorphic Soft)
+
+A pure CSS animated Carousel component utilizing a smooth **Fade-In** (cross-fade) interaction transition. It is beautifully styled with a **Neumorphic Soft** design language, showcased as a sleek Audio Player UI.
+
+This component is entirely script-free, leveraging HTML structure and CSS variables to handle interactions, layout, and state.
+
+## Features
+- **Pure CSS State & Routing:** Utilizes the radio-button state hack (`:checked`). Uniquely, this iteration also implements a pure CSS "Next/Prev" routing logic by dynamically overlaying invisible labels over static UI buttons based on the current active state.
+- **Fade-In Transition:** Unlike sliding carousels, items are stacked using `position: absolute`. Inactive items are scaled down, blurred, and faded to `opacity: 0`. The active item cross-fades in seamlessly.
+- **Neumorphic Design:**
+  - Soft, extruded shadows (`var(--neu-extruded)`) for the player body, album covers, and unpressed buttons.
+  - Recessed, inset shadows (`var(--neu-pressed)`) applied when buttons are clicked (active state) and for the center of the vinyl record.
+- **Custom CSS Parameters:** Adjust transition timings, easings, blur amounts, and scale factors via exposed CSS variables in `:root`.
+- **Keyboard Accessible:** Navigation is accessible via keyboard arrow keys by focusing the hidden radio inputs.
+
+## Usage
+Simply launch `demo.html` in your browser. 
+To implement this in your project, copy the HTML structure inside `.neumorphic-player` and the associated CSS logic.
+
+### Configurable CSS Properties
+The core motion configuration is located at the top of `style.css`:
+```css
+:root {
+    --carousel-transition-timing: 0.8s;
+    --carousel-easing: cubic-bezier(0.4, 0, 0.2, 1); /* Smooth crossfade ease */
+    --carousel-scale-inactive: 0.92;
+    --carousel-opacity-inactive: 0;
+    --carousel-blur-inactive: 8px; /* Adds depth to the fade out */
+    
+    /* Neumorphic Tokens */
+    --bg-color: #e0e5ec;
+}
+```
+You can quickly alter `--bg-color` to change the entire physical surface color of the UI.

--- a/submissions/examples/Add CSS Fade-In Carousel for Neumorphic Soft Layouts #50414/demo.html
+++ b/submissions/examples/Add CSS Fade-In Carousel for Neumorphic Soft Layouts #50414/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Carousel - Neumorphic Soft</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="neumorphic-player">
+        <header class="player-header">
+            <button class="neu-icon-btn" aria-label="Menu">
+                <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
+            <span class="now-playing">Now Playing</span>
+            <button class="neu-icon-btn" aria-label="Options">
+                <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+            </button>
+        </header>
+
+        <section class="carousel-wrapper" aria-roledescription="carousel" aria-label="Audio Tracks">
+            <!-- Hidden Radio Inputs for State Management -->
+            <input type="radio" name="neu-fade-slider" id="track-1" class="slider-radio" checked aria-label="Track 1: Midnight Echoes">
+            <input type="radio" name="neu-fade-slider" id="track-2" class="slider-radio" aria-label="Track 2: Ocean Breeze">
+            <input type="radio" name="neu-fade-slider" id="track-3" class="slider-radio" aria-label="Track 3: Neon City Lights">
+            
+            <div class="carousel-viewport">
+                <!-- Stacked Slides for Cross-fade -->
+                <div class="carousel-stack">
+                    
+                    <!-- Slide 1 -->
+                    <article class="carousel-slide slide-1" role="group" aria-roledescription="slide" aria-label="1 of 3">
+                        <div class="cover-art-container">
+                            <div class="cover-art img-1"></div>
+                            <div class="center-hole"></div>
+                        </div>
+                        <div class="track-info">
+                            <h2 class="track-title">Midnight Echoes</h2>
+                            <p class="track-artist">Synthwave Dreams</p>
+                        </div>
+                    </article>
+
+                    <!-- Slide 2 -->
+                    <article class="carousel-slide slide-2" role="group" aria-roledescription="slide" aria-label="2 of 3">
+                        <div class="cover-art-container">
+                            <div class="cover-art img-2"></div>
+                            <div class="center-hole"></div>
+                        </div>
+                        <div class="track-info">
+                            <h2 class="track-title">Ocean Breeze</h2>
+                            <p class="track-artist">Chillhop Essentials</p>
+                        </div>
+                    </article>
+
+                    <!-- Slide 3 -->
+                    <article class="carousel-slide slide-3" role="group" aria-roledescription="slide" aria-label="3 of 3">
+                        <div class="cover-art-container">
+                            <div class="cover-art img-3"></div>
+                            <div class="center-hole"></div>
+                        </div>
+                        <div class="track-info">
+                            <h2 class="track-title">Neon City Lights</h2>
+                            <p class="track-artist">Cybernetic Sounds</p>
+                        </div>
+                    </article>
+
+                </div>
+            </div>
+
+            <!-- Neumorphic Playback Controls -->
+            <div class="playback-controls">
+                <label for="track-1" class="neu-nav-btn prev-btn" aria-label="Previous Track">
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none"><polygon points="19 20 9 12 19 4 19 20"></polygon><line x1="5" y1="19" x2="5" y2="5"></line></svg>
+                </label>
+                
+                <button class="neu-play-btn" aria-label="Play/Pause">
+                    <svg viewBox="0 0 24 24" width="32" height="32" stroke="none" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+                </button>
+                
+                <label for="track-2" class="neu-nav-btn next-btn" aria-label="Next Track">
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none"><polygon points="5 4 15 12 5 20 5 4"></polygon><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                </label>
+            </div>
+            
+            <!-- Hidden labels used to allow "Next" to loop through using sibling selectors.
+                 Since pure CSS can't dynamically assign 'next' to the same button, 
+                 we stack absolute labels and show the correct one based on active state. -->
+            <div class="routing-logic">
+                <!-- If Slide 1 is active: show Slide 2 as Next, Slide 3 as Prev -->
+                <div class="route-1">
+                    <label for="track-2" class="hitbox-next"></label>
+                    <label for="track-3" class="hitbox-prev"></label>
+                </div>
+                <!-- If Slide 2 is active: show Slide 3 as Next, Slide 1 as Prev -->
+                <div class="route-2">
+                    <label for="track-3" class="hitbox-next"></label>
+                    <label for="track-1" class="hitbox-prev"></label>
+                </div>
+                <!-- If Slide 3 is active: show Slide 1 as Next, Slide 2 as Prev -->
+                <div class="route-3">
+                    <label for="track-1" class="hitbox-next"></label>
+                    <label for="track-2" class="hitbox-prev"></label>
+                </div>
+            </div>
+
+            <!-- Dot Indicators (Optional, but good for keyboard nav & state) -->
+            <div class="carousel-dots" aria-hidden="true">
+                <label for="track-1" class="neu-dot"></label>
+                <label for="track-2" class="neu-dot"></label>
+                <label for="track-3" class="neu-dot"></label>
+            </div>
+        </section>
+    </div>
+</body>
+</html>

--- a/submissions/examples/Add CSS Fade-In Carousel for Neumorphic Soft Layouts #50414/style.css
+++ b/submissions/examples/Add CSS Fade-In Carousel for Neumorphic Soft Layouts #50414/style.css
@@ -1,0 +1,379 @@
+/**
+ * CSS Fade-In Carousel
+ * Designed for Neumorphic Soft Interfaces
+ */
+
+ :root {
+    /* 
+      ========================================
+      Carousel Custom Parameters
+      ========================================
+    */
+    --carousel-transition-timing: 0.8s;
+    --carousel-easing: cubic-bezier(0.4, 0, 0.2, 1); /* Smooth crossfade ease */
+    --carousel-scale-inactive: 0.92;
+    --carousel-opacity-inactive: 0;
+    --carousel-blur-inactive: 8px; /* Adds depth to the fade out */
+
+    /* Neumorphic UI Tokens */
+    --bg-color: #e0e5ec;
+    --text-main: #334155;
+    --text-muted: #94a3b8;
+    
+    /* Neumorphic Shadows */
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    
+    --neu-extruded: 
+        10px 10px 20px var(--shadow-dark), 
+        -10px -10px 20px var(--shadow-light);
+    --neu-pressed: 
+        inset 5px 5px 10px var(--shadow-dark), 
+        inset -5px -5px 10px var(--shadow-light);
+    --neu-flat: 
+        0px 0px 0px var(--shadow-dark), 
+        0px 0px 0px var(--shadow-light);
+        
+    /* Accents */
+    --accent-color: #f43f5e; /* Rose accent */
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow-x: hidden;
+    padding: 2rem;
+}
+
+/* ========================================
+   Player Layout
+   ======================================== */
+.neumorphic-player {
+    width: 100%;
+    max-width: 400px;
+    padding: 2.5rem 2rem;
+    border-radius: 3rem;
+    background: var(--bg-color);
+    box-shadow: var(--neu-extruded);
+    position: relative;
+}
+
+.player-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 3rem;
+}
+
+.now-playing {
+    font-size: 0.875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+}
+
+.neu-icon-btn {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--bg-color);
+    border: none;
+    box-shadow: var(--neu-extruded);
+    color: var(--text-muted);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.neu-icon-btn:active {
+    box-shadow: var(--neu-pressed);
+    color: var(--text-main);
+}
+
+/* ========================================
+   Carousel Logic (Fade-In)
+   ======================================== */
+.carousel-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.slider-radio {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.carousel-viewport {
+    position: relative;
+    height: 380px; /* Fixed height for stacked items */
+    margin-bottom: 2rem;
+}
+
+.carousel-stack {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+/* All slides are stacked in the same position */
+.carousel-slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    
+    /* Base Inactive State for Fade-In */
+    opacity: var(--carousel-opacity-inactive);
+    transform: scale(var(--carousel-scale-inactive));
+    filter: blur(var(--carousel-blur-inactive));
+    pointer-events: none;
+    transition: all var(--carousel-transition-timing) var(--carousel-easing);
+    will-change: opacity, transform, filter;
+    z-index: 1;
+}
+
+/* Active Slide State */
+#track-1:checked ~ .carousel-viewport .slide-1,
+#track-2:checked ~ .carousel-viewport .slide-2,
+#track-3:checked ~ .carousel-viewport .slide-3 {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+    pointer-events: auto;
+    z-index: 2;
+}
+
+/* ========================================
+   Track Visuals (Neumorphic Cover Art)
+   ======================================== */
+.cover-art-container {
+    width: 240px;
+    height: 240px;
+    border-radius: 50%;
+    padding: 10px;
+    background: var(--bg-color);
+    box-shadow: var(--neu-extruded);
+    margin-bottom: 2.5rem;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Spinning animation for active track */
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.cover-art {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-size: cover;
+    background-position: center;
+    box-shadow: inset 0 0 20px rgba(0,0,0,0.2);
+}
+
+#track-1:checked ~ .carousel-viewport .slide-1 .cover-art,
+#track-2:checked ~ .carousel-viewport .slide-2 .cover-art,
+#track-3:checked ~ .carousel-viewport .slide-3 .cover-art {
+    animation: spin 20s linear infinite;
+}
+
+/* Dummy Cover Arts using gradients */
+.img-1 { background: linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%); }
+.img-2 { background: linear-gradient(135deg, #84fab0 0%, #8fd3f4 100%); }
+.img-3 { background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%); }
+
+.center-hole {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: var(--bg-color);
+    box-shadow: var(--neu-pressed);
+    border: 4px solid rgba(255,255,255,0.5);
+}
+
+.track-info {
+    text-align: center;
+    width: 100%;
+}
+
+.track-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--text-main);
+    margin-bottom: 0.25rem;
+    transition: transform var(--carousel-transition-timing) var(--carousel-easing);
+}
+
+.track-artist {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+/* ========================================
+   Playback Controls & Routing Logic
+   ======================================== */
+.playback-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 2rem;
+    margin-bottom: 2rem;
+    position: relative;
+    z-index: 10;
+}
+
+.neu-nav-btn {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--bg-color);
+    box-shadow: var(--neu-extruded);
+    color: var(--text-muted);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.neu-nav-btn:active {
+    box-shadow: var(--neu-pressed);
+    color: var(--text-main);
+}
+
+.neu-play-btn {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background: var(--accent-color);
+    border: none;
+    box-shadow: 
+        8px 8px 16px rgba(244, 63, 94, 0.3), 
+        -8px -8px 16px rgba(255, 255, 255, 0.8),
+        inset 0 0 0 transparent;
+    color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.neu-play-btn:active {
+    box-shadow: 
+        0px 0px 0px rgba(244, 63, 94, 0.3), 
+        0px 0px 0px rgba(255, 255, 255, 0.8),
+        inset 4px 4px 8px rgba(159, 18, 57, 0.5),
+        inset -4px -4px 8px rgba(251, 113, 133, 0.5);
+}
+
+/* 
+   Routing Logic for Prev/Next Buttons
+   This overlays invisible labels on top of the visual Prev/Next buttons.
+   Depending on which radio is checked, we bring a different label to the top.
+*/
+.routing-logic {
+    position: absolute;
+    bottom: 50px; /* Align with playback controls */
+    left: 0;
+    width: 100%;
+    height: 80px;
+    pointer-events: none;
+    z-index: 20;
+    display: flex;
+    justify-content: center;
+}
+
+.route-1, .route-2, .route-3 {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    display: none;
+}
+
+#track-1:checked ~ .routing-logic .route-1,
+#track-2:checked ~ .routing-logic .route-2,
+#track-3:checked ~ .routing-logic .route-3 {
+    display: flex;
+    justify-content: center;
+}
+
+.hitbox-prev, .hitbox-next {
+    position: absolute;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    cursor: pointer;
+    pointer-events: auto;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.hitbox-prev { margin-left: -112px; } /* Align over visual Prev button */
+.hitbox-next { margin-left: 112px; }  /* Align over visual Next button */
+
+/* ========================================
+   Carousel Dots (Fallback/Alternative Nav)
+   ======================================== */
+.carousel-dots {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    padding-top: 1rem;
+}
+
+.neu-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--bg-color);
+    box-shadow: var(--neu-extruded);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+#track-1:checked ~ .carousel-dots label[for="track-1"],
+#track-2:checked ~ .carousel-dots label[for="track-2"],
+#track-3:checked ~ .carousel-dots label[for="track-3"] {
+    box-shadow: var(--neu-pressed);
+    background: var(--accent-color);
+}
+
+/* Keyboard Focus */
+#track-1:focus-visible ~ .carousel-dots label[for="track-1"],
+#track-2:focus-visible ~ .carousel-dots label[for="track-2"],
+#track-3:focus-visible ~ .carousel-dots label[for="track-3"] {
+    outline: 2px dashed var(--accent-color);
+    outline-offset: 4px;
+}


### PR DESCRIPTION
#50414

## Pull Request Description

<!-- Briefly describe what you're submitting and the problem it solves. -->
-  created the pure CSS Fade-In Carousel, beautifully styled with a Neumorphic Soft aesthetic to resemble a sleek Audio Player UI.
- Resolves #50414 
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---



## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
