### PR TITLE
feat: add twist message focus state SCSS mixin

### DIFF
--- a/submissions/scss/feature-twist-message-mixin-mixin-GA/Readme.md
+++ b/submissions/scss/feature-twist-message-mixin-mixin-GA/Readme.md
@@ -1,0 +1,43 @@
+# Twist Message (Focus State) Mixin
+
+A reusable SCSS mixin that applies a subtle twist animation when an element receives keyboard focus. It is designed to improve visual feedback while maintaining accessibility.
+
+## Features
+
+- Smooth twist animation on focus
+- Configurable duration, rotation angle, and scale
+- Uses `:focus` and `:focus-visible`
+- Respects `prefers-reduced-motion`
+- Suitable for forms, alerts, messages, and interactive UI components
+
+## Usage
+
+```scss
+.my-message {
+  @include ease-twist-message-mixin-mixin-GA();
+}
+```
+
+### Custom Example
+
+```scss
+.my-message {
+  @include ease-twist-message-mixin-mixin-GA(
+    $duration: 0.4s,
+    $angle: 6deg,
+    $scale: 1.05
+  );
+}
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `$duration` | `0.5s` | Transition duration |
+| `$angle` | `4deg` | Rotation angle |
+| `$scale` | `1.02` | Scale factor |
+
+## Accessibility
+
+The mixin supports `prefers-reduced-motion: reduce` by disabling the transform animation for users who prefer reduced motion.

--- a/submissions/scss/feature-twist-message-mixin-mixin-GA/_twist-message-mixin.scss
+++ b/submissions/scss/feature-twist-message-mixin-mixin-GA/_twist-message-mixin.scss
@@ -1,0 +1,32 @@
+/// Twist Message (Focus State) Mixin
+/// Applies a subtle twist animation when an element receives focus.
+///
+/// @param {Time} $duration - Transition duration.
+/// @param {Angle} $angle - Rotation angle.
+/// @param {Number} $scale - Scale factor.
+@mixin ease-twist-message-mixin-mixin-GA(
+  $duration: 0.5s,
+  $angle: 4deg,
+  $scale: 1.02
+) {
+  transition:
+    transform $duration ease,
+    box-shadow $duration ease,
+    outline-offset $duration ease;
+
+  &:focus,
+  &:focus-visible {
+    transform: rotate($angle) scale($scale);
+    outline: 2px solid currentColor;
+    outline-offset: 4px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:focus,
+    &:focus-visible {
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a reusable SCSS mixin for a Twist Message (Focus State) animation.

### Changes
- Added `_twist-message-mixin.scss`
- Added `README.md` with usage instructions
- Supports configurable duration, rotation angle, and scale
- Respects `prefers-reduced-motion`
- Uses accessible `:focus` and `:focus-visible` states

Fixes #52627 