### PR TITLE
feat: add draw-border line tabs for neumorphic soft layouts

### DIFF
--- a/submissions/examples/draw-border-line-tabs-neumorphic-soft-sd/README.md
+++ b/submissions/examples/draw-border-line-tabs-neumorphic-soft-sd/README.md
@@ -1,0 +1,48 @@
+# CSS Draw-Border Line Tabs - Neumorphic Soft
+
+### 1. What does this do?
+
+This is a pure CSS horizontal tab component styled with a soft neumorphic appearance. When switching between tabs, the active tab transitions to a raised neumorphic elevation while a smooth draw-border line animation plays on the underline indicator.
+
+### 2. How is it used?
+
+Include `style.css` in your project. Structure the tabs using standard `<input type="radio">` states, labels, and panels under the `.draw-border-line-tabs` class:
+
+```html
+<div class="draw-border-line-tabs">
+  <input type="radio" id="tab-1" name="neumorphic-tabs" class="tab-input" checked>
+  <input type="radio" id="tab-2" name="neumorphic-tabs" class="tab-input">
+  <input type="radio" id="tab-3" name="neumorphic-tabs" class="tab-input">
+
+  <div class="tabs-header">
+    <label for="tab-1" class="tab-label">General</label>
+    <label for="tab-2" class="tab-label">Settings</label>
+    <label for="tab-3" class="tab-label">Status</label>
+  </div>
+
+  <div class="tab-panels">
+    <div class="tab-panel" id="panel-1">...</div>
+    <div class="tab-panel" id="panel-2">...</div>
+    <div class="tab-panel" id="panel-3">...</div>
+  </div>
+</div>
+```
+
+Configure style overrides directly on the container via custom CSS variables:
+
+```css
+.draw-border-line-tabs {
+  --tabs-duration: 0.3s;
+  --tabs-easing: ease;
+  --tabs-line-color: #3b82f6;
+  --tabs-line-thickness: 3px;
+  --tabs-scale: 1;
+}
+```
+
+### 3. Why is it useful?
+
+- **Zero JavaScript Overhead:** Runs purely on high-performance CSS logic.
+- **Fluid & Responsive:** The header track and labels adjust automatically to all viewports.
+- **Soft Neumorphic Styling:** Delivers a modern soft-UI appearance with customizable shadow/accent overrides.
+- **Accessible-First:** Navigable via keyboard arrow keys (standard radio behavior), has distinct focus-visible states, and respects motion reduction preferences.

