### PR TITLE
feat: add zoom-in tabs analytics example (#50039)

### DIFF
--- a/submissions/examples/feat-zoom-in-tabs-analytics-issue-50039/README.md
+++ b/submissions/examples/feat-zoom-in-tabs-analytics-issue-50039/README.md
@@ -1,0 +1,50 @@
+# Zoom-In Tabs — Dashboard Analytics
+
+A pure CSS tabs component with a zoom-in reveal, styled for a dashboard analytics metric switcher. No JavaScript required.
+
+## What it does
+
+- Switching between metrics (Revenue, Users, Conversion) scales the panel up from slightly smaller than full size while fading in, like a chart snapping into focus.
+- The active tab gets a quick scale "pop" of its own, reinforcing the zoom motif at the trigger point, not just the destination.
+- Each panel includes a small CSS-only bar chart (plain `<div>`s with inline `height`, no SVG/JS) so the zoom has real content to draw attention to.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-zoom:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the zoom-in keyframe, which animates `transform: scale()` from `--tabs-scale-start` to `1` alongside opacity.
+- The active tab's own `transform: scale(1.04)` is a separate, instant style change (not the keyframe animation) so the trigger feels responsive.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-zoom` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `340ms` | Zoom-in animation length |
+| `--tabs-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Easing curve |
+| `--tabs-scale-start` | `0.85` | Starting scale of the panel before it zooms to full size |
+| `--tabs-radius` | `12px` | Corner radius |
+| `--tabs-accent` | `#10b981` | Accent color (active bar, delta text, active tab tint) |
+| `--tabs-bg` / `--tabs-panel-bg` | `#0b1220` / `#121b2e` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | light / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-zoom" style="--tabs-scale-start: 0.7; --tabs-accent: #6366f1;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- Visible focus ring via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the active-tab scale pop and the panel zoom-in animation.
+- Decorative bar chart is marked `aria-hidden="true"`; the metric value and delta are readable as plain text.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven zoom-in pattern in the dashboard analytics aesthetic requested in issue #50039 — responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-zoom-in-tabs-analytics-issue-50039/demo.html
+++ b/submissions/examples/feat-zoom-in-tabs-analytics-issue-50039/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Zoom-In Tabs — Dashboard Analytics</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@500;600&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #070b13;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-zoom">
+  <div class="tabs-zoom__list" role="tablist" aria-label="Analytics metrics">
+
+    <input class="tabs-zoom__input" type="radio" name="zoom-tabs" id="tab-revenue" checked />
+    <label class="tabs-zoom__tab" for="tab-revenue" role="tab" aria-selected="true">Revenue</label>
+
+    <input class="tabs-zoom__input" type="radio" name="zoom-tabs" id="tab-users" />
+    <label class="tabs-zoom__tab" for="tab-users" role="tab" aria-selected="false">Users</label>
+
+    <input class="tabs-zoom__input" type="radio" name="zoom-tabs" id="tab-conversion" />
+    <label class="tabs-zoom__tab" for="tab-conversion" role="tab" aria-selected="false">Conversion</label>
+
+  </div>
+
+  <div class="tabs-zoom__panels">
+
+    <section class="tabs-zoom__panel" id="panel-revenue">
+      <div class="tabs-zoom__panel-head">
+        <span class="tabs-zoom__metric">$84,210</span>
+        <span class="tabs-zoom__delta">+6.8%</span>
+      </div>
+      <p class="tabs-zoom__panel-label">Last 7 days</p>
+      <div class="tabs-zoom__bars" aria-hidden="true">
+        <div class="tabs-zoom__bar" style="height: 40%"></div>
+        <div class="tabs-zoom__bar" style="height: 55%"></div>
+        <div class="tabs-zoom__bar" style="height: 48%"></div>
+        <div class="tabs-zoom__bar" style="height: 70%"></div>
+        <div class="tabs-zoom__bar" style="height: 62%"></div>
+        <div class="tabs-zoom__bar" style="height: 85%"></div>
+        <div class="tabs-zoom__bar tabs-zoom__bar--active" style="height: 100%"></div>
+      </div>
+    </section>
+
+    <section class="tabs-zoom__panel" id="panel-users">
+      <div class="tabs-zoom__panel-head">
+        <span class="tabs-zoom__metric">18,204</span>
+        <span class="tabs-zoom__delta">+3.2%</span>
+      </div>
+      <p class="tabs-zoom__panel-label">Active users, last 7 days</p>
+      <div class="tabs-zoom__bars" aria-hidden="true">
+        <div class="tabs-zoom__bar" style="height: 60%"></div>
+        <div class="tabs-zoom__bar" style="height: 65%"></div>
+        <div class="tabs-zoom__bar" style="height: 58%"></div>
+        <div class="tabs-zoom__bar" style="height: 72%"></div>
+        <div class="tabs-zoom__bar" style="height: 80%"></div>
+        <div class="tabs-zoom__bar" style="height: 76%"></div>
+        <div class="tabs-zoom__bar tabs-zoom__bar--active" style="height: 90%"></div>
+      </div>
+    </section>
+
+    <section class="tabs-zoom__panel" id="panel-conversion">
+      <div class="tabs-zoom__panel-head">
+        <span class="tabs-zoom__metric">4.7%</span>
+        <span class="tabs-zoom__delta">+0.4%</span>
+      </div>
+      <p class="tabs-zoom__panel-label">Checkout conversion, last 7 days</p>
+      <div class="tabs-zoom__bars" aria-hidden="true">
+        <div class="tabs-zoom__bar" style="height: 50%"></div>
+        <div class="tabs-zoom__bar" style="height: 44%"></div>
+        <div class="tabs-zoom__bar" style="height: 62%"></div>
+        <div class="tabs-zoom__bar" style="height: 58%"></div>
+        <div class="tabs-zoom__bar" style="height: 68%"></div>
+        <div class="tabs-zoom__bar" style="height: 74%"></div>
+        <div class="tabs-zoom__bar tabs-zoom__bar--active" style="height: 82%"></div>
+      </div>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-zoom-in-tabs-analytics-issue-50039/style.css
+++ b/submissions/examples/feat-zoom-in-tabs-analytics-issue-50039/style.css
@@ -1,0 +1,196 @@
+/* ==========================================================================
+   Zoom-In Tabs — Dashboard Analytics
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-zoom (see README).
+   ========================================================================== */
+
+.tabs-zoom {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 340ms;
+  --tabs-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tabs-scale-start: 0.85;      /* panel's starting scale on reveal */
+  --tabs-radius: 12px;
+  --tabs-accent: #10b981;
+  --tabs-accent-soft: rgba(16, 185, 129, 0.14);
+  --tabs-bg: #0b1220;
+  --tabs-panel-bg: #121b2e;
+  --tabs-bar-track: #1c2740;
+  --tabs-border: #223049;
+  --tabs-text: #eef2f8;
+  --tabs-text-dim: #7d8aa3;
+  --tabs-font-ui: "Sora", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 460px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 18px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-zoom__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-zoom__list {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--tabs-panel-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tabs-zoom__tab {
+  flex: 1 0 auto;
+  padding: 8px 14px;
+  border-radius: calc(var(--tabs-radius) - 4px);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  text-align: center;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--tabs-text-dim);
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing),
+    transform var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-zoom__tab:hover {
+  color: var(--tabs-text);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-zoom__input:focus-visible + .tabs-zoom__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+/* active tab gets a quick scale "pop" as part of the zoom motif */
+.tabs-zoom__input:checked + .tabs-zoom__tab {
+  color: var(--tabs-text);
+  background: var(--tabs-accent-soft);
+  transform: scale(1.04);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-zoom__panels {
+  position: relative;
+  margin-top: 14px;
+  padding: 20px;
+  background: var(--tabs-panel-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  overflow: hidden;
+}
+
+.tabs-zoom__panel {
+  display: none;
+  transform-origin: center;
+}
+
+.tabs-zoom__panel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.tabs-zoom__metric {
+  font-family: var(--tabs-font-mono);
+  font-size: 1.9rem;
+  font-weight: 500;
+  color: var(--tabs-text);
+}
+
+.tabs-zoom__delta {
+  font-family: var(--tabs-font-mono);
+  font-size: 0.78rem;
+  color: var(--tabs-accent);
+}
+
+.tabs-zoom__panel-label {
+  margin: 0 0 16px;
+  font-size: 0.8rem;
+  color: var(--tabs-text-dim);
+}
+
+/* mini bar chart made of plain divs, no JS/SVG */
+.tabs-zoom__bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 64px;
+}
+
+.tabs-zoom__bar {
+  flex: 1;
+  border-radius: 3px 3px 0 0;
+  background: var(--tabs-bar-track);
+}
+
+.tabs-zoom__bar--active {
+  background: var(--tabs-accent);
+}
+
+/* show + zoom in the panel that matches the checked tab */
+.tabs-zoom:has(#tab-revenue:checked) #panel-revenue,
+.tabs-zoom:has(#tab-users:checked) #panel-users,
+.tabs-zoom:has(#tab-conversion:checked) #panel-conversion {
+  display: block;
+  animation: tabs-zoom-in var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-zoom-in {
+  from {
+    opacity: 0;
+    transform: scale(var(--tabs-scale-start));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-zoom__tab {
+    transition: none;
+  }
+  .tabs-zoom__input:checked + .tabs-zoom__tab {
+    transform: none;
+  }
+  .tabs-zoom__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-zoom {
+    padding: 14px;
+  }
+  .tabs-zoom__metric {
+    font-size: 1.6rem;
+  }
+  .tabs-zoom__bars {
+    height: 52px;
+  }
+}


### PR DESCRIPTION
Description:

What this adds

A pure CSS tabs component with a zoom-in reveal, styled for a dashboard analytics metric switcher, added under submissions/examples/zoom-in-tabs-analytics-issue-50039/.

Files
demo.html — standalone demo markup (3 metric tabs: Revenue, Users, Conversion), each with a value, delta, and CSS-only bar chart
style.css — component styles, zoom-in animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers the zoom-in keyframe when its tab is checked.
The panel animates transform: scale() from a configurable starting scale up to 1 alongside a fade, giving the "snapping into focus" feel.
The active tab also gets its own instant scale "pop" (separate from the panel's animation) so the trigger itself feels responsive.
Each panel includes a small CSS-only bar chart (plain divs with inline heights, no SVG/JS).
All timing, easing, starting scale, and colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion (disables both the tab pop and the panel zoom animation).
Decorative bar chart is aria-hidden; the metric value and delta remain readable as plain text.
Testing

Opened demo.html directly in the browser and verified:

All three metric tabs switch correctly via click and keyboard (arrow keys)
Zoom-in animation plays smoothly on each panel reveal
Layout holds up down to mobile width
No console errors

Closes #50039