### PR TITLE
feat: add skeleton card wave example

### DIFF
--- a/submissions/examples/skeleton-card-wave/README.md
+++ b/submissions/examples/skeleton-card-wave/README.md
@@ -1,0 +1,15 @@
+# Skeleton Card Wave
+
+A CSS-only loading card skeleton with a repeated shimmer wave for article, product, or dashboard preview placeholders.
+
+## Files
+
+- `demo.html` contains the skeleton media block, text lines, avatar, and metadata pill.
+- `style.css` defines the card layout, shimmer wave, hover speed change, and responsive sizing.
+
+## What it demonstrates
+
+- Loading placeholder UI without JavaScript.
+- Shimmer motion using a pseudo-element and transform animation.
+- Stable card dimensions for preview loading states.
+- Responsive media and footer placeholder sizing.

--- a/submissions/examples/skeleton-card-wave/demo.html
+++ b/submissions/examples/skeleton-card-wave/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skeleton Card Wave</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <article class="skeleton-card" aria-label="Loading article preview">
+    <div class="media shimmer"></div>
+    <div class="line title shimmer"></div>
+    <div class="line shimmer"></div>
+    <div class="line short shimmer"></div>
+    <div class="footer">
+      <span class="avatar shimmer"></span>
+      <span class="pill shimmer"></span>
+    </div>
+  </article>
+</body>
+</html>

--- a/submissions/examples/skeleton-card-wave/style.css
+++ b/submissions/examples/skeleton-card-wave/style.css
@@ -1,0 +1,100 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f1f5f9;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.skeleton-card {
+  width: min(92vw, 380px);
+  border: 1px solid #dbe4ef;
+  border-radius: 8px;
+  padding: 18px;
+  background: #ffffff;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+}
+
+.media {
+  height: 150px;
+  border-radius: 8px;
+  margin-bottom: 18px;
+}
+
+.line {
+  height: 14px;
+  border-radius: 999px;
+  margin-top: 11px;
+}
+
+.title {
+  width: 72%;
+  height: 18px;
+}
+
+.short {
+  width: 52%;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.avatar {
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+}
+
+.pill {
+  width: 120px;
+  height: 24px;
+  border-radius: 999px;
+}
+
+.shimmer {
+  position: relative;
+  overflow: hidden;
+  background: #e2e8f0;
+}
+
+.shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-110%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.7), transparent);
+  animation: wave 1.8s ease-in-out infinite;
+}
+
+.skeleton-card:hover .shimmer::after,
+.skeleton-card:focus-within .shimmer::after {
+  animation-duration: 1.1s;
+}
+
+@keyframes wave {
+  to {
+    transform: translateX(110%);
+  }
+}
+
+@media (max-width: 420px) {
+  .media {
+    height: 130px;
+  }
+
+  .pill {
+    width: 96px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only skeleton card wave example
- include shimmer placeholders for media, text, avatar, and metadata
- document loading-state behavior and responsive sizing

## Test
- git diff --cached --check