### PR TITLE
[FEATURE] Anchor-Positioned Contextual Command Center

### DIFF
--- a/submissions/examples/anchor-positioned-command-center/README.md
+++ b/submissions/examples/anchor-positioned-command-center/README.md
@@ -1,0 +1,59 @@
+# Anchor-Positioned Contextual Command Center
+
+A self-contained EaseMotion CSS example demonstrating the native **CSS Anchor
+Positioning API** — overlays (popovers, menus, notification cards, command
+suggestions) that snap precisely to the element that triggered them, using
+only CSS. No JavaScript is used to calculate placement.
+
+Live in this folder:
+
+    submissions/examples/anchor-positioned-command-center/
+    ├── demo.html
+    ├── style.css
+    └── README.md
+
+## What it demonstrates
+
+- **anchor-name / position-anchor / anchor()** — every trigger
+  (the *New File* button, the search box, the notification bell, the
+  profile avatar, and each card's kebab menu) declares an `anchor-name`.
+  Its corresponding overlay sets `position-anchor` to that name and reads
+  coordinates straight off it with `anchor(top)`, `anchor(bottom)`,
+  `anchor(left)`, `anchor(right)`.
+- **anchor-size()** — the command-suggestions popover matches the width
+  of its search input with `width: anchor-size(width)`.
+- **position-try-fallbacks** — each popover can flip to the opposite
+  side automatically if it would overflow the viewport, with zero
+  JavaScript re-measuring.
+- **The native Popover API** (`popover="auto"` / `popovertarget`) — every
+  overlay is a real top-layer popover, so it gets light-dismiss,
+  Esc-to-close, and correct stacking for free.
+- **:has() + :popover-open** — the optional "Highlight anchor ↔
+  overlay link" toggle lights up a trigger while its popover is open,
+  purely as a CSS relational selector. This is the example's signature
+  touch: it makes the otherwise-invisible anchor relationship visible.
+- **Graceful degradation** — `@supports not (anchor-name: --cc-a)` falls
+  back to a simple centered layout on browsers that don't yet support
+  anchor positioning, so the interface never breaks, only de-anchors.
+- **Accessibility** — every popover has an appropriate ARIA role, focus
+  moves to the first menu item on open, arrow keys move focus between
+  items, and `prefers-reduced-motion` disables the open/close animation.
+
+## Browser support
+
+CSS Anchor Positioning currently ships in Chromium-based browsers
+(Chrome/Edge 125+). On browsers without support, the @supports fallback
+keeps every popover fully usable — it just isn't pinned to its trigger —
+and a short on-page note explains this automatically via a CSS.supports()
+check.
+
+## Try it
+
+Open demo.html in a recent Chromium browser and:
+
+1. Click New File, the search box, the bell, or the avatar.
+2. Click the kebab (three dots) on any card for a per-card contextual menu.
+3. Toggle "Highlight anchor ↔ overlay link" to see the trigger glow
+   while its overlay is open.
+4. Resize the window near an edge to see position-try-fallbacks flip
+   a popover to stay on-screen.

--- a/submissions/examples/anchor-positioned-command-center/demo.html
+++ b/submissions/examples/anchor-positioned-command-center/demo.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Anchor-Positioned Contextual Command Center · EaseMotion CSS</title>
+<meta name="description" content="A self-contained EaseMotion CSS example demonstrating the native CSS Anchor Positioning API through a command-center style interface." />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="cc-noise" aria-hidden="true"></div>
+
+  <header class="cc-toolbar">
+    <div class="cc-brand">
+      <span class="cc-brand-mark">◈</span>
+      <span class="cc-brand-text">Command Center</span>
+      <span class="cc-brand-tag">anchor positioning demo</span>
+    </div>
+
+    <div class="cc-search-wrap">
+      <label class="cc-visually-hidden" for="cc-search">Search commands</label>
+      <span class="cc-search-icon" aria-hidden="true">⌕</span>
+      <input
+        id="cc-search"
+        class="cc-search"
+        type="text"
+        placeholder="Type a command or search…"
+        autocomplete="off"
+        popovertarget="cc-suggestions"
+      />
+      <kbd class="cc-kbd">⌘K</kbd>
+
+      <div id="cc-suggestions" class="cc-popover cc-suggestions" popover="auto" role="listbox" aria-label="Command suggestions">
+        <p class="cc-popover-eyebrow">Suggested</p>
+        <button class="cc-suggestion" role="option">
+          <span class="cc-suggestion-icon">▤</span>
+          <span>
+            <span class="cc-suggestion-title">Open recent project</span>
+            <span class="cc-suggestion-sub">easemotion-css/submissions</span>
+          </span>
+          <kbd class="cc-kbd cc-kbd-sm">↵</kbd>
+        </button>
+        <button class="cc-suggestion" role="option">
+          <span class="cc-suggestion-icon">✎</span>
+          <span>
+            <span class="cc-suggestion-title">Create new snippet</span>
+            <span class="cc-suggestion-sub">Starts a blank component file</span>
+          </span>
+        </button>
+        <button class="cc-suggestion" role="option">
+          <span class="cc-suggestion-icon">⇄</span>
+          <span>
+            <span class="cc-suggestion-title">Switch theme</span>
+            <span class="cc-suggestion-sub">Light / dark / system</span>
+          </span>
+        </button>
+      </div>
+    </div>
+
+    <div class="cc-actions">
+      <button
+        id="cc-new-file-btn"
+        class="cc-btn cc-btn-primary cc-anchor-new-file"
+        popovertarget="cc-command-popover"
+      >
+        <span class="cc-btn-plus">+</span> New File
+      </button>
+
+      <div id="cc-command-popover" class="cc-popover cc-command-popover" popover="auto" role="menu" aria-label="New file actions">
+        <button class="cc-menu-item" role="menuitem">
+          <span class="cc-menu-icon">▣</span> Create Project
+        </button>
+        <button class="cc-menu-item" role="menuitem">
+          <span class="cc-menu-icon">▢</span> Open Folder
+        </button>
+        <button class="cc-menu-item" role="menuitem">
+          <span class="cc-menu-icon">⇩</span> Import Files
+        </button>
+      </div>
+
+      <button
+        id="cc-bell-btn"
+        class="cc-btn cc-btn-icon cc-anchor-bell"
+        popovertarget="cc-notif-popover"
+        aria-label="Notifications, 2 unread"
+      >
+        🔔
+        <span class="cc-dot" aria-hidden="true"></span>
+      </button>
+
+      <div id="cc-notif-popover" class="cc-popover cc-notif-popover" popover="auto" role="dialog" aria-label="Notifications">
+        <p class="cc-popover-eyebrow">Notifications</p>
+        <div class="cc-notif-item">
+          <span class="cc-notif-dot cc-notif-dot--teal" aria-hidden="true"></span>
+          <span>
+            <strong>Build passed</strong>
+            <span class="cc-notif-sub">anchor-positioned-command-center · 2m ago</span>
+          </span>
+        </div>
+        <div class="cc-notif-item">
+          <span class="cc-notif-dot cc-notif-dot--amber" aria-hidden="true"></span>
+          <span>
+            <strong>Review requested</strong>
+            <span class="cc-notif-sub">on submissions/examples · 1h ago</span>
+          </span>
+        </div>
+      </div>
+
+      <button
+        id="cc-avatar-btn"
+        class="cc-btn cc-btn-icon cc-avatar cc-anchor-avatar"
+        popovertarget="cc-profile-popover"
+        aria-label="Open profile menu"
+      >
+        JD
+      </button>
+
+      <div id="cc-profile-popover" class="cc-popover cc-profile-popover" popover="auto" role="menu" aria-label="Profile menu">
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">⚙</span> Preferences</button>
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">◐</span> Reduce motion</button>
+        <hr class="cc-menu-divider" />
+        <button class="cc-menu-item cc-menu-item--danger" role="menuitem"><span class="cc-menu-icon">⏻</span> Sign out</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="cc-main">
+    <div class="cc-main-head">
+      <h1 class="cc-h1">Contextual action cards</h1>
+      <label class="cc-tether-toggle">
+        <input type="checkbox" id="cc-tether-check" />
+        <span>Highlight anchor ↔ overlay link</span>
+      </label>
+    </div>
+
+    <div class="cc-grid">
+
+      <article class="cc-card" style="anchor-name: --cc-card-1">
+        <div class="cc-card-top">
+          <span class="cc-card-badge cc-card-badge--teal">Active</span>
+          <button class="cc-kebab" popovertarget="cc-card-menu-1" aria-label="More actions for Design Review">⋮</button>
+        </div>
+        <h2 class="cc-card-title">Design Review</h2>
+        <p class="cc-card-desc">Anchor Positioning walkthrough &amp; component pass with the contributor team.</p>
+        <footer class="cc-card-foot">Due Friday</footer>
+      </article>
+
+      <div id="cc-card-menu-1" class="cc-popover cc-card-menu" popover="auto" role="menu" style="position-anchor: --cc-card-1" aria-label="Design Review actions">
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">✎</span> Rename</button>
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">⧉</span> Duplicate</button>
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">🗄</span> Archive</button>
+        <hr class="cc-menu-divider" />
+        <button class="cc-menu-item cc-menu-item--danger" role="menuitem"><span class="cc-menu-icon">🗑</span> Delete</button>
+      </div>
+
+      <article class="cc-card" style="anchor-name: --cc-card-2">
+        <div class="cc-card-top">
+          <span class="cc-card-badge cc-card-badge--amber">Pending</span>
+          <button class="cc-kebab" popovertarget="cc-card-menu-2" aria-label="More actions for Release Notes">⋮</button>
+        </div>
+        <h2 class="cc-card-title">Release Notes</h2>
+        <p class="cc-card-desc">Draft the v2.4 changelog covering new overlay utilities.</p>
+        <footer class="cc-card-foot">Due Monday</footer>
+      </article>
+
+      <div id="cc-card-menu-2" class="cc-popover cc-card-menu" popover="auto" role="menu" style="position-anchor: --cc-card-2" aria-label="Release Notes actions">
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">✎</span> Rename</button>
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">⧉</span> Duplicate</button>
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">🗄</span> Archive</button>
+        <hr class="cc-menu-divider" />
+        <button class="cc-menu-item cc-menu-item--danger" role="menuitem"><span class="cc-menu-icon">🗑</span> Delete</button>
+      </div>
+
+      <article class="cc-card" style="anchor-name: --cc-card-3">
+        <div class="cc-card-top">
+          <span class="cc-card-badge">Backlog</span>
+          <button class="cc-kebab" popovertarget="cc-card-menu-3" aria-label="More actions for Accessibility Audit">⋮</button>
+        </div>
+        <h2 class="cc-card-title">Accessibility Audit</h2>
+        <p class="cc-card-desc">Verify focus order and reduced-motion behaviour across all popovers.</p>
+        <footer class="cc-card-foot">Unscheduled</footer>
+      </article>
+
+      <div id="cc-card-menu-3" class="cc-popover cc-card-menu" popover="auto" role="menu" style="position-anchor: --cc-card-3" aria-label="Accessibility Audit actions">
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">✎</span> Rename</button>
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">⧉</span> Duplicate</button>
+        <button class="cc-menu-item" role="menuitem"><span class="cc-menu-icon">🗄</span> Archive</button>
+        <hr class="cc-menu-divider" />
+        <button class="cc-menu-item cc-menu-item--danger" role="menuitem"><span class="cc-menu-icon">🗑</span> Delete</button>
+      </div>
+
+    </div>
+
+    <p class="cc-fallback-note" id="cc-fallback-note" hidden>
+      Your browser doesn't support the CSS Anchor Positioning API yet, so overlays above are shown
+      in a simplified stacked layout instead of being pinned to their triggers. Everything still works —
+      it just isn't anchored.
+    </p>
+  </main>
+
+  <script>
+    // Progressive enhancement note only — no JS is used to calculate popover
+    // placement. All positioning above comes from anchor-name / position-anchor
+    // / anchor() in style.css. This script only wires up two accessibility
+    // niceties: arrow-key navigation inside menus, and a supports() check
+    // that reveals a plain-language fallback notice on older browsers.
+
+    if (!CSS.supports('anchor-name: --a')) {
+      document.getElementById('cc-fallback-note').hidden = false;
+    }
+
+    document.querySelectorAll('.cc-popover[role="menu"], .cc-popover[role="listbox"]').forEach((menu) => {
+      const items = () => Array.from(menu.querySelectorAll('button'));
+      menu.addEventListener('keydown', (e) => {
+        const list = items();
+        const active = document.activeElement;
+        const i = list.indexOf(active);
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          (list[i + 1] || list[0]).focus();
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          (list[i - 1] || list[list.length - 1]).focus();
+        }
+      });
+      menu.addEventListener('toggle', (e) => {
+        if (e.newState === 'open') {
+          requestAnimationFrame(() => items()[0]?.focus());
+        }
+      });
+    });
+
+    const tetherCheck = document.getElementById('cc-tether-check');
+    tetherCheck.addEventListener('change', () => {
+      document.body.classList.toggle('cc-show-tethers', tetherCheck.checked);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/anchor-positioned-command-center/style.css
+++ b/submissions/examples/anchor-positioned-command-center/style.css
@@ -1,0 +1,460 @@
+/* =========================================================================
+   Anchor-Positioned Contextual Command Center
+   EaseMotion CSS · submissions/examples/anchor-positioned-command-center
+
+   This file demonstrates the CSS Anchor Positioning API:
+     - `anchor-name`      marks a trigger element as a positioning anchor
+     - `position-anchor`  ties an absolutely-positioned element to that anchor
+     - `anchor()`         reads coordinates off the anchor (bottom/left/etc.)
+     - `position-try-fallbacks` lets the overlay flip itself when it would
+                          overflow the viewport — still zero JavaScript.
+
+   No JS is used anywhere in this file's logic to calculate placement.
+   ========================================================================= */
+
+:root {
+  /* -- palette -------------------------------------------------------- */
+  --cc-bg:          #0a0e14;
+  --cc-surface:     #12161f;
+  --cc-surface-2:   #171c27;
+  --cc-border:      #262c3a;
+  --cc-border-soft: #1c2230;
+  --cc-text:        #e7eaf2;
+  --cc-text-muted:  #8b93a7;
+  --cc-teal:        #17e0b8;
+  --cc-teal-dim:    rgba(23, 224, 184, 0.16);
+  --cc-amber:       #ffb020;
+  --cc-amber-dim:   rgba(255, 176, 32, 0.16);
+  --cc-danger:      #ff6b6b;
+
+  /* -- type ------------------------------------------------------------ */
+  --cc-font-ui:   'Space Grotesk', system-ui, sans-serif;
+  --cc-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  /* -- motion ------------------------------------------------------------ */
+  --cc-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --cc-dur: 160ms;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--cc-bg);
+  color: var(--cc-text);
+  font-family: var(--cc-font-ui);
+  position: relative;
+}
+
+/* faint grain so the near-black background doesn't feel flat/templated */
+.cc-noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.05;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 22px 22px;
+}
+
+.cc-visually-hidden {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+/* =========================================================================
+   Toolbar
+   ========================================================================= */
+
+.cc-toolbar {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 14px 28px;
+  background: var(--cc-surface);
+  border-bottom: 1px solid var(--cc-border);
+}
+
+.cc-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  white-space: nowrap;
+}
+.cc-brand-mark { color: var(--cc-teal); font-size: 1.2rem; }
+.cc-brand-text { font-weight: 600; letter-spacing: 0.01em; }
+.cc-brand-tag {
+  font-family: var(--cc-font-mono);
+  font-size: 0.7rem;
+  color: var(--cc-text-muted);
+  border: 1px solid var(--cc-border);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.cc-search-wrap {
+  position: relative;
+  flex: 1;
+  max-width: 420px;
+  /* This element is the anchor for the #cc-suggestions popover */
+  anchor-name: --cc-search-anchor;
+}
+.cc-search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--cc-text-muted);
+}
+.cc-search {
+  width: 100%;
+  padding: 9px 40px 9px 34px;
+  border-radius: 8px;
+  border: 1px solid var(--cc-border);
+  background: var(--cc-surface-2);
+  color: var(--cc-text);
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+.cc-search:focus-visible { outline: 2px solid var(--cc-teal); outline-offset: 1px; }
+.cc-kbd {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--cc-font-mono);
+  font-size: 0.7rem;
+  color: var(--cc-text-muted);
+  border: 1px solid var(--cc-border);
+  border-radius: 5px;
+  padding: 2px 6px;
+  background: var(--cc-surface);
+}
+.cc-kbd-sm { position: static; transform: none; }
+
+.cc-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.cc-btn {
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--cc-text);
+  background: var(--cc-surface-2);
+  border: 1px solid var(--cc-border);
+  border-radius: 8px;
+  padding: 9px 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background var(--cc-dur) var(--cc-ease), border-color var(--cc-dur) var(--cc-ease),
+              box-shadow var(--cc-dur) var(--cc-ease);
+}
+.cc-btn:hover { border-color: #3a4256; }
+.cc-btn:focus-visible { outline: 2px solid var(--cc-teal); outline-offset: 2px; }
+
+.cc-btn-primary {
+  background: var(--cc-teal);
+  border-color: var(--cc-teal);
+  color: #04241d;
+  font-weight: 600;
+}
+.cc-btn-primary:hover { background: #29f0c8; }
+.cc-btn-plus { font-size: 1rem; line-height: 1; }
+
+.cc-btn-icon {
+  position: relative;
+  padding: 9px;
+  width: 38px;
+  height: 38px;
+  justify-content: center;
+}
+.cc-dot {
+  position: absolute;
+  top: 6px; right: 6px;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--cc-amber);
+  box-shadow: 0 0 0 2px var(--cc-surface);
+}
+.cc-avatar {
+  background: var(--cc-surface-2);
+  font-family: var(--cc-font-mono);
+  font-size: 0.75rem;
+}
+
+/* Anchors: each trigger declares an anchor-name so a popover elsewhere in
+   the DOM can be pinned to it via position-anchor. */
+.cc-anchor-new-file { anchor-name: --cc-new-file-anchor; }
+.cc-anchor-bell      { anchor-name: --cc-bell-anchor; }
+.cc-anchor-avatar    { anchor-name: --cc-avatar-anchor; }
+
+/* =========================================================================
+   Popover base (native <div popover> reset + shared shell)
+   ========================================================================= */
+
+.cc-popover {
+  margin: 0;              /* popovers are top-layer; margin: auto centering is off by default */
+  padding: 8px;
+  border: 1px solid var(--cc-border);
+  border-radius: 10px;
+  background: var(--cc-surface-2);
+  color: var(--cc-text);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  min-width: 220px;
+
+  /* entry/exit choreography, driven by the popover's own open state */
+  opacity: 0;
+  transform: scale(0.94) translateY(-4px);
+  transition: opacity var(--cc-dur) var(--cc-ease), transform var(--cc-dur) var(--cc-ease),
+              overlay var(--cc-dur) allow-discrete, display var(--cc-dur) allow-discrete;
+}
+.cc-popover:popover-open {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+@starting-style {
+  .cc-popover:popover-open {
+    opacity: 0;
+    transform: scale(0.94) translateY(-4px);
+  }
+}
+
+.cc-popover-eyebrow {
+  margin: 4px 8px 6px;
+  font-family: var(--cc-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--cc-text-muted);
+}
+
+.cc-menu-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--cc-text);
+  font-family: inherit;
+  font-size: 0.86rem;
+  text-align: left;
+  cursor: pointer;
+}
+.cc-menu-item:hover, .cc-menu-item:focus-visible { background: var(--cc-surface); }
+.cc-menu-item:focus-visible { outline: 2px solid var(--cc-teal); outline-offset: -2px; }
+.cc-menu-item--danger { color: var(--cc-danger); }
+.cc-menu-icon { width: 1.1em; text-align: center; opacity: 0.85; }
+.cc-menu-divider { border: 0; border-top: 1px solid var(--cc-border); margin: 6px 4px; }
+
+/* =========================================================================
+   Anchor positioning per popover — the actual feature being demonstrated
+   ========================================================================= */
+
+.cc-command-popover {
+  position: absolute;
+  position-anchor: --cc-new-file-anchor;
+  top: calc(anchor(bottom) + 8px);
+  left: anchor(left);
+  position-try-fallbacks: flip-block;
+}
+
+.cc-suggestions {
+  position: absolute;
+  position-anchor: --cc-search-anchor;
+  top: calc(anchor(bottom) + 8px);
+  left: anchor(left);
+  width: anchor-size(width);
+  position-try-fallbacks: flip-block;
+}
+.cc-suggestion {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--cc-text);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.cc-suggestion:hover, .cc-suggestion:focus-visible { background: var(--cc-surface); }
+.cc-suggestion-icon { opacity: 0.85; }
+.cc-suggestion-title { display: block; font-size: 0.86rem; }
+.cc-suggestion-sub { display: block; font-size: 0.72rem; color: var(--cc-text-muted); }
+
+.cc-notif-popover {
+  position: absolute;
+  position-anchor: --cc-bell-anchor;
+  top: calc(anchor(bottom) + 10px);
+  right: anchor(right);
+  width: 260px;
+  position-try-fallbacks: flip-block;
+}
+.cc-notif-item { display: flex; gap: 10px; padding: 8px 10px; font-size: 0.82rem; }
+.cc-notif-sub { display: block; color: var(--cc-text-muted); font-size: 0.72rem; }
+.cc-notif-dot { width: 8px; height: 8px; border-radius: 50%; margin-top: 5px; flex: none; }
+.cc-notif-dot--teal { background: var(--cc-teal); }
+.cc-notif-dot--amber { background: var(--cc-amber); }
+
+.cc-profile-popover {
+  position: absolute;
+  position-anchor: --cc-avatar-anchor;
+  top: calc(anchor(bottom) + 10px);
+  right: anchor(right);
+  min-width: 190px;
+  position-try-fallbacks: flip-block;
+}
+
+.cc-card-menu {
+  position: absolute;
+  top: calc(anchor(top) + 34px);
+  right: calc(anchor(right) - 10px);
+  min-width: 170px;
+  position-try-fallbacks: flip-block;
+}
+
+/* =========================================================================
+   Main content
+   ========================================================================= */
+
+.cc-main {
+  position: relative;
+  z-index: 1;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+}
+.cc-main-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 22px;
+}
+.cc-h1 { font-size: 1.4rem; margin: 0; font-weight: 600; }
+
+.cc-tether-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: var(--cc-text-muted);
+  cursor: pointer;
+}
+
+.cc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.cc-card {
+  position: relative;
+  background: var(--cc-surface);
+  border: 1px solid var(--cc-border);
+  border-radius: 12px;
+  padding: 18px;
+  transition: box-shadow var(--cc-dur) var(--cc-ease), border-color var(--cc-dur) var(--cc-ease);
+}
+.cc-card-top { display: flex; justify-content: space-between; align-items: flex-start; }
+.cc-card-badge {
+  font-family: var(--cc-font-mono);
+  font-size: 0.68rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--cc-border);
+  color: var(--cc-text-muted);
+}
+.cc-card-badge--teal { color: var(--cc-teal); background: var(--cc-teal-dim); border-color: transparent; }
+.cc-card-badge--amber { color: var(--cc-amber); background: var(--cc-amber-dim); border-color: transparent; }
+
+.cc-kebab {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--cc-text-muted);
+  border-radius: 6px;
+  width: 26px; height: 26px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.cc-kebab:hover { background: var(--cc-surface-2); color: var(--cc-text); }
+.cc-kebab:focus-visible { outline: 2px solid var(--cc-teal); outline-offset: 1px; }
+
+.cc-card-title { margin: 12px 0 6px; font-size: 1rem; font-weight: 600; }
+.cc-card-desc { margin: 0; font-size: 0.84rem; color: var(--cc-text-muted); line-height: 1.5; }
+.cc-card-foot { margin-top: 14px; font-family: var(--cc-font-mono); font-size: 0.72rem; color: var(--cc-text-muted); }
+
+.cc-fallback-note {
+  margin-top: 24px;
+  padding: 12px 14px;
+  border: 1px dashed var(--cc-border);
+  border-radius: 8px;
+  color: var(--cc-text-muted);
+  font-size: 0.82rem;
+  max-width: 640px;
+}
+
+/* =========================================================================
+   Signature interaction: the "live tether" ring.
+   When a popover is open, its own anchor trigger lights up — proving the
+   anchor ↔ overlay relationship visually. Done entirely with :has() and
+   :popover-open, no JavaScript geometry involved.
+   ========================================================================= */
+
+.cc-show-tethers .cc-search-wrap:has(#cc-suggestions:popover-open) .cc-search,
+.cc-show-tethers:has(#cc-command-popover:popover-open) .cc-anchor-new-file,
+.cc-show-tethers:has(#cc-notif-popover:popover-open) .cc-anchor-bell,
+.cc-show-tethers:has(#cc-profile-popover:popover-open) .cc-anchor-avatar {
+  box-shadow: 0 0 0 3px var(--cc-teal-dim), 0 0 0 1px var(--cc-teal);
+}
+
+.cc-show-tethers .cc-card:has(+ .cc-card-menu:popover-open) {
+  border-color: var(--cc-teal);
+  box-shadow: 0 0 0 3px var(--cc-teal-dim);
+}
+
+/* =========================================================================
+   Fallback for browsers without Anchor Positioning support.
+   Overlays still work (via the native Popover API) — they just render as
+   a simple centered/stacked layer instead of pinned to their trigger.
+   ========================================================================= */
+
+@supports not (anchor-name: --cc-a) {
+  .cc-popover {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(320px, 90vw);
+  }
+  .cc-popover:popover-open { transform: translate(-50%, -50%); }
+}
+
+/* =========================================================================
+   Motion & accessibility preferences
+   ========================================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  .cc-popover, .cc-btn, .cc-card { transition: none; }
+  .cc-popover { opacity: 1; transform: none; }
+}
+
+::backdrop { background: transparent; }


### PR DESCRIPTION
Closes #52796

Adds a self-contained example demonstrating the CSS Anchor Positioning API
via a command-center style interface (command popover, search suggestions,
notifications, profile menu, and per-card contextual menus).

- Files added only under submissions/examples/anchor-positioned-command-center/
- No changes to core/, components/, docs/, or build files
- Includes graceful @supports fallback and reduced-motion support