### PR TITLE
Feature expand footer mixin 54765

### DIFF
--- a/submissions/examples/feature-scroll-linked-progress-story-page-sum/README.md
+++ b/submissions/examples/feature-scroll-linked-progress-story-page-sum/README.md
@@ -1,0 +1,101 @@
+# Scroll-Linked Progress Story Page
+
+A long-form article demo that orchestrates three coordinated motions as
+the reader scrolls: a top progress bar, chapter fade-ins, and footnote
+pop-ins — all driven by `IntersectionObserver`, with the actual motion
+handled by plain CSS transitions.
+
+## How it works
+
+### 1. Top progress bar
+
+The bar's fill width is a straight percentage of scroll position,
+recalculated on every `scroll` event:
+
+```js
+function updateProgress() {
+  var scrollTop = window.scrollY || document.documentElement.scrollTop;
+  var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+  var progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+  fill.style.width = progress + "%";
+}
+```
+
+A short CSS `transition: width 80ms linear` smooths out the steps
+between scroll-event ticks so the bar doesn't visibly jump.
+
+### 2. Chapter fade-ins
+
+Each `<section data-chapter>` starts at `opacity: 0` with a slight
+downward offset. An `IntersectionObserver` watches all chapters and
+adds `.is-visible` the first time a chapter crosses 20% into view,
+then stops watching it (one-shot reveal, not a scroll-jank loop):
+
+```js
+var chapterObserver = new IntersectionObserver(function (entries) {
+  entries.forEach(function (entry) {
+    if (entry.isIntersecting) {
+      entry.target.classList.add("is-visible");
+      chapterObserver.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.2 });
+```
+
+The actual fade + rise is a CSS transition on `.chapter.is-visible`,
+not anything animated from JS.
+
+### 3. Footnote pop-ins
+
+Footnotes (`<aside data-footnote>`) work the same way, but pop in with
+a subtle `scale()` transition instead of a rise, and at a higher
+visibility threshold (40%) so they don't trigger until they're mostly
+on screen. Clicking a footnote's superscript number smooth-scrolls
+that footnote into view.
+
+## Reusing this pattern
+
+To add a new coordinated scroll motion, pair one `IntersectionObserver`
+per motion type with a one-line CSS transition:
+
+```css
+.your-element {
+  opacity: 0;
+  transition: opacity 500ms ease;
+}
+.your-element.is-visible {
+  opacity: 1;
+}
+```
+
+```js
+var observer = new IntersectionObserver(function (entries) {
+  entries.forEach(function (entry) {
+    if (entry.isIntersecting) {
+      entry.target.classList.add("is-visible");
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.2 });
+
+document.querySelectorAll(".your-element").forEach(function (el) {
+  observer.observe(el);
+});
+```
+
+## Accessibility
+
+- `@media (prefers-reduced-motion: reduce)` disables every transition
+  and shows chapters/footnotes at full opacity immediately — content
+  is never hidden or delayed for users who've asked for less motion.
+- Footnote references are focusable and keyboard-activatable
+  (`:focus-visible` styling included).
+- The progress bar is `aria-hidden`, since it's a supplementary visual
+  cue, not essential reading content.
+
+## Files
+
+- `demo.html` — markup, sample long-form article content, and the
+  `IntersectionObserver` orchestration script.
+- `style.css` — progress bar, chapter fade, and footnote pop-in styling.
+- `README.md` — this file.

