### PR TITLE
Integrate useEaseMotion hook with components in motion engine

### DIFF
--- a/submissions/react/react-use-ease-motion-adrish/AnimatedCard.jsx
+++ b/submissions/react/react-use-ease-motion-adrish/AnimatedCard.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useEaseMotion } from './useEaseMotion';
+
+/**
+ * AnimatedCard — demo consumer of useEaseMotion().
+ * Any `em=""`-valid token string works here (same grammar the DSL
+ * already documents), including engine plugins like the em-scroll
+ * attribute from the scroll-trigger plugin, once that's merged too.
+ */
+export default function AnimatedCard({
+  title,
+  children,
+  tokens = 'fade-in 500ms ease-out',
+}) {
+  const ref = useEaseMotion(tokens);
+
+  return (
+    <div ref={ref} className="ease-card ease-card-hover">
+      <div className="ease-card-header">
+        <h3 className="ease-card-title">{title}</h3>
+      </div>
+      <div className="ease-card-body">{children}</div>
+    </div>
+  );
+}

--- a/submissions/react/react-use-ease-motion-adrish/README.md
+++ b/submissions/react/react-use-ease-motion-adrish/README.md
@@ -6,7 +6,7 @@ Motion Engine `em=""` DSL, instead of hand-writing `useEffect` +
 animation.
 
 > Submission track: `submissions/react/react-use-ease-motion-adrish/`
-> Resolves: #<issue-number>
+> Resolves: #<55062>
 
 ---
 

--- a/submissions/react/react-use-ease-motion-adrish/README.md
+++ b/submissions/react/react-use-ease-motion-adrish/README.md
@@ -1,0 +1,110 @@
+# useEaseMotion — React Hook for the Motion Engine
+
+A reusable React hook that wires any DOM node into EaseMotion CSS's
+Motion Engine `em=""` DSL, instead of hand-writing `useEffect` +
+`setAttribute` boilerplate in every component that wants engine-driven
+animation.
+
+> Submission track: `submissions/react/react-use-ease-motion-adrish/`
+> Resolves: #<issue-number>
+
+---
+
+## What does this do?
+
+`useEaseMotion(tokens)` returns a ref. Attach it to any element and the
+element gets the real `em=""` attribute set — the engine's own
+`runtime.js` (already running its `MutationObserver` on `attributeFilter:
+['em']`) picks up the change and compiles/applies the animation exactly
+like it would for a hand-written `<div em="...">`. No engine internals
+are touched by this hook; it's purely a React-lifecycle-to-attribute
+bridge.
+
+## How is it used?
+
+```jsx
+import { useEaseMotion } from './useEaseMotion';
+
+function Banner() {
+  const ref = useEaseMotion('slide-in-from-bottom 600ms ease-out');
+  return <div ref={ref} className="ease-card">Hello</div>;
+}
+```
+
+`AnimatedCard.jsx` in this submission is a working demo consumer:
+
+```jsx
+import AnimatedCard from './AnimatedCard';
+
+<AnimatedCard title="Real-time sync" tokens="fade-in 400ms ease-out">
+  Your changes save automatically.
+</AnimatedCard>
+```
+
+## Props / API reference
+
+### `useEaseMotion(tokens, deps?)`
+
+| Param | Type | Description |
+|---|---|---|
+| `tokens` | `string` | Any valid `em=""` token string (e.g. `"fade-in 500ms ease-out delay-200ms"`) |
+| `deps` | `any[]` (optional) | Effect dependency array — defaults to `[tokens]`, re-applies the attribute whenever the token string changes |
+
+Returns a `RefObject` — attach it to the DOM node you want animated.
+
+### `<AnimatedCard />` (demo component)
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `title` | `string` | — | Card heading |
+| `children` | `ReactNode` | — | Card body content |
+| `tokens` | `string` | `"fade-in 500ms ease-out"` | Passed straight through to `useEaseMotion` |
+
+## How is this different from existing hook proposals?
+
+Two prior issues cover adjacent but distinct ground:
+
+- **#34686 (`useEaseReveal`, merged via #34987)** wraps the existing
+  vanilla `ease-scroll-reveal` + `reveal.js` utility for scroll-gated
+  reveals specifically. `useEaseMotion` wraps the separate `em=""`
+  Motion Engine DSL instead, for any animation (mount-time or
+  otherwise) — not scroll-gated, and not built on `IntersectionObserver`.
+- **#43920 (`useMotionOrchestrator`)** uses the native Web Animations
+  API (`element.animate()`) directly to orchestrate staggered
+  sequences across multiple elements. `useEaseMotion` doesn't use
+  WAAPI at all and isn't a stagger/orchestration tool — it's a
+  single-element bridge into the engine's existing attribute-driven
+  compile pipeline.
+
+No existing hook wraps the `em=""` engine DSL itself.
+
+## Why is this useful?
+
+- VISION.md lists "Framework integrations (React, Vue, Astro)" as an
+  unshipped long-term goal. This is the React half of that, built the
+  lowest-risk way possible.
+- 619 existing submissions in `submissions/react/` use EaseMotion's
+  static `ease-*` classNames, but none of them wire a component into
+  the actual Motion Engine DSL — every animated React usage today means
+  re-deriving this same `useEffect`/`setAttribute` pattern by hand.
+  This makes it a one-line reusable primitive instead.
+- **Zero changes to `parser.js`, `compiler.js`, or `runtime.js`** —
+  same low-risk shape as the already-merged scroll-trigger plugin: ride
+  the existing attribute-mutation observer, don't add a second code
+  path.
+- Self-contained — no edits to `core/`, `components/`, or engine files,
+  compliant with the current submissions-only freeze.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `useEaseMotion.js` | The reusable hook |
+| `AnimatedCard.jsx` | Demo component consuming the hook, using real `ease-card` classes |
+| `README.md` | This document |
+
+## Compliance notes
+
+- Only new files inside `submissions/react/react-use-ease-motion-adrish/`.
+- No edits to `core/`, `components/`, `parser.js`, `compiler.js`,
+  `runtime.js`, or any config/workflow file.

