### PR TITLE
feat: add avatar print optimization demo (#51900)

### DIFF
--- a/submissions/docs/avatar-print-optimization-sap/README.md
+++ b/submissions/docs/avatar-print-optimization-sap/README.md
@@ -1,0 +1,12 @@
+# Avatar Print Optimization
+
+**What does this do?**
+Strips the heavy background color and box-shadow from the avatar component when printed, replacing them with a thin border so the avatar shape stays visible while saving ink.
+
+**How is it used?**
+```html
+<div class="avatar">AK</div>
+```
+
+**Why is it useful?**
+Avatars with solid colored backgrounds print as heavy ink blocks, especially in lists or profile cards. This keeps the avatar recognizable as a bordered circle in print, consistent with EaseMotion's focus on practical, real-world UI behavior.

--- a/submissions/docs/avatar-print-optimization-sap/demo.html
+++ b/submissions/docs/avatar-print-optimization-sap/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Avatar Print Optimization Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="avatar">AK</div>
+  <p>Try printing this page (Ctrl+P) to see the print-optimized version.</p>
+</body>
+</html>

--- a/submissions/docs/avatar-print-optimization-sap/style.css
+++ b/submissions/docs/avatar-print-optimization-sap/style.css
@@ -1,0 +1,21 @@
+.avatar {
+  background: #22c55e;
+  color: #fff;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+@media print {
+  .avatar {
+    background: transparent !important;
+    color: #000 !important;
+    box-shadow: none !important;
+    border: 1px solid #000 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a self-contained demo showing print-optimized styling for the avatar component. Fixes #51900 — the avatar currently wastes ink when printed due to a heavy background color and box-shadow.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/avatar-print-optimization-sap/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A `@media print` override for the `.avatar` component that strips the background color and box-shadow when printed, replacing them with a thin border so the avatar shape stays visible while saving ink.

**How does a developer use it?**
```html
<div class="avatar">AK</div>
```
No extra markup needed — the print behavior activates automatically via the media query.

**Why does it fit EaseMotion CSS?**
It preserves the avatar's polished look on-screen while degrading gracefully for print — in line with EaseMotion's focus on practical, real-world UI behavior beyond just animation.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari 

---
## Notes for Maintainer
This is the third of a small set of near-identical print-optimization issues (carousel #51911, button #51906, avatar #51900). Followed the same border-fallback pattern across all three for consistency — happy to consolidate into a single PR if you'd prefer that over one-per-component.