### PR TITLE
feat: add 3D flip tabs cyberpunk neon example (#50061)

### DIFF
--- a/submissions/examples/feat-3d-flip-tabs-cyberpunk-issue-50061/README.md
+++ b/submissions/examples/feat-3d-flip-tabs-cyberpunk-issue-50061/README.md
@@ -1,0 +1,52 @@
+# 3D Flip Tabs — Cyberpunk Neon
+
+A pure CSS tabs component with a 3D flip transition, styled as a cyberpunk HUD/terminal panel switcher (System / Network / Security). No JavaScript required.
+
+## What it does
+
+- Switching panels flips the content in on its Y axis while a brief `hue-rotate` sweep passes over it mid-flip, reading as a signal glitch rather than a clean, mechanical rotation.
+- The active tab's label gets a layered neon text-shadow glow instead of a filled background, keeping the dark HUD aesthetic instead of looking like a conventional button state.
+- A faint repeating-gradient scanline texture sits over every panel for a CRT/terminal feel, done in pure CSS with no image assets.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-cyber:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the flip keyframe.
+- `perspective` on `.tabs-cyber__stage` gives the `rotateY()` real 3D depth; `backface-visibility: hidden` avoids a mirrored flash mid-flip.
+- The glitch effect is a three-step keyframe: start rotated and hue-shifted, pass through a stronger hue-rotate at 40%, then settle flat and color-true by 100% — a small departure from a simple two-keyframe flip that gives it a "signal locking in" feel.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-cyber` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `420ms` | Flip animation length |
+| `--tabs-easing` | `cubic-bezier(0.5, 0, 0.2, 1)` | Easing curve |
+| `--tabs-flip-angle` | `100deg` | Starting Y-axis rotation before the panel settles flat |
+| `--tabs-perspective` | `1000px` | 3D perspective depth |
+| `--tabs-radius` | `4px` | Corner radius (kept small/angular for the HUD look) |
+| `--tabs-cyan` / `--tabs-magenta` | `#00f0ff` / `#ff2bd6` | The two neon accents (active tab glow / tag border) |
+| `--tabs-bg` / `--tabs-panel-bg` | `#0a0018` / `#120026` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | light / muted violet-gray | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-cyber" style="--tabs-cyan: #39ff14; --tabs-magenta: #ff073a;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the flip/glitch animation entirely — the panel still switches, just without the rotation or hue sweep.
+- The cyan-on-dark-violet text combination was chosen to stay legible despite the neon aesthetic; body copy uses the dimmer muted tone rather than full-saturation neon to avoid eye strain over longer reads.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven 3D flip pattern in the cyberpunk neon aesthetic requested in issue #50061 — responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-3d-flip-tabs-cyberpunk-issue-50061/demo.html
+++ b/submissions/examples/feat-3d-flip-tabs-cyberpunk-issue-50061/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Flip Tabs — Cyberpunk Neon</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #050010;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-cyber">
+  <div class="tabs-cyber__list" role="tablist" aria-label="System panels">
+
+    <input class="tabs-cyber__input" type="radio" name="cyber-tabs" id="tab-system" checked />
+    <label class="tabs-cyber__tab" for="tab-system" role="tab" aria-selected="true">SYSTEM</label>
+
+    <input class="tabs-cyber__input" type="radio" name="cyber-tabs" id="tab-network" />
+    <label class="tabs-cyber__tab" for="tab-network" role="tab" aria-selected="false">NETWORK</label>
+
+    <input class="tabs-cyber__input" type="radio" name="cyber-tabs" id="tab-security" />
+    <label class="tabs-cyber__tab" for="tab-security" role="tab" aria-selected="false">SECURITY</label>
+
+  </div>
+
+  <div class="tabs-cyber__stage">
+
+    <section class="tabs-cyber__panel" id="panel-system">
+      <span class="tabs-cyber__tag">CORE</span>
+      <h3>System Diagnostics</h3>
+      <p>All subsystems nominal. Uptime tracked continuously since last reboot, no unscheduled restarts logged this cycle.</p>
+      <div class="tabs-cyber__readout">CPU 34% · MEM 6.2/16GB · UPTIME 14d 06h</div>
+    </section>
+
+    <section class="tabs-cyber__panel" id="panel-network">
+      <span class="tabs-cyber__tag">LINK</span>
+      <h3>Network Relay</h3>
+      <p>Uplink stable across all active nodes. Packet loss remains within acceptable tolerance for real-time traffic.</p>
+      <div class="tabs-cyber__readout">PING 12ms · THROUGHPUT 940Mbps · NODES 6/6</div>
+    </section>
+
+    <section class="tabs-cyber__panel" id="panel-security">
+      <span class="tabs-cyber__tag">GUARD</span>
+      <h3>Security Perimeter</h3>
+      <p>Intrusion detection active. No unauthorized access attempts recorded in the current monitoring window.</p>
+      <div class="tabs-cyber__readout">FIREWALL ON · THREATS 0 · SCAN 100%</div>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-3d-flip-tabs-cyberpunk-issue-50061/style.css
+++ b/submissions/examples/feat-3d-flip-tabs-cyberpunk-issue-50061/style.css
@@ -1,0 +1,201 @@
+/* ==========================================================================
+   3D Flip Tabs — Cyberpunk Neon
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Configure via the custom properties on .tabs-cyber (see README).
+   ========================================================================== */
+
+.tabs-cyber {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 420ms;
+  --tabs-easing: cubic-bezier(0.5, 0, 0.2, 1);
+  --tabs-flip-angle: 100deg;
+  --tabs-perspective: 1000px;
+  --tabs-radius: 4px;
+  --tabs-cyan: #00f0ff;
+  --tabs-magenta: #ff2bd6;
+  --tabs-bg: #0a0018;
+  --tabs-panel-bg: #120026;
+  --tabs-border: #3a1a5c;
+  --tabs-text: #eef0ff;
+  --tabs-text-dim: #8b7fb0;
+  --tabs-font-display: "Orbitron", "Sora", system-ui, sans-serif;
+  --tabs-font-mono: "Share Tech Mono", "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 460px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 4px);
+  padding: 18px;
+  font-family: var(--tabs-font-mono);
+  color: var(--tabs-text);
+  box-shadow: 0 0 40px -12px rgba(255, 43, 214, 0.25);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-cyber__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-cyber__list {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--tabs-border);
+  padding-bottom: 4px;
+}
+
+.tabs-cyber__tab {
+  flex: 1;
+  padding: 9px 10px;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  border: 1px solid transparent;
+  border-radius: var(--tabs-radius);
+  font-family: var(--tabs-font-display);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--tabs-text-dim);
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    border-color var(--tabs-duration) var(--tabs-easing),
+    text-shadow var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-cyber__tab:hover {
+  color: var(--tabs-cyan);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-cyber__input:focus-visible + .tabs-cyber__tab {
+  outline: 2px solid var(--tabs-cyan);
+  outline-offset: 2px;
+}
+
+/* active tab: neon glow via layered text-shadow, no glow filter needed */
+.tabs-cyber__input:checked + .tabs-cyber__tab {
+  color: var(--tabs-cyan);
+  border-color: var(--tabs-cyan);
+  text-shadow: 0 0 8px var(--tabs-cyan), 0 0 18px rgba(0, 240, 255, 0.6);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-cyber__stage {
+  margin-top: 14px;
+  perspective: var(--tabs-perspective);
+}
+
+.tabs-cyber__panel {
+  display: none;
+  position: relative;
+  padding: 18px;
+  background: var(--tabs-panel-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  transform-origin: center;
+  backface-visibility: hidden;
+  overflow: hidden;
+}
+
+/* faint scanline texture, purely decorative */
+.tabs-cyber__panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.025) 0px,
+    rgba(255, 255, 255, 0.025) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+
+.tabs-cyber__tag {
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 2px 8px;
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  color: var(--tabs-magenta);
+  border: 1px solid var(--tabs-magenta);
+  border-radius: 2px;
+}
+
+.tabs-cyber__panel h3 {
+  margin: 0 0 8px;
+  font-family: var(--tabs-font-display);
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  color: var(--tabs-cyan);
+}
+
+.tabs-cyber__panel p {
+  margin: 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.86rem;
+  line-height: 1.6;
+}
+
+.tabs-cyber__readout {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--tabs-border);
+  font-size: 0.76rem;
+  color: var(--tabs-cyan);
+}
+
+/* show + glitch-flip in the panel that matches the checked tab */
+.tabs-cyber:has(#tab-system:checked) #panel-system,
+.tabs-cyber:has(#tab-network:checked) #panel-network,
+.tabs-cyber:has(#tab-security:checked) #panel-security {
+  display: block;
+  animation: tabs-cyber-flip var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-cyber-flip {
+  0% {
+    opacity: 0;
+    transform: rotateY(var(--tabs-flip-angle));
+    filter: hue-rotate(0deg);
+  }
+  40% {
+    opacity: 1;
+    filter: hue-rotate(40deg);
+  }
+  100% {
+    opacity: 1;
+    transform: rotateY(0deg);
+    filter: hue-rotate(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-cyber__tab {
+    transition: none;
+  }
+  .tabs-cyber__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-cyber {
+    padding: 14px;
+  }
+  .tabs-cyber__tab {
+    font-size: 0.64rem;
+    padding: 8px 6px;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a 3D flip transition, styled as a cyberpunk HUD/terminal panel switcher, added under submissions/examples/3d-flip-tabs-cyberpunk-issue-50061/.

### Files
demo.html — standalone demo markup (3 panels: System, Network, Security) with terminal-style readouts
style.css — component styles, glitch-flip animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes

### How it works

Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel and triggers the flip keyframe when its tab is checked.
perspective gives the panel's rotateY() real 3D depth; backface-visibility: hidden avoids a mirrored flash mid-flip.
The flip keyframe passes through a stronger hue-rotate at its midpoint before settling color-true and flat, reading as a signal-glitch rather than a plain mechanical rotation.
The active tab uses a layered neon text-shadow glow (cyan) instead of a filled background, keeping the dark HUD look.
A pure-CSS repeating-gradient scanline texture sits over each panel — no image assets.
All timing, easing, flip angle, perspective, and both neon accent colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion — disables the flip/glitch animation entirely, panel still switches correctly.
Body copy uses a dimmer muted tone rather than full-saturation neon, to stay legible over longer reads despite the neon aesthetic.

### Testing
Opened demo.html directly in the browser and verified:

All three panels switch correctly via click and keyboard (arrow keys)
Flip + hue-rotate glitch animates smoothly, no backface flashing
Layout holds up down to mobile width
No console errors

Closes #50061