### PR TITLE
Add expand-footer SCSS mixin (issue SAPTARSHI-coder#54765)

### DIFF
--- a/submissions/scss/expand-footer/README.md
+++ b/submissions/scss/expand-footer/README.md
@@ -1,0 +1,34 @@
+﻿# Expand Footer Mixin
+
+A reusable SCSS mixin that collapses a footer to a fixed preview height and
+smoothly expands to full height on hover or keyboard focus (`:focus-within`).
+
+## Usage
+
+```scss
+@use "expand-footer" as *;
+
+.site-footer {
+  @include ease-expand-footer(0.4s);
+}
+```
+
+## Parameters
+
+| Parameter          | Default     | Description                              |
+|---------------------|-------------|-------------------------------------------|
+| `$duration`          | `0.4s`      | Transition duration                       |
+| `$collapsed-height`  | `60px`      | Height of the footer in its collapsed state |
+| `$easing`            | `ease-in-out` | Transition timing function              |
+
+## Why it fits EaseMotion CSS
+
+A small, single-purpose, readable mixin with sensible defaults, matching the
+project's animation-first, human-readable philosophy. Fully respects
+`prefers-reduced-motion` by disabling the transition for users who prefer
+reduced motion.
+
+## Demo
+
+Open `demo.html` in a browser and hover over (or Tab-focus into) the footer
+to see the expand effect.

--- a/submissions/scss/expand-footer/_expand-footer.scss
+++ b/submissions/scss/expand-footer/_expand-footer.scss
@@ -1,0 +1,20 @@
+﻿// ==========================================================================
+// Expand Footer Mixin
+// Collapses a footer to a preview height, expands smoothly on hover/focus.
+// Respects prefers-reduced-motion.
+// ==========================================================================
+
+@mixin ease-expand-footer($duration: 0.4s, $collapsed-height: 60px, $easing: ease-in-out) {
+  overflow: hidden;
+  max-height: $collapsed-height;
+  transition: max-height $duration $easing;
+
+  &:hover,
+  &:focus-within {
+    max-height: 600px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}

--- a/submissions/scss/expand-footer/demo.html
+++ b/submissions/scss/expand-footer/demo.html
@@ -1,0 +1,38 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Expand Footer Mixin Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <p class="page-hint">Hover or Tab-focus into the footer below to see it expand smoothly.</p>
+
+  <footer class="site-footer" tabindex="0">
+    <h3>Company Name</h3>
+    <p class="preview-line">Hover or focus to see more &darr;</p>
+
+    <div class="footer-columns">
+      <div>
+        <h4>Product</h4>
+        <a href="#" tabindex="0">Features</a>
+        <a href="#" tabindex="0">Pricing</a>
+        <a href="#" tabindex="0">Changelog</a>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <a href="#" tabindex="0">About</a>
+        <a href="#" tabindex="0">Careers</a>
+        <a href="#" tabindex="0">Contact</a>
+      </div>
+      <div>
+        <h4>Resources</h4>
+        <a href="#" tabindex="0">Docs</a>
+        <a href="#" tabindex="0">Support</a>
+        <a href="#" tabindex="0">Community</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/submissions/scss/expand-footer/style.css
+++ b/submissions/scss/expand-footer/style.css
@@ -1,0 +1,85 @@
+﻿* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f1117;
+  color: #e8e8ea;
+  margin: 0;
+  padding: 60px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.page-hint {
+  max-width: 480px;
+  text-align: center;
+  color: #9a9aa2;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.site-footer {
+  width: 100%;
+  max-width: 640px;
+  background: #1b1e27;
+  border: 1px solid #2b2f3a;
+  border-radius: 12px;
+  padding: 20px 24px;
+  overflow: hidden;
+  max-height: 60px;
+  transition: max-height 0.4s ease-in-out;
+  cursor: pointer;
+}
+
+.site-footer:hover,
+.site-footer:focus-within {
+  max-height: 600px;
+}
+
+.site-footer h3 {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  color: #ffffff;
+}
+
+.site-footer .preview-line {
+  color: #9a9aa2;
+  font-size: 0.85rem;
+}
+
+.footer-columns {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-top: 16px;
+}
+
+.footer-columns h4 {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+  color: #ffffff;
+}
+
+.footer-columns a {
+  display: block;
+  color: #9a9aa2;
+  text-decoration: none;
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+}
+
+.footer-columns a:hover,
+.footer-columns a:focus-visible {
+  color: #7c9eff;
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-footer {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a standalone SCSS mixin for a smooth "Expand Footer" hover/focus effect, as requested in issue #54765.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `README.md` — explains what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A reusable SCSS mixin (`ease-expand-footer`) that collapses a footer to a fixed preview height and smoothly expands to full height on hover or keyboard focus (`:focus-within`).

**How does a developer use it?**
```scss
@use "expand-footer" as *;

.site-footer {
  @include ease-expand-footer(0.4s);
}
```

**Why does it fit EaseMotion CSS?**
It's a small, readable, single-purpose mixin with sensible defaults, matching the project's human-readable, animation-first philosophy. Fully respects `prefers-reduced-motion`.

## Notes for Maintainer
Resubmission of a previous attempt (#55200) that was closed due to out-of-scope files and merge conflicts from a mixed branch history. This PR is built from a fresh branch off current `main` and contains only the 4 required files under `submissions/scss/expand-footer/`.