### PR TITLE
add CSS-only loading animations

### DIFF
--- a/submissions/examples/loading-animations0/README.md
+++ b/submissions/examples/loading-animations0/README.md
@@ -1,0 +1,27 @@
+# Loading Animations
+
+A collection of pure‑CSS, GPU‑accelerated loading indicators.
+
+## Demo
+Open `demo.html` in your browser to see:
+- Pulsing circle
+- Bouncing dots
+- Spinning circle
+
+## Usage
+Include the stylesheet:
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- Pulsing loader -->
+<div class="loader pulse"></div>
+
+<!-- Bouncing dots -->
+<div class="dots">
+  <div class="dot"></div>
+  <div class="dot"></div>
+  <div class="dot"></div>
+</div>
+
+<!-- Spinning circle -->
+<div class="spinner"></div>

--- a/submissions/examples/loading-animations0/demo.html
+++ b/submissions/examples/loading-animations0/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion – Loading Animations</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Loading Animations</h1>
+
+  <!-- Pulsing loader -->
+  <section>
+    <h2>Pulsing Loader</h2>
+    <div class="loader pulse"></div>
+  </section>
+
+  <!-- Bouncing dots -->
+  <section>
+    <h2>Bouncing Dots</h2>
+    <div class="dots">
+      <div class="dot"></div>
+      <div class="dot"></div>
+      <div class="dot"></div>
+    </div>
+  </section>
+
+  <!-- Spinning circle -->
+  <section>
+    <h2>Spinning Circle</h2>
+    <div class="spinner"></div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/loading-animations0/style.css
+++ b/submissions/examples/loading-animations0/style.css
@@ -1,0 +1,73 @@
+/* ==============================================================
+   EaseMotion – Loading Animations
+   --------------------------------------------------------------
+   Pure‑CSS, GPU‑accelerated, smooth loading indicators
+   ============================================================== */
+
+/* Body styles */
+body {
+  margin: 0;
+  padding: 3rem 1rem;
+  background: #f0f4f8;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #222;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+}
+h1 { text-align: center; margin-bottom: 2rem; font-size: 2.2rem; }
+section { margin-bottom: 3rem; }
+h2 { margin-bottom: .6rem; font-size: 1.2rem; color: #555; }
+
+/* Loader: pulsing */
+.loader.pulse {
+  width: 50px;
+  height: 50px;
+  margin: 0 auto;
+  background-color: #6366f1;
+  border-radius: 50%;
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.2); opacity: 0.7; }
+}
+
+/* Bouncing dots */
+.dots {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+.dot {
+  width: 15px;
+  height: 15px;
+  background-color: #10b981;
+  border-radius: 50%;
+  animation: bounce 1.4s infinite ease-in-out;
+}
+.dot:nth-child(1) { animation-delay: 0s; }
+.dot:nth-child(2) { animation-delay: 0.2s; }
+.dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-20px); }
+}
+
+/* Spinning circle */
+.spinner {
+  width: 50px;
+  height: 50px;
+  margin: 0 auto;
+  border: 6px solid #e2e8f0;
+  border-top-color: #6366f1;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Closes #53798

**Title**

feat: add CSS-only loading animations

**Description**

### Overview
This PR adds a new module with CSS-only loading indicators:
- Pulsing circle
- Bouncing dots
- Spinning circle

### Files
- `loading-animations/demo.html`: Live demonstration of all loaders.
- `loading-animations/style.css`: Styles and animations.
- `loading-animations/README.md`: Documentation and usage.

### Why this feature?
- Pure CSS, no dependencies
- GPU-accelerated animations for smooth performance
- Easy to customize

### Testing
Open `loading-animations/demo.html` in your browser to verify all animations work smoothly and look as intended.

### Future ideas
- Add more loader styles
- Make sizes and colors customizable via CSS variables

Please review and let me know if any improvements are needed!

