### PR TITLE
feat: add accordion icon spin example

### DIFF
--- a/submissions/examples/accordion-icon-spin/README.md
+++ b/submissions/examples/accordion-icon-spin/README.md
@@ -1,0 +1,15 @@
+# Accordion Icon Spin
+
+A native HTML accordion that uses CSS to spin the expand icon and softly reveal content when a panel opens.
+
+## Files
+
+- `demo.html` contains three accessible `details` and `summary` panels.
+- `style.css` defines the icon rotation, panel reveal, hover state, and focus-visible treatment.
+
+## What it demonstrates
+
+- No-JavaScript accordion behavior with native HTML elements.
+- Animated plus icon rotation on hover, focus, and open states.
+- Smooth content reveal with opacity and transform.
+- Compact responsive spacing for support or FAQ sections.

--- a/submissions/examples/accordion-icon-spin/demo.html
+++ b/submissions/examples/accordion-icon-spin/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accordion Icon Spin</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="faq">
+    <h1>Support FAQ</h1>
+    <details open>
+      <summary>How fast is setup?</summary>
+      <p>The starter can be added to an existing page with only HTML and CSS.</p>
+    </details>
+    <details>
+      <summary>Does it need JavaScript?</summary>
+      <p>No. The expand state, icon spin, and panel reveal all use native details behavior.</p>
+    </details>
+    <details>
+      <summary>Is keyboard access supported?</summary>
+      <p>Yes. The summary remains focusable and includes a visible focus treatment.</p>
+    </details>
+  </section>
+</body>
+</html>

--- a/submissions/examples/accordion-icon-spin/style.css
+++ b/submissions/examples/accordion-icon-spin/style.css
@@ -1,0 +1,107 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f4f7f5;
+  color: #132018;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.faq {
+  width: min(92vw, 640px);
+}
+
+h1 {
+  margin: 0 0 20px;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  letter-spacing: 0;
+}
+
+details {
+  overflow: hidden;
+  border: 1px solid #b7c9bd;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 14px 34px rgba(19, 32, 24, 0.08);
+}
+
+details + details {
+  margin-top: 12px;
+}
+
+summary {
+  position: relative;
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  padding: 0 58px 0 18px;
+  cursor: pointer;
+  font-weight: 900;
+  list-style: none;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+summary::after {
+  content: "+";
+  position: absolute;
+  right: 18px;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #0f766e;
+  color: #ffffff;
+  font-size: 1.25rem;
+  line-height: 1;
+  transition: transform 220ms ease, background 220ms ease;
+}
+
+summary:hover::after,
+summary:focus-visible::after {
+  transform: rotate(90deg) scale(1.08);
+  background: #115e59;
+}
+
+details[open] summary::after {
+  transform: rotate(135deg);
+}
+
+details p {
+  margin: 0;
+  padding: 0 18px 18px;
+  color: #4b6352;
+  line-height: 1.7;
+  animation: reveal 240ms ease both;
+}
+
+summary:focus-visible {
+  outline: 3px solid rgba(15, 118, 110, 0.28);
+  outline-offset: -3px;
+}
+
+@keyframes reveal {
+  from {
+    transform: translateY(-8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 520px) {
+  summary {
+    min-height: 64px;
+    padding-left: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only accordion icon spin example
- use native details and summary elements for interaction
- document focus, reveal, and icon rotation behavior

## Test
- git diff --cached --check