### PR TITLE
feat: add spring physics tabs glassmorphism component

### DIFF
--- a/submissions/examples/33125-spring-physics-tabs-hebafatima/README.md
+++ b/submissions/examples/33125-spring-physics-tabs-hebafatima/README.md
@@ -1,0 +1,35 @@
+# Spring Physics Tabs
+
+## What does this do?
+A pure-CSS tab component where the active-state indicator and panel transitions use a spring/overshoot easing curve instead of a linear one, styled with a glassmorphism (frosted-glass) aesthetic.
+
+## How is it used?
+Structure three radio inputs paired with labels inside a `.spring-tabs` container, followed by a `.spring-tab-indicator` element and one `.spring-tab-panel` per tab:
+
+```html
+<div class="spring-tabs" role="tablist">
+  <input type="radio" name="spring-tabs" id="tab-1" class="spring-tab-input" checked>
+  <label class="spring-tab-label" for="tab-1">Overview</label>
+
+  <input type="radio" name="spring-tabs" id="tab-2" class="spring-tab-input">
+  <label class="spring-tab-label" for="tab-2">Details</label>
+
+  <span class="spring-tab-indicator" aria-hidden="true"></span>
+
+  <div class="spring-tab-panel" id="panel-1">...</div>
+  <div class="spring-tab-panel" id="panel-2">...</div>
+</div>
+```
+
+The spring feel is tunable without touching any rule, via custom properties set on `.spring-tabs`:
+
+```css
+.spring-tabs {
+  --spring-duration: 0.6s;
+  --spring-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --tab-active-scale: 1.04;
+}
+```
+
+## Why is it useful?
+It fits EaseMotion's zero-JavaScript philosophy: tab switching, the sliding indicator, and panel entry are all driven by the native `:checked` state and CSS sibling selectors, with no script required. Because the radio inputs stay in the tab order and respond to arrow keys and space, the component is keyboard accessible by default rather than needing ARIA scripting bolted on afterward. `prefers-reduced-motion` is respected so the spring effect degrades gracefully for users who need it to.

