### PR TITLE
feat: add metric card flip example

### DIFF
--- a/submissions/examples/metric-card-flip/README.md
+++ b/submissions/examples/metric-card-flip/README.md
@@ -1,0 +1,19 @@
+# Metric Card Flip
+
+A CSS-only analytics card that flips from a headline metric to a compact breakdown on hover or keyboard focus. It is useful for dashboards, KPI reports, billing summaries, and admin panels.
+
+## Files
+
+- `demo.html` contains the metric card markup.
+- `style.css` contains the responsive layout, flip transform, and supporting animations.
+
+## Animation details
+
+- `card-settle` introduces the card on load.
+- `metric-glow` highlights the positive change badge.
+- The hover/focus transform rotates the card face with a 3D perspective effect.
+- `bar-fill` animates the breakdown bars on the reverse side.
+
+## Usage
+
+Hover the metric card or focus it with the keyboard to reveal the detailed KPI breakdown.

--- a/submissions/examples/metric-card-flip/demo.html
+++ b/submissions/examples/metric-card-flip/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Metric Card Flip Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="metric-stage" aria-label="Animated metric card flip">
+    <section class="metric-card" tabindex="0">
+      <div class="metric-face front">
+        <p class="eyebrow">Revenue Pulse</p>
+        <h1>Metric Card Flip</h1>
+        <div class="metric-value">
+          <span>$84.2k</span>
+          <small>+18.4%</small>
+        </div>
+      </div>
+
+      <div class="metric-face back">
+        <p class="eyebrow">Breakdown</p>
+        <h2>Strongest channel</h2>
+        <ul>
+          <li><span>Subscriptions</span><strong>62%</strong></li>
+          <li><span>Services</span><strong>24%</strong></li>
+          <li><span>Add-ons</span><strong>14%</strong></li>
+        </ul>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/metric-card-flip/style.css
+++ b/submissions/examples/metric-card-flip/style.css
@@ -1,0 +1,180 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: #eef2f1;
+  color: #17231f;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.metric-stage {
+  width: min(92vw, 680px);
+  padding: 24px;
+  perspective: 1100px;
+}
+
+.metric-card {
+  position: relative;
+  min-height: 430px;
+  border-radius: 8px;
+  outline: none;
+  transform-style: preserve-3d;
+  animation: card-settle 720ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  transition: transform 760ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.metric-card:hover,
+.metric-card:focus {
+  transform: rotateY(180deg);
+}
+
+.metric-face {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  align-content: space-between;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid rgba(23, 35, 31, 0.12);
+  border-radius: 8px;
+  backface-visibility: hidden;
+  box-shadow: 0 24px 72px rgba(23, 35, 31, 0.16);
+}
+
+.front {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(231, 242, 237, 0.96)),
+    radial-gradient(circle at 80% 18%, rgba(37, 132, 99, 0.18), transparent 34%);
+}
+
+.back {
+  background:
+    linear-gradient(135deg, rgba(23, 35, 31, 0.96), rgba(42, 67, 58, 0.96)),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.06) 0 1px, transparent 1px 64px);
+  color: #ffffff;
+  transform: rotateY(180deg);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #60756c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.back .eyebrow {
+  color: #b8c9c2;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+h1 {
+  max-width: 520px;
+  font-size: clamp(2.3rem, 7vw, 4.8rem);
+  line-height: 0.96;
+}
+
+h2 {
+  font-size: clamp(2rem, 6vw, 3.6rem);
+  line-height: 1;
+}
+
+.metric-value {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.metric-value span {
+  font-size: clamp(3rem, 10vw, 6.6rem);
+  font-weight: 900;
+  line-height: 0.9;
+}
+
+.metric-value small {
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: #258463;
+  color: #ffffff;
+  font-weight: 900;
+  animation: metric-glow 2s ease-in-out infinite;
+}
+
+ul {
+  display: grid;
+  gap: 16px;
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+li::after {
+  content: "";
+  grid-column: 1 / -1;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #7fe0b6, #f0bf58);
+  transform-origin: left;
+  animation: bar-fill 1.4s ease-out both;
+}
+
+li:nth-child(2)::after {
+  animation-delay: 120ms;
+}
+
+li:nth-child(3)::after {
+  animation-delay: 240ms;
+}
+
+li strong {
+  color: #f0bf58;
+}
+
+@keyframes card-settle {
+  from {
+    opacity: 0;
+    transform: translateY(18px) rotateX(6deg);
+  }
+}
+
+@keyframes metric-glow {
+  50% {
+    box-shadow: 0 0 0 10px rgba(37, 132, 99, 0.14);
+  }
+}
+
+@keyframes bar-fill {
+  from {
+    transform: scaleX(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .metric-card {
+    min-height: 500px;
+  }
+
+  .metric-value {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only metric card flip demo under submissions/examples/metric-card-flip
- include a hover/focus KPI card that flips to a compact breakdown view
- document the animation names and usage in the example README

## Verification
- confirmed the example slug and branch are unique
- verified the submission contains demo.html, style.css, and README.md only
- ran git diff --cached --check