### PR TITLE
feat: add select menu webkit appearance prefix example

### DIFF
--- a/submissions/examples/select-vendor-prefix-shrey/README.md
+++ b/submissions/examples/select-vendor-prefix-shrey/README.md
@@ -1,0 +1,5 @@
+# Select Menu Vendor Prefix Fix
+
+1. What does this do? Demonstrates adding `-webkit-appearance: none;` to form select components for WebKit browser compatibility.
+2. How is it used? Apply `.custom-select-shrey` to standard HTML `<select>` elements to hide native browser arrows on iOS Safari.
+3. Why is it useful? Prevents native OS arrows from visually overlapping with custom SVG dropdown icons.

--- a/submissions/examples/select-vendor-prefix-shrey/demo.html
+++ b/submissions/examples/select-vendor-prefix-shrey/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Select Vendor Prefix Showcase</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <div class="select-container">
+    <label for="country-select">Choose Option:</label>
+    <select id="country-select" class="custom-select-shrey">
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+    </select>
+  </div>
+</body>
+</html>

--- a/submissions/examples/select-vendor-prefix-shrey/style.css
+++ b/submissions/examples/select-vendor-prefix-shrey/style.css
@@ -1,0 +1,15 @@
+/* submissions/examples/select-vendor-prefix-shrey/style.css */
+.select-container {
+  padding: 1.5rem;
+  font-family: system-ui, sans-serif;
+}
+
+.custom-select-shrey {
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 0.5rem 1rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  background-color: #ffffff;
+  color: #1e293b;
+}


### PR DESCRIPTION
## Description
This submission demonstrates adding `-webkit-appearance: none;` to form select components for WebKit browser compatibility.

## Questions Answered:
1. What does this do? Demonstrates adding `-webkit-appearance: none;` to form select components for WebKit browser compatibility.
2. How is it used? Apply `.custom-select-shrey` to standard HTML `<select>` elements to hide native browser arrows on iOS Safari.
3. Why is it useful? Prevents native OS arrows from visually overlapping with custom SVG dropdown icons.