### PR TITLE
feat: add SCSS text shadow mixin (#51847)

### DIFF
--- a/submissions/scss/text-shadow-ak/README.md
+++ b/submissions/scss/text-shadow-ak/README.md
@@ -1,0 +1,30 @@
+# Text Shadow Mixin
+
+A reusable SCSS mixin for applying consistent, layered text shadows across EaseMotion CSS components.
+
+## Parameters
+
+`ease-text-shadow($color, $x, $y, $blur)`
+- `$color` — shadow color (default: `rgba(0, 0, 0, 0.4)`)
+- `$x` — horizontal offset (default: `1px`)
+- `$y` — vertical offset (default: `1px`)
+- `$blur` — blur radius (default: `3px`)
+
+Also includes three presets:
+- `ease-text-shadow-soft($color)` — subtle shadow for body text
+- `ease-text-shadow-strong($color)` — bold shadow for headings/emphasis
+- `ease-text-shadow-glow($color)` — glowing shadow, useful alongside EaseMotion's entrance/hover animations
+
+## Usage
+
+```scss
+@import 'text-shadow';
+
+.hero-title {
+  @include ease-text-shadow-strong();
+}
+
+.glow-text {
+  @include ease-text-shadow-glow(rgba(99, 102, 241, 0.8));
+}
+```

--- a/submissions/scss/text-shadow-ak/_text-shadow.scss
+++ b/submissions/scss/text-shadow-ak/_text-shadow.scss
@@ -1,0 +1,20 @@
+// EaseMotion Text Shadow Mixin
+// Reusable SCSS mixin for applying layered text shadows,
+// designed to complement EaseMotion's animation-first components.
+
+@mixin ease-text-shadow($color: rgba(0, 0, 0, 0.4), $x: 1px, $y: 1px, $blur: 3px) {
+  text-shadow: $x $y $blur $color;
+}
+
+// Preset variants for common use cases
+@mixin ease-text-shadow-soft($color: rgba(0, 0, 0, 0.25)) {
+  @include ease-text-shadow($color, 0, 1px, 2px);
+}
+
+@mixin ease-text-shadow-strong($color: rgba(0, 0, 0, 0.6)) {
+  @include ease-text-shadow($color, 2px, 2px, 4px);
+}
+
+@mixin ease-text-shadow-glow($color: rgba(255, 255, 255, 0.8)) {
+  text-shadow: 0 0 8px $color, 0 0 16px $color;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a reusable SCSS mixin for applying text shadows, for use alongside EaseMotion's animation components. Fixes #51847.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below): SCSS mixin (SCSS Integration track)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/scss/text-shadow-ak/`)
- [ ] Includes `demo.html` — N/A, this is an SCSS-track submission (no demo.html required per contribution guide)
- [ ] Includes `style.css` — N/A, submission is `_text-shadow.scss` instead, per SCSS track requirements
- [x] Includes `README.md` — documents the mixin, its parameters, and usage with `@include`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

**SCSS Track files included:**
- [x] `_text-shadow.scss` — the mixin
- [x] `README.md` — parameters + usage docs

---
## Feature Description

**What does this add?**
A reusable SCSS mixin (`ease-text-shadow`) for applying layered text shadows, with `soft`, `strong`, and `glow` preset variants, built to complement EaseMotion animations.

**How does a developer use it?**
```scss
@import 'text-shadow';

.hero-title {
  @include ease-text-shadow-strong();
}
```

**Why does it fit EaseMotion CSS?**
It extends EaseMotion's design language into SCSS tooling, letting developers layer consistent, configurable text shadows on top of animated elements without repeating raw `text-shadow` declarations.

---
## Demo
- [ ] Demo added — N/A for SCSS track; no `demo.html` required

---
## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari — N/A, this is a build-time SCSS mixin with no runtime browser-specific behavior to test

---
## Notes for Maintainer
This follows the SCSS Integration track (not the standard HTML/CSS track), so `demo.html`/`style.css` were intentionally omitted in favor of `_text-shadow.scss` per the contribution guide's SCSS Track requirements. Let me know if a compiled CSS output example would also help review.