### PR TITLE
docs: add package exports-map fix submission

### DIFF
--- a/submissions/docs/exports-map-fix-shrey/README.md
+++ b/submissions/docs/exports-map-fix-shrey/README.md
@@ -1,0 +1,5 @@
+# Package Exports Map Fix
+
+1. What does this do? Proposes expanding the `exports` map in `package.json` with wildcards (`./components/*`, `./core/*`, `./easemotion/*`) to allow sub-path CSS imports.
+2. How is it used? Developers can import individual stylesheets directly (e.g. `import 'easemotion-css/components/buttons.css'`).
+3. Why is it useful? It unblocks modular tree-shaking and allows users to import targeted CSS components instead of the full bundle.

--- a/submissions/docs/exports-map-fix-shrey/demo.html
+++ b/submissions/docs/exports-map-fix-shrey/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Exports Map Fix Showcase</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="demo-card">
+    <h2>Package.json Exports Map Showcase</h2>
+    <p>This submission documents expanding package exports for modular sub-path CSS importing.</p>
+  </div>
+</body>
+</html>

--- a/submissions/docs/exports-map-fix-shrey/style.css
+++ b/submissions/docs/exports-map-fix-shrey/style.css
@@ -1,0 +1,9 @@
+/* submissions/docs/exports-map-fix-shrey/style.css */
+.demo-card {
+  padding: 1.5rem;
+  background-color: #f8fafc;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  font-family: system-ui, sans-serif;
+  color: #0f172a;
+}


### PR DESCRIPTION
## Description
This submission documents expanding the `exports` map in `package.json` with wildcard paths (`./components/*`, `./core/*`, `./easemotion/*`).

## Questions Answered:
1. What does this do? Proposes expanding the `exports` map in `package.json` with wildcards to allow sub-path CSS imports.
2. How is it used? Developers can import individual stylesheets directly (e.g. `import 'easemotion-css/components/buttons.css'`).
3. Why is it useful? It unblocks modular tree-shaking and allows users to import targeted CSS components instead of the full bundle.