### PR TITLE
feat: add 3D flip tabs product catalog example (#50055)

### DIFF
--- a/submissions/examples/feat-3d-flip-tabs-catalog-issue-50055/README.md
+++ b/submissions/examples/feat-3d-flip-tabs-catalog-issue-50055/README.md
@@ -1,0 +1,50 @@
+# 3D Flip Tabs — Product Catalog
+
+A pure CSS tabs component with a 3D flip transition, styled for a product catalog / category switcher. No JavaScript required.
+
+## What it does
+
+- Switching category tabs flips the featured-product card in on its Y axis, like a card spinning into view, using real 3D transforms (`perspective` + `rotateY`) rather than a simulated effect.
+- Active category chips get a solid accent fill; inactive ones stay outlined.
+- Panel switching and the flip animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-flip:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the flip keyframe.
+- `perspective` is set on the `.tabs-flip__stage` wrapper so the child panel's `rotateY()` reads as genuine 3D depth rather than a flat squash.
+- Each panel has `backface-visibility: hidden` so it never renders upside-down mid-flip.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-flip` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `460ms` | Flip animation length |
+| `--tabs-easing` | `cubic-bezier(0.25, 0.8, 0.4, 1)` | Easing curve |
+| `--tabs-flip-angle` | `90deg` | Starting Y-axis rotation before the panel settles flat |
+| `--tabs-perspective` | `1000px` | 3D perspective depth — lower values exaggerate the flip |
+| `--tabs-radius` | `14px` | Corner radius |
+| `--tabs-accent` | `#2f5fff` | Accent color (active tab, category label, image backdrop) |
+| `--tabs-bg` / `--tabs-card-bg` | `#f7f7f5` / `#ffffff` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | dark / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-flip" style="--tabs-perspective: 600px; --tabs-accent: #16a34a;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the tab-chip transition and the panel flip animation.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven 3D flip pattern in the product-catalog aesthetic requested in issue #50055 — responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-3d-flip-tabs-catalog-issue-50055/demo.html
+++ b/submissions/examples/feat-3d-flip-tabs-catalog-issue-50055/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Flip Tabs — Product Catalog</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@700;800&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #eeeeec;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-flip">
+  <div class="tabs-flip__list" role="tablist" aria-label="Product categories">
+
+    <input class="tabs-flip__input" type="radio" name="flip-tabs" id="tab-all" checked />
+    <label class="tabs-flip__tab" for="tab-all" role="tab" aria-selected="true">All</label>
+
+    <input class="tabs-flip__input" type="radio" name="flip-tabs" id="tab-apparel" />
+    <label class="tabs-flip__tab" for="tab-apparel" role="tab" aria-selected="false">Apparel</label>
+
+    <input class="tabs-flip__input" type="radio" name="flip-tabs" id="tab-electronics" />
+    <label class="tabs-flip__tab" for="tab-electronics" role="tab" aria-selected="false">Electronics</label>
+
+    <input class="tabs-flip__input" type="radio" name="flip-tabs" id="tab-home" />
+    <label class="tabs-flip__tab" for="tab-home" role="tab" aria-selected="false">Home</label>
+
+  </div>
+
+  <div class="tabs-flip__stage">
+
+    <section class="tabs-flip__panel" id="panel-all">
+      <div class="tabs-flip__product-image" aria-hidden="true">🎒</div>
+      <span class="tabs-flip__product-category">FEATURED</span>
+      <h3>Trail Pack 24L</h3>
+      <p>Weatherproof daypack with a padded laptop sleeve and side bottle pockets.</p>
+      <div class="tabs-flip__product-meta">
+        <span class="tabs-flip__product-price">$68.00</span>
+        <span class="tabs-flip__product-rating">★ 4.8 (312)</span>
+      </div>
+    </section>
+
+    <section class="tabs-flip__panel" id="panel-apparel">
+      <div class="tabs-flip__product-image" aria-hidden="true">🧥</div>
+      <span class="tabs-flip__product-category">APPAREL</span>
+      <h3>Fleece-Lined Jacket</h3>
+      <p>Water-resistant shell with a brushed fleece interior for cold-weather layering.</p>
+      <div class="tabs-flip__product-meta">
+        <span class="tabs-flip__product-price">$124.00</span>
+        <span class="tabs-flip__product-rating">★ 4.6 (198)</span>
+      </div>
+    </section>
+
+    <section class="tabs-flip__panel" id="panel-electronics">
+      <div class="tabs-flip__product-image" aria-hidden="true">🎧</div>
+      <span class="tabs-flip__product-category">ELECTRONICS</span>
+      <h3>Wireless ANC Headphones</h3>
+      <p>30-hour battery life with adaptive noise cancellation and multipoint pairing.</p>
+      <div class="tabs-flip__product-meta">
+        <span class="tabs-flip__product-price">$179.00</span>
+        <span class="tabs-flip__product-rating">★ 4.7 (541)</span>
+      </div>
+    </section>
+
+    <section class="tabs-flip__panel" id="panel-home">
+      <div class="tabs-flip__product-image" aria-hidden="true">🕯️</div>
+      <span class="tabs-flip__product-category">HOME</span>
+      <h3>Ceramic Pour-Over Set</h3>
+      <p>Hand-glazed dripper and carafe, sized for two cups, dishwasher safe.</p>
+      <div class="tabs-flip__product-meta">
+        <span class="tabs-flip__product-price">$54.00</span>
+        <span class="tabs-flip__product-rating">★ 4.9 (87)</span>
+      </div>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-3d-flip-tabs-catalog-issue-50055/style.css
+++ b/submissions/examples/feat-3d-flip-tabs-catalog-issue-50055/style.css
@@ -1,0 +1,197 @@
+/* ==========================================================================
+   3D Flip Tabs — Product Catalog
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-flip (see README).
+   ========================================================================== */
+
+.tabs-flip {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 460ms;
+  --tabs-easing: cubic-bezier(0.25, 0.8, 0.4, 1);
+  --tabs-flip-angle: 90deg;      /* how far the panel rotates on its Y axis */
+  --tabs-perspective: 1000px;
+  --tabs-radius: 14px;
+  --tabs-accent: #2f5fff;
+  --tabs-accent-soft: #ebf0ff;
+  --tabs-bg: #f7f7f5;
+  --tabs-card-bg: #ffffff;
+  --tabs-border: #e6e6e2;
+  --tabs-text: #14151a;
+  --tabs-text-dim: #6b6d76;
+  --tabs-font-ui: "Manrope", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 420px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 18px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-flip__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-flip__list {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  padding-bottom: 2px;
+}
+
+.tabs-flip__tab {
+  flex: none;
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--tabs-border);
+  background: var(--tabs-card-bg);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--tabs-text-dim);
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing),
+    border-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-flip__tab:hover {
+  color: var(--tabs-text);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-flip__input:focus-visible + .tabs-flip__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+.tabs-flip__input:checked + .tabs-flip__tab {
+  color: #fff;
+  background: var(--tabs-accent);
+  border-color: var(--tabs-accent);
+}
+
+/* --- panels: true 3D flip on the Y axis --------------------------------- */
+.tabs-flip__stage {
+  margin-top: 14px;
+  perspective: var(--tabs-perspective);
+}
+
+.tabs-flip__panel {
+  display: none;
+  background: var(--tabs-card-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  padding: 18px;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+}
+
+.tabs-flip__product-image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  margin-bottom: 14px;
+  border-radius: calc(var(--tabs-radius) - 4px);
+  background: var(--tabs-accent-soft);
+  font-size: 2.6rem;
+}
+
+.tabs-flip__product-category {
+  display: inline-block;
+  margin-bottom: 6px;
+  font-family: var(--tabs-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: var(--tabs-accent);
+}
+
+.tabs-flip__panel h3 {
+  margin: 0 0 4px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1.05rem;
+}
+
+.tabs-flip__product-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+
+.tabs-flip__product-price {
+  font-family: var(--tabs-font-mono);
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--tabs-text);
+}
+
+.tabs-flip__product-rating {
+  font-size: 0.78rem;
+  color: var(--tabs-text-dim);
+}
+
+.tabs-flip__panel p {
+  margin: 8px 0 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+/* show + 3D-flip in the panel that matches the checked tab */
+.tabs-flip:has(#tab-all:checked) #panel-all,
+.tabs-flip:has(#tab-apparel:checked) #panel-apparel,
+.tabs-flip:has(#tab-electronics:checked) #panel-electronics,
+.tabs-flip:has(#tab-home:checked) #panel-home {
+  display: block;
+  animation: tabs-flip-in var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-flip-in {
+  from {
+    opacity: 0;
+    transform: rotateY(var(--tabs-flip-angle));
+  }
+  to {
+    opacity: 1;
+    transform: rotateY(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-flip__tab {
+    transition: none;
+  }
+  .tabs-flip__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-flip {
+    padding: 14px;
+  }
+  .tabs-flip__product-image {
+    height: 100px;
+    font-size: 2.2rem;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a real 3D flip transition, styled for a product catalog category switcher, added under submissions/examples/3d-flip-tabs-catalog-issue-50055/.

### Files
demo.html — standalone demo markup (4 category tabs: All, Apparel, Electronics, Home)
style.css — component styles, 3D flip animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers the flip keyframe when its tab is checked.
perspective is applied on the panel stage so the panel's rotateY() reads as genuine 3D depth, not a flat squash.
Each panel has backface-visibility: hidden so it never renders upside-down mid-flip.
All timing, easing, flip angle, perspective depth, and colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion.

### Testing

Opened demo.html directly in the browser and verified:

All four category tabs switch correctly via click and keyboard (arrow keys)
3D flip animation plays smoothly on each panel reveal, no backface flashing
Layout holds up down to mobile width
No console errors

Closes #50055