### PR TITLE
Add CSS fade-in accordion for creative portfolio layouts

### DIFF
--- a/submissions/examples/css-fade-in-accordion/README.md
+++ b/submissions/examples/css-fade-in-accordion/README.md
@@ -1,0 +1,46 @@
+# CSS Fade-In Accordion
+
+A pure CSS accordion built for a creative portfolio layout (e.g. a "working with me" FAQ section), with a fade-in expand animation. No JavaScript, no dependencies.
+This demo uses a dark theme to match common creative-portfolio aesthetics. All colors are exposed as custom properties (see below) so it can be re-themed to light or match the framework's own palette.
+
+## How it works
+
+The toggle uses a hidden checkbox paired with a label, so clicking a question just checks a box instead of running any script. Everything else is driven off that `:checked` state through CSS.
+
+Since `height: auto` can't be transitioned in CSS, the content wrapper animates `grid-template-rows` from `0fr` to `1fr` instead. The inner content also plays a small fade + slide keyframe animation when it opens, so it doesn't feel like it just snaps into place.
+
+## Files
+
+- `demo.html` – accordion markup, styled as a portfolio "working with me" FAQ section
+- `style.css` – all styling and animation
+- `README.md` – this file
+
+## Custom properties
+
+These live on `:root` in `style.css` and control the whole component:
+
+- `--ease-accordion-duration` – 0.4s
+- `--ease-accordion-easing` – ease
+- `--ease-accordion-radius` – 10px
+- `--ease-accordion-gap` – spacing between items
+- `--ease-accordion-bg` – item background color
+- `--ease-accordion-border` – border color
+- `--ease-accordion-hover-bg` – trigger hover background
+- `--ease-accordion-text` – trigger text color
+- `--ease-accordion-muted-text` – body text color
+- `--ease-accordion-accent` – icon, eyebrow, and focus color
+
+Override any of them to reskin it, for example:
+
+```css
+:root {
+  --ease-accordion-accent: #f97316;
+  --ease-accordion-duration: 0.25s;
+}
+```
+
+## Notes
+
+- Fully responsive, with breakpoints at 768px and 480px
+- Trigger is a real label/checkbox pair, so it's keyboard accessible and has a visible focus outline
+- Respects `prefers-reduced-motion` — all transitions and animations are disabled if the user has that set

