### PR TITLE
feat: add rotate-click tabs SaaS example (#50072)

### DIFF
--- a/submissions/examples/rotate-click-tabs-saas-issue-50072/README.md
+++ b/submissions/examples/rotate-click-tabs-saas-issue-50072/README.md
@@ -1,0 +1,50 @@
+# Rotate-Click Tabs — SaaS Showcase
+
+A pure CSS tabs component with a rotate-click interaction, styled for SaaS product/account settings layouts. No JavaScript required.
+
+## What it does
+
+- Each tab has a small dial indicator that sits rotated off-axis at rest and **clicks into its upright position** when selected, like a physical knob settling into place — the easing includes a slight overshoot for that tactile "click" feel.
+- The panel content reveals with a matching rotate: it flips in from a tilted 3D angle (`rotateX`) to flat, as if the whole panel clicked into position along with the dial.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-rotate:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the rotate-click keyframe.
+- The dial's rest/active rotation is controlled by `--tabs-dial-angle`, transitioning via `.tabs-rotate__input:checked + .tabs-rotate__tab .tabs-rotate__dial { transform: rotate(0deg); }`.
+- The panel's 3D flip uses `perspective` on `.tabs-rotate__panels` and a `rotateX()` keyframe on the panel itself, controlled by `--tabs-flip-angle`.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-rotate` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `380ms` | Transition/animation length |
+| `--tabs-easing` | `cubic-bezier(0.34, 1.35, 0.64, 1)` | Easing curve (includes overshoot for the "click" feel) |
+| `--tabs-dial-angle` | `35deg` | Dial's rest rotation before it clicks upright |
+| `--tabs-flip-angle` | `70deg` | Panel's starting rotateX angle on reveal |
+| `--tabs-radius` | `12px` | Corner radius |
+| `--tabs-accent` | `#4f46e5` | Accent color (active tab, dial, tag) |
+| `--tabs-bg` / `--tabs-surface` | `#ffffff` / `#f6f7fb` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | dark / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-rotate" style="--tabs-dial-angle: 50deg; --tabs-accent: #0ea5e9;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the dial rotation transition and the panel flip animation.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven rotate-click pattern in the SaaS aesthetic requested in issue #50072 — responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/rotate-click-tabs-saas-issue-50072/demo.html
+++ b/submissions/examples/rotate-click-tabs-saas-issue-50072/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Click Tabs — SaaS Showcase</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #eef0f6;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-rotate">
+  <div class="tabs-rotate__list" role="tablist" aria-label="Account settings">
+
+    <input class="tabs-rotate__input" type="radio" name="rotate-tabs" id="tab-plans" checked />
+    <label class="tabs-rotate__tab" for="tab-plans" role="tab" aria-selected="true">
+      <span class="tabs-rotate__dial" aria-hidden="true"></span>
+      Plans
+    </label>
+
+    <input class="tabs-rotate__input" type="radio" name="rotate-tabs" id="tab-usage" />
+    <label class="tabs-rotate__tab" for="tab-usage" role="tab" aria-selected="false">
+      <span class="tabs-rotate__dial" aria-hidden="true"></span>
+      Usage
+    </label>
+
+    <input class="tabs-rotate__input" type="radio" name="rotate-tabs" id="tab-api" />
+    <label class="tabs-rotate__tab" for="tab-api" role="tab" aria-selected="false">
+      <span class="tabs-rotate__dial" aria-hidden="true"></span>
+      API keys
+    </label>
+
+    <input class="tabs-rotate__input" type="radio" name="rotate-tabs" id="tab-team" />
+    <label class="tabs-rotate__tab" for="tab-team" role="tab" aria-selected="false">
+      <span class="tabs-rotate__dial" aria-hidden="true"></span>
+      Team
+    </label>
+
+  </div>
+
+  <div class="tabs-rotate__panels">
+
+    <section class="tabs-rotate__panel" id="panel-plans">
+      <span class="tabs-rotate__panel-tag">BILLING</span>
+      <h3>Growth plan</h3>
+      <p>$49/month, billed annually. Includes 10 seats, unlimited projects, and priority support. Switch plans any time — changes apply on your next billing cycle.</p>
+    </section>
+
+    <section class="tabs-rotate__panel" id="panel-usage">
+      <span class="tabs-rotate__panel-tag">METRICS</span>
+      <h3>2,340 / 5,000 requests</h3>
+      <p>You're at 47% of this month's request quota. Usage resets on the 1st. Set up an alert to get notified before you hit your limit.</p>
+    </section>
+
+    <section class="tabs-rotate__panel" id="panel-api">
+      <span class="tabs-rotate__panel-tag">DEVELOPER</span>
+      <h3>Manage API keys</h3>
+      <p>Generate scoped keys for staging and production separately. Rotate a key at any time without disrupting requests made with your other active keys.</p>
+    </section>
+
+    <section class="tabs-rotate__panel" id="panel-team">
+      <span class="tabs-rotate__panel-tag">MEMBERS</span>
+      <h3>6 team members</h3>
+      <p>Invite teammates by email and assign roles — Admin, Editor, or Viewer. Pending invitations expire after 7 days if not accepted.</p>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/rotate-click-tabs-saas-issue-50072/style.css
+++ b/submissions/examples/rotate-click-tabs-saas-issue-50072/style.css
@@ -1,0 +1,208 @@
+/* ==========================================================================
+   Rotate-Click Tabs — SaaS Showcase
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-rotate (see README).
+   ========================================================================== */
+
+.tabs-rotate {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 380ms;
+  --tabs-easing: cubic-bezier(0.34, 1.35, 0.64, 1); /* slight overshoot = "click" feel */
+  --tabs-dial-angle: 35deg;      /* how far the dial rotates from rest to active */
+  --tabs-flip-angle: 70deg;      /* panel rotateX starting angle on reveal */
+  --tabs-radius: 12px;
+  --tabs-accent: #4f46e5;
+  --tabs-accent-soft: #eef0fd;
+  --tabs-bg: #ffffff;
+  --tabs-surface: #f6f7fb;
+  --tabs-border: #e3e5ef;
+  --tabs-text: #1c1e2b;
+  --tabs-text-dim: #74778c;
+  --tabs-font-ui: "Plus Jakarta Sans", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 620px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 20px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+  box-shadow: 0 16px 40px -24px rgba(31, 33, 60, 0.25);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-rotate__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-rotate__list {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--tabs-surface);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tabs-rotate__tab {
+  position: relative;
+  flex: 1 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border-radius: calc(var(--tabs-radius) - 4px);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--tabs-text-dim);
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-rotate__tab:hover {
+  color: var(--tabs-text);
+}
+
+/* the dial: a notched ring that rotates like a knob clicking into place */
+.tabs-rotate__dial {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  flex: none;
+  border-radius: 50%;
+  border: 2px solid var(--tabs-text-dim);
+  transition:
+    transform var(--tabs-duration) var(--tabs-easing),
+    border-color var(--tabs-duration) var(--tabs-easing);
+  transform: rotate(calc(-1 * var(--tabs-dial-angle)));
+}
+
+.tabs-rotate__dial::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: 50%;
+  width: 2px;
+  height: 4px;
+  background: currentColor;
+  transform: translateX(-50%);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-rotate__input:focus-visible + .tabs-rotate__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+/* --- active tab: dial clicks to its resting position, accent fills in -- */
+.tabs-rotate__input:checked + .tabs-rotate__tab {
+  color: var(--tabs-accent);
+  background: var(--tabs-accent-soft);
+}
+
+.tabs-rotate__input:checked + .tabs-rotate__tab .tabs-rotate__dial {
+  transform: rotate(0deg);
+  border-color: var(--tabs-accent);
+  color: var(--tabs-accent);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-rotate__panels {
+  position: relative;
+  margin-top: 16px;
+  padding: 22px;
+  background: var(--tabs-surface);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  overflow: hidden;
+  perspective: 900px;
+}
+
+.tabs-rotate__panel {
+  display: none;
+  transform-origin: top center;
+}
+
+.tabs-rotate__panel-tag {
+  display: inline-block;
+  margin-bottom: 10px;
+  padding: 3px 8px;
+  font-family: var(--tabs-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: var(--tabs-accent);
+  background: var(--tabs-accent-soft);
+  border-radius: 999px;
+}
+
+.tabs-rotate__panel h3 {
+  margin: 0 0 8px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1.05rem;
+}
+
+.tabs-rotate__panel p {
+  margin: 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+/* show + click-rotate-in the panel that matches the checked tab */
+.tabs-rotate:has(#tab-plans:checked) #panel-plans,
+.tabs-rotate:has(#tab-usage:checked) #panel-usage,
+.tabs-rotate:has(#tab-api:checked) #panel-api,
+.tabs-rotate:has(#tab-team:checked) #panel-team {
+  display: block;
+  animation: tabs-rotate-click var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-rotate-click {
+  from {
+    opacity: 0;
+    transform: rotateX(calc(-1 * var(--tabs-flip-angle)));
+  }
+  to {
+    opacity: 1;
+    transform: rotateX(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-rotate__tab,
+  .tabs-rotate__dial {
+    transition: none;
+  }
+  .tabs-rotate__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-rotate {
+    padding: 14px;
+  }
+  .tabs-rotate__tab {
+    padding: 8px 10px;
+    font-size: 0.8rem;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a rotate-click interaction, styled for a SaaS account-settings layout, added under submissions/examples/rotate-click-tabs-saas-issue-50072/.

### Files
demo.html — standalone demo markup (4 tabs: Plans, Usage, API keys, Team)
style.css — component styles, dial rotation, panel flip animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel when its tab is checked.
Each tab has a small dial indicator that sits rotated off-axis at rest and clicks upright when active, using an overshoot easing curve for a tactile "click" feel.
The revealed panel flips in via a 3D rotateX() animation (using perspective on the panels container), echoing the dial's click motion.
All timing, easing, dial angle, flip angle, and colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion.
### Testing

Opened demo.html directly in the browser and verified:

All four tabs switch correctly via click and keyboard (arrow keys)
Dial rotation and panel flip animate smoothly on each switch
Layout holds up down to mobile width
No console errors

Closes #50072