### PR TITLE
feat: add neon glow tabs component for marketing landing pages

### DIFF
--- a/submissions/examples/ease-neon-glow-tabs/README.md
+++ b/submissions/examples/ease-neon-glow-tabs/README.md
@@ -1,0 +1,51 @@
+# Ease Neon Glow Tabs
+
+## Description
+A pure CSS pill-tab interface styled for marketing landing pages — active tabs light up with a continuously hue-shifting neon glow (pink → cyan → violet), and switching tabs fades/scales the panel content in. Ideal for pricing plan showcases. Driven entirely by radio inputs — zero JavaScript.
+
+## Features
+- Neon glow ring that fades in behind the active tab, with a continuous animated hue-shift
+- Fade + scale panel transition on tab switch
+- Pricing-card style panel content (badge, gradient price text, feature checklist)
+- Fully keyboard accessible (native radio inputs, `role="tablist"`/`"tab"`/`"tabpanel"`)
+- Responsive (tab pills wrap on narrow screens)
+- Fully customizable via CSS custom properties
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-tabs-neon-glow" role="tablist" aria-label="Pricing plans">
+  <input type="radio" name="glow-tab" id="gtab1" class="tab-input" checked />
+  <input type="radio" name="glow-tab" id="gtab2" class="tab-input" />
+
+  <div class="tab-list">
+    <label for="gtab1" class="tab-label" role="tab">Starter</label>
+    <label for="gtab2" class="tab-label" role="tab">Growth</label>
+  </div>
+
+  <div class="tab-panels">
+    <div class="tab-panel panel-1" role="tabpanel">
+      <div class="panel-inner">...</div>
+    </div>
+    <div class="tab-panel panel-2" role="tabpanel">
+      <div class="panel-inner">...</div>
+    </div>
+  </div>
+</div>
+```
+Each `.tab-panel` needs a unique class (`panel-1`, `panel-2`, ...) matched to its radio's `id` in the CSS rule `#gtabN:checked ~ .tab-panels .panel-N`.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--tabs-duration` | `0.5s` | Panel transition duration |
+| `--tabs-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Timing function |
+| `--neon-a` | `#ff2ea6` | Neon gradient color 1 (pink) |
+| `--neon-b` | `#00e5ff` | Neon gradient color 2 (cyan) |
+| `--neon-c` | `#7c3aed` | Neon gradient color 3 (violet) |
+| `--tabs-radius` | `20px` | Outer container corner rounding |
+
+## Files
+- `demo.html` — live working example (3-tier pricing tab example)
+- `style.css` — component styles and all animations
+- `README.md` — this file

