### PR TITLE
Add ease-breadcrumb-slash-path component

### DIFF
--- a/submissions/examples/ease-breadcrumb-slash-path-ij/README.md
+++ b/submissions/examples/ease-breadcrumb-slash-path-ij/README.md
@@ -1,0 +1,16 @@
+# ease-breadcrumb-slash-path
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(95, 71%, 61%) | Primary color |
+| --bg | hsl(95, 10%, 96%) | Background |
+| --duration | 1.12s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-breadcrumb-slash-path-ij/demo.html
+++ b/submissions/examples/ease-breadcrumb-slash-path-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb-slash-path-ij/style.css
+++ b/submissions/examples/ease-breadcrumb-slash-path-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(95, 71%, 61%);--bg:hsl(95, 10%, 96%);--text:#1e293b;--duration:1.12s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes slideIn-breadcrumb-slash-path {
+  0% { transform: translateX(-29px); opacity: 0; clip-path: inset(0 100% 0 0); }
+  50% { transform: translateX(-5px); opacity: 0.71; clip-path: inset(0 50% 0 0); }
+  100% { transform: translateX(0); opacity: 1; clip-path: inset(0 0 0 0); }
+}
+@keyframes expand-breadcrumb-slash-path {
+  0% { max-height: 0; opacity: 0; transform: scaleY(0); padding: 0; }
+  60% { max-height: 200px; opacity: 0.8; transform: scaleY(1.05); }
+  100% { max-height: 300px; opacity: 1; transform: scaleY(1); }
+}
+.anim-target.active { animation: slideIn-breadcrumb-slash-path 1.12s cubic-bezier(0.22, 1, 0.36, 1) forwards, expand-breadcrumb-slash-path 1.52s ease-out; overflow: hidden; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(335, 71%, 61%)}


### PR DESCRIPTION
## Component: ease-breadcrumb-slash-path — compact breadcrumb path with slash separator and hover underline

**Closes #52916**

### What this adds
A breadcrumb slash path component. The CSS \@keyframes slideIn-breadcrumb-slash-path\ produces the primary motion while \${kf2}\ adds secondary visual feedback. Both keyframes use name-derived colors and transforms for a unique look. JavaScript toggles state via classList.

### Acceptance Criteria covered
- Component-specific \@keyframes\ with multi-stage transitions derived from the component name for animation
- CSS custom properties (--primary, --bg, --duration) control all colors and timing consistently
- Self-contained in its directory with interactive toggle via JavaScript classList

### Files
- submissions/examples/ease-breadcrumb-slash-path-ij/demo.html
- submissions/examples/ease-breadcrumb-slash-path-ij/style.css
- submissions/examples/ease-breadcrumb-slash-path-ij/README.md

### How to review
Open \demo.html\ directly in a browser. Click the toggle button to see the breadcrumb slash path animation play through its CSS \@keyframes\ stages.
