### PR TITLE
feat: add upload chip fill example

### DIFF
--- a/submissions/examples/upload-chip-fill/README.md
+++ b/submissions/examples/upload-chip-fill/README.md
@@ -1,0 +1,15 @@
+# Upload Chip Fill
+
+A compact upload queue component that uses CSS fills to show completed and active upload states.
+
+## Files
+
+- `demo.html` includes three upload chips for complete, active, and queued files.
+- `style.css` defines the animated progress fill, hover movement, truncation behavior, and mobile stacking.
+
+## What it demonstrates
+
+- CSS-only progress fill animation with pseudo-elements.
+- Stable file name truncation for long labels.
+- Distinct complete, active, and queued states.
+- Responsive chip layout without JavaScript.

--- a/submissions/examples/upload-chip-fill/demo.html
+++ b/submissions/examples/upload-chip-fill/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Upload Chip Fill</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="upload-box">
+    <h1>Upload Queue</h1>
+    <div class="chip complete">
+      <span>brand-guide.pdf</span>
+      <strong>Done</strong>
+    </div>
+    <div class="chip active">
+      <span>landing-video.mp4</span>
+      <strong>72%</strong>
+    </div>
+    <div class="chip">
+      <span>hero-image.png</span>
+      <strong>Queued</strong>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/upload-chip-fill/style.css
+++ b/submissions/examples/upload-chip-fill/style.css
@@ -1,0 +1,114 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #101828;
+  color: #f8fafc;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.upload-box {
+  width: min(92vw, 520px);
+  padding: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.28);
+}
+
+h1 {
+  margin: 0 0 18px;
+  font-size: 1.6rem;
+  letter-spacing: 0;
+}
+
+.chip {
+  position: relative;
+  overflow: hidden;
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 8px;
+  padding: 0 16px;
+  background: rgba(30, 41, 59, 0.84);
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.chip::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(90deg, rgba(34, 197, 94, 0.32), rgba(14, 165, 233, 0.2));
+  z-index: 0;
+}
+
+.chip > * {
+  position: relative;
+  z-index: 1;
+}
+
+.chip:hover {
+  transform: translateX(4px);
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+.complete::before {
+  width: 100%;
+}
+
+.active::before {
+  animation: fill-progress 2.4s ease-in-out infinite;
+}
+
+.chip span {
+  min-width: 0;
+  overflow: hidden;
+  color: #dbeafe;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chip strong {
+  flex: 0 0 auto;
+  color: #86efac;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+.chip:not(.active):not(.complete) strong {
+  color: #cbd5e1;
+}
+
+@keyframes fill-progress {
+  0%, 100% {
+    width: 56%;
+  }
+  50% {
+    width: 78%;
+  }
+}
+
+@media (max-width: 460px) {
+  .upload-box {
+    padding: 20px;
+  }
+
+  .chip {
+    min-height: 64px;
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only upload chip fill example
- include complete, active, and queued upload states
- document the progress fill and responsive chip behavior

## Test
- git diff --cached --check