### PR TITLE
feat: add toast progress ring example

### DIFF
--- a/submissions/examples/toast-progress-ring/README.md
+++ b/submissions/examples/toast-progress-ring/README.md
@@ -1,0 +1,15 @@
+# Toast Progress Ring
+
+A CSS-only toast notification with an animated conic progress ring and subtle lift feedback.
+
+## Files
+
+- `demo.html` contains the toast message and progress ring.
+- `style.css` defines the card layout, conic-gradient ring, hover lift, and mobile stacking.
+
+## What it demonstrates
+
+- Progress-ring styling using `conic-gradient`.
+- Toast notification layout without JavaScript.
+- Hover and focus-within elevation feedback.
+- Responsive stacking for narrow screens.

--- a/submissions/examples/toast-progress-ring/demo.html
+++ b/submissions/examples/toast-progress-ring/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast Progress Ring</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="toast" role="status">
+    <div class="ring" aria-hidden="true"></div>
+    <div>
+      <strong>Export almost ready</strong>
+      <p>Your design package is being prepared.</p>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/toast-progress-ring/style.css
+++ b/submissions/examples/toast-progress-ring/style.css
@@ -1,0 +1,80 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f7f9fc;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.toast {
+  width: min(92vw, 460px);
+  display: grid;
+  grid-template-columns: 62px 1fr;
+  align-items: center;
+  gap: 16px;
+  border: 1px solid #dbe4ef;
+  border-radius: 8px;
+  padding: 18px;
+  background: #ffffff;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.13);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.toast:hover,
+.toast:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 30px 72px rgba(37, 99, 235, 0.18);
+}
+
+.ring {
+  position: relative;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background: conic-gradient(#2563eb 0deg, #22c55e 250deg, #e2e8f0 250deg);
+  animation: ring-sweep 2.8s ease-in-out infinite;
+}
+
+.ring::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border-radius: inherit;
+  background: #ffffff;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+strong {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 1rem;
+}
+
+p {
+  margin: 0;
+  color: #64748b;
+  line-height: 1.55;
+}
+
+@keyframes ring-sweep {
+  0%, 100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(18deg) scale(1.06);
+  }
+}
+
+@media (max-width: 420px) {
+  .toast {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only toast progress ring example
- include conic-gradient progress ring, toast card layout, and hover lift feedback
- document responsive notification behavior

## Test
- git diff --cached --check