### PR TITLE
feat: add floating stacked toast notification demo

### DIFF
--- a/submissions/examples/floating-stacked-toast-ag/README.md
+++ b/submissions/examples/floating-stacked-toast-ag/README.md
@@ -1,0 +1,26 @@
+# Floating stacked toast notifications
+
+## What does this do?
+
+This submission provides a CSS-only stacked toast notification demo that expands from a compact deck into readable individual notifications on hover or keyboard focus.
+
+## How is it used?
+
+Place the toast cards inside a `toast-stack-ag` container and use `toast-card-ag` for each notification:
+
+```html
+<section class="toast-stack-ag" aria-label="Notifications" aria-live="polite">
+  <article class="toast-card-ag toast-card-success-ag">
+    <span class="toast-icon-ag" aria-hidden="true">✓</span>
+    <div class="toast-copy-ag">
+      <h2>Changes saved</h2>
+      <p>Your profile settings have been updated.</p>
+    </div>
+    <button class="toast-dismiss-ag" type="button" aria-label="Dismiss notification">×</button>
+  </article>
+</section>
+```
+
+## Why is it useful?
+
+The stacked layout keeps multiple notifications unobtrusive while still making them easy to inspect. It uses semantic notification cards, labelled dismiss buttons, keyboard-triggered expansion through `:focus-within`, and a reduced-motion fallback for a polished, accessible interface.

--- a/submissions/examples/floating-stacked-toast-ag/demo.html
+++ b/submissions/examples/floating-stacked-toast-ag/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Floating stacked toast notifications</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="toast-demo-ag">
+      <section class="toast-stack-ag" aria-label="Notifications" aria-live="polite">
+        <article class="toast-card-ag toast-card-success-ag">
+          <span class="toast-icon-ag" aria-hidden="true">✓</span>
+          <div class="toast-copy-ag">
+            <h2>Changes saved</h2>
+            <p>Your profile settings have been updated.</p>
+          </div>
+          <button class="toast-dismiss-ag" type="button" aria-label="Dismiss Changes saved notification">×</button>
+        </article>
+
+        <article class="toast-card-ag toast-card-info-ag">
+          <span class="toast-icon-ag" aria-hidden="true">i</span>
+          <div class="toast-copy-ag">
+            <h2>New update available</h2>
+            <p>Refresh when you are ready to see what changed.</p>
+          </div>
+          <button class="toast-dismiss-ag" type="button" aria-label="Dismiss New update available notification">×</button>
+        </article>
+
+        <article class="toast-card-ag toast-card-warning-ag">
+          <span class="toast-icon-ag" aria-hidden="true">!</span>
+          <div class="toast-copy-ag">
+            <h2>Storage nearly full</h2>
+            <p>Free some space to keep uploads running smoothly.</p>
+          </div>
+          <button class="toast-dismiss-ag" type="button" aria-label="Dismiss Storage nearly full notification">×</button>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/floating-stacked-toast-ag/style.css
+++ b/submissions/examples/floating-stacked-toast-ag/style.css
@@ -1,0 +1,148 @@
+:root {
+  color: #172033;
+  background: #eef3ff;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.toast-demo-ag {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: end;
+  background:
+    radial-gradient(circle at 78% 18%, #d9e7ff 0, transparent 30rem),
+    linear-gradient(135deg, #f7f9ff, #e9efff);
+}
+
+.toast-stack-ag {
+  display: grid;
+  width: min(100%, 25rem);
+  perspective: 60rem;
+}
+
+.toast-card-ag {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.8rem;
+  align-items: center;
+  grid-area: 1 / 1;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgb(255 255 255 / 80%);
+  border-radius: 1rem;
+  background: rgb(255 255 255 / 92%);
+  box-shadow: 0 1.25rem 3rem rgb(37 62 120 / 18%);
+  backdrop-filter: blur(0.8rem);
+  transform-origin: center bottom;
+  transition: transform 260ms cubic-bezier(.2, .8, .2, 1), opacity 260ms ease;
+  animation: toast-arrive-ag 550ms cubic-bezier(.16, 1, .3, 1) both;
+}
+
+.toast-card-ag:nth-child(1) {
+  z-index: 3;
+  animation-delay: 80ms;
+}
+
+.toast-card-ag:nth-child(2) {
+  z-index: 2;
+  animation-delay: 160ms;
+  transform: translateY(-0.55rem) scale(.96);
+}
+
+.toast-card-ag:nth-child(3) {
+  z-index: 1;
+  animation-delay: 240ms;
+  transform: translateY(-1.1rem) scale(.92);
+}
+
+.toast-stack-ag:hover .toast-card-ag,
+.toast-stack-ag:focus-within .toast-card-ag {
+  transform: translateY(0) scale(1);
+}
+
+.toast-stack-ag:hover .toast-card-ag:nth-child(2),
+.toast-stack-ag:focus-within .toast-card-ag:nth-child(2) {
+  transform: translateY(-5.9rem) scale(1);
+}
+
+.toast-stack-ag:hover .toast-card-ag:nth-child(3),
+.toast-stack-ag:focus-within .toast-card-ag:nth-child(3) {
+  transform: translateY(-11.8rem) scale(1);
+}
+
+.toast-icon-ag {
+  display: grid;
+  width: 2.2rem;
+  aspect-ratio: 1;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 800;
+}
+
+.toast-card-success-ag .toast-icon-ag { background: #16865b; }
+.toast-card-info-ag .toast-icon-ag { background: #376add; }
+.toast-card-warning-ag .toast-icon-ag { background: #bd7410; }
+
+.toast-copy-ag h2,
+.toast-copy-ag p {
+  margin: 0;
+}
+
+.toast-copy-ag h2 {
+  font-size: 0.94rem;
+}
+
+.toast-copy-ag p {
+  margin-top: 0.18rem;
+  color: #566176;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.toast-dismiss-ag {
+  width: 2rem;
+  aspect-ratio: 1;
+  border: 0;
+  border-radius: 50%;
+  color: #59657a;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.toast-dismiss-ag:hover { background: #edf1f8; }
+.toast-dismiss-ag:focus-visible { outline: 3px solid #376add; outline-offset: 2px; }
+
+@keyframes toast-arrive-ag {
+  from { opacity: 0; transform: translate3d(1.5rem, 1.5rem, 0) scale(.9); }
+  to { opacity: 1; }
+}
+
+@media (max-width: 30rem) {
+  .toast-demo-ag { padding: 1rem; }
+  .toast-stack-ag:hover .toast-card-ag:nth-child(2),
+  .toast-stack-ag:focus-within .toast-card-ag:nth-child(2) { transform: translateY(-6.6rem) scale(1); }
+  .toast-stack-ag:hover .toast-card-ag:nth-child(3),
+  .toast-stack-ag:focus-within .toast-card-ag:nth-child(3) { transform: translateY(-13.2rem) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS-only floating stacked toast-notification demo for #55013.

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained and opens in a browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — explains what it does, how to use it, and why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A compact deck of three floating toast notifications that expands smoothly on hover or keyboard focus.

**How does a developer use it?**

```html
<section class="toast-stack-ag" aria-label="Notifications" aria-live="polite">
  <article class="toast-card-ag">...</article>
</section>
```

**Why does it fit EaseMotion CSS?**

It is a small, dependency-free, animation-first UI example with semantic notification markup, focus-visible styles, and a `prefers-reduced-motion` fallback.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Notes for Maintainer

All files are contained in `submissions/examples/floating-stacked-toast-ag/`. The folder and custom CSS classes use the required `-ag` suffix.
