### PR TITLE
Add CSS Glitch-Flicker Popover for creative portfolio layouts (closes…

### DIFF
--- a/submissions/examples/glitch-flicker-popover/README.md
+++ b/submissions/examples/glitch-flicker-popover/README.md
@@ -1,0 +1,111 @@
+# Glitch-Flicker Popover
+
+A pure CSS/HTML popover component that reveals project details with a
+cyberpunk-style RGB-split glitch and neon flicker effect — built for
+creative portfolio layouts. No JavaScript required.
+
+## 🎬 Preview
+
+Hover or keyboard-focus a **"View details"** button to trigger the
+popover. The title text splits into cyan/magenta layers and flickers
+like an unstable neon sign or CRT signal while the popover is open.
+
+## 📦 Files
+
+```
+submissions/examples/glitch-flicker-popover/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## 🚀 Usage
+
+Include `style.css` and reuse the markup pattern below for any
+portfolio card:
+
+```html
+<div class="em-glitch-popover-wrap">
+  <button class="em-glitch-trigger" aria-describedby="glitch-pop-1">
+    View details
+  </button>
+
+  <div id="glitch-pop-1" class="em-glitch-popover" role="tooltip">
+    <span class="em-glitch-popover__text" data-text="SYSTEM ONLINE">
+      SYSTEM ONLINE
+    </span>
+    <p class="em-glitch-popover__desc">
+      Your project description goes here.
+    </p>
+  </div>
+</div>
+```
+
+**Important:** the `data-text` attribute on
+`.em-glitch-popover__text` must match the element's visible text
+content exactly — the glitch layers are generated from
+`attr(data-text)`.
+
+Give each popover a unique `id` and match it to the trigger's
+`aria-describedby` so assistive tech announces the right content.
+
+## 🎛️ CSS Custom Properties
+
+All properties are defined on `:root` and can be overridden globally
+or scoped to a single card:
+
+| Property | Default | Description |
+|---|---|---|
+| `--em-glitch-color-1` | `#ff2ec4` | First glitch split-layer color (magenta) |
+| `--em-glitch-color-2` | `#2ee6ff` | Second glitch split-layer color (cyan) |
+| `--em-glitch-accent` | `#7c4dff` | Trigger button accent color |
+| `--em-glitch-surface` | `#16161f` | Card background |
+| `--em-glitch-border` | `#2a2a38` | Card/popover border color |
+| `--em-glitch-text` | `#f2f2f5` | Base text color |
+| `--em-glitch-muted` | `#a3a3b3` | Secondary/description text color |
+| `--em-glitch-radius` | `10px` | Card border radius |
+| `--em-glitch-popover-width` | `280px` | Popover panel width |
+| `--em-glitch-flicker-duration` | `1.6s` | Length of one flicker cycle |
+| `--em-glitch-shift-duration` | `3.2s` | Length of one RGB-split shift cycle |
+| `--em-glitch-reveal-duration` | `220ms` | Fade/slide-in duration for the popover panel |
+
+Example override for a single card:
+
+```css
+.em-glitch-card--danger {
+  --em-glitch-color-1: #ff003c;
+  --em-glitch-color-2: #ffb400;
+  --em-glitch-accent: #ff003c;
+}
+```
+
+## ✨ Features
+
+- **Pure CSS/HTML** — no JavaScript, no dependencies.
+- **RGB-split glitch title** using layered `::before`/`::after`
+  pseudo-elements clipped and offset with `clip-path`.
+- **Irregular flicker** via a `steps()` keyframe animation that mimics
+  unstable neon/CRT signal behavior.
+- **Keyboard accessible** — the popover opens on both `:hover` and
+  `:focus-within`, so it's fully usable via Tab navigation.
+- **Fully responsive** — the popover re-centers under its trigger and
+  shrinks to fit on narrow viewports (tested down to 320px).
+- **`prefers-reduced-motion` support** — all glitch/flicker animations
+  are disabled for users who request reduced motion; the split-color
+  effect degrades gracefully to a static offset instead of vanishing.
+- **Semantic & ARIA-aware** — uses `role="tooltip"` and
+  `aria-describedby` to connect the trigger to its popover content.
+
+## ♿ Accessibility Notes
+
+- Animations respect `prefers-reduced-motion: reduce`.
+- The trigger is a real `<button>`, so it is natively focusable and
+  operable with the keyboard/Enter/Space.
+- Color is never the only signal — the popover's visibility is driven
+  by `opacity`/`visibility`/`transform`, not color alone.
+
+## 🌐 Browser Support
+
+Works in all modern evergreen browsers (Chrome, Edge, Firefox,
+Safari) — relies only on standard CSS: `clip-path`, custom properties,
+`:focus-within`, and keyframe animations.

--- a/submissions/examples/glitch-flicker-popover/demo.html
+++ b/submissions/examples/glitch-flicker-popover/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Glitch-Flicker Popover — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="em-page-header">
+    <h1>Glitch-Flicker Popover</h1>
+    <p>A pure CSS popover with a cyberpunk-style glitch/flicker reveal, built for creative portfolio layouts.</p>
+  </header>
+
+  <main class="em-portfolio-grid">
+
+    <!-- Project Card 1 -->
+    <article class="em-glitch-card">
+      <div class="em-glitch-card__thumb" style="background:linear-gradient(135deg,#1f1147,#38126b);">
+        <span class="em-glitch-card__label">Project 01</span>
+      </div>
+      <h2 class="em-glitch-card__title">Neon Interfaces</h2>
+
+      <div class="em-glitch-popover-wrap">
+        <button class="em-glitch-trigger" aria-describedby="glitch-pop-1">
+          View details
+        </button>
+
+        <div id="glitch-pop-1" class="em-glitch-popover" role="tooltip">
+          <span class="em-glitch-popover__text" data-text="SYSTEM ONLINE">SYSTEM ONLINE</span>
+          <p class="em-glitch-popover__desc">
+            A UI concept exploring neon-lit dashboards for a fictional
+            night-city transit system. Built with layered gradients and
+            motion-driven emphasis.
+          </p>
+        </div>
+      </div>
+    </article>
+
+    <!-- Project Card 2 -->
+    <article class="em-glitch-card">
+      <div class="em-glitch-card__thumb" style="background:linear-gradient(135deg,#0f2f2b,#0c5c4c);">
+        <span class="em-glitch-card__label">Project 02</span>
+      </div>
+      <h2 class="em-glitch-card__title">Signal Decay</h2>
+
+      <div class="em-glitch-popover-wrap">
+        <button class="em-glitch-trigger" aria-describedby="glitch-pop-2">
+          View details
+        </button>
+
+        <div id="glitch-pop-2" class="em-glitch-popover" role="tooltip">
+          <span class="em-glitch-popover__text" data-text="CONNECTION LOST">CONNECTION LOST</span>
+          <p class="em-glitch-popover__desc">
+            A generative art series simulating corrupted broadcast signals,
+            rendered entirely with CSS gradients and animation timing.
+          </p>
+        </div>
+      </div>
+    </article>
+
+    <!-- Project Card 3 -->
+    <article class="em-glitch-card">
+      <div class="em-glitch-card__thumb" style="background:linear-gradient(135deg,#3a0d1f,#7a1030);">
+        <span class="em-glitch-card__label">Project 03</span>
+      </div>
+      <h2 class="em-glitch-card__title">Red Static</h2>
+
+      <div class="em-glitch-popover-wrap">
+        <button class="em-glitch-trigger" aria-describedby="glitch-pop-3">
+          View details
+        </button>
+
+        <div id="glitch-pop-3" class="em-glitch-popover" role="tooltip">
+          <span class="em-glitch-popover__text" data-text="ACCESS DENIED">ACCESS DENIED</span>
+          <p class="em-glitch-popover__desc">
+            A poster series inspired by analog TV static and CRT scanlines,
+            reimagined as an interactive web micro-experience.
+          </p>
+        </div>
+      </div>
+    </article>
+
+  </main>
+
+  <footer class="em-page-footer">
+    <p>EaseMotion CSS — Pure CSS/HTML showcase example. Hover or focus a "View details" button to trigger the popover.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/glitch-flicker-popover/style.css
+++ b/submissions/examples/glitch-flicker-popover/style.css
@@ -1,0 +1,312 @@
+/* =========================================================
+   EaseMotion CSS — Glitch-Flicker Popover
+   Pure CSS/HTML component for creative portfolio layouts.
+   No JavaScript required.
+   ========================================================= */
+
+:root {
+  --em-glitch-bg: #0d0d12;
+  --em-glitch-surface: #16161f;
+  --em-glitch-border: #2a2a38;
+  --em-glitch-text: #f2f2f5;
+  --em-glitch-muted: #a3a3b3;
+
+  --em-glitch-color-1: #ff2ec4;   /* magenta split layer   */
+  --em-glitch-color-2: #2ee6ff;   /* cyan split layer      */
+  --em-glitch-accent: #7c4dff;
+
+  --em-glitch-radius: 10px;
+  --em-glitch-popover-width: 280px;
+
+  --em-glitch-flicker-duration: 1.6s;
+  --em-glitch-shift-duration: 3.2s;
+  --em-glitch-reveal-duration: 220ms;
+}
+
+/* ---------- Page scaffolding (demo only, not required) ---------- */
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--em-glitch-bg);
+  color: var(--em-glitch-text);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  padding: 48px 24px 80px;
+}
+
+.em-page-header {
+  max-width: 760px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.em-page-header h1 {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  margin-bottom: 8px;
+  letter-spacing: 0.5px;
+}
+
+.em-page-header p {
+  color: var(--em-glitch-muted);
+  margin: 0;
+}
+
+.em-page-footer {
+  max-width: 760px;
+  margin: 56px auto 0;
+  text-align: center;
+  color: var(--em-glitch-muted);
+  font-size: 0.85rem;
+}
+
+.em-portfolio-grid {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ---------- Card ---------- */
+
+.em-glitch-card {
+  background: var(--em-glitch-surface);
+  border: 1px solid var(--em-glitch-border);
+  border-radius: var(--em-glitch-radius);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.em-glitch-card__thumb {
+  border-radius: calc(var(--em-glitch-radius) - 4px);
+  height: 140px;
+  display: flex;
+  align-items: flex-end;
+  padding: 10px;
+}
+
+.em-glitch-card__label {
+  font-size: 0.75rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.em-glitch-card__title {
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+/* ---------- Popover trigger + wrapper ---------- */
+
+.em-glitch-popover-wrap {
+  position: relative;
+  display: inline-block;
+  margin-top: auto;
+}
+
+.em-glitch-trigger {
+  font: inherit;
+  cursor: pointer;
+  background: transparent;
+  color: var(--em-glitch-accent);
+  border: 1px solid var(--em-glitch-accent);
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.em-glitch-trigger:hover,
+.em-glitch-trigger:focus-visible {
+  background-color: var(--em-glitch-accent);
+  color: #0d0d12;
+  outline: none;
+}
+
+/* ---------- Popover panel ---------- */
+
+.em-glitch-popover {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 14px);
+  width: var(--em-glitch-popover-width);
+  max-width: 80vw;
+  background: #0a0a10;
+  border: 1px solid var(--em-glitch-border);
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(6px);
+  transition: opacity var(--em-glitch-reveal-duration) ease,
+              transform var(--em-glitch-reveal-duration) ease,
+              visibility 0s linear var(--em-glitch-reveal-duration);
+  z-index: 20;
+}
+
+/* small pointer/tail */
+.em-glitch-popover::after {
+  content: "";
+  position: absolute;
+  bottom: -7px;
+  left: 22px;
+  width: 12px;
+  height: 12px;
+  background: #0a0a10;
+  border-right: 1px solid var(--em-glitch-border);
+  border-bottom: 1px solid var(--em-glitch-border);
+  transform: rotate(45deg);
+}
+
+.em-glitch-popover-wrap:hover .em-glitch-popover,
+.em-glitch-popover-wrap:focus-within .em-glitch-popover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transition: opacity var(--em-glitch-reveal-duration) ease,
+              transform var(--em-glitch-reveal-duration) ease,
+              visibility 0s linear 0s;
+}
+
+/* ---------- Glitch title text ---------- */
+
+.em-glitch-popover__text {
+  position: relative;
+  display: inline-block;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--em-glitch-text);
+}
+
+/* Layered pseudo-elements create the RGB-split glitch look */
+.em-glitch-popover__text::before,
+.em-glitch-popover__text::after {
+  content: attr(data-text);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  overflow: hidden;
+  background: transparent;
+}
+
+.em-glitch-popover__text::before {
+  color: var(--em-glitch-color-1);
+  clip-path: inset(0 0 55% 0);
+}
+
+.em-glitch-popover__text::after {
+  color: var(--em-glitch-color-2);
+  clip-path: inset(55% 0 0 0);
+}
+
+/* Glitch runs only while the popover is visible */
+.em-glitch-popover-wrap:hover .em-glitch-popover__text::before,
+.em-glitch-popover-wrap:focus-within .em-glitch-popover__text::before {
+  animation: em-glitch-shift-1 var(--em-glitch-shift-duration) infinite linear;
+}
+
+.em-glitch-popover-wrap:hover .em-glitch-popover__text::after,
+.em-glitch-popover-wrap:focus-within .em-glitch-popover__text::after {
+  animation: em-glitch-shift-2 var(--em-glitch-shift-duration) infinite linear;
+}
+
+.em-glitch-popover-wrap:hover .em-glitch-popover__text,
+.em-glitch-popover-wrap:focus-within .em-glitch-popover__text {
+  animation: em-glitch-flicker var(--em-glitch-flicker-duration) infinite steps(1, end);
+}
+
+.em-glitch-popover__desc {
+  margin: 10px 0 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--em-glitch-muted);
+}
+
+/* ---------- Keyframes ---------- */
+
+@keyframes em-glitch-shift-1 {
+  0%, 100%   { transform: translate(0, 0); }
+  20%        { transform: translate(-2px, -1px); }
+  40%        { transform: translate(2px, 1px); }
+  60%        { transform: translate(-1px, 1px); }
+  80%        { transform: translate(1px, -1px); }
+}
+
+@keyframes em-glitch-shift-2 {
+  0%, 100%   { transform: translate(0, 0); }
+  20%        { transform: translate(2px, 1px); }
+  40%        { transform: translate(-2px, -1px); }
+  60%        { transform: translate(1px, -1px); }
+  80%        { transform: translate(-1px, 1px); }
+}
+
+/* Flicker fades the base text opacity in short irregular bursts,
+   mimicking an unstable CRT / neon-sign signal. */
+@keyframes em-glitch-flicker {
+  0%   { opacity: 1; }
+  4%   { opacity: 0.4; }
+  6%   { opacity: 1; }
+  18%  { opacity: 1; }
+  20%  { opacity: 0.3; }
+  22%  { opacity: 1; }
+  55%  { opacity: 1; }
+  57%  { opacity: 0.5; }
+  60%  { opacity: 1; }
+  100% { opacity: 1; }
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 480px) {
+  .em-glitch-popover {
+    width: min(var(--em-glitch-popover-width), 72vw);
+    left: 50%;
+    transform: translate(-50%, 6px);
+  }
+
+  .em-glitch-popover-wrap:hover .em-glitch-popover,
+  .em-glitch-popover-wrap:focus-within .em-glitch-popover {
+    transform: translate(-50%, 0);
+  }
+
+  .em-glitch-popover::after {
+    left: 50%;
+    transform: translate(-50%, 0) rotate(45deg);
+  }
+}
+
+/* ---------- Accessibility: reduced motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .em-glitch-popover,
+  .em-glitch-trigger {
+    transition-duration: 1ms;
+  }
+
+  .em-glitch-popover__text::before,
+  .em-glitch-popover__text::after,
+  .em-glitch-popover__text {
+    animation: none !important;
+  }
+
+  /* Keep the split-color look as a static accent instead of a moving glitch */
+  .em-glitch-popover__text::before {
+    transform: translate(-1px, 0);
+    opacity: 0.6;
+  }
+
+  .em-glitch-popover__text::after {
+    transform: translate(1px, 0);
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Add CSS Glitch-Flicker Popover for Creative Portfolio Layouts

Closes #54488

### 🎯 What this adds
A pure CSS/HTML popover component for creative portfolio layouts. Hovering
or focusing a "View details" trigger reveals a popover whose title text
uses a layered RGB-split glitch effect combined with an irregular neon-style
flicker animation.

### 📦 Files added
submissions/examples/glitch-flicker-popover/
├── demo.html
├── style.css
└── README.md

### ✨ Features
- 100% pure CSS/HTML — no JavaScript dependencies
- RGB-split glitch title using `::before`/`::after` pseudo-elements with
  `clip-path` and `attr(data-text)`
- Irregular flicker via `steps()` keyframes, mimicking an unstable
  neon/CRT signal
- Opens on both `:hover` and `:focus-within` — fully keyboard accessible
- `prefers-reduced-motion` support — animations disable gracefully,
  falling back to a static two-tone offset
- Fully responsive (tested down to 320px viewport width)
- Semantic markup with `role="tooltip"` and `aria-describedby` linking
  trigger to popover content
- Fully customizable via CSS custom properties (`--em-glitch-color-1`,
  `--em-glitch-color-2`, `--em-glitch-flicker-duration`, etc.) — documented
  in the README

### ✅ Testing done
- Verified in a modern desktop browser at various viewport widths
  (desktop / tablet / mobile)
- Verified keyboard navigation (Tab to trigger, popover opens on focus)
- Verified `prefers-reduced-motion: reduce` disables the glitch/flicker
  animation and falls back to the static split-color style

### 📸 Screenshots
<!-- add before/after screenshots or a short screen recording here -->