### PR TITLE
Feat/fade in tabs neumorphic issue 50019

### DIFF
--- a/submissions/examples/fade-in-tabs-neumorphic-issue-50019/index.html
+++ b/submissions/examples/fade-in-tabs-neumorphic-issue-50019/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-fade-tabs-neumorphic — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-stage">
+    <h1 class="demo-title">ease-fade-tabs-neumorphic</h1>
+    <p class="demo-sub">Pure CSS tabs — soft neumorphic surface, fade-in panel transitions, zero JavaScript.</p>
+
+    <!-- ==== COMPONENT: drop this block into your project ==== -->
+    <div class="ease-tabs" style="--ease-tabs-duration: 0.45s; --ease-tabs-easing: cubic-bezier(0.22, 1, 0.36, 1); --ease-tabs-scale: 0.97;">
+
+      <!-- state inputs (visually hidden, drive everything below) -->
+      <input type="radio" name="ease-tabs-demo" id="ease-tab-1" class="ease-tabs__input" checked>
+      <input type="radio" name="ease-tabs-demo" id="ease-tab-2" class="ease-tabs__input">
+      <input type="radio" name="ease-tabs-demo" id="ease-tab-3" class="ease-tabs__input">
+
+      <div class="ease-tabs__nav" role="tablist" aria-label="Demo tabs">
+        <label for="ease-tab-1" class="ease-tabs__tab" role="tab">Overview</label>
+        <label for="ease-tab-2" class="ease-tabs__tab" role="tab">Details</label>
+        <label for="ease-tab-3" class="ease-tabs__tab" role="tab">Settings</label>
+      </div>
+
+      <div class="ease-tabs__panels">
+        <div class="ease-tabs__panel" id="ease-panel-1">
+          <h3>Overview</h3>
+          <p>Tab, or use Arrow keys once focused, to move between tabs — the underlying <code>&lt;input type="radio"&gt;</code> group handles all of it natively, no JavaScript involved.</p>
+        </div>
+        <div class="ease-tabs__panel" id="ease-panel-2">
+          <h3>Details</h3>
+          <p>Each panel cross-fades in place using CSS Grid stacking, so the container never jumps height when you switch tabs.</p>
+        </div>
+        <div class="ease-tabs__panel" id="ease-panel-3">
+          <h3>Settings</h3>
+          <p>Tune <code>--ease-tabs-duration</code>, <code>--ease-tabs-easing</code>, and <code>--ease-tabs-scale</code> to change the feel of the transition.</p>
+        </div>
+      </div>
+
+    </div>
+    <!-- ==== END COMPONENT ==== -->
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-tabs-neumorphic-issue-50019/style.css
+++ b/submissions/examples/fade-in-tabs-neumorphic-issue-50019/style.css
@@ -1,0 +1,194 @@
+/*
+  ease-fade-tabs-neumorphic
+  Pure CSS tabs with a soft neumorphic surface and fade-in panel transitions.
+  Zero JavaScript. Built on native <input type="radio"> state + CSS Grid stacking.
+
+  Customize via CSS custom properties on .ease-tabs:
+    --ease-tabs-duration   transition length            (default 0.4s)
+    --ease-tabs-easing     transition timing function   (default ease)
+    --ease-tabs-scale      starting scale for fade-in   (default 0.98)
+*/
+
+:root {
+  --ease-tabs-bg: #e4e9f2;
+  --ease-tabs-shadow-dark: rgba(163, 177, 198, 0.65);
+  --ease-tabs-shadow-light: rgba(255, 255, 255, 0.85);
+  --ease-tabs-text: #3c4657;
+  --ease-tabs-text-muted: #7c8697;
+  --ease-tabs-accent: #5b6ee8;
+}
+
+.ease-tabs {
+  --ease-tabs-duration: 0.4s;
+  --ease-tabs-easing: ease;
+  --ease-tabs-scale: 0.98;
+
+  width: 100%;
+  max-width: 32rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Hide the real inputs but keep them focusable/keyboard-operable */
+.ease-tabs__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-tabs__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.4rem;
+  border-radius: 1rem;
+  background: var(--ease-tabs-bg);
+  box-shadow:
+    inset 3px 3px 6px var(--ease-tabs-shadow-dark),
+    inset -3px -3px 6px var(--ease-tabs-shadow-light);
+}
+
+.ease-tabs__tab {
+  flex: 1 1 auto;
+  text-align: center;
+  padding: 0.65rem 1rem;
+  border-radius: 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ease-tabs-text-muted);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    color 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.ease-tabs__tab:hover {
+  color: var(--ease-tabs-text);
+}
+
+/* Active tab: raised neumorphic "button" look */
+.ease-tabs__input:nth-of-type(1):checked ~ .ease-tabs__nav label[for="ease-tab-1"],
+.ease-tabs__input:nth-of-type(2):checked ~ .ease-tabs__nav label[for="ease-tab-2"],
+.ease-tabs__input:nth-of-type(3):checked ~ .ease-tabs__nav label[for="ease-tab-3"] {
+  color: var(--ease-tabs-accent);
+  background: var(--ease-tabs-bg);
+  box-shadow:
+    2px 2px 5px var(--ease-tabs-shadow-dark),
+    -2px -2px 5px var(--ease-tabs-shadow-light);
+}
+
+/* Visible keyboard focus ring on the label tied to the focused input */
+#ease-tab-1:focus-visible ~ .ease-tabs__nav label[for="ease-tab-1"],
+#ease-tab-2:focus-visible ~ .ease-tabs__nav label[for="ease-tab-2"],
+#ease-tab-3:focus-visible ~ .ease-tabs__nav label[for="ease-tab-3"] {
+  outline: 2px solid var(--ease-tabs-accent);
+  outline-offset: 2px;
+}
+
+/* Panels: stacked in one grid cell so height never jumps between tabs */
+.ease-tabs__panels {
+  position: relative;
+  display: grid;
+  margin-top: 1rem;
+  border-radius: 1rem;
+  background: var(--ease-tabs-bg);
+  box-shadow:
+    6px 6px 14px var(--ease-tabs-shadow-dark),
+    -6px -6px 14px var(--ease-tabs-shadow-light);
+}
+
+.ease-tabs__panel {
+  grid-area: 1 / 1;
+  padding: 1.25rem 1.5rem;
+  color: var(--ease-tabs-text);
+  opacity: 0;
+  transform: translateY(0.35rem) scale(var(--ease-tabs-scale));
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    opacity var(--ease-tabs-duration) var(--ease-tabs-easing),
+    transform var(--ease-tabs-duration) var(--ease-tabs-easing),
+    visibility 0s linear var(--ease-tabs-duration);
+}
+
+.ease-tabs__panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.ease-tabs__panel p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ease-tabs-text-muted);
+}
+
+.ease-tabs__panel code {
+  background: rgba(0, 0, 0, 0.06);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.35rem;
+  font-size: 0.85em;
+}
+
+#ease-tab-1:checked ~ .ease-tabs__panels #ease-panel-1,
+#ease-tab-2:checked ~ .ease-tabs__panels #ease-panel-2,
+#ease-tab-3:checked ~ .ease-tabs__panels #ease-panel-3 {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+  visibility: visible;
+  transition:
+    opacity var(--ease-tabs-duration) var(--ease-tabs-easing),
+    transform var(--ease-tabs-duration) var(--ease-tabs-easing),
+    visibility 0s linear 0s;
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs__panel {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Stack tabs vertically on narrow viewports */
+@media (max-width: 30rem) {
+  .ease-tabs__nav {
+    flex-direction: column;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component; remove if lifting only the tabs) ---- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e4e9f2;
+}
+
+.demo-stage {
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.demo-title {
+  font-family: system-ui, sans-serif;
+  color: #3c4657;
+  margin-bottom: 0.35rem;
+}
+
+.demo-sub {
+  font-family: system-ui, sans-serif;
+  color: #7c8697;
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
## Description

Adds `ease-fade-tabs-neumorphic`, a pure CSS tabs component with a
soft neumorphic surface and fade-in panel transitions, resolving #50019.

(Supersedes #55233, which was auto-closed due to an empty `index.html`
in the first push — fixed here.)

## Implementation Details

- **Zero JavaScript**: driven entirely by native `<input type="radio">`
  state + the `:checked` pseudo-class — Tab/Arrow keys/Space all work
  out of the box.
- **No layout jump**: panels are stacked in a single CSS Grid cell so
  switching tabs never changes the container's height.
- **Fade-in transition**: active panel animates opacity + a subtle
  scale/translate via CSS custom properties.
- **Customizable**: exposes `--ease-tabs-duration`, `--ease-tabs-easing`,
  and `--ease-tabs-scale` for consumers to tune timing and feel.
- **Neumorphic styling**: soft inset/outset shadows, muted background,
  no harsh borders.
- **Accessible**: visible focus ring via `:focus-visible`, respects
  `prefers-reduced-motion`, tabs stack vertically under 30rem width.

## Files Changed

- `submissions/examples/fade-in-tabs-neumorphic-issue-50019/index.html`
- `submissions/examples/fade-in-tabs-neumorphic-issue-50019/style.css`

Resolves #50019