--- a/submissions/examples/33125-spring-physics-tabs-hebafatima/demo.html
+++ b/submissions/examples/33125-spring-physics-tabs-hebafatima/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Spring Physics Tabs — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="spring-tabs-demo-bg">
+    <div class="spring-tabs" role="tablist" aria-label="Spring physics tab demo">
+
+      <input type="radio" name="spring-tabs" id="tab-1" class="spring-tab-input" checked>
+      <label class="spring-tab-label" for="tab-1">Overview</label>
+
+      <input type="radio" name="spring-tabs" id="tab-2" class="spring-tab-input">
+      <label class="spring-tab-label" for="tab-2">Details</label>
+
+      <input type="radio" name="spring-tabs" id="tab-3" class="spring-tab-input">
+      <label class="spring-tab-label" for="tab-3">Settings</label>
+
+      <span class="spring-tab-indicator" aria-hidden="true"></span>
+
+      <div class="spring-tab-panel" id="panel-1">
+        <h3>Overview</h3>
+        <p>This panel shows a spring-loaded tab switch. Click or use arrow keys + space to move between tabs and watch the indicator overshoot slightly before settling.</p>
+      </div>
+
+      <div class="spring-tab-panel" id="panel-2">
+        <h3>Details</h3>
+        <p>The bounce is driven entirely by a single CSS custom property, so any consumer of this component can tune the feel without touching the underlying rules.</p>
+      </div>
+
+      <div class="spring-tab-panel" id="panel-3">
+        <h3>Settings</h3>
+        <p>Try changing <code>--spring-easing</code> or <code>--spring-duration</code> in the CSS to feel the difference a spring curve makes versus a linear one.</p>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/33125-spring-physics-tabs-hebafatima/style.css
+++ b/submissions/examples/33125-spring-physics-tabs-hebafatima/style.css
@@ -1,0 +1,161 @@
+/* ============================================
+   Spring Physics Tabs — Glassmorphism UI
+   Pure CSS. Zero JavaScript.
+   ============================================ */
+
+.spring-tabs-demo-bg {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: linear-gradient(135deg, #6d5dfc 0%, #23a6d5 50%, #23d5ab 100%);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.spring-tabs {
+  /* -------- tunable custom properties -------- */
+  --spring-duration: 0.6s;
+  --spring-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* overshoot + settle */
+  --tab-active-scale: 1.04;
+  --glass-blur: 14px;
+  --glass-bg: rgba(255, 255, 255, 0.14);
+  --glass-border: rgba(255, 255, 255, 0.35);
+
+  position: relative;
+  width: min(560px, 100%);
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+/* Hide native radio visually, keep it focusable for keyboard/screen readers */
+.spring-tab-input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.spring-tab-label {
+  grid-row: 1;
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  padding: 0.75rem 0.5rem;
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border-radius: 12px;
+  user-select: none;
+  transition: color 0.3s ease, transform var(--spring-duration) var(--spring-easing);
+}
+
+.spring-tab-label:hover {
+  color: #fff;
+}
+
+/* Clear focus ring for keyboard users tabbing to the hidden input */
+.spring-tab-input:focus-visible + .spring-tab-label {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+.spring-tab-input:checked + .spring-tab-label {
+  color: #1a1a2e;
+  transform: scale(var(--tab-active-scale));
+}
+
+/* Sliding glass pill indicator — driven purely by :checked + general sibling combinator */
+.spring-tab-indicator {
+  grid-row: 1;
+  grid-column: 1;
+  align-self: stretch;
+  justify-self: stretch;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 12px;
+  z-index: 1;
+  transition: transform var(--spring-duration) var(--spring-easing);
+}
+
+#tab-1:checked ~ .spring-tab-indicator { transform: translateX(0%); }
+#tab-2:checked ~ .spring-tab-indicator { transform: translateX(100%); }
+#tab-3:checked ~ .spring-tab-indicator { transform: translateX(200%); }
+
+/* Panels */
+.spring-tab-panel {
+  grid-column: 1 / -1;
+  display: none;
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #fff;
+  opacity: 0;
+  transform: translateY(6px) scale(0.98);
+  animation: spring-panel-in var(--spring-duration) var(--spring-easing) forwards;
+}
+
+.spring-tab-panel h3 {
+  margin: 0 0 0.5rem;
+}
+
+.spring-tab-panel p {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.spring-tab-panel code {
+  background: rgba(0, 0, 0, 0.25);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+#tab-1:checked ~ #panel-1,
+#tab-2:checked ~ #panel-2,
+#tab-3:checked ~ #panel-3 {
+  display: block;
+}
+
+@keyframes spring-panel-in {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .spring-tab-label,
+  .spring-tab-indicator,
+  .spring-tab-panel {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+/* Responsive: stack labels on very small screens */
+@media (max-width: 420px) {
+  .spring-tabs {
+    grid-template-columns: 1fr;
+  }
+  .spring-tab-label,
+  .spring-tab-indicator {
+    grid-column: 1;
+  }
+  #tab-1:checked ~ .spring-tab-indicator,
+  #tab-2:checked ~ .spring-tab-indicator,
+  #tab-3:checked ~ .spring-tab-indicator {
+    display: none; /* pill-slide doesn't make sense stacked; rely on checked label color instead */
+  }
+}


### PR DESCRIPTION
## Summary
Adds a pure-CSS "Spring Physics Tabs" example for the Glassmorphism UI pattern.

## What this adds
- New self-contained submission at `submissions/examples/33125-spring-physics-tabs-hebafatima/`
- `demo.html` — standalone demo, opens directly in a browser, no server/CDN/build step required
- `style.css` — raw CSS implementing the tabs and animation
- `README.md` — answers what it does, how to use it, and why it fits EaseMotion

## How it works
- Tab switching is handled entirely with radio inputs + labels + CSS sibling selectors — zero JavaScript
- The active-tab indicator uses a `cubic-bezier(0.34, 1.56, 0.64, 1)` easing curve to create an overshoot-and-settle "spring" feel
- Glassmorphism styling via `backdrop-filter: blur()` + translucent background/border
- Timing, easing, and active-state scale are exposed as CSS custom properties (`--spring-duration`, `--spring-easing`, `--tab-active-scale`)
- Keyboard accessible by default: radio inputs stay in natural tab order and respond to arrow keys + space
- Respects `prefers-reduced-motion`; layout adapts on small screens

## Checklist
- [x] Submission is self-contained inside `submissions/examples/`
- [x] No edits to files in `core/` or `components/`
- [x] No new folders created directly under `submissions/`
- [x] Includes all three required files: `demo.html`, `style.css`, `README.md`
- [x] One PR, one feature/component
- [x] Did not self-merge