### PR TITLE
feat: add CSS glitch-flicker carousel for accessible layouts (issue #…

### DIFF
--- a/submissions/examples/glitch-flicker-carousel-ag/README.md
+++ b/submissions/examples/glitch-flicker-carousel-ag/README.md
@@ -1,0 +1,33 @@
+# Glitch-Flicker Carousel
+
+Pure CSS carousel where each slide arrives with a short glitch-style flicker, addressing #54203.
+
+## Files
+- `demo.html` — three-slide carousel using radio-input navigation
+- `style.css` — flicker entrance keyframes, fully theme-able via CSS custom properties
+- `README.md` — this file
+
+## Usage
+Open `demo.html`. Click a nav dot (or tab to it and press Space/Enter) to switch slides — the newly active slide plays a brief flicker-in sequence before settling at full opacity.
+
+## How slide-switching works (no JS)
+Same pattern as the Blur-Entrance Carousel: hidden radio inputs sharing one `name`, toggled by visible `<label>` dots, revealed via `#slide-N:checked ~ .carousel-track .carousel-slide--N`.
+
+## Customization
+Exposed as CSS custom properties on `:root`:
+- `--carousel-bg`, `--carousel-border`, `--carousel-text` — panel colors
+- `--carousel-accent` — active dot color
+- `--carousel-dot-inactive` — inactive dot color
+- `--carousel-radius` — track corner rounding
+- `--carousel-height` — track height (auto-reduced on small viewports)
+- `--carousel-duration` — flicker sequence duration (default `0.6s`)
+
+## Accessibility
+- Nav dots are real `<label>` elements bound to radio inputs — keyboard-focusable, toggleable with Space/Enter, `tabindex="0"`.
+- Each dot has visually-hidden text announcing which slide it selects.
+- Visible `:focus-visible` outline on dots.
+- **Photosensitivity consideration:** the flicker is intentionally a handful of low-contrast opacity/offset steps over ~0.6s using `steps(1, end)`, not a fast high-contrast strobe, to keep it well clear of seizure-trigger thresholds. It also plays once per slide activation rather than looping.
+- Respects `prefers-reduced-motion: reduce` — the flicker animation is fully disabled and the slide simply appears at full opacity.
+
+## Notes on scope
+Pure CSS/HTML, no JavaScript. As with the Blur-Entrance Carousel, navigation is fixed radio-button-driven slides rather than swipe/drag or auto-play, since those would require JS.

--- a/submissions/examples/glitch-flicker-carousel-ag/demo.html
+++ b/submissions/examples/glitch-flicker-carousel-ag/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Glitch-Flicker Carousel</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="carousel-demo">
+    <h1>Glitch-Flicker Carousel</h1>
+    <p>Pure CSS, keyboard accessible, each slide arrives with a brief glitch-style flicker.</p>
+
+    <div class="carousel">
+      <input type="radio" name="carousel-slide" id="slide-1" class="carousel-radio" checked>
+      <input type="radio" name="carousel-slide" id="slide-2" class="carousel-radio">
+      <input type="radio" name="carousel-slide" id="slide-3" class="carousel-radio">
+
+      <div class="carousel-track">
+        <figure class="carousel-slide carousel-slide--1">
+          <div class="carousel-card">
+            <h2>System Status</h2>
+            <p>Live uptime and incident history for every service.</p>
+          </div>
+        </figure>
+        <figure class="carousel-slide carousel-slide--2">
+          <div class="carousel-card">
+            <h2>Deployment Log</h2>
+            <p>Every release, rollback, and build in one timeline.</p>
+          </div>
+        </figure>
+        <figure class="carousel-slide carousel-slide--3">
+          <div class="carousel-card">
+            <h2>API Metrics</h2>
+            <p>Latency, error rate, and throughput at a glance.</p>
+          </div>
+        </figure>
+      </div>
+
+      <nav class="carousel-nav" aria-label="Carousel slide selection">
+        <label for="slide-1" class="carousel-dot" tabindex="0">
+          <span class="sr-only">Go to slide 1</span>
+        </label>
+        <label for="slide-2" class="carousel-dot" tabindex="0">
+          <span class="sr-only">Go to slide 2</span>
+        </label>
+        <label for="slide-3" class="carousel-dot" tabindex="0">
+          <span class="sr-only">Go to slide 3</span>
+        </label>
+      </nav>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/glitch-flicker-carousel-ag/style.css
+++ b/submissions/examples/glitch-flicker-carousel-ag/style.css
@@ -1,0 +1,152 @@
+:root {
+  --carousel-bg: #14141a;
+  --carousel-border: #2a2a34;
+  --carousel-text: #e8e8ec;
+  --carousel-accent: #5eead4;
+  --carousel-dot-inactive: #3a3a46;
+  --carousel-radius: 16px;
+  --carousel-height: 260px;
+  --carousel-duration: 0.6s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f7f7fb;
+  color: #1a1a1a;
+  padding: 2rem;
+}
+
+.carousel-demo {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.carousel {
+  position: relative;
+}
+
+.carousel-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.carousel-track {
+  position: relative;
+  height: var(--carousel-height);
+  border-radius: var(--carousel-radius);
+  overflow: hidden;
+  border: 1px solid var(--carousel-border);
+  background: var(--carousel-bg);
+}
+
+.carousel-slide {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  color: var(--carousel-text);
+}
+
+.carousel-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  letter-spacing: 0.02em;
+}
+
+.carousel-card p {
+  margin: 0;
+  line-height: 1.5;
+  color: #b8b8c4;
+}
+
+/* Gentle, low-contrast flicker-in: a handful of opacity/offset steps, not a fast strobe */
+#slide-1:checked ~ .carousel-track .carousel-slide--1,
+#slide-2:checked ~ .carousel-track .carousel-slide--2,
+#slide-3:checked ~ .carousel-track .carousel-slide--3 {
+  opacity: 1;
+  pointer-events: auto;
+  animation: glitch-flicker var(--carousel-duration) steps(1, end) 1;
+}
+
+@keyframes glitch-flicker {
+  0%   { opacity: 0;   transform: translateX(0); }
+  15%  { opacity: 0.35; transform: translateX(-3px); }
+  30%  { opacity: 0.15; transform: translateX(2px); }
+  45%  { opacity: 0.6;  transform: translateX(-1px); }
+  60%  { opacity: 0.3;  transform: translateX(1px); }
+  80%  { opacity: 0.85; transform: translateX(0); }
+  100% { opacity: 1;    transform: translateX(0); }
+}
+
+.carousel-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.carousel-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--carousel-dot-inactive);
+  cursor: pointer;
+  display: inline-block;
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.carousel-dot:hover {
+  transform: scale(1.15);
+}
+
+#slide-1:checked ~ .carousel-nav label:nth-child(1),
+#slide-2:checked ~ .carousel-nav label:nth-child(2),
+#slide-3:checked ~ .carousel-nav label:nth-child(3) {
+  background: var(--carousel-accent);
+}
+
+.carousel-dot:focus-visible {
+  outline: 2px solid var(--carousel-accent);
+  outline-offset: 3px;
+}
+
+@media (max-width: 600px) {
+  :root {
+    --carousel-height: 220px;
+  }
+  .carousel-card h2 {
+    font-size: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel-slide {
+    animation: none !important;
+    opacity: 1;
+  }
+  #slide-1:checked ~ .carousel-track .carousel-slide--1,
+  #slide-2:checked ~ .carousel-track .carousel-slide--2,
+  #slide-3:checked ~ .carousel-track .carousel-slide--3 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS Glitch-Flicker Carousel for accessible web layouts, as requested in #54203.

## Changes
- New folder: `submissions/examples/glitch-flicker-carousel-ag/`
- `demo.html` — three-slide carousel using radio-input navigation
- `style.css` — low-contrast flicker-in entrance animation, fully driven by CSS custom properties
- `README.md` — usage, customization, and accessibility notes

## Features
- Slide switching via radio-input `:checked` hack — no JavaScript
- Each slide plays a brief glitch-style flicker sequence on activation, then settles at full opacity
- Deliberately low-contrast, single-play flicker (not a strobe) to avoid photosensitivity risk
- Keyboard-accessible nav dots (real `<label>` elements, focusable, `sr-only` text)
- Respects `prefers-reduced-motion: reduce` — flicker fully disabled
- Exposed CSS custom properties for colors, radius, height, and duration

## Notes
Pure CSS/HTML, no JavaScript. Fixed radio-driven slide navigation rather than swipe/drag/auto-play, consistent with the "no JS" constraint.

No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #54203