--- a/submissions/examples/css-fade-in-accordion/demo.html
+++ b/submissions/examples/css-fade-in-accordion/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Fade-In Accordion — Portfolio FAQ</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Frequently Asked</p>
+    <h1 class="ease-heading">Working With Me</h1>
+    <p class="ease-subtitle">A pure CSS accordion, styled for a creative portfolio page.</p>
+
+    <div class="ease-accordion">
+
+      <div class="ease-accordion-item">
+        <input type="checkbox" id="ease-acc-1" class="ease-accordion-toggle" />
+        <label for="ease-acc-1" class="ease-accordion-trigger">
+          What kind of projects do you take on?
+          <span class="ease-accordion-icon" aria-hidden="true">+</span>
+        </label>
+        <div class="ease-accordion-content">
+          <div class="ease-accordion-content-inner">
+            <p>Mostly brand identity, landing pages, and product UI work. I like projects where design and motion are treated as part of the same decision, not an afterthought.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-accordion-item">
+        <input type="checkbox" id="ease-acc-2" class="ease-accordion-toggle" />
+        <label for="ease-acc-2" class="ease-accordion-trigger">
+          What does your process look like?
+          <span class="ease-accordion-icon" aria-hidden="true">+</span>
+        </label>
+        <div class="ease-accordion-content">
+          <div class="ease-accordion-content-inner">
+            <p>Discovery call, a moodboard and rough layout for feedback, then design and build in parallel so what you approve is close to what actually ships.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-accordion-item">
+        <input type="checkbox" id="ease-acc-3" class="ease-accordion-toggle" />
+        <label for="ease-acc-3" class="ease-accordion-trigger">
+          How long does a typical project take?
+          <span class="ease-accordion-icon" aria-hidden="true">+</span>
+        </label>
+        <div class="ease-accordion-content">
+          <div class="ease-accordion-content-inner">
+            <p>A landing page usually takes one to two weeks. Full brand and site builds run four to six weeks depending on scope and revisions.</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-fade-in-accordion/style.css
+++ b/submissions/examples/css-fade-in-accordion/style.css
@@ -1,0 +1,203 @@
+:root {
+  --ease-accordion-duration: 0.4s;
+  --ease-accordion-easing: ease;
+  --ease-accordion-radius: 10px;
+  --ease-accordion-gap: 0.75rem;
+  --ease-accordion-bg: #16181d;
+  --ease-accordion-border: #2a2d34;
+  --ease-accordion-hover-bg: #1c1f26;
+  --ease-accordion-text: #f0f0f0;
+  --ease-accordion-muted-text: #c4c4c4;
+  --ease-accordion-accent: #6c63ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-accordion-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-accordion-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-accordion-gap);
+}
+
+.ease-accordion-item {
+  position: relative;
+  border: 1px solid var(--ease-accordion-border);
+  border-radius: var(--ease-accordion-radius);
+  overflow: hidden;
+  background: var(--ease-accordion-bg);
+}
+
+.ease-accordion-toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-accordion-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  color: var(--ease-accordion-text);
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s var(--ease-accordion-easing);
+}
+
+.ease-accordion-trigger:hover {
+  background-color: var(--ease-accordion-hover-bg);
+}
+
+.ease-accordion-toggle:focus-visible + .ease-accordion-trigger {
+  outline: 2px solid var(--ease-accordion-accent);
+  outline-offset: -2px;
+}
+
+.ease-accordion-icon {
+  font-size: 1.25rem;
+  color: var(--ease-accordion-accent);
+  transition: transform var(--ease-accordion-duration) var(--ease-accordion-easing);
+  flex-shrink: 0;
+  margin-left: 1rem;
+}
+
+.ease-accordion-toggle:checked ~ .ease-accordion-trigger .ease-accordion-icon {
+  transform: rotate(45deg);
+}
+
+.ease-accordion-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--ease-accordion-duration) var(--ease-accordion-easing);
+}
+
+.ease-accordion-toggle:checked ~ .ease-accordion-content {
+  grid-template-rows: 1fr;
+}
+
+.ease-accordion-content-inner {
+  overflow: hidden;
+}
+
+.ease-accordion-content-inner p {
+  margin: 0;
+  padding: 0 1.25rem 1.25rem;
+  color: var(--ease-accordion-muted-text);
+  line-height: 1.6;
+  font-size: 0.925rem;
+  opacity: 0;
+}
+
+@keyframes ease-accordion-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-accordion-toggle:checked ~ .ease-accordion-content .ease-accordion-content-inner p {
+  animation: ease-accordion-fade-in var(--ease-accordion-duration) var(--ease-accordion-easing) forwards;
+  animation-delay: 0.05s;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+
+  .ease-accordion-trigger {
+    padding: 0.875rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .ease-accordion-content-inner p {
+    padding: 0 1rem 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-accordion-trigger {
+    padding: 0.75rem 0.875rem;
+    font-size: 0.9rem;
+  }
+
+  .ease-accordion-icon {
+    font-size: 1.1rem;
+  }
+
+  .ease-accordion-content-inner p {
+    padding: 0 0.875rem 0.875rem;
+    font-size: 0.875rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-accordion-content,
+  .ease-accordion-icon,
+  .ease-accordion-trigger,
+  .ease-accordion-content-inner p {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .ease-accordion-toggle:checked ~ .ease-accordion-content .ease-accordion-content-inner p {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML fade-in accordion component styled as a "working with me" FAQ section for creative portfolio layouts, per issue #54584.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-fade-in-accordion/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A fade-in accordion built entirely with CSS and HTML — no JavaScript — using a checkbox-based toggle.

**How does a developer use it?**
```html
<div class="ease-accordion-item">
  <input type="checkbox" id="ease-acc-1" class="ease-accordion-toggle" />
  <label for="ease-acc-1" class="ease-accordion-trigger">
    Question goes here
    <span class="ease-accordion-icon" aria-hidden="true">+</span>
  </label>
  <div class="ease-accordion-content">
    <div class="ease-accordion-content-inner">
      <p>Answer goes here.</p>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-accordion-trigger`, `ease-accordion-content`), there are zero dependencies, and the animation logic (CSS Grid `grid-template-rows` transition + a `@keyframes` fade-in) is a genuinely reusable pattern rather than a one-off effect. It's also fully theme-able through CSS custom properties, in line with how the rest of the framework exposes design tokens.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*
---

## Notes for Maintainer
Used the checkbox hack instead of `<details>`/`<summary>` since it gives smoother control over the grid-based expand animation across browsers. All colors/timing are exposed as CSS custom properties on `:root` (documented in the README) so this can be re-themed to match the framework's own palette if integrated into `components/`. Also respects `prefers-reduced-motion`.