### PR TITLE
feat: add inline validation pulse example

### DIFF
--- a/submissions/examples/inline-validation-pulse/README.md
+++ b/submissions/examples/inline-validation-pulse/README.md
@@ -1,0 +1,19 @@
+# Inline Validation Pulse
+
+A CSS-only form validation demo that uses animated field borders, status dots, and helper text to show valid, warning, and ready states without JavaScript.
+
+## Files
+
+- `demo.html` contains the accessible form fields and status messages.
+- `style.css` contains the responsive layout and validation animations.
+
+## Animation details
+
+- `field-enter` stages the form fields on load.
+- `validation-pulse` highlights active status dots.
+- `border-scan` sweeps a soft validation edge around each field.
+- `helper-rise` keeps helper text visible while adding subtle feedback motion.
+
+## Usage
+
+Use the pattern for sign-up forms, settings panels, checkout fields, or profile editors that need visible validation states.

--- a/submissions/examples/inline-validation-pulse/demo.html
+++ b/submissions/examples/inline-validation-pulse/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inline Validation Pulse Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="validation-stage" aria-label="Animated inline validation form">
+    <section class="validation-card">
+      <p class="eyebrow">Signup Flow</p>
+      <h1>Inline Validation Pulse</h1>
+
+      <form class="validation-form">
+        <label class="field valid">
+          <span>Email address</span>
+          <input type="email" value="maya@example.com" aria-describedby="email-status">
+          <small id="email-status">Verified format</small>
+        </label>
+
+        <label class="field warning">
+          <span>Password strength</span>
+          <input type="password" value="sunrise42" aria-describedby="password-status">
+          <small id="password-status">Add one symbol</small>
+        </label>
+
+        <label class="field ready">
+          <span>Workspace name</span>
+          <input type="text" value="Design Ops" aria-describedby="workspace-status">
+          <small id="workspace-status">Ready to claim</small>
+        </label>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/inline-validation-pulse/style.css
+++ b/submissions/examples/inline-validation-pulse/style.css
@@ -1,0 +1,192 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #eef3f6;
+  color: #182331;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.validation-stage {
+  width: min(92vw, 720px);
+  padding: 24px;
+}
+
+.validation-card {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid rgba(24, 35, 49, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(236, 246, 247, 0.96)),
+    radial-gradient(circle at 12% 12%, rgba(47, 139, 117, 0.16), transparent 32%);
+  box-shadow: 0 24px 72px rgba(24, 35, 49, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #5e7181;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 560px;
+  margin: 0 0 34px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.validation-form {
+  display: grid;
+  gap: 14px;
+}
+
+.field {
+  position: relative;
+  display: grid;
+  gap: 8px;
+  overflow: hidden;
+  padding: 18px;
+  border: 1px solid rgba(24, 35, 49, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 14px 30px rgba(24, 35, 49, 0.08);
+  animation: field-enter 620ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.field:nth-child(2) {
+  animation-delay: 110ms;
+}
+
+.field:nth-child(3) {
+  animation-delay: 220ms;
+}
+
+.field::before {
+  content: "";
+  position: absolute;
+  inset: auto 18px 0;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--state-color), transparent);
+  opacity: 0;
+}
+
+.field:hover::before,
+.field:focus-within::before {
+  animation: border-scan 1.6s ease-in-out infinite;
+  opacity: 1;
+}
+
+.field span {
+  color: #516475;
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.field input {
+  width: 100%;
+  border: 0;
+  border-bottom: 2px solid rgba(24, 35, 49, 0.12);
+  padding: 8px 0 10px;
+  background: transparent;
+  color: #182331;
+  font: inherit;
+  font-size: clamp(1rem, 4vw, 1.25rem);
+  font-weight: 800;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: var(--state-color);
+}
+
+.field small {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #5e7181;
+  font-size: 0.82rem;
+  font-weight: 700;
+  animation: helper-rise 2.4s ease-in-out infinite;
+}
+
+.field small::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--state-color);
+  box-shadow: 0 0 0 0 var(--pulse-color);
+  animation: validation-pulse 1.8s ease-out infinite;
+}
+
+.valid {
+  --state-color: #2f8b75;
+  --pulse-color: rgba(47, 139, 117, 0.24);
+}
+
+.warning {
+  --state-color: #d4932c;
+  --pulse-color: rgba(212, 147, 44, 0.24);
+}
+
+.ready {
+  --state-color: #536ac8;
+  --pulse-color: rgba(83, 106, 200, 0.24);
+}
+
+@keyframes field-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+}
+
+@keyframes validation-pulse {
+  70% {
+    box-shadow: 0 0 0 12px rgba(255, 255, 255, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+  }
+}
+
+@keyframes border-scan {
+  0% {
+    transform: translateX(-26%);
+  }
+  50% {
+    transform: translateX(26%);
+  }
+  100% {
+    transform: translateX(-26%);
+  }
+}
+
+@keyframes helper-rise {
+  50% {
+    transform: translateY(-2px);
+  }
+}
+
+@media (max-width: 560px) {
+  .field {
+    padding: 16px;
+  }
+
+  .validation-form {
+    gap: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only inline validation pulse demo under submissions/examples/inline-validation-pulse
- include accessible fields for valid, warning, and ready states
- document the animation names and usage in the example README

## Verification
- confirmed the example slug and branch are unique
- verified the submission contains demo.html, style.css, and README.md only
- ran git diff --cached --check