### PR TITLE
feat: add avatar stack spread example

### DIFF
--- a/submissions/examples/avatar-stack-spread/README.md
+++ b/submissions/examples/avatar-stack-spread/README.md
@@ -1,0 +1,15 @@
+# Avatar Stack Spread
+
+A CSS-only avatar stack that spreads and tilts collaborator initials when the card is hovered or focused.
+
+## Files
+
+- `demo.html` contains the team card and stacked avatars.
+- `style.css` defines the avatar overlap, spread motion, alternating tilt, and responsive sizing.
+
+## What it demonstrates
+
+- Avatar stack interaction without JavaScript.
+- Coordinated hover and focus-within transitions.
+- Alternating transform directions for visual separation.
+- Compact team-card layout for dashboards.

--- a/submissions/examples/avatar-stack-spread/demo.html
+++ b/submissions/examples/avatar-stack-spread/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Avatar Stack Spread</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="team-card">
+    <div class="avatars" aria-label="Project members">
+      <span>AN</span>
+      <span>KP</span>
+      <span>RS</span>
+      <span>MJ</span>
+    </div>
+    <h1>Design review team</h1>
+    <p>Hover the stack to reveal each collaborator.</p>
+  </section>
+</body>
+</html>

--- a/submissions/examples/avatar-stack-spread/style.css
+++ b/submissions/examples/avatar-stack-spread/style.css
@@ -1,0 +1,92 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.team-card {
+  width: min(92vw, 430px);
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 30px;
+  background: #ffffff;
+  text-align: center;
+  box-shadow: 0 22px 54px rgba(15, 23, 42, 0.12);
+}
+
+.avatars {
+  min-height: 74px;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+
+.avatars span {
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  margin-left: -16px;
+  border: 4px solid #ffffff;
+  border-radius: 50%;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 900;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+  transition: transform 220ms ease, margin 220ms ease;
+}
+
+.avatars span:first-child {
+  margin-left: 0;
+  background: #0f766e;
+}
+
+.avatars span:nth-child(3) {
+  background: #7c3aed;
+}
+
+.avatars span:nth-child(4) {
+  background: #ea580c;
+}
+
+.team-card:hover .avatars span,
+.team-card:focus-within .avatars span {
+  margin-left: 6px;
+}
+
+.team-card:hover .avatars span:nth-child(odd),
+.team-card:focus-within .avatars span:nth-child(odd) {
+  transform: translateY(-8px) rotate(-4deg);
+}
+
+.team-card:hover .avatars span:nth-child(even),
+.team-card:focus-within .avatars span:nth-child(even) {
+  transform: translateY(6px) rotate(4deg);
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 1.5rem;
+  letter-spacing: 0;
+}
+
+p {
+  margin: 0;
+  color: #64748b;
+  line-height: 1.6;
+}
+
+@media (max-width: 420px) {
+  .avatars span {
+    width: 54px;
+    height: 54px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only avatar stack spread example
- include stack separation, alternating tilt, and card hover behavior
- document responsive avatar sizing

## Test
- git diff --cached --check