### PR TITLE
feat: add slide-up tabs glassmorphism example (#50030)

### DIFF
--- a/submissions/examples/feat-slide-up-tabs-glass-issue-50030/README.md
+++ b/submissions/examples/feat-slide-up-tabs-glass-issue-50030/README.md
@@ -1,0 +1,52 @@
+# Slide-Up Tabs — Glassmorphism UI
+
+A pure CSS tabs component with a smooth slide-up reveal, styled with a glassmorphism aesthetic (frosted, translucent, blurred surfaces). No JavaScript required.
+
+## What it does
+
+- Clicking (or keyboard-selecting) a tab reveals its panel with a slide-up + fade + soft blur-out transition, like it's coming into focus through frosted glass.
+- The active tab lifts up off the glass tray, gaining a stronger tint and a light-catching inset highlight along its top edge.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-glass:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` reveals the matching panel and triggers the slide-up-and-unblur keyframe.
+- The glass look comes from `backdrop-filter: blur()` plus a low-opacity white background and border on each translucent layer (tray, tab, panel) — layered at slightly different opacities to suggest physical depth.
+- A demo gradient scene (`.tabs-glass-scene`) is included so the blur effect has something to refract; the component itself works over any backdrop.
+
+## Customization
+
+All animation and visual values are exposed as CSS custom properties on the `.tabs-glass` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `400ms` | Transition/animation length |
+| `--tabs-easing` | `cubic-bezier(0.22, 1, 0.36, 1)` | Easing curve |
+| `--tabs-lift` | `8px` | How far the active tab rises off the tray |
+| `--tabs-slide-distance` | `16px` | How far the panel travels on reveal |
+| `--tabs-radius` | `18px` | Corner radius |
+| `--tabs-blur` | `18px` | Backdrop blur strength |
+| `--tabs-glass-bg` / `--tabs-glass-bg-strong` | translucent white | Base / active-state glass tint |
+| `--tabs-glass-border` | translucent white | Glass edge highlight |
+| `--tabs-text` / `--tabs-text-dim` | white / muted white | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-glass" style="--tabs-blur: 28px; --tabs-lift: 12px;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab's label via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the lift transition and slide-up/blur animation.
+- Includes a `@supports` fallback to a solid translucent background for browsers without `backdrop-filter` support, so text stays readable either way.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven animation pattern in the glassmorphism aesthetic requested in issue #50030 — responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-slide-up-tabs-glass-issue-50030/demo.html
+++ b/submissions/examples/feat-slide-up-tabs-glass-issue-50030/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Slide-Up Tabs — Glassmorphism UI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@500;600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { margin: 0; }
+</style>
+</head>
+<body>
+
+<div class="tabs-glass-scene">
+  <div class="tabs-glass">
+    <div class="tabs-glass__list" role="tablist" aria-label="Design properties">
+
+      <input class="tabs-glass__input" type="radio" name="glass-tabs" id="tab-frost" checked />
+      <label class="tabs-glass__tab" for="tab-frost" role="tab" aria-selected="true">Frost</label>
+
+      <input class="tabs-glass__input" type="radio" name="glass-tabs" id="tab-blur" />
+      <label class="tabs-glass__tab" for="tab-blur" role="tab" aria-selected="false">Blur</label>
+
+      <input class="tabs-glass__input" type="radio" name="glass-tabs" id="tab-depth" />
+      <label class="tabs-glass__tab" for="tab-depth" role="tab" aria-selected="false">Depth</label>
+
+      <input class="tabs-glass__input" type="radio" name="glass-tabs" id="tab-light" />
+      <label class="tabs-glass__tab" for="tab-light" role="tab" aria-selected="false">Light</label>
+
+    </div>
+
+    <div class="tabs-glass__panels">
+
+      <section class="tabs-glass__panel" id="panel-frost">
+        <span class="tabs-glass__panel-icon" aria-hidden="true">❄</span>
+        <h3>Frosted surfaces</h3>
+        <p>A translucent white tint over a blurred backdrop gives every panel the look of etched glass, letting color from behind bleed through softly.</p>
+      </section>
+
+      <section class="tabs-glass__panel" id="panel-blur">
+        <span class="tabs-glass__panel-icon" aria-hidden="true">◐</span>
+        <h3>Backdrop blur</h3>
+        <p><code>backdrop-filter: blur()</code> does the heavy lifting — content behind the panel stays readable as color, not detail, keeping focus on the foreground.</p>
+      </section>
+
+      <section class="tabs-glass__panel" id="panel-depth">
+        <span class="tabs-glass__panel-icon" aria-hidden="true">▦</span>
+        <h3>Layered depth</h3>
+        <p>Nested translucent surfaces — tray, active tab, panel — each sit at a slightly different opacity to imply physical stacking without heavy shadows.</p>
+      </section>
+
+      <section class="tabs-glass__panel" id="panel-light">
+        <span class="tabs-glass__panel-icon" aria-hidden="true">◇</span>
+        <h3>Caught light</h3>
+        <p>A thin inset highlight along the top edge of the active tab mimics light catching the rim of glass as it lifts off the tray.</p>
+      </section>
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-slide-up-tabs-glass-issue-50030/style.css
+++ b/submissions/examples/feat-slide-up-tabs-glass-issue-50030/style.css
@@ -1,0 +1,207 @@
+/* ==========================================================================
+   Slide-Up Tabs — Glassmorphism UI
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-glass (see README).
+   ========================================================================== */
+
+.tabs-glass-scene {
+  /* vivid backdrop so the frosted-glass effect has something to refract */
+  --scene-a: #6d5bff;
+  --scene-b: #ff5bb0;
+  --scene-c: #35d9d9;
+  min-height: 420px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  background:
+    radial-gradient(circle at 15% 20%, var(--scene-a), transparent 55%),
+    radial-gradient(circle at 85% 15%, var(--scene-c), transparent 50%),
+    radial-gradient(circle at 50% 90%, var(--scene-b), transparent 55%),
+    #14121f;
+}
+
+.tabs-glass {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 400ms;
+  --tabs-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --tabs-lift: 8px;
+  --tabs-slide-distance: 16px;
+  --tabs-radius: 18px;
+  --tabs-blur: 18px;
+  --tabs-accent: #ffffff;
+  --tabs-glass-bg: rgba(255, 255, 255, 0.10);
+  --tabs-glass-bg-strong: rgba(255, 255, 255, 0.18);
+  --tabs-glass-border: rgba(255, 255, 255, 0.28);
+  --tabs-text: #ffffff;
+  --tabs-text-dim: rgba(255, 255, 255, 0.62);
+  --tabs-font-ui: "Sora", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+
+  /* --- layout ----------------------------------------------------------- */
+  width: 100%;
+  max-width: 460px;
+  padding: 18px;
+  border-radius: calc(var(--tabs-radius) + 8px);
+  background: var(--tabs-glass-bg);
+  border: 1px solid var(--tabs-glass-border);
+  -webkit-backdrop-filter: blur(var(--tabs-blur));
+  backdrop-filter: blur(var(--tabs-blur));
+  box-shadow: 0 20px 50px -20px rgba(0, 0, 0, 0.5);
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-glass__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-glass__list {
+  display: flex;
+  gap: 6px;
+  padding: 5px;
+  border-radius: var(--tabs-radius);
+  background: rgba(0, 0, 0, 0.14);
+  border: 1px solid var(--tabs-glass-border);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tabs-glass__tab {
+  position: relative;
+  flex: 1 0 auto;
+  padding: 10px 16px;
+  border-radius: calc(var(--tabs-radius) - 5px);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  text-align: center;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--tabs-text-dim);
+  transition:
+    transform var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing),
+    color var(--tabs-duration) var(--tabs-easing),
+    box-shadow var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-glass__tab:hover {
+  color: var(--tabs-text);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-glass__input:focus-visible + .tabs-glass__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+/* --- active tab: lifts up out of the glass tray, catching more light --- */
+.tabs-glass__input:checked + .tabs-glass__tab {
+  transform: translateY(calc(-1 * var(--tabs-lift)));
+  background: var(--tabs-glass-bg-strong);
+  border: 1px solid var(--tabs-glass-border);
+  color: var(--tabs-text);
+  box-shadow:
+    0 10px 24px -10px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-glass__panels {
+  position: relative;
+  margin-top: 14px;
+  padding: 20px;
+  border-radius: var(--tabs-radius);
+  background: rgba(0, 0, 0, 0.14);
+  border: 1px solid var(--tabs-glass-border);
+  overflow: hidden;
+}
+
+.tabs-glass__panel {
+  display: none;
+}
+
+.tabs-glass__panel-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 10px;
+  border-radius: 10px;
+  background: var(--tabs-glass-bg-strong);
+  border: 1px solid var(--tabs-glass-border);
+  font-size: 1rem;
+}
+
+.tabs-glass__panel h3 {
+  margin: 0 0 6px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1.05rem;
+}
+
+.tabs-glass__panel p {
+  margin: 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+/* show + slide up the panel that matches the checked tab */
+.tabs-glass:has(#tab-frost:checked) #panel-frost,
+.tabs-glass:has(#tab-blur:checked) #panel-blur,
+.tabs-glass:has(#tab-depth:checked) #panel-depth,
+.tabs-glass:has(#tab-light:checked) #panel-light {
+  display: block;
+  animation: tabs-glass-slide-up var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-glass-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(var(--tabs-slide-distance));
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-glass__tab {
+    transition: none;
+  }
+  .tabs-glass__panel {
+    animation: none !important;
+  }
+}
+
+/* graceful fallback where backdrop-filter isn't supported */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .tabs-glass {
+    background: rgba(30, 26, 46, 0.88);
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-glass {
+    padding: 14px;
+  }
+  .tabs-glass__tab {
+    padding: 9px 12px;
+    font-size: 0.82rem;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a smooth slide-up reveal, styled with a glassmorphism aesthetic, added under submissions/examples/slide-up-tabs-glass-issue-50030/.

### Files
demo.html — standalone demo markup (4 tabs: Frost, Blur, Depth, Light) over a gradient scene
style.css — component styles, blur/glass layering, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers a slide-up + blur-to-focus animation when its tab is checked.
backdrop-filter: blur() plus low-opacity white surfaces (tray, tab, panel) at slightly different opacities create the layered glass depth.
The active tab lifts off the tray with a stronger tint and a light-catching inset highlight.
All timing, easing, blur strength, lift distance, and glass tint are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion.
@supports fallback to a solid translucent background for browsers without backdrop-filter, so text stays readable either way.
### Testing

Opened demo.html directly in the browser and verified:

All four tabs switch correctly via click and keyboard (arrow keys)
Slide-up + blur-focus animation plays smoothly on each panel reveal
Glass/blur effect renders correctly over the gradient backdrop
Layout holds up down to mobile width
No console errors

Closes #50030