### PR TITLE
fix: add -webkit-backdrop-filter fallback for Safari

### DIFF
--- a/components/command-palette.css
+++ b/components/command-palette.css
@@ -9,6 +9,7 @@
     inset: 0;
     background-color: rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     z-index: var(--ease-z-modal, 1000);
     display: flex;
     align-items: flex-start;

--- a/components/footer.css
+++ b/components/footer.css
@@ -290,6 +290,7 @@
   padding: 1.5rem;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border: 1px solid var(--ease-footer-border);
   border-radius: 16px;
   transition: var(--ease-footer-transition);
@@ -381,6 +382,7 @@
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   color: var(--ease-footer-text);
   text-decoration: none;
   border: 1px solid var(--ease-footer-border);


### PR DESCRIPTION
## Pull Request Description

Fixes #55205 

This PR fixes a Safari compatibility issue by adding the missing `-webkit-backdrop-filter` declarations to components that use `backdrop-filter`.

The change ensures the frosted glass blur effect renders consistently across Safari (desktop and iOS) while preserving existing behavior in Chrome, Firefox, and Edge.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> This is a bug fix to existing components, so the feature submission checklist below is not applicable.

* [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
* [ ] Includes `demo.html` — self-contained, opens in browser with no server
* [ ] Includes `style.css` — raw CSS for the proposed feature
* [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [ ] **No changes to `core/`**
* [ ] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This PR does not add a new feature. It fixes Safari compatibility by adding the missing `-webkit-backdrop-filter` declarations to existing components.

**How does a developer use it?**

No API or usage changes are required. Existing components will now render the backdrop blur correctly in Safari.

**Why does it fit EaseMotion CSS?**

This improves cross-browser compatibility and makes the implementation consistent with other components (such as the modal) that already include both `backdrop-filter` and `-webkit-backdrop-filter`.

---

## Demo

* [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari *(not tested directly)*

---

## Notes for Maintainer

This PR adds the missing Safari fallback declarations to the following locations:

* `components/command-palette.css`

  * `.ease-command-palette-overlay`
* `components/footer.css`

  * `.ease-footer-newsletter`
  * Footer social icon links

The existing blur values were preserved (`8px` and `10px` respectively), and the implementation now matches the pattern already used in `components/modals.css`.
