### PR TITLE
feat: add slide-right neumorphic tabs submission

### DIFF
--- a/submissions/examples/slide-right-neumorphic-tabs-sd/README.md
+++ b/submissions/examples/slide-right-neumorphic-tabs-sd/README.md
@@ -1,0 +1,54 @@
+# Slide-Right Neumorphic Tabs
+
+### 1. What does this do?
+
+This is a pure CSS tabs component that features a smooth horizontal slide-right active indicator and content transition. It is styled with a modern, soft neumorphic appearance (subtle light-source shadows and inset recess panels) and works entirely without JavaScript.
+
+### 2. How is it used?
+
+Include `style.css` in your HTML, structure the markup using radio inputs linked to labels and content panels, and wrap the component in a container with the `.slide-right-tabs-sd` class.
+
+Example markup:
+
+```html
+<div class="slide-right-tabs-sd">
+  <input type="radio" id="tab1" name="tabs" checked class="tab-input-sd" />
+  <input type="radio" id="tab2" name="tabs" class="tab-input-sd" />
+  <input type="radio" id="tab3" name="tabs" class="tab-input-sd" />
+
+  <div class="tab-header-sd">
+    <label for="tab1" class="tab-label-sd">Tab 1</label>
+    <label for="tab2" class="tab-label-sd">Tab 2</label>
+    <label for="tab3" class="tab-label-sd">Tab 3</label>
+    <div class="tab-indicator-sd"></div>
+  </div>
+
+  <div class="tab-panels-sd">
+    <div class="tab-panels-inner-sd">
+      <div class="tab-panel-sd" id="panel1">Content 1</div>
+      <div class="tab-panel-sd" id="panel2">Content 2</div>
+      <div class="tab-panel-sd" id="panel3">Content 3</div>
+    </div>
+  </div>
+</div>
+```
+
+Customization is exposed through CSS variables:
+
+```css
+.slide-right-tabs-sd {
+  --tabs-duration: 0.45s;
+  --tabs-easing: cubic-bezier(0.25, 1, 0.5, 1);
+  --tabs-radius: 16px;
+  --tabs-shadow:
+    6px 6px 12px rgba(163, 177, 198, 0.6),
+    -6px -6px 12px rgba(255, 255, 255, 0.9);
+  --tabs-scale: 1;
+}
+```
+
+### 3. Why is it useful?
+
+- **Zero JavaScript Overhead**: Relies entirely on native browser engines for input handling and rendering, improving performance and eliminating scripts.
+- **Naturally Accessible & Responsive**: Uses native HTML radio buttons for automatic arrow-key keyboard navigation and screen reader support. Designed without fixed widths to dynamically adapt to any screen size.
+- **Highly Customisable**: Allows fine-tuning of transition duration, easing, border radius, shadows, and scaling through standard CSS custom properties.

