### PR TITLE
feat: add progress stepper bounce example

### DIFF
--- a/submissions/examples/progress-stepper-bounce/README.md
+++ b/submissions/examples/progress-stepper-bounce/README.md
@@ -1,0 +1,19 @@
+# Progress Stepper Bounce
+
+A CSS-only onboarding stepper that highlights completed and active steps with animated markers, a flowing connector, and responsive stacked layout support.
+
+## Files
+
+- `demo.html` contains the ordered stepper markup.
+- `style.css` contains the layout, connector, and animation utilities.
+
+## Animation details
+
+- `step-enter` stages each step into the card.
+- `marker-bounce` calls attention to the active step marker.
+- `connector-flow` animates the progress line between completed steps.
+- `step-glow` adds subtle focus to the current step state.
+
+## Usage
+
+Use the pattern for onboarding, checkout, setup wizards, deployment pipelines, or any multi-step progress flow.

--- a/submissions/examples/progress-stepper-bounce/demo.html
+++ b/submissions/examples/progress-stepper-bounce/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Stepper Bounce Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stepper-stage" aria-label="Animated progress stepper">
+    <section class="stepper-card">
+      <p class="eyebrow">Onboarding Flow</p>
+      <h1>Progress Stepper Bounce</h1>
+
+      <ol class="stepper" aria-label="Account setup progress">
+        <li class="step done">
+          <span class="marker">1</span>
+          <strong>Profile</strong>
+          <small>Complete</small>
+        </li>
+        <li class="step active">
+          <span class="marker">2</span>
+          <strong>Workspace</strong>
+          <small>In progress</small>
+        </li>
+        <li class="step">
+          <span class="marker">3</span>
+          <strong>Invite</strong>
+          <small>Next</small>
+        </li>
+        <li class="step">
+          <span class="marker">4</span>
+          <strong>Launch</strong>
+          <small>Ready soon</small>
+        </li>
+      </ol>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/progress-stepper-bounce/style.css
+++ b/submissions/examples/progress-stepper-bounce/style.css
@@ -1,0 +1,185 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f2f5f2;
+  color: #182622;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.stepper-stage {
+  width: min(92vw, 760px);
+  padding: 24px;
+}
+
+.stepper-card {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid rgba(24, 38, 34, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(233, 243, 236, 0.96)),
+    repeating-linear-gradient(90deg, rgba(33, 132, 99, 0.08) 0 1px, transparent 1px 72px);
+  box-shadow: 0 24px 72px rgba(24, 38, 34, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #64766f;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 560px;
+  margin: 0 0 38px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.stepper {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stepper::before {
+  content: "";
+  position: absolute;
+  top: 24px;
+  left: 12%;
+  right: 12%;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #218463, #e0a536, #d5ddd8);
+  background-size: 180% 100%;
+  animation: connector-flow 2.4s linear infinite;
+}
+
+.step {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 4px 8px 0;
+  text-align: center;
+  animation: step-enter 560ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.step:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.step:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.step:nth-child(4) {
+  animation-delay: 300ms;
+}
+
+.marker {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  border: 3px solid #ffffff;
+  border-radius: 50%;
+  background: #d5ddd8;
+  color: #405148;
+  font-weight: 900;
+  box-shadow: 0 12px 24px rgba(24, 38, 34, 0.14);
+}
+
+.done .marker {
+  background: #218463;
+  color: #ffffff;
+}
+
+.active .marker {
+  background: #e0a536;
+  color: #182622;
+  animation: marker-bounce 1.8s ease-in-out infinite, step-glow 2.2s ease-in-out infinite;
+}
+
+.step strong {
+  font-size: clamp(0.95rem, 3vw, 1.12rem);
+}
+
+.step small {
+  color: #64766f;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+@keyframes step-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+}
+
+@keyframes marker-bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+@keyframes connector-flow {
+  to {
+    background-position: -180% 0;
+  }
+}
+
+@keyframes step-glow {
+  50% {
+    box-shadow: 0 0 0 12px rgba(224, 165, 54, 0.16), 0 12px 24px rgba(24, 38, 34, 0.14);
+  }
+}
+
+@media (max-width: 620px) {
+  .stepper {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .stepper::before {
+    top: 24px;
+    bottom: 24px;
+    left: 26px;
+    right: auto;
+    width: 4px;
+    height: auto;
+    background: linear-gradient(180deg, #218463, #e0a536, #d5ddd8);
+    background-size: 100% 180%;
+  }
+
+  .step {
+    grid-template-columns: auto 1fr;
+    justify-items: start;
+    text-align: left;
+  }
+
+  .step small {
+    grid-column: 2;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only progress stepper bounce demo under submissions/examples/progress-stepper-bounce
- include responsive step states for completed, active, and upcoming setup steps
- document the animation names and usage in the example README

## Verification
- confirmed the example slug and branch are unique
- verified the submission contains demo.html, style.css, and README.md only
- ran git diff --cached --check