### PR TITLE
fix: add type module to package.json to resolve native Node ESM import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "easemotion-css",
   "version": "1.2.0",
+  "type": "module",
   "description": "Human-readable, animation-first CSS framework with a zero-config motion engine. Zero dependencies.",
   "main": "easemotion.css",
   "style": "easemotion.css",


### PR DESCRIPTION
## Description
This PR explicitly declares the package as an ES Module by adding `"type": "module"` to the [package.json](cci:7://file:///c:/gssoc%2026/EaseMotion-css/package.json:0:0-0:0).

## Why is this needed?
The [easemotion/index.js](cci:7://file:///c:/gssoc%2026/EaseMotion-css/easemotion/index.js:0:0-0:0) engine (and related files) utilize ES Modules syntax (`export { ... }`). Without the `"type": "module"` declaration, Node.js assumes [.js](cci:7://file:///c:/gssoc%2026/EaseMotion-css/vitest.config.js:0:0-0:0) files are CommonJS by default. When developers attempt to import this engine natively in Node applications or SSR frameworks (like Next.js/Nuxt), it triggers ugly `[MODULE_TYPELESS_PACKAGE_JSON]` warnings and can cause critical import failures. 

## Impact
Zero breaking changes. It simply gives Node.js runtime engines the correct parsing context, preventing integration errors for users.