--- a/submissions/react/react-use-ease-motion-adrish/README.md
+++ b/submissions/react/react-use-ease-motion-adrish/README.md
@@ -6,7 +6,7 @@ Motion Engine `em=""` DSL, instead of hand-writing `useEffect` +
 animation.
 
 > Submission track: `submissions/react/react-use-ease-motion-adrish/`
-> Resolves: #<55062>
+> Resolves: #55062
 
 ---
 

--- a/submissions/react/react-use-ease-motion-adrish/README.md
+++ b/submissions/react/react-use-ease-motion-adrish/README.md
@@ -102,6 +102,7 @@ No existing hook wraps the `em=""` engine DSL itself.
 | `useEaseMotion.js` | The reusable hook |
 | `AnimatedCard.jsx` | Demo component consuming the hook, using real `ease-card` classes |
 | `README.md` | This document |
+| `demo.html` | Self-contained browser demo (CDN React + Babel, no build step) |
 
 ## Compliance notes
 

--- a/submissions/react/react-use-ease-motion-adrish/demo.html
+++ b/submissions/react/react-use-ease-motion-adrish/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>useEaseMotion — Demo</title>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #0d1117;
+    color: #e6edf3;
+    margin: 0;
+    padding: 40px;
+  }
+  h1 {
+    font-size: 20px;
+    margin-bottom: 4px;
+  }
+  p.sub {
+    color: #8b949e;
+    margin-top: 0;
+    margin-bottom: 32px;
+  }
+  .grid {
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+  .ease-card {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 10px;
+    padding: 20px;
+    width: 260px;
+  }
+  .ease-card h3 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+  }
+  .ease-card p {
+    margin: 0;
+    color: #c9d1d9;
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .note {
+    margin-top: 32px;
+    font-size: 13px;
+    color: #8b949e;
+    max-width: 640px;
+  }
+  code {
+    background: #21262d;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+</style>
+</head>
+<body>
+
+<h1>useEaseMotion — Demo</h1>
+<p class="sub">
+  Two &lt;AnimatedCard /&gt; instances, each driven by <code>useEaseMotion(tokens)</code>.
+  Open devtools and inspect either card's DOM node — you'll see the real
+  <code>em="..."</code> attribute set on mount, which is what the engine's
+  <code>runtime.js</code> MutationObserver picks up in the full EaseMotion CSS build.
+</p>
+
+<div id="root" class="grid"></div>
+
+<p class="note">
+  This page has no server dependency and no build step — it loads React, ReactDOM,
+  and Babel standalone from a CDN and compiles the JSX below in-browser. It is
+  intentionally NOT wired to the full EaseMotion engine bundle (parser.js /
+  compiler.js / runtime.js), since this submission adds no engine files; the point
+  of this demo is only to show the hook correctly setting the <code>em</code>
+  attribute on the DOM node it's attached to, which you can verify by inspecting
+  the elements above.
+</p>
+
+<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+<script type="text/babel">
+  const { useEffect, useRef } = React;
+
+  // useEaseMotion(tokens, deps?) -> ref
+  // Sets the real em="" attribute on the attached DOM node. In the full
+  // EaseMotion CSS repo, runtime.js's MutationObserver (attributeFilter: ['em'])
+  // picks this up and compiles/applies it. This hook does not touch engine
+  // internals — it is purely a React-lifecycle-to-attribute bridge.
+  function useEaseMotion(tokens, deps = [tokens]) {
+    const ref = useRef(null);
+    useEffect(() => {
+      if (ref.current) {
+        ref.current.setAttribute('em', tokens);
+      }
+    }, deps);
+    return ref;
+  }
+
+  function AnimatedCard({ title, children, tokens = 'fade-in 500ms ease-out' }) {
+    const ref = useEaseMotion(tokens);
+    return (
+      <div ref={ref} className="ease-card">
+        <h3>{title}</h3>
+        <p>{children}</p>
+      </div>
+    );
+  }
+
+  function Demo() {
+    return (
+      <React.Fragment>
+        <AnimatedCard title="Real-time sync" tokens="fade-in 400ms ease-out">
+          Your changes save automatically.
+        </AnimatedCard>
+        <AnimatedCard title="Slide-in banner" tokens="slide-in-from-bottom 600ms ease-out">
+          Wired via useEaseMotion — inspect the em attribute in devtools.
+        </AnimatedCard>
+      </React.Fragment>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(<Demo />);
+</script>
+
+</body>
+</html>

--- a/submissions/react/react-use-ease-motion-adrish/useEaseMotion.js
+++ b/submissions/react/react-use-ease-motion-adrish/useEaseMotion.js
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * useEaseMotion(tokens, deps)
+ * -----------------------------------------------------------------
+ * Wires a DOM ref into EaseMotion CSS's Motion Engine `em=""` DSL
+ * directly from React — no dangerouslySetInnerHTML, no manual
+ * classList management, no re-implementation of the engine.
+ *
+ * How it works: easemotion/engine/runtime.js already runs a
+ * MutationObserver (attributeFilter: ['em']) against the whole
+ * document as soon as the engine is imported. This hook's only job
+ * is to set/update/remove the `em` attribute on the ref'd element at
+ * the right point in the React lifecycle — the existing runtime
+ * observer picks up the change itself and does the real parse +
+ * compile + class-injection work. No calls into parser.js,
+ * compiler.js, or runtime.js internals from this hook.
+ *
+ * @param {string} tokens - an em="" token string, e.g. "fade-in 500ms ease-out"
+ * @param {any[]} deps - effect dependency array (defaults to re-running only if tokens changes)
+ * @returns {React.RefObject} attach to the element you want animated
+ */
+export function useEaseMotion(tokens, deps = [tokens]) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !tokens) return undefined;
+
+    el.setAttribute('em', tokens);
+
+    return () => {
+      el.removeAttribute('em');
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return ref;
+}
+
+export default useEaseMotion;


### PR DESCRIPTION
## Pull Request Description
Adds `useEaseMotion`, a React hook that wires a DOM ref into the existing `em=""` Motion Engine DSL — replacing the hand-rolled `useEffect` + `setAttribute` boilerplate every React consumer currently has to write for engine-driven animation. Includes a working demo component (`AnimatedCard.jsx`), a browser-openable `demo.html` (CDN React + Babel standalone, no build step), and no new CSS.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` (`submissions/react/react-use-ease-motion-adrish/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature *(N/A — this hook adds no new CSS; it only sets the `em` attribute that the engine's existing `runtime.js` observer already watches for)*
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A `useEaseMotion(tokens)` React hook that returns a ref you attach to any element to drive it through the engine's `em=""` DSL.

**How does a developer use it?**
```jsx
import { useEaseMotion } from './useEaseMotion';

function Banner() {
  const ref = useEaseMotion('slide-in-from-bottom 600ms ease-out');
  return <div ref={ref} className="ease-card">Hello</div>;
}
```

**Why does it fit EaseMotion CSS?**
`VISION.md` lists React/Vue/Astro framework integrations as an unshipped goal — this is the React half of that. It's a zero-risk, attribute-only bridge: no changes to `parser.js`, `compiler.js`, or `runtime.js`, and it rides the same `MutationObserver` (`attributeFilter: ['em']`) the engine already runs, rather than adding a second code path. 619 existing `submissions/react/` entries use static `ease-*` classNames only; none wire a component into the actual Motion Engine DSL, so every animated React usage today means re-deriving this same boilerplate by hand.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
No new CSS ships with this PR — the hook only sets the existing `em=""` attribute your `runtime.js` observer already watches for, so `style.css` doesn't apply here (noted in the checklist above rather than glossed over). `demo.html` is self-contained (CDN React + Babel standalone) and demonstrates the hook setting the `em` attribute on mount; it's intentionally not wired to the full engine bundle since this submission doesn't touch engine internals. Differentiated in the README against two adjacent prior hooks: #34686 (`useEaseReveal`, scroll-gated, merged) and #43920 (`useMotionOrchestrator`, WAAPI stagger) — neither wraps the `em=""` DSL itself.

Resolves #55062 .

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.