### PR TITLE
Add CSS glitch-flicker toast for creative portfolio layouts

### DIFF
--- a/submissions/examples/css-glitch-flicker-toast/README.md
+++ b/submissions/examples/css-glitch-flicker-toast/README.md
@@ -1,0 +1,44 @@
+# CSS Glitch-Flicker Toast
+
+A pure CSS toast notification component with a glitch-flicker entrance animation, built for a creative portfolio "recent activity" section. No JavaScript, no dependencies.
+
+## How it works
+
+Each toast plays a single `@keyframes` animation on load. Instead of a smooth linear fade, the keyframe steps through several rapid opacity and horizontal-position jumps before settling into its resting state, giving a glitch-like flicker rather than a plain fade-in.
+
+Since toasts are meant to appear once rather than stay toggleable, this doesn't use the checkbox-hack pattern from other submissions — a single `animation` on each `.ease-toast` element, staggered with `animation-delay`, is enough.
+
+## Files
+
+- `demo.html` – three toast variants (success, info, alert) styled as portfolio activity notifications
+- `style.css` – all styling, custom properties, and the glitch-flicker keyframe
+- `README.md` – this file
+
+## Custom properties
+
+These live on `:root` in `style.css`:
+
+- `--ease-toast-duration` – 0.9s
+- `--ease-toast-easing` – ease-out
+- `--ease-toast-radius` – 10px
+- `--ease-toast-gap` – spacing between stacked toasts
+- `--ease-toast-bg` – toast background color
+- `--ease-toast-border` – border color
+- `--ease-toast-text` – title text color
+- `--ease-toast-muted-text` – message text color
+- `--ease-toast-success` / `--ease-toast-info` / `--ease-toast-alert` – accent colors per toast type
+
+Override any of them to reskin, for example:
+
+```css
+:root {
+  --ease-toast-duration: 0.6s;
+  --ease-toast-info: #38bdf8;
+}
+```
+
+## Notes
+
+- Fully responsive, with breakpoints at 768px and 480px
+- Respects `prefers-reduced-motion` — the animation is disabled entirely and toasts appear instantly at full opacity for users who have that set
+- Dark theme is a deliberate stylistic choice to match common portfolio aesthetics; all colors are custom properties so it can be re-themed easilycl

--- a/submissions/examples/css-glitch-flicker-toast/demo.html
+++ b/submissions/examples/css-glitch-flicker-toast/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Glitch-Flicker Toast — Portfolio Notifications</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Live Activity</p>
+    <h1 class="ease-heading">Recent Updates</h1>
+    <p class="ease-subtitle">A pure CSS glitch-flicker toast, styled for a creative portfolio page.</p>
+
+    <div class="ease-toast-stack">
+
+      <div class="ease-toast ease-toast-success">
+        <span class="ease-toast-icon" aria-hidden="true">✓</span>
+        <div class="ease-toast-body">
+          <p class="ease-toast-title">Project shipped</p>
+          <p class="ease-toast-message">Nova Landing Page just went live.</p>
+        </div>
+      </div>
+
+      <div class="ease-toast ease-toast-info">
+        <span class="ease-toast-icon" aria-hidden="true">i</span>
+        <div class="ease-toast-body">
+          <p class="ease-toast-title">New message</p>
+          <p class="ease-toast-message">A client left feedback on your latest draft.</p>
+        </div>
+      </div>
+
+      <div class="ease-toast ease-toast-alert">
+        <span class="ease-toast-icon" aria-hidden="true">!</span>
+        <div class="ease-toast-body">
+          <p class="ease-toast-title">Review needed</p>
+          <p class="ease-toast-message">Your case study is ready for final approval.</p>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-glitch-flicker-toast/style.css
+++ b/submissions/examples/css-glitch-flicker-toast/style.css
@@ -1,0 +1,207 @@
+:root {
+  --ease-toast-duration: 0.9s;
+  --ease-toast-easing: ease-out;
+  --ease-toast-radius: 10px;
+  --ease-toast-gap: 0.75rem;
+  --ease-toast-bg: #16181d;
+  --ease-toast-border: #2a2d34;
+  --ease-toast-text: #f0f0f0;
+  --ease-toast-muted-text: #a8a8a8;
+  --ease-toast-success: #4ade80;
+  --ease-toast-info: #6c63ff;
+  --ease-toast-alert: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-toast-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-toast-info);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-toast-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-toast-gap);
+}
+
+.ease-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--ease-toast-border);
+  border-radius: var(--ease-toast-radius);
+  background: var(--ease-toast-bg);
+  border-left: 3px solid var(--ease-toast-info);
+  animation: ease-toast-glitch-in var(--ease-toast-duration) var(--ease-toast-easing) both;
+}
+
+.ease-toast-success {
+  border-left-color: var(--ease-toast-success);
+  animation-delay: 0s;
+}
+
+.ease-toast-info {
+  border-left-color: var(--ease-toast-info);
+  animation-delay: 0.25s;
+}
+
+.ease-toast-alert {
+  border-left-color: var(--ease-toast-alert);
+  animation-delay: 0.5s;
+}
+
+.ease-toast-icon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 0.8rem;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ease-toast-success .ease-toast-icon {
+  color: var(--ease-toast-success);
+}
+
+.ease-toast-info .ease-toast-icon {
+  color: var(--ease-toast-info);
+}
+
+.ease-toast-alert .ease-toast-icon {
+  color: var(--ease-toast-alert);
+}
+
+.ease-toast-title {
+  margin: 0 0 0.15rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.ease-toast-message {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ease-toast-muted-text);
+  line-height: 1.5;
+}
+
+/* Glitch-flicker entrance: multiple rapid opacity/position jumps
+   before settling into the resting state */
+@keyframes ease-toast-glitch-in {
+  0% {
+    opacity: 0;
+    transform: translateX(14px);
+  }
+  10% {
+    opacity: 1;
+    transform: translateX(-4px);
+  }
+  20% {
+    opacity: 0.3;
+    transform: translateX(3px);
+  }
+  30% {
+    opacity: 1;
+    transform: translateX(-2px);
+  }
+  40% {
+    opacity: 0.4;
+    transform: translateX(2px);
+  }
+  50% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  70% {
+    opacity: 0.85;
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+
+  .ease-toast {
+    padding: 0.875rem 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-toast {
+    flex-direction: row;
+    padding: 0.75rem 0.875rem;
+    gap: 0.6rem;
+  }
+
+  .ease-toast-title {
+    font-size: 0.85rem;
+  }
+
+  .ease-toast-message {
+    font-size: 0.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML glitch-flicker toast component styled as a "recent activity" notification feed for creative portfolio layouts, per issue #54608.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-glitch-flicker-toast/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A toast notification component with a glitch-flicker entrance animation, driven entirely by a single CSS keyframe — no JavaScript, no toggle needed since toasts appear once rather than being interactively opened/closed.

**How does a developer use it?**
```html
<div class="ease-toast ease-toast-success">
  <span class="ease-toast-icon" aria-hidden="true">✓</span>
  <div class="ease-toast-body">
    <p class="ease-toast-title">Title goes here</p>
    <p class="ease-toast-message">Message goes here.</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-toast-success`, `ease-toast-title`), zero dependencies, and the glitch-flicker keyframe is a distinct animation technique from smooth transitions — multiple rapid opacity/position steps rather than a single easing curve. Fully theme-able through CSS custom properties.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Since toasts are meant to appear once rather than stay toggleable, this uses a single `@keyframes` animation with staggered `animation-delay` per toast, rather than the checkbox-hack pattern from my previous accordion submission. Respects `prefers-reduced-motion`.