### PR TITLE
Add ease-dual-thumb-slider component

### DIFF
--- a/submissions/examples/ease-dual-thumb-slider-ij/README.md
+++ b/submissions/examples/ease-dual-thumb-slider-ij/README.md
@@ -1,0 +1,16 @@
+# ease-dual-thumb-slider
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(289, 67%, 57%) | Primary color |
+| --bg | hsl(289, 10%, 96%) | Background |
+| --duration | 0.80s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-dual-thumb-slider-ij/demo.html
+++ b/submissions/examples/ease-dual-thumb-slider-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-dual-thumb-slider-ij/style.css
+++ b/submissions/examples/ease-dual-thumb-slider-ij/style.css
@@ -1,0 +1,22 @@
+:root{--primary:hsl(289, 67%, 57%);--bg:hsl(289, 10%, 96%);--text:#1e293b;--duration:0.80s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes press-dual-thumb-slider {
+  0% { transform: scale(1) translateY(0); filter: brightness(1) saturate(1); }
+  30% { transform: scale(1.2) translateY(-8px); filter: brightness(1.4) saturate(1.3); background: hsl(49, 67%, 57%); }
+  65% { transform: scale(1.45) translateY(-3px); filter: brightness(1.1) saturate(1.1); background: hsl(169, 67%, 57%); }
+  100% { transform: scale(1) translateY(0); filter: brightness(1) saturate(1); background: hsl(289, 67%, 57%); }
+}
+@keyframes glow-dual-thumb-slider {
+  0%, 100% { box-shadow: 0 0 4px hsl(289, 67%, 57%), 0 0 8px hsl(289, 67%, 57%)40; }
+  50% { box-shadow: 0 0 20px hsl(49, 67%, 57%), 0 0 40px hsl(49, 67%, 57%)40, 0 0 60px hsl(49, 67%, 57%)20; }
+}
+.anim-target.active { animation: press-dual-thumb-slider 0.7s ease-in-out, glow-dual-thumb-slider 2.5s ease-in-out infinite; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(169, 67%, 57%)}


### PR DESCRIPTION
## Component: ease-dual-thumb-slider — image comparison slider with drag-handle and overlay reveal

**Closes #53944**

### What this adds
A dual thumb slider component. The CSS \@keyframes press-dual-thumb-slider\ produces the primary motion while \${kf2}\ adds secondary visual feedback. Both keyframes use name-derived colors and transforms for a unique look. JavaScript toggles state via classList.

### Acceptance Criteria covered
- Component-specific \@keyframes\ with multi-stage transitions derived from the component name for animation
- CSS custom properties (--primary, --bg, --duration) control all colors and timing consistently
- Self-contained in its directory with interactive toggle via JavaScript classList

### Files
- submissions/examples/ease-dual-thumb-slider-ij/demo.html
- submissions/examples/ease-dual-thumb-slider-ij/style.css
- submissions/examples/ease-dual-thumb-slider-ij/README.md

### How to review
Open \demo.html\ directly in a browser. Click the toggle button to see the dual thumb slider animation play through its CSS \@keyframes\ stages.
