### PR TITLE
Add CSS scale-hover badge for creative portfolio layouts

### DIFF
--- a/submissions/examples/css-scale-hover-badge/README.md
+++ b/submissions/examples/css-scale-hover-badge/README.md
@@ -1,0 +1,46 @@
+# CSS Scale-Hover Badge
+
+A pure CSS badge component styled as a portfolio "skills" section, with a pop-in entrance and a smooth scale-up on hover. No JavaScript, no dependencies.
+
+## How it works
+
+Two separate CSS techniques are combined here:
+
+- **Entrance:** each badge plays a `@keyframes` pop-in animation on load, staggered with `animation-delay` per badge using `nth-child`, so they appear one after another instead of all at once.
+- **Hover:** a plain `transition` on `transform` and `background-color` scales the badge up smoothly and swaps its colors when hovered, no keyframes needed for this part since it's a two-state change.
+
+## Files
+
+- `demo.html` – a "skills & tools" badge group, portfolio-styled
+- `style.css` – all styling, custom properties, keyframe entrance, and hover transition
+- `README.md` – this file
+
+## Custom properties
+
+These live on `:root` in `style.css`:
+
+- `--ease-badge-duration` – 0.25s
+- `--ease-badge-easing` – ease
+- `--ease-badge-radius` – 999px (pill shape)
+- `--ease-badge-gap` – spacing between badges
+- `--ease-badge-bg` – default background
+- `--ease-badge-border` – border color
+- `--ease-badge-text` – default text color
+- `--ease-badge-hover-bg` – background color on hover
+- `--ease-badge-hover-text` – text color on hover
+- `--ease-badge-scale` – how much the badge scales up on hover (1.12 = 12%)
+
+Override any of them to reskin, for example:
+
+```css
+:root {
+  --ease-badge-hover-bg: #f97316;
+  --ease-badge-scale: 1.2;
+}
+```
+
+## Notes
+
+- Fully responsive, with breakpoints at 768px and 480px
+- Respects `prefers-reduced-motion` — both the entrance animation and hover transition are disabled for users who have that set
+- Dark theme is a deliberate stylistic choice to match common portfolio aesthetics; all colcors are custom properties so it can be re-themed easily

--- a/submissions/examples/css-scale-hover-badge/demo.html
+++ b/submissions/examples/css-scale-hover-badge/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scale-Hover Badge — Portfolio Skills</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">About Me</p>
+    <h1 class="ease-heading">Skills &amp; Tools</h1>
+    <p class="ease-subtitle">A pure CSS scale-hover badge, styled for a creative portfolio page.</p>
+
+    <div class="ease-badge-group">
+      <span class="ease-badge">HTML</span>
+      <span class="ease-badge">CSS</span>
+      <span class="ease-badge">JavaScript</span>
+      <span class="ease-badge">Figma</span>
+      <span class="ease-badge">React</span>
+      <span class="ease-badge">Git</span>
+      <span class="ease-badge">UI Design</span>
+      <span class="ease-badge">Animation</span>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-scale-hover-badge/style.css
+++ b/submissions/examples/css-scale-hover-badge/style.css
@@ -1,0 +1,153 @@
+:root {
+  --ease-badge-duration: 0.25s;
+  --ease-badge-easing: ease;
+  --ease-badge-radius: 999px;
+  --ease-badge-gap: 0.6rem;
+  --ease-badge-bg: #16181d;
+  --ease-badge-border: #2a2d34;
+  --ease-badge-text: #d8d8d8;
+  --ease-badge-hover-bg: #6c63ff;
+  --ease-badge-hover-text: #0f1115;
+  --ease-badge-scale: 1.12;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: #f0f0f0;
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-badge-hover-bg);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ease-badge-gap);
+}
+
+.ease-badge {
+  display: inline-block;
+  padding: 0.45rem 1rem;
+  border-radius: var(--ease-badge-radius);
+  border: 1px solid var(--ease-badge-border);
+  background: var(--ease-badge-bg);
+  color: var(--ease-badge-text);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: default;
+  transition: transform var(--ease-badge-duration) var(--ease-badge-easing),
+              background-color var(--ease-badge-duration) var(--ease-badge-easing),
+              color var(--ease-badge-duration) var(--ease-badge-easing);
+  animation: ease-badge-pop-in 0.5s var(--ease-badge-easing) both;
+}
+
+.ease-badge:hover {
+  transform: scale(var(--ease-badge-scale));
+  background: var(--ease-badge-hover-bg);
+  color: var(--ease-badge-hover-text);
+}
+
+/* Stagger the entrance so badges pop in one after another */
+.ease-badge-group .ease-badge:nth-child(1) { animation-delay: 0.05s; }
+.ease-badge-group .ease-badge:nth-child(2) { animation-delay: 0.1s; }
+.ease-badge-group .ease-badge:nth-child(3) { animation-delay: 0.15s; }
+.ease-badge-group .ease-badge:nth-child(4) { animation-delay: 0.2s; }
+.ease-badge-group .ease-badge:nth-child(5) { animation-delay: 0.25s; }
+.ease-badge-group .ease-badge:nth-child(6) { animation-delay: 0.3s; }
+.ease-badge-group .ease-badge:nth-child(7) { animation-delay: 0.35s; }
+.ease-badge-group .ease-badge:nth-child(8) { animation-delay: 0.4s; }
+
+@keyframes ease-badge-pop-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  70% {
+    opacity: 1;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+
+  .ease-badge {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.9rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-badge-group {
+    gap: 0.5rem;
+  }
+
+  .ease-badge {
+    font-size: 0.75rem;
+    padding: 0.35rem 0.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-badge {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1;
+    transform: none;
+  }
+
+  .ease-badge:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML scale-hover badge component styled as a "skills & tools" section for creative portfolio layouts, per issue #54572.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-scale-hover-badge/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A badge component with a staggered pop-in entrance on load and a smooth scale-up transition on hover.

**How does a developer use it?**
```html
<div class="ease-badge-group">
  <span class="ease-badge">HTML</span>
  <span class="ease-badge">CSS</span>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-badge`, `ease-badge-group`), zero dependencies, and it combines two distinct CSS techniques (keyframe entrance + transition-based hover) in one small, reusable component. Fully theme-able through CSS custom properties.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Entrance and hover use separate mechanisms deliberately — `@keyframes` for the one-time pop-in, plain `transition` for the repeatable hover state. Respects `prefers-reduced-motion`.