### PR TITLE
feat: add ease-rotate-click-tabs-glassmorphism component (#50073)

### DIFF
--- a/submissions/examples/feat-rotate-click-tabs-glassmorphism-issue-50073/README.md
+++ b/submissions/examples/feat-rotate-click-tabs-glassmorphism-issue-50073/README.md
@@ -1,0 +1,55 @@
+# ease-rotate-click-tabs-glassmorphism
+
+Pure CSS tabs component with a frosted glass surface and a rotate-click panel transition. Zero JavaScript.
+
+Resolves #50073.
+
+## What it does
+
+A tabbed interface where clicking a tab rotates the incoming panel in from a slight 3D tilt while fading up, then settles flat — a subtle "click" flourish — over a frosted glassmorphism surface (translucent background, blur, soft border).
+
+## How to use it
+
+Copy `style.css` into your project (or the relevant classes into your framework bundle), then mark up the tabs like this:
+
+```html
+<div class="ease-tabs-glass" style="--ease-tabs-glass-duration: 0.5s; --ease-tabs-glass-easing: cubic-bezier(0.34, 1.56, 0.64, 1); --ease-tabs-glass-rotate: 18deg;">
+
+  <input type="radio" name="my-tabs" id="tab-1" class="ease-tabs-glass__input" checked>
+  <input type="radio" name="my-tabs" id="tab-2" class="ease-tabs-glass__input">
+
+  <div class="ease-tabs-glass__nav" role="tablist">
+    <label for="tab-1" class="ease-tabs-glass__tab" role="tab">One</label>
+    <label for="tab-2" class="ease-tabs-glass__tab" role="tab">Two</label>
+  </div>
+
+  <div class="ease-tabs-glass__panels">
+    <div class="ease-tabs-glass__panel" id="panel-1">Content one</div>
+    <div class="ease-tabs-glass__panel" id="panel-2">Content two</div>
+  </div>
+
+</div>
+```
+
+Glassmorphism reads best over a colorful or image background — open `demo.html` directly in a browser to see it running against a gradient backdrop, no build step or server needed.
+
+### Customizing
+
+Three CSS custom properties control the feel of the transition:
+
+| Property | Default | Effect |
+|---|---|---|
+| `--ease-tabs-glass-duration` | `0.5s` | Length of the rotate/fade transition |
+| `--ease-tabs-glass-easing` | `ease` | Timing function for the transition |
+| `--ease-tabs-glass-rotate` | `16deg` | Starting 3D tilt (rotateX) of the incoming panel |
+
+## Why it fits EaseMotion CSS
+
+- **No JavaScript**: state is driven entirely by native `<input type="radio">` + the `:checked` pseudo-class, in line with the framework's zero-dependency philosophy.
+- **Keyboard accessible**: Tab and Arrow keys move between tabs natively; a visible focus ring is shown via `:focus-visible`.
+- **No layout jump**: panels are stacked in a single CSS Grid cell, so the container height stays fixed to the tallest panel across all tabs.
+- **Respects `prefers-reduced-motion`** and stacks the tab nav vertically under 30rem width.
+
+## Browsers tested
+
+Chrome · Firefox · Edge (backdrop-filter has broad support in all three; a solid-fallback background color renders underneath for browsers without it)

--- a/submissions/examples/feat-rotate-click-tabs-glassmorphism-issue-50073/demo.html
+++ b/submissions/examples/feat-rotate-click-tabs-glassmorphism-issue-50073/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-rotate-click-tabs-glassmorphism — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-stage">
+    <h1 class="demo-title">ease-rotate-click-tabs-glassmorphism</h1>
+    <p class="demo-sub">Pure CSS tabs — frosted glass surface, rotate-click panel transitions, zero JavaScript.</p>
+
+    <!-- ==== COMPONENT: drop this block into your project ==== -->
+    <div class="ease-tabs-glass" style="--ease-tabs-glass-duration: 0.5s; --ease-tabs-glass-easing: cubic-bezier(0.34, 1.56, 0.64, 1); --ease-tabs-glass-rotate: 18deg;">
+
+      <!-- state inputs (visually hidden, drive everything below) -->
+      <input type="radio" name="ease-tabs-glass-demo" id="ease-glass-tab-1" class="ease-tabs-glass__input" checked>
+      <input type="radio" name="ease-tabs-glass-demo" id="ease-glass-tab-2" class="ease-tabs-glass__input">
+      <input type="radio" name="ease-tabs-glass-demo" id="ease-glass-tab-3" class="ease-tabs-glass__input">
+
+      <div class="ease-tabs-glass__nav" role="tablist" aria-label="Demo tabs">
+        <label for="ease-glass-tab-1" class="ease-tabs-glass__tab" role="tab">Explore</label>
+        <label for="ease-glass-tab-2" class="ease-tabs-glass__tab" role="tab">Create</label>
+        <label for="ease-glass-tab-3" class="ease-tabs-glass__tab" role="tab">Share</label>
+      </div>
+
+      <div class="ease-tabs-glass__panels">
+        <div class="ease-tabs-glass__panel" id="ease-glass-panel-1">
+          <h3>Explore</h3>
+          <p>Tab, or use Arrow keys once focused, to move between tabs — the underlying <code>&lt;input type="radio"&gt;</code> group handles all of it natively, no JavaScript involved.</p>
+        </div>
+        <div class="ease-tabs-glass__panel" id="ease-glass-panel-2">
+          <h3>Create</h3>
+          <p>On click, the incoming panel rotates in from a slight tilt while fading up, then settles flat — a subtle 3D "click" flourish over a frosted glass surface.</p>
+        </div>
+        <div class="ease-tabs-glass__panel" id="ease-glass-panel-3">
+          <h3>Share</h3>
+          <p>Tune <code>--ease-tabs-glass-duration</code>, <code>--ease-tabs-glass-easing</code>, and <code>--ease-tabs-glass-rotate</code> to change the feel of the rotation.</p>
+        </div>
+      </div>
+
+    </div>
+    <!-- ==== END COMPONENT ==== -->
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/feat-rotate-click-tabs-glassmorphism-issue-50073/style.css
+++ b/submissions/examples/feat-rotate-click-tabs-glassmorphism-issue-50073/style.css
@@ -1,0 +1,194 @@
+/*
+  ease-rotate-click-tabs-glassmorphism
+  Pure CSS tabs with a frosted glass surface and a rotate-click panel transition.
+  Zero JavaScript. Built on native <input type="radio"> state + CSS Grid stacking.
+
+  Customize via CSS custom properties on .ease-tabs-glass:
+    --ease-tabs-glass-duration   transition length              (default 0.5s)
+    --ease-tabs-glass-easing     transition timing function     (default ease)
+    --ease-tabs-glass-rotate     starting tilt for rotate-click  (default 16deg)
+*/
+
+.ease-tabs-glass {
+  --ease-tabs-glass-duration: 0.5s;
+  --ease-tabs-glass-easing: ease;
+  --ease-tabs-glass-rotate: 16deg;
+
+  --ease-tabs-glass-surface: rgba(255, 255, 255, 0.14);
+  --ease-tabs-glass-surface-active: rgba(255, 255, 255, 0.28);
+  --ease-tabs-glass-border: rgba(255, 255, 255, 0.35);
+  --ease-tabs-glass-text: #ffffff;
+  --ease-tabs-glass-text-muted: rgba(255, 255, 255, 0.7);
+  --ease-tabs-glass-accent: #ffe8a3;
+
+  width: 100%;
+  max-width: 32rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Hide the real inputs but keep them focusable/keyboard-operable */
+.ease-tabs-glass__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-tabs-glass__nav {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.35rem;
+  border-radius: 1rem;
+  background: var(--ease-tabs-glass-surface);
+  border: 1px solid var(--ease-tabs-glass-border);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.ease-tabs-glass__tab {
+  flex: 1 1 auto;
+  text-align: center;
+  padding: 0.6rem 1rem;
+  border-radius: 0.7rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ease-tabs-glass-text-muted);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    color 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.ease-tabs-glass__tab:hover {
+  color: var(--ease-tabs-glass-text);
+}
+
+/* Active tab: brighter glass pill with the accent color */
+#ease-glass-tab-1:checked ~ .ease-tabs-glass__nav label[for="ease-glass-tab-1"],
+#ease-glass-tab-2:checked ~ .ease-tabs-glass__nav label[for="ease-glass-tab-2"],
+#ease-glass-tab-3:checked ~ .ease-tabs-glass__nav label[for="ease-glass-tab-3"] {
+  color: var(--ease-tabs-glass-accent);
+  background: var(--ease-tabs-glass-surface-active);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+}
+
+/* Visible keyboard focus ring on the label tied to the focused input */
+#ease-glass-tab-1:focus-visible ~ .ease-tabs-glass__nav label[for="ease-glass-tab-1"],
+#ease-glass-tab-2:focus-visible ~ .ease-tabs-glass__nav label[for="ease-glass-tab-2"],
+#ease-glass-tab-3:focus-visible ~ .ease-tabs-glass__nav label[for="ease-glass-tab-3"] {
+  outline: 2px solid var(--ease-tabs-glass-accent);
+  outline-offset: 2px;
+}
+
+/* Panels: stacked in one grid cell so height never jumps between tabs.
+   perspective on the panels container gives the rotate-click its 3D depth. */
+.ease-tabs-glass__panels {
+  position: relative;
+  display: grid;
+  margin-top: 1rem;
+  border-radius: 1.1rem;
+  background: var(--ease-tabs-glass-surface);
+  border: 1px solid var(--ease-tabs-glass-border);
+  box-shadow: 0 8px 32px rgba(31, 38, 135, 0.25);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  perspective: 60rem;
+}
+
+.ease-tabs-glass__panel {
+  grid-area: 1 / 1;
+  padding: 1.5rem;
+  color: var(--ease-tabs-glass-text);
+  opacity: 0;
+  transform-origin: bottom center;
+  transform: rotateX(var(--ease-tabs-glass-rotate)) translateY(0.5rem);
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    opacity var(--ease-tabs-glass-duration) var(--ease-tabs-glass-easing),
+    transform var(--ease-tabs-glass-duration) var(--ease-tabs-glass-easing),
+    visibility 0s linear var(--ease-tabs-glass-duration);
+}
+
+.ease-tabs-glass__panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.ease-tabs-glass__panel p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--ease-tabs-glass-text-muted);
+}
+
+.ease-tabs-glass__panel code {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--ease-tabs-glass-accent);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.35rem;
+  font-size: 0.85em;
+}
+
+#ease-glass-tab-1:checked ~ .ease-tabs-glass__panels #ease-glass-panel-1,
+#ease-glass-tab-2:checked ~ .ease-tabs-glass__panels #ease-glass-panel-2,
+#ease-glass-tab-3:checked ~ .ease-tabs-glass__panels #ease-glass-panel-3 {
+  opacity: 1;
+  transform: rotateX(0deg) translateY(0);
+  pointer-events: auto;
+  visibility: visible;
+  transition:
+    opacity var(--ease-tabs-glass-duration) var(--ease-tabs-glass-easing),
+    transform var(--ease-tabs-glass-duration) var(--ease-tabs-glass-easing),
+    visibility 0s linear 0s;
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-glass__panel {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Stack tabs vertically on narrow viewports */
+@media (max-width: 30rem) {
+  .ease-tabs-glass__nav {
+    flex-direction: column;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component; remove if lifting only the tabs) ---- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+}
+
+.demo-stage {
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.demo-title {
+  font-family: system-ui, sans-serif;
+  color: #ffffff;
+  margin-bottom: 0.35rem;
+}
+
+.demo-sub {
+  font-family: system-ui, sans-serif;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
## Description

Adds `ease-rotate-click-tabs-glassmorphism`, a pure CSS tabs component
with a frosted glass surface and a rotate-click panel transition,
resolving #50073.

## Implementation Details

- **Zero JavaScript**: driven entirely by native `<input type="radio">`
  state + the `:checked` pseudo-class — Tab/Arrow keys/Space all work
  out of the box.
- **No layout jump**: panels are stacked in a single CSS Grid cell so
  switching tabs never changes the container's height.
- **Rotate-click transition**: the incoming panel starts tilted
  (`rotateX`) and faded, then rotates flat with a subtle spring-like
  overshoot easing on click.
- **Customizable**: exposes `--ease-tabs-glass-duration`,
  `--ease-tabs-glass-easing`, and `--ease-tabs-glass-rotate`.
- **Glassmorphism styling**: translucent background, `backdrop-filter`
  blur, soft white border, layered shadow — reads best over a colorful
  or image backdrop (demo uses a gradient).
- **Accessible**: visible focus ring via `:focus-visible`, respects
  `prefers-reduced-motion`, tabs stack vertically under 30rem width.

## Files Changed

- `submissions/examples/rotate-click-tabs-glassmorphism-issue-50073/demo.html`
- `submissions/examples/rotate-click-tabs-glassmorphism-issue-50073/style.css`
- `submissions/examples/rotate-click-tabs-glassmorphism-issue-50073/README.md`

Resolves #50073