### PR TITLE
feat: add spring physics tabs for interactive interface layouts

### DIFF
--- a/submissions/examples/spring-physics-tabs-interactive-interface-sd/README.md
+++ b/submissions/examples/spring-physics-tabs-interactive-interface-sd/README.md
@@ -1,0 +1,13 @@
+# Spring Physics Tabs
+
+## What does this do?
+
+A pure-CSS tab panel that uses a spring-like easing curve for smooth, bouncy transitions between tab states.
+
+## How is it used?
+
+Add a `.spring-physics-tabs` container with radio inputs, labels, and content panels. The spring feel is adjustable via custom properties.
+
+## Why is it useful?
+
+It provides accessible, responsive tabs with a polished motion feel using zero JavaScript and minimal CSS.

--- a/submissions/examples/spring-physics-tabs-interactive-interface-sd/demo.html
+++ b/submissions/examples/spring-physics-tabs-interactive-interface-sd/demo.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Spring Physics Tabs — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        background: #f5f5f5;
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+      }
+      .spring-physics-tabs {
+        width: min(480px, 90vw);
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+      }
+      .spring-physics-tabs > label {
+        flex: 1;
+        text-align: center;
+        font-weight: 500;
+        font-size: 0.9rem;
+      }
+      .spring-physics-tabs__panel h3 {
+        margin: 0 0 0.5rem;
+      }
+      .spring-physics-tabs__panel p {
+        margin: 0;
+        line-height: 1.6;
+        color: #555;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spring-physics-tabs">
+      <input type="radio" name="t" id="t1" checked />
+      <label for="t1">Tab 1</label>
+      <input type="radio" name="t" id="t2" />
+      <label for="t2">Tab 2</label>
+      <input type="radio" name="t" id="t3" />
+      <label for="t3">Tab 3</label>
+      <div class="spring-physics-tabs__panels">
+        <div class="spring-physics-tabs__panel">
+          <h3>Tab 1</h3>
+          <p>
+            Spring physics tabs use a cubic-bezier easing with overshoot for a
+            natural bounce feel.
+          </p>
+        </div>
+        <div class="spring-physics-tabs__panel">
+          <h3>Tab 2</h3>
+          <p>
+            All transitions are driven by CSS custom properties --tabs-duration,
+            --tabs-easing, and --tabs-bounce-scale.
+          </p>
+        </div>
+        <div class="spring-physics-tabs__panel">
+          <h3>Tab 3</h3>
+          <p>
+            Keyboard accessible via radio inputs. Focus visible state is shown
+            with the accent color.
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/spring-physics-tabs-interactive-interface-sd/style.css
+++ b/submissions/examples/spring-physics-tabs-interactive-interface-sd/style.css
@@ -1,0 +1,59 @@
+.spring-physics-tabs {
+  --tabs-duration: 0.4s;
+  --tabs-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --tabs-bounce-scale: 0.97;
+  --tabs-accent-color: #6366f1;
+  --tabs-scale: 1;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.spring-physics-tabs > input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.spring-physics-tabs > label {
+  padding: 0.75em 1.25em;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    border-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.spring-physics-tabs > input:checked + label {
+  color: var(--tabs-accent-color);
+  border-bottom-color: var(--tabs-accent-color);
+}
+
+.spring-physics-tabs > input:focus-visible + label {
+  outline: 2px solid var(--tabs-accent-color);
+  outline-offset: -2px;
+}
+
+.spring-physics-tabs__panels {
+  display: grid;
+  width: 100%;
+  overflow: hidden;
+}
+
+.spring-physics-tabs__panel {
+  grid-area: 1 / 1;
+  padding: 1.25em;
+  transform: scale(var(--tabs-bounce-scale));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--tabs-duration) var(--tabs-easing),
+    opacity var(--tabs-duration) var(--tabs-easing);
+}
+
+.spring-physics-tabs:has(#t1:checked) .spring-physics-tabs__panel:nth-child(1),
+.spring-physics-tabs:has(#t2:checked) .spring-physics-tabs__panel:nth-child(2),
+.spring-physics-tabs:has(#t3:checked) .spring-physics-tabs__panel:nth-child(3) {
+  transform: scale(var(--tabs-scale));
+  opacity: 1;
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS tabs component featuring a smooth spring-style interaction designed for interactive interface layouts. The component is responsive, keyboard accessible, and customizable through CSS custom properties without requiring JavaScript.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS tabs component with a subtle spring-style transition that adds a responsive, interactive feel to tab switching.

**How does a developer use it?**

```html id="6e1vxt"
<div class="spring-physics-tabs">
  <!-- tabs -->
</div>
```

**Why does it fit EaseMotion CSS?**

It provides a lightweight animation-focused navigation pattern that enhances interaction feedback while remaining reusable, customizable, and JavaScript-free.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari _(optional but appreciated)_

---

## Notes for Maintainer

- Uses native radio inputs and CSS selectors.
- Implements a lightweight spring-style transition.
- Designed for interactive interface layouts.
- Fully responsive and keyboard accessible.
- Customizable through CSS variables.

Closes #50330
