### PR TITLE
feat: add table row highlight example

### DIFF
--- a/submissions/examples/table-row-highlight/README.md
+++ b/submissions/examples/table-row-highlight/README.md
@@ -1,0 +1,15 @@
+# Table Row Highlight
+
+A compact data-table interaction that lifts hovered rows and adds a soft color sweep behind the active row.
+
+## Files
+
+- `demo.html` builds an invoice status table.
+- `style.css` defines the row lift, highlight sweep, status badges, and mobile scrolling behavior.
+
+## What it demonstrates
+
+- Row-level hover motion for dense dashboards.
+- A pseudo-element highlight sweep behind table content.
+- Status badge styling for paid and pending states.
+- Responsive table overflow handling for narrow screens.

--- a/submissions/examples/table-row-highlight/demo.html
+++ b/submissions/examples/table-row-highlight/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Table Row Highlight</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="table-card">
+    <h1>Invoice Status</h1>
+    <table>
+      <thead>
+        <tr><th>Client</th><th>Status</th><th>Total</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Northwind</td><td><span class="paid">Paid</span></td><td>$2,420</td></tr>
+        <tr><td>Acme Studio</td><td><span class="pending">Pending</span></td><td>$880</td></tr>
+        <tr><td>Orbit Labs</td><td><span class="paid">Paid</span></td><td>$1,560</td></tr>
+      </tbody>
+    </table>
+  </section>
+</body>
+</html>

--- a/submissions/examples/table-row-highlight/style.css
+++ b/submissions/examples/table-row-highlight/style.css
@@ -1,0 +1,104 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #1f2937;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.table-card {
+  width: min(94vw, 720px);
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 24px;
+  background: #ffffff;
+  box-shadow: 0 22px 54px rgba(15, 23, 42, 0.12);
+}
+
+h1 {
+  margin: 0 0 18px;
+  font-size: 1.5rem;
+  letter-spacing: 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow: hidden;
+}
+
+th,
+td {
+  padding: 16px;
+  text-align: left;
+}
+
+th {
+  color: #64748b;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+tbody tr {
+  position: relative;
+  border-top: 1px solid #e5e7eb;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+tbody tr::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(14, 165, 233, 0.14), rgba(34, 197, 94, 0.1));
+  opacity: 0;
+  transform: scaleX(0.96);
+  transition: transform 180ms ease, opacity 180ms ease;
+  z-index: -1;
+}
+
+tbody tr:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.1);
+}
+
+tbody tr:hover::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+span {
+  display: inline-flex;
+  min-width: 76px;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.paid {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.pending {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+@media (max-width: 560px) {
+  .table-card {
+    overflow-x: auto;
+    padding: 18px;
+  }
+
+  table {
+    min-width: 540px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only table row highlight example
- include row lift, highlight sweep, and status badges
- document dashboard-friendly responsive behavior

## Test
- git diff --cached --check