### PR TITLE
fix: declare package as ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "easemotion-css",
   "version": "1.2.0",
+  "type":"module",
   "description": "Human-readable, animation-first CSS framework with a zero-config motion engine. Zero dependencies.",
   "main": "easemotion.css",
   "style": "easemotion.css",


### PR DESCRIPTION
## Description

This PR resolves the `MODULE_TYPELESS_PACKAGE_JSON` warning by explicitly declaring the package as an ES Module.

### Changes Made

- Added `"type": "module"` to the root `package.json`.

### Why

The project uses ES Module syntax (e.g. `import` / `export`), but without `"type": "module"` Node.js treats `.js` files as CommonJS by default. This can produce `MODULE_TYPELESS_PACKAGE_JSON` warnings or errors in SSR environments and modern Node.js tooling.

### Benefits

- Eliminates `MODULE_TYPELESS_PACKAGE_JSON` warnings
- Ensures Node.js correctly interprets `.js` files as ES Modules
- Improves compatibility with SSR, build tools, and native ESM environments

Closes #53754