### PR TITLE
Fix exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "./engine/compiler": "./easemotion/engine/compiler.js",
     "./engine/optimizer": "./easemotion/engine/optimizer.js",
     "./engine/runtime": "./easemotion/engine/runtime.js",
-    "./core": "./core/animations.css"
+    "./core": "./core/animations.css",
+    "./core/*": "./core/*.css",
+    "./components/*": "./components/*.css",
+    "./easemotion/*": "./easemotion/*.css"
   },
   "files": [
     "easemotion.css",

--- a/submissions/docs/fix-exports-map/README.md
+++ b/submissions/docs/fix-exports-map/README.md
@@ -1,0 +1,5 @@
+# Fix Exports Map
+
+1. What does this do? Documents the bug fix for expanding the `exports` map in package.json to wildcard directories.
+2. How is it used? The fix operates transparently inside `package.json`, enabling developers to import CSS sub-modules.
+3. Why is it useful? It ensures EaseMotion-css is actually modular and tree-shakable as advertised, unblocking selective CSS imports.

--- a/submissions/docs/fix-exports-map/demo.html
+++ b/submissions/docs/fix-exports-map/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>EaseMotion Exports Map Fix</title>
+    <link rel="stylesheet" href="./style.css">
+</head>
+
+<body>
+    <div class="fix-demo">
+        <p>This folder documents the package.json exports branch fix.</p>
+    </div>
+</body>
+
+</html>

--- a/submissions/docs/fix-exports-map/style.css
+++ b/submissions/docs/fix-exports-map/style.css
@@ -1,0 +1,7 @@
+/* submissions/docs/fix-exports-map/style.css */
+.fix-demo {
+    padding: 1rem;
+    background: #f8fafc;
+    border-radius: 8px;
+    font-family: system-ui;
+}


### PR DESCRIPTION
## Description
This PR expands the `"exports"` map in [package.json](cci:7://file:///c:/gssoc%2026/EaseMotion-css/package.json:0:0-0:0) to include wildcard paths for `/core/`, `/components/`, and `/easemotion/`.

## Why is this needed?
Currently, the strict `exports` map only exposes the root `.css` file, the minified CSS, and the engine JS. This unintentionally blocks developers from selectively importing individual modules (e.g., `import 'easemotion-css/components/buttons.css'`). 

Since EaseMotion CSS advertises itself as a "tree-shaking" friendly and modular framework, users should be able to import only the utilities they need. This fix unblocks those paths.

## Impact
Developers can now import isolated component CSS directly without being forced to bundle the entire `easemotion.css` root framework.