### PR TITLE
feat: add slide-up tabs SaaS showcase example (#50029)

### DIFF
--- a/submissions/examples/slide-up-tabs-saas-issue-50029/Demo.html
+++ b/submissions/examples/slide-up-tabs-saas-issue-50029/Demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Slide-Up Tabs — SaaS Showcase</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #0a0b10;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-saas">
+  <div class="tabs-saas__list" role="tablist" aria-label="Product showcase">
+
+    <input class="tabs-saas__input" type="radio" name="saas-tabs" id="tab-overview" checked />
+    <label class="tabs-saas__tab" for="tab-overview" role="tab" aria-selected="true">
+      <span class="tabs-saas__tab-index">01</span>
+      <span class="tabs-saas__tab-label">Overview</span>
+    </label>
+
+    <input class="tabs-saas__input" type="radio" name="saas-tabs" id="tab-analytics" />
+    <label class="tabs-saas__tab" for="tab-analytics" role="tab" aria-selected="false">
+      <span class="tabs-saas__tab-index">02</span>
+      <span class="tabs-saas__tab-label">Analytics</span>
+    </label>
+
+    <input class="tabs-saas__input" type="radio" name="saas-tabs" id="tab-integrations" />
+    <label class="tabs-saas__tab" for="tab-integrations" role="tab" aria-selected="false">
+      <span class="tabs-saas__tab-index">03</span>
+      <span class="tabs-saas__tab-label">Integrations</span>
+    </label>
+
+    <input class="tabs-saas__input" type="radio" name="saas-tabs" id="tab-billing" />
+    <label class="tabs-saas__tab" for="tab-billing" role="tab" aria-selected="false">
+      <span class="tabs-saas__tab-index">04</span>
+      <span class="tabs-saas__tab-label">Billing</span>
+    </label>
+
+  </div>
+
+  <div class="tabs-saas__panels">
+
+    <section class="tabs-saas__panel" id="panel-overview">
+      <span class="tabs-saas__panel-tag">WORKSPACE</span>
+      <h3>Everything in one pane</h3>
+      <p>See active projects, recent activity, and team status at a glance. Overview pulls live data from every connected workspace so nothing needs a separate check-in.</p>
+    </section>
+
+    <section class="tabs-saas__panel" id="panel-analytics">
+      <span class="tabs-saas__panel-tag">METRICS</span>
+      <h3>Usage, tracked in real time</h3>
+      <p>Session counts, conversion funnels, and retention curves update as events come in. Filter by team, plan tier, or date range without leaving the tab.</p>
+    </section>
+
+    <section class="tabs-saas__panel" id="panel-integrations">
+      <span class="tabs-saas__panel-tag">CONNECT</span>
+      <h3>Plug in your stack</h3>
+      <p>Native connectors for Slack, GitHub, and your data warehouse. Each integration authenticates once and syncs on a schedule you control.</p>
+    </section>
+
+    <section class="tabs-saas__panel" id="panel-billing">
+      <span class="tabs-saas__panel-tag">ACCOUNT</span>
+      <h3>Plan and usage, side by side</h3>
+      <p>Track spend against your plan limit in real time, with a breakdown by seat and by feature so upgrades are never a surprise.</p>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/slide-up-tabs-saas-issue-50029/README.md
+++ b/submissions/examples/slide-up-tabs-saas-issue-50029/README.md
@@ -1,0 +1,49 @@
+# Slide-Up Tabs — SaaS Showcase
+
+A pure CSS tabs component with a smooth slide-up reveal, styled for SaaS product showcase layouts. No JavaScript required.
+
+## What it does
+
+- Clicking (or keyboard-selecting) a tab reveals its panel with a slide-up + fade transition.
+- The active tab visually lifts, like a key rising, with a soft accent glow underneath.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios in the same `name` group give native keyboard support for free: `Tab` focuses the group, arrow keys move between tabs, and the group always has exactly one selection.
+- `.tabs-saas:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the slide-up keyframe only when its tab is active.
+- The active tab's lift/glow state is driven by an adjacent-sibling selector: `.tabs-saas__input:checked + .tabs-saas__tab`.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-saas` wrapper, so consumers can retheme or retime the component without touching the CSS file:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `420ms` | Transition/animation length |
+| `--tabs-easing` | `cubic-bezier(0.22, 1, 0.36, 1)` | Easing curve for lift + slide-up |
+| `--tabs-lift` | `6px` | How far the active tab rises |
+| `--tabs-slide-distance` | `18px` | How far the panel travels on reveal |
+| `--tabs-radius` | `12px` | Corner radius |
+| `--tabs-accent` | `#7c5cfc` | Accent color (active tab glow, tag, index number) |
+| `--tabs-bg` / `--tabs-panel-bg` | `#12141c` / `#171a23` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | `#e8e9f0` / `#8b8fa3` | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-saas" style="--tabs-duration: 250ms; --tabs-accent: #22c55e;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup for screen reader clarity.
+- A visible focus ring is applied to the active tab's label via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the lift transition and slide-up animation.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven animation pattern in the SaaS aesthetic requested in issue #50029 — responsive down to mobile, keyboard accessible out of the box via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/slide-up-tabs-saas-issue-50029/style.css
+++ b/submissions/examples/slide-up-tabs-saas-issue-50029/style.css
@@ -1,0 +1,202 @@
+/* ==========================================================================
+   Slide-Up Tabs — SaaS Showcase
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-saas (see README).
+   ========================================================================== */
+
+.tabs-saas {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 420ms;
+  --tabs-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --tabs-lift: 6px;               /* how far the active tab rises */
+  --tabs-slide-distance: 18px;    /* how far panels travel on reveal */
+  --tabs-radius: 12px;
+  --tabs-accent: #7c5cfc;
+  --tabs-accent-soft: rgba(124, 92, 252, 0.16);
+  --tabs-bg: #12141c;
+  --tabs-panel-bg: #171a23;
+  --tabs-border: #262a38;
+  --tabs-text: #e8e9f0;
+  --tabs-text-dim: #8b8fa3;
+  --tabs-font-ui: "Space Grotesk", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "JetBrains Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 640px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 20px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-saas__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-saas__list {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--tabs-panel-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tabs-saas__tab {
+  position: relative;
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 16px;
+  border-radius: calc(var(--tabs-radius) - 4px);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  font-family: var(--tabs-font-ui);
+  transition:
+    transform var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing),
+    box-shadow var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-saas__tab-index {
+  font-family: var(--tabs-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: var(--tabs-text-dim);
+}
+
+.tabs-saas__tab-label {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--tabs-text-dim);
+  transition: color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-saas__tab:hover .tabs-saas__tab-label {
+  color: var(--tabs-text);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-saas__input:focus-visible + .tabs-saas__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+/* --- active tab: rises up, like a key being pressed upward ------------- */
+.tabs-saas:has(.tabs-saas__input:checked) .tabs-saas__tab {
+  background: transparent;
+}
+
+.tabs-saas__input:checked + .tabs-saas__tab {
+  transform: translateY(calc(-1 * var(--tabs-lift)));
+  background: var(--tabs-accent-soft);
+  box-shadow: 0 8px 20px -8px var(--tabs-accent);
+}
+
+.tabs-saas__input:checked + .tabs-saas__tab .tabs-saas__tab-label {
+  color: var(--tabs-text);
+}
+
+.tabs-saas__input:checked + .tabs-saas__tab .tabs-saas__tab-index {
+  color: var(--tabs-accent);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-saas__panels {
+  position: relative;
+  margin-top: 16px;
+  padding: 22px;
+  background: var(--tabs-panel-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  overflow: hidden;
+}
+
+.tabs-saas__panel {
+  display: none;
+}
+
+.tabs-saas__panel h3 {
+  margin: 0 0 8px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1.05rem;
+}
+
+.tabs-saas__panel p {
+  margin: 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.tabs-saas__panel-tag {
+  display: inline-block;
+  margin-bottom: 10px;
+  padding: 3px 8px;
+  font-family: var(--tabs-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: var(--tabs-accent);
+  background: var(--tabs-accent-soft);
+  border-radius: 999px;
+}
+
+/* show + slide up the panel that matches the checked tab */
+.tabs-saas:has(#tab-overview:checked) #panel-overview,
+.tabs-saas:has(#tab-analytics:checked) #panel-analytics,
+.tabs-saas:has(#tab-integrations:checked) #panel-integrations,
+.tabs-saas:has(#tab-billing:checked) #panel-billing {
+  display: block;
+  animation: tabs-saas-slide-up var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-saas-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(var(--tabs-slide-distance));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-saas__tab,
+  .tabs-saas__tab-label {
+    transition: none;
+  }
+  .tabs-saas__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-saas {
+    padding: 14px;
+  }
+  .tabs-saas__tab {
+    padding: 9px 12px;
+  }
+  .tabs-saas__tab-label {
+    font-size: 0.85rem;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a smooth slide-up reveal transition, styled for SaaS product showcase layouts, added under submissions/examples/slide-up-tabs-saas-issue-50029/.

### Files
demo.html — standalone demo markup (4 tabs: Overview, Analytics, Integrations, Billing)
style.css — component styles, animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers the slide-up keyframe when its tab is checked.
The active tab visually lifts with an accent glow via an adjacent-sibling selector on the checked input.
All timing, easing, distances, and colors are exposed as CSS custom properties on the .tabs-saas wrapper for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion.
### Testing

Opened demo.html directly in the browser and verified:

All four tabs switch correctly via click and keyboard (arrow keys)
Slide-up animation plays smoothly on each panel reveal
Layout holds up down to mobile width
No console errors

Closes #50029