### PR TITLE
feat: add 3D flip Saas showcase example (#50058)

### DIFF
--- a/submissions/examples/feat-3d-flip-tabs-saas-issue-50058/README.md
+++ b/submissions/examples/feat-3d-flip-tabs-saas-issue-50058/README.md
@@ -1,0 +1,50 @@
+# 3D Flip Tabs — SaaS Showcase
+
+A pure CSS tabs component with a real 3D flip, styled as a pricing-plan showcase. Instead of swapping panels in and out, this uses a single **rotating 3-sided prism card** — selecting a plan physically turns the card so that plan's face rotates to the front. No JavaScript required.
+
+## What it does
+
+- Three plan faces (Starter, Pro, Business) are pre-arranged around a single card at 0°, 120°, and 240° using `rotateY()` + `translateZ()`.
+- Selecting a tab rotates the *entire card*, not the individual faces — the card turns until the selected plan's face is the one facing the viewer, exactly like spinning a physical triangular prism.
+- `backface-visibility: hidden` means only the face currently pointed at the viewer is visible; the other two are hidden behind the card at any given moment.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-prism:has(#tab-x:checked) .tabs-prism__card { transform: rotateY(...); }` rotates the whole card to the angle that brings face `x` to the front (0° for Starter, -120° for Pro, -240° for Business).
+- `perspective` is set on `.tabs-prism__stage` so the rotation reads as real 3D depth.
+- Unlike a typical enter/exit flip animation, nothing here toggles `display` — all three faces exist simultaneously in 3D space at all times; only the card's own rotation changes.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-prism` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `620ms` | Prism rotation length |
+| `--tabs-easing` | `cubic-bezier(0.65, 0, 0.35, 1)` | Easing curve |
+| `--tabs-depth` | `150px` | Distance each face sits from the card's center — larger values make the prism feel "wider" |
+| `--tabs-perspective` | `1400px` | 3D perspective depth — lower values exaggerate the rotation |
+| `--tabs-radius` | `16px` | Corner radius |
+| `--tabs-accent` | `#0891b2` | Accent color (active tab, plan label, CTA button) |
+| `--tabs-bg` / `--tabs-card-bg` | `#f7fafa` / `#ffffff` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | dark / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-prism" style="--tabs-depth: 200px; --tabs-accent: #7c3aed;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling both the tab-chip transition and the card rotation (the correct face still appears, just without the spin).
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven 3D flip pattern in the SaaS showcase aesthetic requested in issue #50058 — using a genuinely different flip mechanic (a rotating multi-face prism) from a typical single-panel flip, responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-3d-flip-tabs-saas-issue-50058/demo.html
+++ b/submissions/examples/feat-3d-flip-tabs-saas-issue-50058/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Flip Tabs — SaaS Showcase</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@700;800&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #eef2f2;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-prism">
+  <div class="tabs-prism__list" role="tablist" aria-label="Pricing plans">
+
+    <input class="tabs-prism__input" type="radio" name="prism-tabs" id="tab-starter" checked />
+    <label class="tabs-prism__tab" for="tab-starter" role="tab" aria-selected="true">Starter</label>
+
+    <input class="tabs-prism__input" type="radio" name="prism-tabs" id="tab-pro" />
+    <label class="tabs-prism__tab" for="tab-pro" role="tab" aria-selected="false">Pro</label>
+
+    <input class="tabs-prism__input" type="radio" name="prism-tabs" id="tab-business" />
+    <label class="tabs-prism__tab" for="tab-business" role="tab" aria-selected="false">Business</label>
+
+  </div>
+
+  <div class="tabs-prism__stage">
+    <div class="tabs-prism__card">
+
+      <section class="tabs-prism__face tabs-prism__face--starter">
+        <span class="tabs-prism__plan">STARTER</span>
+        <h3>For side projects</h3>
+        <div class="tabs-prism__price">$0<span> / month</span></div>
+        <ul class="tabs-prism__features">
+          <li>1 workspace</li>
+          <li>Up to 3 members</li>
+          <li>Community support</li>
+        </ul>
+        <a class="tabs-prism__cta" href="#">Get started free</a>
+      </section>
+
+      <section class="tabs-prism__face tabs-prism__face--pro">
+        <span class="tabs-prism__plan">PRO</span>
+        <h3>For growing teams</h3>
+        <div class="tabs-prism__price">$29<span> / month</span></div>
+        <ul class="tabs-prism__features">
+          <li>Unlimited workspaces</li>
+          <li>Up to 20 members</li>
+          <li>Priority email support</li>
+        </ul>
+        <a class="tabs-prism__cta" href="#">Start free trial</a>
+      </section>
+
+      <section class="tabs-prism__face tabs-prism__face--business">
+        <span class="tabs-prism__plan">BUSINESS</span>
+        <h3>For scaling companies</h3>
+        <div class="tabs-prism__price">$99<span> / month</span></div>
+        <ul class="tabs-prism__features">
+          <li>Unlimited everything</li>
+          <li>SSO &amp; audit logs</li>
+          <li>Dedicated success manager</li>
+        </ul>
+        <a class="tabs-prism__cta" href="#">Talk to sales</a>
+      </section>
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-3d-flip-tabs-saas-issue-50058/style.css
+++ b/submissions/examples/feat-3d-flip-tabs-saas-issue-50058/style.css
@@ -1,0 +1,224 @@
+/* ==========================================================================
+   3D Flip Tabs — SaaS Showcase
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Unlike a simple in/out flip, the panel here is a single 3-sided
+   prism card that physically rotates to bring the selected plan's
+   face to the front. Configure via the custom properties on
+   .tabs-prism (see README).
+   ========================================================================== */
+
+.tabs-prism {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 620ms;
+  --tabs-easing: cubic-bezier(0.65, 0, 0.35, 1);
+  --tabs-depth: 150px;           /* how far each face sits from the card's center */
+  --tabs-perspective: 1400px;
+  --tabs-radius: 16px;
+  --tabs-accent: #0891b2;
+  --tabs-accent-soft: #e3f6fa;
+  --tabs-bg: #f7fafa;
+  --tabs-card-bg: #ffffff;
+  --tabs-border: #dfe6e6;
+  --tabs-text: #10201f;
+  --tabs-text-dim: #667777;
+  --tabs-font-ui: "Manrope", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 420px;
+  margin-inline: auto;
+  padding: 18px;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-prism__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-prism__list {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--tabs-card-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+}
+
+.tabs-prism__tab {
+  flex: 1;
+  padding: 9px 10px;
+  border-radius: calc(var(--tabs-radius) - 5px);
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.84rem;
+  font-weight: 700;
+  color: var(--tabs-text-dim);
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-prism__tab:hover {
+  color: var(--tabs-text);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-prism__input:focus-visible + .tabs-prism__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+.tabs-prism__input:checked + .tabs-prism__tab {
+  color: #fff;
+  background: var(--tabs-accent);
+}
+
+/* --- the prism stage: fixed-height window with real 3D perspective ----- */
+.tabs-prism__stage {
+  position: relative;
+  height: 300px;
+  margin-top: 16px;
+  perspective: var(--tabs-perspective);
+}
+
+/* the card itself never leaves the DOM flow or toggles display — it
+   physically rotates on its Y axis so a different pre-positioned
+   face lands in front */
+.tabs-prism__card {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-prism__face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 22px;
+  background: var(--tabs-card-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  backface-visibility: hidden;
+  box-shadow: 0 20px 40px -28px rgba(16, 32, 31, 0.35);
+}
+
+.tabs-prism__face--starter {
+  transform: rotateY(0deg) translateZ(var(--tabs-depth));
+}
+
+.tabs-prism__face--pro {
+  transform: rotateY(120deg) translateZ(var(--tabs-depth));
+}
+
+.tabs-prism__face--business {
+  transform: rotateY(240deg) translateZ(var(--tabs-depth));
+}
+
+/* rotate the whole prism so the selected plan's face faces forward */
+.tabs-prism:has(#tab-starter:checked) .tabs-prism__card {
+  transform: rotateY(0deg);
+}
+
+.tabs-prism:has(#tab-pro:checked) .tabs-prism__card {
+  transform: rotateY(-120deg);
+}
+
+.tabs-prism:has(#tab-business:checked) .tabs-prism__card {
+  transform: rotateY(-240deg);
+}
+
+.tabs-prism__plan {
+  font-family: var(--tabs-font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  color: var(--tabs-accent);
+}
+
+.tabs-prism__face h3 {
+  margin: 4px 0 2px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1.3rem;
+}
+
+.tabs-prism__price {
+  font-family: var(--tabs-font-mono);
+  font-size: 1.6rem;
+  margin: 6px 0 14px;
+}
+
+.tabs-prism__price span {
+  font-size: 0.8rem;
+  color: var(--tabs-text-dim);
+}
+
+.tabs-prism__features {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  flex: 1;
+}
+
+.tabs-prism__features li {
+  padding: 6px 0;
+  border-top: 1px solid var(--tabs-border);
+  font-size: 0.86rem;
+  color: var(--tabs-text-dim);
+}
+
+.tabs-prism__features li:first-child {
+  border-top: none;
+}
+
+.tabs-prism__cta {
+  display: block;
+  margin-top: 14px;
+  padding: 10px;
+  border-radius: 999px;
+  text-align: center;
+  text-decoration: none;
+  font-family: var(--tabs-font-ui);
+  font-weight: 700;
+  font-size: 0.86rem;
+  color: #fff;
+  background: var(--tabs-accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-prism__tab {
+    transition: none;
+  }
+  .tabs-prism__card {
+    transition: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-prism {
+    padding: 14px;
+  }
+  .tabs-prism__stage {
+    height: 340px;
+  }
+  .tabs-prism__face {
+    padding: 18px;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a real 3D flip, styled as a pricing-plan showcase, added under submissions/examples/3d-flip-tabs-saas-issue-50058/. Rather than a panel flipping in/out, this uses a single rotating 3-sided prism card — selecting a plan physically turns the card so that plan's face rotates to the front.

### Files
demo.html — standalone demo markup (3 pricing tabs: Starter, Pro, Business), each mapped to one face of the prism
style.css — component styles, 3D prism rotation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector sets the rotation angle on the card when a tab is checked.
Three plan faces are pre-positioned around a single card at 0°, 120°, and 240° using rotateY() + translateZ() inside a transform-style: preserve-3d container.
Selecting a tab rotates the whole card (not individual panels) until the chosen face points at the viewer — like spinning a physical triangular prism. backface-visibility: hidden keeps only the front-facing plan visible at any moment.
All timing, easing, face depth, perspective, and colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion — the correct face still switches, just without the rotation animation.
### Testing

Opened demo.html directly in the browser and verified:

All three plan tabs switch correctly via click and keyboard (arrow keys)
Prism rotation animates smoothly with no visible backface flashing
Layout holds up down to mobile width
No console errors

Closes #50058