### PR TITLE
feat: add empty inbox swing example

### DIFF
--- a/submissions/examples/empty-inbox-swing/README.md
+++ b/submissions/examples/empty-inbox-swing/README.md
@@ -1,0 +1,15 @@
+# Empty Inbox Swing
+
+A CSS-only empty inbox state with a gently swinging envelope icon and a clear compose action.
+
+## Files
+
+- `demo.html` contains the empty-state content, icon, and action link.
+- `style.css` defines the card layout, swinging icon animation, action feedback, and responsive spacing.
+
+## What it demonstrates
+
+- Empty-state UI for inbox and messaging screens.
+- Icon motion using transform-origin and rotation keyframes.
+- Hover and focus-visible feedback for the action link.
+- Centered responsive layout without JavaScript.

--- a/submissions/examples/empty-inbox-swing/demo.html
+++ b/submissions/examples/empty-inbox-swing/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Empty Inbox Swing</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="empty-inbox">
+    <div class="envelope" aria-hidden="true">✉</div>
+    <h1>Inbox is clear</h1>
+    <p>No pending messages right now. New updates will appear here automatically.</p>
+    <a href="#compose">Compose</a>
+  </section>
+</body>
+</html>

--- a/submissions/examples/empty-inbox-swing/style.css
+++ b/submissions/examples/empty-inbox-swing/style.css
@@ -1,0 +1,87 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f5f7fb;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.empty-inbox {
+  width: min(92vw, 430px);
+  display: grid;
+  justify-items: center;
+  border: 1px solid #dbe4ef;
+  border-radius: 8px;
+  padding: 40px 28px;
+  background: #ffffff;
+  text-align: center;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+}
+
+.envelope {
+  width: 76px;
+  height: 76px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 2.2rem;
+  transform-origin: top center;
+  animation: inbox-swing 2.4s ease-in-out infinite;
+}
+
+h1 {
+  margin: 22px 0 8px;
+  font-size: 1.85rem;
+  letter-spacing: 0;
+}
+
+p {
+  max-width: 330px;
+  margin: 0;
+  color: #64748b;
+  line-height: 1.65;
+}
+
+a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 24px;
+  border-radius: 8px;
+  padding: 0 18px;
+  background: #0369a1;
+  color: #ffffff;
+  font-weight: 900;
+  text-decoration: none;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+a:hover,
+a:focus-visible {
+  transform: translateY(-3px);
+  background: #075985;
+}
+
+@keyframes inbox-swing {
+  0%, 100% {
+    transform: rotate(-5deg);
+  }
+  50% {
+    transform: rotate(5deg);
+  }
+}
+
+@media (max-width: 420px) {
+  .empty-inbox {
+    padding: 34px 22px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only empty inbox swing example
- include swinging envelope motion and compose action feedback
- document responsive empty-state behavior

## Test
- git diff --cached --check