### PR TITLE
feat: add CSS Jello-Hover Tabs for Dashboard Analytics Layouts (#50228)

### DIFF
--- a/submissions/examples/jello-hover-tabs-50228/README.md
+++ b/submissions/examples/jello-hover-tabs-50228/README.md
@@ -1,0 +1,73 @@
+# CSS Jello-Hover Tabs - Dashboard Analytics Layouts
+
+A pure HTML/CSS tab component featuring a rubbery jello animation on hover, designed for dashboard analytics interface aesthetics.
+
+Related Issue: #50228
+
+---
+
+## Repository Standard Answers
+
+### 1. What does this do?
+It renders a CSS-only tab component where tab triggers deform with a squishy, rubbery jello effect on hover and keyboard focus, providing playful tactile feedback. Panels slide in with a scale-entrance animation. Designed for dark-themed dashboard analytics interfaces.
+
+### 2. How is it used?
+Use the radio button hack pattern: pair hidden radio inputs with labels as tab triggers, and show/hide panels via CSS sibling selectors. Apply the `.jht` class to the container.
+
+```html
+<section class="jht" aria-label="Analytics">
+  <div class="jht__list" role="tablist">
+    <input type="radio" name="stats" id="s-1" class="jht__input" checked>
+    <label for="s-1" class="jht__trigger" role="tab">Tab 1</label>
+    <input type="radio" name="stats" id="s-2" class="jht__input">
+    <label for="s-2" class="jht__trigger" role="tab">Tab 2</label>
+  </div>
+  <div class="jht__panels">
+    <div class="jht__panel" role="tabpanel"><p>Panel 1</p></div>
+    <div class="jht__panel" role="tabpanel"><p>Panel 2</p></div>
+  </div>
+</section>
+```
+
+### 3. Why is it useful?
+It provides a zero-JS tab component with a fun, engaging jello animation that draws attention on interaction. The dark dashboard theme makes it immediately usable for analytics panels, data dashboards, and monitoring interfaces where playful motion enhances the experience.
+
+---
+
+## Features
+
+- **Pure HTML + CSS**: Zero JavaScript dependencies. Uses radio button hack for tab switching.
+- **Jello Animation**: Triggers squish and deform on hover with a rubbery bounce-back effect.
+- **Dashboard Theme**: Dark analytics-inspired design with glowing accent colors.
+- **Panel Scale-In Animation**: Active panels animate in with a scale-and-slide entrance.
+- **Multiple Variants**: Default (pill tabs) and Analytics (underline tabs) styles.
+- **Keyboard Accessible**: Jello fires on `:focus-visible` for keyboard users.
+- **Reduced Motion**: Disables jello animation when `prefers-reduced-motion` is enabled.
+- **Responsive**: Stacks tabs vertically on small screens.
+
+---
+
+## Customization
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `--jht-duration` | Jello animation duration | `0.45s` |
+| `--jht-easing` | Jello easing curve | `cubic-bezier(0.25, 0.46, 0.45, 0.94)` |
+| `--jht-jello-scale-x` | Horizontal squish factor | `1.15` |
+| `--jht-jello-scale-y` | Vertical squish factor | `0.88` |
+| `--jht-panel-duration` | Panel entrance duration | `0.3s` |
+| `--jht-bg` | Page background | `#0f172a` |
+| `--jht-surface` | Card surface | `#1e293b` |
+| `--jht-accent` | Active tab color | `#38bdf8` |
+| `--jht-accent-glow` | Active tab glow | `rgba(56, 189, 248, 0.25)` |
+
+---
+
+## Folder Structure
+
+```text
+submissions/examples/jello-hover-tabs-50228/
+├── demo.html       ← Dashboard Analytics demo with Overview and Users tabs
+├── style.css       ← Component styles with jello animation and CSS custom properties
+└── README.md       ← This file
+```

--- a/submissions/examples/jello-hover-tabs-50228/demo.html
+++ b/submissions/examples/jello-hover-tabs-50228/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Jello-Hover Tabs - Dashboard Analytics Layouts | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Jello-<span>Hover</span> Tabs</h1>
+    <p>Pure CSS tabs with a rubbery jello animation on hover, built for dashboard analytics interfaces.</p>
+  </header>
+
+  <main class="jht-grid">
+
+    <!-- Tab Component 1: Overview -->
+    <section class="jht" aria-label="Overview analytics">
+      <div class="jht__list" role="tablist">
+        <input type="radio" name="tab-1" id="tab-1-1" class="jht__input" checked>
+        <label for="tab-1-1" class="jht__trigger" role="tab" tabindex="0">Overview</label>
+
+        <input type="radio" name="tab-1" id="tab-1-2" class="jht__input">
+        <label for="tab-1-2" class="jht__trigger" role="tab" tabindex="0">Traffic</label>
+
+        <input type="radio" name="tab-1" id="tab-1-3" class="jht__input">
+        <label for="tab-1-3" class="jht__trigger" role="tab" tabindex="0">Revenue</label>
+      </div>
+
+      <div class="jht__panels">
+        <div class="jht__panel" role="tabpanel">
+          <p class="jht__panel-title">Dashboard Overview</p>
+          <p class="jht__panel-text">Active users: 12,847 | Sessions: 34,291 | Bounce rate: 32.4%. Peak traffic at 3 PM UTC.</p>
+        </div>
+        <div class="jht__panel" role="tabpanel">
+          <p class="jht__panel-title">Traffic Sources</p>
+          <p class="jht__panel-text">Organic: 48% | Direct: 24% | Referral: 18% | Social: 10%. Top channel: Google Search.</p>
+        </div>
+        <div class="jht__panel" role="tabpanel">
+          <p class="jht__panel-title">Revenue Breakdown</p>
+          <p class="jht__panel-text">Pro: 58% | Team: 32% | Enterprise: 10%. MRR: $67,400 growing 11% MoM.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tab Component 2: Analytics (underline variant) -->
+    <section class="jht jht--analytics" aria-label="Detailed analytics">
+      <div class="jht__list" role="tablist">
+        <input type="radio" name="tab-2" id="tab-2-1" class="jht__input" checked>
+        <label for="tab-2-1" class="jht__trigger" role="tab" tabindex="0">Users</label>
+
+        <input type="radio" name="tab-2" id="tab-2-2" class="jht__input">
+        <label for="tab-2-2" class="jht__trigger" role="tab" tabindex="0">Sessions</label>
+
+        <input type="radio" name="tab-2" id="tab-2-3" class="jht__input">
+        <label for="tab-2-3" class="jht__trigger" role="tab" tabindex="0">Retention</label>
+      </div>
+
+      <div class="jht__panels">
+        <div class="jht__panel" role="tabpanel">
+          <p class="jht__panel-title">User Metrics</p>
+          <p class="jht__panel-text">New users: 8,412 | Returning: 4,435 | Avg session: 4m 32s. Day-7 retention: 64%.</p>
+        </div>
+        <div class="jht__panel" role="tabpanel">
+          <p class="jht__panel-title">Session Analysis</p>
+          <p class="jht__panel-text">Pageviews: 89,214 | Pages/session: 6.8 | Avg duration: 4m 12s. Top page: /dashboard.</p>
+        </div>
+        <div class="jht__panel" role="tabpanel">
+          <p class="jht__panel-title">User Retention</p>
+          <p class="jht__panel-text">Day-1: 82% | Day-7: 64% | Day-30: 41%. Cohort NPS: 72.</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="margin-top: 3rem; color: var(--jht-text-muted); font-size: 0.75rem; text-align: center;">
+    EaseMotion-css &bull; Jello-Hover Tabs &bull; Pure HTML + CSS
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/jello-hover-tabs-50228/style.css
+++ b/submissions/examples/jello-hover-tabs-50228/style.css
@@ -1,0 +1,333 @@
+/* ==========================================================================
+   CSS Jello-Hover Tabs - Dashboard Analytics Layouts
+   Pure CSS component for EaseMotion CSS (#50228)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design Tokens (CSS Custom Properties)
+   -------------------------------------------------------------------------- */
+:root {
+  /* Jello Animation */
+  --jht-duration: 0.45s;
+  --jht-easing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  --jht-jello-scale-x: 1.15;
+  --jht-jello-scale-y: 0.88;
+  --jht-jello-skew: 4deg;
+
+  /* Panel Entrance */
+  --jht-panel-duration: 0.3s;
+  --jht-panel-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Dashboard Analytics Theme */
+  --jht-bg: #0f172a;
+  --jht-surface: #1e293b;
+  --jht-surface-hover: #263348;
+  --jht-text: #e2e8f0;
+  --jht-text-muted: #94a3b8;
+  --jht-accent: #38bdf8;
+  --jht-accent-glow: rgba(56, 189, 248, 0.25);
+  --jht-success: #4ade80;
+  --jht-warning: #fbbf24;
+  --jht-border: #334155;
+
+  /* Shadows */
+  --jht-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --jht-shadow-glow: 0 0 20px rgba(56, 189, 248, 0.15);
+
+  /* Radii */
+  --jht-radius: 12px;
+  --jht-radius-sm: 8px;
+}
+
+/* --------------------------------------------------------------------------
+   2. Base Reset & Layout
+   -------------------------------------------------------------------------- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background-color: var(--jht-bg);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: var(--jht-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  max-width: 560px;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.5rem;
+  color: var(--jht-text);
+}
+
+.page-header h1 span {
+  color: var(--jht-accent);
+}
+
+.page-header p {
+  color: var(--jht-text-muted);
+  font-size: 1rem;
+}
+
+.jht-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 800px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Jello-Hover Tabs Core
+   -------------------------------------------------------------------------- */
+.jht {
+  background-color: var(--jht-surface);
+  border-radius: var(--jht-radius);
+  box-shadow: var(--jht-shadow);
+  border: 1px solid var(--jht-border);
+  padding: 1.5rem;
+  overflow: hidden;
+}
+
+.jht__list {
+  display: flex;
+  gap: 0.25rem;
+  list-style: none;
+  margin-bottom: 1.25rem;
+  padding: 0.25rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: var(--jht-radius-sm);
+}
+
+/* Tab Trigger */
+.jht__trigger {
+  flex: 1;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--jht-text-muted);
+  cursor: pointer;
+  position: relative;
+  transform-origin: center center;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.jht__trigger:hover {
+  color: var(--jht-text);
+}
+
+/* Jello effect on hover */
+.jht__trigger:hover {
+  animation: jht-jello var(--jht-duration) var(--jht-easing);
+}
+
+/* Hidden radio */
+.jht__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* Active tab */
+.jht__input:checked + .jht__trigger {
+  color: var(--jht-bg);
+  background: var(--jht-accent);
+  box-shadow: 0 0 16px var(--jht-accent-glow);
+}
+
+.jht__input:checked + .jht__trigger:hover {
+  animation: jht-jello var(--jht-duration) var(--jht-easing);
+}
+
+/* Focus visible */
+.jht__input:focus-visible + .jht__trigger {
+  outline: 2px solid var(--jht-accent);
+  outline-offset: 2px;
+  animation: jht-jello var(--jht-duration) var(--jht-easing);
+}
+
+/* Tab Panels */
+.jht__panel {
+  display: none;
+  min-height: 80px;
+}
+
+.jht__panel-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--jht-text);
+  margin-bottom: 0.375rem;
+}
+
+.jht__panel-text {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--jht-text-muted);
+}
+
+/* --------------------------------------------------------------------------
+   4. Jello Keyframe
+   -------------------------------------------------------------------------- */
+@keyframes jht-jello {
+  0%   { transform: scale(1, 1); }
+  15%  { transform: scale(var(--jht-jello-scale-x), var(--jht-jello-scale-y)); }
+  30%  { transform: scale(0.92, 1.08); }
+  45%  { transform: scale(var(--jht-jello-scale-x), 0.94); }
+  60%  { transform: scale(0.97, 1.03); }
+  75%  { transform: scale(1.02, 0.98); }
+  100% { transform: scale(1, 1); }
+}
+
+/* --------------------------------------------------------------------------
+   5. Panel Entrance Animation
+   -------------------------------------------------------------------------- */
+.jht__input:nth-of-type(1):checked ~ .jht__panels .jht__panel:nth-child(1),
+.jht__input:nth-of-type(2):checked ~ .jht__panels .jht__panel:nth-child(2),
+.jht__input:nth-of-type(3):checked ~ .jht__panels .jht__panel:nth-child(3),
+.jht__input:nth-of-type(4):checked ~ .jht__panels .jht__panel:nth-child(4) {
+  display: block;
+  animation: jht-panel-in var(--jht-panel-duration) var(--jht-panel-easing) both;
+}
+
+@keyframes jht-panel-in {
+  0% {
+    opacity: 0;
+    transform: translateY(8px) scale(0.97);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   6. Dashboard Analytics Variant
+   -------------------------------------------------------------------------- */
+.jht--analytics .jht__list {
+  gap: 0.125rem;
+  background: transparent;
+  border-bottom: 1px solid var(--jht-border);
+  border-radius: 0;
+  padding: 0;
+  margin-bottom: 1.25rem;
+}
+
+.jht--analytics .jht__trigger {
+  border-radius: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0.625rem 0.75rem;
+}
+
+.jht--analytics .jht__input:checked + .jht__trigger {
+  background: transparent;
+  color: var(--jht-accent);
+  border-bottom-color: var(--jht-accent);
+  box-shadow: none;
+}
+
+.jht--analytics .jht__input:checked + .jht__trigger:hover {
+  background: rgba(56, 189, 248, 0.08);
+}
+
+/* Stat card variant */
+.jht--stat-card {
+  padding: 1rem;
+}
+
+.jht--stat-card .jht__list {
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+}
+
+.jht--stat-card .jht__trigger {
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+}
+
+.jht--stat-card .jht__panel-title {
+  font-size: 0.875rem;
+}
+
+.jht--stat-card .jht__panel-text {
+  font-size: 0.8125rem;
+}
+
+/* --------------------------------------------------------------------------
+   7. Accessibility
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .jht__trigger,
+  .jht__panel {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+.jht-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --------------------------------------------------------------------------
+   8. Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .jht-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .jht__list {
+    flex-direction: column;
+  }
+
+  .jht__trigger {
+    text-align: left;
+  }
+
+  .jht--analytics .jht__trigger {
+    border-bottom: none;
+    border-left: 2px solid transparent;
+  }
+
+  .jht--analytics .jht__input:checked + .jht__trigger {
+    border-bottom: none;
+    border-left-color: var(--jht-accent);
+  }
+}


### PR DESCRIPTION
## Enhancement: Add CSS Jello-Hover Tabs for Dashboard Analytics Layouts

Related Issue: #50228

### What it does
A pure CSS tab component featuring a rubbery jello animation on hover, designed for dark-themed dashboard analytics interfaces. Tab triggers squish and deform with a playful bounce-back effect. Panels slide in with a scale-entrance animation.

### What's included
- `style.css` — Component with CSS custom properties for timing, easing, and scale factors
- `demo.html` — Dashboard Analytics demo with Overview and Users tab variants
- `README.md` — Documentation with 3 required sections (What, How, Why)

### Features
- Pure HTML + CSS, zero JavaScript
- Jello hover animation with configurable scale/squish parameters
- Dashboard dark theme with glowing accent colors
- Two variants: pill tabs (default) and underline tabs (analytics)
- Keyboard accessible (`:focus-visible` triggers jello)
- `prefers-reduced-motion` respected
- Responsive — stacks vertically on small screens
- All custom properties exposed for theming

### Checklist
- [x] Only files inside `submissions/examples/jello-hover-tabs-50228/`
- [x] No existing files modified
- [x] 3 required files: `demo.html`, `style.css`, `README.md`
- [x] README has 3 sections: What it does, How to use, Why useful
- [x] Responsive, keyboard accessible
- [x] CSS custom properties for customization