### PR TITLE
feat: add action toast stack example

### DIFF
--- a/submissions/examples/action-toast-stack/README.md
+++ b/submissions/examples/action-toast-stack/README.md
@@ -1,0 +1,19 @@
+# Action Toast Stack
+
+A CSS-only notification stack that expands on hover or keyboard focus. The pattern is useful for dashboard alerts, upload notifications, background job updates, and quick action confirmations.
+
+## Files
+
+- `demo.html` contains the notification stack markup.
+- `style.css` contains the layout, responsive rules, and motion utilities.
+
+## Animation details
+
+- `toast-rise` lifts the panel into view on page load.
+- `toast-pulse` highlights each notification status dot.
+- `toast-spread` expands the collapsed stack into readable rows on hover or focus.
+- `action-glow` adds a subtle action-button response without JavaScript.
+
+## Usage
+
+Hover the notification panel or tab into it to expand the stacked toasts and reveal each quick action.

--- a/submissions/examples/action-toast-stack/demo.html
+++ b/submissions/examples/action-toast-stack/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Action Toast Stack Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="toast-stage" aria-label="Animated action toast stack">
+    <section class="toast-panel" tabindex="0">
+      <p class="eyebrow">Notification Center</p>
+      <h1>Action Toast Stack</h1>
+
+      <div class="toast-stack" aria-label="Recent notifications">
+        <article class="toast primary">
+          <span class="status-dot"></span>
+          <div>
+            <strong>Export ready</strong>
+            <p>Quarterly report is available.</p>
+          </div>
+          <button type="button">Open</button>
+        </article>
+
+        <article class="toast secondary">
+          <span class="status-dot"></span>
+          <div>
+            <strong>Sync complete</strong>
+            <p>24 dashboard cards updated.</p>
+          </div>
+          <button type="button">View</button>
+        </article>
+
+        <article class="toast tertiary">
+          <span class="status-dot"></span>
+          <div>
+            <strong>Invite sent</strong>
+            <p>Team access email delivered.</p>
+          </div>
+          <button type="button">Done</button>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/action-toast-stack/style.css
+++ b/submissions/examples/action-toast-stack/style.css
@@ -1,0 +1,213 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f3f0ea;
+  color: #1f2933;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.toast-stage {
+  width: min(92vw, 720px);
+  padding: 24px;
+}
+
+.toast-panel {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid rgba(31, 41, 51, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(245, 239, 226, 0.96)),
+    repeating-linear-gradient(135deg, rgba(46, 125, 110, 0.08) 0 1px, transparent 1px 18px);
+  box-shadow: 0 24px 72px rgba(31, 41, 51, 0.16);
+  animation: toast-rise 700ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.toast-panel:focus {
+  outline: 3px solid rgba(46, 125, 110, 0.28);
+  outline-offset: 4px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #61717c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 520px;
+  margin: 0 0 34px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.toast-stack {
+  position: relative;
+  min-height: 244px;
+}
+
+.toast {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  min-height: 82px;
+  padding: 16px;
+  border: 1px solid rgba(31, 41, 51, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 16px 34px rgba(31, 41, 51, 0.12);
+  transition: transform 420ms cubic-bezier(0.2, 0.8, 0.2, 1), opacity 240ms ease;
+}
+
+.secondary {
+  transform: translateY(18px) scale(0.96);
+  opacity: 0.82;
+}
+
+.tertiary {
+  transform: translateY(36px) scale(0.92);
+  opacity: 0.68;
+}
+
+.toast-panel:hover .toast,
+.toast-panel:focus-within .toast {
+  animation: toast-spread 560ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.toast-panel:hover .secondary,
+.toast-panel:focus-within .secondary {
+  transform: translateY(94px) scale(1);
+  opacity: 1;
+}
+
+.toast-panel:hover .tertiary,
+.toast-panel:focus-within .tertiary {
+  transform: translateY(188px) scale(1);
+  opacity: 1;
+}
+
+.status-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #2e7d6e;
+  box-shadow: 0 0 0 0 rgba(46, 125, 110, 0.34);
+  animation: toast-pulse 1.8s ease-out infinite;
+}
+
+.secondary .status-dot {
+  background: #d38d26;
+  animation-delay: 220ms;
+}
+
+.tertiary .status-dot {
+  background: #485d88;
+  animation-delay: 440ms;
+}
+
+.toast strong,
+.toast p {
+  margin: 0;
+}
+
+.toast strong {
+  font-size: clamp(1rem, 4vw, 1.2rem);
+}
+
+.toast p {
+  margin-top: 4px;
+  color: #65727c;
+  font-size: 0.9rem;
+}
+
+.toast button {
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: #1f2933;
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.toast button:hover,
+.toast button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(31, 41, 51, 0.18);
+  outline: none;
+  animation: action-glow 900ms ease-in-out infinite;
+}
+
+@keyframes toast-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+}
+
+@keyframes toast-pulse {
+  70% {
+    box-shadow: 0 0 0 14px rgba(46, 125, 110, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(46, 125, 110, 0);
+  }
+}
+
+@keyframes toast-spread {
+  0% {
+    filter: blur(2px);
+  }
+  100% {
+    filter: blur(0);
+  }
+}
+
+@keyframes action-glow {
+  50% {
+    box-shadow: 0 0 0 6px rgba(31, 41, 51, 0.1);
+  }
+}
+
+@media (max-width: 560px) {
+  .toast {
+    grid-template-columns: auto 1fr;
+  }
+
+  .toast button {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .toast-stack {
+    min-height: 302px;
+  }
+
+  .toast-panel:hover .secondary,
+  .toast-panel:focus-within .secondary {
+    transform: translateY(112px) scale(1);
+  }
+
+  .toast-panel:hover .tertiary,
+  .toast-panel:focus-within .tertiary {
+    transform: translateY(224px) scale(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only action toast stack demo under submissions/examples/action-toast-stack
- include responsive stacked notifications with hover and keyboard-focus expansion
- document the animation names and usage in the example README

## Verification
- confirmed the example slug and branch are unique
- verified the submission contains demo.html, style.css, and README.md only
- ran git diff --cached --check