### PR TITLE
feat: add rotate-click tabs dashboard example (#50077)

### DIFF
--- a/submissions/examples/feat-rotate-click-tabs-dashboard-issue-50077/README.md
+++ b/submissions/examples/feat-rotate-click-tabs-dashboard-issue-50077/README.md
@@ -1,0 +1,50 @@
+# Rotate-Click Tabs — Responsive Dashboard
+
+A pure CSS tabs component with a rotate-click interaction, styled as a dashboard system-monitor switcher (CPU / Memory / Network). Each tab is a small gauge whose needle swings to point "active" when selected, like a speedometer snapping to a new reading. No JavaScript required.
+
+## What it does
+
+- Every tab has a tiny circular gauge with a needle resting at an angle. Selecting that tab snaps the needle upright with a slight overshoot, giving a tactile "click" feel rather than a smooth glide.
+- The panel content rotates and scales in from a slight tilt to settle flat, echoing the same snap motion as the needle.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>` containing a gauge (`.tabs-gauge__dial` + `.tabs-gauge__needle`) and a text label. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-gauge:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the click keyframe.
+- The needle's rest/active rotation is controlled by `--tabs-needle-angle`, transitioning via `.tabs-gauge__input:checked + .tabs-gauge__tab .tabs-gauge__needle { transform: rotate(0deg); }`. The overshoot comes entirely from the easing curve, not extra keyframe steps.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-gauge` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `420ms` | Transition/animation length |
+| `--tabs-easing` | `cubic-bezier(0.34, 1.4, 0.64, 1)` | Easing curve (the overshoot creates the "snap") |
+| `--tabs-needle-angle` | `-35deg` | Needle's rest angle before it snaps upright |
+| `--tabs-panel-rotate` | `6deg` | Panel's starting rotation before it settles flat |
+| `--tabs-radius` | `12px` | Corner radius |
+| `--tabs-accent` | `#f97316` | Accent color (active gauge, needle, tab border) |
+| `--tabs-bg` / `--tabs-surface` | `#0d1117` / `#161b22` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | light / muted | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-gauge" style="--tabs-needle-angle: -50deg; --tabs-accent: #38bdf8;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the needle rotation, tab-chip transition, and the panel click animation.
+- Gauge/needle graphics are `aria-hidden`; the label text carries the meaning for screen readers.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven rotate-click pattern in the dashboard aesthetic requested in issue #50077 — using a distinct gauge-needle mechanic (rather than a dial-knob), responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-rotate-click-tabs-dashboard-issue-50077/demo.html
+++ b/submissions/examples/feat-rotate-click-tabs-dashboard-issue-50077/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Click Tabs — Responsive Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #070a0e;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-gauge">
+  <div class="tabs-gauge__list" role="tablist" aria-label="System readings">
+
+    <input class="tabs-gauge__input" type="radio" name="gauge-tabs" id="tab-cpu" checked />
+    <label class="tabs-gauge__tab" for="tab-cpu" role="tab" aria-selected="true">
+      <span class="tabs-gauge__dial" aria-hidden="true"><span class="tabs-gauge__needle"></span></span>
+      <span class="tabs-gauge__label">CPU</span>
+    </label>
+
+    <input class="tabs-gauge__input" type="radio" name="gauge-tabs" id="tab-memory" />
+    <label class="tabs-gauge__tab" for="tab-memory" role="tab" aria-selected="false">
+      <span class="tabs-gauge__dial" aria-hidden="true"><span class="tabs-gauge__needle"></span></span>
+      <span class="tabs-gauge__label">Memory</span>
+    </label>
+
+    <input class="tabs-gauge__input" type="radio" name="gauge-tabs" id="tab-network" />
+    <label class="tabs-gauge__tab" for="tab-network" role="tab" aria-selected="false">
+      <span class="tabs-gauge__dial" aria-hidden="true"><span class="tabs-gauge__needle"></span></span>
+      <span class="tabs-gauge__label">Network</span>
+    </label>
+
+  </div>
+
+  <div class="tabs-gauge__panels">
+
+    <section class="tabs-gauge__panel" id="panel-cpu">
+      <div class="tabs-gauge__reading">34<span>%</span></div>
+      <p>4 cores active, no throttling. Load has stayed under 40% for the last hour.</p>
+    </section>
+
+    <section class="tabs-gauge__panel" id="panel-memory">
+      <div class="tabs-gauge__reading">6.2<span>GB / 16GB</span></div>
+      <p>Memory usage is steady with no leaks detected in the last monitoring cycle.</p>
+    </section>
+
+    <section class="tabs-gauge__panel" id="panel-network">
+      <div class="tabs-gauge__reading">940<span>Mbps</span></div>
+      <p>Throughput is within normal range across all active connections.</p>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-rotate-click-tabs-dashboard-issue-50077/style.css
+++ b/submissions/examples/feat-rotate-click-tabs-dashboard-issue-50077/style.css
@@ -1,0 +1,201 @@
+/* ==========================================================================
+   Rotate-Click Tabs — Responsive Dashboard
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Each tab is a small gauge with a needle that swings to point at the
+   active reading, like a speedometer snapping to a new value.
+   Configure via the custom properties on .tabs-gauge (see README).
+   ========================================================================== */
+
+.tabs-gauge {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 420ms;
+  --tabs-easing: cubic-bezier(0.34, 1.4, 0.64, 1); /* overshoot = needle snap */
+  --tabs-needle-angle: -35deg;   /* rest position before a tab is active */
+  --tabs-panel-rotate: 6deg;     /* small rotate the panel settles out of */
+  --tabs-radius: 12px;
+  --tabs-accent: #f97316;
+  --tabs-accent-soft: rgba(249, 115, 22, 0.14);
+  --tabs-bg: #0d1117;
+  --tabs-surface: #161b22;
+  --tabs-border: #262c36;
+  --tabs-text: #e6edf3;
+  --tabs-text-dim: #7d8590;
+  --tabs-font-ui: "Sora", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+  --tabs-font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 460px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 6px);
+  padding: 20px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-gauge__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-gauge__list {
+  display: flex;
+  gap: 6px;
+}
+
+.tabs-gauge__tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 8px;
+  border-radius: var(--tabs-radius);
+  border: 1px solid var(--tabs-border);
+  background: var(--tabs-surface);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-gauge__tab:hover {
+  border-color: var(--tabs-accent);
+}
+
+/* the gauge: a fixed arc with a needle that rotates to "point" at
+   the reading once its tab becomes active */
+.tabs-gauge__dial {
+  position: relative;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 2px solid var(--tabs-border);
+}
+
+.tabs-gauge__needle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 11px;
+  background: var(--tabs-text-dim);
+  transform-origin: bottom center;
+  transform: translate(-50%, -100%) rotate(var(--tabs-needle-angle));
+  transition:
+    transform var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-gauge__label {
+  font-family: var(--tabs-font-ui);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--tabs-text-dim);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-gauge__input:focus-visible + .tabs-gauge__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+/* active tab: needle snaps upright, dial and label pick up the accent */
+.tabs-gauge__input:checked + .tabs-gauge__tab {
+  border-color: var(--tabs-accent);
+  background: var(--tabs-accent-soft);
+}
+
+.tabs-gauge__input:checked + .tabs-gauge__tab .tabs-gauge__dial {
+  border-color: var(--tabs-accent);
+}
+
+.tabs-gauge__input:checked + .tabs-gauge__tab .tabs-gauge__needle {
+  transform: translate(-50%, -100%) rotate(0deg);
+  background: var(--tabs-accent);
+}
+
+.tabs-gauge__input:checked + .tabs-gauge__tab .tabs-gauge__label {
+  color: var(--tabs-text);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-gauge__panels {
+  position: relative;
+  margin-top: 16px;
+  padding: 20px;
+  background: var(--tabs-surface);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+}
+
+.tabs-gauge__panel {
+  display: none;
+}
+
+.tabs-gauge__reading {
+  font-family: var(--tabs-font-mono);
+  font-size: 2rem;
+  color: var(--tabs-text);
+}
+
+.tabs-gauge__reading span {
+  font-size: 0.9rem;
+  color: var(--tabs-text-dim);
+}
+
+.tabs-gauge__panel p {
+  margin: 6px 0 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+/* show + click-rotate the panel that matches the checked tab */
+.tabs-gauge:has(#tab-cpu:checked) #panel-cpu,
+.tabs-gauge:has(#tab-memory:checked) #panel-memory,
+.tabs-gauge:has(#tab-network:checked) #panel-network {
+  display: block;
+  animation: tabs-gauge-click var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-gauge-click {
+  from {
+    opacity: 0;
+    transform: rotate(var(--tabs-panel-rotate)) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-gauge__tab,
+  .tabs-gauge__needle {
+    transition: none;
+  }
+  .tabs-gauge__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-gauge {
+    padding: 14px;
+  }
+  .tabs-gauge__label {
+    font-size: 0.7rem;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a rotate-click interaction, styled as a dashboard system-monitor switcher, added under submissions/examples/rotate-click-tabs-dashboard-issue-50077/.

### Files
demo.html — standalone demo markup (3 tabs: CPU, Memory, Network), each with a gauge-needle icon and a live-reading panel
style.css — component styles, needle-snap animation, panel click animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel when its tab is checked.
Each tab has a small gauge with a needle resting at an angle; selecting that tab snaps the needle upright using an overshoot easing curve, giving a tactile "click" feel rather than a smooth glide.
The revealed panel rotates and scales in from a slight tilt to flat, echoing the same snap motion as the needle.
All timing, easing, needle angle, panel rotation, and colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion.
Gauge/needle graphics are aria-hidden; the text label carries meaning for screen readers.

### Testing

Opened demo.html directly in the browser and verified:

All three tabs switch correctly via click and keyboard (arrow keys)
Needle snap and panel click animate smoothly on each switch
Layout holds up down to mobile width
No console errors

Closes #50077