### PR TITLE
fix: optimize breadcrumb component for printing

### DIFF
--- a/components/breadcrumb.css
+++ b/components/breadcrumb.css
@@ -52,4 +52,20 @@
   .bg-dark .ease-breadcrumb-active {
     color: #9ca3af;
   }
+
+ @media print {
+   .ease-breadcrumb-link,
+   .ease-breadcrumb-link:hover,
+   .ease-breadcrumb-active,
+   .ease-breadcrumb-separator {
+     color: #000 !important;
+     background: transparent !important;
+     box-shadow: none !important;
+     text-shadow: none !important;
+  }
+
+   .ease-breadcrumb-link {
+     text-decoration: underline;
+  }
+}
 }


### PR DESCRIPTION
## Summary

This PR adds print-specific styles to the breadcrumb component to improve print readability and reduce unnecessary ink usage.

### Changes
- Added a `@media print` block to the breadcrumb component.
- Changed breadcrumb text and separators to black when printing.
- Removed background, box-shadow, and text-shadow styles in print mode.
- Kept breadcrumb links underlined for better visibility in printed documents.

Fixes #51904