### PR TITLE
feat: add native dark mode support for accordion component (issue #55…

### DIFF
--- a/submissions/examples/dark-mode-accordion-ag/README.md
+++ b/submissions/examples/dark-mode-accordion-ag/README.md
@@ -1,0 +1,32 @@
+# Accordion — Native Dark Mode
+
+Part of the "Add Native Dark Mode (prefers-color-scheme) for all 30 Components" effort (#55139), scoped to the **accordion** component.
+
+## Files
+- `demo.html` — accordion markup using native `<details>`/`<summary>`
+- `style.css` — light theme by default, dark theme applied automatically via `@media (prefers-color-scheme: dark)`
+- `README.md` — this file
+
+## Usage
+Open `demo.html` in a browser. Switch your OS/browser color scheme preference to see the accordion repaint automatically — no toggle button, no JS.
+
+## Customization
+All colors are exposed as CSS custom properties on `:root`, redefined inside the dark media query:
+- `--accordion-bg`
+- `--accordion-border`
+- `--accordion-text`
+- `--accordion-summary-bg`
+- `--accordion-summary-hover`
+- `--accordion-accent`
+- `--accordion-radius`
+- `--accordion-transition`
+
+Override any of these in your own stylesheet to reskin the component.
+
+## Accessibility
+- Uses native `<details>`/`<summary>`, which is keyboard-operable and exposes correct expanded/collapsed semantics out of the box.
+- Visible `:focus-visible` outline on the summary control.
+- Color contrast checked against both light and dark palettes.
+
+## Notes on scope
+This PR only covers **accordion**. The parent issue lists 30 components; each is being submitted as its own separate PR/folder rather than one large PR, since this repo's contribution model is one new self-contained folder per submission (no edits to existing files).

--- a/submissions/examples/dark-mode-accordion-ag/demo.html
+++ b/submissions/examples/dark-mode-accordion-ag/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Accordion — Native Dark Mode</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="accordion-demo">
+    <h1>Accordion (Dark Mode Aware)</h1>
+    <p>Toggle your OS theme to see it switch automatically — no JS.</p>
+
+    <div class="accordion">
+      <details class="accordion-item" open>
+        <summary>What is EaseMotion-css?</summary>
+        <div class="accordion-content">
+          <p>A collection of CSS animation examples contributed by the community.</p>
+        </div>
+      </details>
+
+      <details class="accordion-item">
+        <summary>How does dark mode work here?</summary>
+        <div class="accordion-content">
+          <p>CSS custom properties are redefined inside a <code>prefers-color-scheme: dark</code> media query, so the palette follows the user's OS setting automatically.</p>
+        </div>
+      </details>
+
+      <details class="accordion-item">
+        <summary>Does this need JavaScript?</summary>
+        <div class="accordion-content">
+          <p>No. The expand/collapse behavior uses the native <code>&lt;details&gt;</code>/<code>&lt;summary&gt;</code> elements, and theme switching is handled entirely by the browser via media queries.</p>
+        </div>
+      </details>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dark-mode-accordion-ag/style.css
+++ b/submissions/examples/dark-mode-accordion-ag/style.css
@@ -1,0 +1,88 @@
+:root {
+  --accordion-bg: #ffffff;
+  --accordion-border: #e0e0e0;
+  --accordion-text: #1a1a1a;
+  --accordion-summary-bg: #f5f5f5;
+  --accordion-summary-hover: #ebebeb;
+  --accordion-accent: #4f46e5;
+  --accordion-radius: 10px;
+  --accordion-transition: 0.25s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --accordion-bg: #1e1e24;
+    --accordion-border: #33333d;
+    --accordion-text: #e8e8ec;
+    --accordion-summary-bg: #26262e;
+    --accordion-summary-hover: #302f3a;
+    --accordion-accent: #8b7ffc;
+  }
+}
+
+body {
+  background: var(--accordion-bg);
+  color: var(--accordion-text);
+  font-family: system-ui, sans-serif;
+  transition: background var(--accordion-transition), color var(--accordion-transition);
+  padding: 2rem;
+}
+
+.accordion-demo {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.accordion-item {
+  border: 1px solid var(--accordion-border);
+  border-radius: var(--accordion-radius);
+  overflow: hidden;
+  background: var(--accordion-bg);
+  transition: background var(--accordion-transition), border-color var(--accordion-transition);
+}
+
+.accordion-item summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 1rem 1.25rem;
+  background: var(--accordion-summary-bg);
+  font-weight: 600;
+  transition: background var(--accordion-transition);
+}
+
+.accordion-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-item summary:hover {
+  background: var(--accordion-summary-hover);
+}
+
+.accordion-item summary::before {
+  content: "▸";
+  display: inline-block;
+  margin-right: 0.5rem;
+  color: var(--accordion-accent);
+  transition: transform var(--accordion-transition);
+}
+
+.accordion-item[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.accordion-content {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--accordion-border);
+  line-height: 1.5;
+}
+
+.accordion-item summary:focus-visible {
+  outline: 2px solid var(--accordion-accent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Description
Adds native dark mode support (`prefers-color-scheme`) for the accordion component, as part of the tracked effort in #55139.

## Changes
- New folder: `submissions/examples/dark-mode-accordion-ag/`
- `demo.html` — accordion markup using native `<details>`/`<summary>` elements
- `style.css` — light theme by default, dark palette applied automatically via `@media (prefers-color-scheme: dark)`, all colors exposed as CSS custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Automatic dark/light theme switching based on OS preference, no JS or toggle button
- Fully CSS-variable-driven palette for easy reskinning
- Keyboard-accessible via native `<details>`/`<summary>` semantics
- Visible focus outline for accessibility

## Notes
This PR covers only the **accordion** component from the 30 listed in #55139. Since this repo's contribution model requires each submission to be a new, self-contained folder (no edits to existing files), the remaining components will be submitted as separate follow-up PRs rather than one large PR.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Addresses part of #55139