--- a/submissions/examples/ease-neon-glow-tabs/demo.html
+++ b/submissions/examples/ease-neon-glow-tabs/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Neon Glow Tabs — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at 50% 0%, #1a1128 0%, #05040a 70%);
+      padding: 30px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-tabs-neon-glow" role="tablist" aria-label="Pricing plans">
+    <input type="radio" name="glow-tab" id="gtab1" class="tab-input" checked />
+    <input type="radio" name="glow-tab" id="gtab2" class="tab-input" />
+    <input type="radio" name="glow-tab" id="gtab3" class="tab-input" />
+
+    <div class="tab-list">
+      <label for="gtab1" class="tab-label" role="tab">Starter</label>
+      <label for="gtab2" class="tab-label" role="tab">Growth</label>
+      <label for="gtab3" class="tab-label" role="tab">Scale</label>
+    </div>
+
+    <div class="tab-panels">
+      <div class="tab-panel panel-1" role="tabpanel">
+        <div class="panel-inner">
+          <span class="panel-badge">Free Forever</span>
+          <h3 class="panel-title">Starter</h3>
+          <p class="panel-price">$0<span> / month</span></p>
+          <ul class="panel-features">
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>1 project</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Community support</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Basic analytics</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="tab-panel panel-2" role="tabpanel">
+        <div class="panel-inner">
+          <span class="panel-badge">Most Popular</span>
+          <h3 class="panel-title">Growth</h3>
+          <p class="panel-price">$29<span> / month</span></p>
+          <ul class="panel-features">
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Unlimited projects</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Priority support</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Advanced analytics</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Team collaboration</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="tab-panel panel-3" role="tabpanel">
+        <div class="panel-inner">
+          <span class="panel-badge">Enterprise Ready</span>
+          <h3 class="panel-title">Scale</h3>
+          <p class="panel-price">$99<span> / month</span></p>
+          <ul class="panel-features">
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Everything in Growth</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Dedicated account manager</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>Custom integrations</li>
+            <li><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"></polyline></svg>SLA guarantee</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-neon-glow-tabs/style.css
+++ b/submissions/examples/ease-neon-glow-tabs/style.css
@@ -1,0 +1,206 @@
+/* Ease Neon Glow Tabs — pure CSS, marketing landing page style, zero JS */
+
+.ease-tabs-neon-glow {
+  --neon-a: #ff2ea6;
+  --neon-b: #00e5ff;
+  --neon-c: #7c3aed;
+  --tabs-bg: #0c0a14;
+  --tabs-panel-bg: #120f1e;
+  --tabs-border: #221d33;
+  --tabs-fg: #f5f3ff;
+  --tabs-muted: #8b85a3;
+  --tabs-duration: 0.5s;
+  --tabs-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --tabs-radius: 20px;
+
+  width: min(560px, 92vw);
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  padding: 24px;
+  font-family: system-ui, sans-serif;
+  box-sizing: border-box;
+}
+
+.ease-tabs-neon-glow .tab-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+}
+
+.ease-tabs-neon-glow .tab-list {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 22px;
+  justify-content: center;
+}
+
+.ease-tabs-neon-glow .tab-label {
+  position: relative;
+  padding: 11px 22px;
+  border-radius: 999px;
+  border: 1px solid var(--tabs-border);
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--tabs-muted);
+  cursor: pointer;
+  user-select: none;
+  overflow: hidden;
+  transition: color var(--tabs-duration) ease, border-color var(--tabs-duration) ease;
+}
+
+/* neon glow ring that fades in behind the active tab */
+.ease-tabs-neon-glow .tab-label::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: inherit;
+  background: linear-gradient(120deg, var(--neon-a), var(--neon-b), var(--neon-c));
+  background-size: 300% 300%;
+  opacity: 0;
+  filter: blur(10px);
+  z-index: -1;
+  transition: opacity var(--tabs-duration) ease;
+  animation: neon-hue-shift 4s linear infinite;
+}
+
+.ease-tabs-neon-glow .tab-label:hover {
+  color: var(--tabs-fg);
+}
+
+.ease-tabs-neon-glow .tab-input:focus-visible + .tab-label {
+  outline: 2px solid var(--neon-b);
+  outline-offset: 2px;
+}
+
+.ease-tabs-neon-glow .tab-input:checked + .tab-label {
+  color: #fff;
+  border-color: transparent;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.6);
+}
+
+.ease-tabs-neon-glow .tab-input:checked + .tab-label::before {
+  opacity: 1;
+}
+
+@keyframes neon-hue-shift {
+  0%, 100% { background-position: 0% 50%; }
+  50%      { background-position: 100% 50%; }
+}
+
+/* ---- panels ---- */
+.ease-tabs-neon-glow .tab-panels {
+  position: relative;
+  min-height: 220px;
+}
+
+.ease-tabs-neon-glow .tab-panel {
+  position: absolute;
+  inset: 0;
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px) scale(0.98);
+  transition:
+    opacity var(--tabs-duration) var(--tabs-easing),
+    transform var(--tabs-duration) var(--tabs-easing),
+    visibility var(--tabs-duration);
+  pointer-events: none;
+}
+
+#gtab1:checked ~ .tab-panels .panel-1,
+#gtab2:checked ~ .tab-panels .panel-2,
+#gtab3:checked ~ .tab-panels .panel-3 {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.ease-tabs-neon-glow .panel-inner {
+  background: var(--tabs-panel-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: 16px;
+  padding: 28px;
+  text-align: center;
+}
+
+.ease-tabs-neon-glow .panel-badge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, var(--neon-a), var(--neon-b));
+  color: #0b0f19;
+  margin-bottom: 14px;
+}
+
+.ease-tabs-neon-glow .panel-title {
+  margin: 0 0 8px;
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--tabs-fg);
+}
+
+.ease-tabs-neon-glow .panel-price {
+  font-size: 2rem;
+  font-weight: 900;
+  background: linear-gradient(120deg, var(--neon-a), var(--neon-b));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  margin-bottom: 4px;
+}
+
+.ease-tabs-neon-glow .panel-price span {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--tabs-muted);
+  -webkit-text-fill-color: var(--tabs-muted);
+}
+
+.ease-tabs-neon-glow .panel-features {
+  list-style: none;
+  margin: 20px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-align: left;
+}
+
+.ease-tabs-neon-glow .panel-features li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.85rem;
+  color: #cbd5e1;
+}
+
+.ease-tabs-neon-glow .panel-features li svg {
+  width: 16px;
+  height: 16px;
+  stroke: var(--neon-b);
+  fill: none;
+  stroke-width: 2.5;
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-neon-glow .tab-panel,
+  .ease-tabs-neon-glow .tab-label::before {
+    transition: opacity 0.2s ease;
+    animation: none !important;
+    transform: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .ease-tabs-neon-glow .tab-list {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
Closes #50125

## Pull Request Description
Adds a pure CSS pill-tab component styled for marketing landing pages — the active tab glows with a continuously hue-shifting neon gradient (pink → cyan → violet), and switching tabs fades/scales the panel content in. Includes a pricing-card style panel layout as the demo use case. Driven entirely by radio inputs — zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-neon-glow-tabs-savni/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pill-style tab component (`ease-tabs-neon-glow`) where the active tab lights up with a continuously animated multi-color neon glow, and panel switching uses a fade + scale transition. Demo showcases a 3-tier pricing plan layout (Starter / Growth / Scale) as a common marketing landing page use case.