### PR TITLE
feat: add zoom-in tabs marketing landing page example (#50040)

### DIFF
--- a/submissions/examples/feat-zoom-in-tabs-marketing-issue-50040/README.md
+++ b/submissions/examples/feat-zoom-in-tabs-marketing-issue-50040/README.md
@@ -1,0 +1,51 @@
+# Zoom-In Tabs — Marketing Landing Page
+
+A pure CSS tabs component with a bouncy zoom-in reveal, styled for a marketing landing page audience switcher (Teams / Individuals / Enterprise). No JavaScript required.
+
+## What it does
+
+- Switching audience tabs zooms the panel in from a smaller scale with a slight bounce/overshoot, giving it an energetic, marketing-page feel rather than a subtle dashboard fade.
+- The panel's icon badge pops in on a short delay after the panel itself, layering two zoom moments instead of one flat reveal.
+- The active tab fills with a two-color gradient to match the CTA button, tying the whole component to a consistent brand accent.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-market:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the zoom-in keyframe.
+- The badge inside each panel runs its own `tabs-market-badge-pop` animation with a short `animation-delay`, so it visibly zooms in just after the panel container.
+- The bouncy feel comes entirely from the easing curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`), not extra keyframe steps — swapping `--tabs-easing` to a standard ease removes the bounce without changing anything else.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-market` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `500ms` | Zoom-in animation length |
+| `--tabs-easing` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Easing curve (the overshoot creates the bounce) |
+| `--tabs-scale-start` | `0.75` | Starting scale of the panel before it zooms to full size |
+| `--tabs-radius` | `16px` | Corner radius |
+| `--tabs-accent-a` / `--tabs-accent-b` | `#ff3d6e` / `#ff8a3d` | Gradient accent (active tab, badge, CTA button) |
+| `--tabs-bg` / `--tabs-surface` | `#ffffff` / `#faf7f5` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | dark / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-market" style="--tabs-accent-a: #7c3aed; --tabs-accent-b: #06b6d4;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling both the panel zoom-in and the badge pop animations.
+- CTA links use standard `<a>` elements so they're reachable and operable like any other link.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven zoom-in pattern in the marketing landing page aesthetic requested in issue #50040 — responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-zoom-in-tabs-marketing-issue-50040/demo.html
+++ b/submissions/examples/feat-zoom-in-tabs-marketing-issue-50040/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Zoom-In Tabs — Marketing Landing Page</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Urbanist:wght@700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f1ef;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-market">
+  <div class="tabs-market__list" role="tablist" aria-label="Who it's for">
+
+    <input class="tabs-market__input" type="radio" name="market-tabs" id="tab-teams" checked />
+    <label class="tabs-market__tab" for="tab-teams" role="tab" aria-selected="true">Teams</label>
+
+    <input class="tabs-market__input" type="radio" name="market-tabs" id="tab-individuals" />
+    <label class="tabs-market__tab" for="tab-individuals" role="tab" aria-selected="false">Individuals</label>
+
+    <input class="tabs-market__input" type="radio" name="market-tabs" id="tab-enterprise" />
+    <label class="tabs-market__tab" for="tab-enterprise" role="tab" aria-selected="false">Enterprise</label>
+
+  </div>
+
+  <div class="tabs-market__panels">
+
+    <section class="tabs-market__panel" id="panel-teams">
+      <span class="tabs-market__badge" aria-hidden="true">👥</span>
+      <h3>Built for teams that ship fast</h3>
+      <p>Shared workspaces, real-time comments, and one-click handoff — everyone stays in sync without the status-update meetings.</p>
+      <a class="tabs-market__cta" href="#">Start a team trial</a>
+    </section>
+
+    <section class="tabs-market__panel" id="panel-individuals">
+      <span class="tabs-market__badge" aria-hidden="true">✦</span>
+      <h3>Everything you need, solo</h3>
+      <p>Unlimited projects on the free plan, no credit card required. Upgrade only when you actually need more room.</p>
+      <a class="tabs-market__cta" href="#">Create free account</a>
+    </section>
+
+    <section class="tabs-market__panel" id="panel-enterprise">
+      <span class="tabs-market__badge" aria-hidden="true">◆</span>
+      <h3>Security and scale, built in</h3>
+      <p>SSO, audit logs, and a dedicated success manager. Custom contracts and volume pricing for teams over 200 seats.</p>
+      <a class="tabs-market__cta" href="#">Talk to sales</a>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-zoom-in-tabs-marketing-issue-50040/style.css
+++ b/submissions/examples/feat-zoom-in-tabs-marketing-issue-50040/style.css
@@ -1,0 +1,201 @@
+/* ==========================================================================
+   Zoom-In Tabs — Marketing Landing Page
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-market (see README).
+   ========================================================================== */
+
+.tabs-market {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 500ms;
+  --tabs-easing: cubic-bezier(0.34, 1.56, 0.64, 1); /* bouncy overshoot */
+  --tabs-scale-start: 0.75;
+  --tabs-radius: 16px;
+  --tabs-accent-a: #ff3d6e;
+  --tabs-accent-b: #ff8a3d;
+  --tabs-accent-soft: #fff1ee;
+  --tabs-bg: #ffffff;
+  --tabs-surface: #faf7f5;
+  --tabs-border: #f0e6e2;
+  --tabs-text: #201820;
+  --tabs-text-dim: #8a8188;
+  --tabs-font-ui: "Urbanist", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 560px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 20px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+  box-shadow: 0 24px 60px -32px rgba(255, 61, 110, 0.35);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-market__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-market__list {
+  display: flex;
+  gap: 6px;
+  padding: 4px;
+  background: var(--tabs-surface);
+  border-radius: var(--tabs-radius);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tabs-market__tab {
+  flex: 1 0 auto;
+  padding: 10px 16px;
+  border-radius: calc(var(--tabs-radius) - 5px);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  text-align: center;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--tabs-text-dim);
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-market__tab:hover {
+  color: var(--tabs-text);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-market__input:focus-visible + .tabs-market__tab {
+  outline: 2px solid var(--tabs-accent-a);
+  outline-offset: 2px;
+}
+
+.tabs-market__input:checked + .tabs-market__tab {
+  color: #fff;
+  background: linear-gradient(135deg, var(--tabs-accent-a), var(--tabs-accent-b));
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-market__panels {
+  position: relative;
+  margin-top: 20px;
+  padding: 28px 24px;
+  text-align: center;
+  background: var(--tabs-surface);
+  border-radius: var(--tabs-radius);
+  overflow: hidden;
+}
+
+.tabs-market__panel {
+  display: none;
+}
+
+.tabs-market__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  margin-bottom: 14px;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  background: linear-gradient(135deg, var(--tabs-accent-a), var(--tabs-accent-b));
+}
+
+.tabs-market__panel h3 {
+  margin: 0 0 8px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1.35rem;
+  font-weight: 800;
+}
+
+.tabs-market__panel p {
+  max-width: 34ch;
+  margin: 0 auto 18px;
+  color: var(--tabs-text-dim);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.tabs-market__cta {
+  display: inline-block;
+  padding: 10px 22px;
+  border-radius: 999px;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, var(--tabs-accent-a), var(--tabs-accent-b));
+  text-decoration: none;
+}
+
+/* show + zoom in the panel that matches the checked tab */
+.tabs-market:has(#tab-teams:checked) #panel-teams,
+.tabs-market:has(#tab-individuals:checked) #panel-individuals,
+.tabs-market:has(#tab-enterprise:checked) #panel-enterprise {
+  display: block;
+  animation: tabs-market-zoom-in var(--tabs-duration) var(--tabs-easing);
+}
+
+/* badge pops in slightly after the panel, for a layered zoom */
+.tabs-market__panel .tabs-market__badge {
+  animation: tabs-market-badge-pop var(--tabs-duration) var(--tabs-easing) both;
+  animation-delay: 60ms;
+}
+
+@keyframes tabs-market-zoom-in {
+  from {
+    opacity: 0;
+    transform: scale(var(--tabs-scale-start));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes tabs-market-badge-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-market__tab {
+    transition: none;
+  }
+  .tabs-market__panel,
+  .tabs-market__badge {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-market {
+    padding: 14px;
+  }
+  .tabs-market__panels {
+    padding: 22px 16px;
+  }
+  .tabs-market__panel h3 {
+    font-size: 1.15rem;
+  }
+}


### PR DESCRIPTION
Description:

What this adds

A pure CSS tabs component with a bouncy zoom-in reveal, styled for a marketing landing page audience switcher, added under submissions/examples/zoom-in-tabs-marketing-issue-50040/.

Files
demo.html — standalone demo markup (3 audience tabs: Teams, Individuals, Enterprise), each with a badge, headline, and CTA
style.css — component styles, bouncy zoom-in animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers the zoom-in keyframe when its tab is checked.
The panel scales in from a smaller size with a slight bounce (overshoot easing), and the icon badge pops in on a short delay after the panel for a layered zoom effect.
The active tab fills with a two-color gradient matching the CTA button.
All timing, easing, starting scale, and gradient colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion (disables both the panel zoom and badge pop).
Testing

Opened demo.html directly in the browser and verified:

All three tabs switch correctly via click and keyboard (arrow keys)
Zoom-in and badge pop animate smoothly on each panel reveal
Layout holds up down to mobile width
No console errors

Closes #50040