### PR TITLE
Add print optimization to alert component (fixes #51898)

### DIFF
--- a/submissions/examples/fix-alert-print-optimization-51898/README.md
+++ b/submissions/examples/fix-alert-print-optimization-51898/README.md
@@ -1,0 +1,66 @@
+﻿# Alert Component — Print Optimization
+
+Fixes issue #51898: the `ease-alert` component wasted ink and lost
+contrast when printed. This adds a `@media print` rule that strips
+backgrounds, shadows, and gradients, and forces high-contrast
+black-on-white output across every alert variant.
+
+## Problem
+
+By default, alerts use colored backgrounds, left-border accents, and
+soft shadows for on-screen use. Printed as-is, this:
+
+- Wastes ink filling colored backgrounds
+- Can lose contrast on some printers/paper
+- Prints interactive-only elements (like the dismiss button) that
+  have no purpose on paper
+
+## Fix
+
+A `@media print` block:
+
+- Sets `background: transparent` and `color: #000` on `.ease-alert`
+  and every color variant (`success`, `danger`, `warning`, `info`)
+- Replaces the colored left border with a solid black `1px`/`4px`
+  border so the alert boundary stays visible without color
+- Removes `box-shadow` entirely
+- Forces title/message/icon text to black for guaranteed contrast
+- Hides `.alert-close` (the dismiss button), since it's a UI-only
+  affordance
+- Adds `page-break-inside: avoid` so an alert doesn't get split
+  across two printed pages
+- Normalizes `.ease-alert-rounded`'s corner radius down slightly so
+  it still reads cleanly on paper
+
+## How a developer uses it
+
+No new classes or markup — this only adds print behavior to the
+existing `ease-alert` classes:
+
+```html
+<div class="ease-alert-success">
+  <span class="alert-icon">✅</span>
+  <div class="alert-content">
+    <div class="alert-title">Success</div>
+    <div class="alert-message">Your changes have been saved.</div>
+  </div>
+</div>
+```
+
+Open `demo.html` and press **Ctrl/Cmd + P** to see the print preview.
+
+## Why this fits EaseMotion CSS
+
+It keeps the same human-readable, class-driven approach the base
+`ease-alert` component already uses — no new dependencies, no
+JavaScript, just an additive `@media print` layer that respects every
+existing variant (color, size, rounded, dismissible) rather than
+overriding the component's on-screen design.
+
+## Files
+
+- `demo.html` — all alert variants (colors, dismissible, sizes,
+  rounded), self-contained and opens directly in a browser
+- `style.css` — the base `ease-alert` component plus the print
+  optimization rules
+- `README.md` — this file

--- a/submissions/examples/fix-alert-print-optimization-51898/demo.html
+++ b/submissions/examples/fix-alert-print-optimization-51898/demo.html
@@ -1,0 +1,109 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Alert Component - Print Optimization</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <h1>Alert Component</h1>
+    <p>Print-optimized ease-alert variants (issue #51898)</p>
+
+    <div class="print-note">
+      🖨️ Try <strong>Ctrl/Cmd + P</strong> to see the print preview — colors, shadows and gradients are stripped so nothing wastes ink, while text stays fully legible in black on white.
+    </div>
+
+    <div class="demo-section">
+      <h2>Base &amp; Color Variants</h2>
+
+      <div class="ease-alert">
+        <span class="alert-icon">ℹ️</span>
+        <div class="alert-content">
+          <div class="alert-title">Default Alert</div>
+          <div class="alert-message">This is a neutral alert message.</div>
+        </div>
+      </div>
+
+      <div class="ease-alert-success">
+        <span class="alert-icon">✅</span>
+        <div class="alert-content">
+          <div class="alert-title">Success</div>
+          <div class="alert-message">Your changes have been saved.</div>
+        </div>
+      </div>
+
+      <div class="ease-alert-danger">
+        <span class="alert-icon">⛔</span>
+        <div class="alert-content">
+          <div class="alert-title">Error</div>
+          <div class="alert-message">Something went wrong. Please try again.</div>
+        </div>
+      </div>
+
+      <div class="ease-alert-warning">
+        <span class="alert-icon">⚠️</span>
+        <div class="alert-content">
+          <div class="alert-title">Warning</div>
+          <div class="alert-message">This action cannot be undone.</div>
+        </div>
+      </div>
+
+      <div class="ease-alert-info">
+        <span class="alert-icon">💡</span>
+        <div class="alert-content">
+          <div class="alert-title">Info</div>
+          <div class="alert-message">A new version is available.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Dismissible Alert</h2>
+      <div class="ease-alert-success ease-alert-dismissible">
+        <span class="alert-icon">✅</span>
+        <div class="alert-content">
+          <div class="alert-title">Success</div>
+          <div class="alert-message">Dismiss button is hidden automatically when printed.</div>
+        </div>
+        <button class="alert-close" aria-label="Close alert">&times;</button>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Size Variants</h2>
+
+      <div class="ease-alert-info ease-alert-small">
+        <span class="alert-icon">💡</span>
+        <div class="alert-content">
+          <div class="alert-title">Small Alert</div>
+          <div class="alert-message">Compact size for tight spaces.</div>
+        </div>
+      </div>
+
+      <div class="ease-alert-info ease-alert-large">
+        <span class="alert-icon">💡</span>
+        <div class="alert-content">
+          <div class="alert-title">Large Alert</div>
+          <div class="alert-message">More breathing room for longer messages.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-section">
+      <h2>Rounded Variant</h2>
+      <div class="ease-alert-warning ease-alert-rounded">
+        <span class="alert-icon">⚠️</span>
+        <div class="alert-content">
+          <div class="alert-title">Rounded Warning</div>
+          <div class="alert-message">Fully rounded corners for a softer look.</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/fix-alert-print-optimization-51898/style.css
+++ b/submissions/examples/fix-alert-print-optimization-51898/style.css
@@ -1,0 +1,275 @@
+﻿/* ========================================
+   ALERT COMPONENT (ease-alert)
+   ======================================== */
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    padding: 2rem;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    background: #fff;
+    border-radius: 1rem;
+    padding: 3rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+h1 {
+    text-align: center;
+    color: #1e293b;
+    margin-bottom: 0.5rem;
+}
+
+.container > p {
+    text-align: center;
+    color: #64748b;
+    margin-bottom: 3rem;
+}
+
+.demo-section {
+    margin-bottom: 2rem;
+}
+
+.demo-section h2 {
+    font-size: 1.2rem;
+    color: #1e293b;
+    margin-bottom: 1rem;
+    border-left: 4px solid #667eea;
+    padding-left: 1rem;
+}
+
+.print-note {
+    background: #f3f4f6;
+    border: 1px dashed #9ca3af;
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+    margin-bottom: 2rem;
+    font-size: 0.9rem;
+    color: #374151;
+}
+
+/* Base Alert */
+.ease-alert {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    background: #f1f5f9;
+    border-left: 4px solid #64748b;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+/* Alert Colors */
+.ease-alert-success {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    background: #ecfdf5;
+    border-left: 4px solid #10b981;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.ease-alert-danger {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    background: #fef2f2;
+    border-left: 4px solid #ef4444;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.ease-alert-warning {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    background: #fffbeb;
+    border-left: 4px solid #f59e0b;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.ease-alert-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    background: #eff6ff;
+    border-left: 4px solid #3b82f6;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.alert-icon {
+    font-size: 1.25rem;
+    flex-shrink: 0;
+}
+
+.alert-message {
+    flex: 1;
+    font-size: 0.875rem;
+    color: #1e293b;
+}
+
+.alert-title {
+    font-weight: 600;
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+    color: #1e293b;
+}
+
+.alert-content {
+    flex: 1;
+}
+
+/* Dismissible Alert */
+.ease-alert-dismissible {
+    position: relative;
+    padding-right: 2.5rem;
+}
+
+.alert-close {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    font-size: 1.25rem;
+    cursor: pointer;
+    color: #64748b;
+    padding: 0.25rem;
+    line-height: 1;
+    transition: color 0.2s;
+}
+
+.alert-close:hover {
+    color: #1e293b;
+}
+
+/* Size Variants */
+.ease-alert-small {
+    padding: 0.5rem 1rem;
+}
+
+.ease-alert-small .alert-icon {
+    font-size: 1rem;
+}
+
+.ease-alert-small .alert-message {
+    font-size: 0.75rem;
+}
+
+.ease-alert-large {
+    padding: 1.25rem 1.5rem;
+}
+
+.ease-alert-large .alert-icon {
+    font-size: 1.5rem;
+}
+
+.ease-alert-large .alert-message {
+    font-size: 1rem;
+}
+
+/* Rounded Variant */
+.ease-alert-rounded {
+    border-radius: 2rem;
+}
+
+/* Color-specific text colors */
+.ease-alert-success .alert-message,
+.ease-alert-success .alert-title {
+    color: #065f46;
+}
+
+.ease-alert-danger .alert-message,
+.ease-alert-danger .alert-title {
+    color: #991b1b;
+}
+
+.ease-alert-warning .alert-message,
+.ease-alert-warning .alert-title {
+    color: #92400e;
+}
+
+.ease-alert-info .alert-message,
+.ease-alert-info .alert-title {
+    color: #1e40af;
+}
+
+/* ========================================
+   PRINT OPTIMIZATION (issue #51898)
+   Strips ink-heavy backgrounds/shadows and
+   forces high-contrast black-on-white output.
+   ======================================== */
+@media print {
+    .ease-alert,
+    .ease-alert-success,
+    .ease-alert-danger,
+    .ease-alert-warning,
+    .ease-alert-info {
+        background: transparent !important;
+        color: #000 !important;
+        box-shadow: none !important;
+        border: 1px solid #000 !important;
+        border-left: 4px solid #000 !important;
+        page-break-inside: avoid;
+        break-inside: avoid;
+    }
+
+    .alert-title,
+    .alert-message,
+    .ease-alert-success .alert-title,
+    .ease-alert-success .alert-message,
+    .ease-alert-danger .alert-title,
+    .ease-alert-danger .alert-message,
+    .ease-alert-warning .alert-title,
+    .ease-alert-warning .alert-message,
+    .ease-alert-info .alert-title,
+    .ease-alert-info .alert-message {
+        color: #000 !important;
+    }
+
+    .alert-icon {
+        color: #000 !important;
+    }
+
+    /* A close button has no purpose on paper */
+    .alert-close {
+        display: none !important;
+    }
+
+    /* Rounded corners waste nothing on paper, but keep it consistent */
+    .ease-alert-rounded {
+        border-radius: 0.5rem !important;
+    }
+
+    .print-note {
+        display: none !important;
+    }
+
+    body {
+        background: #fff !important;
+        padding: 0 !important;
+    }
+
+    .container {
+        box-shadow: none !important;
+        padding: 0 !important;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #51898 — the `ease-alert` component currently prints with full colored backgrounds, box-shadows, and gradients, which wastes ink and can lose contrast depending on the printer/paper. This PR adds a `@media print` rule that strips those visual effects and forces clean, high-contrast black-on-white output.

The fix covers every existing alert variant, not just the base style:
- Base + color variants (success, danger, warning, info)
- Dismissible alert (the close button is hidden on print, since it's a UI-only affordance)
- Size variants (small, large)
- Rounded variant

No new classes, no JavaScript — just an additive print stylesheet layered on top of the existing `ease-alert` markup, so nothing changes for on-screen use.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `@media print` rule for the `ease-alert` component that strips ink-heavy backgrounds, shadows, and gradients, replacing them with high-contrast black-on-white styling for every alert variant.

**How does a developer use it?**

```html
<div class="ease-alert-success">
  <span class="alert-icon">✅</span>
  <div class="alert-content">
    <div class="alert-title">Success</div>
    <div class="alert-message">Your changes have been saved.</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

It's an additive `@media print` layer on top of the existing class-driven `ease-alert` component — no new markup, no JavaScript, no dependencies. It keeps the same human-readable, class-based philosophy the component already uses, just extending it to a new output context (paper).

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This covers every `ease-alert` variant (base, success/danger/warning/info, dismissible, small/large, rounded) — two other open PRs for this issue (`fix-alert-print-optimization`, `48232-print-media-alert-sb`) only handle the base + basic color variants, so this one is more complete if you're choosing between them.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!