### PR TITLE
feat: add empty state reveal example

### DIFF
--- a/submissions/examples/empty-state-reveal/README.md
+++ b/submissions/examples/empty-state-reveal/README.md
@@ -1,0 +1,19 @@
+# Empty State Reveal
+
+A CSS-only empty-state card that reveals a helpful reset action with soft orbit motion, search-filter hints, and a focused call to action.
+
+## Files
+
+- `demo.html` contains the empty-state markup.
+- `style.css` contains the responsive layout and animation utilities.
+
+## Animation details
+
+- `panel-rise` introduces the empty-state message.
+- `orbit-spin` adds motion around the empty icon.
+- `filter-pop` staggers the small filter indicators.
+- `button-breathe` gently highlights the reset action.
+
+## Usage
+
+Use the pattern for search screens, dashboards, filtered tables, inboxes, or product grids that need a polished no-results state.

--- a/submissions/examples/empty-state-reveal/demo.html
+++ b/submissions/examples/empty-state-reveal/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Empty State Reveal Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="empty-stage" aria-label="Animated empty state reveal">
+    <section class="empty-card">
+      <p class="eyebrow">Search Results</p>
+      <h1>Empty State Reveal</h1>
+
+      <div class="search-shell" aria-hidden="true">
+        <span class="search-bar"></span>
+        <span class="filter-dot one"></span>
+        <span class="filter-dot two"></span>
+      </div>
+
+      <div class="reveal-panel">
+        <span class="orbit"></span>
+        <div class="empty-icon">
+          <span></span>
+          <span></span>
+        </div>
+        <strong>No matching records</strong>
+        <p>Try clearing one filter or widening the date range.</p>
+        <button type="button">Reset filters</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/empty-state-reveal/style.css
+++ b/submissions/examples/empty-state-reveal/style.css
@@ -1,0 +1,202 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #f0f4f6;
+  color: #172432;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.empty-stage {
+  width: min(92vw, 720px);
+  padding: 24px;
+}
+
+.empty-card {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid rgba(23, 36, 50, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(235, 244, 247, 0.96)),
+    radial-gradient(circle at 78% 18%, rgba(72, 108, 196, 0.14), transparent 34%);
+  box-shadow: 0 24px 72px rgba(23, 36, 50, 0.16);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #627386;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 520px;
+  margin: 0 0 30px;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.search-shell {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding: 14px;
+  border: 1px solid rgba(23, 36, 50, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.search-bar {
+  height: 14px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #dce5ea 30%, #c6d5dc 50%, #dce5ea 70%);
+  background-size: 200% 100%;
+  animation: shimmer-line 2.4s linear infinite;
+}
+
+.filter-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #486cc4;
+  animation: filter-pop 1.9s ease-in-out infinite;
+}
+
+.filter-dot.two {
+  background: #d39332;
+  animation-delay: 180ms;
+}
+
+.reveal-panel {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 12px;
+  padding: clamp(24px, 5vw, 38px);
+  border: 1px dashed rgba(23, 36, 50, 0.2);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  text-align: center;
+  animation: panel-rise 720ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.orbit {
+  position: absolute;
+  top: 26px;
+  width: 82px;
+  height: 82px;
+  border: 2px solid rgba(72, 108, 196, 0.18);
+  border-top-color: #486cc4;
+  border-radius: 50%;
+  animation: orbit-spin 4s linear infinite;
+}
+
+.empty-icon {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 70px;
+  height: 70px;
+  margin-bottom: 8px;
+  border-radius: 50%;
+  background: #172432;
+}
+
+.empty-icon span {
+  position: absolute;
+  width: 28px;
+  height: 4px;
+  border-radius: 999px;
+  background: #ffffff;
+}
+
+.empty-icon span:first-child {
+  transform: rotate(45deg);
+}
+
+.empty-icon span:last-child {
+  transform: rotate(-45deg);
+}
+
+.reveal-panel strong {
+  font-size: clamp(1.2rem, 4vw, 1.6rem);
+}
+
+.reveal-panel p {
+  max-width: 360px;
+  margin: 0;
+  color: #627386;
+  line-height: 1.5;
+}
+
+.reveal-panel button {
+  margin-top: 8px;
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 18px;
+  background: #486cc4;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  animation: button-breathe 2.2s ease-in-out infinite;
+}
+
+.reveal-panel button:hover,
+.reveal-panel button:focus-visible {
+  outline: none;
+  transform: translateY(-2px);
+}
+
+@keyframes shimmer-line {
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@keyframes filter-pop {
+  50% {
+    transform: translateY(-5px) scale(1.08);
+  }
+}
+
+@keyframes panel-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+}
+
+@keyframes orbit-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes button-breathe {
+  50% {
+    box-shadow: 0 0 0 10px rgba(72, 108, 196, 0.12);
+  }
+}
+
+@media (max-width: 560px) {
+  .search-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-dot {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only empty state reveal demo under submissions/examples/empty-state-reveal
- include search/filter hints, an animated empty icon, and a reset action
- document the animation names and usage in the example README

## Verification
- confirmed the example slug and branch are unique
- verified the submission contains demo.html, style.css, and README.md only
- ran git diff --cached --check