### PR TITLE
feat: add empty state sparkle example

### DIFF
--- a/submissions/examples/empty-state-sparkle/README.md
+++ b/submissions/examples/empty-state-sparkle/README.md
@@ -1,0 +1,15 @@
+# Empty State Sparkle
+
+A CSS-only empty-state component with a pulsing sparkle badge and a lifted action button.
+
+## Files
+
+- `demo.html` contains the empty-state message, icon, and action.
+- `style.css` defines the sparkle pulse, button feedback, card styling, and responsive spacing.
+
+## What it demonstrates
+
+- Empty-state motion for dashboards and content tools.
+- A pulsing icon using transform and shadow animation.
+- Hover and focus-visible feedback on the primary action.
+- Centered responsive layout without JavaScript.

--- a/submissions/examples/empty-state-sparkle/demo.html
+++ b/submissions/examples/empty-state-sparkle/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Empty State Sparkle</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="empty-state">
+    <div class="sparkle" aria-hidden="true">✦</div>
+    <h1>No drafts yet</h1>
+    <p>Create your first draft and it will appear here with recent activity.</p>
+    <button>New Draft</button>
+  </section>
+</body>
+</html>

--- a/submissions/examples/empty-state-sparkle/style.css
+++ b/submissions/examples/empty-state-sparkle/style.css
@@ -1,0 +1,87 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.empty-state {
+  width: min(92vw, 430px);
+  display: grid;
+  justify-items: center;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 42px 28px;
+  background: #ffffff;
+  text-align: center;
+  box-shadow: 0 24px 56px rgba(15, 23, 42, 0.12);
+}
+
+.sparkle {
+  width: 78px;
+  height: 78px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #fef3c7;
+  color: #d97706;
+  font-size: 2.4rem;
+  animation: sparkle-pop 1.8s ease-in-out infinite;
+}
+
+h1 {
+  margin: 22px 0 10px;
+  font-size: 2rem;
+  letter-spacing: 0;
+}
+
+p {
+  max-width: 320px;
+  margin: 0;
+  color: #64748b;
+  line-height: 1.65;
+}
+
+button {
+  min-height: 46px;
+  margin-top: 26px;
+  border: 0;
+  border-radius: 8px;
+  padding: 0 20px;
+  background: #111827;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-3px);
+  background: #d97706;
+}
+
+@keyframes sparkle-pop {
+  0%, 100% {
+    transform: scale(1) rotate(0deg);
+    box-shadow: 0 0 0 0 rgba(217, 119, 6, 0.24);
+  }
+  50% {
+    transform: scale(1.08) rotate(12deg);
+    box-shadow: 0 0 0 14px rgba(217, 119, 6, 0);
+  }
+}
+
+@media (max-width: 420px) {
+  .empty-state {
+    padding: 34px 22px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only empty state sparkle example
- include pulsing icon feedback and primary action lift
- document the responsive empty-state behavior

## Test
- git diff --cached --check