### PR TITLE
feat: add progress step connector example

### DIFF
--- a/submissions/examples/progress-step-connector/README.md
+++ b/submissions/examples/progress-step-connector/README.md
@@ -1,0 +1,15 @@
+# Progress Step Connector
+
+A responsive checkout progress tracker that animates completed connectors and gives the active step a subtle pulsing highlight.
+
+## Files
+
+- `demo.html` defines four progress steps with current and completed states.
+- `style.css` handles the connector fill animation, dot feedback, and mobile vertical layout.
+
+## What it demonstrates
+
+- CSS-only connector fill using transform scaling.
+- Active step emphasis through a repeating pulse animation.
+- Desktop horizontal and mobile vertical progress layouts.
+- Clear state classes for completed, current, and pending steps.

--- a/submissions/examples/progress-step-connector/demo.html
+++ b/submissions/examples/progress-step-connector/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Step Connector</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="tracker" aria-label="Checkout progress">
+    <article class="step done">
+      <span class="dot">1</span>
+      <h2>Cart</h2>
+      <p>Items confirmed</p>
+    </article>
+    <article class="step done">
+      <span class="dot">2</span>
+      <h2>Address</h2>
+      <p>Delivery saved</p>
+    </article>
+    <article class="step current">
+      <span class="dot">3</span>
+      <h2>Payment</h2>
+      <p>Choose method</p>
+    </article>
+    <article class="step">
+      <span class="dot">4</span>
+      <h2>Review</h2>
+      <p>Place order</p>
+    </article>
+  </section>
+</body>
+</html>

--- a/submissions/examples/progress-step-connector/style.css
+++ b/submissions/examples/progress-step-connector/style.css
@@ -1,0 +1,136 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #172033;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.tracker {
+  width: min(94vw, 900px);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  padding: 30px;
+}
+
+.step {
+  position: relative;
+  padding: 0 18px;
+  text-align: center;
+}
+
+.step::before {
+  content: "";
+  position: absolute;
+  top: 23px;
+  left: -50%;
+  width: 100%;
+  height: 4px;
+  border-radius: 999px;
+  background: #d1d5db;
+  z-index: 0;
+}
+
+.step:first-child::before {
+  display: none;
+}
+
+.done::before,
+.current::before {
+  background: linear-gradient(90deg, #22c55e, #06b6d4);
+  transform-origin: left;
+  animation: connector-fill 900ms ease both;
+}
+
+.dot {
+  position: relative;
+  z-index: 1;
+  width: 50px;
+  height: 50px;
+  display: inline-grid;
+  place-items: center;
+  border: 4px solid #d1d5db;
+  border-radius: 50%;
+  background: #ffffff;
+  color: #6b7280;
+  font-weight: 900;
+  transition: transform 180ms ease, border-color 180ms ease, color 180ms ease;
+}
+
+.done .dot {
+  border-color: #22c55e;
+  color: #15803d;
+}
+
+.current .dot {
+  border-color: #06b6d4;
+  color: #0e7490;
+  animation: current-pop 1.6s ease-in-out infinite;
+}
+
+h2 {
+  margin: 14px 0 6px;
+  font-size: 1rem;
+}
+
+p {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.88rem;
+}
+
+.step:hover .dot,
+.step:focus-within .dot {
+  transform: translateY(-4px) scale(1.04);
+}
+
+@keyframes connector-fill {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes current-pop {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(6, 182, 212, 0.34);
+  }
+  50% {
+    box-shadow: 0 0 0 12px rgba(6, 182, 212, 0);
+  }
+}
+
+@media (max-width: 680px) {
+  .tracker {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 24px;
+  }
+
+  .step {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    column-gap: 14px;
+    text-align: left;
+  }
+
+  .step::before {
+    top: -24px;
+    left: 25px;
+    width: 4px;
+    height: 24px;
+  }
+
+  .step h2 {
+    margin-top: 2px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only progress step connector example
- include animated connector fill and active step pulse
- document responsive horizontal and vertical layouts

## Test
- git diff --cached --check