### PR TITLE
feat: add ease-hover-reveal-card image-to-content reveal card (closes…

### DIFF
--- a/submissions/examples/ease-hover-reveal-card-v1/README.md
+++ b/submissions/examples/ease-hover-reveal-card-v1/README.md
@@ -1,0 +1,76 @@
+# ease-hover-reveal-card
+
+Submission for Issue #51335
+
+## What this adds
+
+A reusable card component where a background image is visible
+by default and a content overlay panel reveals on hover.
+Four reveal styles: slide-up, fade, peek, and caption bar.
+Zero JavaScript required.
+
+## HTML Structure
+
+```html
+<div class="ease-hover-reveal-card ease-hover-reveal-card--md"
+     style="background-image: url('img.jpg')"
+     tabindex="0"
+     role="img"
+     aria-label="Card description">
+  <div class="ease-hover-reveal-content">
+    <span class="ease-hover-reveal-card__tag">Category</span>
+    <h3 class="ease-hover-reveal-card__title">Card Title</h3>
+    <p class="ease-hover-reveal-card__body">Description text here.</p>
+    <a href="#" class="ease-hover-reveal-card__btn">View Project →</a>
+  </div>
+</div>
+```
+
+## Classes
+
+### Reveal Variants
+| Class | Effect |
+|---|---|
+| `ease-hover-reveal-card` | Slide-up overlay (default) |
+| `--fade` | Fade-in overlay |
+| `--peek` | Caption always visible, expands on hover |
+| `--caption` | Gradient caption bar fades in |
+| `--slide-down` | Overlay slides down from top |
+
+### Size Presets
+| Class | Height |
+|---|---|
+| `--sm` | 200px |
+| `--md` | 280px |
+| `--lg` | 360px |
+| `--xl` | 440px |
+| `--sq` | 1:1 aspect ratio |
+
+### Overlay Colors
+`--dark`, `--green`, `--blue`, `--purple`
+
+### Speed
+| Class | Duration |
+|---|---|
+| `--fast` | 0.2s |
+| default | 0.4s |
+| `--slow` | 0.7s |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--reveal-duration` | 0.4s | Transition speed |
+| `--reveal-ease` | cubic-bezier spring | Easing function |
+| `--overlay-bg` | rgba(15,23,42,0.88) | Overlay color |
+| `--card-radius` | 12px | Border radius |
+
+## Accessibility
+
+- `tabindex="0"` — keyboard focusable
+- `role="img"` + `aria-label` for screen readers
+- `prefers-reduced-motion`: all slides replaced with opacity fade
+
+## Theme Support
+
+Supports `data-theme="neon"`, `data-theme="dracula"`, `data-theme="dark"`.

--- a/submissions/examples/ease-hover-reveal-card-v1/demo.html
+++ b/submissions/examples/ease-hover-reveal-card-v1/demo.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-hover-reveal-card — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      background: #0f172a;
+      font-family: sans-serif;
+      color: #e2e8f0;
+      padding: 2rem;
+    }
+    h2 {
+      margin-top: 2.5rem;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #64748b;
+      margin-bottom: 1.25rem;
+    }
+    p.desc { color: #64748b; font-size: 0.85rem; margin: 0.25rem 0 1.5rem; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 1.25rem;
+      margin-bottom: 2.5rem;
+    }
+    .demo-cell { display: flex; flex-direction: column; gap: 0.4rem; }
+    label { font-size: 0.65rem; color: #334155; font-family: monospace; }
+    .controls {
+      display: flex;
+      gap: 0.75rem;
+      margin: 1.5rem 0;
+      flex-wrap: wrap;
+    }
+    button {
+      padding: 6px 14px;
+      cursor: pointer;
+      background: #1e293b;
+      color: #e2e8f0;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      font-size: 0.8rem;
+    }
+    button:hover { background: #334155; }
+
+    /* Color swatches for demo cards (replacing real images) */
+    .bg-mountains { background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 40%, #1a3a2a 100%); }
+    .bg-sunset    { background: linear-gradient(135deg, #7c3aed 0%, #db2777 50%, #f97316 100%); }
+    .bg-ocean     { background: linear-gradient(135deg, #0891b2 0%, #0f172a 60%, #1e3a5f 100%); }
+    .bg-forest    { background: linear-gradient(135deg, #052e16 0%, #14532d 50%, #1a3a2a 100%); }
+    .bg-neon      { background: linear-gradient(135deg, #0d0d1a 0%, #1a0a2e 50%, #0d1a1a 100%); }
+    .bg-abstract  { background: linear-gradient(135deg, #312e81 0%, #be185d 50%, #0891b2 100%); }
+  </style>
+</head>
+<body>
+
+<h1>🖼️ ease-hover-reveal-card</h1>
+<p class="desc">Image-to-content reveal cards — pure CSS :hover transitions. Hover any card to reveal its content.</p>
+
+<!-- REVEAL VARIANTS -->
+<h2>Reveal Variants</h2>
+<div class="grid">
+
+  <!-- Slide Up (default) -->
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--md bg-mountains"
+         tabindex="0" role="img" aria-label="Mountains project card">
+      <div class="ease-hover-reveal-content">
+        <span class="ease-hover-reveal-card__tag">Portfolio</span>
+        <h3 class="ease-hover-reveal-card__title">Mountain Escape</h3>
+        <p class="ease-hover-reveal-card__body">A landscape photography series exploring the alpine regions of the Himalayas.</p>
+        <a href="#" class="ease-hover-reveal-card__btn">View Project →</a>
+      </div>
+    </div>
+    <label>.ease-hover-reveal-card (slide-up)</label>
+  </div>
+
+  <!-- Fade In -->
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--fade ease-hover-reveal-card--md bg-sunset"
+         tabindex="0" role="img" aria-label="Sunset fade card">
+      <div class="ease-hover-reveal-content">
+        <span class="ease-hover-reveal-card__tag">Design</span>
+        <h3 class="ease-hover-reveal-card__title">Sunset Palette</h3>
+        <p class="ease-hover-reveal-card__body">Brand identity design for a luxury lifestyle brand inspired by golden hour.</p>
+        <a href="#" class="ease-hover-reveal-card__btn">View Project →</a>
+      </div>
+    </div>
+    <label>.ease-hover-reveal-card--fade</label>
+  </div>
+
+  <!-- Peek -->
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--peek ease-hover-reveal-card--md bg-ocean"
+         tabindex="0" role="img" aria-label="Ocean peek card">
+      <div class="ease-hover-reveal-content">
+        <span class="ease-hover-reveal-card__tag">Development</span>
+        <h3 class="ease-hover-reveal-card__title">Ocean Dashboard</h3>
+        <p class="ease-hover-reveal-card__body">Real-time marine data visualization built with D3.js and WebSockets.</p>
+        <a href="#" class="ease-hover-reveal-card__btn">View Project →</a>
+      </div>
+    </div>
+    <label>.ease-hover-reveal-card--peek (caption always visible)</label>
+  </div>
+
+  <!-- Caption Bar -->
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--caption ease-hover-reveal-card--md bg-forest"
+         tabindex="0" role="img" aria-label="Forest caption card">
+      <div class="ease-hover-reveal-content">
+        <h3 class="ease-hover-reveal-card__title">Forest Retreat</h3>
+        <p class="ease-hover-reveal-card__subtitle">Nature Photography · 2026</p>
+      </div>
+    </div>
+    <label>.ease-hover-reveal-card--caption</label>
+  </div>
+
+  <!-- Slide Down -->
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--slide-down ease-hover-reveal-card--md bg-abstract"
+         tabindex="0" role="img" aria-label="Abstract slide-down card">
+      <div class="ease-hover-reveal-content">
+        <span class="ease-hover-reveal-card__tag">Abstract</span>
+        <h3 class="ease-hover-reveal-card__title">Abstract Series</h3>
+        <p class="ease-hover-reveal-card__body">Generative art collection exploring color theory and geometric forms.</p>
+      </div>
+    </div>
+    <label>.ease-hover-reveal-card--slide-down</label>
+  </div>
+
+  <!-- Square aspect ratio -->
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--sq ease-hover-reveal-card--green bg-forest"
+         tabindex="0" role="img" aria-label="Square card">
+      <div class="ease-hover-reveal-content">
+        <h3 class="ease-hover-reveal-card__title">Square Format</h3>
+        <p class="ease-hover-reveal-card__body">1:1 aspect ratio — perfect for Instagram-style grids.</p>
+      </div>
+    </div>
+    <label>.ease-hover-reveal-card--sq.ease-hover-reveal-card--green</label>
+  </div>
+
+</div>
+
+<!-- OVERLAY COLOR VARIANTS -->
+<h2>Overlay Color Variants</h2>
+<div class="grid">
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--md ease-hover-reveal-card--dark bg-mountains" tabindex="0">
+      <div class="ease-hover-reveal-content">
+        <h3 class="ease-hover-reveal-card__title">Dark Overlay</h3>
+        <p class="ease-hover-reveal-card__body">Pure black overlay for maximum contrast.</p>
+      </div>
+    </div>
+    <label>--dark</label>
+  </div>
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--md ease-hover-reveal-card--blue bg-ocean" tabindex="0">
+      <div class="ease-hover-reveal-content">
+        <h3 class="ease-hover-reveal-card__title">Blue Overlay</h3>
+        <p class="ease-hover-reveal-card__body">Deep navy overlay matches ocean tones.</p>
+      </div>
+    </div>
+    <label>--blue</label>
+  </div>
+  <div class="demo-cell">
+    <div class="ease-hover-reveal-card ease-hover-reveal-card--md ease-hover-reveal-card--purple bg-abstract" tabindex="0">
+      <div class="ease-hover-reveal-content">
+        <h3 class="ease-hover-reveal-card__title">Purple Overlay</h3>
+        <p class="ease-hover-reveal-card__body">Deep violet overlay for creative portfolios.</p>
+      </div>
+    </div>
+    <label>--purple</label>
+  </div>
+</div>
+
+<!-- THEMES -->
+<h2>Themes</h2>
+<div class="controls">
+  <button onclick="setTheme('')">Default</button>
+  <button onclick="setTheme('neon')">Neon</button>
+  <button onclick="setTheme('dracula')">Dracula</button>
+  <button onclick="setTheme('dark')">Dark</button>
+</div>
+<div id="theme-demo" class="grid">
+  <div class="ease-hover-reveal-card ease-hover-reveal-card--md bg-neon" tabindex="0">
+    <div class="ease-hover-reveal-content">
+      <span class="ease-hover-reveal-card__tag">Theme</span>
+      <h3 class="ease-hover-reveal-card__title">Theme Preview</h3>
+      <p class="ease-hover-reveal-card__body">Hover to see theme-specific overlay and button colors.</p>
+      <a href="#" class="ease-hover-reveal-card__btn">View →</a>
+    </div>
+  </div>
+</div>
+
+<script>
+  function setTheme(t) {
+    document.getElementById('theme-demo').dataset.theme = t;
+  }
+</script>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-reveal-card-v1/style.css
+++ b/submissions/examples/ease-hover-reveal-card-v1/style.css
@@ -1,0 +1,282 @@
+/* =============================================
+   ease-hover-reveal-card
+   Image-to-Content Reveal Card
+   Zero JavaScript | CSS :hover transitions
+   ============================================= */
+
+/* =====================
+   BASE CARD
+   ===================== */
+.ease-hover-reveal-card {
+  --reveal-duration:  0.4s;
+  --reveal-ease:      cubic-bezier(0.22, 1, 0.36, 1);
+  --overlay-bg:       rgba(15, 23, 42, 0.88);
+  --overlay-height:   100%;
+  --card-radius:      12px;
+
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--card-radius);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  display: block;
+  cursor: pointer;
+}
+
+/* Image scale on hover */
+.ease-hover-reveal-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: inherit;
+  background-size: cover;
+  background-position: center;
+  transition: transform var(--reveal-duration) var(--reveal-ease);
+  border-radius: inherit;
+}
+
+.ease-hover-reveal-card:hover::before {
+  transform: scale(1.06);
+}
+
+/* =====================
+   CONTENT OVERLAY
+   ===================== */
+.ease-hover-reveal-content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: var(--overlay-height);
+  background: var(--overlay-bg);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.25rem;
+  box-sizing: border-box;
+  transform: translateY(100%);
+  transition: transform var(--reveal-duration) var(--reveal-ease);
+  border-radius: 0 0 var(--card-radius) var(--card-radius);
+}
+
+.ease-hover-reveal-card:hover .ease-hover-reveal-content {
+  transform: translateY(0);
+}
+
+/* =====================
+   FADE-IN VARIANT
+   ===================== */
+.ease-hover-reveal-card--fade .ease-hover-reveal-content {
+  transform: none;
+  opacity: 0;
+  transition: opacity var(--reveal-duration) ease;
+}
+
+.ease-hover-reveal-card--fade:hover .ease-hover-reveal-content {
+  opacity: 1;
+}
+
+/* =====================
+   PARTIAL PEEK VARIANT
+   (caption always visible, expands on hover)
+   ===================== */
+.ease-hover-reveal-card--peek .ease-hover-reveal-content {
+  transform: translateY(calc(100% - 56px));
+  transition: transform var(--reveal-duration) var(--reveal-ease);
+}
+
+.ease-hover-reveal-card--peek:hover .ease-hover-reveal-content {
+  transform: translateY(0);
+}
+
+/* =====================
+   CAPTION BAR VARIANT
+   (bottom-anchored, fixed height)
+   ===================== */
+.ease-hover-reveal-card--caption .ease-hover-reveal-content {
+  height: auto;
+  transform: none;
+  opacity: 0;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(
+    to top,
+    rgba(15, 23, 42, 0.95) 0%,
+    rgba(15, 23, 42, 0.7) 70%,
+    transparent 100%
+  );
+  transition: opacity var(--reveal-duration) ease;
+  border-radius: inherit;
+}
+
+.ease-hover-reveal-card--caption:hover .ease-hover-reveal-content {
+  opacity: 1;
+}
+
+/* =====================
+   SLIDE-DOWN VARIANT
+   ===================== */
+.ease-hover-reveal-card--slide-down .ease-hover-reveal-content {
+  top: 0;
+  bottom: auto;
+  transform: translateY(-100%);
+  justify-content: flex-start;
+  border-radius: var(--card-radius) var(--card-radius) 0 0;
+}
+
+.ease-hover-reveal-card--slide-down:hover .ease-hover-reveal-content {
+  transform: translateY(0);
+}
+
+/* =====================
+   CONTENT ELEMENTS
+   ===================== */
+.ease-hover-reveal-card__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  font-family: sans-serif;
+  margin: 0 0 0.3rem;
+  line-height: 1.3;
+}
+
+.ease-hover-reveal-card__subtitle {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  font-family: sans-serif;
+  margin: 0 0 0.6rem;
+}
+
+.ease-hover-reveal-card__body {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-family: sans-serif;
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.ease-hover-reveal-card__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  background: rgba(74, 222, 128, 0.12);
+  color: #4ade80;
+  border: 1px solid rgba(74, 222, 128, 0.25);
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  font-family: sans-serif;
+  margin-bottom: 0.5rem;
+}
+
+.ease-hover-reveal-card__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.4rem 0.9rem;
+  background: #4ade80;
+  color: #052e16;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-family: sans-serif;
+  text-decoration: none;
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  transition: opacity 0.2s ease;
+}
+
+.ease-hover-reveal-card__btn:hover { opacity: 0.85; }
+
+/* =====================
+   OVERLAY COLOR VARIANTS
+   ===================== */
+.ease-hover-reveal-card--dark {
+  --overlay-bg: rgba(0, 0, 0, 0.92);
+}
+
+.ease-hover-reveal-card--green {
+  --overlay-bg: rgba(5, 46, 22, 0.9);
+}
+
+.ease-hover-reveal-card--blue {
+  --overlay-bg: rgba(7, 24, 60, 0.92);
+}
+
+.ease-hover-reveal-card--purple {
+  --overlay-bg: rgba(30, 10, 60, 0.92);
+}
+
+/* =====================
+   SIZE PRESETS
+   ===================== */
+.ease-hover-reveal-card--sm  { height: 200px; }
+.ease-hover-reveal-card--md  { height: 280px; }
+.ease-hover-reveal-card--lg  { height: 360px; }
+.ease-hover-reveal-card--xl  { height: 440px; }
+.ease-hover-reveal-card--sq  { aspect-ratio: 1 / 1; }
+
+/* =====================
+   SPEED VARIANTS
+   ===================== */
+.ease-hover-reveal-card--fast { --reveal-duration: 0.2s; }
+.ease-hover-reveal-card--slow { --reveal-duration: 0.7s; }
+
+/* =====================
+   THEME OVERRIDES
+   ===================== */
+[data-theme="neon"] .ease-hover-reveal-content {
+  --overlay-bg: rgba(13, 13, 26, 0.92);
+  border-top: 1px solid rgba(240, 171, 252, 0.2);
+}
+[data-theme="neon"] .ease-hover-reveal-card__tag {
+  background: rgba(240,171,252,0.12);
+  color: #f0abfc;
+  border-color: rgba(240,171,252,0.25);
+}
+[data-theme="neon"] .ease-hover-reveal-card__btn {
+  background: #f0abfc;
+  color: #1a0020;
+}
+
+[data-theme="dracula"] .ease-hover-reveal-content {
+  --overlay-bg: rgba(40, 42, 54, 0.95);
+}
+[data-theme="dracula"] .ease-hover-reveal-card__tag {
+  background: rgba(189,147,249,0.12);
+  color: #bd93f9;
+  border-color: rgba(189,147,249,0.25);
+}
+[data-theme="dracula"] .ease-hover-reveal-card__btn {
+  background: #bd93f9;
+  color: #1a0040;
+}
+
+[data-theme="dark"] .ease-hover-reveal-content {
+  --overlay-bg: rgba(17, 24, 39, 0.92);
+}
+[data-theme="dark"] .ease-hover-reveal-card__btn {
+  background: #34d399;
+  color: #022c22;
+}
+
+/* =====================
+   REDUCED MOTION
+   ===================== */
+@media (prefers-reduced-motion: reduce) {
+  .ease-hover-reveal-card::before {
+    transition: none;
+  }
+  .ease-hover-reveal-content {
+    transition: opacity 0.2s ease;
+    transform: none !important;
+    opacity: 0;
+  }
+  .ease-hover-reveal-card:hover .ease-hover-reveal-content {
+    opacity: 1;
+  }
+  .ease-hover-reveal-card--peek .ease-hover-reveal-content {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Closes #51335

## What this PR adds

Implements the `ease-hover-reveal-card` CSS component — a reusable
card where a background image is visible by default and a content
overlay panel reveals on hover. Four reveal styles, four overlay
colors, five size presets, and speed controls.
Zero JavaScript required.

---

## Files Added

submissions/examples/ease-hover-reveal-card-v1/
├── style.css    ← all reveal variants, overlay colors, size presets, theme overrides
├── demo.html    ← live grid demo with all variants and theme switcher
└── README.md    ← usage docs, HTML structure, class reference table

---

## Reveal Variants Implemented

| Class | Reveal Style |
|---|---|
| `ease-hover-reveal-card` | Content slides up from bottom (default) |
| `--fade` | Overlay fades in over full card |
| `--peek` | Caption always peeking, expands to full on hover |
| `--caption` | Gradient caption bar fades in at bottom |
| `--slide-down` | Overlay slides down from top |

---

## Additional Variants

### Overlay Colors
| Class | Color |
|---|---|
| default | Dark slate rgba(15,23,42,0.88) |
| `--dark` | Pure black rgba(0,0,0,0.92) |
| `--green` | Deep green rgba(5,46,22,0.9) |
| `--blue` | Deep navy rgba(7,24,60,0.92) |
| `--purple` | Deep violet rgba(30,10,60,0.92) |

### Size Presets
| Class | Height |
|---|---|
| `--sm` | 200px |
| `--md` | 280px |
| `--lg` | 360px |
| `--xl` | 440px |
| `--sq` | 1:1 aspect ratio |

### Speed
| Class | Duration |
|---|---|
| `--fast` | 0.2s |
| default | 0.4s |
| `--slow` | 0.7s |

---

## CSS Custom Properties

| Property | Default | Description |
|---|---|---|
| `--reveal-duration` | 0.4s | Transition speed |
| `--reveal-ease` | spring cubic-bezier | Easing function |
| `--overlay-bg` | rgba(15,23,42,0.88) | Overlay background |
| `--card-radius` | 12px | Card border radius |

---

## Accessibility

- `tabindex="0"` on card wrapper — keyboard focusable
- `role="img"` + `aria-label` for screen readers
- Fully respects `prefers-reduced-motion` — all slide
  transitions replaced with simple opacity fade

---

## Theme Support

All variants render correctly under:
- Default
- `data-theme="neon"`
- `data-theme="dracula"`
- `data-theme="dark"`

---

## Checklist

- [x] Files placed inside `submissions/examples/` only
- [x] Folder suffix used: `ease-hover-reveal-card-v1`
- [x] No changes to `core/` or `components/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Zero JavaScript
- [x] Slide-up overlay reveal present
- [x] Fade-in overlay reveal present
- [x] Partial peek + full reveal on hover present
- [x] Bottom-anchored caption bar present
- [x] Overlay background and opacity customizable
- [x] Reveal duration and easing customizable
- [x] prefers-reduced-motion fallback included
- [x] Keyboard accessible via tabindex
- [x] References issue #51335