--- a/submissions/examples/slide-right-neumorphic-tabs-sd/demo.html
+++ b/submissions/examples/slide-right-neumorphic-tabs-sd/demo.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Slide-Right Neumorphic Tabs</title>
+    <!-- Premium Modern Font -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Link component styles -->
+    <link rel="stylesheet" href="style.css" />
+
+    <style>
+      /* Demo-only page layout and styles */
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+        background-color: #e0e5ec;
+        font-family: "Outfit", sans-serif;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        color: #2d3748;
+      }
+
+      .demo-container {
+        width: 90%;
+        max-width: 600px;
+        padding: 20px;
+        box-sizing: border-box;
+      }
+
+      .demo-header {
+        text-align: center;
+        margin-bottom: 40px;
+      }
+
+      .demo-header h1 {
+        font-size: 2rem;
+        font-weight: 700;
+        margin: 0 0 8px 0;
+        color: #1a252c;
+        letter-spacing: -0.5px;
+      }
+
+      .demo-header p {
+        font-size: 0.95rem;
+        color: #627280;
+        margin: 0;
+      }
+
+      /* Content styling inside panels */
+      .panel-content {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .panel-content h2 {
+        font-size: 1.35rem;
+        font-weight: 700;
+        margin: 0 0 4px 0;
+        color: #1a252c;
+      }
+
+      .panel-content p {
+        font-size: 0.95rem;
+        line-height: 1.6;
+        color: #5c6b73;
+        margin: 0;
+      }
+
+      /* Icon styling */
+      .tab-icon {
+        flex-shrink: 0;
+        transition: stroke 0.3s ease;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-container">
+      <header class="demo-header">
+        <h1>Slide-Right Neumorphic Tabs</h1>
+        <p>
+          A pure CSS responsive tabbed interface with a smooth slide-right
+          active indicator
+        </p>
+      </header>
+
+      <!-- Slide-Right Neumorphic Tabs Component -->
+      <div class="slide-right-tabs-sd">
+        <!-- Hidden Radio Inputs for Tab Control -->
+        <input
+          type="radio"
+          id="tab-sd-1"
+          name="slide-right-tabs"
+          class="tab-input-sd"
+          checked
+        />
+        <input
+          type="radio"
+          id="tab-sd-2"
+          name="slide-right-tabs"
+          class="tab-input-sd"
+        />
+        <input
+          type="radio"
+          id="tab-sd-3"
+          name="slide-right-tabs"
+          class="tab-input-sd"
+        />
+
+        <!-- Navigation Header -->
+        <div class="tab-header-sd">
+          <label for="tab-sd-1" class="tab-label-sd" id="label-sd-1">
+            <svg
+              class="tab-icon"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="3" y="3" width="7" height="9"></rect>
+              <rect x="14" y="3" width="7" height="5"></rect>
+              <rect x="14" y="12" width="7" height="9"></rect>
+              <rect x="3" y="16" width="7" height="5"></rect>
+            </svg>
+            Overview
+          </label>
+          <label for="tab-sd-2" class="tab-label-sd" id="label-sd-2">
+            <svg
+              class="tab-icon"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="18" y1="20" x2="18" y2="10"></line>
+              <line x1="12" y1="20" x2="12" y2="4"></line>
+              <line x1="6" y1="20" x2="6" y2="14"></line>
+            </svg>
+            Analytics
+          </label>
+          <label for="tab-sd-3" class="tab-label-sd" id="label-sd-3">
+            <svg
+              class="tab-icon"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <circle cx="12" cy="12" r="3"></circle>
+              <path
+                d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+              ></path>
+            </svg>
+            Settings
+          </label>
+
+          <!-- Sliding active indicator background -->
+          <div class="tab-indicator-sd"></div>
+        </div>
+
+        <!-- Content Panels -->
+        <div class="tab-panels-sd">
+          <div class="tab-panels-inner-sd">
+            <!-- Panel 1 -->
+            <div
+              class="tab-panel-sd"
+              id="panel-sd-1"
+              role="tabpanel"
+              aria-labelledby="label-sd-1"
+            >
+              <div class="panel-content">
+                <h2>Dashboard Overview</h2>
+                <p>
+                  Welcome to your soft neumorphic dashboard system. This section
+                  displays a high-level summary of your application statistics,
+                  current activities, and quick access shortcuts.
+                </p>
+                <p>
+                  Everything is designed with a premium, tactile feel,
+                  replicating physical push buttons and light/dark casting
+                  shadows for maximum visual comfort.
+                </p>
+              </div>
+            </div>
+
+            <!-- Panel 2 -->
+            <div
+              class="tab-panel-sd"
+              id="panel-sd-2"
+              role="tabpanel"
+              aria-labelledby="label-sd-2"
+            >
+              <div class="panel-content">
+                <h2>Analytics & Reports</h2>
+                <p>
+                  Track your data flow and system metrics with deep real-time
+                  analytics. Review chart data, check performance stats, and
+                  download monthly summary worksheets.
+                </p>
+                <p>
+                  Transition animations are hardware-accelerated for
+                  buttery-smooth horizontal motion without layout shifting or
+                  page rendering stutter.
+                </p>
+              </div>
+            </div>
+
+            <!-- Panel 3 -->
+            <div
+              class="tab-panel-sd"
+              id="panel-sd-3"
+              role="tabpanel"
+              aria-labelledby="label-sd-3"
+            >
+              <div class="panel-content">
+                <h2>System Settings</h2>
+                <p>
+                  Configure interface options, user accounts, and security keys.
+                  Control transition timings, spacing, and border radius
+                  directly using CSS custom variables.
+                </p>
+                <p>
+                  Set custom properties locally or globally on the root element
+                  to instantly theme your entire soft neumorphic application
+                  stack.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/slide-right-neumorphic-tabs-sd/style.css
+++ b/submissions/examples/slide-right-neumorphic-tabs-sd/style.css
@@ -1,0 +1,188 @@
+/* ==========================================================================
+   EaseMotion - CSS Slide-Right Tabs for Neumorphic Soft Layouts
+   Contributor: sd
+   ========================================================================== */
+
+.slide-right-tabs-sd {
+  /* Default Configuration Custom Variables */
+  --tabs-bg: #e0e5ec;
+  --tabs-shadow-dark: rgba(163, 177, 198, 0.6);
+  --tabs-shadow-light: rgba(255, 255, 255, 0.9);
+
+  /* Required Customizable CSS Variables */
+  --tabs-duration: 0.45s;
+  --tabs-easing: cubic-bezier(0.25, 1, 0.5, 1);
+  --tabs-radius: 16px;
+  --tabs-shadow:
+    6px 6px 12px var(--tabs-shadow-dark),
+    -6px -6px 12px var(--tabs-shadow-light);
+  --tabs-scale: 1;
+
+  /* Internal Helper Variables */
+  --tabs-shadow-inset:
+    inset 3px 3px 6px var(--tabs-shadow-dark),
+    inset -3px -3px 6px var(--tabs-shadow-light);
+  --tabs-text-color: #627280;
+  --tabs-text-active: #2d3748;
+
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* Hide Radio Inputs Accessibly */
+.slide-right-tabs-sd .tab-input-sd {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Tab Header container (Sunken Neumorphic Surface) */
+.slide-right-tabs-sd .tab-header-sd {
+  display: flex;
+  position: relative;
+  background: var(--tabs-bg);
+  box-shadow: var(--tabs-shadow-inset);
+  border-radius: var(--tabs-radius);
+  padding: 6px;
+  user-select: none;
+  isolation: isolate;
+  box-sizing: border-box;
+}
+
+/* Tab Labels */
+.slide-right-tabs-sd .tab-label-sd {
+  flex: 1;
+  text-align: center;
+  padding: 14px 16px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--tabs-text-color);
+  cursor: pointer;
+  z-index: 2;
+  transition: color var(--tabs-duration) var(--tabs-easing);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  box-sizing: border-box;
+  border-radius: calc(var(--tabs-radius) - 4px);
+}
+
+.slide-right-tabs-sd .tab-label-sd:hover {
+  color: var(--tabs-text-active);
+}
+
+/* Active tab indicator (Raised Neumorphic Pill) */
+.slide-right-tabs-sd .tab-indicator-sd {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  height: calc(100% - 12px);
+  width: calc((100% - 12px) / 3);
+  background: var(--tabs-bg);
+  box-shadow: var(--tabs-shadow);
+  border-radius: calc(var(--tabs-radius) - 4px);
+  z-index: 1;
+  pointer-events: none;
+  transition: transform var(--tabs-duration) var(--tabs-easing);
+  box-sizing: border-box;
+}
+
+/* Active state translations for the indicator (left to right transition) */
+.slide-right-tabs-sd #tab-sd-1:checked ~ .tab-header-sd .tab-indicator-sd {
+  transform: translateX(0);
+}
+
+.slide-right-tabs-sd #tab-sd-2:checked ~ .tab-header-sd .tab-indicator-sd {
+  transform: translateX(100%);
+}
+
+.slide-right-tabs-sd #tab-sd-3:checked ~ .tab-header-sd .tab-indicator-sd {
+  transform: translateX(200%);
+}
+
+/* Active state color for labels */
+.slide-right-tabs-sd #tab-sd-1:checked ~ .tab-header-sd label[for="tab-sd-1"],
+.slide-right-tabs-sd #tab-sd-2:checked ~ .tab-header-sd label[for="tab-sd-2"],
+.slide-right-tabs-sd #tab-sd-3:checked ~ .tab-header-sd label[for="tab-sd-3"] {
+  color: var(--tabs-text-active);
+}
+
+/* Accessibility Focus States for Keyboard Navigation */
+.slide-right-tabs-sd
+  #tab-sd-1:focus-visible
+  ~ .tab-header-sd
+  label[for="tab-sd-1"],
+.slide-right-tabs-sd
+  #tab-sd-2:focus-visible
+  ~ .tab-header-sd
+  label[for="tab-sd-2"],
+.slide-right-tabs-sd
+  #tab-sd-3:focus-visible
+  ~ .tab-header-sd
+  label[for="tab-sd-3"] {
+  outline: 2px solid var(--tabs-text-active);
+  outline-offset: -2px;
+}
+
+/* Content Panels Container (Raised Neumorphic Surface) */
+.slide-right-tabs-sd .tab-panels-sd {
+  overflow: hidden;
+  background: var(--tabs-bg);
+  box-shadow: var(--tabs-shadow);
+  border-radius: var(--tabs-radius);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Horizontal slide wrapper */
+.slide-right-tabs-sd .tab-panels-inner-sd {
+  display: flex;
+  width: 300%;
+  transition: transform var(--tabs-duration) var(--tabs-easing);
+  box-sizing: border-box;
+}
+
+/* Individual Panel */
+.slide-right-tabs-sd .tab-panel-sd {
+  width: calc(100% / 3);
+  padding: 36px 32px;
+  box-sizing: border-box;
+  opacity: 0.4;
+  transform: scale(calc(var(--tabs-scale) * 0.97));
+  transition:
+    opacity var(--tabs-duration) var(--tabs-easing),
+    transform var(--tabs-duration) var(--tabs-easing);
+}
+
+/* Slide position selectors */
+.slide-right-tabs-sd #tab-sd-1:checked ~ .tab-panels-sd .tab-panels-inner-sd {
+  transform: translateX(0);
+}
+
+.slide-right-tabs-sd #tab-sd-2:checked ~ .tab-panels-sd .tab-panels-inner-sd {
+  transform: translateX(-33.3333333333%);
+}
+
+.slide-right-tabs-sd #tab-sd-3:checked ~ .tab-panels-sd .tab-panels-inner-sd {
+  transform: translateX(-66.6666666667%);
+}
+
+/* Active panel content animation */
+.slide-right-tabs-sd #tab-sd-1:checked ~ .tab-panels-sd #panel-sd-1,
+.slide-right-tabs-sd #tab-sd-2:checked ~ .tab-panels-sd #panel-sd-2,
+.slide-right-tabs-sd #tab-sd-3:checked ~ .tab-panels-sd #panel-sd-3 {
+  opacity: 1;
+  transform: scale(var(--tabs-scale));
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS slide-right tabs component styled with a soft neumorphic design. The component provides smooth tab transitions without JavaScript, supports keyboard navigation, remains responsive across screen sizes, and exposes customization options through CSS custom properties.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS slide-right tabs component featuring smooth animated transitions and a soft neumorphic interface aesthetic.

**How does a developer use it?**

```html
<div class="slide-right-tabs-sd">
  <!-- radio inputs, tab labels, and content panels -->
</div>
```

**Why does it fit EaseMotion CSS?**

It provides a modern, animation-first UI pattern that is lightweight, reusable, responsive, customizable through CSS variables, and requires zero JavaScript.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
- Implemented using native radio inputs and CSS selectors with no JavaScript dependency.
- Includes smooth slide-right indicator and panel transitions.
- Styled with a soft neumorphic appearance using subtle shadow layers.
- Supports keyboard navigation and visible focus states.
- Exposes customization through:
  - `--tabs-duration`
  - `--tabs-easing`
  - `--tabs-radius`
  - `--tabs-shadow`
  - `--tabs-scale`

Closes #50252

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
