### PR TITLE
feat: add CSS elastic-slide progress bar for responsive dashboards (i…

### DIFF
--- a/submissions/examples/elastic-slide-progress-ag/README.md
+++ b/submissions/examples/elastic-slide-progress-ag/README.md
@@ -1,0 +1,34 @@
+# Elastic-Slide Progress Bar
+
+Pure CSS progress bar with an elastic overshoot fill animation, for responsive dashboard layouts. Addresses #54187.
+
+## Files
+- `demo.html` — three example progress bars at different completion levels
+- `style.css` — elastic keyframe fill animation, fully theme-able via CSS custom properties
+- `README.md` — this file
+
+## Usage
+Open `demo.html`. Each `.progress-track` contains a `.progress-fill` with a modifier class (`--45`, `--72`, `--100`) setting the `--progress-target` width. On load, the fill slides in, slightly overshoots, then settles at the target percentage.
+
+To add a new bar at, say, 30%:
+```html
+<div class="progress-track" role="progressbar" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100">
+  <div class="progress-fill progress-fill--30" style="--progress-target: 30%;"></div>
+</div>
+```
+
+## Customization
+Exposed as CSS custom properties on `:root`:
+- `--progress-track-bg` — track background color
+- `--progress-fill-color` — fill color
+- `--progress-radius` — corner rounding
+- `--progress-height` — bar height (auto-reduced on small viewports)
+- `--progress-duration` — animation duration (default `0.9s`)
+- `--progress-easing` — timing function (default a bouncy cubic-bezier)
+
+## Accessibility
+- Each track uses `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` and an `aria-label`.
+- Respects `prefers-reduced-motion: reduce` — the elastic animation is disabled and the fill jumps straight to its target width.
+
+## Notes on scope
+Fully responsive: bar height and container padding adjust at the 600px breakpoint for tablet/mobile. No JavaScript is used anywhere; the "elastic" overshoot is achieved purely with a multi-step `@keyframes` animation.

--- a/submissions/examples/elastic-slide-progress-ag/demo.html
+++ b/submissions/examples/elastic-slide-progress-ag/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Elastic-Slide Progress Bar</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="progress-demo">
+    <h1>Elastic-Slide Progress Bar</h1>
+    <p>Pure CSS, responsive, with an elastic overshoot fill animation.</p>
+
+    <section class="progress-group">
+      <div class="progress-label">
+        <span>Storage used</span>
+        <span>72%</span>
+      </div>
+      <div class="progress-track" role="progressbar" aria-valuenow="72" aria-valuemin="0" aria-valuemax="100" aria-label="Storage used">
+        <div class="progress-fill progress-fill--72"></div>
+      </div>
+    </section>
+
+    <section class="progress-group">
+      <div class="progress-label">
+        <span>Monthly goal</span>
+        <span>45%</span>
+      </div>
+      <div class="progress-track" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" aria-label="Monthly goal">
+        <div class="progress-fill progress-fill--45"></div>
+      </div>
+    </section>
+
+    <section class="progress-group">
+      <div class="progress-label">
+        <span>Upload complete</span>
+        <span>100%</span>
+      </div>
+      <div class="progress-track" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" aria-label="Upload complete">
+        <div class="progress-fill progress-fill--100"></div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/elastic-slide-progress-ag/style.css
+++ b/submissions/examples/elastic-slide-progress-ag/style.css
@@ -1,0 +1,96 @@
+:root {
+  --progress-track-bg: #e9e9f2;
+  --progress-fill-color: #4f46e5;
+  --progress-text: #1a1a1a;
+  --progress-radius: 999px;
+  --progress-height: 14px;
+  --progress-duration: 0.9s;
+  --progress-easing: cubic-bezier(0.22, 1.4, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f7f7fb;
+  color: var(--progress-text);
+  padding: 2rem;
+}
+
+.progress-demo {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.progress-group {
+  margin-bottom: 1.75rem;
+}
+
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.progress-track {
+  width: 100%;
+  height: var(--progress-height);
+  background: var(--progress-track-bg);
+  border-radius: var(--progress-radius);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: var(--progress-radius);
+  background: var(--progress-fill-color);
+  width: 0%;
+  transform-origin: left center;
+  animation: elastic-slide var(--progress-duration) var(--progress-easing) forwards;
+}
+
+.progress-fill--45 {
+  --progress-target: 45%;
+}
+.progress-fill--72 {
+  --progress-target: 72%;
+}
+.progress-fill--100 {
+  --progress-target: 100%;
+}
+
+@keyframes elastic-slide {
+  0% {
+    width: 0%;
+  }
+  60% {
+    width: calc(var(--progress-target) + 6%);
+  }
+  80% {
+    width: calc(var(--progress-target) - 3%);
+  }
+  100% {
+    width: var(--progress-target);
+  }
+}
+
+@media (max-width: 600px) {
+  .progress-demo {
+    padding: 0 1rem;
+  }
+  :root {
+    --progress-height: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill {
+    animation: none;
+    width: var(--progress-target);
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS Elastic-Slide Progress Bar for responsive dashboard layouts, as requested in #54187.

## Changes
- New folder: `submissions/examples/elastic-slide-progress-ag/`
- `demo.html` — three example progress bars (45%, 72%, 100%) using standard EaseMotion markup patterns
- `style.css` — multi-step `@keyframes` elastic overshoot fill animation, fully driven by CSS custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Elastic/overshoot fill animation on load (slides past target, settles back) using pure CSS keyframes
- Fully responsive: bar height and spacing adjust at the 600px breakpoint
- `role="progressbar"` with proper `aria-valuenow`/`aria-valuemin`/`aria-valuemax` on each bar
- Respects `prefers-reduced-motion: reduce` — disables the elastic animation and jumps straight to target width
- Exposed CSS custom properties for track/fill color, radius, height, duration, and easing

## Notes
No external JS frameworks or scripts used — pure CSS/HTML, per the issue requirements.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #54187