### PR TITLE
Add CSS Swing-Hover Tabs for Product Catalog Layouts #50186

### DIFF
--- a/submissions/examples/swing-hover-tabs-product-catalog/README.md
+++ b/submissions/examples/swing-hover-tabs-product-catalog/README.md
@@ -1,0 +1,25 @@
+# Swing Hover Tabs - Product Catalog Layouts
+
+## Overview
+
+A pure CSS animated tab component designed for product catalog interfaces.
+
+The component uses a smooth Swing-Hover interaction that creates a playful motion effect when users interact with tabs.
+
+## Features
+
+- Pure CSS animation
+- No JavaScript required
+- Responsive design
+- Keyboard accessible
+- Customizable CSS variables
+- Lightweight and easy to integrate
+
+## Usage
+
+Add the class:
+
+```html
+<button class="swing-tab">
+    Electronics
+</button>

--- a/submissions/examples/swing-hover-tabs-product-catalog/demo.html
+++ b/submissions/examples/swing-hover-tabs-product-catalog/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Swing Hover Tabs - Product Catalog</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="catalog">
+        <h1>Product Catalog</h1>
+
+        <div class="tabs">
+            <button class="swing-tab">Electronics</button>
+            <button class="swing-tab">Fashion</button>
+            <button class="swing-tab">Accessories</button>
+            <button class="swing-tab">Offers</button>
+        </div>
+
+        <div class="content">
+            <h2>Featured Products</h2>
+            <p>Explore latest products with smooth animated tabs.</p>
+        </div>
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/swing-hover-tabs-product-catalog/style.css
+++ b/submissions/examples/swing-hover-tabs-product-catalog/style.css
@@ -1,0 +1,82 @@
+:root {
+    --swing-duration: 0.35s;
+    --swing-angle: 8deg;
+    --swing-scale: 1.08;
+    --tab-radius: 12px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-family: Arial, sans-serif;
+    background: #f5f7fb;
+}
+
+.catalog {
+    text-align: center;
+    width: 90%;
+    max-width: 700px;
+}
+
+h1 {
+    margin-bottom: 30px;
+}
+
+.tabs {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 15px;
+}
+
+.swing-tab {
+    padding: 14px 25px;
+    border: none;
+    border-radius: var(--tab-radius);
+    background: white;
+    color: #333;
+    font-size: 16px;
+    cursor: pointer;
+
+    transition:
+        transform var(--swing-duration) ease,
+        box-shadow var(--swing-duration) ease;
+}
+
+.swing-tab:hover,
+.swing-tab:focus {
+    transform:
+        rotate(var(--swing-angle))
+        scale(var(--swing-scale));
+
+    box-shadow: 0 10px 25px rgba(0,0,0,0.15);
+}
+
+.swing-tab:active {
+    transform: scale(0.95);
+}
+
+.content {
+    margin-top: 35px;
+    padding: 25px;
+    background: white;
+    border-radius: var(--tab-radius);
+}
+
+
+@media(max-width:600px) {
+
+    .tabs {
+        flex-direction: column;
+    }
+
+    .swing-tab {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS Swing-Hover Tabs component for Product Catalog layouts.
The component provides smooth hover animations, responsive design, keyboard accessibility, and customizable CSS variables without using JavaScript.

--- Closes #50186

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Feature Description

**What does this add?**

This adds a CSS-only Swing-Hover Tabs component designed for Product Catalog interfaces with smooth interactive transitions.

**How does a developer use it?**

```html
<button class="swing-tab">
    Electronics
</button>
Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari (optional but appreciated)