### PR TITLE
feat: add filter chip shuffle example

### DIFF
--- a/submissions/examples/filter-chip-shuffle/README.md
+++ b/submissions/examples/filter-chip-shuffle/README.md
@@ -1,0 +1,19 @@
+# Filter Chip Shuffle
+
+A CSS-only filter panel that animates selected chips and shuffles result cards into a focused stack. It is useful for search filters, tag pickers, dashboards, and compact product list controls.
+
+## Files
+
+- `demo.html` contains the filter panel markup and sample result cards.
+- `style.css` contains the responsive layout, chip states, and shuffle animations.
+
+## Animation details
+
+- `chip-pop` gives the active filter a quick selected-state lift.
+- `chip-sheen` adds a light sweep across the active chip.
+- `result-shuffle` reorders the card stack with staggered motion on hover or keyboard focus.
+- `status-float` adds subtle idle movement without relying on JavaScript.
+
+## Usage
+
+Hover the panel or focus one of the filter buttons to see the card stack shuffle while the chip controls stay accessible.

--- a/submissions/examples/filter-chip-shuffle/demo.html
+++ b/submissions/examples/filter-chip-shuffle/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filter Chip Shuffle Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="filter-stage" aria-label="Animated filter chip shuffle">
+    <section class="filter-card">
+      <p class="eyebrow">Search Board</p>
+      <h1>Filter Chip Shuffle</h1>
+
+      <div class="chip-row" aria-label="Filter options">
+        <button class="chip active" type="button">All</button>
+        <button class="chip" type="button">UI</button>
+        <button class="chip" type="button">Motion</button>
+        <button class="chip" type="button">CSS</button>
+      </div>
+
+      <div class="result-stack" aria-hidden="true">
+        <article class="result-card primary">
+          <span></span>
+          <strong>Micro interactions</strong>
+        </article>
+        <article class="result-card secondary">
+          <span></span>
+          <strong>Accessible filters</strong>
+        </article>
+        <article class="result-card tertiary">
+          <span></span>
+          <strong>Dashboard states</strong>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/filter-chip-shuffle/style.css
+++ b/submissions/examples/filter-chip-shuffle/style.css
@@ -1,0 +1,194 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #edf4f8;
+  color: #152332;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.filter-stage {
+  width: min(92vw, 720px);
+  padding: 24px;
+}
+
+.filter-card {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid rgba(21, 35, 50, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(230, 244, 247, 0.94)),
+    radial-gradient(circle at top right, rgba(236, 154, 41, 0.16), transparent 36%);
+  box-shadow: 0 24px 72px rgba(20, 45, 62, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #547083;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 520px;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 30px 0 34px;
+}
+
+.chip {
+  position: relative;
+  min-width: 72px;
+  overflow: hidden;
+  border: 1px solid rgba(21, 35, 50, 0.14);
+  border-radius: 999px;
+  padding: 10px 16px;
+  background: #ffffff;
+  color: #2d465a;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.chip::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  translate: -115% 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+}
+
+.chip:hover,
+.chip:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(20, 142, 126, 0.42);
+  box-shadow: 0 12px 24px rgba(20, 45, 62, 0.12);
+  outline: none;
+}
+
+.chip.active {
+  background: #148e7e;
+  color: #f9fffd;
+  animation: chip-pop 1.8s ease-in-out infinite;
+}
+
+.chip.active::after {
+  animation: chip-sheen 2.4s ease-in-out infinite;
+}
+
+.result-stack {
+  display: grid;
+  gap: 12px;
+  perspective: 900px;
+}
+
+.result-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 72px;
+  padding: 18px;
+  border: 1px solid rgba(21, 35, 50, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 24px rgba(20, 45, 62, 0.08);
+  transform-origin: left center;
+  animation: status-float 3.8s ease-in-out infinite;
+}
+
+.result-card span {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ec9a29;
+  box-shadow: 0 0 0 6px rgba(236, 154, 41, 0.16);
+}
+
+.result-card strong {
+  font-size: clamp(1rem, 4vw, 1.3rem);
+}
+
+.secondary {
+  animation-delay: 120ms;
+}
+
+.tertiary {
+  animation-delay: 240ms;
+}
+
+.filter-card:hover .primary,
+.filter-card:focus-within .primary {
+  animation: result-shuffle 760ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.filter-card:hover .secondary,
+.filter-card:focus-within .secondary {
+  animation: result-shuffle 760ms 90ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.filter-card:hover .tertiary,
+.filter-card:focus-within .tertiary {
+  animation: result-shuffle 760ms 180ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+@keyframes chip-pop {
+  0%, 100% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(-2px) scale(1.04);
+  }
+}
+
+@keyframes chip-sheen {
+  45%, 100% {
+    translate: 115% 0;
+  }
+}
+
+@keyframes status-float {
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@keyframes result-shuffle {
+  0% {
+    transform: translateX(0) rotateY(0);
+  }
+  42% {
+    transform: translateX(22px) rotateY(-10deg);
+  }
+  100% {
+    transform: translateX(0) rotateY(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .chip {
+    flex: 1 1 calc(50% - 10px);
+  }
+
+  .result-card {
+    min-height: 68px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only filter chip shuffle demo under submissions/examples/filter-chip-shuffle
- include accessible filter buttons, responsive result cards, and hover/focus shuffle motion
- document the animation names and usage in the example README

## Verification
- confirmed the example slug and branch are unique
- verified the submission contains demo.html, style.css, and README.md only
- ran git diff --cached --check