### PR TITLE
feat: add carousel print optimization demo (#51911)

### DIFF
--- a/submissions/docs/carousel-print-optimization-sap/README.md
+++ b/submissions/docs/carousel-print-optimization-sap/README.md
@@ -1,0 +1,16 @@
+# Carousel Print Optimization
+
+**What does this do?**
+Strips heavy background colors, text colors, and box-shadows from the carousel component when printed, reducing ink usage.
+
+**How is it used?**
+Just include the CSS as-is; the `@media print` block automatically activates when the page is printed or previewed for printing.
+
+```html
+<div class="carousel">
+  <div class="carousel-slide">Content</div>
+</div>
+```
+
+**Why is it useful?**
+Printing a carousel with dark backgrounds and shadows wastes significant ink. This ensures the component degrades gracefully to a clean, ink-friendly layout in print contexts, matching EaseMotion's focus on practical, polished UI behavior.

--- a/submissions/docs/carousel-print-optimization-sap/demo.html
+++ b/submissions/docs/carousel-print-optimization-sap/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Carousel Print Optimization Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="carousel">
+    <div class="carousel-slide">Slide 1: Try printing this page (Ctrl+P)</div>
+  </div>
+</body>
+</html>

--- a/submissions/docs/carousel-print-optimization-sap/style.css
+++ b/submissions/docs/carousel-print-optimization-sap/style.css
@@ -1,0 +1,21 @@
+.carousel {
+  background: #1e1e2f;
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.carousel-slide {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+@media print {
+  .carousel,
+  .carousel * {
+    background: transparent !important;
+    color: #000 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a self-contained demo showing print-optimized styling for the carousel component. Fixes #51911 — the carousel currently wastes ink when printed due to heavy background colors and box-shadows.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/carousel-print-optimization-sap/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A `@media print` override for the `.carousel` component that strips background colors, text colors, and box-shadows when the page is printed, reducing ink usage.

**How does a developer use it?**
```html
<div class="carousel">
  <div class="carousel-slide">Content</div>
</div>
```
No extra markup needed — the print behavior activates automatically via the media query.

**Why does it fit EaseMotion CSS?**
It keeps the carousel visually rich on-screen while degrading gracefully and practically for print — consistent with EaseMotion's focus on polished, real-world UI behavior rather than animation for its own sake.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari 

---
## Notes for Maintainer
Used a generic `.carousel` / `.carousel-slide` naming in the raw submission per the contribution guide — happy to adjust selectors once standardized to `ease-*` naming during integration.