### PR TITLE
feat: add pure CSS network status indicator with signal bars, connection states, and WiFi scanner

### DIFF
--- a/submissions/examples/network-status-indicator-kks/README.md
+++ b/submissions/examples/network-status-indicator-kks/README.md
@@ -1,0 +1,66 @@
+# Network Status Indicator — Pure CSS
+
+## What does this do?
+
+An interactive network connectivity panel with signal strength bars, connection state switching (Connected/Connecting/Disconnected), and a WiFi network scanner — all driven by radio inputs and the `:has()` CSS selector. Zero JavaScript.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<div class="ns-container">
+  <!-- Connection state tabs -->
+  <input type="radio" name="conn-state" id="state-connected" checked>
+  <input type="radio" name="conn-state" id="state-disconnected">
+  <div class="ns-state-tabs" role="tablist">
+    <label for="state-connected" class="ns-state-tab" role="tab">Connected</label>
+    <label for="state-disconnected" class="ns-state-tab" role="tab">Disconnected</label>
+  </div>
+
+  <!-- Signal bars -->
+  <div class="ns-signal-bars">
+    <span class="ns-bar ns-bar-1"></span>
+    <span class="ns-bar ns-bar-2"></span>
+    <span class="ns-bar ns-bar-3"></span>
+    <span class="ns-bar ns-bar-4"></span>
+    <span class="ns-bar ns-bar-5"></span>
+  </div>
+
+  <!-- Signal level switcher -->
+  <input type="radio" name="signal-level" id="sig-excellent" class="ns-sig-input" checked>
+  <label for="sig-excellent" class="ns-sig-label">Excellent</label>
+
+  <!-- Network list -->
+  <ul class="ns-network-list">
+    <li>
+      <input type="radio" name="selected-network" id="net-home">
+      <label for="net-home">Home-WiFi-5G</label>
+    </li>
+  </ul>
+</div>
+```
+
+All state transitions are CSS-only:
+- Signal level → `:has(#sig-{level}:checked)` colors the bars
+- Connection state → `:has(#state-{name}:checked)` toggles overlays
+- Network selection → `input:checked + label` highlights the active network
+
+## Why is it useful?
+
+A network/connectivity panel is a common UI pattern in dashboards, mobile apps, and system settings that usually requires JavaScript. This submission proves that radio-driven state management with `:has()` can handle multi-state interactions declaratively, reducing dependency on imperative code.
+
+**Features:**
+- **Zero JavaScript** — Signal bars, connection states, and network selection are CSS-driven
+- **3 connection states** — Connected, Connecting (with spinner), Disconnected (with overlay)
+- **5 signal levels** — None, Weak, Fair, Good, Excellent with animated bar transitions
+- **WiFi network picker** — Radio-based network list with select highlight
+- **Dark mode** — Automatic via `prefers-color-scheme` with manual toggle
+- **`prefers-reduced-motion`** — Disables all animations and spinner
+- **`prefers-contrast`** — Enhanced borders for visibility
+- **`forced-colors: active`** — Full Windows High Contrast Mode support
+- **Keyboard accessible** — Tab through state tabs, signal levels, and network list
+- **`aria-label`** on signal bars and secured/open indicators
+- **`role="tablist"` / `role="tab"`** on connection state selector
+- **Responsive** — adapts from 320px mobile to wide screens
+- **Print-friendly** — Strips interactive chrome

--- a/submissions/examples/network-status-indicator-kks/demo.html
+++ b/submissions/examples/network-status-indicator-kks/demo.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>Network Status Indicator | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!--
+    NETWORK STATUS INDICATOR — Pure CSS
+    =====================================
+    Zero JavaScript. Signal strength, connection states, and WiFi network
+    scanner are all driven by radio inputs and CSS :has() selectors.
+
+    The component simulates four signal-strength tiers and three connection
+    states (Connected, Connecting, Disconnected) with animated visual feedback.
+  -->
+
+  <input type="checkbox" id="theme-switch" class="theme-switch-input" aria-label="Toggle dark mode">
+  <label for="theme-switch" class="theme-switch-label" title="Toggle dark mode" tabindex="0" role="switch">
+    <span class="theme-switch-icon"></span>
+  </label>
+
+  <main class="ns-container">
+
+    <header class="ns-header">
+      <h1 class="ns-title">Network Status</h1>
+      <p class="ns-subtitle">Pure CSS connectivity indicator — no JavaScript</p>
+    </header>
+
+    <!--
+      The state radio group controls which connection mode is active.
+      Labels act as tab-like selectors for the three states.
+    -->
+    <input type="radio" name="conn-state" id="state-connected" class="ns-state-input" checked>
+    <input type="radio" name="conn-state" id="state-connecting" class="ns-state-input">
+    <input type="radio" name="conn-state" id="state-disconnected" class="ns-state-input">
+
+    <div class="ns-state-tabs" role="tablist" aria-label="Connection state">
+      <label for="state-connected" class="ns-state-tab" role="tab" aria-selected="true">Connected</label>
+      <label for="state-connecting" class="ns-state-tab" role="tab" aria-selected="false">Connecting</label>
+      <label for="state-disconnected" class="ns-state-tab" role="tab" aria-selected="false">Disconnected</label>
+    </div>
+
+    <!-- MAIN CARD -->
+    <div class="ns-card">
+
+      <!-- SIGNAL BARS -->
+      <div class="ns-signal-section">
+        <div class="ns-signal-label">Signal Strength</div>
+        <div class="ns-signal-bars" aria-label="Signal strength indicator">
+          <span class="ns-bar ns-bar-1"></span>
+          <span class="ns-bar ns-bar-2"></span>
+          <span class="ns-bar ns-bar-3"></span>
+          <span class="ns-bar ns-bar-4"></span>
+          <span class="ns-bar ns-bar-5"></span>
+        </div>
+        <div class="ns-signal-text">
+          <span class="ns-text-excellent">Excellent</span>
+          <span class="ns-text-good">Good</span>
+          <span class="ns-text-fair">Fair</span>
+          <span class="ns-text-weak">Weak</span>
+          <span class="ns-text-none">No Signal</span>
+        </div>
+      </div>
+
+      <!-- SIGNAL LEVEL PICKER (radio-driven) -->
+      <div class="ns-level-picker">
+        <span class="ns-level-label">Simulate:</span>
+        <input type="radio" name="signal-level" id="sig-excellent" class="ns-sig-input" checked>
+        <label for="sig-excellent" class="ns-sig-label">Excellent</label>
+
+        <input type="radio" name="signal-level" id="sig-good" class="ns-sig-input">
+        <label for="sig-good" class="ns-sig-label">Good</label>
+
+        <input type="radio" name="signal-level" id="sig-fair" class="ns-sig-input">
+        <label for="sig-fair" class="ns-sig-label">Fair</label>
+
+        <input type="radio" name="signal-level" id="sig-weak" class="ns-sig-input">
+        <label for="sig-weak" class="ns-sig-label">Weak</label>
+
+        <input type="radio" name="signal-level" id="sig-none" class="ns-sig-input">
+        <label for="sig-none" class="ns-sig-label">None</label>
+      </div>
+
+      <!-- CONNECTION DETAILS -->
+      <div class="ns-details">
+        <div class="ns-detail-row">
+          <span class="ns-detail-label">Status</span>
+          <span class="ns-detail-value">
+            <span class="ns-status-dot" aria-hidden="true"></span>
+            <span class="ns-status-text">Connected</span>
+          </span>
+        </div>
+        <div class="ns-detail-row">
+          <span class="ns-detail-label">Network</span>
+          <span class="ns-detail-value ns-network-name">Home-WiFi-5G</span>
+        </div>
+        <div class="ns-detail-row">
+          <span class="ns-detail-label">IP Address</span>
+          <span class="ns-detail-value">192.168.1.42</span>
+        </div>
+        <div class="ns-detail-row">
+          <span class="ns-detail-label">Security</span>
+          <span class="ns-detail-value ns-security-badge">WPA3</span>
+        </div>
+      </div>
+
+      <!-- DISCONNECTED OVERLAY -->
+      <div class="ns-disconnected-overlay" aria-hidden="true">
+        <div class="ns-disconnected-icon">!</div>
+        <div class="ns-disconnected-text">Disconnected</div>
+        <div class="ns-disconnected-sub">Check your network connection</div>
+      </div>
+
+      <!-- CONNECTING ANIMATION -->
+      <div class="ns-connecting-indicator" aria-hidden="true">
+        <div class="ns-spinner"></div>
+        <div class="ns-connecting-text">Connecting...</div>
+      </div>
+
+    </div>
+
+    <!-- AVAILABLE NETWORKS -->
+    <div class="ns-networks-card">
+      <h2 class="ns-networks-title">Available Networks</h2>
+      <ul class="ns-network-list">
+
+        <li class="ns-network-item">
+          <input type="radio" name="selected-network" id="net-home" class="ns-net-radio" checked>
+          <label for="net-home" class="ns-net-label">
+            <span class="ns-net-signal ns-net-signal-4" aria-hidden="true"></span>
+            <span class="ns-net-name">Home-WiFi-5G</span>
+            <span class="ns-net-lock" aria-label="Secured network">&#128274;</span>
+            <span class="ns-net-check"></span>
+          </label>
+        </li>
+
+        <li class="ns-network-item">
+          <input type="radio" name="selected-network" id="net-office" class="ns-net-radio">
+          <label for="net-office" class="ns-net-label">
+            <span class="ns-net-signal ns-net-signal-3" aria-hidden="true"></span>
+            <span class="ns-net-name">Office-Guest</span>
+            <span class="ns-net-lock" aria-label="Secured network">&#128274;</span>
+            <span class="ns-net-check"></span>
+          </label>
+        </li>
+
+        <li class="ns-network-item">
+          <input type="radio" name="selected-network" id="net-coffee" class="ns-net-radio">
+          <label for="net-coffee" class="ns-net-label">
+            <span class="ns-net-signal ns-net-signal-2" aria-hidden="true"></span>
+            <span class="ns-net-name">Coffee-Shop-Free</span>
+            <span class="ns-net-lock ns-net-open" aria-label="Open network">&#128275;</span>
+            <span class="ns-net-check"></span>
+          </label>
+        </li>
+
+        <li class="ns-network-item">
+          <input type="radio" name="selected-network" id="net-neighbor" class="ns-net-radio">
+          <label for="net-neighbor" class="ns-net-label">
+            <span class="ns-net-signal ns-net-signal-1" aria-hidden="true"></span>
+            <span class="ns-net-name">Neighbor-Net-24</span>
+            <span class="ns-net-lock" aria-label="Secured network">&#128274;</span>
+            <span class="ns-net-check"></span>
+          </label>
+        </li>
+
+      </ul>
+    </div>
+
+    <!-- HOW IT WORKS -->
+    <details class="ns-info">
+      <summary class="ns-info-summary">How does pure CSS state switching work?</summary>
+      <div class="ns-info-body">
+        <p>Radio inputs and the <code>:has()</code> selector drive all state changes:</p>
+        <ul>
+          <li><strong>Signal bars</strong> fill based on <code>:has(#sig-{level}:checked)</code></li>
+          <li><strong>Connection state</strong> (Connected/Connecting/Disconnected) toggles via <code>:has(#state-{name}:checked)</code></li>
+          <li><strong>Network selection</strong> highlights via <code>input:checked + label</code></li>
+          <li><strong>Connecting animation</strong> — CSS <code>@keyframes</code> spinner</li>
+        </ul>
+      </div>
+    </details>
+
+  </main>
+
+  <footer class="ns-footer">
+    <p>Built with pure HTML &amp; CSS — <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css" target="_blank" rel="noopener">EaseMotion CSS</a></p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/network-status-indicator-kks/style.css
+++ b/submissions/examples/network-status-indicator-kks/style.css
@@ -1,0 +1,770 @@
+/* ============================================================
+   Network Status Indicator — Pure CSS
+   ============================================================
+   Signal bars, connection state, and network selection all
+   driven by radio inputs + :has() selector. Zero JavaScript.
+   ============================================================ */
+
+/* ---------- CUSTOM PROPERTIES ---------- */
+:root {
+  --ns-bg: #f5f6fa;
+  --ns-surface: #ffffff;
+  --ns-surface-hover: #f0f1f7;
+  --ns-border: #e2e5ef;
+  --ns-border-focus: #6366f1;
+  --ns-text: #1e1b4b;
+  --ns-text-secondary: #6b7280;
+  --ns-text-muted: #9ca3af;
+  --ns-signal-excellent: #10b981;
+  --ns-signal-good: #22c55e;
+  --ns-signal-fair: #f59e0b;
+  --ns-signal-weak: #f97316;
+  --ns-signal-none: #d1d5db;
+  --ns-connected: #10b981;
+  --ns-connecting: #f59e0b;
+  --ns-disconnected: #ef4444;
+  --ns-disconnected-bg: #fef2f2;
+  --ns-primary: #6366f1;
+  --ns-primary-hover: #4f46e5;
+  --ns-primary-light: #eef2ff;
+  --ns-net-selected-bg: #eef2ff;
+  --ns-ring: rgba(99, 102, 241, 0.3);
+  --ns-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
+  --ns-shadow-card: 0 2px 12px rgba(0, 0, 0, 0.08);
+  --ns-radius-sm: 0.375rem;
+  --ns-radius-md: 0.625rem;
+  --ns-radius-lg: 0.875rem;
+  --ns-radius-full: 9999px;
+  --ns-font: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --ns-transition: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ---------- DARK MODE ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ns-bg: #0f1119;
+    --ns-surface: #1a1d2e;
+    --ns-surface-hover: #252840;
+    --ns-border: #2e3148;
+    --ns-border-focus: #818cf8;
+    --ns-text: #e4e6f0;
+    --ns-text-secondary: #94a3b8;
+    --ns-text-muted: #64748b;
+    --ns-signal-excellent: #34d399;
+    --ns-signal-good: #4ade80;
+    --ns-signal-fair: #fbbf24;
+    --ns-signal-weak: #fb923c;
+    --ns-signal-none: #374151;
+    --ns-connected: #34d399;
+    --ns-connecting: #fbbf24;
+    --ns-disconnected: #f87171;
+    --ns-disconnected-bg: #451a1a;
+    --ns-primary: #818cf8;
+    --ns-primary-hover: #6366f1;
+    --ns-primary-light: #1e1b4b;
+    --ns-net-selected-bg: #1e1b4b;
+    --ns-ring: rgba(129, 140, 248, 0.3);
+    --ns-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    --ns-shadow-card: 0 2px 12px rgba(0, 0, 0, 0.5);
+  }
+}
+
+/* Manual overrides via theme toggle */
+.theme-switch-input:checked ~ .ns-container {
+  --ns-bg: #0f1119;
+  --ns-surface: #1a1d2e;
+  --ns-surface-hover: #252840;
+  --ns-border: #2e3148;
+  --ns-border-focus: #818cf8;
+  --ns-text: #e4e6f0;
+  --ns-text-secondary: #94a3b8;
+  --ns-text-muted: #64748b;
+  --ns-signal-excellent: #34d399;
+  --ns-signal-good: #4ade80;
+  --ns-signal-fair: #fbbf24;
+  --ns-signal-weak: #fb923c;
+  --ns-signal-none: #374151;
+  --ns-connected: #34d399;
+  --ns-connecting: #fbbf24;
+  --ns-disconnected: #f87171;
+  --ns-disconnected-bg: #451a1a;
+  --ns-primary: #818cf8;
+  --ns-primary-hover: #6366f1;
+  --ns-primary-light: #1e1b4b;
+  --ns-net-selected-bg: #1e1b4b;
+  --ns-ring: rgba(129, 140, 248, 0.3);
+  --ns-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --ns-shadow-card: 0 2px 12px rgba(0, 0, 0, 0.5);
+}
+
+/* ---------- RESET ---------- */
+*,
+*::before,
+*::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--ns-font);
+  background: var(--ns-bg);
+  color: var(--ns-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  line-height: 1.6;
+  transition: background var(--ns-transition), color var(--ns-transition);
+}
+
+/* ---------- THEME TOGGLE ---------- */
+.theme-switch-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.theme-switch-label {
+  position: fixed;
+  top: 1.25rem; right: 1.25rem;
+  z-index: 100;
+  width: 2.5rem; height: 2.5rem;
+  border-radius: var(--ns-radius-full);
+  background: var(--ns-surface);
+  border: 2px solid var(--ns-border);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color var(--ns-transition);
+  box-shadow: var(--ns-shadow);
+}
+
+.theme-switch-label:hover { border-color: var(--ns-primary); }
+.theme-switch-label:focus-visible {
+  outline: 2px solid var(--ns-primary);
+  outline-offset: 3px;
+}
+
+.theme-switch-icon {
+  display: block;
+  width: 1.125rem; height: 1.125rem;
+  border-radius: 50%;
+  background: var(--ns-text-secondary);
+  box-shadow: inset -3px -1px 0 var(--ns-text);
+  transition: background var(--ns-transition), box-shadow var(--ns-transition);
+}
+
+.theme-switch-input:checked ~ .theme-switch-label .theme-switch-icon {
+  background: var(--ns-signal-fair);
+  box-shadow: inset -1px -0.5px 0 var(--ns-text);
+}
+
+/* ---------- CONTAINER ---------- */
+.ns-container {
+  width: 100%;
+  max-width: 28rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ---------- HEADER ---------- */
+.ns-header { text-align: center; }
+.ns-title {
+  font-size: clamp(1.5rem, 4vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.ns-subtitle {
+  font-size: 0.875rem;
+  color: var(--ns-text-secondary);
+  margin-top: 0.25rem;
+}
+
+/* ---------- STATE TABS ---------- */
+.ns-state-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.ns-state-tabs {
+  display: flex;
+  gap: 0.25rem;
+  background: var(--ns-surface);
+  border: 1px solid var(--ns-border);
+  border-radius: var(--ns-radius-md);
+  padding: 0.25rem;
+  box-shadow: var(--ns-shadow);
+}
+
+.ns-state-tab {
+  flex: 1;
+  text-align: center;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.825rem;
+  font-weight: 600;
+  border-radius: var(--ns-radius-sm);
+  cursor: pointer;
+  color: var(--ns-text-secondary);
+  transition: background var(--ns-transition), color var(--ns-transition);
+  user-select: none;
+}
+
+.ns-state-tab:hover { color: var(--ns-text); }
+
+/* connected tab active */
+#state-connected:checked ~ .ns-state-tabs label[for="state-connected"] {
+  background: var(--ns-connected);
+  color: #ffffff;
+}
+
+/* connecting tab active */
+#state-connecting:checked ~ .ns-state-tabs label[for="state-connecting"] {
+  background: var(--ns-connecting);
+  color: #ffffff;
+}
+
+/* disconnected tab active */
+#state-disconnected:checked ~ .ns-state-tabs label[for="state-disconnected"] {
+  background: var(--ns-disconnected);
+  color: #ffffff;
+}
+
+.ns-state-tab:focus-visible {
+  outline: 2px solid var(--ns-primary);
+  outline-offset: 2px;
+}
+
+/* ---------- MAIN CARD ---------- */
+.ns-card {
+  position: relative;
+  background: var(--ns-surface);
+  border: 1px solid var(--ns-border);
+  border-radius: var(--ns-radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--ns-shadow-card);
+  transition: border-color var(--ns-transition), background var(--ns-transition);
+  overflow: hidden;
+}
+
+/* ---------- SIGNAL SECTION ---------- */
+.ns-signal-section {
+  text-align: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--ns-border);
+  margin-bottom: 1rem;
+}
+
+.ns-signal-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ns-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.ns-signal-bars {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 0.375rem;
+  height: 3rem;
+  margin-bottom: 0.625rem;
+}
+
+.ns-bar {
+  display: block;
+  width: 0.625rem;
+  border-radius: var(--ns-radius-sm) var(--ns-radius-sm) 0 0;
+  background: var(--ns-signal-none);
+  transition: background var(--ns-transition), height var(--ns-transition);
+}
+
+.ns-bar-1 { height: 20%; }
+.ns-bar-2 { height: 35%; }
+.ns-bar-3 { height: 50%; }
+.ns-bar-4 { height: 70%; }
+.ns-bar-5 { height: 90%; }
+
+/* -- SIGNAL LEVEL: EXCELLENT -- */
+.ns-container:has(#sig-excellent:checked) .ns-bar {
+  background: var(--ns-signal-excellent);
+}
+
+/* -- SIGNAL LEVEL: GOOD -- */
+.ns-container:has(#sig-good:checked) .ns-bar-1 { background: var(--ns-signal-none); }
+.ns-container:has(#sig-good:checked) .ns-bar-2,
+.ns-container:has(#sig-good:checked) .ns-bar-3,
+.ns-container:has(#sig-good:checked) .ns-bar-4,
+.ns-container:has(#sig-good:checked) .ns-bar-5 { background: var(--ns-signal-good); }
+
+/* -- SIGNAL LEVEL: FAIR -- */
+.ns-container:has(#sig-fair:checked) .ns-bar { background: var(--ns-signal-none); }
+.ns-container:has(#sig-fair:checked) .ns-bar-3,
+.ns-container:has(#sig-fair:checked) .ns-bar-4,
+.ns-container:has(#sig-fair:checked) .ns-bar-5 { background: var(--ns-signal-fair); }
+
+/* -- SIGNAL LEVEL: WEAK -- */
+.ns-container:has(#sig-weak:checked) .ns-bar { background: var(--ns-signal-none); }
+.ns-container:has(#sig-weak:checked) .ns-bar-4,
+.ns-container:has(#sig-weak:checked) .ns-bar-5 { background: var(--ns-signal-weak); }
+
+/* -- SIGNAL LEVEL: NONE -- */
+.ns-container:has(#sig-none:checked) .ns-bar { background: var(--ns-signal-none); }
+
+/* Disconnected state overrides all bars to gray */
+.ns-container:has(#state-disconnected:checked) .ns-bar {
+  background: var(--ns-signal-none);
+}
+
+/* ---------- SIGNAL TEXT ---------- */
+.ns-signal-text {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.ns-text-excellent, .ns-text-good, .ns-text-fair,
+.ns-text-weak, .ns-text-none { display: none; }
+
+.ns-container:has(#sig-excellent:checked):not(:has(#state-disconnected:checked)) .ns-text-excellent { display: block; color: var(--ns-signal-excellent); }
+.ns-container:has(#sig-good:checked):not(:has(#state-disconnected:checked)):not(:has(#sig-excellent:checked)) .ns-text-good { display: block; color: var(--ns-signal-good); }
+.ns-container:has(#sig-fair:checked):not(:has(#state-disconnected:checked)):not(:has(#sig-excellent:checked)):not(:has(#sig-good:checked)) .ns-text-fair { display: block; color: var(--ns-signal-fair); }
+.ns-container:has(#sig-weak:checked):not(:has(#state-disconnected:checked)):not(:has(#sig-excellent:checked)):not(:has(#sig-good:checked)):not(:has(#sig-fair:checked)) .ns-text-weak { display: block; color: var(--ns-signal-weak); }
+.ns-container:has(#sig-none:checked):not(:has(#state-disconnected:checked)) .ns-text-none { display: block; color: var(--ns-text-muted); }
+
+.ns-container:has(#state-disconnected:checked) .ns-text-none { display: block; color: var(--ns-disconnected); }
+.ns-container:has(#state-disconnected:checked) .ns-text-excellent,
+.ns-container:has(#state-disconnected:checked) .ns-text-good,
+.ns-container:has(#state-disconnected:checked) .ns-text-fair,
+.ns-container:has(#state-disconnected:checked) .ns-text-weak { display: none; }
+
+/* ---------- LEVEL PICKER ---------- */
+.ns-level-picker {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--ns-border);
+  margin-bottom: 1rem;
+}
+
+.ns-sig-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.ns-level-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ns-text-secondary);
+  margin-right: 0.5rem;
+}
+
+.ns-sig-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--ns-radius-full);
+  border: 1.5px solid var(--ns-border);
+  color: var(--ns-text-secondary);
+  cursor: pointer;
+  transition: all var(--ns-transition);
+  user-select: none;
+}
+
+.ns-sig-label:hover {
+  border-color: var(--ns-primary);
+  color: var(--ns-primary);
+}
+
+.ns-sig-input:checked + .ns-sig-label {
+  background: var(--ns-primary);
+  border-color: var(--ns-primary);
+  color: #ffffff;
+}
+
+.ns-sig-input:focus-visible + .ns-sig-label {
+  outline: 2px solid var(--ns-primary);
+  outline-offset: 2px;
+}
+
+/* ---------- DETAILS ---------- */
+.ns-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ns-detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ns-detail-label {
+  font-size: 0.825rem;
+  color: var(--ns-text-secondary);
+  font-weight: 500;
+}
+
+.ns-detail-value {
+  font-size: 0.825rem;
+  font-weight: 600;
+  color: var(--ns-text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Status dot */
+.ns-status-dot {
+  width: 0.5rem; height: 0.5rem;
+  border-radius: 50%;
+  display: inline-block;
+  background: var(--ns-connected);
+  transition: background var(--ns-transition);
+}
+
+.ns-container:has(#state-connected:checked) .ns-status-dot { background: var(--ns-connected); }
+.ns-container:has(#state-connecting:checked) .ns-status-dot {
+  background: var(--ns-connecting);
+  animation: ns-pulse 1.2s ease-in-out infinite;
+}
+.ns-container:has(#state-disconnected:checked) .ns-status-dot { background: var(--ns-disconnected); }
+
+@keyframes ns-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* Status text */
+.ns-status-text::after { content: 'Connected'; }
+.ns-container:has(#state-connecting:checked) .ns-status-text::after { content: 'Connecting'; }
+.ns-container:has(#state-disconnected:checked) .ns-status-text::after { content: 'Disconnected'; }
+.ns-container:has(#state-connecting:checked) .ns-status-text { color: var(--ns-connecting); }
+.ns-container:has(#state-disconnected:checked) .ns-status-text { color: var(--ns-disconnected); }
+.ns-container:has(#state-connected:checked) .ns-status-text { color: var(--ns-connected); }
+
+/* Security badge */
+.ns-security-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--ns-radius-full);
+  background: var(--ns-primary-light);
+  color: var(--ns-primary);
+  letter-spacing: 0.03em;
+}
+
+/* ---------- DISCONNECTED OVERLAY ---------- */
+.ns-disconnected-overlay {
+  display: none;
+}
+
+.ns-container:has(#state-disconnected:checked) .ns-disconnected-overlay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--ns-disconnected-bg) 85%, transparent);
+  backdrop-filter: blur(3px);
+  border-radius: var(--ns-radius-lg);
+  z-index: 2;
+}
+
+.ns-disconnected-icon {
+  width: 3rem; height: 3rem;
+  border-radius: 50%;
+  background: var(--ns-disconnected);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: 800;
+}
+
+.ns-disconnected-text {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--ns-disconnected);
+}
+
+.ns-disconnected-sub {
+  font-size: 0.8rem;
+  color: var(--ns-text-secondary);
+}
+
+/* ---------- CONNECTING INDICATOR ---------- */
+.ns-connecting-indicator {
+  display: none;
+}
+
+.ns-container:has(#state-connecting:checked) .ns-connecting-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--ns-surface) 85%, transparent);
+  backdrop-filter: blur(3px);
+  border-radius: var(--ns-radius-lg);
+  z-index: 2;
+}
+
+.ns-spinner {
+  width: 2.5rem; height: 2.5rem;
+  border: 3px solid var(--ns-border);
+  border-top-color: var(--ns-connecting);
+  border-radius: 50%;
+  animation: ns-spin 0.8s linear infinite;
+}
+
+@keyframes ns-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ns-connecting-text {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ns-connecting);
+  animation: ns-pulse 1.5s ease-in-out infinite;
+}
+
+/* ---------- NETWORK LIST ---------- */
+.ns-networks-card {
+  background: var(--ns-surface);
+  border: 1px solid var(--ns-border);
+  border-radius: var(--ns-radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--ns-shadow);
+}
+
+.ns-networks-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--ns-text);
+}
+
+.ns-network-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.ns-net-radio {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.ns-net-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--ns-radius-md);
+  cursor: pointer;
+  transition: background var(--ns-transition);
+}
+
+.ns-net-label:hover { background: var(--ns-surface-hover); }
+.ns-net-radio:checked + .ns-net-label { background: var(--ns-net-selected-bg); }
+.ns-net-radio:focus-visible + .ns-net-label {
+  outline: 2px solid var(--ns-primary);
+  outline-offset: 2px;
+}
+
+/* Mini signal bars inside network items */
+.ns-net-signal {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+.ns-net-signal::before,
+.ns-net-signal::after { content: ''; display: block; border-radius: 1px 1px 0 0; }
+.ns-net-signal-4::before { width: 3px; height: 0.2rem; background: var(--ns-text-muted); }
+.ns-net-signal-4::after  { width: 3px; height: 0.5rem; background: var(--ns-text-muted); }
+
+.ns-net-signal-3::before { width: 3px; height: 0.2rem; background: var(--ns-text-muted); }
+.ns-net-signal-3::after  { width: 3px; height: 0.35rem; background: var(--ns-text-muted); }
+
+.ns-net-signal-2::before { width: 3px; height: 0.15rem; background: var(--ns-text-muted); }
+.ns-net-signal-2::after  { width: 3px; height: 0.25rem; background: var(--ns-text-muted); }
+
+.ns-net-signal-1::before { width: 3px; height: 0.15rem; background: var(--ns-text-muted); }
+.ns-net-signal-1::after  { width: 3px; height: 0.15rem; background: var(--ns-text-muted); }
+
+.ns-net-name {
+  flex: 1;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ns-text);
+}
+
+.ns-net-lock { font-size: 0.75rem; opacity: 0.6; }
+.ns-net-open  { opacity: 0.4; }
+
+.ns-net-check {
+  width: 1rem; height: 1rem;
+  border-radius: 50%;
+  border: 2px solid var(--ns-border);
+  transition: border-color var(--ns-transition), background var(--ns-transition);
+  position: relative;
+}
+
+.ns-net-check::after {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: 50%;
+  background: transparent;
+  transition: background var(--ns-transition);
+}
+
+.ns-net-radio:checked + .ns-net-label .ns-net-check {
+  border-color: var(--ns-primary);
+}
+
+.ns-net-radio:checked + .ns-net-label .ns-net-check::after {
+  background: var(--ns-primary);
+}
+
+/* ---------- INFO ---------- */
+.ns-info {
+  background: var(--ns-surface);
+  border: 1px solid var(--ns-border);
+  border-radius: var(--ns-radius-lg);
+  overflow: hidden;
+}
+
+.ns-info[open] { border-color: var(--ns-primary); }
+
+.ns-info-summary {
+  padding: 0.875rem 1.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--ns-text);
+  user-select: none;
+}
+
+.ns-info-summary:hover { color: var(--ns-primary); }
+.ns-info-summary:focus-visible {
+  outline: 2px solid var(--ns-primary);
+  outline-offset: -2px;
+}
+
+.ns-info-body {
+  padding: 0 1.25rem 1.25rem;
+  font-size: 0.825rem;
+  color: var(--ns-text-secondary);
+  line-height: 1.7;
+}
+
+.ns-info-body code {
+  font-family: 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 0.85em;
+  background: var(--ns-surface-hover);
+  padding: 0.1em 0.35em;
+  border-radius: 0.25em;
+}
+
+.ns-info-body ul {
+  list-style: none;
+  padding: 0.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.ns-info-body li::before { content: '→ '; color: var(--ns-primary); font-weight: 700; }
+
+/* ---------- FOOTER ---------- */
+.ns-footer {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--ns-text-secondary);
+}
+
+.ns-footer a { color: var(--ns-primary); text-decoration: none; font-weight: 500; }
+.ns-footer a:hover { text-decoration: underline; }
+
+/* ---------- RESPONSIVE ---------- */
+@media (max-width: 400px) {
+  body { padding: 1rem 0.75rem; }
+  .ns-card { padding: 1.125rem; }
+  .ns-state-tab { font-size: 0.75rem; padding: 0.4rem 0.5rem; }
+  .ns-level-picker { gap: 0.25rem; }
+  .ns-sig-label { font-size: 0.7rem; padding: 0.2rem 0.5rem; }
+}
+
+/* ---------- REDUCED MOTION ---------- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .ns-spinner { animation: none; border-top-color: var(--ns-connecting); }
+}
+
+/* ---------- PREFERS CONTRAST ---------- */
+@media (prefers-contrast: high) {
+  .ns-card, .ns-networks-card {
+    border-width: 2px;
+  }
+  .ns-signal-bars .ns-bar {
+    border: 1px solid var(--ns-text);
+  }
+  .ns-status-dot {
+    border: 1px solid var(--ns-text);
+  }
+}
+
+/* ---------- FORCED COLORS ---------- */
+@media (forced-colors: active) {
+  .ns-bar { background: ButtonText; }
+  .ns-container:has(#sig-none:checked) .ns-bar { background: GrayText; }
+  .ns-container:has(#state-disconnected:checked) .ns-bar { background: GrayText; }
+  .ns-status-dot { border: 1px solid ButtonText; background: ButtonText; }
+  .ns-sig-input:checked + .ns-sig-label { background: Highlight; color: HighlightText; }
+  .ns-net-radio:checked + .ns-net-label { background: Highlight; color: HighlightText; }
+  .ns-state-input:checked ~ .ns-state-tabs label[for="state-connected"],
+  .ns-state-input:checked ~ .ns-state-tabs label[for="state-connecting"],
+  .ns-state-input:checked ~ .ns-state-tabs label[for="state-disconnected"] {
+    background: Highlight;
+    color: HighlightText;
+  }
+}
+
+/* ---------- PRINT ---------- */
+@media print {
+  .theme-switch-label, .ns-info, .ns-footer, .ns-level-picker,
+  .ns-state-tabs, .ns-disconnected-overlay, .ns-connecting-indicator {
+    display: none;
+  }
+  body { background: #ffffff; color: #000000; }
+}


### PR DESCRIPTION
## Summary

An interactive network connectivity panel with animated signal strength bars,
three connection states (Connected, Connecting, Disconnected), and a WiFi
network picker — all driven by radio inputs and CSS `:has()`. Zero JavaScript.

## What It Demonstrates

- **5-tier signal bars** fill based on `:has(#sig-{level}:checked)` combinators
- **3 connection states** toggle via radio-driven tab interface
- **Connecting state** shows a CSS `@keyframes` spinner with pulse animation
- **Disconnected state** displays a full-card overlay with icon
- **WiFi network list** with radio selection highlighting and lock icons
- **CSS `::after` content switching** — status text changes via `:has()`
without modifying any DOM

## Features

- Zero JavaScript — all state is CSS radio/`:has()` driven
- Dark mode — auto `prefers-color-scheme` with manual toggle
- `prefers-reduced-motion` — disables spinner and all transitions
- `prefers-contrast: high` — enhanced borders
- `forced-colors: active` — full Windows High Contrast Mode support
- Keyboard accessible — tab through state tabs, signal levels, networks
- `role="tablist"` / `role="tab"` on connection state tabs
- `aria-label` on signal bars and network lock indicators
- Responsive — 320px to wide screens
- Print-friendly

## Files
- `submissions/examples/network-status-indicator-kks/demo.html`
- `submissions/examples/network-status-indicator-kks/style.css`
- `submissions/examples/network-status-indicator-kks/README.md`

## Testing
Open `demo.html` in any modern browser. Click the Connected/Connecting/Disconnected
tabs to switch states. Use the signal level pills to change bar strength.
Select different WiFi networks from the list. All interactions are CSS-only.