### PR TITLE
feat: add rotate-click tabs cyberpunk neon example (#50075)

### DIFF
--- a/submissions/examples/feat-rotate-click-tabs-cyberpunk-issue-50075/README.md
+++ b/submissions/examples/feat-rotate-click-tabs-cyberpunk-issue-50075/README.md
@@ -1,0 +1,51 @@
+# Rotate-Click Tabs — Cyberpunk Neon
+
+A pure CSS tabs component with a rotate-click interaction, styled as a cyberpunk "access node" switcher (Access / Uplink / Defense). Each tab is a small hexagonal node that rotates into a "locked" angle and lights up neon green when selected. No JavaScript required.
+
+## What it does
+
+- Each tab has a hexagon (a rotated, clipped square) that sits dim and unrotated at rest. Selecting the tab spins it to a locked angle while it lights up with a neon glow, like a terminal access node engaging.
+- The panel content rotates in from a slight tilt and settles flat, echoing the same click motion as the node.
+- A secondary magenta accent is used only for tags/borders, keeping the primary neon green reserved for the "active/locked" state so the two colors carry distinct meaning rather than being interchangeable decoration.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>` containing a hex node (`.tabs-node__hex`, a `clip-path` hexagon) and a text label. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-node:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel and triggers the click keyframe.
+- The hex's rotation on activation is a plain `transform: rotate()` transition, not a keyframe animation — so it can be freely combined with the panel's separate entrance animation without timing conflicts.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-node` wrapper:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `380ms` | Transition/animation length |
+| `--tabs-easing` | `cubic-bezier(0.4, 0, 0.2, 1)` | Easing curve |
+| `--tabs-node-angle` | `45deg` | Angle the hex rotates to when "locked" |
+| `--tabs-panel-angle` | `8deg` | Panel's starting rotation before it settles flat |
+| `--tabs-radius` | `4px` | Corner radius (kept small/angular for the HUD look) |
+| `--tabs-accent` / `--tabs-accent-2` | `#39ff14` / `#ff2bd6` | Primary (active/lock) and secondary (tags/borders) neon colors |
+| `--tabs-bg` / `--tabs-panel-bg` | `#050806` / `#0c130e` | Background surfaces |
+| `--tabs-text` / `--tabs-text-dim` | light / muted green-gray | Text colors |
+
+Example override:
+
+```html
+<div class="tabs-node" style="--tabs-accent: #00f0ff; --tabs-node-angle: 90deg;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input.
+- Respects `prefers-reduced-motion` by disabling the hex rotation, label color transition, and the panel click animation.
+- Hex node graphics are `aria-hidden`; the text label carries the meaning for screen readers.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven rotate-click pattern in the cyberpunk neon aesthetic requested in issue #50075 — using a distinct hex-node lock mechanic (rather than a dial or gauge needle), responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-rotate-click-tabs-cyberpunk-issue-50075/demo.html
+++ b/submissions/examples/feat-rotate-click-tabs-cyberpunk-issue-50075/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Click Tabs — Cyberpunk Neon</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #020403;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-node">
+  <div class="tabs-node__list" role="tablist" aria-label="Access nodes">
+
+    <input class="tabs-node__input" type="radio" name="node-tabs" id="tab-access" checked />
+    <label class="tabs-node__tab" for="tab-access" role="tab" aria-selected="true">
+      <span class="tabs-node__hex" aria-hidden="true"></span>
+      <span class="tabs-node__label">ACCESS</span>
+    </label>
+
+    <input class="tabs-node__input" type="radio" name="node-tabs" id="tab-uplink" />
+    <label class="tabs-node__tab" for="tab-uplink" role="tab" aria-selected="false">
+      <span class="tabs-node__hex" aria-hidden="true"></span>
+      <span class="tabs-node__label">UPLINK</span>
+    </label>
+
+    <input class="tabs-node__input" type="radio" name="node-tabs" id="tab-defense" />
+    <label class="tabs-node__tab" for="tab-defense" role="tab" aria-selected="false">
+      <span class="tabs-node__hex" aria-hidden="true"></span>
+      <span class="tabs-node__label">DEFENSE</span>
+    </label>
+
+  </div>
+
+  <div class="tabs-node__stage">
+
+    <section class="tabs-node__panel" id="panel-access">
+      <span class="tabs-node__tag">NODE_01</span>
+      <h3>Access Control</h3>
+      <p>Credential handshake verified. Session token refreshes automatically every 15 minutes without a re-auth prompt.</p>
+    </section>
+
+    <section class="tabs-node__panel" id="panel-uplink">
+      <span class="tabs-node__tag">NODE_02</span>
+      <h3>Uplink Relay</h3>
+      <p>Signal routed through 3 relay points. Latency holds steady even under high concurrent load.</p>
+    </section>
+
+    <section class="tabs-node__panel" id="panel-defense">
+      <span class="tabs-node__tag">NODE_03</span>
+      <h3>Defense Grid</h3>
+      <p>Perimeter scan running continuously. Zero breach attempts logged in the current cycle.</p>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-rotate-click-tabs-cyberpunk-issue-50075/style.css
+++ b/submissions/examples/feat-rotate-click-tabs-cyberpunk-issue-50075/style.css
@@ -1,0 +1,194 @@
+/* ==========================================================================
+   Rotate-Click Tabs — Cyberpunk Neon
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Each tab is a hexagonal "access node" that rotates into lock and
+   strobes once on activation. Configure via the custom properties
+   on .tabs-node (see README).
+   ========================================================================== */
+
+.tabs-node {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 380ms;
+  --tabs-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --tabs-node-angle: 45deg;      /* how far the hex rotates when it "locks" */
+  --tabs-panel-angle: 8deg;      /* small rotate the panel settles out of */
+  --tabs-radius: 4px;
+  --tabs-accent: #39ff14;
+  --tabs-accent-2: #ff2bd6;
+  --tabs-bg: #050806;
+  --tabs-panel-bg: #0c130e;
+  --tabs-border: #1c3324;
+  --tabs-text: #eafff0;
+  --tabs-text-dim: #6f8f7a;
+  --tabs-font-display: "Orbitron", "Sora", system-ui, sans-serif;
+  --tabs-font-mono: "Share Tech Mono", "IBM Plex Mono", ui-monospace, monospace;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 460px;
+  margin-inline: auto;
+  background: var(--tabs-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: calc(var(--tabs-radius) + 4px);
+  padding: 18px;
+  font-family: var(--tabs-font-mono);
+  color: var(--tabs-text);
+  box-shadow: 0 0 40px -14px rgba(57, 255, 20, 0.25);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-node__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-node__list {
+  display: flex;
+  gap: 8px;
+}
+
+.tabs-node__tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 8px;
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-node__tab:hover {
+  border-color: var(--tabs-accent-2);
+}
+
+/* the hex node: a rotated square clipped to a hexagon, spins into
+   its "locked" angle on activation */
+.tabs-node__hex {
+  width: 20px;
+  height: 20px;
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+  background: var(--tabs-border);
+  transition:
+    transform var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-node__label {
+  font-family: var(--tabs-font-display);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--tabs-text-dim);
+  transition: color var(--tabs-duration) var(--tabs-easing);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-node__input:focus-visible + .tabs-node__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 2px;
+}
+
+.tabs-node__input:checked + .tabs-node__tab {
+  border-color: var(--tabs-accent);
+}
+
+.tabs-node__input:checked + .tabs-node__tab .tabs-node__hex {
+  transform: rotate(var(--tabs-node-angle));
+  background: var(--tabs-accent);
+  box-shadow: 0 0 10px var(--tabs-accent);
+}
+
+.tabs-node__input:checked + .tabs-node__tab .tabs-node__label {
+  color: var(--tabs-accent);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-node__stage {
+  margin-top: 14px;
+}
+
+.tabs-node__panel {
+  display: none;
+  padding: 18px;
+  background: var(--tabs-panel-bg);
+  border: 1px solid var(--tabs-border);
+  border-radius: var(--tabs-radius);
+  transform-origin: center;
+}
+
+.tabs-node__tag {
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 2px 8px;
+  font-size: 0.64rem;
+  letter-spacing: 0.1em;
+  color: var(--tabs-accent-2);
+  border: 1px solid var(--tabs-accent-2);
+  border-radius: 2px;
+}
+
+.tabs-node__panel h3 {
+  margin: 0 0 8px;
+  font-family: var(--tabs-font-display);
+  font-size: 0.95rem;
+  letter-spacing: 0.03em;
+  color: var(--tabs-accent);
+}
+
+.tabs-node__panel p {
+  margin: 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.84rem;
+  line-height: 1.6;
+}
+
+/* show + rotate-click in the panel that matches the checked node */
+.tabs-node:has(#tab-access:checked) #panel-access,
+.tabs-node:has(#tab-uplink:checked) #panel-uplink,
+.tabs-node:has(#tab-defense:checked) #panel-defense {
+  display: block;
+  animation: tabs-node-click var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-node-click {
+  from {
+    opacity: 0;
+    transform: rotate(var(--tabs-panel-angle)) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-node__tab,
+  .tabs-node__hex,
+  .tabs-node__label {
+    transition: none;
+  }
+  .tabs-node__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-node {
+    padding: 14px;
+  }
+  .tabs-node__label {
+    font-size: 0.6rem;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a rotate-click interaction, styled as a cyberpunk "access node" switcher, added under submissions/examples/rotate-click-tabs-cyberpunk-issue-50075/.

### Files

demo.html — standalone demo markup (3 nodes: Access, Uplink, Defense), each with a hex-node icon and a terminal-style readout panel
style.css — component styles, hex-lock rotation, panel click animation, and configurable custom properties
README.md — explains how it works, customization options, and accessibility notes
### How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel when its tab is checked.
Each tab has a hexagonal node (a clip-path-clipped square) that rotates to a "locked" angle and lights up neon green when selected.
The revealed panel rotates in from a slight tilt to flat, echoing the node's click motion.
A secondary magenta accent is used only for tags/borders, keeping the primary neon green reserved specifically for the active/locked state.
All timing, easing, lock angle, panel rotation, and both accent colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input.
Respects prefers-reduced-motion.
Hex node graphics are aria-hidden; text labels carry meaning for screen readers.\

### Testing

Opened demo.html directly in the browser and verified:

All three nodes switch correctly via click and keyboard (arrow keys)
Hex lock rotation and panel click animate smoothly on each switch
Layout holds up down to mobile width
No console errors

Closes #50075