### PR TITLE
feat: add search bar morph example

### DIFF
--- a/submissions/examples/search-bar-morph/README.md
+++ b/submissions/examples/search-bar-morph/README.md
@@ -1,0 +1,15 @@
+# Search Bar Morph
+
+A CSS-only search input pattern that expands on focus, rotates the leading icon, and reveals a compact helper hint.
+
+## Files
+
+- `demo.html` contains the search label, input, icon, and hint.
+- `style.css` defines the focus morph, icon animation, hint reveal, and responsive behavior.
+
+## What it demonstrates
+
+- `:focus-within` based container animation.
+- Smooth width expansion without JavaScript.
+- Icon and helper text transitions tied to input focus.
+- Mobile layout that hides optional hint text.

--- a/submissions/examples/search-bar-morph/demo.html
+++ b/submissions/examples/search-bar-morph/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Search Bar Morph</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="search-shell">
+    <label class="search-box">
+      <span class="icon">⌕</span>
+      <input type="search" value="motion tokens" aria-label="Search examples">
+      <span class="hint">Press enter</span>
+    </label>
+  </main>
+</body>
+</html>

--- a/submissions/examples/search-bar-morph/style.css
+++ b/submissions/examples/search-bar-morph/style.css
@@ -1,0 +1,93 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #eff6ff, #fdf2f8);
+  color: #172033;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.search-shell {
+  width: min(92vw, 640px);
+  display: grid;
+  place-items: center;
+}
+
+.search-box {
+  width: min(100%, 360px);
+  min-height: 58px;
+  display: grid;
+  grid-template-columns: 34px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  padding: 0 16px;
+  background: #ffffff;
+  box-shadow: 0 20px 48px rgba(79, 70, 229, 0.16);
+  transition: width 260ms ease, border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.search-box:focus-within {
+  width: min(100%, 540px);
+  transform: translateY(-3px);
+  border-color: #7c3aed;
+  box-shadow: 0 28px 64px rgba(124, 58, 237, 0.22);
+}
+
+.icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #eef2ff;
+  color: #4f46e5;
+  font-size: 1.5rem;
+  transition: transform 220ms ease, background 220ms ease, color 220ms ease;
+}
+
+.search-box:focus-within .icon {
+  transform: rotate(-12deg) scale(1.08);
+  background: #7c3aed;
+  color: #ffffff;
+}
+
+input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  color: #111827;
+  font: inherit;
+  font-weight: 800;
+}
+
+.hint {
+  transform: translateX(8px);
+  opacity: 0;
+  color: #7c3aed;
+  font-size: 0.78rem;
+  font-weight: 900;
+  white-space: nowrap;
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.search-box:focus-within .hint {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+@media (max-width: 520px) {
+  .search-box {
+    grid-template-columns: 34px 1fr;
+  }
+
+  .hint {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only search bar morph example
- include focus expansion, icon rotation, and helper hint reveal
- document responsive behavior and interaction states

## Test
- git diff --cached --check