### PR TITLE
feat: add CSS float-drift progress bar for responsive dashboards (iss…

### DIFF
--- a/submissions/examples/float-drift-progress-ag/README.md
+++ b/submissions/examples/float-drift-progress-ag/README.md
@@ -1,0 +1,34 @@
+# Float-Drift Progress Bar
+
+Pure CSS progress bar with a continuous drifting gradient shimmer on the fill, for responsive dashboard layouts. Addresses #54191.
+
+## Files
+- `demo.html` — three example progress bars at different completion levels
+- `style.css` — fill-in animation followed by an infinite drifting gradient, fully theme-able via CSS custom properties
+- `README.md` — this file
+
+## Usage
+Open `demo.html`. Each `.progress-track` contains a `.progress-fill` with a modifier class (`--38`, `--63`, `--90`) setting `--progress-target`. On load, the bar fills to its target width, then the gradient inside it drifts continuously left.
+
+To add a new bar at, say, 55%:
+```html
+<div class="progress-track" role="progressbar" aria-valuenow="55" aria-valuemin="0" aria-valuemax="100">
+  <div class="progress-fill progress-fill--55" style="--progress-target: 55%;"></div>
+</div>
+```
+
+## Customization
+Exposed as CSS custom properties on `:root`:
+- `--progress-track-bg` — track background color
+- `--progress-fill-color` / `--progress-fill-color-alt` — the two gradient stops that create the drift shimmer
+- `--progress-radius` — corner rounding
+- `--progress-height` — bar height (auto-reduced on small viewports)
+- `--progress-fill-duration` — how long the initial fill-in takes (default `0.8s`)
+- `--progress-drift-duration` — how long one full drift cycle takes (default `2.4s`)
+
+## Accessibility
+- Each track uses `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` and an `aria-label`.
+- Respects `prefers-reduced-motion: reduce` — both the fill-in and the drift animation are disabled, and the bar renders directly at its target width with a static gradient.
+
+## Notes on scope
+Fully responsive: bar height and container padding adjust at the 600px breakpoint. No JavaScript is used; the drift effect is a background-position keyframe loop on a gradient, distinct from the elastic overshoot approach used in the companion "Elastic-Slide" submission (#54187).

--- a/submissions/examples/float-drift-progress-ag/demo.html
+++ b/submissions/examples/float-drift-progress-ag/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Float-Drift Progress Bar</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="progress-demo">
+    <h1>Float-Drift Progress Bar</h1>
+    <p>Pure CSS, responsive, with a gentle continuous drift shimmer on the fill.</p>
+
+    <section class="progress-group">
+      <div class="progress-label">
+        <span>CPU usage</span>
+        <span>63%</span>
+      </div>
+      <div class="progress-track" role="progressbar" aria-valuenow="63" aria-valuemin="0" aria-valuemax="100" aria-label="CPU usage">
+        <div class="progress-fill progress-fill--63"></div>
+      </div>
+    </section>
+
+    <section class="progress-group">
+      <div class="progress-label">
+        <span>Sync progress</span>
+        <span>38%</span>
+      </div>
+      <div class="progress-track" role="progressbar" aria-valuenow="38" aria-valuemin="0" aria-valuemax="100" aria-label="Sync progress">
+        <div class="progress-fill progress-fill--38"></div>
+      </div>
+    </section>
+
+    <section class="progress-group">
+      <div class="progress-label">
+        <span>Download</span>
+        <span>90%</span>
+      </div>
+      <div class="progress-track" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" aria-label="Download">
+        <div class="progress-fill progress-fill--90"></div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/float-drift-progress-ag/style.css
+++ b/submissions/examples/float-drift-progress-ag/style.css
@@ -1,0 +1,110 @@
+:root {
+  --progress-track-bg: #e9e9f2;
+  --progress-fill-color: #0ea5a4;
+  --progress-fill-color-alt: #34d3d1;
+  --progress-text: #1a1a1a;
+  --progress-radius: 999px;
+  --progress-height: 14px;
+  --progress-fill-duration: 0.8s;
+  --progress-fill-easing: ease-out;
+  --progress-drift-duration: 2.4s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f7f7fb;
+  color: var(--progress-text);
+  padding: 2rem;
+}
+
+.progress-demo {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.progress-group {
+  margin-bottom: 1.75rem;
+}
+
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.progress-track {
+  width: 100%;
+  height: var(--progress-height);
+  background: var(--progress-track-bg);
+  border-radius: var(--progress-radius);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: var(--progress-radius);
+  width: 0%;
+  background: linear-gradient(
+    90deg,
+    var(--progress-fill-color) 0%,
+    var(--progress-fill-color-alt) 50%,
+    var(--progress-fill-color) 100%
+  );
+  background-size: 200% 100%;
+  animation:
+    fill-in var(--progress-fill-duration) ease-out forwards,
+    drift var(--progress-drift-duration) linear infinite;
+  animation-delay: 0s, var(--progress-fill-duration);
+}
+
+.progress-fill--38 {
+  --progress-target: 38%;
+}
+.progress-fill--63 {
+  --progress-target: 63%;
+}
+.progress-fill--90 {
+  --progress-target: 90%;
+}
+
+@keyframes fill-in {
+  from {
+    width: 0%;
+  }
+  to {
+    width: var(--progress-target);
+  }
+}
+
+@keyframes drift {
+  0% {
+    background-position: 0% 0%;
+  }
+  100% {
+    background-position: -200% 0%;
+  }
+}
+
+@media (max-width: 600px) {
+  .progress-demo {
+    padding: 0 1rem;
+  }
+  :root {
+    --progress-height: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill {
+    animation: none;
+    width: var(--progress-target);
+    background-position: 0% 0%;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS Float-Drift Progress Bar for responsive dashboard layouts, as requested in #54191.

## Changes
- New folder: `submissions/examples/float-drift-progress-ag/`
- `demo.html` — three example progress bars (38%, 63%, 90%) using standard EaseMotion markup patterns
- `style.css` — fill-in animation followed by an infinite drifting gradient shimmer, fully driven by CSS custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Initial fill-to-target animation, followed by a continuous drifting gradient shimmer inside the bar
- Fully responsive: bar height and spacing adjust at the 600px breakpoint
- `role="progressbar"` with proper `aria-valuenow`/`aria-valuemin`/`aria-valuemax` on each bar
- Respects `prefers-reduced-motion: reduce` — disables both fill and drift animations, rendering directly at target width
- Exposed CSS custom properties for gradient colors, radius, height, fill duration, and drift duration

## Notes
No external JS frameworks or scripts used — pure CSS/HTML, per the issue requirements. Distinct visual approach from the companion "Elastic-Slide" progress bar (#54187): this one uses a continuous gradient drift rather than a one-time elastic overshoot.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #54191