### PR TITLE
feat: add zoom-in tabs accessible web example (#50049)

### DIFF
--- a/submissions/examples/feat-zoom-in-tabs-accessible-issue-50049/README.md
+++ b/submissions/examples/feat-zoom-in-tabs-accessible-issue-50049/README.md
@@ -1,0 +1,52 @@
+# Zoom-In Tabs — Accessible Web
+
+A pure CSS tabs component with a subtle zoom-in reveal, where the "Accessible Web" brief shapes the actual visual and interaction design rather than being treated as an afterthought. No JavaScript required.
+
+## What it does
+
+- Switching tabs reveals the panel with a short, subtle scale-and-fade (96% → 100%, 200ms) — enough to draw the eye without becoming a distraction.
+- Every tab has a minimum 44×44px target size, per WCAG 2.5.5 target-size guidance.
+- Focus and selection are visually distinct: the keyboard focus ring is amber, the selected-tab fill is blue, so a sighted keyboard user can always tell "where I am" from "what's chosen."
+- Set in Atkinson Hyperlegible, a typeface designed specifically to increase legibility for readers with low vision.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs) — this is called out explicitly in the demo copy rather than left implicit.
+- `.tabs-a11y:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the zoom-in keyframe.
+- `prefers-reduced-motion: reduce` fully removes the animation (not just shortens it) — the panel simply appears.
+
+## Customization
+
+All values are exposed as CSS custom properties on the `.tabs-a11y` wrapper. If you retheme colors, re-check contrast — the defaults are chosen to pass WCAG AA, and swapping them without checking can silently break that:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `200ms` | Zoom-in animation length (kept short intentionally) |
+| `--tabs-easing` | `ease-out` | Easing curve |
+| `--tabs-scale-start` | `0.96` | Starting scale of the panel (kept subtle intentionally) |
+| `--tabs-radius` | `8px` | Corner radius |
+| `--tabs-accent` / `--tabs-accent-contrast` | `#1a56db` / `#ffffff` | Selected-tab fill and its text color (passes AA together) |
+| `--tabs-focus-ring` | `#b45309` | Keyboard focus ring — deliberately distinct from `--tabs-accent` |
+| `--tabs-text` / `--tabs-text-dim` | `#111827` / `#374151` | Text colors, both AA-passing on white |
+
+Example override:
+
+```html
+<div class="tabs-a11y" style="--tabs-accent: #0f766e; --tabs-focus-ring: #9333ea;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs: keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS or ARIA-managed focus logic.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- Minimum 44×44px tap targets on every tab.
+- Focus ring color is distinct from the selected-state color so the two states are never visually ambiguous.
+- All text/background pairs (including secondary/dim text) meet WCAG AA contrast.
+- `prefers-reduced-motion: reduce` removes the animation entirely rather than just reducing its duration.
+- On narrow viewports, tabs stack to full-width instead of shrinking below a legible/tappable size.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven zoom-in pattern where the "Accessible Web" aesthetic requested in issue #50049 is expressed through actual accessibility decisions (contrast, target size, focus visibility, motion respect) rather than through visual styling alone.

--- a/submissions/examples/feat-zoom-in-tabs-accessible-issue-50049/demo.html
+++ b/submissions/examples/feat-zoom-in-tabs-accessible-issue-50049/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Zoom-In Tabs — Accessible Web</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #e5e7eb;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-a11y">
+  <div class="tabs-a11y__list" role="tablist" aria-label="Accessibility topics">
+
+    <input class="tabs-a11y__input" type="radio" name="a11y-tabs" id="tab-contrast" checked />
+    <label class="tabs-a11y__tab" for="tab-contrast" role="tab" aria-selected="true">Contrast</label>
+
+    <input class="tabs-a11y__input" type="radio" name="a11y-tabs" id="tab-keyboard" />
+    <label class="tabs-a11y__tab" for="tab-keyboard" role="tab" aria-selected="false">Keyboard</label>
+
+    <input class="tabs-a11y__input" type="radio" name="a11y-tabs" id="tab-motion" />
+    <label class="tabs-a11y__tab" for="tab-motion" role="tab" aria-selected="false">Motion</label>
+
+  </div>
+
+  <div class="tabs-a11y__panels">
+
+    <section class="tabs-a11y__panel" id="panel-contrast">
+      <h3>Contrast that holds up</h3>
+      <p>Every text and border color pair in this component meets WCAG AA contrast (4.5:1 for body text) against its background — including the "dim" secondary text, which is often the first thing to fail in components like this.</p>
+    </section>
+
+    <section class="tabs-a11y__panel" id="panel-keyboard">
+      <h3>Keyboard-first by construction</h3>
+      <p>Tabs are native radio inputs, so keyboard support isn't bolted on — arrow keys move between tabs and Tab/Shift+Tab enter and leave the group, exactly as users already expect from radio groups.</p>
+      <ul class="tabs-a11y__list-plain">
+        <li>Tab: focus enters the group on the checked tab</li>
+        <li>Arrow keys: move selection between tabs</li>
+        <li>Focus ring uses a color distinct from the selected-state color</li>
+      </ul>
+    </section>
+
+    <section class="tabs-a11y__panel" id="panel-motion">
+      <h3>Motion that respects the setting</h3>
+      <p>The zoom-in is short and subtle by default (200ms, 4% scale change) rather than a showy effect, and it's removed entirely — not just shortened — for anyone with <code>prefers-reduced-motion: reduce</code> set.</p>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-zoom-in-tabs-accessible-issue-50049/style.css
+++ b/submissions/examples/feat-zoom-in-tabs-accessible-issue-50049/style.css
@@ -1,0 +1,167 @@
+/* ==========================================================================
+   Zoom-In Tabs — Accessible Web
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-a11y (see README).
+   ========================================================================== */
+
+.tabs-a11y {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 200ms;        /* deliberately short — accessible motion should be quick and subtle */
+  --tabs-easing: ease-out;
+  --tabs-scale-start: 0.96;      /* subtle scale, not a dramatic zoom */
+  --tabs-radius: 8px;
+  --tabs-accent: #1a56db;        /* AA-contrast blue on white */
+  --tabs-accent-contrast: #ffffff;
+  --tabs-bg: #ffffff;
+  --tabs-surface: #f3f4f6;
+  --tabs-border: #4b5563;
+  --tabs-text: #111827;
+  --tabs-text-dim: #374151;      /* still passes AA on white, unlike lighter grays */
+  --tabs-focus-ring: #b45309;    /* high-contrast amber, distinct from the blue accent */
+  --tabs-font: "Atkinson Hyperlegible", "Inter", system-ui, sans-serif;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 520px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 2px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 4px);
+  padding: 20px;
+  font-family: var(--tabs-font);
+  font-size: 1rem;
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-a11y__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-a11y__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* 44x44px minimum target size, per WCAG 2.5.5 / mobile accessibility guidance */
+.tabs-a11y__tab {
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border: 2px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  cursor: pointer;
+  user-select: none;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--tabs-text);
+  background: var(--tabs-bg);
+  transition:
+    background-color var(--tabs-duration) var(--tabs-easing),
+    color var(--tabs-duration) var(--tabs-easing),
+    border-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-a11y__tab:hover {
+  border-color: var(--tabs-accent);
+}
+
+/* strong, high-contrast focus ring — always visible on keyboard focus,
+   uses a color distinct from the selection accent so focus and
+   selection are never confused with each other */
+.tabs-a11y__input:focus-visible + .tabs-a11y__tab {
+  outline: 3px solid var(--tabs-focus-ring);
+  outline-offset: 2px;
+}
+
+.tabs-a11y__input:checked + .tabs-a11y__tab {
+  background: var(--tabs-accent);
+  border-color: var(--tabs-accent);
+  color: var(--tabs-accent-contrast);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-a11y__panels {
+  position: relative;
+  margin-top: 16px;
+  padding: 20px;
+  background: var(--tabs-surface);
+  border: 2px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+}
+
+.tabs-a11y__panel {
+  display: none;
+}
+
+.tabs-a11y__panel h3 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.tabs-a11y__panel p {
+  margin: 0;
+  color: var(--tabs-text-dim);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.tabs-a11y__list-plain {
+  margin: 10px 0 0;
+  padding-left: 20px;
+  color: var(--tabs-text-dim);
+  line-height: 1.7;
+}
+
+/* show + zoom in the panel that matches the checked tab */
+.tabs-a11y:has(#tab-contrast:checked) #panel-contrast,
+.tabs-a11y:has(#tab-keyboard:checked) #panel-keyboard,
+.tabs-a11y:has(#tab-motion:checked) #panel-motion {
+  display: block;
+  animation: tabs-a11y-zoom-in var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-a11y-zoom-in {
+  from {
+    opacity: 0;
+    transform: scale(var(--tabs-scale-start));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* respected fully, not just present as a token gesture: motion drops
+   to zero and the panel simply appears */
+@media (prefers-reduced-motion: reduce) {
+  .tabs-a11y__tab {
+    transition: none;
+  }
+  .tabs-a11y__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-a11y {
+    padding: 14px;
+  }
+  .tabs-a11y__list {
+    flex-direction: column;
+  }
+  .tabs-a11y__tab {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a subtle zoom-in reveal, built around actual accessibility decisions rather than styling alone, added under submissions/examples/zoom-in-tabs-accessible-issue-50049/.

### Files
demo.html — standalone demo markup (3 tabs: Contrast, Keyboard, Motion), each explaining a specific accessibility choice made in the component
style.css — component styles, restrained zoom-in animation, and configurable custom properties
README.md — explains how it works, customization options, and the accessibility decisions behind the design

### How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers a short, subtle zoom-in (96% → 100%, 200ms) when its tab is checked.
All timing, scale, and colors are exposed as CSS custom properties for easy retheming — with a note in the README to re-check contrast if colors are swapped.
Accessibility
Set in Atkinson Hyperlegible, a typeface designed for low-vision readability.
Every tab meets a minimum 44×44px tap target (WCAG 2.5.5).
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
Focus ring color (amber) is distinct from the selected-state color (blue) so focus and selection are never visually ambiguous.
All text/background color pairs, including secondary text, meet WCAG AA contrast.
prefers-reduced-motion: reduce removes the animation entirely, not just shortens it.
role="tablist" / role="tab" / aria-selected included on markup.
Tabs stack to full-width on narrow viewports instead of shrinking below a legible/tappable size.
### Testing

Opened demo.html directly in the browser and verified:

All three tabs switch correctly via click and keyboard (arrow keys)
Zoom-in animation plays smoothly and briefly on each panel reveal
Contrast checked against WCAG AA for all text/background pairs
Layout holds up down to mobile width, tabs stack correctly
No console errors

Closes #50049