### PR TITLE
feat: add modal backdrop zoom example

### DIFF
--- a/submissions/examples/modal-backdrop-zoom/README.md
+++ b/submissions/examples/modal-backdrop-zoom/README.md
@@ -1,14 +1,15 @@
 # Modal Backdrop Zoom
 
-A modal-style overlay preview that combines a soft backdrop fade with a focused dialog zoom.
+A CSS-only modal presentation with a softly zooming backdrop glow and a pop-in dialog entrance.
 
 ## Files
 
-- `demo.html` - preview overlay, backdrop, and dialog markup.
-- `style.css` - backdrop fade, dialog zoom, and reduced-motion handling.
+- `demo.html` contains a static dialog layout with action buttons.
+- `style.css` defines the animated backdrop, modal entrance, button feedback, and mobile action layout.
 
-## Highlights
+## What it demonstrates
 
-- Separates backdrop and dialog motion for a clearer entrance pattern.
-- Keeps the dialog centered in a fixed preview area.
-- Removes animation when reduced motion is requested.
+- Backdrop motion using a radial-gradient pseudo-element.
+- Dialog entrance animation with transform and opacity.
+- Button hover and focus-visible feedback.
+- Responsive modal actions for narrow screens.

--- a/submissions/examples/modal-backdrop-zoom/demo.html
+++ b/submissions/examples/modal-backdrop-zoom/demo.html
@@ -1,25 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Modal Backdrop Zoom</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <main class="scene" aria-labelledby="demo-title">
-    <p class="eyebrow">EaseMotion overlay</p>
-    <h1 id="demo-title">Modal backdrop zoom</h1>
-    <p class="intro">A CSS-only preview of a modal entering with a soft backdrop and focused content zoom.</p>
-
-    <section class="modal-preview" aria-label="Preview modal">
-      <div class="backdrop"></div>
-      <article class="dialog">
-        <span class="pill">Preview ready</span>
-        <h2>Publish changes?</h2>
-        <p>Review the final motion pass before making this update visible.</p>
-        <button type="button">Continue</button>
-      </article>
+  <main class="scene">
+    <section class="modal" role="dialog" aria-labelledby="modal-title">
+      <span class="status">New</span>
+      <h1 id="modal-title">Confirm workspace invite</h1>
+      <p>Review the invite details and approve access for the selected team member.</p>
+      <div class="actions">
+        <button class="secondary">Cancel</button>
+        <button>Approve</button>
+      </div>
     </section>
   </main>
 </body>

--- a/submissions/examples/modal-backdrop-zoom/style.css
+++ b/submissions/examples/modal-backdrop-zoom/style.css
@@ -7,126 +7,123 @@ body {
   margin: 0;
   display: grid;
   place-items: center;
+  background: #0f172a;
+  color: #f8fafc;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: #182033;
-  background: linear-gradient(135deg, #f8fafc 0%, #fdf2f8 48%, #eef2ff 100%);
 }
 
 .scene {
-  width: min(92vw, 32rem);
-  padding: 2.2rem;
-  border: 1px solid rgba(190, 24, 93, 0.16);
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 1.5rem 3.75rem rgba(15, 23, 42, 0.13);
+  position: relative;
+  width: min(92vw, 680px);
+  min-height: 420px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #1e293b, #334155);
 }
 
-.eyebrow {
-  margin: 0 0 0.75rem;
-  color: #be185d;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
+.scene::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(14, 165, 233, 0.32), transparent 62%);
+  animation: backdrop-zoom 3.4s ease-in-out infinite;
+}
+
+.modal {
+  position: relative;
+  width: min(88%, 430px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  padding: 28px;
+  background: rgba(15, 23, 42, 0.88);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.36);
+  animation: modal-pop 520ms ease both;
+}
+
+.status {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: rgba(45, 212, 191, 0.16);
+  color: #5eead4;
+  font-size: 0.76rem;
+  font-weight: 900;
   text-transform: uppercase;
 }
 
 h1 {
+  margin: 16px 0 10px;
+  font-size: clamp(1.7rem, 5vw, 2.3rem);
+  letter-spacing: 0;
+}
+
+p {
   margin: 0;
-  font-size: clamp(2rem, 6vw, 3.1rem);
-  line-height: 1;
+  color: #cbd5e1;
+  line-height: 1.7;
 }
 
-.intro {
-  margin: 1rem 0 2rem;
-  color: #526173;
-  line-height: 1.65;
-}
-
-.modal-preview {
-  position: relative;
-  min-height: 16rem;
-  display: grid;
-  place-items: center;
-  overflow: hidden;
-  border-radius: 1rem;
-  background: linear-gradient(135deg, #e2e8f0, #f8fafc);
-}
-
-.backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.52);
-  animation: backdrop-fade 1600ms ease-in-out infinite alternate;
-}
-
-.dialog {
-  position: relative;
-  width: min(88%, 22rem);
-  padding: 1.35rem;
-  border-radius: 1rem;
-  background: #ffffff;
-  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.28);
-  transform-origin: center;
-  animation: dialog-zoom 1600ms ease-in-out infinite alternate;
-}
-
-.pill {
-  display: inline-flex;
-  margin-bottom: 0.9rem;
-  padding: 0.3rem 0.7rem;
-  border-radius: 999px;
-  color: #be185d;
-  background: #fce7f3;
-  font-size: 0.78rem;
-  font-weight: 900;
-}
-
-h2 {
-  margin: 0;
-  font-size: 1.45rem;
-}
-
-.dialog p {
-  margin: 0.7rem 0 1rem;
-  color: #64748b;
-  line-height: 1.55;
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 24px;
 }
 
 button {
+  min-height: 44px;
   border: 0;
-  border-radius: 999px;
-  padding: 0.75rem 1rem;
-  color: #ffffff;
-  background: #be185d;
+  border-radius: 8px;
+  padding: 0 16px;
+  background: #2dd4bf;
+  color: #0f172a;
+  cursor: pointer;
   font: inherit;
-  font-weight: 800;
+  font-weight: 900;
+  transition: transform 160ms ease, filter 160ms ease;
 }
 
-@keyframes backdrop-fade {
-  from {
-    opacity: 0.6;
-  }
+.secondary {
+  background: rgba(255, 255, 255, 0.12);
+  color: #e2e8f0;
+}
 
-  to {
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  filter: brightness(1.08);
+}
+
+@keyframes backdrop-zoom {
+  0%, 100% {
+    transform: scale(0.9);
+    opacity: 0.72;
+  }
+  50% {
+    transform: scale(1.14);
     opacity: 1;
   }
 }
 
-@keyframes dialog-zoom {
+@keyframes modal-pop {
   from {
-    opacity: 0.92;
-    transform: translateY(0.45rem) scale(0.96);
+    transform: translateY(18px) scale(0.96);
+    opacity: 0;
   }
-
   to {
-    opacity: 1;
     transform: translateY(0) scale(1);
+    opacity: 1;
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .backdrop,
-  .dialog {
-    animation: none;
+@media (max-width: 460px) {
+  .actions {
+    flex-direction: column-reverse;
+  }
+
+  button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add a CSS-only modal backdrop zoom example
- include animated backdrop glow, dialog entrance, and button feedback
- document responsive action behavior

## Test
- git diff --cached --check