### PR TITLE
feat: add button print optimization demo (#51906)

### DIFF
--- a/submissions/docs/button-print-optimization-sap/README.md
+++ b/submissions/docs/button-print-optimization-sap/README.md
@@ -1,0 +1,12 @@
+# Button Print Optimization
+
+**What does this do?**
+Strips heavy background color and box-shadow from the button component when printed, replacing them with a simple bordered outline to keep the button legible while saving ink.
+
+**How is it used?**
+```html
+<button class="button">Click Me</button>
+```
+
+**Why is it useful?**
+Buttons with vivid backgrounds and shadows waste ink and can render as solid dark blocks when printed. This ensures buttons degrade to a clean, minimal, ink-friendly outline in print, consistent with EaseMotion's practical, real-world UI philosophy.

--- a/submissions/docs/button-print-optimization-sap/demo.html
+++ b/submissions/docs/button-print-optimization-sap/demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Button Print Optimization Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button class="button">Click Me — Try Printing (Ctrl+P)</button>
+</body>
+</html>

--- a/submissions/docs/button-print-optimization-sap/style.css
+++ b/submissions/docs/button-print-optimization-sap/style.css
@@ -1,0 +1,18 @@
+.button {
+  background: #4f46e5;
+  color: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+  border: none;
+  border-radius: 6px;
+  padding: 10px 20px;
+  font-weight: 600;
+}
+
+@media print {
+  .button {
+    background: transparent !important;
+    color: #000 !important;
+    box-shadow: none !important;
+    border: 1px solid #000 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a self-contained demo showing print-optimized styling for the button component. Fixes #51906 — the button currently wastes ink when printed due to a heavy background color and box-shadow.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/button-print-optimization-sap/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A `@media print` override for the `.button` component that strips the background color and box-shadow when printed, replacing them with a thin border so the button stays visible while saving ink.

**How does a developer use it?**
```html
<button class="button">Click Me</button>
```
No extra markup needed — the print behavior activates automatically via the media query.

**Why does it fit EaseMotion CSS?**
It preserves the button's polished look on-screen while degrading gracefully for print — in line with EaseMotion's focus on practical, real-world UI behavior beyond just animation.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
Added a thin black border in print mode as a fallback so the button remains visually distinguishable once the background and shadow are removed — happy to drop this if it's not wanted. Also used generic `.button` naming per the contribution guide; ready to adjust to `ease-*` naming during integration.