### PR TITLE
fix: add missing @keyframes for Motion Engine animation tokens (#52721)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -635,18 +635,6 @@
   }
 }
 
-@keyframes ease-float {
-
-  0%,
-  100% {
-    transform: translate3d(0, 0, 0);
-  }
-
-  50% {
-    transform: translate3d(0, -10px, 0);
-  }
-}
-
 @keyframes ease-kf-zoom-out {
   from {
     transform: scale(1.5);
@@ -671,6 +659,71 @@
   to { clip-path: circle(75% at center); }
 }
 
+/* ── Missing Motion Engine Keyframes ───────────────────────── */
+/* These keyframes are required by the Motion Engine (compiler.js KEYFRAME_MAP)
+   but were previously absent, causing em="" animations for these tokens
+   to compile successfully but never execute. */
+
+@keyframes ease-kf-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes ease-kf-wobble {
+  0%   { transform: translate3d(0, 0, 0); }
+  15%  { transform: translate3d(-25%, 0, 0) rotate(-5deg); }
+  30%  { transform: translate3d(20%, 0, 0) rotate(3deg); }
+  45%  { transform: translate3d(-15%, 0, 0) rotate(-3deg); }
+  60%  { transform: translate3d(10%, 0, 0) rotate(2deg); }
+  75%  { transform: translate3d(-5%, 0, 0) rotate(-1deg); }
+  100% { transform: translate3d(0, 0, 0); }
+}
+
+@keyframes ease-kf-flip-x {
+  from {
+    transform: perspective(400px) rotateX(90deg);
+    opacity: 0;
+  }
+  to {
+    transform: perspective(400px) rotateX(0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-flip-y {
+  from {
+    transform: perspective(400px) rotateY(90deg);
+    opacity: 0;
+  }
+  to {
+    transform: perspective(400px) rotateY(0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-float {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50%      { transform: translate3d(0, -10px, 0); }
+}
+
+@keyframes ease-kf-heartbeat {
+  0%   { transform: scale(1); }
+  14%  { transform: scale(1.3); }
+  28%  { transform: scale(1); }
+  42%  { transform: scale(1.3); }
+  70%  { transform: scale(1); }
+}
+
+@keyframes ease-kf-rubber-band {
+  0%   { transform: scale(1); }
+  30%  { transform: scaleX(1.25) scaleY(0.75); }
+  40%  { transform: scaleX(0.75) scaleY(1.25); }
+  50%  { transform: scaleX(1.15) scaleY(0.85); }
+  65%  { transform: scaleX(0.95) scaleY(1.05); }
+  75%  { transform: scaleX(1.05) scaleY(0.95); }
+  100% { transform: scale(1); }
+}
+
 /* ── Animation Utility Classes ─────────────────────────────── */
 .ease-bounce-in {
   animation: ease-kf-bounce-in var(--ease-speed-medium) var(--ease-ease-bounce) both;
@@ -680,7 +733,7 @@
 }
 
 .ease-float {
-  animation: ease-float 3s ease-in-out infinite;
+  animation: ease-kf-float 3s ease-in-out infinite;
 }
 .ease-zoom-in {
   animation: ease-kf-zoom-in var(--ease-speed-medium) var(--ease-ease-bounce) both;


### PR DESCRIPTION
Fixes #52721

## Problem

The JavaScript Motion Engine (`compiler.js` `KEYFRAME_MAP`) maps 7 animation tokens to `@keyframes` names that did not exist in `core/animations.css`:

| Token | Expected Keyframe | Status |
|-------|------------------|--------|
| `spin` | `ease-kf-spin` | Was MISSING |
| `wobble` | `ease-kf-wobble` | Was MISSING |
| `flip-x` | `ease-kf-flip-x` | Was MISSING |
| `flip-y` | `ease-kf-flip-y` | Was MISSING |
| `float` | `ease-kf-float` | Was MISSING |
| `heartbeat` | `ease-kf-heartbeat` | Was MISSING |
| `rubber-band` | `ease-kf-rubber-band` | Was MISSING |

This caused `em=""` animations using these tokens (e.g. `em="spin repeat-infinite"`) to compile successfully but **never execute** at runtime, because the browser could not find the referenced `@keyframes`.

## Changes

- Added all 7 missing `@keyframes` definitions to `core/animations.css`
- Renamed legacy `@keyframes ease-float` → `@keyframes ease-kf-float` to match the compiler's naming convention
- Updated `.ease-float` utility class to reference the corrected keyframe name

## Verification

All 61 tests pass (`npm test`). No new files added; only `core/animations.css` modified.