### PR TITLE
feat: add toast stack slide example

### DIFF
--- a/submissions/examples/toast-stack-slide/README.md
+++ b/submissions/examples/toast-stack-slide/README.md
@@ -1,0 +1,15 @@
+# Toast Stack Slide
+
+A CSS-only notification stack with staggered slide-in motion and a timer bar that pauses when a toast is hovered.
+
+## Files
+
+- `demo.html` defines success, info, and warning toast messages.
+- `style.css` contains the staggered entrance animation, timer bar, hover pause, and responsive spacing.
+
+## What it demonstrates
+
+- Staggered notification motion with `nth-child` delays.
+- CSS timer bars using transform scaling.
+- Different visual states for success, info, and warning messages.
+- Hover-based pause behavior without JavaScript.

--- a/submissions/examples/toast-stack-slide/demo.html
+++ b/submissions/examples/toast-stack-slide/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Stack Slide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="toast-panel" aria-label="Notification stack">
+    <article class="toast success">
+      <strong>Build finished</strong>
+      <span>Deployment is ready for preview.</span>
+    </article>
+    <article class="toast info">
+      <strong>Review requested</strong>
+      <span>Two teammates were notified.</span>
+    </article>
+    <article class="toast warning">
+      <strong>Storage almost full</strong>
+      <span>Archive old exports to continue.</span>
+    </article>
+  </section>
+</body>
+</html>

--- a/submissions/examples/toast-stack-slide/style.css
+++ b/submissions/examples/toast-stack-slide/style.css
@@ -1,0 +1,120 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f3f4f6;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.toast-panel {
+  width: min(92vw, 430px);
+  display: grid;
+  gap: 12px;
+}
+
+.toast {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px 18px 16px 22px;
+  background: #ffffff;
+  box-shadow: 0 18px 42px rgba(17, 24, 39, 0.12);
+  animation: slide-toast 520ms ease both;
+}
+
+.toast:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.toast:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+.toast::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+  background: #2563eb;
+}
+
+.toast::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  background: currentColor;
+  opacity: 0.34;
+  transform-origin: left;
+  animation: toast-timer 4s linear infinite;
+}
+
+.toast:hover::after {
+  animation-play-state: paused;
+}
+
+.success::before,
+.success {
+  color: #16a34a;
+}
+
+.info::before,
+.info {
+  color: #2563eb;
+}
+
+.warning::before,
+.warning {
+  color: #d97706;
+}
+
+.toast strong,
+.toast span {
+  display: block;
+}
+
+.toast strong {
+  margin-bottom: 5px;
+  color: #111827;
+  font-size: 0.98rem;
+}
+
+.toast span {
+  color: #4b5563;
+  line-height: 1.55;
+}
+
+@keyframes slide-toast {
+  from {
+    transform: translateX(34px) scale(0.98);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes toast-timer {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+@media (max-width: 460px) {
+  .toast {
+    padding-right: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only toast stack slide example
- include staggered entrance, timer bars, and hover pause behavior
- document notification states and animation details

## Test
- git diff --cached --check