### PR TITLE
feat: add ease-rotate-click-tabs- (#50074)

### DIFF
--- a/submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/README.md
+++ b/submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/README.md
@@ -1,0 +1,56 @@
+# ease-rotate-click-tabs-minimal-tech
+
+Pure CSS tabs component with a flat, monochrome, minimalist tech surface and a quick rotate-click panel transition. Zero JavaScript.
+
+Resolves #50074.
+
+## What it does
+
+A tabbed interface where clicking a tab snaps the incoming panel in with a quick horizontal rotate-and-settle — no bounce, no shadow flourish — over a flat dark surface with hairline borders, sharp corners, and a monospace type treatment.
+
+## How to use it
+
+Copy `style.css` into your project (or the relevant classes into your framework bundle), then mark up the tabs like this:
+
+```html
+<div class="ease-tabs-tech" style="--ease-tabs-tech-duration: 0.3s; --ease-tabs-tech-easing: linear; --ease-tabs-tech-rotate: 12deg;">
+
+  <input type="radio" name="my-tabs" id="tab-1" class="ease-tabs-tech__input" checked>
+  <input type="radio" name="my-tabs" id="tab-2" class="ease-tabs-tech__input">
+
+  <div class="ease-tabs-tech__nav" role="tablist">
+    <label for="tab-1" class="ease-tabs-tech__tab" role="tab">01 / ONE</label>
+    <label for="tab-2" class="ease-tabs-tech__tab" role="tab">02 / TWO</label>
+  </div>
+
+  <div class="ease-tabs-tech__panels">
+    <div class="ease-tabs-tech__panel" id="panel-1">Content one</div>
+    <div class="ease-tabs-tech__panel" id="panel-2">Content two</div>
+  </div>
+
+</div>
+```
+
+Open `demo.html` directly in a browser to see it running — no build step or server needed.
+
+### Customizing
+
+Three CSS custom properties control the feel of the transition:
+
+| Property | Default | Effect |
+|---|---|---|
+| `--ease-tabs-tech-duration` | `0.3s` | Length of the rotate/fade transition |
+| `--ease-tabs-tech-easing` | `linear` | Timing function for the transition |
+| `--ease-tabs-tech-rotate` | `10deg` | Starting 3D tilt (rotateY) of the incoming panel |
+
+## Why it fits EaseMotion CSS
+
+- **No JavaScript**: state is driven entirely by native `<input type="radio">` + the `:checked` pseudo-class, in line with the framework's zero-dependency philosophy.
+- **Keyboard accessible**: Tab and Arrow keys move between tabs natively; a visible focus ring is shown via `:focus-visible`.
+- **No layout jump**: panels are stacked in a single CSS Grid cell, so the container height stays fixed to the tallest panel across all tabs.
+- **Respects `prefers-reduced-motion`** and stacks the tab nav vertically under 30rem width.
+- Distinct from the framework's other tab variants (e.g. neumorphic, glassmorphism) by using a flat, sharp-cornered, monospace-driven tech aesthetic with `rotateY` instead of `rotateX`, and a linear/mechanical easing rather than a spring.
+
+## Browsers tested
+
+Chrome · Firefox · Edge

--- a/submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/demo.html
+++ b/submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-rotate-click-tabs-minimal-tech — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-stage">
+    <h1 class="demo-title">ease-rotate-click-tabs-minimal-tech</h1>
+    <p class="demo-sub">Pure CSS tabs — minimalist tech surface, rotate-click panel transitions, zero JavaScript.</p>
+
+    <!-- ==== COMPONENT: drop this block into your project ==== -->
+    <div class="ease-tabs-tech" style="--ease-tabs-tech-duration: 0.3s; --ease-tabs-tech-easing: linear; --ease-tabs-tech-rotate: 12deg;">
+
+      <!-- state inputs (visually hidden, drive everything below) -->
+      <input type="radio" name="ease-tabs-tech-demo" id="ease-tech-tab-1" class="ease-tabs-tech__input" checked>
+      <input type="radio" name="ease-tabs-tech-demo" id="ease-tech-tab-2" class="ease-tabs-tech__input">
+      <input type="radio" name="ease-tabs-tech-demo" id="ease-tech-tab-3" class="ease-tabs-tech__input">
+
+      <div class="ease-tabs-tech__nav" role="tablist" aria-label="Demo tabs">
+        <label for="ease-tech-tab-1" class="ease-tabs-tech__tab" role="tab">01 / STATUS</label>
+        <label for="ease-tech-tab-2" class="ease-tabs-tech__tab" role="tab">02 / LOGS</label>
+        <label for="ease-tech-tab-3" class="ease-tabs-tech__tab" role="tab">03 / CONFIG</label>
+      </div>
+
+      <div class="ease-tabs-tech__panels">
+        <div class="ease-tabs-tech__panel" id="ease-tech-panel-1">
+          <h3>Status</h3>
+          <p>Tab, or use Arrow keys once focused, to move between tabs — the underlying <code>&lt;input type="radio"&gt;</code> group handles all of it natively, no JavaScript involved.</p>
+        </div>
+        <div class="ease-tabs-tech__panel" id="ease-tech-panel-2">
+          <h3>Logs</h3>
+          <p>On click, the incoming panel snaps in with a quick rotate-and-settle — flat, mechanical, no bounce — matching a minimalist tech feel.</p>
+        </div>
+        <div class="ease-tabs-tech__panel" id="ease-tech-panel-3">
+          <h3>Config</h3>
+          <p>Tune <code>--ease-tabs-tech-duration</code>, <code>--ease-tabs-tech-easing</code>, and <code>--ease-tabs-tech-rotate</code> to change the feel of the rotation.</p>
+        </div>
+      </div>
+
+    </div>
+    <!-- ==== END COMPONENT ==== -->
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/style.css
+++ b/submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/style.css
@@ -1,0 +1,203 @@
+/*
+  ease-rotate-click-tabs-minimal-tech
+  Pure CSS tabs with a flat, monochrome, minimalist tech surface and a
+  quick rotate-click panel transition. Zero JavaScript. Built on native
+  <input type="radio"> state + CSS Grid stacking.
+
+  Customize via CSS custom properties on .ease-tabs-tech:
+    --ease-tabs-tech-duration   transition length              (default 0.3s)
+    --ease-tabs-tech-easing     transition timing function     (default linear)
+    --ease-tabs-tech-rotate     starting tilt for rotate-click  (default 10deg)
+*/
+
+.ease-tabs-tech {
+  --ease-tabs-tech-duration: 0.3s;
+  --ease-tabs-tech-easing: linear;
+  --ease-tabs-tech-rotate: 10deg;
+
+  --ease-tabs-tech-bg: #0d0f12;
+  --ease-tabs-tech-surface: #14171b;
+  --ease-tabs-tech-border: #2a2f36;
+  --ease-tabs-tech-text: #e4e7eb;
+  --ease-tabs-tech-text-muted: #6b7280;
+  --ease-tabs-tech-accent: #39ff98;
+
+  width: 100%;
+  max-width: 32rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+}
+
+/* Hide the real inputs but keep them focusable/keyboard-operable */
+.ease-tabs-tech__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-tabs-tech__nav {
+  display: flex;
+  border: 1px solid var(--ease-tabs-tech-border);
+  border-radius: 0;
+  background: var(--ease-tabs-tech-bg);
+}
+
+.ease-tabs-tech__tab {
+  flex: 1 1 auto;
+  text-align: center;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0;
+  border-right: 1px solid var(--ease-tabs-tech-border);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--ease-tabs-tech-text-muted);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s linear, background 0.15s linear;
+}
+
+.ease-tabs-tech__tab:last-child {
+  border-right: none;
+}
+
+.ease-tabs-tech__tab:hover {
+  color: var(--ease-tabs-tech-text);
+}
+
+/* Active tab: flat accent underline, no shadow, no radius — hairline aesthetic */
+#ease-tech-tab-1:checked ~ .ease-tabs-tech__nav label[for="ease-tech-tab-1"],
+#ease-tech-tab-2:checked ~ .ease-tabs-tech__nav label[for="ease-tech-tab-2"],
+#ease-tech-tab-3:checked ~ .ease-tabs-tech__nav label[for="ease-tech-tab-3"] {
+  color: var(--ease-tabs-tech-accent);
+  background: var(--ease-tabs-tech-surface);
+  box-shadow: inset 0 -2px 0 var(--ease-tabs-tech-accent);
+}
+
+/* Visible keyboard focus ring on the label tied to the focused input */
+#ease-tech-tab-1:focus-visible ~ .ease-tabs-tech__nav label[for="ease-tech-tab-1"],
+#ease-tech-tab-2:focus-visible ~ .ease-tabs-tech__nav label[for="ease-tech-tab-2"],
+#ease-tech-tab-3:focus-visible ~ .ease-tabs-tech__nav label[for="ease-tech-tab-3"] {
+  outline: 1px solid var(--ease-tabs-tech-accent);
+  outline-offset: -1px;
+}
+
+/* Panels: stacked in one grid cell so height never jumps between tabs.
+   perspective on the panels container gives the rotate-click its 3D depth. */
+.ease-tabs-tech__panels {
+  position: relative;
+  display: grid;
+  margin-top: 0.5rem;
+  border: 1px solid var(--ease-tabs-tech-border);
+  border-radius: 0;
+  background: var(--ease-tabs-tech-surface);
+  perspective: 60rem;
+}
+
+.ease-tabs-tech__panel {
+  grid-area: 1 / 1;
+  padding: 1.4rem 1.5rem;
+  color: var(--ease-tabs-tech-text);
+  opacity: 0;
+  transform-origin: left center;
+  transform: rotateY(var(--ease-tabs-tech-rotate));
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    opacity var(--ease-tabs-tech-duration) var(--ease-tabs-tech-easing),
+    transform var(--ease-tabs-tech-duration) var(--ease-tabs-tech-easing),
+    visibility 0s linear var(--ease-tabs-tech-duration);
+}
+
+.ease-tabs-tech__panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ease-tabs-tech-accent);
+}
+
+.ease-tabs-tech__panel p {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: var(--ease-tabs-tech-text-muted);
+}
+
+.ease-tabs-tech__panel code {
+  background: #1c2027;
+  color: var(--ease-tabs-tech-accent);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0;
+  font-size: 0.85em;
+}
+
+#ease-tech-tab-1:checked ~ .ease-tabs-tech__panels #ease-tech-panel-1,
+#ease-tech-tab-2:checked ~ .ease-tabs-tech__panels #ease-tech-panel-2,
+#ease-tech-tab-3:checked ~ .ease-tabs-tech__panels #ease-tech-panel-3 {
+  opacity: 1;
+  transform: rotateY(0deg);
+  pointer-events: auto;
+  visibility: visible;
+  transition:
+    opacity var(--ease-tabs-tech-duration) var(--ease-tabs-tech-easing),
+    transform var(--ease-tabs-tech-duration) var(--ease-tabs-tech-easing),
+    visibility 0s linear 0s;
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-tech__panel {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Stack tabs vertically on narrow viewports */
+@media (max-width: 30rem) {
+  .ease-tabs-tech__nav {
+    flex-direction: column;
+  }
+  .ease-tabs-tech__tab {
+    border-right: none;
+    border-bottom: 1px solid var(--ease-tabs-tech-border);
+  }
+  .ease-tabs-tech__tab:last-child {
+    border-bottom: none;
+  }
+}
+
+/* ---- Demo page chrome (not part of the component; remove if lifting only the tabs) ---- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0d0f12;
+}
+
+.demo-stage {
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.demo-title {
+  font-family: "JetBrains Mono", monospace;
+  color: #e4e7eb;
+  font-size: 1.1rem;
+  margin-bottom: 0.35rem;
+}
+
+.demo-sub {
+  font-family: "JetBrains Mono", monospace;
+  color: #6b7280;
+  font-size: 0.78rem;
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
## Description

Adds `ease-rotate-click-tabs-minimal-tech`, a pure CSS tabs component
with a flat, monochrome, minimalist tech surface and a quick
rotate-click panel transition, resolving #50074.

## Implementation Details

- **Zero JavaScript**: driven entirely by native `<input type="radio">`
  state + the `:checked` pseudo-class — Tab/Arrow keys/Space all work
  out of the box.
- **No layout jump**: panels are stacked in a single CSS Grid cell so
  switching tabs never changes the container's height.
- **Rotate-click transition**: incoming panel snaps in with a quick
  `rotateY` tilt-to-flat motion using `linear` easing — mechanical,
  no bounce, distinct from the framework's other rotate-click variant.
- **Customizable**: exposes `--ease-tabs-tech-duration`,
  `--ease-tabs-tech-easing`, and `--ease-tabs-tech-rotate`.
- **Minimalist tech styling**: flat dark surface, sharp corners, hairline
  borders, monospace type, flat accent underline on the active tab —
  no shadows or elevation.
- **Accessible**: visible focus ring via `:focus-visible`, respects
  `prefers-reduced-motion`, tabs stack vertically under 30rem width.

## Files Changed

- `submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/demo.html`
- `submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/style.css`
- `submissions/examples/rotate-click-tabs-minimalist-tech-issue-50074/README.md`

Resolves #50074