### PR TITLE
feat: add profile chip orbit example

### DIFF
--- a/submissions/examples/profile-chip-orbit/README.md
+++ b/submissions/examples/profile-chip-orbit/README.md
@@ -1,0 +1,15 @@
+# Profile Chip Orbit
+
+A CSS-only profile chip with an orbiting avatar ring, hover lift, and pulsing online indicator.
+
+## Files
+
+- `demo.html` contains the profile chip markup.
+- `style.css` defines the avatar orbit ring, status pulse, hover lift, and mobile layout.
+
+## What it demonstrates
+
+- Avatar emphasis using a rotating dashed ring.
+- Online presence feedback with a pulse animation.
+- Compact profile card hover interaction.
+- Responsive chip layout for narrow screens.

--- a/submissions/examples/profile-chip-orbit/demo.html
+++ b/submissions/examples/profile-chip-orbit/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile Chip Orbit</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="profile-chip">
+    <div class="avatar" aria-hidden="true">KP</div>
+    <div>
+      <h1>Kunal Pattanaik</h1>
+      <p>Frontend contributor</p>
+    </div>
+    <span class="status">Online</span>
+  </section>
+</body>
+</html>

--- a/submissions/examples/profile-chip-orbit/style.css
+++ b/submissions/examples/profile-chip-orbit/style.css
@@ -1,0 +1,112 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #ecfeff, #f0fdf4);
+  color: #10201c;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.profile-chip {
+  width: min(92vw, 480px);
+  display: grid;
+  grid-template-columns: 72px 1fr auto;
+  align-items: center;
+  gap: 16px;
+  border: 1px solid #a7f3d0;
+  border-radius: 8px;
+  padding: 18px;
+  background: #ffffff;
+  box-shadow: 0 22px 54px rgba(13, 148, 136, 0.16);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.profile-chip:hover,
+.profile-chip:focus-within {
+  transform: translateY(-5px);
+  box-shadow: 0 28px 66px rgba(13, 148, 136, 0.24);
+}
+
+.avatar {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #0f766e;
+  color: #ffffff;
+  font-weight: 900;
+}
+
+.avatar::after {
+  content: "";
+  position: absolute;
+  inset: -7px;
+  border: 2px dashed #14b8a6;
+  border-radius: 50%;
+  animation: orbit-ring 4s linear infinite;
+}
+
+h1 {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+  letter-spacing: 0;
+}
+
+p {
+  margin: 0;
+  color: #64748b;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border-radius: 999px;
+  padding: 7px 10px;
+  background: #dcfce7;
+  color: #15803d;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.status::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  animation: status-pulse 1.5s ease-out infinite;
+}
+
+@keyframes orbit-ring {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes status-pulse {
+  70% {
+    box-shadow: 0 0 0 8px rgba(34, 197, 94, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+  }
+}
+
+@media (max-width: 520px) {
+  .profile-chip {
+    grid-template-columns: 64px 1fr;
+  }
+
+  .status {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only profile chip orbit example
- include avatar orbit ring, hover lift, and online status pulse
- document responsive profile-chip behavior

## Test
- git diff --cached --check