### PR TITLE
feat: add calendar event pop example

### DIFF
--- a/submissions/examples/calendar-event-pop/README.md
+++ b/submissions/examples/calendar-event-pop/README.md
@@ -1,14 +1,15 @@
 # Calendar Event Pop
 
-A calendar date tile where the event marker pops into view on hover or keyboard focus.
+A CSS-only calendar interaction that highlights scheduled days with a pulsing marker and reveals short event labels on hover or keyboard focus.
 
 ## Files
 
-- `demo.html` - accessible date tile button markup.
-- `style.css` - tile lift, event marker pop, focus-visible state, and reduced-motion support.
+- `demo.html` builds a compact weekly calendar layout.
+- `style.css` handles the event marker pulse, tile lift, active day state, and responsive grid.
 
-## Highlights
+## What it demonstrates
 
-- Uses a native button for interaction.
-- Keeps the event marker readable before and after motion.
-- Preserves keyboard focus styling.
+- Animated event indicators with `box-shadow` keyframes.
+- Revealed event labels using transforms and opacity.
+- Keyboard-friendly `:focus-visible` states.
+- A mobile layout that keeps calendar tiles readable.

--- a/submissions/examples/calendar-event-pop/demo.html
+++ b/submissions/examples/calendar-event-pop/demo.html
@@ -1,22 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Calendar Event Pop</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <main class="panel" aria-labelledby="demo-title">
-    <p class="eyebrow">EaseMotion calendar</p>
-    <h1 id="demo-title">Calendar event pop</h1>
-    <p class="intro">A calendar date tile where an event marker pops into view on interaction.</p>
-
-    <button class="date-tile" type="button" aria-label="July 15 has 3 events">
-      <span class="month">Jul</span>
-      <strong>15</strong>
-      <span class="events">3 events</span>
-    </button>
-  </main>
+  <section class="calendar">
+    <header>
+      <span>July</span>
+      <strong>Team Calendar</strong>
+    </header>
+    <div class="grid">
+      <button>17</button>
+      <button>18</button>
+      <button class="event">19<span>Sync</span></button>
+      <button>20</button>
+      <button class="event active">21<span>Demo</span></button>
+      <button>22</button>
+      <button class="event">23<span>Review</span></button>
+    </div>
+  </section>
 </body>
 </html>

--- a/submissions/examples/calendar-event-pop/style.css
+++ b/submissions/examples/calendar-event-pop/style.css
@@ -7,103 +7,115 @@ body {
   margin: 0;
   display: grid;
   place-items: center;
+  background: #eef2ff;
+  color: #1f2937;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: #172033;
-  background: linear-gradient(135deg, #f8fafc 0%, #fff7ed 50%, #f0fdfa 100%);
 }
 
-.panel {
-  width: min(92vw, 30rem);
-  padding: 2.2rem;
-  border: 1px solid rgba(234, 88, 12, 0.18);
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
-}
-
-.eyebrow {
-  margin: 0 0 0.75rem;
-  color: #ea580c;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-h1 {
-  margin: 0;
-  font-size: clamp(2rem, 6vw, 3.1rem);
-  line-height: 1;
-}
-
-.intro {
-  margin: 1rem 0 2rem;
-  color: #526173;
-  line-height: 1.65;
-}
-
-.date-tile {
-  display: grid;
-  justify-items: center;
-  gap: 0.35rem;
-  width: 8.5rem;
-  min-height: 9rem;
-  border: 0;
-  border-radius: 1.1rem;
-  padding: 1rem;
-  color: #172033;
+.calendar {
+  width: min(92vw, 560px);
+  border: 1px solid #d8b4fe;
+  border-radius: 8px;
+  padding: 24px;
   background: #ffffff;
-  font: inherit;
-  cursor: pointer;
-  box-shadow: 0 1rem 2rem rgba(234, 88, 12, 0.12);
-  transition: transform 180ms ease, box-shadow 180ms ease;
+  box-shadow: 0 24px 60px rgba(79, 70, 229, 0.16);
 }
 
-.month {
-  color: #ea580c;
-  font-size: 0.8rem;
-  font-weight: 900;
-  letter-spacing: 0.08em;
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+header span {
+  color: #7c3aed;
+  font-weight: 800;
   text-transform: uppercase;
 }
 
-.date-tile strong {
-  font-size: 3rem;
-  line-height: 1;
+header strong {
+  font-size: 1.1rem;
 }
 
-.events {
-  border-radius: 999px;
-  padding: 0.32rem 0.68rem;
-  color: #ffffff;
-  background: #0f766e;
-  font-size: 0.8rem;
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(42px, 1fr));
+  gap: 10px;
+}
+
+button {
+  position: relative;
+  min-height: 70px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #f9fafb;
+  color: #374151;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-4px);
+  border-color: #a78bfa;
+  box-shadow: 0 16px 28px rgba(124, 58, 237, 0.16);
+}
+
+button span {
+  position: absolute;
+  left: 50%;
+  bottom: 9px;
+  transform: translate(-50%, 8px) scale(0.82);
+  opacity: 0;
+  color: #6d28d9;
+  font-size: 0.72rem;
   font-weight: 900;
-  transform: scale(0.86);
-  transition: transform 180ms ease, background 180ms ease;
+  transition: transform 180ms ease, opacity 180ms ease;
 }
 
-.date-tile:hover,
-.date-tile:focus-visible {
-  transform: translateY(-0.25rem);
-  box-shadow: 0 1.3rem 2.5rem rgba(234, 88, 12, 0.18);
+.event::before {
+  content: "";
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #f59e0b;
+  box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.45);
+  animation: event-pulse 1.8s ease-out infinite;
 }
 
-.date-tile:hover .events,
-.date-tile:focus-visible .events {
-  background: #ea580c;
-  transform: scale(1.08);
+.event:hover span,
+.event:focus-visible span,
+.active span {
+  transform: translate(-50%, 0) scale(1);
+  opacity: 1;
 }
 
-.date-tile:focus-visible {
-  outline: 0.18rem solid #fdba74;
-  outline-offset: 0.25rem;
+.active {
+  border-color: #7c3aed;
+  background: #f5f3ff;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    transition-duration: 1ms !important;
+@keyframes event-pulse {
+  70% {
+    box-shadow: 0 0 0 12px rgba(245, 158, 11, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(245, 158, 11, 0);
+  }
+}
+
+@media (max-width: 520px) {
+  .calendar {
+    padding: 16px;
+  }
+
+  .grid {
+    grid-template-columns: repeat(4, minmax(54px, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- add a CSS-only calendar event pop example
- include pulsing event markers and hover/focus labels
- document the motion and responsive behavior

## Test
- git diff --cached --check