### PR TITLE
Fix browser runtime crash when process is undefined

### DIFF
--- a/easemotion/engine/runtime.js
+++ b/easemotion/engine/runtime.js
@@ -52,9 +52,14 @@ function processElement(el) {
 
   const ast = parse(value);
   if (!ast) {
-    if (process?.env?.NODE_ENV !== 'production') {
-      console.warn(`[EaseMotion Engine] Could not parse em="${value}". Unknown animation name.`);
-    }
+    if(
+  typeof process !== 'undefined' &&
+  process.env?.NODE_ENV !== 'production'
+) {
+  console.warn(
+    `[EaseMotion Engine] Could not parse em="${value}". Unknown animation name.`
+  );
+}
     return;
   }
 


### PR DESCRIPTION
## Pull Request Description

This PR addresses issue #52722, where the browser runtime could throw a `ReferenceError: process is not defined` while parsing invalid `em` attributes in environments where `process` is unavailable.

## Changes

- Updated `easemotion/engine/runtime.js`.
- Added a safe `typeof process !== 'undefined'` check before accessing `process.env.NODE_ENV`.
- Preserved the existing development-only warning behavior.

---

## Testing

- Ran the existing test suite successfully  using `npm test`.
- All 61 tests passed.

Fixes #52722





