### PR TITLE
feat: add rotate-click tabs neumorphic soft example (#50076)

### DIFF
--- a/submissions/examples/feat-rotate-click-tabs-neumorphic-issue-50076/README.md
+++ b/submissions/examples/feat-rotate-click-tabs-neumorphic-issue-50076/README.md
@@ -1,0 +1,51 @@
+# Rotate-Click Tabs — Neumorphic Soft
+
+A pure CSS tabs component with a rotate-click interaction, styled in the neumorphic "soft UI" aesthetic (monochrome surfaces, dual light/dark shadows, no borders). Each tab presses inward like a physical button and its dial indicator rotates upright on selection. No JavaScript required.
+
+## What it does
+
+- Every tab has a soft embossed dial with a small dot at rest, tilted off-angle. Selecting the tab rotates the dot upright while the whole tab's shadow flips from raised (convex) to pressed (concave) — mimicking a soft physical button being pushed in and a dial catching.
+- All depth comes from dual box-shadows (a light shadow and a dark shadow on opposite corners) against a single flat background color — the defining neumorphic technique, with no borders or gradients used for depth.
+- Panel switching and animation are handled entirely with the `:has()` CSS selector reacting to native radio input state — zero JS.
+
+## How it works
+
+- Each tab is a hidden `<input type="radio">` paired with a `<label>` containing a dial (`.tabs-soft__dial` + `.tabs-soft__dot`) and a text label. Radios sharing a `name` give native keyboard support for free (`Tab` focuses the group, arrow keys move between tabs).
+- `.tabs-soft:has(#tab-x:checked) #panel-x { display: block; animation: ...; }` shows the matching panel.
+- The "pressed" look on the active tab comes from swapping the outer shadow direction to `inset` — same two colors, opposite placement, so the surface itself never needs a background or border change to read as pushed in.
+- The dot's rotation (`--tabs-dial-angle` to `0deg`) is a plain CSS transition, layered independently of the panel's own settle animation.
+
+## Customization
+
+All animation and color values are exposed as CSS custom properties on the `.tabs-soft` wrapper. Because neumorphism depends on the shadow colors being derived from the base background, retheming the base color usually means adjusting the shadow colors to match — see the note below the table:
+
+| Property | Default | Controls |
+|---|---|---|
+| `--tabs-duration` | `340ms` | Transition/animation length |
+| `--tabs-easing` | `cubic-bezier(0.4, 0, 0.2, 1)` | Easing curve |
+| `--tabs-dial-angle` | `-40deg` | Dot's rest angle before it rotates upright |
+| `--tabs-radius` | `18px` | Corner radius (kept generous for the soft look) |
+| `--tabs-accent` | `#6c7ae0` | Accent color (active dot, active label) |
+| `--tabs-base` | `#e6e9f0` | The single background color everything sits on |
+| `--tabs-shadow-light` / `--tabs-shadow-dark` | `#ffffff` / `#b9c0d4` | The two shadow colors that create the embossed/pressed depth — should stay a lighter and darker tint of `--tabs-base` |
+| `--tabs-text` / `--tabs-text-dim` | dark / muted slate | Text colors |
+
+Example override (a warmer neumorphic palette):
+
+```html
+<div class="tabs-soft" style="--tabs-base: #f0e9e0; --tabs-shadow-light: #ffffff; --tabs-shadow-dark: #c9beae; --tabs-accent: #d97757;">
+  ...
+</div>
+```
+
+## Accessibility
+
+- Built on native radio inputs, so keyboard navigation (Tab in, arrow keys between tabs) works without any custom JS.
+- `role="tablist"` / `role="tab"` and `aria-selected` are set on the markup.
+- A visible focus ring is applied to the active tab via `:focus-visible` on the (visually hidden) input — necessary since neumorphic UIs often have low inherent contrast and can't rely on shadow alone to signal keyboard focus.
+- Respects `prefers-reduced-motion` by disabling the dot rotation, shadow transition, and panel settle animation.
+- Dial/dot graphics are `aria-hidden`; the text label carries the meaning for screen readers.
+
+## Why it fits EaseMotion
+
+Adds a zero-JS, CSS-custom-property-driven rotate-click pattern in the neumorphic soft aesthetic requested in issue #50076 — using the raised/pressed shadow swap as the core "click" feedback (distinct from the dial-knob and gauge-needle mechanics used elsewhere), responsive down to mobile, keyboard accessible via native radio grouping, and fully retheme-able through custom properties.

--- a/submissions/examples/feat-rotate-click-tabs-neumorphic-issue-50076/demo.html
+++ b/submissions/examples/feat-rotate-click-tabs-neumorphic-issue-50076/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Click Tabs — Neumorphic Soft</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #e6e9f0;
+    padding: 32px 16px;
+  }
+</style>
+</head>
+<body>
+
+<div class="tabs-soft">
+  <div class="tabs-soft__list" role="tablist" aria-label="Account settings">
+
+    <input class="tabs-soft__input" type="radio" name="soft-tabs" id="tab-profile" checked />
+    <label class="tabs-soft__tab" for="tab-profile" role="tab" aria-selected="true">
+      <span class="tabs-soft__dial" aria-hidden="true"><span class="tabs-soft__dot"></span></span>
+      <span class="tabs-soft__label">Profile</span>
+    </label>
+
+    <input class="tabs-soft__input" type="radio" name="soft-tabs" id="tab-preferences" />
+    <label class="tabs-soft__tab" for="tab-preferences" role="tab" aria-selected="false">
+      <span class="tabs-soft__dial" aria-hidden="true"><span class="tabs-soft__dot"></span></span>
+      <span class="tabs-soft__label">Preferences</span>
+    </label>
+
+    <input class="tabs-soft__input" type="radio" name="soft-tabs" id="tab-privacy" />
+    <label class="tabs-soft__tab" for="tab-privacy" role="tab" aria-selected="false">
+      <span class="tabs-soft__dial" aria-hidden="true"><span class="tabs-soft__dot"></span></span>
+      <span class="tabs-soft__label">Privacy</span>
+    </label>
+
+  </div>
+
+  <div class="tabs-soft__panels">
+
+    <section class="tabs-soft__panel" id="panel-profile">
+      <h3>Profile details</h3>
+      <p>Update your name, photo, and public bio. Changes here are visible to anyone who views your profile.</p>
+    </section>
+
+    <section class="tabs-soft__panel" id="panel-preferences">
+      <h3>Preferences</h3>
+      <p>Choose your default language, timezone, and how often you'd like to receive digest emails.</p>
+    </section>
+
+    <section class="tabs-soft__panel" id="panel-privacy">
+      <h3>Privacy controls</h3>
+      <p>Decide who can see your activity and whether your profile appears in search results.</p>
+    </section>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feat-rotate-click-tabs-neumorphic-issue-50076/style.css
+++ b/submissions/examples/feat-rotate-click-tabs-neumorphic-issue-50076/style.css
@@ -1,0 +1,200 @@
+/* ==========================================================================
+   Rotate-Click Tabs — Neumorphic Soft
+   Pure CSS, zero JS. Radio-driven tabs with :has() state matching.
+   Each tab is a soft embossed dial that presses inward (neumorphic
+   "pressed" shadow) and its indicator dot rotates into position on
+   selection. Configure via the custom properties on .tabs-soft (see README).
+   ========================================================================== */
+
+.tabs-soft {
+  /* --- configurable custom properties -------------------------------- */
+  --tabs-duration: 340ms;
+  --tabs-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --tabs-dial-angle: -40deg;
+  --tabs-radius: 18px;
+  --tabs-accent: #6c7ae0;
+  --tabs-base: #e6e9f0;
+  --tabs-shadow-light: #ffffff;
+  --tabs-shadow-dark: #b9c0d4;
+  --tabs-text: #3d4260;
+  --tabs-text-dim: #8890ab;
+  --tabs-font-ui: "Sora", "Inter", system-ui, sans-serif;
+  --tabs-font-body: "Inter", system-ui, sans-serif;
+
+  /* --- layout ----------------------------------------------------------- */
+  max-width: 440px;
+  margin-inline: auto;
+  background: var(--tabs-base);
+  border-radius: calc(var(--tabs-radius) + 8px);
+  padding: 22px;
+  font-family: var(--tabs-font-body);
+  color: var(--tabs-text);
+}
+
+/* visually hide the radios but keep them in the tab order for keyboard nav */
+.tabs-soft__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-soft__list {
+  display: flex;
+  gap: 14px;
+}
+
+.tabs-soft__tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 8px;
+  border-radius: var(--tabs-radius);
+  background: var(--tabs-base);
+  cursor: pointer;
+  user-select: none;
+  box-shadow:
+    6px 6px 12px var(--tabs-shadow-dark),
+    -6px -6px 12px var(--tabs-shadow-light);
+  transition:
+    box-shadow var(--tabs-duration) var(--tabs-easing),
+    color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-soft__tab:hover {
+  color: var(--tabs-accent);
+}
+
+/* the dial: a soft embossed circle with a small indicator dot that
+   rotates from resting angle to upright on selection */
+.tabs-soft__dial {
+  position: relative;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--tabs-base);
+  box-shadow:
+    inset 3px 3px 6px var(--tabs-shadow-dark),
+    inset -3px -3px 6px var(--tabs-shadow-light);
+}
+
+.tabs-soft__dot {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--tabs-text-dim);
+  transform-origin: 50% 11px;
+  transform: translateX(-50%) rotate(var(--tabs-dial-angle));
+  transition:
+    transform var(--tabs-duration) var(--tabs-easing),
+    background-color var(--tabs-duration) var(--tabs-easing);
+}
+
+.tabs-soft__label {
+  font-family: var(--tabs-font-ui);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--tabs-text-dim);
+  transition: color var(--tabs-duration) var(--tabs-easing);
+}
+
+/* keyboard focus ring — visible even though the native input is hidden */
+.tabs-soft__input:focus-visible + .tabs-soft__tab {
+  outline: 2px solid var(--tabs-accent);
+  outline-offset: 3px;
+}
+
+/* active tab: the whole tab presses inward (convex -> concave), and
+   the dial's dot rotates upright and picks up the accent color */
+.tabs-soft__input:checked + .tabs-soft__tab {
+  box-shadow:
+    inset 4px 4px 8px var(--tabs-shadow-dark),
+    inset -4px -4px 8px var(--tabs-shadow-light);
+}
+
+.tabs-soft__input:checked + .tabs-soft__tab .tabs-soft__dot {
+  transform: translateX(-50%) rotate(0deg);
+  background: var(--tabs-accent);
+}
+
+.tabs-soft__input:checked + .tabs-soft__tab .tabs-soft__label {
+  color: var(--tabs-accent);
+}
+
+/* --- panels -------------------------------------------------------------- */
+.tabs-soft__panels {
+  position: relative;
+  margin-top: 18px;
+  padding: 20px;
+  border-radius: var(--tabs-radius);
+  background: var(--tabs-base);
+  box-shadow:
+    inset 5px 5px 10px var(--tabs-shadow-dark),
+    inset -5px -5px 10px var(--tabs-shadow-light);
+}
+
+.tabs-soft__panel {
+  display: none;
+}
+
+.tabs-soft__panel h3 {
+  margin: 0 0 6px;
+  font-family: var(--tabs-font-ui);
+  font-size: 1rem;
+}
+
+.tabs-soft__panel p {
+  margin: 0;
+  color: var(--tabs-text-dim);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+/* show + settle in the panel that matches the checked tab */
+.tabs-soft:has(#tab-profile:checked) #panel-profile,
+.tabs-soft:has(#tab-preferences:checked) #panel-preferences,
+.tabs-soft:has(#tab-privacy:checked) #panel-privacy {
+  display: block;
+  animation: tabs-soft-settle var(--tabs-duration) var(--tabs-easing);
+}
+
+@keyframes tabs-soft-settle {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-soft__tab,
+  .tabs-soft__dot,
+  .tabs-soft__label {
+    transition: none;
+  }
+  .tabs-soft__panel {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-soft {
+    padding: 16px;
+  }
+  .tabs-soft__label {
+    font-size: 0.7rem;
+  }
+}


### PR DESCRIPTION
### Description:

### What this adds

A pure CSS tabs component with a rotate-click interaction, styled in the neumorphic "soft UI" aesthetic, added under submissions/examples/rotate-click-tabs-neumorphic-issue-50076/.

### Files
demo.html — standalone demo markup (3 tabs: Profile, Preferences, Privacy), each with an embossed dial icon
style.css — component styles, raised/pressed shadow swap, dial rotation, and configurable custom properties
README.md — explains how it works, customization options (including a note on retheming shadow colors), and accessibility notes
How it works
Zero JavaScript. Tabs are hidden radio inputs paired with labels; the :has() selector reveals the matching panel when its tab is checked.
Every tab has a soft embossed dial with a dot at rest, tilted off-angle. Selecting the tab rotates the dot upright while the tab's outer shadow flips from raised (convex) to pressed (concave) — the core neumorphic depth technique, using only dual box-shadows against a flat background, no borders or gradients.
The "pressed" state is achieved purely by swapping shadow direction to inset with the same two colors — no background or border change needed.
All timing, easing, dial angle, corner radius, accent color, base color, and both shadow colors are exposed as CSS custom properties for easy retheming.
Accessibility
Native radio grouping gives keyboard navigation for free (Tab in, arrow keys between tabs).
role="tablist" / role="tab" / aria-selected included on markup.
Visible focus ring via :focus-visible on the hidden input — important here since neumorphic UIs have low inherent contrast and can't rely on shadow alone to signal keyboard focus.
Respects prefers-reduced-motion.
Dial/dot graphics are aria-hidden; text labels carry meaning for screen readers.
### Testing

Opened demo.html directly in the browser and verified:

All three tabs switch correctly via click and keyboard (arrow keys)
Shadow press and dial rotation animate smoothly on each switch
Layout holds up down to mobile width
No console errors

Closes #50076