### PR TITLE
feat: add badge count pop example

### DIFF
--- a/submissions/examples/badge-count-pop/README.md
+++ b/submissions/examples/badge-count-pop/README.md
@@ -1,0 +1,15 @@
+# Badge Count Pop
+
+A CSS-only notification button with a count badge that pops and pulses to draw attention to unread updates.
+
+## Files
+
+- `demo.html` contains the notification button and unread count badge.
+- `style.css` defines the badge pulse, button lift, and compact toolbar layout.
+
+## What it demonstrates
+
+- Count badge emphasis with transform and shadow animation.
+- Hover and focus-visible button feedback.
+- Faster badge motion while the trigger is active.
+- A reusable compact notification control.

--- a/submissions/examples/badge-count-pop/demo.html
+++ b/submissions/examples/badge-count-pop/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Badge Count Pop</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="toolbar">
+    <button class="notification" aria-label="Notifications, 7 unread">
+      <span class="bell">!</span>
+      <span class="badge">7</span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/badge-count-pop/style.css
+++ b/submissions/examples/badge-count-pop/style.css
@@ -1,0 +1,84 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #111827;
+  color: #ffffff;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.toolbar {
+  display: grid;
+  place-items: center;
+  width: min(92vw, 320px);
+  min-height: 240px;
+}
+
+.notification {
+  position: relative;
+  width: 74px;
+  height: 74px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: #1f2937;
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+.notification:hover,
+.notification:focus-visible {
+  transform: translateY(-4px) rotate(-2deg);
+  background: #243244;
+}
+
+.bell {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  margin: auto;
+  border-radius: 50%;
+  background: #374151;
+  color: #facc15;
+  font-size: 1.4rem;
+  font-weight: 900;
+}
+
+.badge {
+  position: absolute;
+  top: -9px;
+  right: -9px;
+  min-width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 3px solid #111827;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 900;
+  animation: badge-pop 1.6s ease-in-out infinite;
+}
+
+.notification:hover .badge,
+.notification:focus-visible .badge {
+  animation-duration: 900ms;
+}
+
+@keyframes badge-pop {
+  0%, 100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.42);
+  }
+  50% {
+    transform: scale(1.18);
+    box-shadow: 0 0 0 12px rgba(239, 68, 68, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only badge count pop example
- include unread badge pulse and notification button feedback
- document compact reusable control behavior

## Test
- git diff --cached --check