### PR TITLE
feat: add CSS Zoom-In Tooltip for Accessible Web Layouts

### DIFF
--- a/submissions/examples/zoom-in-tooltip-accessible-web/README.md
+++ b/submissions/examples/zoom-in-tooltip-accessible-web/README.md
@@ -1,0 +1,36 @@
+﻿# CSS Zoom-In Tooltip — Accessible Web Layout
+
+A pure CSS tooltip that scales up from a small point into full size when shown, giving a punchy entrance.
+
+## CSS Custom Properties
+
+| Property                      | Default                                | Description                        |
+|-----------------------------------|-------------------------------------------|----------------------------------------|
+| `--ease-tooltip-zoom-duration`  | `0.25s`                                     | Duration of the zoom-in transition     |
+| `--ease-tooltip-zoom-easing`    | `cubic-bezier(0.34, 1.56, 0.64, 1)`        | Overshoot easing curve                  |
+| `--ease-tooltip-bg`             | `#111827`                                   | Tooltip background color                |
+| `--ease-tooltip-text`           | `#f9fafb`                                   | Tooltip text color                      |
+| `--ease-tooltip-radius`         | `8px`                                       | Tooltip corner radius                   |
+| `--ease-tooltip-focus-ring`     | `#1d4ed8`                                   | Focus outline color on the trigger      |
+
+## Usage
+
+```html
+<div class="ease-tooltip-wrap">
+  <button class="ease-tooltip-trigger" aria-describedby="tooltip1">Hover or Focus Me</button>
+  <span class="ease-tooltip" role="tooltip" id="tooltip1">Tooltip text</span>
+</div>
+```
+
+The tooltip shows and zooms in on `:hover` and `:focus-within`.
+
+## Accessibility
+
+- Uses `role="tooltip"` and `aria-describedby` linking trigger to tooltip content.
+- Fully keyboard accessible — `:focus-within` shows the tooltip for keyboard users, not just mouse hover.
+- Strong border and high-contrast trigger styling avoid relying on color alone.
+- `prefers-reduced-motion: reduce` shortens the transition and removes the scale effect, keeping a quick fade only.
+
+## Why it fits EaseMotion CSS
+
+Uses `ease-` prefixed class names and exposes timing/easing via CSS custom properties for easy theming, matching the framework's zero-JS-overhead, animation-first philosophy.

--- a/submissions/examples/zoom-in-tooltip-accessible-web/demo.html
+++ b/submissions/examples/zoom-in-tooltip-accessible-web/demo.html
@@ -1,0 +1,22 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Zoom-In Tooltip Demo — Accessible Web</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body { font-family: -apple-system, "Segoe UI", sans-serif; min-height: 100vh; display: flex; align-items: center; justify-content: center; margin: 0; background: #f9fafb; }
+    .wrap { text-align: center; }
+    h2 { color: #111827; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h2>CSS Zoom-In Tooltip — Accessible Web</h2>
+    <div class="ease-tooltip-wrap">
+      <button class="ease-tooltip-trigger" aria-describedby="tooltip1">Hover or Focus Me</button>
+      <span class="ease-tooltip" role="tooltip" id="tooltip1">Zooms in on show</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/zoom-in-tooltip-accessible-web/style.css
+++ b/submissions/examples/zoom-in-tooltip-accessible-web/style.css
@@ -1,0 +1,75 @@
+﻿:root {
+  --ease-tooltip-zoom-duration: 0.25s;
+  --ease-tooltip-zoom-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-tooltip-bg: #111827;
+  --ease-tooltip-text: #f9fafb;
+  --ease-tooltip-radius: 8px;
+  --ease-tooltip-focus-ring: #1d4ed8;
+}
+
+.ease-tooltip-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-tooltip-trigger {
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: 2px solid #1d4ed8;
+  background: #ffffff;
+  color: #1d4ed8;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ease-tooltip-trigger:focus-visible {
+  outline: 3px solid var(--ease-tooltip-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Zoom-In: the tooltip scales up from a small point into full size when
+   shown, giving a punchy, attention-grabbing entrance. */
+.ease-tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  background: var(--ease-tooltip-bg);
+  color: var(--ease-tooltip-text);
+  padding: 8px 14px;
+  border-radius: var(--ease-tooltip-radius);
+  font-size: 13px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateX(-50%) scale(0.4);
+  transform-origin: center bottom;
+  transition: opacity var(--ease-tooltip-zoom-duration) var(--ease-tooltip-zoom-easing),
+              transform var(--ease-tooltip-zoom-duration) var(--ease-tooltip-zoom-easing),
+              visibility var(--ease-tooltip-zoom-duration) var(--ease-tooltip-zoom-easing);
+}
+
+.ease-tooltip-wrap:hover .ease-tooltip,
+.ease-tooltip-wrap:focus-within .ease-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+}
+
+.ease-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--ease-tooltip-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip {
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+    transform: translateX(-50%) scale(1) !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS tooltip with a zoom-in scale entrance, styled for accessible web layouts. Resolves #54301

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes inside `submissions/examples/zoom-in-tooltip-accessible-web/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A tooltip that scales up from a small point into full size on show, giving a punchy entrance.
**Usage:**
```html
<div class="ease-tooltip-wrap">
  <button class="ease-tooltip-trigger" aria-describedby="tooltip1">Hover or Focus Me</button>
  <span class="ease-tooltip" role="tooltip" id="tooltip1">Tooltip text</span>
</div>
```
**Why EaseMotion CSS?** `ease-` prefixed classes, themeable via custom properties, zero-JS pure CSS.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Uses `role="tooltip"` + `aria-describedby`, shows on `:focus-within` (not just hover) for full keyboard accessibility. `prefers-reduced-motion` removes the scale, keeping a quick fade only.