### PR TITLE
feat: add pure CSS zoom-in popover for SaaS layouts (issue #46394)

### DIFF
--- a/submissions/examples/zoom-in-popover-ag/README.md
+++ b/submissions/examples/zoom-in-popover-ag/README.md
@@ -1,0 +1,29 @@
+# Zoom-In Popover (SaaS Style)
+
+Pure CSS animated popover with a smooth zoom-in transition, addressing #46394.
+
+## Files
+- `demo.html` — trigger button + popover panel using the native HTML `popover` attribute and `popovertarget`
+- `style.css` — zoom-in open/close animation, fully theme-able via CSS custom properties
+- `README.md` — this file
+
+## Usage
+Open `demo.html` and click "Show plan details." The panel zooms in from `var(--popover-scale-start)` to full scale. Click "Close" or click outside to dismiss — all native browser behavior, zero JavaScript.
+
+## Customization
+Exposed as CSS custom properties on `:root`:
+- `--popover-bg`, `--popover-text`, `--popover-border` — colors
+- `--popover-shadow` — drop shadow
+- `--popover-accent` — button/link accent color
+- `--popover-radius` — corner rounding
+- `--popover-scale-start` — starting scale factor for the zoom-in (default `0.85`)
+- `--popover-duration` — animation duration (default `0.28s`)
+- `--popover-easing` — timing function (default a slight overshoot cubic-bezier for a springy feel)
+
+## Accessibility
+- Uses the native HTML Popover API (`popover`, `popovertarget`, `popovertargetaction`), which handles focus management, `Esc`-to-close, and light-dismiss (click-outside) automatically.
+- Trigger and close button both have visible `:focus-visible` outlines.
+- No custom JS event handling means no risk of broken keyboard traps.
+
+## Notes on scope
+The Popover API (`popover` attribute, `:popover-open`, `@starting-style`) is a modern CSS/HTML feature and may not render the zoom transition in older browsers that lack support — in unsupported browsers the panel will still show/hide correctly (native fallback), just without the animated zoom-in. No JavaScript was used anywhere in this submission, per the "zero JavaScript overhead" requirement in the issue.

--- a/submissions/examples/zoom-in-popover-ag/demo.html
+++ b/submissions/examples/zoom-in-popover-ag/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Zoom-In Popover — SaaS Style</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="popover-demo">
+    <h1>Zoom-In Popover</h1>
+    <p>Pure CSS, zero JavaScript — uses the native HTML Popover API.</p>
+
+    <button class="popover-trigger" popovertarget="feature-popover">
+      Show plan details
+    </button>
+
+    <div id="feature-popover" popover class="popover-panel">
+      <h2>Pro Plan</h2>
+      <p>Everything in Free, plus unlimited projects, priority support, and advanced analytics.</p>
+      <ul>
+        <li>Unlimited team members</li>
+        <li>Custom integrations</li>
+        <li>24/7 priority support</li>
+      </ul>
+      <button class="popover-close" popovertarget="feature-popover" popovertargetaction="hide">Close</button>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/zoom-in-popover-ag/style.css
+++ b/submissions/examples/zoom-in-popover-ag/style.css
@@ -1,0 +1,114 @@
+:root {
+  --popover-bg: #ffffff;
+  --popover-text: #1a1a1a;
+  --popover-border: #e2e2e8;
+  --popover-shadow: 0 12px 32px rgba(0, 0, 0, 0.15);
+  --popover-accent: #4f46e5;
+  --popover-radius: 14px;
+  --popover-scale-start: 0.85;
+  --popover-duration: 0.28s;
+  --popover-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #f7f7fb;
+  color: var(--popover-text);
+}
+
+.popover-demo {
+  text-align: center;
+  max-width: 480px;
+}
+
+.popover-trigger {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  background: var(--popover-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.popover-trigger:hover {
+  background: #4338ca;
+}
+
+.popover-trigger:active {
+  transform: scale(0.97);
+}
+
+/* Popover panel */
+.popover-panel {
+  border: 1px solid var(--popover-border);
+  border-radius: var(--popover-radius);
+  padding: 1.5rem;
+  max-width: 340px;
+  background: var(--popover-bg);
+  box-shadow: var(--popover-shadow);
+  text-align: left;
+
+  /* Zoom-in transition setup */
+  opacity: 0;
+  transform: scale(var(--popover-scale-start));
+  transition:
+    opacity var(--popover-duration) var(--popover-easing),
+    transform var(--popover-duration) var(--popover-easing),
+    display var(--popover-duration) allow-discrete,
+    overlay var(--popover-duration) allow-discrete;
+}
+
+.popover-panel:popover-open {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@starting-style {
+  .popover-panel:popover-open {
+    opacity: 0;
+    transform: scale(var(--popover-scale-start));
+  }
+}
+
+.popover-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.popover-panel p {
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.popover-panel ul {
+  margin: 0 0 1rem;
+  padding-left: 1.2rem;
+  line-height: 1.6;
+}
+
+.popover-close {
+  border: none;
+  background: none;
+  color: var(--popover-accent);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.95rem;
+}
+
+.popover-close:hover {
+  text-decoration: underline;
+}
+
+.popover-trigger:focus-visible,
+.popover-close:focus-visible {
+  outline: 2px solid var(--popover-accent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Description
Adds a pure CSS animated popover with a smooth zoom-in transition, styled for modern SaaS interfaces, as requested in #46394.

## Changes
- New folder: `submissions/examples/zoom-in-popover-ag/`
- `demo.html` — trigger button + popover panel using the native HTML `popover` attribute and `popovertarget`
- `style.css` — zoom-in open/close animation via `@starting-style`/`:popover-open`, fully driven by CSS custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Zero JavaScript — uses the native HTML Popover API for open/close, focus handling, `Esc`-to-close, and light-dismiss
- Springy zoom-in animation with configurable scale, duration, and easing via CSS variables
- Fully responsive and keyboard accessible
- Exposed custom properties for timing, easing, and scale factor as requested in the issue

## Notes
The zoom transition relies on `@starting-style` and `:popover-open`, modern CSS features. In browsers without support, the popover still opens/closes correctly via native fallback, just without the animated zoom.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #46394