### PR TITLE
feat: add dropdown menu cascade example

### DIFF
--- a/submissions/examples/dropdown-menu-cascade/README.md
+++ b/submissions/examples/dropdown-menu-cascade/README.md
@@ -1,0 +1,15 @@
+# Dropdown Menu Cascade
+
+A CSS-only dropdown menu with staggered item reveal, hover access, and keyboard-friendly focus-within behavior.
+
+## Files
+
+- `demo.html` contains the dropdown trigger and action menu.
+- `style.css` defines the menu reveal, staggered item transitions, link feedback, and mobile alignment.
+
+## What it demonstrates
+
+- Dropdown visibility using hover and focus-within.
+- Cascading menu items with small transition delays.
+- Accessible link focus states without JavaScript.
+- Responsive positioning for narrow screens.

--- a/submissions/examples/dropdown-menu-cascade/demo.html
+++ b/submissions/examples/dropdown-menu-cascade/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown Menu Cascade</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="dropdown">
+    <button>Actions</button>
+    <ul>
+      <li><a href="#rename">Rename project</a></li>
+      <li><a href="#duplicate">Duplicate board</a></li>
+      <li><a href="#archive">Archive workspace</a></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dropdown-menu-cascade/style.css
+++ b/submissions/examples/dropdown-menu-cascade/style.css
@@ -1,0 +1,113 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f6f7fb;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.dropdown {
+  position: relative;
+}
+
+button {
+  min-height: 46px;
+  border: 0;
+  border-radius: 8px;
+  padding: 0 20px;
+  background: #111827;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  background: #334155;
+}
+
+ul {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 230px;
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 22px 52px rgba(15, 23, 42, 0.16);
+  list-style: none;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-8px) scale(0.98);
+  transform-origin: top right;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+.dropdown:hover ul,
+.dropdown:focus-within ul {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+li {
+  transform: translateY(-6px);
+  opacity: 0;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+li:nth-child(2) {
+  transition-delay: 50ms;
+}
+
+li:nth-child(3) {
+  transition-delay: 100ms;
+}
+
+.dropdown:hover li,
+.dropdown:focus-within li {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+a {
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  border-radius: 8px;
+  padding: 0 12px;
+  color: #334155;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+@media (max-width: 420px) {
+  ul {
+    right: 50%;
+    transform-origin: top center;
+  }
+
+  .dropdown:hover ul,
+  .dropdown:focus-within ul {
+    transform: translate(50%, 0) scale(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only dropdown menu cascade example
- include staggered item reveal and focus-within menu behavior
- document responsive dropdown positioning

## Test
- git diff --cached --check