### PR TITLE
feat: add CSS blur-entrance carousel for accessible layouts (issue #5…

### DIFF
--- a/submissions/examples/blur-entrance-carousel-ag/README.md
+++ b/submissions/examples/blur-entrance-carousel-ag/README.md
@@ -1,0 +1,33 @@
+# Blur-Entrance Carousel
+
+Pure CSS carousel where each slide fades in from a blur when activated, addressing #54199.
+
+## Files
+- `demo.html` — three-slide carousel using radio-input navigation
+- `style.css` — blur-to-sharp entrance transition, fully theme-able via CSS custom properties
+- `README.md` — this file
+
+## Usage
+Open `demo.html`. Click a nav dot (or tab to it and press Space/Enter) to switch slides — the newly active slide transitions from blurred/scaled-up/transparent to sharp/full-opacity.
+
+## How slide-switching works (no JS)
+Each slide is paired with a hidden radio input (`#slide-1`, `#slide-2`, `#slide-3`) sharing the same `name`, so only one can be checked at a time. The visible `<label for="...">` dots toggle the radios. CSS general sibling selectors (`#slide-N:checked ~ .carousel-track .carousel-slide--N`) reveal the matching slide and highlight the matching dot.
+
+## Customization
+Exposed as CSS custom properties on `:root`:
+- `--carousel-bg`, `--carousel-border` — track colors
+- `--carousel-accent` — active dot color
+- `--carousel-dot-inactive` — inactive dot color
+- `--carousel-radius` — track corner rounding
+- `--carousel-height` — track height (auto-reduced on small viewports)
+- `--carousel-blur-amount` — how blurred an inactive slide is before it enters (default `14px`)
+- `--carousel-duration` — transition duration (default `0.5s`)
+
+## Accessibility
+- Nav dots are real `<label>` elements bound to radio inputs, so they're natively keyboard-focusable and toggleable with Space/Enter, and `tabindex="0"` keeps them in the tab order.
+- Each dot has visually-hidden (`sr-only`) text announcing which slide it selects.
+- Visible `:focus-visible` outline on dots.
+- Respects `prefers-reduced-motion: reduce` — the blur/scale/opacity transition is removed, and slides switch instantly.
+
+## Notes on scope
+Since this is pure CSS/HTML with no JavaScript, this carousel uses fixed, pre-defined slides selected via radio buttons rather than swipe/drag gestures or auto-play. Auto-advancing timed slides and touch-swipe support would require JavaScript and are out of scope here, per the "no JS" constraint; the radio-based dot navigation is the CSS-only equivalent.

--- a/submissions/examples/blur-entrance-carousel-ag/demo.html
+++ b/submissions/examples/blur-entrance-carousel-ag/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Blur-Entrance Carousel</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="carousel-demo">
+    <h1>Blur-Entrance Carousel</h1>
+    <p>Pure CSS, keyboard accessible, each slide fades in from a blur when activated.</p>
+
+    <div class="carousel">
+      <input type="radio" name="carousel-slide" id="slide-1" class="carousel-radio" checked>
+      <input type="radio" name="carousel-slide" id="slide-2" class="carousel-radio">
+      <input type="radio" name="carousel-slide" id="slide-3" class="carousel-radio">
+
+      <div class="carousel-track">
+        <figure class="carousel-slide carousel-slide--1">
+          <div class="carousel-card">
+            <h2>Analytics Dashboard</h2>
+            <p>Real-time insights into how your team uses the product.</p>
+          </div>
+        </figure>
+        <figure class="carousel-slide carousel-slide--2">
+          <div class="carousel-card">
+            <h2>Team Collaboration</h2>
+            <p>Comment, assign, and track work without leaving the page.</p>
+          </div>
+        </figure>
+        <figure class="carousel-slide carousel-slide--3">
+          <div class="carousel-card">
+            <h2>Automated Reports</h2>
+            <p>Weekly summaries delivered straight to your inbox.</p>
+          </div>
+        </figure>
+      </div>
+
+      <nav class="carousel-nav" aria-label="Carousel slide selection">
+        <label for="slide-1" class="carousel-dot" tabindex="0">
+          <span class="sr-only">Go to slide 1</span>
+        </label>
+        <label for="slide-2" class="carousel-dot" tabindex="0">
+          <span class="sr-only">Go to slide 2</span>
+        </label>
+        <label for="slide-3" class="carousel-dot" tabindex="0">
+          <span class="sr-only">Go to slide 3</span>
+        </label>
+      </nav>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/blur-entrance-carousel-ag/style.css
+++ b/submissions/examples/blur-entrance-carousel-ag/style.css
@@ -1,0 +1,140 @@
+:root {
+  --carousel-bg: #ffffff;
+  --carousel-border: #e2e2e8;
+  --carousel-accent: #4f46e5;
+  --carousel-dot-inactive: #d5d5e0;
+  --carousel-radius: 16px;
+  --carousel-height: 260px;
+  --carousel-blur-amount: 14px;
+  --carousel-duration: 0.5s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f7f7fb;
+  color: #1a1a1a;
+  padding: 2rem;
+}
+
+.carousel-demo {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.carousel {
+  position: relative;
+}
+
+.carousel-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.carousel-track {
+  position: relative;
+  height: var(--carousel-height);
+  border-radius: var(--carousel-radius);
+  overflow: hidden;
+  border: 1px solid var(--carousel-border);
+  background: var(--carousel-bg);
+}
+
+.carousel-slide {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+  opacity: 0;
+  filter: blur(var(--carousel-blur-amount));
+  transform: scale(1.02);
+  transition: opacity var(--carousel-duration) ease, filter var(--carousel-duration) ease, transform var(--carousel-duration) ease;
+  pointer-events: none;
+}
+
+.carousel-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.carousel-card p {
+  margin: 0;
+  line-height: 1.5;
+  color: #444;
+}
+
+/* Show slide 1 by default (radio checked) */
+#slide-1:checked ~ .carousel-track .carousel-slide--1,
+#slide-2:checked ~ .carousel-track .carousel-slide--2,
+#slide-3:checked ~ .carousel-track .carousel-slide--3 {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.carousel-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.carousel-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--carousel-dot-inactive);
+  cursor: pointer;
+  display: inline-block;
+  transition: background var(--carousel-duration) ease, transform 0.2s ease;
+}
+
+.carousel-dot:hover {
+  transform: scale(1.15);
+}
+
+#slide-1:checked ~ .carousel-nav label:nth-child(1),
+#slide-2:checked ~ .carousel-nav label:nth-child(2),
+#slide-3:checked ~ .carousel-nav label:nth-child(3) {
+  background: var(--carousel-accent);
+}
+
+.carousel-dot:focus-visible {
+  outline: 2px solid var(--carousel-accent);
+  outline-offset: 3px;
+}
+
+@media (max-width: 600px) {
+  :root {
+    --carousel-height: 220px;
+  }
+  .carousel-card h2 {
+    font-size: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel-slide {
+    transition: opacity 0.01ms;
+    filter: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS Blur-Entrance Carousel for accessible web layouts, as requested in #54199.

## Changes
- New folder: `submissions/examples/blur-entrance-carousel-ag/`
- `demo.html` — three-slide carousel using radio-input navigation
- `style.css` — blur-to-sharp entrance transition, fully driven by CSS custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Slide switching via radio-input `:checked` hack — no JavaScript
- Each slide transitions from blurred/scaled/transparent to sharp/full-opacity on activation
- Keyboard-accessible nav dots (real `<label>` elements, focusable, `sr-only` text)
- Respects `prefers-reduced-motion: reduce` — transition removed, instant slide switching
- Exposed CSS custom properties for colors, radius, height, blur amount, and duration

## Notes
Pure CSS/HTML, no JavaScript. Slide navigation uses fixed radio-button-driven slides rather than swipe/drag or auto-play, since those would require JS — out of scope per the issue's "no JS" constraint.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #54199