### PR TITLE
feat: add zoom-out tabs for responsive dashboards (#50281)

### DIFF
--- a/submissions/examples/zoom-out-tabs-ak/README.md
+++ b/submissions/examples/zoom-out-tabs-ak/README.md
@@ -1,0 +1,63 @@
+# Zoom-Out Tabs (`zoom-out-tabs-ak`)
+
+## What it does
+
+`.zoom-tabs-ak` is a pure CSS tab component for dashboard-style layouts.
+Switching tabs crossfades the panels while the incoming panel zooms out
+from a slightly enlarged state down to its normal size, giving view
+changes a smooth, modern feel — with **zero JavaScript**.
+
+## How to use it
+
+1. Link `style.css` in your page.
+2. Copy the markup structure from `demo.html`: a `fieldset` of hidden
+   radio inputs paired with visible tab labels, followed by a stack of
+   panels (one per tab, in the same order):
+
+```html
+   <div class="zoom-tabs-ak" style="--zoom-duration: 0.35s; --zoom-scale: 0.85;">
+     <fieldset class="zoom-tabs-fieldset-ak">
+       <legend class="sr-only">Dashboard view</legend>
+
+       <input type="radio" name="zoom-tabs-ak" id="zoom-tab-overview-ak" class="zoom-tab-input-ak" checked />
+       <label for="zoom-tab-overview-ak" class="zoom-tab-ak">Overview</label>
+       <!-- …repeat input/label pairs for each tab… -->
+     </fieldset>
+
+     <div class="zoom-tab-panels-ak">
+       <div class="zoom-tab-panel-ak">…</div>
+       <!-- …one panel per tab, in matching order… -->
+     </div>
+   </div>
+```
+
+3. Adjust the custom properties on `.zoom-tabs-ak` to tune the effect:
+
+   | Property          | Default | Description                              |
+   |-------------------|---------|--------------------------------------------|
+   | `--zoom-duration` | `0.3s`  | Transition duration for the crossfade/zoom |
+   | `--zoom-easing`   | `ease`  | Timing function for the transition         |
+   | `--zoom-scale`    | `0.9`   | Starting scale of an inactive panel        |
+
+## Why it's useful
+
+- **Zero JavaScript** — tab switching is handled entirely by a native
+  radio group and the `:has()` relational selector; the browser's
+  built-in radio behavior (click-to-select, arrow-key navigation
+  between options) provides keyboard support for free.
+- **Accessible by default** — the `fieldset`/`legend` grouping means
+  screen readers correctly announce the tabs as a related set of
+  options, and `:focus-visible` styling keeps keyboard focus visible.
+- **Configurable via CSS custom properties** — timing, easing, and the
+  zoom scale factor can all be tuned per-instance without touching the
+  underlying rules, as requested for exposing animation parameters.
+- **Responsive** — tabs wrap and stack vertically on narrow viewports so
+  the component holds up on dashboard layouts at any screen size.
+- **Reduced-motion friendly** — under `prefers-reduced-motion: reduce`,
+  the zoom/scale transform is dropped and panels simply crossfade.
+
+## Browser support note
+
+This component relies on the `:has()` CSS relational selector, which is
+supported in all current evergreen browsers (Chrome, Edge, Safari, and
+Firefox 121+).

--- a/submissions/examples/zoom-out-tabs-ak/demo.html
+++ b/submissions/examples/zoom-out-tabs-ak/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Zoom-Out Tabs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div
+    class="zoom-tabs-ak"
+    style="--zoom-duration: 0.35s; --zoom-scale: 0.85;"
+  >
+    <fieldset class="zoom-tabs-fieldset-ak">
+      <legend class="sr-only">Dashboard view</legend>
+
+      <input
+        type="radio"
+        name="zoom-tabs-ak"
+        id="zoom-tab-overview-ak"
+        class="zoom-tab-input-ak"
+        checked
+      />
+      <label for="zoom-tab-overview-ak" class="zoom-tab-ak">Overview</label>
+
+      <input
+        type="radio"
+        name="zoom-tabs-ak"
+        id="zoom-tab-analytics-ak"
+        class="zoom-tab-input-ak"
+      />
+      <label for="zoom-tab-analytics-ak" class="zoom-tab-ak">Analytics</label>
+
+      <input
+        type="radio"
+        name="zoom-tabs-ak"
+        id="zoom-tab-settings-ak"
+        class="zoom-tab-input-ak"
+      />
+      <label for="zoom-tab-settings-ak" class="zoom-tab-ak">Settings</label>
+    </fieldset>
+
+    <div class="zoom-tab-panels-ak">
+      <div class="zoom-tab-panel-ak">
+        <h2>Overview</h2>
+        <p>A quick summary of your dashboard's key metrics.</p>
+      </div>
+      <div class="zoom-tab-panel-ak">
+        <h2>Analytics</h2>
+        <p>Charts and trends showing usage over time.</p>
+      </div>
+      <div class="zoom-tab-panel-ak">
+        <h2>Settings</h2>
+        <p>Configure preferences for this dashboard.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/zoom-out-tabs-ak/style.css
+++ b/submissions/examples/zoom-out-tabs-ak/style.css
@@ -1,0 +1,151 @@
+/* ==========================================================================
+   Zoom-Out Tabs (zoom-out-tabs-ak)
+   Pure CSS tabs where switching views crossfades and zooms out from a
+   slightly enlarged state, suited to responsive dashboard layouts.
+   Zero JavaScript: implemented with a native radio group + :has().
+   ========================================================================== */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f1115;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  padding: 1rem;
+}
+
+/* Visually hides text while keeping it available to screen readers. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.zoom-tabs-ak {
+  /* Public custom properties — override on .zoom-tabs-ak to customize. */
+  --zoom-duration: 0.3s;
+  --zoom-easing: ease;
+  --zoom-scale: 0.9;
+
+  width: min(100%, 420px);
+}
+
+.zoom-tabs-fieldset-ak {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border: none;
+  padding: 0;
+  margin: 0 0 0.75rem;
+}
+
+/* Visually hidden but still focusable/keyboard-operable native radios. */
+.zoom-tab-input-ak {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.zoom-tab-ak {
+  padding: 0.5rem 1rem;
+  border-radius: 0.4rem;
+  background: #1c2333;
+  color: #aab3cc;
+  border: 1px solid #2e3752;
+  cursor: pointer;
+  font-size: 0.925rem;
+  transition:
+    background var(--zoom-duration) var(--zoom-easing),
+    color var(--zoom-duration) var(--zoom-easing);
+}
+
+.zoom-tab-input-ak:checked + .zoom-tab-ak {
+  background: #7c9bff;
+  color: #0f1115;
+}
+
+.zoom-tab-input-ak:focus-visible + .zoom-tab-ak {
+  outline: 2px solid #7c9bff;
+  outline-offset: 2px;
+}
+
+.zoom-tab-panels-ak {
+  position: relative;
+  min-height: 120px;
+  border-radius: 0.5rem;
+  border: 1px solid #2e3752;
+  background: #161c2b;
+}
+
+.zoom-tab-panel-ak {
+  position: absolute;
+  inset: 0;
+  padding: 1.25rem;
+  color: #d7ddee;
+  opacity: 0;
+  transform: scale(var(--zoom-scale));
+  pointer-events: none;
+  transition:
+    opacity var(--zoom-duration) var(--zoom-easing),
+    transform var(--zoom-duration) var(--zoom-easing);
+}
+
+.zoom-tab-panel-ak h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+.zoom-tab-panel-ak p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #aab3cc;
+}
+
+/* Show the panel matching whichever radio is currently checked. */
+.zoom-tabs-ak:has(#zoom-tab-overview-ak:checked) .zoom-tab-panel-ak:nth-of-type(1),
+.zoom-tabs-ak:has(#zoom-tab-analytics-ak:checked) .zoom-tab-panel-ak:nth-of-type(2),
+.zoom-tabs-ak:has(#zoom-tab-settings-ak:checked) .zoom-tab-panel-ak:nth-of-type(3) {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+/* Respect users who have requested reduced motion: crossfade only,
+   skip the scale/zoom transform entirely. */
+@media (prefers-reduced-motion: reduce) {
+  .zoom-tab-panel-ak {
+    transition: opacity 0.15s linear;
+    transform: none;
+  }
+
+  .zoom-tabs-ak:has(#zoom-tab-overview-ak:checked) .zoom-tab-panel-ak:nth-of-type(1),
+  .zoom-tabs-ak:has(#zoom-tab-analytics-ak:checked) .zoom-tab-panel-ak:nth-of-type(2),
+  .zoom-tabs-ak:has(#zoom-tab-settings-ak:checked) .zoom-tab-panel-ak:nth-of-type(3) {
+    transform: none;
+  }
+}
+
+/* Responsive: stack tabs full-width on narrow viewports. */
+@media (max-width: 420px) {
+  .zoom-tabs-fieldset-ak {
+    flex-direction: column;
+  }
+
+  .zoom-tab-ak {
+    text-align: center;
+  }
+}


### PR DESCRIPTION
Pushed. Here's the PR description to paste in on GitHub:

---

**Title:** feat: add Zoom-Out Tabs for responsive dashboard layouts (#50281)

**Description:**

Closes #50281

### What this adds

A pure CSS tab component styled for dashboard layouts. Switching tabs crossfades the panels while the incoming panel zooms out from a slightly enlarged state to its normal size — implemented with **zero JavaScript**.

### Files

```
submissions/examples/zoom-out-tabs-ak/
├── demo.html
├── style.css
└── README.md
```

### Details

- Tab switching driven entirely by a native radio group + the `:has()` relational selector — no JS
- Native radio behavior gives keyboard support (arrow-key navigation, click-to-select) for free
- Exposes `--zoom-duration`, `--zoom-easing`, and `--zoom-scale` as custom properties for easy tuning
- Responsive: tabs wrap/stack vertically on narrow viewports
- `fieldset`/`legend` grouping for correct screen-reader semantics; visible `:focus-visible` states
- Respects `prefers-reduced-motion: reduce` — drops the zoom transform, keeps a simple crossfade
- No changes to `core/`, `components/`, `docs/`, or existing `examples/` outside this new folder

### Browser support note

Relies on `:has()`, supported in all current evergreen browsers (Chrome, Edge, Safari, Firefox 121+).

### Checklist

- [x] Fully responsive
- [x] Keyboard accessible
- [x] Custom properties exposed for timing/easing/scale
- [x] Reduced-motion handled
- [x] README explains what it does, how to use it, and why it's useful

---

One note: this issue got auto-unassigned since no one had an open PR yet — you may want to comment `/claim` on it before or right after opening the PR, so it's linked to you.