### PR TITLE
feat: add tooltip nudge example

### DIFF
--- a/submissions/examples/tooltip-nudge/README.md
+++ b/submissions/examples/tooltip-nudge/README.md
@@ -1,0 +1,15 @@
+# Tooltip Nudge
+
+A CSS-only tooltip pattern that appears with a small upward nudge when the trigger is hovered or focused.
+
+## Files
+
+- `demo.html` contains a button and accessible tooltip text.
+- `style.css` defines the tooltip position, reveal motion, arrow, and button feedback.
+
+## What it demonstrates
+
+- Tooltip reveal using hover and focus-visible states.
+- Transform and opacity transitions for a quick nudge effect.
+- A compact tooltip arrow built with borders.
+- Responsive max-width handling for narrow screens.

--- a/submissions/examples/tooltip-nudge/demo.html
+++ b/submissions/examples/tooltip-nudge/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Nudge</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stage">
+    <button class="tool-button" aria-describedby="tip-save">
+      Save
+      <span id="tip-save" role="tooltip">Saved changes sync instantly</span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tooltip-nudge/style.css
+++ b/submissions/examples/tooltip-nudge/style.css
@@ -1,0 +1,80 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.stage {
+  display: grid;
+  place-items: center;
+  width: min(92vw, 420px);
+  min-height: 280px;
+}
+
+.tool-button {
+  position: relative;
+  min-height: 48px;
+  border: 0;
+  border-radius: 8px;
+  padding: 0 22px;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+.tool-button:hover,
+.tool-button:focus-visible {
+  transform: translateY(-3px);
+  background: #1d4ed8;
+}
+
+[role="tooltip"] {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 14px);
+  width: max-content;
+  max-width: 240px;
+  transform: translate(-50%, 8px) scale(0.96);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #111827;
+  color: #ffffff;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+[role="tooltip"]::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translateX(-50%);
+  border: 7px solid transparent;
+  border-top-color: #111827;
+}
+
+.tool-button:hover [role="tooltip"],
+.tool-button:focus-visible [role="tooltip"] {
+  transform: translate(-50%, 0) scale(1);
+  opacity: 1;
+}
+
+@media (max-width: 420px) {
+  [role="tooltip"] {
+    max-width: 190px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only tooltip nudge example
- include hover and focus-visible tooltip reveal motion
- document arrow, responsive width, and button feedback

## Test
- git diff --cached --check