### PR TITLE
feat: add breadcrumb step sweep example

### DIFF
--- a/submissions/examples/breadcrumb-step-sweep/README.md
+++ b/submissions/examples/breadcrumb-step-sweep/README.md
@@ -1,0 +1,15 @@
+# Breadcrumb Step Sweep
+
+A responsive breadcrumb navigation pattern where each link receives a smooth gradient sweep on hover, focus, and active states.
+
+## Files
+
+- `demo.html` provides the breadcrumb trail.
+- `style.css` defines the sweep animation, active link treatment, separator behavior, and mobile stacking.
+
+## What it demonstrates
+
+- CSS-only breadcrumb link transitions.
+- Gradient sweep motion using pseudo-elements.
+- Active and focus-visible navigation feedback.
+- A stacked mobile breadcrumb layout.

--- a/submissions/examples/breadcrumb-step-sweep/demo.html
+++ b/submissions/examples/breadcrumb-step-sweep/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Breadcrumb Step Sweep</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <a href="#home">Home</a>
+    <a href="#library">Library</a>
+    <a href="#motion" class="active">Motion</a>
+    <span>Examples</span>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-step-sweep/style.css
+++ b/submissions/examples/breadcrumb-step-sweep/style.css
@@ -1,0 +1,110 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f5f7fb;
+  color: #172033;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.breadcrumbs {
+  width: min(92vw, 680px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid #dbe3ef;
+  border-radius: 8px;
+  padding: 14px;
+  background: #ffffff;
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);
+}
+
+a,
+span {
+  position: relative;
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 8px;
+  padding: 0 14px;
+  color: #475569;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+a {
+  overflow: hidden;
+  transition: color 180ms ease, transform 180ms ease;
+}
+
+a::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #2563eb, #14b8a6);
+  transform: translateX(-102%);
+  transition: transform 240ms ease;
+  z-index: 0;
+}
+
+a::after {
+  content: "›";
+  margin-left: 12px;
+  color: #94a3b8;
+  z-index: 1;
+}
+
+a:hover,
+a:focus-visible,
+.active {
+  transform: translateY(-2px);
+  color: #ffffff;
+}
+
+a:hover::before,
+a:focus-visible::before,
+.active::before {
+  transform: translateX(0);
+}
+
+a:hover::after,
+a:focus-visible::after,
+.active::after {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+a {
+  isolation: isolate;
+}
+
+a:not(:empty) {
+  z-index: 1;
+}
+
+a::first-letter {
+  position: relative;
+}
+
+span {
+  background: #eef2f7;
+  color: #111827;
+}
+
+@media (max-width: 520px) {
+  .breadcrumbs {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  a,
+  span {
+    width: 100%;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only breadcrumb step sweep example
- include gradient sweep, active state, and responsive stacked layout
- document navigation interaction behavior

## Test
- git diff --cached --check