### PR TITLE
feat(submission): add ease-blur-entrance-dropdown component (#54619)

### DIFF
--- a/submissions/examples/ease-blur-entrance-dropdown-ksk/README.md
+++ b/submissions/examples/ease-blur-entrance-dropdown-ksk/README.md
@@ -1,0 +1,36 @@
+# Blur-Entrance Dropdown (`ease-blur-entrance-dropdown-ksk`)
+
+1. What does this do?  
+An animated dropdown menu component. Hovering or focusing the trigger container activates a blur-entrance transition where the menu scales, slides, and transitions from a blurred state (`filter: blur(12px) scale(0.95) translateY(8px)`) to high-clarity full scale using a spring bezier curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`).
+
+2. How is it used?  
+Wrap the trigger and the menu inside `.dropdown-wrapper`. No JS is required for display:
+
+```html
+<div class="dropdown-wrapper" tabindex="0">
+  <div class="dropdown-trigger">
+    <span>Dropdown</span>
+  </div>
+  <div class="dropdown-menu">
+    <a href="#" class="dropdown-item">Item 1</a>
+    <a href="#" class="dropdown-item">Item 2</a>
+  </div>
+</div>
+```
+
+Configure parameters using CSS variables:
+```css
+.dropdown-wrapper {
+  --ease-dropdown-duration: 0.35s;
+  --ease-dropdown-easing:   cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-dropdown-blur:     12px;          /* initial blur offset */
+  --ease-dropdown-scale:    0.95;          /* starting scale factor */
+  --ease-dropdown-offset:   8px;           /* starting vertical offset */
+}
+```
+
+3. Why is it useful?  
+Standard menus open abruptly. This enhancement animates the card upward and resolves blur focus organic transitions while remaining lightweight, fully keyboard focusable, prefers-reduced-motion compatible, and supports both Light and Dark theme modes.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #54619.*

--- a/submissions/examples/ease-blur-entrance-dropdown-ksk/demo.html
+++ b/submissions/examples/ease-blur-entrance-dropdown-ksk/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blur-Entrance Dropdown Demo — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <!-- Main Showcase Container -->
+  <div class="demo-page" id="app-root">
+
+    <div class="demo-card">
+      <h1 class="demo-title">Blur-Entrance Dropdown</h1>
+      <p class="demo-desc">
+        Hover or focus on the dropdown trigger below to reveal the menu options. The menu enters with a blur-entrance transition.
+      </p>
+
+      <div style="display:flex;gap:12px;justify-content:center;align-items:center;margin-bottom:24px;">
+        
+        <!-- Dropdown Component -->
+        <div class="dropdown-wrapper" tabindex="0">
+          <div class="dropdown-trigger">
+            <span>Filter Projects</span>
+            <svg class="dropdown-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </div>
+          
+          <div class="dropdown-menu" role="menu">
+            <a href="#" class="dropdown-item" role="menuitem">Web Art Designs</a>
+            <a href="#" class="dropdown-item" role="menuitem">3D Renderings</a>
+            <a href="#" class="dropdown-item" role="menuitem">UI/UX Prototypes</a>
+            <button class="dropdown-item" role="menuitem" style="color:var(--ease-dropdown-accent);">Reset Filters</button>
+          </div>
+        </div>
+
+      </div>
+
+      <button class="demo-btn" id="themeBtn" style="background:rgba(255,255,255,0.06);color:inherit;border:1px solid var(--ease-dropdown-border);">
+        Toggle Theme
+      </button>
+    </div>
+
+  </div>
+
+  <script>
+    // Theme toggle helper
+    const themeBtn = document.getElementById('themeBtn');
+    const appRoot = document.getElementById('app-root');
+    themeBtn.addEventListener('click', () => {
+      appRoot.classList.toggle('light-theme');
+      document.querySelector('.dropdown-wrapper').classList.toggle('light-theme');
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-blur-entrance-dropdown-ksk/style.css
+++ b/submissions/examples/ease-blur-entrance-dropdown-ksk/style.css
@@ -1,0 +1,199 @@
+/* ============================================================
+   EaseMotion CSS — Blur-Entrance Dropdown (Creative Portfolio)
+   submissions/examples/ease-blur-entrance-dropdown-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .dropdown-wrapper or any ancestor.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-dropdown-duration: 0.35s;         /* transition speed             */
+  --ease-dropdown-easing:   cubic-bezier(0.34, 1.56, 0.64, 1); /* spring   */
+  --ease-dropdown-blur:     12px;          /* entrance blur amount         */
+  --ease-dropdown-scale:    0.95;          /* starting scale ratio         */
+  --ease-dropdown-offset:   8px;           /* starting vertical offset     */
+  --ease-dropdown-bg:       #0f111a;
+  --ease-dropdown-surface:  #161929;
+  --ease-dropdown-border:   rgba(255, 255, 255, 0.08);
+  --ease-dropdown-color:    #f8fafc;
+  --ease-dropdown-accent:   #f43f5e;
+  --ease-dropdown-radius:   12px;
+}
+
+/* Light Theme Overrides */
+.light-theme {
+  --ease-dropdown-bg:       #f8fafc;
+  --ease-dropdown-surface:  #ffffff;
+  --ease-dropdown-border:   rgba(15, 23, 42, 0.08);
+  --ease-dropdown-color:    #0f172a;
+  --ease-dropdown-accent:   #e11d48;
+}
+
+/* ── Dropdown Wrapper & Trigger ──────────────────────────── */
+.dropdown-wrapper {
+  position: relative;
+  display: inline-block;
+  outline: none;
+}
+
+.dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 99px;
+  background: var(--ease-dropdown-surface);
+  border: 1px solid var(--ease-dropdown-border);
+  color: var(--ease-dropdown-color);
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.25s ease, background 0.25s ease;
+}
+
+.dropdown-trigger:hover,
+.dropdown-trigger:focus {
+  border-color: var(--ease-dropdown-accent);
+}
+
+.dropdown-chevron {
+  width: 12px;
+  height: 12px;
+  transition: transform var(--ease-dropdown-duration) var(--ease-dropdown-easing);
+}
+
+/* ── Dropdown Menu (Blur-Entrance state) ────────────────── */
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 200px;
+  background: var(--ease-dropdown-surface);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.35);
+  padding: 8px;
+  box-sizing: border-box;
+  z-index: 100;
+  
+  /* Initial collapsed state (shifted down + blurred + scaled down) */
+  opacity: 0;
+  filter: blur(var(--ease-dropdown-blur));
+  transform: translateY(var(--ease-dropdown-offset)) scale(var(--ease-dropdown-scale));
+  pointer-events: none;
+  
+  transition:
+    opacity var(--ease-dropdown-duration) ease,
+    filter var(--ease-dropdown-duration) ease,
+    transform var(--ease-dropdown-duration) var(--ease-dropdown-easing);
+}
+
+/* Trigger Reveal on Hover & Focus-within */
+.dropdown-wrapper:hover .dropdown-menu,
+.dropdown-wrapper:focus-within .dropdown-menu {
+  opacity: 1;
+  filter: blur(0);
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.dropdown-wrapper:hover .dropdown-chevron,
+.dropdown-wrapper:focus-within .dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+/* Dropdown Menu Items */
+.dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 8px;
+  color: var(--ease-dropdown-color);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  box-sizing: border-box;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.dropdown-item:hover,
+.dropdown-item:focus {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--ease-dropdown-accent);
+}
+
+.light-theme .dropdown-item:hover,
+.light-theme .dropdown-item:focus {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+/* ── prefers-reduced-motion Support ─────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .dropdown-menu, .dropdown-chevron {
+    transition: opacity var(--ease-dropdown-duration) ease !important;
+    transform: none !important;
+    filter: none !important;
+  }
+}
+
+/* ── Demo Page Styles ───────────────────────────────────── */
+.demo-page {
+  min-height: 100vh;
+  background: var(--ease-dropdown-bg);
+  color: var(--ease-dropdown-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  box-sizing: border-box;
+  font-family: system-ui, -apple-system, sans-serif;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 480px;
+  background: var(--ease-dropdown-surface);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: 16px;
+  padding: 32px;
+  text-align: center;
+  box-shadow: 0 12px 28px rgba(0,0,0,0.2);
+}
+
+.demo-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin: 0 0 10px;
+}
+
+.demo-desc {
+  font-size: 0.86rem;
+  color: #64748b;
+  margin: 0 0 24px;
+  line-height: 1.5;
+}
+
+.demo-btn {
+  display: inline-block;
+  padding: 10px 20px;
+  border-radius: 10px;
+  background: var(--ease-dropdown-accent);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease;
+}
+
+.demo-btn:hover {
+  transform: translateY(-1px);
+}


### PR DESCRIPTION
Closes #54619

Adds an interactive Blur-Entrance Dropdown component under `submissions/examples/ease-blur-entrance-dropdown-ksk/`.

#### Key Features & Requirements Met

1. **Blur-Entrance Transition** — The dropdown menu transitions in from a shifted down, blurred, and scaled-down state (`transform: translateY(8px) scale(0.95); filter: blur(12px); opacity: 0`) to clear and full scale using spring-like easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`).
2. **Interactive Caret Chevron** — Includes a vector chevron icon that rotates 180° upon trigger activation (on hover or focus).
3. **prefers-reduced-motion Support** — Disables spatial and filter transforms under the `prefers-reduced-motion: reduce` query, safely defaulting to a clean opacity transition.
4. **Light & Dark Theme Support** — Built-in CSS variables for dark slate menus and light high-contrast themes (`.light-theme`).
5. **No JavaScript** — Operates 100% in pure HTML and CSS utilizing standard hover and focus-within state selectors.

#### File Breakdown
| File | Description |
|------|-------------|
| `style.css` | Dropdown coordinates, chevron rotation, blur transitions, and reduced-motion overrides |
| `demo.html` | Interactive card template with dropdown list elements, theme switcher, and focus states |
| `README.md` | Usage guide, HTML snippet, and CSS variables reference table, resolving `#54619` |