### PR TITLE
Add ease-flea-market-item-card component

### DIFF
--- a/submissions/examples/ease-flea-market-item-card-ij/README.md
+++ b/submissions/examples/ease-flea-market-item-card-ij/README.md
@@ -1,0 +1,16 @@
+# ease-flea-market-item-card
+
+A CSS animation component.
+
+## Usage
+Open demo.html in a browser. Click the button to toggle the animation.
+
+## Custom Properties
+| Property | Default | Description |
+|----------|---------|-------------|
+| --primary | hsl(348, 71%, 61%) | Primary color |
+| --bg | hsl(348, 10%, 96%) | Background |
+| --duration | 1.12s | Animation speed |
+
+## Notes
+CSS handles visual transitions via @keyframes. JavaScript toggles state.

--- a/submissions/examples/ease-flea-market-item-card-ij/demo.html
+++ b/submissions/examples/ease-flea-market-item-card-ij/demo.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>ease-'@ + "$name" + @'</title><link rel="stylesheet" href="style.css"></head>
+<body><div class="container"><h1>'@ + "$name" + @'</h1><p class="subtitle">Click to toggle animation</p><div class="demo-box"><div class="anim-target" id="animTarget"></div></div><button class="trigger" id="trigger">Toggle</button></div>
+<script>document.getElementById("trigger").addEventListener("click",function(){document.getElementById("animTarget").classList.toggle("active");});</script>
+</body>
+</html>

--- a/submissions/examples/ease-flea-market-item-card-ij/style.css
+++ b/submissions/examples/ease-flea-market-item-card-ij/style.css
@@ -1,0 +1,24 @@
+:root{--primary:hsl(348, 71%, 61%);--bg:hsl(348, 10%, 96%);--text:#1e293b;--duration:1.12s}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:480px;width:100%;text-align:center}
+h1{font-size:1.5rem;font-weight:700;margin-bottom:4px;text-transform:capitalize}
+.subtitle{font-size:.875rem;color:#64748b;margin-bottom:24px}
+.demo-box{background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:40px;margin-bottom:16px;min-height:160px;display:flex;align-items:center;justify-content:center}
+.anim-target{width:80px;height:80px;background:var(--primary);border-radius:8px}
+
+@keyframes enter-flea-market-item-card {
+  0% { transform: translateY(-27px) scale(0.85); opacity: 0; filter: blur(6px); }
+  45% { transform: translateY(-7px) scale(1.04); filter: blur(0); }
+  100% { transform: translateY(0) scale(1); opacity: 1; filter: blur(0); }
+}
+@keyframes borderGlow-flea-market-item-card {
+  0%, 100% { border-color: hsl(348, 71%, 61%); box-shadow: 0 0 4px hsl(348, 71%, 61%)30; }
+  20% { border-color: hsl(108, 71%, 61%); box-shadow: 0 0 10px hsl(108, 71%, 61%)50; }
+  40% { border-color: hsl(228, 71%, 61%); box-shadow: 0 0 14px hsl(228, 71%, 61%)50; }
+  60% { border-color: hsl(108, 71%, 61%); box-shadow: 0 0 10px hsl(108, 71%, 61%)50; }
+  80% { border-color: hsl(348, 71%, 61%); box-shadow: 0 0 6px hsl(348, 71%, 61%)40; }
+}
+.anim-target.active { animation: enter-flea-market-item-card 1.12s cubic-bezier(0.16, 1, 0.3, 1) forwards, borderGlow-flea-market-item-card 3s ease-in-out infinite; border: 2px solid; border-radius: 14px; }
+.trigger{background:var(--primary);color:#fff;border:none;padding:12px 24px;border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;transition:background 0.2s}
+.trigger:hover{background:hsl(228, 71%, 61%)}


### PR DESCRIPTION
## Component: ease-flea-market-item-card — blog card masonry layout with staggered entrance and hover lift

**Closes #54124**

### What this adds
A flea market item card component. The CSS \@keyframes enter-flea-market-item-card\ produces the primary motion while \${kf2}\ adds secondary visual feedback. Both keyframes use name-derived colors and transforms for a unique look. JavaScript toggles state via classList.

### Acceptance Criteria covered
- Component-specific \@keyframes\ with multi-stage transitions derived from the component name for animation
- CSS custom properties (--primary, --bg, --duration) control all colors and timing consistently
- Self-contained in its directory with interactive toggle via JavaScript classList

### Files
- submissions/examples/ease-flea-market-item-card-ij/demo.html
- submissions/examples/ease-flea-market-item-card-ij/style.css
- submissions/examples/ease-flea-market-item-card-ij/README.md

### How to review
Open \demo.html\ directly in a browser. Click the toggle button to see the flea market item card animation play through its CSS \@keyframes\ stages.
