### PR TITLE
feat: add sidebar item glow example

### DIFF
--- a/submissions/examples/sidebar-item-glow/README.md
+++ b/submissions/examples/sidebar-item-glow/README.md
@@ -1,0 +1,15 @@
+# Sidebar Item Glow
+
+A CSS-only sidebar navigation pattern with a glowing active indicator, hover slide, and icon motion.
+
+## Files
+
+- `demo.html` includes a four-item navigation menu.
+- `style.css` contains the glow effect, active bar, hover movement, and responsive sizing.
+
+## What it demonstrates
+
+- Animated sidebar active states with pseudo-elements.
+- Subtle hover and focus-visible feedback for navigation items.
+- Icon scale and rotation transitions.
+- A compact reusable navigation surface.

--- a/submissions/examples/sidebar-item-glow/demo.html
+++ b/submissions/examples/sidebar-item-glow/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sidebar Item Glow</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="sidebar" aria-label="Project navigation">
+    <a href="#dashboard" class="active"><span>◆</span>Dashboard</a>
+    <a href="#tasks"><span>◇</span>Tasks</a>
+    <a href="#reports"><span>○</span>Reports</a>
+    <a href="#settings"><span>□</span>Settings</a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/sidebar-item-glow/style.css
+++ b/submissions/examples/sidebar-item-glow/style.css
@@ -1,0 +1,109 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #111827;
+  color: #f9fafb;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.sidebar {
+  width: min(90vw, 310px);
+  display: grid;
+  gap: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  padding: 14px;
+  background: #182234;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.3);
+}
+
+a {
+  position: relative;
+  overflow: hidden;
+  min-height: 52px;
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  align-items: center;
+  gap: 10px;
+  border-radius: 8px;
+  padding: 0 14px;
+  color: #cbd5e1;
+  font-weight: 800;
+  text-decoration: none;
+  transition: color 180ms ease, transform 180ms ease, background 180ms ease;
+}
+
+a::before {
+  content: "";
+  position: absolute;
+  inset: 8px auto 8px 0;
+  width: 4px;
+  border-radius: 999px;
+  background: #38bdf8;
+  transform: scaleY(0);
+  transform-origin: center;
+  transition: transform 180ms ease;
+}
+
+a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at left, rgba(56, 189, 248, 0.22), transparent 58%);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+a span,
+a {
+  z-index: 1;
+}
+
+a:hover,
+a:focus-visible,
+.active {
+  transform: translateX(5px);
+  background: rgba(56, 189, 248, 0.08);
+  color: #ffffff;
+}
+
+a:hover::before,
+a:focus-visible::before,
+.active::before {
+  transform: scaleY(1);
+}
+
+a:hover::after,
+a:focus-visible::after,
+.active::after {
+  opacity: 1;
+}
+
+a span {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.12);
+  color: #7dd3fc;
+  transition: transform 180ms ease;
+}
+
+a:hover span,
+a:focus-visible span,
+.active span {
+  transform: scale(1.08) rotate(8deg);
+}
+
+@media (max-width: 420px) {
+  .sidebar {
+    width: 92vw;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only sidebar item glow example
- include active indicator, hover slide, and icon motion states
- document navigation interaction behavior

## Test
- git diff --cached --check