### PR TITLE
feat(submission): add ease-blur-entrance-tooltip component (#54559)

### DIFF
--- a/submissions/examples/ease-blur-entrance-tooltip-ksk/README.md
+++ b/submissions/examples/ease-blur-entrance-tooltip-ksk/README.md
@@ -1,0 +1,34 @@
+# Blur-Entrance Tooltip (`ease-blur-entrance-tooltip-ksk`)
+
+1. What does this do?  
+An animated tooltip component designed for Creative Portfolio details. Hovering or focusing the trigger element reveals a card tooltip that animates in from a blurred, scaled-down state (`filter: blur(14px) scale(0.85)`) to a clear, full-scale card position using a smooth spring transition (`cubic-bezier(0.34, 1.56, 0.64, 1)`).
+
+2. How is it used?  
+Wrap the trigger element and `.ease-tooltip` inside a parent `.ease-tooltip-wrapper`. The transition executes automatically during hover or focus:
+
+```html
+<div class="ease-tooltip-wrapper" tabindex="0" role="button">
+  <span>Hover Me</span>
+  <div class="ease-tooltip" role="tooltip">
+    <p class="tooltip-title">Project Info</p>
+    <p class="tooltip-desc">Detailed analytics information goes here.</p>
+  </div>
+</div>
+```
+
+Customize dimensions and speeds via CSS custom properties:
+```css
+.ease-tooltip-wrapper {
+  --ease-tooltip-blur:     14px;          /* initial blur distance */
+  --ease-tooltip-scale:    0.85;          /* initial scale offset */
+  --ease-tooltip-duration: 0.3s;           /* transition speed */
+  --ease-tooltip-width:    220px;          /* tooltip card width */
+  --ease-tooltip-accent:   #f43f5e;        /* theme highlight color */
+}
+```
+
+3. Why is it useful?  
+Instead of traditional blocky tooltips, the blur-entrance effect adds a premium focal fade-in that feels organic. Features built-in keyboard accessibility (`tabindex`, `:focus-within`), caret arrows, and automatic animation overrides for `prefers-reduced-motion` compliance.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #54559.*

--- a/submissions/examples/ease-blur-entrance-tooltip-ksk/demo.html
+++ b/submissions/examples/ease-blur-entrance-tooltip-ksk/demo.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blur-Entrance Tooltip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background: #06070c;
+      background-image:
+        radial-gradient(ellipse at 20% 30%, rgba(244, 63, 94, 0.1) 0%, transparent 55%),
+        radial-gradient(ellipse at 80% 70%, rgba(99, 102, 241, 0.08) 0%, transparent 55%);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .page-header {
+      text-align: center;
+      margin-bottom: 3rem;
+    }
+    .page-header h1 {
+      font-size: 1.8rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, #f43f5e, #818cf8);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin: 0 0 0.4rem;
+      letter-spacing: -0.015em;
+    }
+    .page-header p {
+      color: #475569;
+      font-size: 0.88rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="page-header">
+    <h1>Creative Portfolio Showcase</h1>
+    <p>Hover over the "i" info badges to reveal project statistics using blur-entrance transitions.</p>
+  </div>
+
+  <!-- Portfolio grid layout -->
+  <div class="portfolio-grid">
+
+    <!-- Card 1: 3D Art Studio -->
+    <article class="portfolio-card">
+      <div class="portfolio-thumbnail-box">
+        <!-- SVG abstract mockup -->
+        <svg width="100%" height="100%" viewBox="0 0 280 180" xmlns="http://www.w3.org/2000/svg">
+          <rect width="280" height="180" fill="#090a10"/>
+          <circle cx="140" cy="90" r="50" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.4"/>
+          <polygon points="140,55 175,115 105,115" fill="rgba(244,63,94,0.15)" stroke="#f43f5e" stroke-width="2"/>
+        </svg>
+      </div>
+      <div class="portfolio-title-row">
+        <h2 class="portfolio-card-title">3D Abstract Studio</h2>
+        
+        <!-- Tooltip Trigger wrapper -->
+        <div class="ease-tooltip-wrapper" tabindex="0" role="button" aria-haspopup="true">
+          <span class="info-badge">i</span>
+          <!-- The Blur-Entrance Tooltip -->
+          <div class="ease-tooltip" role="tooltip">
+            <p class="tooltip-title">3D Abstract Studio</p>
+            <p class="tooltip-desc">High-poly geometric vector configurations rendered with custom shadow shaders.</p>
+            <div class="tooltip-stats">
+              <span>Views: <strong class="tooltip-stat-val">24k</strong></span>
+              <span>Likes: <strong class="tooltip-stat-val">1.8k</strong></span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </article>
+
+    <!-- Card 2: Interactive Web GL -->
+    <article class="portfolio-card">
+      <div class="portfolio-thumbnail-box">
+        <svg width="100%" height="100%" viewBox="0 0 280 180" xmlns="http://www.w3.org/2000/svg">
+          <rect width="280" height="180" fill="#090a10"/>
+          <circle cx="100" cy="90" r="30" fill="rgba(99,102,241,0.15)" stroke="#6366f1" stroke-width="1.5"/>
+          <circle cx="180" cy="90" r="35" fill="rgba(99,102,241,0.1)" stroke="#818cf8" stroke-width="1.5"/>
+          <line x1="130" y1="90" x2="145" y2="90" stroke="#6366f1" stroke-width="2"/>
+        </svg>
+      </div>
+      <div class="portfolio-title-row">
+        <h2 class="portfolio-card-title">WebGL Experiments</h2>
+        
+        <!-- Tooltip Trigger wrapper -->
+        <div class="ease-tooltip-wrapper" style="--ease-tooltip-accent: #6366f1; --ease-tooltip-accent-glow: rgba(99,102,241,0.35);" tabindex="0" role="button" aria-haspopup="true">
+          <span class="info-badge">i</span>
+          <!-- The Blur-Entrance Tooltip -->
+          <div class="ease-tooltip" role="tooltip">
+            <p class="tooltip-title">WebGL Experiments</p>
+            <p class="tooltip-desc">Interactive physics particles running in hardware-accelerated shaders.</p>
+            <div class="tooltip-stats">
+              <span>Views: <strong class="tooltip-stat-val">42k</strong></span>
+              <span>Likes: <strong class="tooltip-stat-val">3.5k</strong></span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </article>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-blur-entrance-tooltip-ksk/style.css
+++ b/submissions/examples/ease-blur-entrance-tooltip-ksk/style.css
@@ -1,0 +1,192 @@
+/* ============================================================
+   EaseMotion CSS — Blur-Entrance Tooltip (Creative Portfolio)
+   submissions/examples/ease-blur-entrance-tooltip-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .ease-tooltip-wrapper or any ancestor.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-tooltip-blur:     14px;          /* initial blur distance         */
+  --ease-tooltip-scale:    0.85;          /* initial scale offset          */
+  --ease-tooltip-duration: 0.3s;          /* transition speed              */
+  --ease-tooltip-easing:   cubic-bezier(0.34, 1.56, 0.64, 1); /* spring     */
+  --ease-tooltip-bg:       #0d0e15;
+  --ease-tooltip-border:   rgba(255, 255, 255, 0.08);
+  --ease-tooltip-radius:   12px;
+  --ease-tooltip-width:    220px;
+  --ease-tooltip-font:     system-ui, -apple-system, sans-serif;
+  --ease-tooltip-accent:   #f43f5e;       /* Rose accent                   */
+  --ease-tooltip-accent-glow: rgba(244, 63, 94, 0.35);
+}
+
+/* ── Sizing and Layout ── */
+.ease-tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+  outline: none;
+}
+
+/* ── Tooltip Element ────────────────────────────────────── */
+.ease-tooltip {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  /* Shift down, shrink, and blur in the initial state */
+  transform: translateX(-50%) translateY(8px) scale(var(--ease-tooltip-scale));
+  width: var(--ease-tooltip-width);
+  background: var(--ease-tooltip-bg);
+  border: 1px solid var(--ease-tooltip-border);
+  border-radius: var(--ease-tooltip-radius);
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  padding: 14px;
+  box-sizing: border-box;
+  font-family: var(--ease-tooltip-font);
+  color: #fff;
+  opacity: 0;
+  filter: blur(var(--ease-tooltip-blur));
+  pointer-events: none;
+  z-index: 100;
+  /* Multi-property transition */
+  transition:
+    opacity var(--ease-tooltip-duration) ease,
+    filter var(--ease-tooltip-duration) ease,
+    transform var(--ease-tooltip-duration) var(--ease-tooltip-easing);
+}
+
+/* Tooltip Caret Arrow */
+.ease-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--ease-tooltip-bg);
+  z-index: 2;
+}
+
+/* Hover and Focus-within Entrance Triggers */
+.ease-tooltip-wrapper:hover .ease-tooltip,
+.ease-tooltip-wrapper:focus-within .ease-tooltip {
+  opacity: 1;
+  filter: blur(0px);
+  transform: translateX(-50%) translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+/* ── Tooltip Content Styles ─────────────────────────────── */
+.tooltip-title {
+  font-size: 0.82rem;
+  font-weight: 800;
+  margin: 0 0 4px;
+  letter-spacing: -0.01em;
+}
+
+.tooltip-desc {
+  font-size: 0.72rem;
+  color: #94a3b8;
+  line-height: 1.5;
+  margin: 0 0 10px;
+}
+
+/* Stats list */
+.tooltip-stats {
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px dashed rgba(255,255,255,0.06);
+  padding-top: 8px;
+  font-size: 0.68rem;
+  color: #64748b;
+}
+
+.tooltip-stat-val {
+  color: var(--ease-tooltip-accent);
+  font-weight: 700;
+}
+
+/* ── Accessibility: prefers-reduced-motion support ──────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip {
+    transition: opacity var(--ease-tooltip-duration) ease !important;
+    filter: none !important;
+    transform: translateX(-50%) translateY(0) scale(1) !important;
+  }
+}
+
+/* ── Demo Page: Creative Portfolio Layout ──────────────── */
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  width: 100%;
+  max-width: 680px;
+}
+
+.portfolio-card {
+  background: #0f111a;
+  border: 1px solid var(--ease-tooltip-border);
+  border-radius: 20px;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 16px 36px rgba(0,0,0,0.3);
+  transition: transform 0.2s ease;
+}
+
+.portfolio-card:hover {
+  transform: translateY(-2px);
+}
+
+.portfolio-thumbnail-box {
+  width: 100%;
+  height: 180px;
+  border-radius: 12px;
+  background: #090a10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 14px;
+}
+
+.portfolio-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.portfolio-card-title {
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: #fff;
+  margin: 0;
+}
+
+/* Floating info badge (the tooltip trigger) */
+.info-badge {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  color: #94a3b8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: bold;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.ease-tooltip-wrapper:hover .info-badge,
+.ease-tooltip-wrapper:focus-within .info-badge {
+  background: var(--ease-tooltip-accent);
+  color: #fff;
+  box-shadow: 0 0 12px var(--ease-tooltip-accent-glow);
+}


### PR DESCRIPTION
Closes #54559

Adds an interactive Blur-Entrance Tooltip component under `submissions/examples/ease-blur-entrance-tooltip-ksk/`.

#### Key Features & Requirements Met

1. **Blur-Entrance Focus Transition** — When trigger badges are hovered or focused, the tooltip card transitions in from a blurred scale state (`filter: blur(14px) scale(0.85) translateY(8px)`) to a clear, full-scale card with spring easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`).
2. **Creative Portfolio Layout** — Showcase page presents a clean, responsive layout grid displaying creative project cards (abstract SVG vector layouts) featuring float info badges as interactive tooltip anchors.
3. **prefers-reduced-motion Support** — Disables spatial and filter transforms under the `prefers-reduced-motion: reduce` query, safely defaulting to a clean opacity transition.
4. **5 Customizable Variables** — Easily configure `--ease-tooltip-blur`, `--ease-tooltip-scale`, `--ease-tooltip-duration`, `--ease-tooltip-width`, and `--ease-tooltip-accent`.
5. **No JavaScript** — Works completely in pure HTML and CSS utilizing standard absolute positioning and focus-within pseudoclass selectors.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Absolute positioning coordinates, caret arrows, blur-entrance transitions, and a11y reduced-motion overrides |
| `demo.html` | Portfolio showcase containing cards with hoverable info triggers and project stats panels |
| `README.md` | Usage notes and variables guide reference table, resolving `#54559` |