--- a/submissions/examples/draw-border-line-tabs-neumorphic-soft-sd/demo.html
+++ b/submissions/examples/draw-border-line-tabs-neumorphic-soft-sd/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Draw-Border Line Tabs - Neumorphic Soft</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 20px;
+      background-color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+    }
+    .demo-container {
+      width: 100%;
+      max-width: 480px;
+    }
+    .panel-content {
+      color: #4b5563;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-container">
+    <div class="draw-border-line-tabs">
+      <input type="radio" id="tab-1" name="neumorphic-tabs" class="tab-input" checked>
+      <input type="radio" id="tab-2" name="neumorphic-tabs" class="tab-input">
+      <input type="radio" id="tab-3" name="neumorphic-tabs" class="tab-input">
+
+      <div class="tabs-header">
+        <label for="tab-1" class="tab-label">General</label>
+        <label for="tab-2" class="tab-label">Settings</label>
+        <label for="tab-3" class="tab-label">Status</label>
+      </div>
+
+      <div class="tab-panels">
+        <div class="tab-panel" id="panel-1">
+          <div class="panel-content">General tab display active. System configuration loaded.</div>
+        </div>
+        <div class="tab-panel" id="panel-2">
+          <div class="panel-content">Customize animation options via local CSS custom variables.</div>
+        </div>
+        <div class="tab-panel" id="panel-3">
+          <div class="panel-content">Neumorphic component functioning correctly with pure CSS.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/draw-border-line-tabs-neumorphic-soft-sd/style.css
+++ b/submissions/examples/draw-border-line-tabs-neumorphic-soft-sd/style.css
@@ -1,0 +1,151 @@
+/* CSS Draw-Border Line Tabs - Neumorphic Soft Layout */
+
+.draw-border-line-tabs {
+  /* Expose Custom Properties for Customization */
+  --tabs-duration: 0.3s;
+  --tabs-easing: ease;
+  --tabs-line-color: #3b82f6;
+  --tabs-line-thickness: 3px;
+  --tabs-scale: 1;
+
+  /* Theme Defaults */
+  --tabs-bg: #e0e0e0;
+  --tabs-shadow-dark: #bebebe;
+  --tabs-shadow-light: #ffffff;
+  --tabs-text-color: #64748b;
+  --tabs-text-active: #1e293b;
+
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+/* Scoped selector to avoid global resets */
+.draw-border-line-tabs *,
+.draw-border-line-tabs *::before,
+.draw-border-line-tabs *::after {
+  box-sizing: border-box;
+}
+
+/* Accessibly Hide Radio Inputs */
+.draw-border-line-tabs .tab-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Inset Neumorphic Track */
+.draw-border-line-tabs .tabs-header {
+  display: flex;
+  gap: 16px;
+  position: relative;
+  padding: 8px;
+  background-color: var(--tabs-bg);
+  border-radius: 12px;
+  box-shadow: inset 4px 4px 8px var(--tabs-shadow-dark), inset -4px -4px 8px var(--tabs-shadow-light);
+}
+
+/* Tab Labels */
+.draw-border-line-tabs .tab-label {
+  position: relative;
+  flex: 1;
+  text-align: center;
+  padding: 12px 8px;
+  font-family: sans-serif;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--tabs-text-color);
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color var(--tabs-duration) var(--tabs-easing),
+              box-shadow var(--tabs-duration) var(--tabs-easing);
+  user-select: none;
+}
+
+/* Smooth Draw-Border Line indicator under active label text */
+.draw-border-line-tabs .tab-label::after {
+  content: "";
+  position: absolute;
+  bottom: 4px;
+  left: 20%;
+  width: 60%;
+  height: var(--tabs-line-thickness);
+  background-color: var(--tabs-line-color);
+  border-radius: var(--tabs-line-thickness);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform var(--tabs-duration) var(--tabs-easing);
+}
+
+/* Active State Outset Neumorphic Shadow & Text Color */
+.draw-border-line-tabs #tab-1:checked ~ .tabs-header label[for="tab-1"],
+.draw-border-line-tabs #tab-2:checked ~ .tabs-header label[for="tab-2"],
+.draw-border-line-tabs #tab-3:checked ~ .tabs-header label[for="tab-3"] {
+  color: var(--tabs-text-active);
+  box-shadow: 4px 4px 8px var(--tabs-shadow-dark), -4px -4px 8px var(--tabs-shadow-light);
+}
+
+/* Active Draw-Border Animation Trigger */
+.draw-border-line-tabs #tab-1:checked ~ .tabs-header label[for="tab-1"]::after,
+.draw-border-line-tabs #tab-2:checked ~ .tabs-header label[for="tab-2"]::after,
+.draw-border-line-tabs #tab-3:checked ~ .tabs-header label[for="tab-3"]::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+/* Focus Indicator for Keyboard Navigability */
+.draw-border-line-tabs #tab-1:focus-visible ~ .tabs-header label[for="tab-1"],
+.draw-border-line-tabs #tab-2:focus-visible ~ .tabs-header label[for="tab-2"],
+.draw-border-line-tabs #tab-3:focus-visible ~ .tabs-header label[for="tab-3"] {
+  outline: 2px solid var(--tabs-line-color);
+  outline-offset: 2px;
+}
+
+/* Tab Panels styling */
+.draw-border-line-tabs .tab-panels {
+  margin-top: 24px;
+}
+
+.draw-border-line-tabs .tab-panel {
+  display: none;
+  padding: 24px;
+  background-color: var(--tabs-bg);
+  border-radius: 12px;
+  box-shadow: 4px 4px 8px var(--tabs-shadow-dark), -4px -4px 8px var(--tabs-shadow-light);
+}
+
+/* Panel Entrance Toggle */
+.draw-border-line-tabs #tab-1:checked ~ .tab-panels #panel-1,
+.draw-border-line-tabs #tab-2:checked ~ .tab-panels #panel-2,
+.draw-border-line-tabs #tab-3:checked ~ .tab-panels #panel-3 {
+  display: block;
+  animation: panelEntrance var(--tabs-duration) var(--tabs-easing) forwards;
+}
+
+@keyframes panelEntrance {
+  from {
+    opacity: 0;
+    transform: scale(calc(var(--tabs-scale) * 0.98));
+  }
+  to {
+    opacity: 1;
+    transform: scale(var(--tabs-scale));
+  }
+}
+
+/* Accessibility: Respect motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .draw-border-line-tabs .tab-label::after {
+    transition: none !important;
+  }
+  .draw-border-line-tabs #tab-1:checked ~ .tab-panels #panel-1,
+  .draw-border-line-tabs #tab-2:checked ~ .tab-panels #panel-2,
+  .draw-border-line-tabs #tab-3:checked ~ .tab-panels #panel-3 {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS tabs component featuring a smooth draw-border line interaction styled for neumorphic soft interfaces. The component is responsive, keyboard accessible, and customizable through CSS custom properties without requiring JavaScript.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS tabs component with an animated draw-border line indicator and soft neumorphic styling.

**How does a developer use it?**

```html
<div class="draw-border-line-tabs">
  <!-- tabs -->
</div>
```

**Why does it fit EaseMotion CSS?**

It provides a lightweight animated navigation pattern that is reusable, customizable, and works without JavaScript.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari _(optional but appreciated)_

---

## Notes for Maintainer

- Uses native radio inputs and CSS selectors.
- Implements a simple draw-border line transition.
- Styled with a soft neumorphic appearance.
- Fully responsive and keyboard accessible.
- Customizable through CSS variables.

Closes #50385
