### PR TITLE
Add ease-call-reject-animation component

### DIFF
--- a/submissions/examples/ease-call-reject-animation-ij/README.md
+++ b/submissions/examples/ease-call-reject-animation-ij/README.md
@@ -1,0 +1,16 @@
+# ease-call-reject-animation
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(29, 71%, 61%) | Primary color |
+| --bg | hsl(29, 10%, 96%) | Background |
+| --duration | 1.12s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-call-reject-animation-ij/demo.html
+++ b/submissions/examples/ease-call-reject-animation-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-call-reject-animation-ij/style.css
+++ b/submissions/examples/ease-call-reject-animation-ij/style.css
@@ -1,0 +1,25 @@
+:root{--primary:hsl(29, 71%, 61%);--bg:hsl(29, 10%, 96%);--text:#1e293b;--duration:1.12s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes morph-call-reject-animation {
+  0% { transform: scale(1) rotate(0deg); border-radius: 8px; background: hsl(29, 71%, 61%); filter: blur(0) hue-rotate(0deg) saturate(1); }
+  16% { transform: scale(1.15) rotate(6.5deg); border-radius: 68px; background: hsl(149, 71%, 61%); filter: saturate(1.5); }
+  33% { transform: scale(1.25) rotate(13deg); border-radius: 50%; background: hsl(269, 71%, 61%); filter: blur(1px) saturate(1); }
+  50% { transform: scale(1.15) rotate(19.5deg); border-radius: 4px; background: hsl(149, 71%, 61%); filter: blur(0) hue-rotate(10deg); }
+  66% { transform: scale(1.1) rotate(26deg); border-radius: 16px; background: hsl(29, 71%, 61%); filter: hue-rotate(20deg) saturate(1.3); }
+  83% { transform: scale(1.25) rotate(32.5deg); border-radius: 30%; background: hsl(269, 71%, 61%); filter: blur(1px); }
+  100% { transform: scale(1) rotate(39deg); border-radius: 8px; background: hsl(29, 71%, 61%); filter: blur(0) hue-rotate(0deg) saturate(1); }
+}
+@keyframes shimmer-call-reject-animation {
+  0% { background-position: -400% 0; }
+  100% { background-position: 400% 0; }
+}
+.anim-target.active { animation: morph-call-reject-animation 1.43s ease-in-out infinite, shimmer-call-reject-animation 3s linear infinite; background-size: 400% 100%; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(269, 71%, 61%)}


### PR DESCRIPTION
## Component: ease-call-reject-animation — call decline slide animation with red transition and end call

**Closes #53038**

### What this adds
A call reject animation component. The CSS \@keyframes morph-call-reject-animation\ produces the primary motion while \${kf2}\ adds secondary visual feedback. Both keyframes use name-derived colors and transforms for a unique look. JavaScript toggles state via classList.

### Acceptance Criteria covered
- Component-specific \@keyframes\ with multi-stage transitions derived from the component name for animation
- CSS custom properties (--primary, --bg, --duration) control all colors and timing consistently
- Self-contained in its directory with interactive toggle via JavaScript classList

### Files
- submissions/examples/ease-call-reject-animation-ij/demo.html
- submissions/examples/ease-call-reject-animation-ij/style.css
- submissions/examples/ease-call-reject-animation-ij/README.md

### How to review
Open \demo.html\ directly in a browser. Click the toggle button to see the call reject animation animation play through its CSS \@keyframes\ stages.
