### PR TITLE
feat: add status pill slide example

### DIFF
--- a/submissions/examples/status-pill-slide/README.md
+++ b/submissions/examples/status-pill-slide/README.md
@@ -1,0 +1,15 @@
+# Status Pill Slide
+
+A CSS-only status pill group with a sliding active indicator for deployment, order, or workflow states.
+
+## Files
+
+- `demo.html` contains the status card and three pill labels.
+- `style.css` defines the active indicator slide, hover breathing motion, and mobile stacked layout.
+
+## What it demonstrates
+
+- Active status highlighting with a pseudo-element.
+- Sliding indicator motion without JavaScript.
+- Stable three-state pill layout for dashboards.
+- Responsive stacked status controls on small screens.

--- a/submissions/examples/status-pill-slide/demo.html
+++ b/submissions/examples/status-pill-slide/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Status Pill Slide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="status-card" aria-label="Deployment status">
+    <p>Pipeline status</p>
+    <div class="pills">
+      <span>Queued</span>
+      <span class="active">Building</span>
+      <span>Ready</span>
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/status-pill-slide/style.css
+++ b/submissions/examples/status-pill-slide/style.css
@@ -1,0 +1,100 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.status-card {
+  width: min(92vw, 460px);
+  border: 1px solid #dbe4ef;
+  border-radius: 8px;
+  padding: 22px;
+  background: #ffffff;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+}
+
+p {
+  margin: 0 0 14px;
+  color: #475569;
+  font-weight: 900;
+}
+
+.pills {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  border-radius: 8px;
+  padding: 8px;
+  background: #eef2f7;
+}
+
+.pills::before {
+  content: "";
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: calc(33.333% + 3px);
+  width: calc(33.333% - 8px);
+  border-radius: 8px;
+  background: #2563eb;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.24);
+  animation: active-slide 1.8s ease both;
+}
+
+span {
+  position: relative;
+  z-index: 1;
+  min-height: 40px;
+  display: grid;
+  place-items: center;
+  color: #64748b;
+  font-weight: 900;
+}
+
+.active {
+  color: #ffffff;
+}
+
+.status-card:hover .pills::before,
+.status-card:focus-within .pills::before {
+  animation: active-breathe 1.2s ease-in-out infinite;
+}
+
+@keyframes active-slide {
+  from {
+    transform: translateX(-108%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes active-breathe {
+  50% {
+    transform: scaleX(1.04);
+  }
+}
+
+@media (max-width: 440px) {
+  .pills {
+    grid-template-columns: 1fr;
+  }
+
+  .pills::before {
+    left: 8px;
+    right: 8px;
+    top: 56px;
+    bottom: auto;
+    width: auto;
+    height: 40px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only status pill slide example
- include sliding active indicator, hover breathing feedback, and responsive stacked layout
- document deployment/status UI usage

## Test
- git diff --cached --check