### PR TITLE
fix: add scroll support for long modal content

### DIFF
--- a/submissions/examples/modal-scroll-fix/README.md
+++ b/submissions/examples/modal-scroll-fix/README.md
@@ -1,0 +1,15 @@
+# Modal Scroll Fix
+
+## Description
+
+Added scroll support for modal components when content exceeds viewport height.
+
+## Fix
+
+- Added `max-height: 90vh`
+- Added `overflow-y: auto`
+- Ensures modal content and action buttons remain accessible on small screens.
+
+## Usage
+
+Open the demo file and resize the browser height to test scrolling.

--- a/submissions/examples/modal-scroll-fix/demo.html
+++ b/submissions/examples/modal-scroll-fix/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Scroll Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<button onclick="openModal()">Open Modal</button>
+
+<div class="modal" id="modal">
+  <div class="modal-content">
+
+    <span class="close" onclick="closeModal()">×</span>
+
+    <h2>Terms & Conditions</h2>
+
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      This is a long modal content example to demonstrate scrolling.
+    </p>
+
+    <p>
+      Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+    </p>
+
+    <p>
+      Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+      dolore eu fugiat nulla pariatur.
+    </p>
+
+    <p>
+      Repeat content to exceed viewport height and test scrolling behavior.
+    </p>
+
+    <p>
+      Additional content ensures that the modal becomes scrollable on small
+      screens.
+    </p>
+
+    <button class="accept-btn">Accept</button>
+
+  </div>
+</div>
+
+
+<script>
+function openModal() {
+  document.getElementById("modal").style.display = "flex";
+}
+
+function closeModal() {
+  document.getElementById("modal").style.display = "none";
+}
+</script>
+
+</body>
+</html>

--- a/submissions/examples/modal-scroll-fix/style.css
+++ b/submissions/examples/modal-scroll-fix/style.css
@@ -1,0 +1,46 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 40px;
+}
+
+
+/* Modal container */
+.modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+
+  align-items: center;
+  justify-content: center;
+
+  padding: 20px;
+}
+
+
+/* Scroll fix */
+.modal-content {
+  background: white;
+  padding: 25px;
+  border-radius: 10px;
+
+  width: 500px;
+  max-width: 100%;
+
+  /* Fix for long content */
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+
+.close {
+  float: right;
+  font-size: 25px;
+  cursor: pointer;
+}
+
+
+.accept-btn {
+  padding: 10px 20px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Pull Request Description

Added a modal scroll fix submission that allows modal content to remain accessible when it exceeds the viewport height. This improves usability on smaller screens by enabling vertical scrolling inside the modal.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a scrollable modal utility that prevents content clipping when modal height exceeds the viewport.

**How does a developer use it?**

```html
<div class="modal-content modal-scroll">
  <h2>Terms & Conditions</h2>
  <p>
    Long modal content goes here...
  </p>
  <button>Accept</button>
</div>