### PR TITLE
feat: add hero CTA shimmer example

### DIFF
--- a/submissions/examples/hero-cta-shimmer/README.md
+++ b/submissions/examples/hero-cta-shimmer/README.md
@@ -1,0 +1,15 @@
+# Hero CTA Shimmer
+
+A focused CSS-only hero call-to-action pattern for product pages, dashboards, and onboarding screens. The primary action uses a restrained shimmer pass, hover lift, active press feedback, and keyboard-visible focus behavior.
+
+## Files
+
+- `demo.html` contains the hero content and action links.
+- `style.css` contains the layout, responsive rules, button states, and shimmer keyframes.
+
+## What it demonstrates
+
+- CSS-only shimmer animation using a pseudo-element.
+- Hover, focus-visible, and active states for a clickable CTA.
+- Responsive stacked actions on narrow screens.
+- A compact hero layout that keeps the animation centered on the primary action.

--- a/submissions/examples/hero-cta-shimmer/demo.html
+++ b/submissions/examples/hero-cta-shimmer/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hero CTA Shimmer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="hero-panel">
+    <p class="eyebrow">Launch flow</p>
+    <h1>Ship polished interface moments faster</h1>
+    <p class="summary">A compact hero button treatment that adds a soft shimmer, press feedback, and focus styling without JavaScript.</p>
+    <div class="actions">
+      <a class="cta" href="#start">Start Project</a>
+      <a class="secondary" href="#preview">Preview Motion</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hero-cta-shimmer/style.css
+++ b/submissions/examples/hero-cta-shimmer/style.css
@@ -1,0 +1,120 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #111827 0%, #243b53 55%, #0f766e 100%);
+  color: #f8fafc;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.hero-panel {
+  width: min(92vw, 760px);
+  padding: 56px;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: #99f6e4;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 680px;
+  margin: 0;
+  font-size: clamp(2.3rem, 6vw, 5rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.summary {
+  max-width: 560px;
+  margin: 22px 0 34px;
+  color: #dbeafe;
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.cta,
+.secondary {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0 22px;
+  color: inherit;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.cta {
+  position: relative;
+  overflow: hidden;
+  background: #14b8a6;
+  box-shadow: 0 16px 36px rgba(20, 184, 166, 0.3);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.cta::after {
+  content: "";
+  position: absolute;
+  inset: -45% auto -45% -40%;
+  width: 34%;
+  transform: skewX(-18deg);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.48), transparent);
+  animation: shimmer 2.4s ease-in-out infinite;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 22px 46px rgba(20, 184, 166, 0.38);
+}
+
+.cta:active {
+  transform: translateY(0) scale(0.98);
+}
+
+.secondary {
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.secondary:hover,
+.secondary:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+@keyframes shimmer {
+  0%, 24% {
+    left: -40%;
+  }
+  58%, 100% {
+    left: 112%;
+  }
+}
+
+@media (max-width: 560px) {
+  .hero-panel {
+    padding: 32px 22px;
+  }
+
+  .actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only hero CTA shimmer example
- include hover, active, and focus-visible button feedback
- document the example structure and motion behavior

## Test
- git diff --cached --check