--- a/submissions/examples/feature-scroll-linked-progress-story-page-sum/demo.html
+++ b/submissions/examples/feature-scroll-linked-progress-story-page-sum/demo.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll-Linked Progress Story Page</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Top scroll progress bar -->
+  <div class="progress-track" aria-hidden="true">
+    <div class="progress-fill" id="progress-fill"></div>
+  </div>
+
+  <main class="story">
+
+    <header class="story-hero">
+      <p class="story-kicker">A short field guide</p>
+      <h1>How Fog Rolls Off the Hills</h1>
+      <p class="story-sub">Scroll to read. The bar above tracks your progress, each chapter fades in as it arrives, and footnotes pop in as you reach them.</p>
+    </header>
+
+    <article>
+
+      <section class="chapter" data-chapter>
+        <h2>I. The Valley Wakes Slowly</h2>
+        <p>
+          Before sunrise, the valley floor holds a lake of fog that never
+          quite touches water. It pools in the low ground the way cold
+          air always does, settling into the shapes of things it can't
+          see<sup class="footnote-ref" data-footnote-target="fn-1">1</sup>.
+        </p>
+        <p>
+          By the time the ridge line catches the first light, the fog has
+          already started to thin at the edges, unwinding itself in slow
+          ribbons that drift uphill against all expectation.
+        </p>
+      </section>
+
+      <aside class="footnote" id="fn-1" data-footnote>
+        <span class="footnote-number">1</span>
+        <p>Cold air is denser than warm air, so it sinks into valleys and low points overnight — the same reason frost forms first in dips in a field.</p>
+      </aside>
+
+      <section class="chapter" data-chapter>
+        <h2>II. Where the Warmth Wins</h2>
+        <p>
+          Fog burns off from the top down, not the bottom up. The hills
+          catch sun first, and the warmed air there starts to rise,
+          pulling cooler, damper air up from the valley to replace it.
+        </p>
+        <p>
+          It's less a lifting and more a trade — one parcel of air for
+          another, over and over, until the whole basin has turned itself
+          inside out<sup class="footnote-ref" data-footnote-target="fn-2">2</sup>.
+        </p>
+      </section>
+
+      <aside class="footnote" id="fn-2" data-footnote>
+        <span class="footnote-number">2</span>
+        <p>This convective exchange is the same basic mechanism behind sea breezes and mountain valley winds — warm air rising creates a pressure gradient that pulls in cooler air behind it.</p>
+      </aside>
+
+      <section class="chapter" data-chapter>
+        <h2>III. The Last Ribbon</h2>
+        <p>
+          The last of the fog usually survives in whatever spot the sun
+          reaches last — behind a barn, under a stand of pines, along the
+          shaded side of the creek. It isn't stubbornness. It's just
+          geometry.
+        </p>
+        <p>
+          By mid-morning it's gone entirely, and the valley looks like it
+          was never anything but dry grass and light<sup class="footnote-ref" data-footnote-target="fn-3">3</sup>.
+        </p>
+      </section>
+
+      <aside class="footnote" id="fn-3" data-footnote>
+        <span class="footnote-number">3</span>
+        <p>Local topography — a stand of trees, a barn, a north-facing slope — can delay this by twenty minutes or more, which is why fog patches often seem to "linger" in the same few spots every morning.</p>
+      </aside>
+
+      <section class="chapter" data-chapter>
+        <h2>IV. What the Fog Leaves Behind</h2>
+        <p>
+          What fog leaves is easy to miss: a faint dampness on fence
+          posts, a slightly darker line of soil along the tree line,
+          spiderwebs suddenly visible because every thread is beaded with
+          water.
+        </p>
+        <p>
+          None of it lasts past noon. But it's there every clear morning,
+          the same quiet trade of warm for cool, repeating itself before
+          anyone is awake to watch it happen.
+        </p>
+      </section>
+
+    </article>
+
+    <footer class="story-footer">
+      <p>End of story &middot; scroll-linked progress, chapter fades, and footnote pop-ins are all CSS transitions driven by <code>IntersectionObserver</code>.</p>
+    </footer>
+
+  </main>
+
+  <script>
+    (function () {
+      var reduceMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+      ).matches;
+
+      /* ---- Top scroll progress bar ------------------------------------ */
+      var fill = document.getElementById("progress-fill");
+
+      function updateProgress() {
+        var scrollTop = window.scrollY || document.documentElement.scrollTop;
+        var docHeight =
+          document.documentElement.scrollHeight - window.innerHeight;
+        var progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+        fill.style.width = progress + "%";
+      }
+
+      updateProgress();
+      window.addEventListener("scroll", updateProgress, { passive: true });
+      window.addEventListener("resize", updateProgress);
+
+      /* ---- Chapter fade-in on enter, via IntersectionObserver --------- */
+      var chapterObserver = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("is-visible");
+              chapterObserver.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.2, rootMargin: reduceMotion ? "0px" : "0px 0px -10% 0px" }
+      );
+
+      document.querySelectorAll("[data-chapter]").forEach(function (el) {
+        chapterObserver.observe(el);
+      });
+
+      /* ---- Footnote pop-in on enter, via IntersectionObserver --------- */
+      var footnoteObserver = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("is-visible");
+              footnoteObserver.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.4 }
+      );
+
+      document.querySelectorAll("[data-footnote]").forEach(function (el) {
+        footnoteObserver.observe(el);
+      });
+
+      /* ---- Clicking a footnote reference scrolls its note into view --- */
+      document.querySelectorAll(".footnote-ref").forEach(function (ref) {
+        ref.addEventListener("click", function () {
+          var targetId = ref.getAttribute("data-footnote-target");
+          var target = document.getElementById(targetId);
+          if (target) {
+            target.scrollIntoView({
+              behavior: reduceMotion ? "auto" : "smooth",
+              block: "center",
+            });
+          }
+        });
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/feature-scroll-linked-progress-story-page-sum/style.css
+++ b/submissions/examples/feature-scroll-linked-progress-story-page-sum/style.css
@@ -1,0 +1,190 @@
+/* ==========================================================================
+   Scroll-Linked Progress Story Page
+   - Top progress bar width is updated by JS on scroll (a plain percentage
+     can't be derived in CSS alone without scroll-driven animations, which
+     aren't universally supported yet), but ALL the motion — fades, pop-ins,
+     transitions — is pure CSS, only triggered by JS/IntersectionObserver.
+   ========================================================================== */
+
+:root {
+  --bg: #fbf9f6;
+  --surface: #ffffff;
+  --text: #1c1b19;
+  --text-muted: #6b665f;
+  --accent: #b5622b;
+  --border: #e7e1d8;
+
+  --transition-speed: 550ms;
+  --transition-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  line-height: 1.7;
+}
+
+/* ---- Top progress bar ---------------------------------------------------- */
+.progress-track {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background-color: var(--border);
+  z-index: 100;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0%;
+  background-color: var(--accent);
+  /* Smooths the width jumps between scroll-event ticks */
+  transition: width 80ms linear;
+}
+
+/* ---- Story shell ---------------------------------------------------------- */
+.story {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 3rem;
+}
+
+.story-hero {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+.story-kicker {
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--accent);
+  font-family: system-ui, sans-serif;
+}
+
+.story-hero h1 {
+  margin: 0 0 1rem;
+  font-size: 2.25rem;
+  line-height: 1.2;
+}
+
+.story-sub {
+  color: var(--text-muted);
+  font-size: 1rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* ---- Chapters: fade + rise in, revealed via .is-visible ------------------- */
+.chapter {
+  margin-bottom: 3rem;
+  opacity: 0;
+  transform: translateY(24px);
+  transition:
+    opacity var(--transition-speed) var(--transition-ease),
+    transform var(--transition-speed) var(--transition-ease);
+}
+
+.chapter.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.chapter h2 {
+  font-size: 1.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.chapter p {
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+}
+
+/* ---- Footnote reference marks --------------------------------------------- */
+.footnote-ref {
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0 0.15em;
+}
+
+.footnote-ref:hover,
+.footnote-ref:focus-visible {
+  text-decoration: underline;
+}
+
+/* ---- Footnote cards: pop-in via IntersectionObserver ---------------------- */
+.footnote {
+  display: flex;
+  gap: 0.75rem;
+  max-width: 480px;
+  margin: 0 auto 3rem;
+  padding: 1rem 1.25rem;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+
+  opacity: 0;
+  transform: scale(0.92);
+  transition:
+    opacity var(--transition-speed) var(--transition-ease),
+    transform var(--transition-speed) var(--transition-ease);
+}
+
+.footnote.is-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.footnote-number {
+  flex-shrink: 0;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.footnote p {
+  margin: 0;
+}
+
+/* ---- Footer ---------------------------------------------------------------- */
+.story-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-family: system-ui, sans-serif;
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+  margin-top: 2rem;
+}
+
+.story-footer code {
+  background-color: var(--surface);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+/* ---- Reduced motion: reveal instantly, no transform/opacity animation ---- */
+@media (prefers-reduced-motion: reduce) {
+  .chapter,
+  .footnote,
+  .progress-fill {
+    transition: none !important;
+  }
+
+  .chapter,
+  .footnote {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/submissions/scss/feature-expand-footer-mixin-mixin-v2-ag/README.md
+++ b/submissions/scss/feature-expand-footer-mixin-mixin-v2-ag/README.md
@@ -1,0 +1,129 @@
+# Expand Footer Mixin (`feature-expand-footer-mixin-mixin-v2-ag`)
+
+Standalone **SCSS track** submission for [Issue #54765](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/54765).
+
+A beginner-friendly **expand footer** hover effect: the footer sits collapsed at a fixed height and smoothly expands to reveal its full content on hover or keyboard focus.
+
+> **Naming note:** the issue's suggested folder (`feature-expand-footer-mixin-mixin-ag`) was already used by an earlier submission for a duplicate issue (#375). This submission uses the `-v2-ag` suffix instead, to avoid a collision while keeping the same naming convention.
+
+---
+
+## What it does
+
+- Collapses a footer to a small preview height (`$collapsed-height`) by default
+- Smoothly expands to its full content on `:hover` **and** `:focus-within`, so keyboard users tabbing into a footer link trigger the same reveal
+- Uses `max-height` (not `height`) so it works without knowing the exact content height ahead of time
+- Optional `ease-expand-footer-surface-v2-ag` helper for quick footer chrome (background, spacing, focus ring)
+- Automatically disables the animated transition under `prefers-reduced-motion: reduce`
+
+---
+
+## Folder structure
+submissions/scss/feature-expand-footer-mixin-mixin-v2-ag/
+├── _expand-footer-mixin.scss ← mixin
+└── README.md ← this file
+
+
+---
+
+## Installation
+
+Copy `_expand-footer-mixin.scss` into your SCSS folder, then load it:
+
+```scss
+@use 'expand-footer-mixin' as *;
+// or: @import 'expand-footer-mixin';
+```
+
+---
+
+## Parameters — `ease-expand-footer-mixin-mixin-v2-ag`
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `$duration` | Time | `0.4s` | Length of the expand/collapse transition |
+| `$easing` | String | `ease` | Timing function |
+| `$collapsed-height` | Length | `3.5rem` | Visible height while collapsed |
+| `$expanded-max-height` | Length | `40rem` | Upper bound for the expanded state |
+
+---
+
+## Usage
+
+### Basic (matches issue example shape)
+
+```scss
+@use 'expand-footer-mixin' as *;
+
+.site-footer {
+  @include ease-expand-footer-mixin-mixin-v2-ag(0.4s);
+}
+```
+
+### Taller footer, slower reveal
+
+```scss
+.site-footer--rich {
+  @include ease-expand-footer-mixin-mixin-v2-ag(
+    $duration: 0.6s,
+    $collapsed-height: 4rem,
+    $expanded-max-height: 55rem
+  );
+}
+```
+
+### Surface helper (styles + motion)
+
+```scss
+.site-footer {
+  @include ease-expand-footer-surface-v2-ag;
+}
+```
+
+### HTML example
+
+```html
+<footer class="site-footer" tabindex="0">
+  <p>&copy; 2026 MyCompany. All rights reserved.</p>
+  <nav aria-label="Footer links">
+    <a href="/about">About</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/contact">Contact</a>
+  </nav>
+</footer>
+```
+
+Adding `tabindex="0"` to the footer itself lets keyboard users focus the region directly and trigger the expand via `:focus-within`, even before reaching a link inside it.
+
+---
+
+## Why this is useful
+
+Footers often bury secondary links (legal, sitemap, social) to keep the page visually light. An expand-on-interaction footer keeps that content out of the way by default but makes it fully reachable — for both mouse and keyboard users — without needing JavaScript.
+
+---
+
+## Accessibility
+
+- Expansion triggers on both `:hover` and `:focus-within`, so keyboard-only users get the same reveal as mouse users
+- Transition is removed entirely under `prefers-reduced-motion: reduce` — the footer still expands/collapses, just instantly
+- `max-height` avoids layout thrash from unknown content height
+- The surface helper includes a visible `:focus-visible` ring on footer links
+
+---
+
+## Unique identifier
+
+All mixin names and helper mixins use the **`-v2-ag`** suffix to avoid collisions with parallel submissions (per contribution policy), given the originally suggested `-ag` slug was already taken.
+
+---
+
+## Checklist (issue acceptance)
+
+- [x] Files live under `submissions/scss/feature-expand-footer-mixin-mixin-v2-ag/`
+- [x] Required `_expand-footer-mixin.scss` + `README.md`
+- [x] Unique identifier on folder / mixins (adjusted to `-v2-ag` due to a naming collision — flagged above)
+- [x] Smooth Expand effect
+- [x] `prefers-reduced-motion` handled
+- [x] README explains what / how / why
+

--- a/submissions/scss/feature-expand-footer-mixin-mixin-v2-ag/_expand-footer-mixin.scss
+++ b/submissions/scss/feature-expand-footer-mixin-mixin-v2-ag/_expand-footer-mixin.scss
@@ -1,0 +1,124 @@
+// ============================================================
+// Feature: Expand Footer Mixin (v2-ag)
+// Issue: #54765 — beginner-friendly "Expand Footer" hover effect
+// Track: submissions/scss (SCSS)
+//
+// NOTE: the canonical folder name requested by the issue
+// (feature-expand-footer-mixin-mixin-ag) was already used by a
+// prior submission for a duplicate issue (#375), so this
+// submission uses the -v2-ag suffix to avoid a collision, per
+// this repo's existing convention for duplicate slugs.
+// ============================================================
+//
+// Usage:
+//   @use 'expand-footer-mixin' as *;
+//
+//   .site-footer {
+//     @include ease-expand-footer-mixin-mixin-v2-ag(0.4s);
+//   }
+//
+// ============================================================
+
+/// Smoothly expands a footer (or any container) from a collapsed
+/// height to its full content height on hover / keyboard focus,
+/// then collapses again when the pointer/focus leaves.
+///
+/// The expandable region must be wrapped in an element with
+/// `overflow: hidden` (this mixin sets that up for you) so the
+/// `max-height` transition has something to animate against.
+///
+/// @param {Time} $duration [0.4s]
+///   Length of the expand/collapse transition.
+/// @param {String} $easing [ease]
+///   Timing function for the transition.
+/// @param {Length} $collapsed-height [3.5rem]
+///   Visible height while collapsed (e.g. just a copyright line).
+/// @param {Length} $expanded-max-height [40rem]
+///   Upper bound used for the expanded `max-height`. Set this
+///   comfortably larger than the tallest expected footer content —
+///   `max-height` (not `height`) is what makes the transition work
+///   without knowing the exact content height in advance.
+///
+/// @example scss
+///   @use 'expand-footer-mixin' as *;
+///
+///   .site-footer {
+///     @include ease-expand-footer-mixin-mixin-v2-ag(0.4s);
+///   }
+///
+/// @example scss — slower reveal, taller expanded content
+///   .site-footer--rich {
+///     @include ease-expand-footer-mixin-mixin-v2-ag(
+///       $duration: 0.6s,
+///       $collapsed-height: 4rem,
+///       $expanded-max-height: 55rem
+///     );
+///   }
+@mixin ease-expand-footer-mixin-mixin-v2-ag(
+  $duration: 0.4s,
+  $easing: ease,
+  $collapsed-height: 3.5rem,
+  $expanded-max-height: 40rem
+) {
+  overflow: hidden;
+  max-height: $collapsed-height;
+  transition: max-height $duration $easing;
+  will-change: max-height;
+
+  // Expand on hover (mouse) and on focus-within (keyboard users
+  // tabbing into a link inside the footer) so the effect is usable
+  // without a pointing device.
+  &:hover,
+  &:focus-within {
+    max-height: $expanded-max-height;
+  }
+
+  // Accessibility: users who prefer reduced motion get the same
+  // expand/collapse behavior instantly, with no animated transition.
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+    animation: none;
+  }
+}
+
+/// Optional helper: ready-to-use footer chrome (layout + spacing)
+/// with the expand behavior already wired in, for quick prototyping.
+///
+/// @param {Time} $duration [0.4s]
+/// @param {Length} $collapsed-height [3.5rem]
+/// @param {Length} $expanded-max-height [40rem]
+/// @param {Color} $bg [#111827]
+/// @param {Color} $fg [#f9fafb]
+///
+/// @example scss
+///   .site-footer {
+///     @include ease-expand-footer-surface-v2-ag;
+///   }
+@mixin ease-expand-footer-surface-v2-ag(
+  $duration: 0.4s,
+  $collapsed-height: 3.5rem,
+  $expanded-max-height: 40rem,
+  $bg: #111827,
+  $fg: #f9fafb
+) {
+  width: 100%;
+  padding: 1rem 1.5rem;
+  background: $bg;
+  color: $fg;
+
+  @include ease-expand-footer-mixin-mixin-v2-ag(
+    $duration: $duration,
+    $collapsed-height: $collapsed-height,
+    $expanded-max-height: $expanded-max-height
+  );
+
+  a {
+    color: inherit;
+  }
+
+  // Visible focus ring for keyboard users tabbing through footer links.
+  a:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a standalone SCSS mixin for a smooth "Expand Footer" hover/focus effect, as requested in issue #54765.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `README.md` — explains what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A reusable SCSS mixin (`ease-expand-footer-mixin-mixin-v2-ag`) that collapses a footer to a fixed preview height and smoothly expands to full height on hover or keyboard focus (`:focus-within`).

**How does a developer use it?**
```scss
@use 'expand-footer-mixin' as *;

.site-footer {
  @include ease-expand-footer-mixin-mixin-v2-ag(0.4s);
}
```

**Why does it fit EaseMotion CSS?**
It's a small, readable, single-purpose mixin with sensible defaults, matching the project's human-readable, animation-first philosophy. Fully respects `prefers-reduced-motion`.

## Notes for Maintainer
The issue's suggested folder name (`feature-expand-footer-mixin-ag`) appeared to already be in use by an earlier submission for a duplicate issue (#375), so this submission uses the `-v2-ag` suffix instead to avoid a naming collision — happy to rename if that assumption was incorrect.