### PR TITLE
Add ease-camera-focus-reticle component

### DIFF
--- a/submissions/examples/ease-camera-focus-reticle-ij/README.md
+++ b/submissions/examples/ease-camera-focus-reticle-ij/README.md
@@ -1,0 +1,16 @@
+# ease-camera-focus-reticle
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(255, 70%, 60%) | Primary color |
+| --bg | hsl(255, 10%, 96%) | Background |
+| --duration | 1.04s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-camera-focus-reticle-ij/demo.html
+++ b/submissions/examples/ease-camera-focus-reticle-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-camera-focus-reticle-ij/style.css
+++ b/submissions/examples/ease-camera-focus-reticle-ij/style.css
@@ -1,0 +1,26 @@
+:root{--primary:hsl(255, 70%, 60%);--bg:hsl(255, 10%, 96%);--text:#1e293b;--duration:1.04s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes countUp-camera-focus-reticle {
+  0% { transform: translateY(-40px) scale(0.8); opacity: 0; clip-path: inset(0 0 100% 0); }
+  35% { transform: translateY(-13px) scale(1.1); opacity: 0.6; clip-path: inset(0 0 40% 0); }
+  70% { transform: translateY(-7px) scale(0.98); opacity: 0.9; }
+  100% { transform: translateY(0) scale(1); opacity: 1; clip-path: inset(0); }
+}
+@keyframes blink-camera-focus-reticle {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  15% { opacity: 0.6; transform: scale(1.08); }
+  30% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.40; transform: scale(1.05); }
+  70% { opacity: 0.9; transform: scale(1); }
+  85% { opacity: 0.6; transform: scale(1.03); }
+}
+.anim-target.active { animation: countUp-camera-focus-reticle 1.04s cubic-bezier(0.16, 1, 0.3, 1) forwards, blink-camera-focus-reticle 1.8s ease-in-out infinite 0.3s; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(135, 70%, 60%)}


### PR DESCRIPTION
## Component: ease-camera-focus-reticle — camcorder recording indicator with red light and recording icon

**Closes #53063**

### What this adds
A camera focus reticle component. The CSS \@keyframes countUp-camera-focus-reticle\ produces the primary motion while \${kf2}\ adds secondary visual feedback. Both keyframes use name-derived colors and transforms for a unique look. JavaScript toggles state via classList.

### Acceptance Criteria covered
- Component-specific \@keyframes\ with multi-stage transitions derived from the component name for animation
- CSS custom properties (--primary, --bg, --duration) control all colors and timing consistently
- Self-contained in its directory with interactive toggle via JavaScript classList

### Files
- submissions/examples/ease-camera-focus-reticle-ij/demo.html
- submissions/examples/ease-camera-focus-reticle-ij/style.css
- submissions/examples/ease-camera-focus-reticle-ij/README.md

### How to review
Open \demo.html\ directly in a browser. Click the toggle button to see the camera focus reticle animation play through its CSS \@keyframes\ stages.
