### PR TITLE
Bug fix : Adds `@media print` media query optimization to the chip component

### DIFF
--- a/submissions/examples/chip-print-media-bk/README.md
+++ b/submissions/examples/chip-print-media-bk/README.md
@@ -1,0 +1,5 @@
+# Chip Print Media Optimization
+
+1. What does this do? Strips away heavy background colors and box-shadows when printing chip components to save ink and maximize text contrast.
+2. How is it used? Apply `.chip-group` wrapper with `.chip` labels and check print preview (Ctrl+P / Cmd+P).
+3. Why is it useful? Conserves printer ink, ensures maximum readability on paper, and removes unnecessary CSS transitions and box-shadows during print rendering.

--- a/submissions/examples/chip-print-media-bk/chip.css
+++ b/submissions/examples/chip-print-media-bk/chip.css
@@ -1,0 +1,177 @@
+/* ============================================================
+   EaseMotion CSS — chip.css (Print Optimized Submission)
+   Multi-select chip group using CSS checkbox pattern
+   ============================================================ */
+
+/* ── Chip Group Wrapper ─────────────────────────────────────── */
+.ease-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* ── Hide native checkbox ───────────────────────────────────── */
+.ease-chip-group input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── Focus visible state (checkbox:focus-visible + label) ───── */
+.ease-chip-group input[type="checkbox"]:focus-visible + .ease-chip {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+/* ── Base Chip (label) ──────────────────────────────────────── */
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid var(--ease-color-neutral-300, #d1d5db);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-700, #374151);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              border-color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              transform var(--ease-speed-fast, 150ms) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+              box-shadow var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.ease-chip:hover {
+  border-color: var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-neutral-200, #e5e7eb);
+  transform: translateY(-1px);
+}
+
+/* ── Checkmark icon (hidden by default) ────────────────────── */
+.ease-chip::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 14px;
+  overflow: hidden;
+  transition: width var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/* ── Selected state (checkbox:checked + label) ──────────────── */
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+  background: var(--ease-color-primary, #6366f1);
+  border-color: var(--ease-color-primary, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+}
+
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+  content: '✓';
+  width: 14px;
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 14px;
+}
+
+/* ── Disabled state ─────────────────────────────────────────── */
+.ease-chip-group input[type="checkbox"]:disabled + .ease-chip {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ── Size variants ──────────────────────────────────────────── */
+.ease-chip-sm {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+}
+
+.ease-chip-lg {
+  padding: 0.5rem 1.125rem;
+  font-size: 0.9rem;
+}
+
+/* ── Dark Mode ───────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .ease-chip {
+    background: var(--ease-color-neutral-700, #374151);
+    border-color: var(--ease-color-neutral-600, #4b5563);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-chip:hover {
+    background: var(--ease-color-neutral-600, #4b5563);
+    border-color: var(--ease-color-primary, #6366f1);
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+    background: var(--ease-color-primary, #6366f1);
+    border-color: var(--ease-color-primary, #6366f1);
+    color: #ffffff;
+    box-shadow: 0 2px 8px rgba(99, 102, 241, 0.5);
+  }
+}
+
+/* ── Reduced Motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-chip {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
+/* ── Windows High Contrast Mode ──────────────────────────────── */
+@media (forced-colors: active) {
+  .ease-chip {
+    outline: 1px solid CanvasText;
+    outline-offset: 1px;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+    background-color: Highlight;
+    border-color: Highlight;
+    color: HighlightText;
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+    color: HighlightText;
+  }
+}
+
+/* ── Print Styles ────────────────────────────────────────────── */
+@media print {
+  .ease-chip {
+    background: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    border: 1px solid #000 !important;
+    color: #000 !important;
+    transition: none !important;
+    transform: none !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+    background: transparent !important;
+    border: 2px solid #000 !important;
+    color: #000 !important;
+    box-shadow: none !important;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+    color: #000 !important;
+  }
+
+  .ease-chip-group input[type="checkbox"]:disabled + .ease-chip {
+    opacity: 0.5 !important;
+  }
+}

--- a/submissions/examples/chip-print-media-bk/demo.html
+++ b/submissions/examples/chip-print-media-bk/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip Print Media Optimization Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body style="padding: 2rem; font-family: system-ui, sans-serif;">
+  <h1>Chip Print Optimization</h1>
+  <p>Press Ctrl+P / Cmd+P to view print preview with stripped backgrounds and box-shadows.</p>
+
+  <div class="ease-chip-group">
+    <input type="checkbox" id="chip1">
+    <label class="ease-chip" for="chip1">Design</label>
+
+    <input type="checkbox" id="chip2">
+    <label class="ease-chip" for="chip2">Development</label>
+
+    <input type="checkbox" id="chip3" checked>
+    <label class="ease-chip" for="chip3">CSS</label>
+
+    <input type="checkbox" id="chip4">
+    <label class="ease-chip" for="chip4">Animation</label>
+
+    <input type="checkbox" id="chip5" disabled>
+    <label class="ease-chip" for="chip5">Disabled</label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/chip-print-media-bk/style.css
+++ b/submissions/examples/chip-print-media-bk/style.css
@@ -1,0 +1,177 @@
+/* ============================================================
+   EaseMotion CSS — chip.css (Print Optimized Submission)
+   Multi-select chip group using CSS checkbox pattern
+   ============================================================ */
+
+/* ── Chip Group Wrapper ─────────────────────────────────────── */
+.ease-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* ── Hide native checkbox ───────────────────────────────────── */
+.ease-chip-group input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── Focus visible state (checkbox:focus-visible + label) ───── */
+.ease-chip-group input[type="checkbox"]:focus-visible + .ease-chip {
+  outline: 2px solid var(--ease-color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+/* ── Base Chip (label) ──────────────────────────────────────── */
+.ease-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid var(--ease-color-neutral-300, #d1d5db);
+  background: var(--ease-color-neutral-100, #f3f4f6);
+  color: var(--ease-color-neutral-700, #374151);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              border-color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              color var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
+              transform var(--ease-speed-fast, 150ms) var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1)),
+              box-shadow var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.ease-chip:hover {
+  border-color: var(--ease-color-primary, #6366f1);
+  background: var(--ease-color-neutral-200, #e5e7eb);
+  transform: translateY(-1px);
+}
+
+/* ── Checkmark icon (hidden by default) ────────────────────── */
+.ease-chip::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 14px;
+  overflow: hidden;
+  transition: width var(--ease-speed-fast, 150ms) var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+/* ── Selected state (checkbox:checked + label) ──────────────── */
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+  background: var(--ease-color-primary, #6366f1);
+  border-color: var(--ease-color-primary, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+}
+
+.ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+  content: '✓';
+  width: 14px;
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 14px;
+}
+
+/* ── Disabled state ─────────────────────────────────────────── */
+.ease-chip-group input[type="checkbox"]:disabled + .ease-chip {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ── Size variants ──────────────────────────────────────────── */
+.ease-chip-sm {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+}
+
+.ease-chip-lg {
+  padding: 0.5rem 1.125rem;
+  font-size: 0.9rem;
+}
+
+/* ── Dark Mode ───────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .ease-chip {
+    background: var(--ease-color-neutral-700, #374151);
+    border-color: var(--ease-color-neutral-600, #4b5563);
+    color: var(--ease-color-neutral-100, #f3f4f6);
+  }
+
+  .ease-chip:hover {
+    background: var(--ease-color-neutral-600, #4b5563);
+    border-color: var(--ease-color-primary, #6366f1);
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+    background: var(--ease-color-primary, #6366f1);
+    border-color: var(--ease-color-primary, #6366f1);
+    color: #ffffff;
+    box-shadow: 0 2px 8px rgba(99, 102, 241, 0.5);
+  }
+}
+
+/* ── Reduced Motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-chip {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
+/* ── Windows High Contrast Mode ──────────────────────────────── */
+@media (forced-colors: active) {
+  .ease-chip {
+    outline: 1px solid CanvasText;
+    outline-offset: 1px;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+    background-color: Highlight;
+    border-color: Highlight;
+    color: HighlightText;
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+    color: HighlightText;
+  }
+}
+
+/* ── Print Styles ────────────────────────────────────────────── */
+@media print {
+  .ease-chip {
+    background: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    border: 1px solid #000 !important;
+    color: #000 !important;
+    transition: none !important;
+    transform: none !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip {
+    background: transparent !important;
+    border: 2px solid #000 !important;
+    color: #000 !important;
+    box-shadow: none !important;
+  }
+
+  .ease-chip-group input[type="checkbox"]:checked + .ease-chip::before {
+    color: #000 !important;
+  }
+
+  .ease-chip-group input[type="checkbox"]:disabled + .ease-chip {
+    opacity: 0.5 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds `@media print` media query optimization to the chip component (`.ease-chip`). When printing, chip elements automatically strip away ink-heavy background colors, background images, and box-shadows, forcing high-contrast black borders (`#000`) and text (`#000`) to conserve printer ink and maximize text contrast on paper.
---
## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)
---
## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` (e.g., `submissions/examples/chip-print-media-bk/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)
---
## Feature Description
**What does this add?**
Adds `@media print` optimization to the chip component to strip ink-heavy backgrounds and box shadows, forcing high-contrast `#000` text and borders when printing.
**How does a developer use it?**
```html
<div class="ease-chip-group">
  <input type="checkbox" id="chip1" checked />
  <label class="ease-chip" for="chip1">CSS</label>
</div>
Why does it fit EaseMotion CSS?

It completes output-media adaptation alongside existing prefers-reduced-motion and forced-colors media queries, ensuring print output is ink-efficient and easily readable on paper.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge

Notes for Maintainer
The submission is located under submissions/examples/chip-print-media-bk/. When integrating into components/chip.css, append the @media print block inside the @layer easemotion-components wrapper after the @media (forced-colors: active) section.

