### PR TITLE
feat: add copy button ripple example

### DIFF
--- a/submissions/examples/copy-button-ripple/README.md
+++ b/submissions/examples/copy-button-ripple/README.md
@@ -1,0 +1,15 @@
+# Copy Button Ripple
+
+A CSS-only command copy control with a hover-triggered ripple effect and stable code truncation.
+
+## Files
+
+- `demo.html` contains a command snippet and copy button.
+- `style.css` defines the ripple animation, button states, code block truncation, and responsive layout.
+
+## What it demonstrates
+
+- Button ripple motion using a pseudo-element.
+- Hover and focus-visible feedback without JavaScript.
+- Safe single-line command truncation.
+- Responsive stacking for smaller screens.

--- a/submissions/examples/copy-button-ripple/demo.html
+++ b/submissions/examples/copy-button-ripple/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Copy Button Ripple</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="copy-card">
+    <code>npm install easemotion-css</code>
+    <button>Copy</button>
+  </section>
+</body>
+</html>

--- a/submissions/examples/copy-button-ripple/style.css
+++ b/submissions/examples/copy-button-ripple/style.css
@@ -1,0 +1,94 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f1f5f9;
+  color: #0f172a;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.copy-card {
+  width: min(92vw, 560px);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 12px;
+  background: #ffffff;
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.12);
+}
+
+code {
+  min-width: 0;
+  overflow: hidden;
+  border-radius: 8px;
+  padding: 14px;
+  background: #0f172a;
+  color: #bfdbfe;
+  font-size: 0.95rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+button {
+  position: relative;
+  overflow: hidden;
+  min-height: 48px;
+  border: 0;
+  border-radius: 8px;
+  padding: 0 20px;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+button::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  transform: translate(-50%, -50%) scale(0);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.42);
+  opacity: 0;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  background: #1d4ed8;
+}
+
+button:hover::after,
+button:focus-visible::after {
+  animation: ripple 700ms ease-out;
+}
+
+@keyframes ripple {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.8;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(9);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .copy-card {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only copy button ripple example
- include ripple button feedback and command truncation
- document responsive copy control behavior

## Test
- git diff --cached --check