### PR TITLE
fix: add "type": "module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "easemotion-css",
   "version": "1.2.0",
+  "type": "module",
   "description": "Human-readable, animation-first CSS framework with a zero-config motion engine. Zero dependencies.",
   "main": "easemotion.css",
   "style": "easemotion.css",

--- a/submissions/docs/fix-type-module/README.md
+++ b/submissions/docs/fix-type-module/README.md
@@ -1,0 +1,5 @@
+# Fix Type Module
+
+1. What does this do? Documents the bug fix for adding `type: module` to package.json to resolve Node.js warnings.
+2. How is it used? The fix operates transparently inside `package.json`.
+3. Why is it useful? It ensures EaseMotion-css integrates smoothly with modern SSR frameworks and Node.js backend tools without throwing CommonJS module errors.

--- a/submissions/docs/fix-type-module/demo.html
+++ b/submissions/docs/fix-type-module/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>EaseMotion Type Module Fix</title>
+    <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+    <div class="fix-demo">
+        <p>This folder documents the package.json type module fix.</p>
+    </div>
+</body>
+</html>

--- a/submissions/docs/fix-type-module/style.css
+++ b/submissions/docs/fix-type-module/style.css
@@ -1,0 +1,7 @@
+/* submissions/docs/fix-type-module/style.css */
+.fix-demo {
+    padding: 1rem;
+    background: #f1f5f9;
+    border-radius: 8px;
+    font-family: system-ui;
+}


### PR DESCRIPTION
## Description
This PR explicitly declares the package as an ES Module by adding `"type": "module"` to the [package.json](cci:7://file:///c:/gssoc%2026/EaseMotion-css/package.json:0:0-0:0).

## Why is this needed?
The [easemotion/index.js](cci:7://file:///c:/gssoc%2026/EaseMotion-css/easemotion/index.js:0:0-0:0) engine (and related files) utilize ES Modules syntax (`export { ... }`). Without the `"type": "module"` declaration, Node.js assumes [.js](cci:7://file:///c:/gssoc%2026/EaseMotion-css/vitest.config.js:0:0-0:0) files are CommonJS by default. When developers attempt to import this engine natively in Node applications or SSR frameworks (like Next.js/Nuxt), it triggers ugly `[MODULE_TYPELESS_PACKAGE_JSON]` warnings and can cause critical import failures. 

## Impact
Zero breaking changes. It simply gives Node.js runtime engines the correct parsing context, preventing integration errors for users.