### PR TITLE
feat: add fade-in tabs SaaS example (#50010)

### DIFF
--- a/submissions/examples/fade-in-tabs-saas-issue-50010/README.md
+++ b/submissions/examples/fade-in-tabs-saas-issue-50010/README.md
@@ -1,0 +1,55 @@
+# ease-fade-tabs-saas
+
+Pure CSS tabs component with a clean modern SaaS surface and fade-in panel transitions. Zero JavaScript.
+
+Resolves #50010.
+
+## What it does
+
+A tabbed interface where switching tabs cross-fades the panel content in place, styled to match a modern SaaS dashboard aesthetic — a segmented-control nav on a light gray track, with the active tab lifting to a white pill with a soft layered shadow and indigo accent.
+
+## How to use it
+
+Copy `style.css` into your project (or the relevant classes into your framework bundle), then mark up the tabs like this:
+
+```html
+<div class="ease-tabs-saas" style="--ease-tabs-saas-duration: 0.35s; --ease-tabs-saas-easing: cubic-bezier(0.16, 1, 0.3, 1); --ease-tabs-saas-scale: 0.98;">
+
+  <input type="radio" name="my-tabs" id="tab-1" class="ease-tabs-saas__input" checked>
+  <input type="radio" name="my-tabs" id="tab-2" class="ease-tabs-saas__input">
+
+  <div class="ease-tabs-saas__nav" role="tablist">
+    <label for="tab-1" class="ease-tabs-saas__tab" role="tab">One</label>
+    <label for="tab-2" class="ease-tabs-saas__tab" role="tab">Two</label>
+  </div>
+
+  <div class="ease-tabs-saas__panels">
+    <div class="ease-tabs-saas__panel" id="panel-1">Content one</div>
+    <div class="ease-tabs-saas__panel" id="panel-2">Content two</div>
+  </div>
+
+</div>
+```
+
+Open `demo.html` directly in a browser to see it running — no build step or server needed.
+
+### Customizing
+
+Three CSS custom properties control the feel of the transition:
+
+| Property | Default | Effect |
+|---|---|---|
+| `--ease-tabs-saas-duration` | `0.35s` | Length of the fade/scale transition |
+| `--ease-tabs-saas-easing` | `ease` | Timing function for the transition |
+| `--ease-tabs-saas-scale` | `0.98` | Starting scale of the incoming panel |
+
+## Why it fits EaseMotion CSS
+
+- **No JavaScript**: state is driven entirely by native `<input type="radio">` + the `:checked` pseudo-class, in line with the framework's zero-dependency philosophy.
+- **Keyboard accessible**: Tab and Arrow keys move between tabs natively; a visible focus ring is shown via `:focus-visible`.
+- **No layout jump**: panels are stacked in a single CSS Grid cell, so the container height stays fixed to the tallest panel across all tabs.
+- **Respects `prefers-reduced-motion`** and stacks the tab nav vertically under 30rem width.
+
+## Browsers tested
+
+Chrome · Firefox · Edge

--- a/submissions/examples/fade-in-tabs-saas-issue-50010/index.html
+++ b/submissions/examples/fade-in-tabs-saas-issue-50010/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-fade-tabs-saas — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-stage">
+    <h1 class="demo-title">ease-fade-tabs-saas</h1>
+    <p class="demo-sub">Pure CSS tabs — modern SaaS surface, fade-in panel transitions, zero JavaScript.</p>
+
+    <!-- ==== COMPONENT: drop this block into your project ==== -->
+    <div class="ease-tabs-saas" style="--ease-tabs-saas-duration: 0.35s; --ease-tabs-saas-easing: cubic-bezier(0.16, 1, 0.3, 1); --ease-tabs-saas-scale: 0.98;">
+
+      <!-- state inputs (visually hidden, drive everything below) -->
+      <input type="radio" name="ease-tabs-saas-demo" id="ease-saas-tab-1" class="ease-tabs-saas__input" checked>
+      <input type="radio" name="ease-tabs-saas-demo" id="ease-saas-tab-2" class="ease-tabs-saas__input">
+      <input type="radio" name="ease-tabs-saas-demo" id="ease-saas-tab-3" class="ease-tabs-saas__input">
+
+      <div class="ease-tabs-saas__nav" role="tablist" aria-label="Demo tabs">
+        <label for="ease-saas-tab-1" class="ease-tabs-saas__tab" role="tab">Dashboard</label>
+        <label for="ease-saas-tab-2" class="ease-tabs-saas__tab" role="tab">Billing</label>
+        <label for="ease-saas-tab-3" class="ease-tabs-saas__tab" role="tab">Team</label>
+      </div>
+
+      <div class="ease-tabs-saas__panels">
+        <div class="ease-tabs-saas__panel" id="ease-saas-panel-1">
+          <h3>Dashboard</h3>
+          <p>Tab, or use Arrow keys once focused, to move between tabs — the underlying <code>&lt;input type="radio"&gt;</code> group handles all of it natively, no JavaScript involved.</p>
+        </div>
+        <div class="ease-tabs-saas__panel" id="ease-saas-panel-2">
+          <h3>Billing</h3>
+          <p>Each panel cross-fades in place using CSS Grid stacking, so the container never jumps height when you switch tabs.</p>
+        </div>
+        <div class="ease-tabs-saas__panel" id="ease-saas-panel-3">
+          <h3>Team</h3>
+          <p>Tune <code>--ease-tabs-saas-duration</code>, <code>--ease-tabs-saas-easing</code>, and <code>--ease-tabs-saas-scale</code> to change the feel of the transition.</p>
+        </div>
+      </div>
+
+    </div>
+    <!-- ==== END COMPONENT ==== -->
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-tabs-saas-issue-50010/style.css
+++ b/submissions/examples/fade-in-tabs-saas-issue-50010/style.css
@@ -1,0 +1,191 @@
+/*
+  ease-fade-tabs-saas
+  Pure CSS tabs with a clean modern SaaS surface and fade-in panel transitions.
+  Zero JavaScript. Built on native <input type="radio"> state + CSS Grid stacking.
+
+  Customize via CSS custom properties on .ease-tabs-saas:
+    --ease-tabs-saas-duration   transition length            (default 0.35s)
+    --ease-tabs-saas-easing     transition timing function   (default ease)
+    --ease-tabs-saas-scale      starting scale for fade-in   (default 0.98)
+*/
+
+:root {
+  --ease-tabs-saas-surface: #ffffff;
+  --ease-tabs-saas-border: #e4e7ec;
+  --ease-tabs-saas-text: #1d2433;
+  --ease-tabs-saas-text-muted: #667085;
+  --ease-tabs-saas-accent: #4f46e5;
+  --ease-tabs-saas-accent-soft: #eef0fe;
+  --ease-tabs-saas-shadow: 0 1px 2px rgba(16, 24, 40, 0.05), 0 1px 3px rgba(16, 24, 40, 0.06);
+}
+
+.ease-tabs-saas {
+  --ease-tabs-saas-duration: 0.35s;
+  --ease-tabs-saas-easing: ease;
+  --ease-tabs-saas-scale: 0.98;
+
+  width: 100%;
+  max-width: 32rem;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Hide the real inputs but keep them focusable/keyboard-operable */
+.ease-tabs-saas__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-tabs-saas__nav {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.3rem;
+  border-radius: 0.65rem;
+  background: #f5f6f8;
+  border: 1px solid var(--ease-tabs-saas-border);
+}
+
+.ease-tabs-saas__tab {
+  flex: 1 1 auto;
+  text-align: center;
+  padding: 0.55rem 1rem;
+  border-radius: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ease-tabs-saas-text-muted);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    color 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.ease-tabs-saas__tab:hover {
+  color: var(--ease-tabs-saas-text);
+}
+
+/* Active tab: elevated pill, matches the panel surface */
+#ease-saas-tab-1:checked ~ .ease-tabs-saas__nav label[for="ease-saas-tab-1"],
+#ease-saas-tab-2:checked ~ .ease-tabs-saas__nav label[for="ease-saas-tab-2"],
+#ease-saas-tab-3:checked ~ .ease-tabs-saas__nav label[for="ease-saas-tab-3"] {
+  color: var(--ease-tabs-saas-accent);
+  background: var(--ease-tabs-saas-surface);
+  box-shadow: var(--ease-tabs-saas-shadow);
+}
+
+/* Visible keyboard focus ring on the label tied to the focused input */
+#ease-saas-tab-1:focus-visible ~ .ease-tabs-saas__nav label[for="ease-saas-tab-1"],
+#ease-saas-tab-2:focus-visible ~ .ease-tabs-saas__nav label[for="ease-saas-tab-2"],
+#ease-saas-tab-3:focus-visible ~ .ease-tabs-saas__nav label[for="ease-saas-tab-3"] {
+  outline: 2px solid var(--ease-tabs-saas-accent);
+  outline-offset: 2px;
+}
+
+/* Panels: stacked in one grid cell so height never jumps between tabs */
+.ease-tabs-saas__panels {
+  position: relative;
+  display: grid;
+  margin-top: 1rem;
+  border-radius: 0.75rem;
+  background: var(--ease-tabs-saas-surface);
+  border: 1px solid var(--ease-tabs-saas-border);
+  box-shadow: var(--ease-tabs-saas-shadow);
+}
+
+.ease-tabs-saas__panel {
+  grid-area: 1 / 1;
+  padding: 1.5rem;
+  color: var(--ease-tabs-saas-text);
+  opacity: 0;
+  transform: translateY(0.35rem) scale(var(--ease-tabs-saas-scale));
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    opacity var(--ease-tabs-saas-duration) var(--ease-tabs-saas-easing),
+    transform var(--ease-tabs-saas-duration) var(--ease-tabs-saas-easing),
+    visibility 0s linear var(--ease-tabs-saas-duration);
+}
+
+.ease-tabs-saas__panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.ease-tabs-saas__panel p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--ease-tabs-saas-text-muted);
+}
+
+.ease-tabs-saas__panel code {
+  background: var(--ease-tabs-saas-accent-soft);
+  color: var(--ease-tabs-saas-accent);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.35rem;
+  font-size: 0.85em;
+}
+
+#ease-saas-tab-1:checked ~ .ease-tabs-saas__panels #ease-saas-panel-1,
+#ease-saas-tab-2:checked ~ .ease-tabs-saas__panels #ease-saas-panel-2,
+#ease-saas-tab-3:checked ~ .ease-tabs-saas__panels #ease-saas-panel-3 {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+  visibility: visible;
+  transition:
+    opacity var(--ease-tabs-saas-duration) var(--ease-tabs-saas-easing),
+    transform var(--ease-tabs-saas-duration) var(--ease-tabs-saas-easing),
+    visibility 0s linear 0s;
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-saas__panel {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Stack tabs vertically on narrow viewports */
+@media (max-width: 30rem) {
+  .ease-tabs-saas__nav {
+    flex-direction: column;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component; remove if lifting only the tabs) ---- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f6f8;
+}
+
+.demo-stage {
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.demo-title {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #1d2433;
+  margin-bottom: 0.35rem;
+}
+
+.demo-sub {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #667085;
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
### Description:

### What this adds

A fade-in tabs UI component styled for SaaS dashboards/landing pages, added under submissions/examples/fade-in-tabs-saas-issue-50010/.

### Files
demo.html — standalone demo markup for the component
style.css — styles for the tabs and fade-in transition
README.md — explains what the component does, how to use it, and why it fits this repo
### 
How it works

Clicking a tab fades out the current panel and fades in the selected one, using CSS transitions triggered by a small JS toggle for the active tab state.

### Testing

Opened demo.html directly in the browser and verified:

All tabs switch correctly
Fade transition plays smoothly on each switch
No console errors

Closes #50010