### PR TITLE
feat: add CSS Float-Drift Tooltip for Accessible Web Layouts

### DIFF
--- a/submissions/examples/float-drift-tooltip-accessible-web/README.md
+++ b/submissions/examples/float-drift-tooltip-accessible-web/README.md
@@ -1,0 +1,36 @@
+﻿# CSS Float-Drift Tooltip — Accessible Web Layout
+
+A pure CSS tooltip that, once visible, gently drifts up and down in a slow continuous loop while it remains open.
+
+## CSS Custom Properties
+
+| Property                       | Default    | Description                        |
+|-----------------------------------|--------------|----------------------------------------|
+| `--ease-tooltip-float-duration` | `3s`          | Duration of one float drift cycle      |
+| `--ease-tooltip-drift-distance` | `4px`         | Vertical drift distance                |
+| `--ease-tooltip-bg`             | `#111827`     | Tooltip background color                |
+| `--ease-tooltip-text`           | `#f9fafb`     | Tooltip text color                      |
+| `--ease-tooltip-radius`         | `8px`         | Tooltip corner radius                   |
+| `--ease-tooltip-focus-ring`     | `#1d4ed8`     | Focus outline color on the trigger      |
+
+## Usage
+
+```html
+<div class="ease-tooltip-wrap">
+  <button class="ease-tooltip-trigger" aria-describedby="tooltip1">Hover or Focus Me</button>
+  <span class="ease-tooltip" role="tooltip" id="tooltip1">Tooltip text</span>
+</div>
+```
+
+The tooltip shows on `:hover` and `:focus-within`, and the float animation starts automatically once visible.
+
+## Accessibility
+
+- Uses `role="tooltip"` and `aria-describedby` linking trigger to tooltip content.
+- Fully keyboard accessible — `:focus-within` shows the tooltip for keyboard users, not just mouse hover.
+- Strong border and high-contrast trigger styling avoid relying on color alone.
+- `prefers-reduced-motion: reduce` disables the float animation, keeping the tooltip static once shown.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing/distance via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy.

--- a/submissions/examples/float-drift-tooltip-accessible-web/demo.html
+++ b/submissions/examples/float-drift-tooltip-accessible-web/demo.html
@@ -1,0 +1,22 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Float-Drift Tooltip Demo — Accessible Web</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; display: flex; align-items: center; justify-content: center; margin: 0; background: #f9fafb; }
+    .wrap { text-align: center; }
+    h2 { color: #111827; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h2>CSS Float-Drift Tooltip — Accessible Web</h2>
+    <div class="ease-tooltip-wrap">
+      <button class="ease-tooltip-trigger" aria-describedby="tooltip1">Hover or Focus Me</button>
+      <span class="ease-tooltip" role="tooltip" id="tooltip1">Gently drifting tooltip</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/float-drift-tooltip-accessible-web/style.css
+++ b/submissions/examples/float-drift-tooltip-accessible-web/style.css
@@ -1,0 +1,77 @@
+﻿:root {
+  --ease-tooltip-float-duration: 3s;
+  --ease-tooltip-bg: #111827;
+  --ease-tooltip-text: #f9fafb;
+  --ease-tooltip-radius: 8px;
+  --ease-tooltip-drift-distance: 4px;
+  --ease-tooltip-focus-ring: #1d4ed8;
+}
+
+.ease-tooltip-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-tooltip-trigger {
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: 2px solid #1d4ed8;
+  background: #ffffff;
+  color: #1d4ed8;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ease-tooltip-trigger:focus-visible {
+  outline: 3px solid var(--ease-tooltip-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Float-Drift: once visible, the tooltip gently drifts up and down in a
+   slow, continuous loop, drawing the eye without being distracting. */
+.ease-tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ease-tooltip-bg);
+  color: var(--ease-tooltip-text);
+  padding: 8px 14px;
+  border-radius: var(--ease-tooltip-radius);
+  font-size: 13px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.ease-tooltip-wrap:hover .ease-tooltip,
+.ease-tooltip-wrap:focus-within .ease-tooltip {
+  opacity: 1;
+  visibility: visible;
+  animation: ease-tooltip-float var(--ease-tooltip-float-duration) ease-in-out infinite;
+}
+
+@keyframes ease-tooltip-float {
+  0%, 100% { transform: translate(-50%, 0); }
+  50% { transform: translate(-50%, calc(-1 * var(--ease-tooltip-drift-distance))); }
+}
+
+.ease-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--ease-tooltip-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip-wrap:hover .ease-tooltip,
+  .ease-tooltip-wrap:focus-within .ease-tooltip {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS tooltip with a gentle float-drift animation once visible, styled for accessible web layouts. Resolves #54311

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes inside `submissions/examples/float-drift-tooltip-accessible-web/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A tooltip that gently drifts up and down in a slow loop while visible, shown on both hover and keyboard focus.
**Usage:**
```html
<div class="ease-tooltip-wrap">
  <button class="ease-tooltip-trigger" aria-describedby="tooltip1">Hover or Focus Me</button>
  <span class="ease-tooltip" role="tooltip" id="tooltip1">Tooltip text</span>
</div>
```
**Why EaseMotion CSS?** `ease-` prefixed classes, themeable via custom properties, zero-JS pure CSS.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Uses `role="tooltip"` + `aria-describedby`, and shows on `:focus-within` (not just hover) for full keyboard accessibility. `prefers-reduced-motion` disables the float loop.