### PR TITLE
docs: add package type-module fix submission

### DIFF
--- a/submissions/docs/type-module-fix-shrey/README.md
+++ b/submissions/docs/type-module-fix-shrey/README.md
@@ -1,0 +1,5 @@
+# Package Type Module Fix
+
+1. What does this do? Proposes adding `"type": "module"` to `package.json` to enable native ES module resolution in Node.js environments.
+2. How is it used? Node.js and modern frameworks (Next.js/Nuxt) will natively recognize `.js` files as ES modules without throwing `[MODULE_TYPELESS_PACKAGE_JSON]` warnings.
+3. Why is it useful? It ensures seamless server-side rendering (SSR) and bundler integration for EaseMotion CSS users.

--- a/submissions/docs/type-module-fix-shrey/demo.html
+++ b/submissions/docs/type-module-fix-shrey/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Type Module Fix Showcase</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="demo-card">
+    <h2>Package.json "type": "module" Showcase</h2>
+    <p>This submission documents enabling ESM resolution for EaseMotion CSS engine modules.</p>
+  </div>
+</body>
+</html>

--- a/submissions/docs/type-module-fix-shrey/style.css
+++ b/submissions/docs/type-module-fix-shrey/style.css
@@ -1,0 +1,9 @@
+/* submissions/docs/type-module-fix-shrey/style.css */
+.demo-card {
+  padding: 1.5rem;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  font-family: system-ui, sans-serif;
+  color: #1e293b;
+}


### PR DESCRIPTION
## Description
This submission documents enabling ESM resolution (`"type": "module"`) in `package.json`.

## Questions Answered:
1. What does this do? Proposes adding `"type": "module"` to `package.json` to enable native ES module resolution in Node.js environments.
2. How is it used? Node.js and modern frameworks (Next.js/Nuxt) will natively recognize `.js` files as ES modules without throwing `[MODULE_TYPELESS_PACKAGE_JSON]` warnings.
3. Why is it useful? It ensures seamless server-side rendering (SSR) and bundler integration for EaseMotion CSS users.