### PR TITLE
Add image zoom hover utility

### DIFF
--- a/submissions/examples/image-zoom-hover-53634/README.md
+++ b/submissions/examples/image-zoom-hover-53634/README.md
@@ -1,0 +1,90 @@
+# Image Zoom Hover Utility
+
+A single reusable CSS class that adds a smooth zoom-in effect when a
+user hovers over an image. Built for image cards, galleries,
+portfolios, and product previews.
+
+## How it works
+
+The effect needs two pieces working together:
+
+1. **A clipping container** (`.image-container`) with `overflow: hidden`.
+   Without this, a scaled-up image would spill past its own corners
+   and shift surrounding layout.
+2. **The utility class** (`.image-zoom-hover`) on the `<img>` itself,
+   which sets a `transition` on `transform` and defines the resting
+   scale (`scale(1)`).
+
+The zoom is triggered by `:hover` (and `:focus-within`, for keyboard
+users) on the **container**, not the image directly — that way the
+effect still fires correctly even if a caption or overlay sits on top
+of the image.
+
+```css
+.image-container {
+  overflow: hidden;
+}
+
+.image-zoom-hover {
+  transform: scale(1);
+  transition: transform 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.image-container:hover .image-zoom-hover,
+.image-container:focus-within .image-zoom-hover {
+  transform: scale(1.12);
+}
+```
+
+## Usage
+
+```html
+<div class="image-container">
+  <img
+    class="image-zoom-hover"
+    src="your-image.jpg"
+    alt="Description"
+  >
+</div>
+```
+
+That's the whole API — one wrapper div, one utility class.
+
+## Customizing the zoom
+
+Three CSS custom properties control the feel of the effect. Override
+them on `.image-container` or a parent scope:
+
+```css
+.image-container {
+  --zoom-scale: 1.2;      /* how much the image scales up */
+  --zoom-duration: 250ms; /* speed of the zoom */
+  --zoom-ease: ease-out;  /* easing curve */
+}
+```
+
+For a rounded/circular frame (e.g. an avatar-style image), add the
+`.image-container--rounded` modifier, which sets `border-radius: 999px`
+and locks the container to a 1:1 aspect ratio.
+
+## Why it fits EaseMotion CSS
+
+It's a single, composable utility class — attach it to any image
+inside any layout without extra markup or JavaScript. The motion is
+driven entirely by native CSS transforms and transitions, matching
+EaseMotion's animation-first, human-readable philosophy.
+
+## Accessibility
+
+- `:focus-within` on the container mirrors the hover effect for
+  keyboard navigation, so the interaction isn't mouse-only.
+- `@media (prefers-reduced-motion: reduce)` removes the transition
+  entirely — the image still displays normally, it simply doesn't
+  animate.
+
+## Files
+
+- `demo.html` — a small gallery showing the utility on four sample
+  images, including a rounded variant.
+- `style.css` — the utility itself, plus demo layout styling.
+- `README.md` — this file.

