### PR TITLE
feat: add file drop zone pulse example

### DIFF
--- a/submissions/examples/file-drop-zone-pulse/README.md
+++ b/submissions/examples/file-drop-zone-pulse/README.md
@@ -1,0 +1,15 @@
+# File Drop Zone Pulse
+
+A CSS-only upload drop zone with a pulsing interior highlight, hover lift, and focused file-input feedback.
+
+## Files
+
+- `demo.html` contains the file input, upload icon, and helper copy.
+- `style.css` defines the pulse animation, hover state, focus-within feedback, and responsive spacing.
+
+## What it demonstrates
+
+- File upload affordance using a styled label and hidden input.
+- Pulsing drop-zone highlight with a pseudo-element.
+- Hover and focus-within motion without JavaScript.
+- A compact responsive upload panel for forms and dashboards.

--- a/submissions/examples/file-drop-zone-pulse/demo.html
+++ b/submissions/examples/file-drop-zone-pulse/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>File Drop Zone Pulse</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="upload-panel">
+    <label class="drop-zone">
+      <input type="file" aria-label="Upload file">
+      <span class="icon">↑</span>
+      <strong>Drop file to upload</strong>
+      <small>PNG, JPG, or PDF up to 10 MB</small>
+    </label>
+  </main>
+</body>
+</html>

--- a/submissions/examples/file-drop-zone-pulse/style.css
+++ b/submissions/examples/file-drop-zone-pulse/style.css
@@ -1,0 +1,108 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.upload-panel {
+  width: min(92vw, 520px);
+}
+
+.drop-zone {
+  position: relative;
+  min-height: 260px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 12px;
+  overflow: hidden;
+  border: 2px dashed #93c5fd;
+  border-radius: 8px;
+  padding: 30px;
+  background: #ffffff;
+  text-align: center;
+  cursor: pointer;
+  box-shadow: 0 24px 60px rgba(37, 99, 235, 0.12);
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.drop-zone::before {
+  content: "";
+  position: absolute;
+  inset: 18px;
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.08);
+  transform: scale(0.88);
+  opacity: 0;
+  animation: zone-pulse 2.2s ease-in-out infinite;
+}
+
+.drop-zone:hover,
+.drop-zone:focus-within {
+  transform: translateY(-4px);
+  border-color: #2563eb;
+  background: #eff6ff;
+}
+
+input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.icon,
+strong,
+small {
+  position: relative;
+  z-index: 1;
+}
+
+.icon {
+  width: 62px;
+  height: 62px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 2rem;
+  font-weight: 900;
+  transition: transform 180ms ease;
+}
+
+.drop-zone:hover .icon,
+.drop-zone:focus-within .icon {
+  transform: translateY(-6px);
+}
+
+strong {
+  font-size: 1.2rem;
+}
+
+small {
+  color: #64748b;
+  line-height: 1.5;
+}
+
+@keyframes zone-pulse {
+  50% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 420px) {
+  .drop-zone {
+    min-height: 230px;
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only file drop zone pulse example
- include pulsing drop-zone highlight, hover lift, and focus-within feedback
- document upload form behavior and responsive spacing

## Test
- git diff --cached --check