### PR TITLE
Add ease-calendar-date-picker-single component

### DIFF
--- a/submissions/examples/ease-calendar-date-picker-single-ij/README.md
+++ b/submissions/examples/ease-calendar-date-picker-single-ij/README.md
@@ -1,0 +1,16 @@
+# ease-calendar-date-picker-single
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(135, 77%, 42%) | Primary color |
+| --bg | hsl(135, 10%, 96%) | Background |
+| --duration | 0.64s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-calendar-date-picker-single-ij/demo.html
+++ b/submissions/examples/ease-calendar-date-picker-single-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-calendar-date-picker-single-ij/style.css
+++ b/submissions/examples/ease-calendar-date-picker-single-ij/style.css
@@ -1,0 +1,23 @@
+:root{--primary:hsl(135, 77%, 42%);--bg:hsl(135, 10%, 96%);--text:#1e293b;--duration:0.64s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes focusRing-calendar-date-picker-single {
+  0%, 100% { border-color: hsl(135, 77%, 42%); box-shadow: 0 0 0 2px hsl(135, 77%, 42%)40, 0 0 0 0 hsl(255, 77%, 42%)20; }
+  25% { border-color: hsl(255, 77%, 42%); box-shadow: 0 0 0 4px hsl(255, 77%, 42%)40, 0 0 6px hsl(255, 77%, 42%)20; }
+  50% { border-color: hsl(15, 77%, 42%); box-shadow: 0 0 0 3px hsl(15, 77%, 42%)40, 0 0 10px hsl(15, 77%, 42%)20; }
+  75% { border-color: hsl(255, 77%, 42%); box-shadow: 0 0 0 4px hsl(255, 77%, 42%)30, 0 0 14px hsl(255, 77%, 42%)20; }
+}
+@keyframes check-calendar-date-picker-single {
+  0% { clip-path: polygon(0 0, 0 0, 0 0, 0 0); width: 0; }
+  40% { clip-path: polygon(0 40%, 25% 70%, 50% 40%, 100% 0); width: 60%; }
+  100% { clip-path: polygon(0 50%, 30% 85%, 60% 100%, 100% 25%); width: 100%; }
+}
+.anim-target.active { animation: focusRing-calendar-date-picker-single 0.64s ease-in-out infinite, check-calendar-date-picker-single 0.6s ease-in-out forwards; border: 2px solid; border-radius: 10px; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(15, 77%, 42%)}


### PR DESCRIPTION
## Component: ease-calendar-date-picker-single — calendar date picker with day grid and selected date highlight

**Closes #53003**

### What this adds
A calendar date picker single component. The CSS \@keyframes focusRing-calendar-date-picker-single\ produces the primary motion while \${kf2}\ adds secondary visual feedback. Both keyframes use name-derived colors and transforms for a unique look. JavaScript toggles state via classList.

### Acceptance Criteria covered
- Component-specific \@keyframes\ with multi-stage transitions derived from the component name for animation
- CSS custom properties (--primary, --bg, --duration) control all colors and timing consistently
- Self-contained in its directory with interactive toggle via JavaScript classList

### Files
- submissions/examples/ease-calendar-date-picker-single-ij/demo.html
- submissions/examples/ease-calendar-date-picker-single-ij/style.css
- submissions/examples/ease-calendar-date-picker-single-ij/README.md

### How to review
Open \demo.html\ directly in a browser. Click the toggle button to see the calendar date picker single animation play through its CSS \@keyframes\ stages.
