### PR TITLE
feat: add pricing badge float example

### DIFF
--- a/submissions/examples/pricing-badge-float/README.md
+++ b/submissions/examples/pricing-badge-float/README.md
@@ -1,0 +1,15 @@
+# Pricing Badge Float
+
+A polished pricing card with a floating popular badge, hover lift, and tactile button states.
+
+## Files
+
+- `demo.html` provides the pricing card markup.
+- `style.css` contains the floating badge animation, card elevation, button feedback, and responsive sizing.
+
+## What it demonstrates
+
+- A rotated promotional badge animated with keyframes.
+- Card-level hover and focus-within motion.
+- Button hover and active feedback without JavaScript.
+- Responsive pricing card spacing for narrow screens.

--- a/submissions/examples/pricing-badge-float/demo.html
+++ b/submissions/examples/pricing-badge-float/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pricing Badge Float</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="pricing">
+    <article class="plan">
+      <span class="badge">Popular</span>
+      <p class="name">Growth</p>
+      <h1>$29</h1>
+      <p class="copy">For teams that need polished collaboration tools and faster delivery.</p>
+      <button>Choose Plan</button>
+    </article>
+  </section>
+</body>
+</html>

--- a/submissions/examples/pricing-badge-float/style.css
+++ b/submissions/examples/pricing-badge-float/style.css
@@ -1,0 +1,111 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, #f8fafc, #dcfce7);
+  color: #0f172a;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.pricing {
+  width: min(92vw, 420px);
+}
+
+.plan {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  padding: 34px;
+  background: #ffffff;
+  box-shadow: 0 24px 56px rgba(22, 101, 52, 0.16);
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.plan:hover,
+.plan:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 30px 70px rgba(22, 101, 52, 0.22);
+}
+
+.badge {
+  position: absolute;
+  top: 22px;
+  right: -44px;
+  width: 160px;
+  padding: 8px 0;
+  transform: rotate(35deg);
+  background: #16a34a;
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-align: center;
+  text-transform: uppercase;
+  animation: badge-float 2.6s ease-in-out infinite;
+}
+
+.name {
+  margin: 0;
+  color: #16a34a;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 10px 0;
+  font-size: 4rem;
+  letter-spacing: 0;
+}
+
+.copy {
+  margin: 0 0 26px;
+  color: #475569;
+  line-height: 1.7;
+}
+
+button {
+  width: 100%;
+  min-height: 48px;
+  border: 0;
+  border-radius: 8px;
+  background: #0f172a;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  background: #16a34a;
+}
+
+button:active {
+  transform: translateY(0) scale(0.98);
+}
+
+@keyframes badge-float {
+  0%, 100% {
+    transform: rotate(35deg) translateY(0);
+  }
+  50% {
+    transform: rotate(35deg) translateY(5px);
+  }
+}
+
+@media (max-width: 440px) {
+  .plan {
+    padding: 28px 24px;
+  }
+
+  h1 {
+    font-size: 3.2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only pricing badge float example
- include card lift, floating badge, and button feedback states
- document the example structure and responsive behavior

## Test
- git diff --cached --check