### PR TITLE
feat: add 3D flip tabs dashboard example (#50063)

### DIFF
--- a/submissions/examples/feat-3d-flip-tabs-dashboard-issue-50063/README.md
+++ b/submissions/examples/feat-3d-flip-tabs-dashboard-issue-50063/README.md
@@ -1,0 +1,53 @@
+# 3D Flip Tabs — Responsive Dashboard
+
+A pure CSS tabs component with a 3D flip transition, styled for a dashboard time-range switcher (Today / This Week / This Month). Unlike a single flipping panel, switching the range here flips **an entire grid of widget cards at once**, each with its own staggered delay. No JavaScript required.
+
+## What it does
+
+- Three widget cards (Revenue, New users, Errors) sit in a grid. Switching the time-range tab swaps in that range's values and flips all three cards in on their Y axis, one after another, using a per-card `animation-delay`.
+- The active tab fills with a two-color gradient, echoed in each widget's icon chip, tying the range switcher and the data cards to the same accent.
+- Panel switching and the staggered flip are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each range is a hidden `<input type="radio">` paired with a `<label>`. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between ranges).
+- Each time range's three widgets live in their own wrapper (`#range-today`, `#range-week`, `#range-month`) styled with `display: contents`, so they act as direct children of the CSS grid layout without adding an extra layout box.
+- All widgets are `display: none` by default; `.tabs-grid:has(#tab-x:checked) #range-x .tabs-grid__widget { display: block; animation: ...; }` reveals only the matching range's three cards.
+- Each revealed card's `animation-delay` is set by `nth-child` position (`0`, `--tabs-stagger`, `--tabs-stagger × 2`), producing the cascading flip.
+- `perspective` on `.tabs-grid__widgets` gives every card's `rotateY()` real 3D depth; `backface-visibility: hidden` avoids a mirrored flash mid-flip.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-grid` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `480ms` | Flip animation length per card |
+| `--tabs-stagger` | `80ms` | Delay between each card's flip in the cascade |
+| `--tabs-easing` | `cubic-bezier(0.3, 0.7, 0.4, 1)` | Easing curve |
+| `--tabs-flip-angle` | `90deg` | Starting Y-axis rotation before each card settles flat |
+| `--tabs-perspective` | `900px` | 3D perspective depth |
+| `--tabs-radius` | `12px` | Corner radius |
+| `--tabs-accent-a` / `--tabs-accent-b` | `#8b5cf6` / `#06b6d4` | Gradient accent (active tab, widget icon chips) |
+| `--tabs-bg` / `--tabs-card-bg` | `#0f1419` / `#171d25` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | light / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-grid" style="--tabs-stagger: 140ms; --tabs-accent-a: #f59e0b; --tabs-accent-b: #ef4444;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between ranges) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling both the tab-chip transition and every card's flip animation — the correct values still display, just without the cascade.
+- The widget grid collapses to a single column on narrow viewports.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven 3D flip pattern in the dashboard aesthetic requested in issue #50063 — using a staggered multi-card flip (distinct from a typical single-panel flip), responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-3d-flip-tabs-dashboard-issue-50063/demo.html
+++ b/submissions/examples/feat-3d-flip-tabs-dashboard-issue-50063/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D Flip Tabs — Responsive Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #090c10;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-grid">
+  <div class="tabs-grid__list" role="tablist" aria-label="Time range">
+
+    <input class="tabs-grid__input" type="radio" name="grid-tabs" id="tab-today" checked />
+    <label class="tabs-grid__tab" for="tab-today" role="tab" aria-selected="true">Today</label>
+
+    <input class="tabs-grid__input" type="radio" name="grid-tabs" id="tab-week" />
+    <label class="tabs-grid__tab" for="tab-week" role="tab" aria-selected="false">This Week</label>
+
+    <input class="tabs-grid__input" type="radio" name="grid-tabs" id="tab-month" />
+    <label class="tabs-grid__tab" for="tab-month" role="tab" aria-selected="false">This Month</label>
+
+  </div>
+
+  <div class="tabs-grid__widgets">
+
+    <div class="tabs-grid__range" id="range-today">
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">💰</span>
+        <span class="tabs-grid__widget-value">$2,140</span>
+        <span class="tabs-grid__widget-label">Revenue</span>
+      </div>
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">👤</span>
+        <span class="tabs-grid__widget-value">312</span>
+        <span class="tabs-grid__widget-label">New users</span>
+      </div>
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">⚠️</span>
+        <span class="tabs-grid__widget-value">2</span>
+        <span class="tabs-grid__widget-label">Errors</span>
+      </div>
+    </div>
+
+    <div class="tabs-grid__range" id="range-week">
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">💰</span>
+        <span class="tabs-grid__widget-value">$16,820</span>
+        <span class="tabs-grid__widget-label">Revenue</span>
+      </div>
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">👤</span>
+        <span class="tabs-grid__widget-value">2,104</span>
+        <span class="tabs-grid__widget-label">New users</span>
+      </div>
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">⚠️</span>
+        <span class="tabs-grid__widget-value">11</span>
+        <span class="tabs-grid__widget-label">Errors</span>
+      </div>
+    </div>
+
+    <div class="tabs-grid__range" id="range-month">
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">💰</span>
+        <span class="tabs-grid__widget-value">$71,340</span>
+        <span class="tabs-grid__widget-label">Revenue</span>
+      </div>
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">👤</span>
+        <span class="tabs-grid__widget-value">9,842</span>
+        <span class="tabs-grid__widget-label">New users</span>
+      </div>
+      <div class="tabs-grid__widget">
+        <span class="tabs-grid__widget-icon" aria-hidden="true">⚠️</span>
+        <span class="tabs-grid__widget-value">38</span>
+        <span class="tabs-grid__widget-label">Errors</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-3d-flip-tabs-dashboard-issue-50063/style.css
+++ b/submissions/examples/feat-3d-flip-tabs-dashboard-issue-50063/style.css
@@ -1,0 +1,184 @@
+/* ==========================================================================
+   3D Flip Tabs — Responsive Dashboard
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Unlike a single flipping panel, switching the time range here flips
+   an entire grid of widget cards at once, each with a staggered delay.
+   Configure via the custom properties on .tabs-grid (see README).
+   ========================================================================== */
+
+.tabs-grid {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 480ms;
+  --tabs-stagger: 80ms;
+  --tabs-easing: cubic-bezier(0.3, 0.7, 0.4, 1);
+  --tabs-flip-angle: 90deg;
+  --tabs-perspective: 900px;
+  --tabs-radius: 12px;
+  --tabs-accent-a: #8b5cf6;
+  --tabs-accent-b: #06b6d4;
+  --tabs-bg: #0f1419;
+  --tabs-card-bg: #171d25;
+  --tabs-border: #262e38;
+  --tabs-text: #eef1f5;
+  --tabs-text-dim: #7c8797;
+  --tabs-font-ui: "Sora", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 560px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 20px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-grid__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-grid__list {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--tabs-card-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+}
+
+.tabs-grid__tab {
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: calc(var(--tabs-radius) - 4px);
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  font-family: var(--tabs-font-ui);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--tabs-text-dim);
+  transition:
+    color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-grid__tab:hover {
+  color: var(--tabs-text);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-grid__input:focus-visible + .tabs-grid__tab {
+  outline: 2px solid var(--tabs-accent-b);
+  outline-offset: 2px;
+}
+
+.tabs-grid__input:checked + .tabs-grid__tab {
+  color: var(--tabs-text);
+  background: linear-gradient(135deg, var(--tabs-accent-a), var(--tabs-accent-b));
+}
+
+/* --- widget grid: every card flips together, staggered ------------------ */
+.tabs-grid__widgets {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-top: 14px;
+  perspective: var(--tabs-perspective);
+}
+
+.tabs-grid__widget {
+  padding: 14px;
+  background: var(--tabs-card-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  backface-visibility: hidden;
+}
+
+.tabs-grid__widget-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: linear-gradient(135deg, var(--tabs-accent-a), var(--tabs-accent-b));
+}
+
+.tabs-grid__widget-value {
+  display: block;
+  font-family: var(--tabs-font-mono);
+  font-size: 1.15rem;
+  color: var(--tabs-text);
+}
+
+.tabs-grid__widget-label {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.72rem;
+  color: var(--tabs-text-dim);
+}
+
+/* each range's set of widget values is its own group; only the group
+   matching the checked tab is shown, and its three cards flip in with
+   a staggered delay */
+.tabs-grid__range {
+  display: contents;
+}
+
+.tabs-grid__range .tabs-grid__widget {
+  display: none;
+}
+
+.tabs-grid:has(#tab-today:checked) #range-today .tabs-grid__widget,
+.tabs-grid:has(#tab-week:checked) #range-week .tabs-grid__widget,
+.tabs-grid:has(#tab-month:checked) #range-month .tabs-grid__widget {
+  display: block;
+  animation: tabs-grid-flip var(--tabs-duration) var(--tabs-easing) both;
+}
+
+.tabs-grid__range .tabs-grid__widget:nth-child(1) { animation-delay: 0ms; }
+.tabs-grid__range .tabs-grid__widget:nth-child(2) { animation-delay: var(--tabs-stagger); }
+.tabs-grid__range .tabs-grid__widget:nth-child(3) { animation-delay: calc(var(--tabs-stagger) * 2); }
+
+@keyframes tabs-grid-flip {
+  from {
+    opacity: 0;
+    transform: rotateY(var(--tabs-flip-angle));
+  }
+  to {
+    opacity: 1;
+    transform: rotateY(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-grid__tab {
+    transition: none;
+  }
+  .tabs-grid__widget {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-grid {
+    padding: 14px;
+  }
+  .tabs-grid__widgets {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Description:

### What this adds

A pure CSS tabs component with a 3D flip transition, styled as a dashboard time-range switcher, added under submissions/examples/3d-flip-tabs-dashboard-issue-50063/. Rather than a single panel flipping, switching the range flips an entire grid of widget cards at once, each with its own staggered delay.

### Files
demo.html — standalone demo markup (3 time-range tabs: Today, This Week, This Month), each mapped to a grid of 3 widget cards (Revenue, New users, Errors)
style.css — component styles, staggered multi-card flip animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes

### How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching range's widget set when its tab is checked.
Each time range's three widgets live in a display: contents wrapper so they act as direct children of the CSS grid without adding an extra layout box.
Each revealed card's animation-delay is set by its nth-child position, producing a cascading flip across the three cards rather than one flat reveal.
perspective on the widget grid gives every card's rotateY() real 3D depth; backface-visibility: hidden avoids a mirrored flash mid-flip.
All timing, stagger delay, flip angle, perspective, and gradient accent colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between ranges).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion — correct values still display, just without the cascade animation.
Widget grid collapses to a single column on narrow viewports.

### Testing

Opened demo.html directly in the browser and verified:

All three time-range tabs switch correctly via click and keyboard (arrow keys)
All three widget cards flip in with the correct stagger on each range switch
Layout holds up down to mobile width
No console errors

Closes #50063