### PR TITLE
feat: add keyboard shortcut ribbon example

### DIFF
--- a/submissions/examples/keyboard-shortcut-ribbon/README.md
+++ b/submissions/examples/keyboard-shortcut-ribbon/README.md
@@ -1,0 +1,15 @@
+# Keyboard Shortcut Ribbon
+
+A CSS-only shortcut ribbon that presents command keycaps with a staggered entrance and subtle pressed feedback on hover or focus.
+
+## Files
+
+- `demo.html` contains the shortcut label and keycap group.
+- `style.css` defines the ribbon hover state, keycap rise animation, tap feedback, and mobile stacking.
+
+## What it demonstrates
+
+- Staggered keycap reveal using `nth-child` delays.
+- Hover and focus-within feedback for command surfaces.
+- Keyboard-style buttons with stable dimensions.
+- Responsive layout for compact toolbars.

--- a/submissions/examples/keyboard-shortcut-ribbon/demo.html
+++ b/submissions/examples/keyboard-shortcut-ribbon/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keyboard Shortcut Ribbon</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="shortcut-ribbon" aria-label="Keyboard shortcuts">
+    <p>Quick command</p>
+    <div class="keys">
+      <kbd>Ctrl</kbd>
+      <kbd>Shift</kbd>
+      <kbd>K</kbd>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/keyboard-shortcut-ribbon/style.css
+++ b/submissions/examples/keyboard-shortcut-ribbon/style.css
@@ -1,0 +1,104 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f6f8fb;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.shortcut-ribbon {
+  width: min(92vw, 520px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  overflow: hidden;
+  border: 1px solid #dbe4ef;
+  border-radius: 8px;
+  padding: 18px;
+  background: #ffffff;
+  box-shadow: 0 22px 54px rgba(15, 23, 42, 0.12);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.shortcut-ribbon:hover,
+.shortcut-ribbon:focus-within {
+  transform: translateY(-4px);
+  border-color: #6366f1;
+  box-shadow: 0 28px 66px rgba(99, 102, 241, 0.18);
+}
+
+p {
+  margin: 0;
+  color: #334155;
+  font-weight: 900;
+}
+
+.keys {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+kbd {
+  min-width: 46px;
+  min-height: 38px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid #c7d2fe;
+  border-bottom-width: 4px;
+  border-radius: 8px;
+  padding: 0 12px;
+  background: #eef2ff;
+  color: #3730a3;
+  font: inherit;
+  font-weight: 900;
+  transform: translateY(12px);
+  opacity: 0;
+  animation: key-rise 520ms ease forwards;
+}
+
+kbd:nth-child(2) {
+  animation-delay: 110ms;
+}
+
+kbd:nth-child(3) {
+  animation-delay: 220ms;
+}
+
+.shortcut-ribbon:hover kbd,
+.shortcut-ribbon:focus-within kbd {
+  animation: key-tap 620ms ease;
+}
+
+@keyframes key-rise {
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes key-tap {
+  45% {
+    transform: translateY(3px);
+    border-bottom-width: 2px;
+  }
+}
+
+@media (max-width: 520px) {
+  .shortcut-ribbon {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .keys {
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only keyboard shortcut ribbon example
- include staggered keycap reveal, tap feedback, and ribbon hover state
- document responsive shortcut layout behavior

## Test
- git diff --cached --check