--- a/submissions/examples/image-zoom-hover-53634/demo.html
+++ b/submissions/examples/image-zoom-hover-53634/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Image Zoom Hover Utility</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <header class="demo-header">
+      <h1>Image Zoom Hover Utility</h1>
+      <p>Hover any card below. The image scales up smoothly inside a clipped frame — nothing else on the page shifts.</p>
+    </header>
+
+    <section class="gallery">
+
+      <div class="image-container">
+        <img
+          class="image-zoom-hover"
+          src="https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?w=500&q=80"
+          alt="Mountain landscape at sunrise"
+        >
+      </div>
+
+      <div class="image-container">
+        <img
+          class="image-zoom-hover"
+          src="https://images.unsplash.com/photo-1465101046530-73398c7f28ca?w=500&q=80"
+          alt="City skyline at dusk"
+        >
+      </div>
+
+      <div class="image-container">
+        <img
+          class="image-zoom-hover"
+          src="https://images.unsplash.com/photo-1500534623283-312aade485b7?w=500&q=80"
+          alt="Forest path in autumn"
+        >
+      </div>
+
+      <div class="image-container image-container--rounded">
+        <img
+          class="image-zoom-hover"
+          src="https://images.unsplash.com/photo-1518791841217-8f162f1e1131?w=500&q=80"
+          alt="Dog portrait outdoors"
+        >
+      </div>
+
+    </section>
+
+    <footer class="demo-footer">
+      <p>Pure CSS &middot; one utility class &middot; respects <code>prefers-reduced-motion</code></p>
+    </footer>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/image-zoom-hover-53634/style.css
+++ b/submissions/examples/image-zoom-hover-53634/style.css
@@ -1,0 +1,125 @@
+/* ==========================================================================
+   Image Zoom Hover Utility
+   A single reusable class: apply `.image-zoom-hover` to any <img> inside
+   an overflow-hidden container and it gains a smooth scale-up on hover.
+   ========================================================================== */
+
+:root {
+  --bg: #f7f7f5;
+  --surface: #ffffff;
+  --text: #1a1a1a;
+  --text-muted: #6b6b6b;
+  --border: #e4e4e0;
+
+  --zoom-scale: 1.12;
+  --zoom-duration: 400ms;
+  --zoom-ease: cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+/* ---- Demo shell ------------------------------------------------------ */
+.demo {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.demo-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+}
+
+.demo-header p {
+  color: var(--text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* ---- Gallery grid ----------------------------------------------------- */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+}
+
+/* ==========================================================================
+   THE UTILITY
+   ========================================================================== */
+
+/* 1. The container clips the overflow so the zoomed image never spills
+      past its own corners or shifts surrounding layout. */
+.image-container {
+  overflow: hidden;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background-color: var(--surface);
+  line-height: 0; /* removes inline-image whitespace gap */
+}
+
+.image-container--rounded {
+  border-radius: 999px;
+  aspect-ratio: 1 / 1;
+}
+
+/* 2. The utility class itself — drop this on any <img>. */
+.image-zoom-hover {
+  display: block;
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  transform: scale(1);
+  transition: transform var(--zoom-duration) var(--zoom-ease);
+}
+
+.image-container--rounded .image-zoom-hover {
+  height: 100%;
+}
+
+/* 3. Scale up on hover of the container (not just the image), so the
+      effect still triggers if a caption or overlay sits above the image. */
+.image-container:hover .image-zoom-hover {
+  transform: scale(var(--zoom-scale));
+}
+
+/* Keyboard/focus parity for accessibility, in case the image is wrapped
+   in a focusable element like a link. */
+.image-container:focus-within .image-zoom-hover {
+  transform: scale(var(--zoom-scale));
+}
+
+/* ---- Footer ------------------------------------------------------------ */
+.demo-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 2.5rem;
+}
+
+.demo-footer code {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+/* ---- Reduced motion: no scale animation, snap instantly ---------------- */
+@media (prefers-reduced-motion: reduce) {
+  .image-zoom-hover {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Pull Request Description

Adds a reusable CSS-only image zoom hover utility — a single class that scales an image smoothly on hover/focus, contained by an overflow-hidden wrapper so nothing else shifts. Useful for image cards, galleries, portfolios, and product previews, as requested in #53634.

Type of Change
 ✨ New animation / hover effect
Submission Checklist
 All changes are inside submissions/ (submissions/examples/image-zoom-hover-53634/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)
Feature Description

What does this add?
A single utility class (.image-zoom-hover) that smoothly scales an image on hover/focus, clipped by a container so it never overflows its frame.

How does a developer use it?

html
<div class="image-container">
  <img class="image-zoom-hover" src="your-image.jpg" alt="Description">
</div>

Why does it fit EaseMotion CSS?
One class, zero JS, driven entirely by native transform/transition — matches EaseMotion's composable, animation-first philosophy. Customizable via CSS variables (--zoom-scale, --zoom-duration, --zoom-ease) and respects prefers-reduced-motion.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari
Notes for Maintainer

This issue is also assigned to @aparna24bce11388 — flagging in case there's overlap with another submission. Opened as draft pending cross-browser check.

Closes #53634