### PR TITLE
feat: add tab underline wave example

### DIFF
--- a/submissions/examples/tab-underline-wave/README.md
+++ b/submissions/examples/tab-underline-wave/README.md
@@ -1,0 +1,15 @@
+# Tab Underline Wave
+
+A CSS-only tab navigation pattern with a sliding underline and a soft wave sweep across active or hovered tabs.
+
+## Files
+
+- `demo.html` defines a four-tab navigation group.
+- `style.css` contains the underline animation, wave sweep, active state, and mobile stacking.
+
+## What it demonstrates
+
+- Animated tab underline with pseudo-elements.
+- Hover, focus-visible, and active tab feedback.
+- A lightweight sweep effect without JavaScript.
+- Responsive tab stacking for small screens.

--- a/submissions/examples/tab-underline-wave/demo.html
+++ b/submissions/examples/tab-underline-wave/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Underline Wave</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="tabs" aria-label="Project sections">
+    <a href="#overview" class="active">Overview</a>
+    <a href="#activity">Activity</a>
+    <a href="#files">Files</a>
+    <a href="#settings">Settings</a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/tab-underline-wave/style.css
+++ b/submissions/examples/tab-underline-wave/style.css
@@ -1,0 +1,86 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #eef2ff;
+  color: #1e1b4b;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.tabs {
+  width: min(92vw, 580px);
+  display: flex;
+  gap: 8px;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  padding: 8px;
+  background: #ffffff;
+  box-shadow: 0 20px 48px rgba(79, 70, 229, 0.14);
+}
+
+a {
+  position: relative;
+  flex: 1 1 0;
+  min-height: 46px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #4f46e5;
+  font-weight: 900;
+  text-decoration: none;
+  transition: color 180ms ease, background 180ms ease;
+}
+
+a::before {
+  content: "";
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 8px;
+  height: 4px;
+  border-radius: 999px;
+  background: #4f46e5;
+  transform: translateX(-110%) scaleX(0.6);
+  transform-origin: left;
+  transition: transform 240ms ease;
+}
+
+a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(79, 70, 229, 0.12), transparent);
+  transform: translateX(-120%);
+  transition: transform 320ms ease;
+}
+
+a:hover,
+a:focus-visible,
+.active {
+  background: #eef2ff;
+  color: #312e81;
+}
+
+a:hover::before,
+a:focus-visible::before,
+.active::before {
+  transform: translateX(0) scaleX(1);
+}
+
+a:hover::after,
+a:focus-visible::after,
+.active::after {
+  transform: translateX(120%);
+}
+
+@media (max-width: 520px) {
+  .tabs {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only tab underline wave example
- include sliding underline, wave sweep, and active tab feedback
- document responsive stacked tabs

## Test
- git diff --cached --check