### PR TITLE
feat: add 3D flip tabs checkout example (#50057)

### DIFF
--- a/submissions/examples/feat-3d-flip-tabs-checkout-issue-50057/README.md
+++ b/submissions/examples/feat-3d-flip-tabs-checkout-issue-50057/README.md
@@ -1,0 +1,51 @@
+# 3D Flip Tabs — E-Commerce Checkout
+
+A pure CSS tabs component with a 3D flip transition, styled for an e-commerce checkout step switcher (Shipping / Payment / Review). No JavaScript required.
+
+## What it does
+
+- Switching checkout steps flips the content panel open on its X axis — like a flap tipping down into place — using real 3D transforms (`perspective` + `rotateX`), not a simulated effect.
+- Numbered step circles fill in with the accent color as each step becomes active, giving a familiar "checkout progress" feel alongside the flip.
+- Panel switching and the flip animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each step is a hidden `<input type="radio">` paired with a `<label>` containing a numbered circle and a text span. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between steps).
+- `.tabs-checkout:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the flip keyframe.
+- `perspective` is set on the `.tabs-checkout__stage` wrapper so the panel's `rotateX()` reads as genuine 3D depth. `backface-visibility: hidden` keeps it from rendering upside-down mid-flip.
+- Note: this uses plain radio inputs for step switching (any step is directly selectable) rather than gating navigation behind form validation — pair it with real validation logic if used in a production multi-step checkout.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-checkout` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `420ms` | Flip animation length |
+| `--tabs-easing` | `cubic-bezier(0.25, 0.8, 0.4, 1)` | Easing curve |
+| `--tabs-flip-angle` | `-80deg` | Starting X-axis rotation before the panel settles flat |
+| `--tabs-perspective` | `1100px` | 3D perspective depth |
+| `--tabs-radius` | `12px` | Corner radius |
+| `--tabs-accent` | `#0ea5a5` | Accent color (active step circle, secure badge) |
+| `--tabs-bg` / `--tabs-surface` | `#ffffff` / `#f4f7f7` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | dark / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-checkout" style="--tabs-flip-angle: -60deg; --tabs-accent: #d97706;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between steps) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active step via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the step-circle transition and the panel flip animation.
+- On very narrow viewports, step labels collapse to numbered circles only, keeping the tap targets legible without truncating text mid-word.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven 3D flip pattern in the e-commerce checkout aesthetic requested in issue #50057 — responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-3d-flip-tabs-checkout-issue-50057/demo.html
+++ b/submissions/examples/feat-3d-flip-tabs-checkout-issue-50057/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Flip Tabs — E-Commerce Checkout</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@700;800&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #eef2f2;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-checkout">
+  <div class="tabs-checkout__list" role="tablist" aria-label="Checkout steps">
+
+    <input class="tabs-checkout__input" type="radio" name="checkout-tabs" id="tab-shipping" checked />
+    <label class="tabs-checkout__tab" for="tab-shipping" role="tab" aria-selected="true">
+      <span class="tabs-checkout__step">1</span>
+      <span>Shipping</span>
+    </label>
+
+    <span class="tabs-checkout__divider" aria-hidden="true"></span>
+
+    <input class="tabs-checkout__input" type="radio" name="checkout-tabs" id="tab-payment" />
+    <label class="tabs-checkout__tab" for="tab-payment" role="tab" aria-selected="false">
+      <span class="tabs-checkout__step">2</span>
+      <span>Payment</span>
+    </label>
+
+    <span class="tabs-checkout__divider" aria-hidden="true"></span>
+
+    <input class="tabs-checkout__input" type="radio" name="checkout-tabs" id="tab-review" />
+    <label class="tabs-checkout__tab" for="tab-review" role="tab" aria-selected="false">
+      <span class="tabs-checkout__step">3</span>
+      <span>Review</span>
+    </label>
+
+  </div>
+
+  <div class="tabs-checkout__stage">
+
+    <section class="tabs-checkout__panel" id="panel-shipping">
+      <h3>Shipping address</h3>
+      <p>Standard shipping (3–5 business days) is included. Express delivery available at checkout.</p>
+      <div class="tabs-checkout__line"><span>Ravi Shah</span><span>221B Baker Street</span></div>
+      <div class="tabs-checkout__line"><span>Delivery method</span><span>Standard</span></div>
+      <span class="tabs-checkout__secure">🔒 SECURE CHECKOUT</span>
+    </section>
+
+    <section class="tabs-checkout__panel" id="panel-payment">
+      <h3>Payment method</h3>
+      <p>Card details are encrypted end-to-end and never stored on our servers.</p>
+      <div class="tabs-checkout__line"><span>Card</span><span>•••• 4242</span></div>
+      <div class="tabs-checkout__line"><span>Billing address</span><span>Same as shipping</span></div>
+      <span class="tabs-checkout__secure">🔒 SECURE CHECKOUT</span>
+    </section>
+
+    <section class="tabs-checkout__panel" id="panel-review">
+      <h3>Review your order</h3>
+      <p>Double-check everything below — you'll get a confirmation email right after you place the order.</p>
+      <div class="tabs-checkout__line"><span>Subtotal</span><span>$142.00</span></div>
+      <div class="tabs-checkout__line"><span>Shipping</span><span>$0.00</span></div>
+      <div class="tabs-checkout__line"><span>Total</span><span>$142.00</span></div>
+      <span class="tabs-checkout__secure">🔒 SECURE CHECKOUT</span>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-3d-flip-tabs-checkout-issue-50057/style.css
+++ b/submissions/examples/feat-3d-flip-tabs-checkout-issue-50057/style.css
@@ -1,0 +1,211 @@
+/* ==========================================================================
+   3D Flip Tabs — E-Commerce Checkout
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-checkout (see README).
+   ========================================================================== */
+
+.tabs-checkout {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 420ms;
+  --tabs-easing: cubic-bezier(0.25, 0.8, 0.4, 1);
+  --tabs-flip-angle: -80deg;     /* panel starts tipped back like a flap opening */
+  --tabs-perspective: 1100px;
+  --tabs-radius: 12px;
+  --tabs-accent: #0ea5a5;
+  --tabs-accent-soft: #e6f6f6;
+  --tabs-bg: #ffffff;
+  --tabs-surface: #f4f7f7;
+  --tabs-border: #e2e8e8;
+  --tabs-text: #12201f;
+  --tabs-text-dim: #6b7876;
+  --tabs-font-ui: "Manrope", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 440px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 20px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-checkout__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-checkout__list {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tabs-checkout__tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  cursor: pointer;
+  user-select: none;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--tabs-text-dim);
+  transition: color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-checkout__step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--tabs-border);
+  font-family: var(--tabs-font-mono);
+  font-size: 0.72rem;
+  color: var(--tabs-text-dim);
+  transition:
+    border-color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing),
+    color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-checkout__divider {
+  flex: 1;
+  height: 2px;
+  background: var(--tabs-border);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-checkout__input:focus-visible + .tabs-checkout__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+.tabs-checkout__input:checked + .tabs-checkout__tab {
+  color: var(--tabs-text);
+}
+
+.tabs-checkout__input:checked + .tabs-checkout__tab .tabs-checkout__step {
+  border-color: var(--tabs-accent);
+  background: var(--tabs-accent);
+  color: #fff;
+}
+
+/* --- panels: flip open on the X axis, like a flap ----------------------- */
+.tabs-checkout__stage {
+  margin-top: 18px;
+  padding: 20px;
+  background: var(--tabs-surface);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  perspective: var(--tabs-perspective);
+  overflow: hidden;
+}
+
+.tabs-checkout__panel {
+  display: none;
+  transform-origin: top center;
+  backface-visibility: hidden;
+}
+
+.tabs-checkout__panel h3 {
+  margin: 0 0 4px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1rem;
+}
+
+.tabs-checkout__panel p {
+  margin: 0 0 14px;
+  color: var(--tabs-text-dim);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.tabs-checkout__line {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-top: 1px dashed var(--tabs-border);
+  font-size: 0.84rem;
+}
+
+.tabs-checkout__line:first-of-type {
+  border-top: none;
+}
+
+.tabs-checkout__line span:last-child {
+  font-family: var(--tabs-font-mono);
+  color: var(--tabs-text);
+}
+
+.tabs-checkout__secure {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--tabs-accent-soft);
+  color: var(--tabs-accent);
+  font-family: var(--tabs-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+}
+
+/* show + flip in the panel that matches the checked tab */
+.tabs-checkout:has(#tab-shipping:checked) #panel-shipping,
+.tabs-checkout:has(#tab-payment:checked) #panel-payment,
+.tabs-checkout:has(#tab-review:checked) #panel-review {
+  display: block;
+  animation: tabs-checkout-flip var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-checkout-flip {
+  from {
+    opacity: 0;
+    transform: rotateX(var(--tabs-flip-angle));
+  }
+  to {
+    opacity: 1;
+    transform: rotateX(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-checkout__tab,
+  .tabs-checkout__step {
+    transition: none;
+  }
+  .tabs-checkout__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-checkout {
+    padding: 14px;
+  }
+  .tabs-checkout__tab span:last-child {
+    display: none; /* keep only the step circle on very small widths */
+  }
+  .tabs-checkout__stage {
+    padding: 16px;
+  }
+}


### PR DESCRIPTION
Description:

What this adds

A pure CSS tabs component with a 3D flip transition, styled for an e-commerce checkout step switcher, added under submissions/examples/3d-flip-tabs-checkout-issue-50057/.

Files
demo.html — standalone demo markup (3 checkout steps: Shipping, Payment, Review) with numbered progress indicators and order-summary line items
style.css — component styles, 3D flip animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Steps are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers the flip keyframe when its step is checked.
perspective is applied on the panel stage so the panel's rotateX() reads as genuine 3D depth — it flips open like a flap tipping down into place, not a flat squash.
backface-visibility: hidden keeps the panel from rendering upside-down mid-flip.
Numbered step circles fill in with the accent color as each step becomes active.
All timing, easing, flip angle, perspective depth, and colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between steps).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion.
Step labels collapse to numbered circles only on very narrow viewports, keeping tap targets legible.
Testing

Opened demo.html directly in the browser and verified:

All three steps switch correctly via click and keyboard (arrow keys)
3D flip animation plays smoothly on each panel reveal, no backface flashing
Layout holds up down to mobile width
No console errors

Closes #50057