### PR TITLE
feat: add CSS Tada-Click Tabs for Neumorphic Soft Layouts (#50208)

### DIFF
--- a/submissions/examples/tada-click-tabs-50208/README.md
+++ b/submissions/examples/tada-click-tabs-50208/README.md
@@ -1,0 +1,73 @@
+# CSS Tada-Click Tabs - Neumorphic Soft Layouts
+
+A pure HTML/CSS tab component featuring a celebratory tada animation on click, designed for neumorphic soft interface aesthetics.
+
+Related Issue: #50208
+
+---
+
+## Repository Standard Answers
+
+### 1. What does this do?
+It renders a CSS-only tab component where tab triggers play a tada (shake + scale) animation on click and keyboard focus, providing celebratory tactile feedback. Panels slide in with a smooth entrance. Designed for soft neumorphic interfaces with inset/outset shadow styling.
+
+### 2. How is it used?
+Use the radio button hack pattern: pair hidden radio inputs with labels as tab triggers, and show/hide panels via CSS sibling selectors. Apply the `.tct` class to the container.
+
+```html
+<section class="tct" aria-label="Settings">
+  <div class="tct__list" role="tablist">
+    <input type="radio" name="settings" id="s-1" class="tct__input" checked>
+    <label for="s-1" class="tct__trigger" role="tab">Tab 1</label>
+    <input type="radio" name="settings" id="s-2" class="tct__input">
+    <label for="s-2" class="tct__trigger" role="tab">Tab 2</label>
+  </div>
+  <div class="tct__panels">
+    <div class="tct__panel" role="tabpanel"><p>Panel 1</p></div>
+    <div class="tct__panel" role="tabpanel"><p>Panel 2</p></div>
+  </div>
+</section>
+```
+
+### 3. Why is it useful?
+It provides a zero-JS tab component with a playful tada animation that delights users on interaction. The neumorphic soft theme makes it immediately usable for settings panels, dashboards, and admin interfaces where tactile, soft UI aesthetics enhance the experience.
+
+---
+
+## Features
+
+- **Pure HTML + CSS**: Zero JavaScript dependencies. Uses radio button hack for tab switching.
+- **Tada Animation**: Triggers shake and scale on click with a celebratory bounce-back.
+- **Neumorphic Soft Theme**: Soft inset/outset shadow styling with muted accent colors.
+- **Panel Entrance**: Active panels animate in with a scale-and-slide entrance.
+- **Keyboard Accessible**: Tada fires on `:focus-visible` for keyboard users.
+- **Reduced Motion**: Disables tada animation when `prefers-reduced-motion` is enabled.
+- **Responsive**: Stacks tabs vertically on small screens.
+
+---
+
+## Customization
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `--tct-duration` | Tada animation duration | `0.5s` |
+| `--tct-easing` | Tada easing curve | `cubic-bezier(0.36, 0.07, 0.19, 0.97)` |
+| `--tct-rotate-peak` | Max rotation angle | `3deg` |
+| `--tct-scale-peak` | Peak scale factor | `1.08` |
+| `--tct-panel-duration` | Panel entrance duration | `0.35s` |
+| `--tct-bg` | Page background | `#e0e5ec` |
+| `--tct-surface` | Card surface | `#e0e5ec` |
+| `--tct-accent` | Active tab color | `#6c63ff` |
+| `--tct-shadow-out` | Outset shadow | `6px 6px 12px #b8bec7, -6px -6px 12px #ffffff` |
+| `--tct-shadow-in` | Inset shadow | `inset 4px 4px 8px #b8bec7, inset -4px -4px 8px #ffffff` |
+
+---
+
+## Folder Structure
+
+```text
+submissions/examples/tada-click-tabs-50208/
+├── demo.html       ← Neumorphic Soft demo with Profile Settings and Analytics tabs
+├── style.css       ← Component styles with tada animation and CSS custom properties
+└── README.md       ← This file
+```

--- a/submissions/examples/tada-click-tabs-50208/demo.html
+++ b/submissions/examples/tada-click-tabs-50208/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Tada-Click Tabs - Neumorphic Soft Layouts | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="page-header">
+    <h1>Tada-<span>Click</span> Tabs</h1>
+    <p>Pure CSS tabs with a celebratory tada animation on click, built for neumorphic soft interfaces.</p>
+  </header>
+
+  <main class="tct-grid">
+
+    <!-- Tab Component 1: Profile Settings -->
+    <section class="tct" aria-label="Profile settings">
+      <div class="tct__list" role="tablist">
+        <input type="radio" name="tab-1" id="tab-1-1" class="tct__input" checked>
+        <label for="tab-1-1" class="tct__trigger" role="tab" tabindex="0">Profile</label>
+
+        <input type="radio" name="tab-1" id="tab-1-2" class="tct__input">
+        <label for="tab-1-2" class="tct__trigger" role="tab" tabindex="0">Security</label>
+
+        <input type="radio" name="tab-1" id="tab-1-3" class="tct__input">
+        <label for="tab-1-3" class="tct__trigger" role="tab" tabindex="0">Billing</label>
+      </div>
+
+      <div class="tct__panels">
+        <div class="tct__panel" role="tabpanel">
+          <p class="tct__panel-title">Profile Settings</p>
+          <p class="tct__panel-text">Manage your display name, avatar, and bio. Changes are reflected across your workspace instantly.</p>
+        </div>
+        <div class="tct__panel" role="tabpanel">
+          <p class="tct__panel-title">Security</p>
+          <p class="tct__panel-text">Enable two-factor authentication, manage active sessions, and review login history for suspicious activity.</p>
+        </div>
+        <div class="tct__panel" role="tabpanel">
+          <p class="tct__panel-title">Billing</p>
+          <p class="tct__panel-text">Current plan: Pro ($12/mo). Next billing date: Aug 1, 2026. 3 seats used of 5 available.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tab Component 2: Dashboard Analytics -->
+    <section class="tct" aria-label="Analytics dashboard">
+      <div class="tct__list" role="tablist">
+        <input type="radio" name="tab-2" id="tab-2-1" class="tct__input" checked>
+        <label for="tab-2-1" class="tct__trigger" role="tab" tabindex="0">Overview</label>
+
+        <input type="radio" name="tab-2" id="tab-2-2" class="tct__input">
+        <label for="tab-2-2" class="tct__trigger" role="tab" tabindex="0">Users</label>
+
+        <input type="radio" name="tab-2" id="tab-2-3" class="tct__input">
+        <label for="tab-2-3" class="tct__trigger" role="tab" tabindex="0">Revenue</label>
+      </div>
+
+      <div class="tct__panels">
+        <div class="tct__panel" role="tabpanel">
+          <p class="tct__panel-title">Dashboard Overview</p>
+          <p class="tct__panel-text">Active users: 8,234 | Sessions: 24,118 | Bounce rate: 28.7%. Peak at 2 PM UTC.</p>
+        </div>
+        <div class="tct__panel" role="tabpanel">
+          <p class="tct__panel-title">User Metrics</p>
+          <p class="tct__panel-text">New: 5,112 | Returning: 3,122 | Avg session: 5m 14s. Day-7 retention: 61%.</p>
+        </div>
+        <div class="tct__panel" role="tabpanel">
+          <p class="tct__panel-title">Revenue</p>
+          <p class="tct__panel-text">MRR: $42,800 | Growth: 8.3% MoM | Churn: 2.1%. Top plan: Team ($29/mo).</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer style="margin-top: 3rem; color: var(--tct-text-muted); font-size: 0.75rem; text-align: center;">
+    EaseMotion-css &bull; Tada-Click Tabs &bull; Pure HTML + CSS
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/tada-click-tabs-50208/style.css
+++ b/submissions/examples/tada-click-tabs-50208/style.css
@@ -1,0 +1,272 @@
+/* ==========================================================================
+   CSS Tada-Click Tabs - Neumorphic Soft Layouts
+   Pure CSS component for EaseMotion CSS (#50208)
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design Tokens (CSS Custom Properties)
+   -------------------------------------------------------------------------- */
+:root {
+  /* Tada Animation */
+  --tct-duration: 0.5s;
+  --tct-easing: cubic-bezier(0.36, 0.07, 0.19, 0.97);
+  --tct-rotate-amount: 3deg;
+  --tct-scale-peak: 1.08;
+
+  /* Panel Entrance */
+  --tct-panel-duration: 0.35s;
+  --tct-panel-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Neumorphic Soft Theme */
+  --tct-bg: #e0e5ec;
+  --tct-surface: #e0e5ec;
+  --tct-text: #31344b;
+  --tct-text-muted: #6b7294;
+  --tct-accent: #6c63ff;
+  --tct-accent-soft: rgba(108, 99, 255, 0.15);
+  --tct-border: rgba(255, 255, 255, 0.6);
+
+  /* Neumorphic Shadows */
+  --tct-shadow-out: 6px 6px 12px #b8bec7, -6px -6px 12px #ffffff;
+  --tct-shadow-in: inset 4px 4px 8px #b8bec7, inset -4px -4px 8px #ffffff;
+  --tct-shadow-hover: 8px 8px 16px #b8bec7, -8px -8px 16px #ffffff;
+
+  /* Radii */
+  --tct-radius: 16px;
+  --tct-radius-sm: 12px;
+  --tct-radius-xs: 8px;
+}
+
+/* --------------------------------------------------------------------------
+   2. Base Reset & Layout
+   -------------------------------------------------------------------------- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background-color: var(--tct-bg);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: var(--tct-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  max-width: 560px;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.5rem;
+  color: var(--tct-text);
+}
+
+.page-header h1 span {
+  color: var(--tct-accent);
+}
+
+.page-header p {
+  color: var(--tct-text-muted);
+  font-size: 1rem;
+}
+
+.tct-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 800px;
+}
+
+/* --------------------------------------------------------------------------
+   3. Tada-Click Tabs Core (Neumorphic Soft)
+   -------------------------------------------------------------------------- */
+.tct {
+  background-color: var(--tct-surface);
+  border-radius: var(--tct-radius);
+  box-shadow: var(--tct-shadow-out);
+  padding: 1.5rem;
+  overflow: hidden;
+}
+
+.tct__list {
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  margin-bottom: 1.25rem;
+  padding: 0.375rem;
+  border-radius: var(--tct-radius-sm);
+  box-shadow: var(--tct-shadow-in);
+}
+
+/* Tab Trigger */
+.tct__trigger {
+  flex: 1;
+  background: none;
+  border: none;
+  border-radius: var(--tct-radius-xs);
+  padding: 0.5rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--tct-text-muted);
+  cursor: pointer;
+  position: relative;
+  transform-origin: center center;
+  transition:
+    color 0.2s ease,
+    box-shadow 0.3s ease,
+    transform 0.15s ease;
+}
+
+.tct__trigger:hover {
+  color: var(--tct-text);
+  box-shadow: var(--tct-shadow-out);
+}
+
+/* Tada effect on click */
+.tct__trigger:active {
+  animation: tct-tada var(--tct-duration) var(--tct-easing);
+}
+
+/* Hidden radio */
+.tct__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* Active tab */
+.tct__input:checked + .tct__trigger {
+  color: var(--tct-accent);
+  background: var(--tct-accent-soft);
+  box-shadow: var(--tct-shadow-in);
+  font-weight: 700;
+}
+
+.tct__input:checked + .tct__trigger:active {
+  animation: tct-tada var(--tct-duration) var(--tct-easing);
+}
+
+/* Focus visible */
+.tct__input:focus-visible + .tct__trigger {
+  outline: 2px solid var(--tct-accent);
+  outline-offset: 2px;
+  animation: tct-tada var(--tct-duration) var(--tct-easing);
+}
+
+/* Tab Panels */
+.tct__panel {
+  display: none;
+  min-height: 80px;
+}
+
+.tct__panel-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--tct-text);
+  margin-bottom: 0.375rem;
+}
+
+.tct__panel-text {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--tct-text-muted);
+}
+
+/* --------------------------------------------------------------------------
+   4. Tada Keyframe
+   -------------------------------------------------------------------------- */
+@keyframes tct-tada {
+  0%   { transform: scale(1) rotate(0deg); }
+  10%  { transform: scale(var(--tct-scale-peak)) rotate(calc(-1 * var(--tct-rotate-amount))); }
+  20%  { transform: scale(var(--tct-scale-peak)) rotate(var(--tct-rotate-amount)); }
+  30%  { transform: scale(calc(1 + (var(--tct-scale-peak) - 1) * 0.5)) rotate(calc(-0.8 * var(--tct-rotate-amount))); }
+  40%  { transform: scale(calc(1 + (var(--tct-scale-peak) - 1) * 0.5)) rotate(0.8 * var(--tct-rotate-amount)); }
+  50%  { transform: scale(1.02) rotate(calc(-0.4 * var(--tct-rotate-amount))); }
+  60%  { transform: scale(1.02) rotate(0.4 * var(--tct-rotate-amount)); }
+  70%  { transform: scale(1.01) rotate(0deg); }
+  100% { transform: scale(1) rotate(0deg); }
+}
+
+/* --------------------------------------------------------------------------
+   5. Panel Entrance Animation
+   -------------------------------------------------------------------------- */
+.tct__input:nth-of-type(1):checked ~ .tct__panels .tct__panel:nth-child(1),
+.tct__input:nth-of-type(2):checked ~ .tct__panels .tct__panel:nth-child(2),
+.tct__input:nth-of-type(3):checked ~ .tct__panels .tct__panel:nth-child(3),
+.tct__input:nth-of-type(4):checked ~ .tct__panels .tct__panel:nth-child(4) {
+  display: block;
+  animation: tct-panel-in var(--tct-panel-duration) var(--tct-panel-easing) both;
+}
+
+@keyframes tct-panel-in {
+  0% {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   6. Accessibility
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .tct__trigger,
+  .tct__panel {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+.tct-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --------------------------------------------------------------------------
+   7. Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .tct-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .tct__list {
+    flex-direction: column;
+  }
+
+  .tct__trigger {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
Related Issue: #50208

### What it does
Pure CSS tab component with a celebratory tada (shake + scale) animation on click, designed for neumorphic soft interfaces with inset/outset shadow styling.

### Files
- style.css — Component with CSS custom properties for timing, easing, and scale factors
- demo.html — Neumorphic Soft demo with Profile Settings and Analytics tabs
- README.md — Documentation (What, How, Why)

### Checklist
- [x] Only files inside submissions/examples/tada-click-tabs-50208/
- [x] No existing files modified
- [x] 3 required files: demo.html, style.css, README.md
- [x] README has 3 sections: What it does, How to use, Why useful
- [x] Responsive, keyboard accessible
- [x] CSS custom properties for customization
- [x] prefers-reduced-motion respected