### PR TITLE
feat: add ease-kubernetes-pod-restart-heatmap-z1

### DIFF
--- a/submissions/examples/ease-kubernetes-pod-restart-heatmap-z1/README.md
+++ b/submissions/examples/ease-kubernetes-pod-restart-heatmap-z1/README.md
@@ -1,0 +1,39 @@
+# Ease Kubernetes Pod Restart Heatmap
+
+## Overview
+
+A responsive Kubernetes reliability component for visualizing pod restart frequency across workloads using a heatmap interface.
+
+## Features
+
+- Pod restart heatmap
+- Multiple restart intensity levels
+- Workload-level restart totals
+- Critical restart animation
+- Namespace-style filters
+- CrashLoopBackOff incident display
+- Restart activity legend
+- Responsive layout
+- Hover interactions
+- Pure HTML and CSS
+
+## Folder Structure
+
+- `demo.html`
+- `style.css`
+- `README.md`
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Why EaseMotion CSS?
+
+The component provides a reusable visual interface for identifying unstable Kubernetes workloads and spotting restart patterns through a compact heatmap-based monitoring experience.

--- a/submissions/examples/ease-kubernetes-pod-restart-heatmap-z1/demo.html
+++ b/submissions/examples/ease-kubernetes-pod-restart-heatmap-z1/demo.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Kubernetes Pod Restart Heatmap</title>
+<link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<main class="restart-board">
+
+<header>
+<div>
+<p class="eyebrow">WORKLOAD RELIABILITY</p>
+<h1>Pod Restart Heatmap</h1>
+<p class="subtitle">Restart activity across production workloads</p>
+</div>
+
+<div class="live">
+<span></span>
+LIVE
+</div>
+</header>
+
+<section class="summary">
+
+<div>
+<strong>48</strong>
+<span>Pods</span>
+</div>
+
+<div>
+<strong>31</strong>
+<span>Stable</span>
+</div>
+
+<div>
+<strong>12</strong>
+<span>Restarted</span>
+</div>
+
+<div class="danger-stat">
+<strong>5</strong>
+<span>Critical</span>
+</div>
+
+</section>
+
+<section class="toolbar">
+
+<div>
+<span class="active-filter">production</span>
+<span>payments</span>
+<span>analytics</span>
+</div>
+
+<p>Last 24 hours</p>
+
+</section>
+
+<section class="heatmap">
+
+<div class="heat-row">
+<div class="row-label">
+<strong>frontend</strong>
+<span>8 pods</span>
+</div>
+
+<div class="cells">
+<span class="cell stable" title="frontend-01: 0 restarts"></span>
+<span class="cell stable"></span>
+<span class="cell low"></span>
+<span class="cell stable"></span>
+<span class="cell stable"></span>
+<span class="cell low"></span>
+<span class="cell stable"></span>
+<span class="cell stable"></span>
+</div>
+
+<div class="restart-count">2</div>
+</div>
+
+<div class="heat-row">
+<div class="row-label">
+<strong>api-service</strong>
+<span>8 pods</span>
+</div>
+
+<div class="cells">
+<span class="cell stable"></span>
+<span class="cell low"></span>
+<span class="cell medium"></span>
+<span class="cell stable"></span>
+<span class="cell medium"></span>
+<span class="cell low"></span>
+<span class="cell stable"></span>
+<span class="cell medium"></span>
+</div>
+
+<div class="restart-count">9</div>
+</div>
+
+<div class="heat-row">
+<div class="row-label">
+<strong>checkout</strong>
+<span>8 pods</span>
+</div>
+
+<div class="cells">
+<span class="cell low"></span>
+<span class="cell medium"></span>
+<span class="cell high"></span>
+<span class="cell stable"></span>
+<span class="cell medium"></span>
+<span class="cell high"></span>
+<span class="cell low"></span>
+<span class="cell stable"></span>
+</div>
+
+<div class="restart-count warning-text">18</div>
+</div>
+
+<div class="heat-row critical-row">
+<div class="row-label">
+<strong>payment-worker</strong>
+<span>8 pods</span>
+</div>
+
+<div class="cells">
+<span class="cell medium"></span>
+<span class="cell critical"></span>
+<span class="cell high"></span>
+<span class="cell critical"></span>
+<span class="cell medium"></span>
+<span class="cell critical"></span>
+<span class="cell high"></span>
+<span class="cell critical"></span>
+</div>
+
+<div class="restart-count critical-text">47</div>
+</div>
+
+<div class="heat-row">
+<div class="row-label">
+<strong>analytics</strong>
+<span>8 pods</span>
+</div>
+
+<div class="cells">
+<span class="cell stable"></span>
+<span class="cell stable"></span>
+<span class="cell low"></span>
+<span class="cell stable"></span>
+<span class="cell stable"></span>
+<span class="cell medium"></span>
+<span class="cell stable"></span>
+<span class="cell low"></span>
+</div>
+
+<div class="restart-count">5</div>
+</div>
+
+</section>
+
+<section class="legend">
+
+<span><i class="stable"></i>0</span>
+<span><i class="low"></i>1–2</span>
+<span><i class="medium"></i>3–5</span>
+<span><i class="high"></i>6–9</span>
+<span><i class="critical"></i>10+</span>
+
+</section>
+
+<section class="incident">
+
+<div class="incident-icon">!</div>
+
+<div class="incident-content">
+<p>RESTART SPIKE</p>
+<h2>payment-worker-7d9f8</h2>
+<span>Container restarted 12 times in the last hour.</span>
+</div>
+
+<div class="incident-meta">
+<strong>CrashLoopBackOff</strong>
+<span>Last restart 42s ago</span>
+</div>
+
+</section>
+
+</main>
+
+</body>
+</html>

--- a/submissions/examples/ease-kubernetes-pod-restart-heatmap-z1/style.css
+++ b/submissions/examples/ease-kubernetes-pod-restart-heatmap-z1/style.css
@@ -1,0 +1,391 @@
+:root{
+--bg:#080b12;
+--panel:#101722;
+--card:#161f2d;
+--border:#293548;
+--text:#f8fafc;
+--muted:#8795a8;
+
+--stable:#253447;
+--low:#2563eb;
+--medium:#8b5cf6;
+--high:#f59e0b;
+--critical:#f43f5e;
+--green:#34d399;
+}
+
+*{
+margin:0;
+padding:0;
+box-sizing:border-box;
+}
+
+body{
+min-height:100vh;
+display:flex;
+justify-content:center;
+align-items:center;
+padding:30px 18px;
+font-family:Arial,sans-serif;
+color:var(--text);
+background:
+radial-gradient(circle at 75% 0,#25153f 0,transparent 30%),
+var(--bg);
+}
+
+.restart-board{
+width:min(850px,100%);
+padding:28px;
+border:1px solid var(--border);
+border-radius:22px;
+background:rgba(16,23,34,.97);
+box-shadow:0 30px 80px rgba(0,0,0,.4);
+animation:boardEnter .7s ease;
+}
+
+header{
+display:flex;
+justify-content:space-between;
+align-items:center;
+gap:20px;
+margin-bottom:22px;
+}
+
+.eyebrow{
+margin-bottom:7px;
+font-size:10px;
+letter-spacing:2px;
+color:#a78bfa;
+}
+
+h1{
+font-size:27px;
+}
+
+.subtitle{
+margin-top:6px;
+font-size:12px;
+color:var(--muted);
+}
+
+.live{
+display:flex;
+align-items:center;
+gap:8px;
+padding:8px 12px;
+border:1px solid var(--border);
+border-radius:20px;
+font-size:9px;
+letter-spacing:1px;
+}
+
+.live span{
+width:8px;
+height:8px;
+border-radius:50%;
+background:var(--green);
+animation:livePulse 1.5s infinite;
+}
+
+.summary{
+display:grid;
+grid-template-columns:repeat(4,1fr);
+gap:10px;
+margin-bottom:18px;
+}
+
+.summary div{
+padding:13px;
+border:1px solid var(--border);
+border-radius:11px;
+background:#131c29;
+}
+
+.summary strong{
+display:block;
+margin-bottom:4px;
+font-size:19px;
+}
+
+.summary span{
+font-size:9px;
+color:var(--muted);
+}
+
+.danger-stat strong{
+color:var(--critical);
+}
+
+.toolbar{
+display:flex;
+justify-content:space-between;
+align-items:center;
+gap:15px;
+margin-bottom:16px;
+padding:10px 12px;
+border:1px solid var(--border);
+border-radius:10px;
+background:#121b28;
+}
+
+.toolbar > div{
+display:flex;
+gap:7px;
+}
+
+.toolbar span{
+padding:5px 8px;
+border-radius:6px;
+font-size:9px;
+color:var(--muted);
+}
+
+.toolbar .active-filter{
+background:#253247;
+color:#fff;
+}
+
+.toolbar p{
+font-size:9px;
+color:var(--muted);
+}
+
+.heatmap{
+padding:10px 0;
+}
+
+.heat-row{
+display:grid;
+grid-template-columns:130px 1fr 40px;
+align-items:center;
+gap:14px;
+padding:11px;
+border-radius:10px;
+transition:.25s ease;
+}
+
+.heat-row:hover{
+background:#141e2c;
+transform:translateX(3px);
+}
+
+.critical-row{
+background:rgba(244,63,94,.035);
+}
+
+.row-label strong{
+display:block;
+margin-bottom:3px;
+font-size:11px;
+}
+
+.row-label span{
+font-size:8px;
+color:var(--muted);
+}
+
+.cells{
+display:grid;
+grid-template-columns:repeat(8,1fr);
+gap:7px;
+}
+
+.cell{
+height:28px;
+border-radius:6px;
+transition:.2s ease;
+}
+
+.cell:hover{
+transform:scale(1.12);
+filter:brightness(1.25);
+}
+
+.cell.stable,
+.legend .stable{
+background:var(--stable);
+}
+
+.cell.low,
+.legend .low{
+background:var(--low);
+}
+
+.cell.medium,
+.legend .medium{
+background:var(--medium);
+}
+
+.cell.high,
+.legend .high{
+background:var(--high);
+}
+
+.cell.critical,
+.legend .critical{
+background:var(--critical);
+}
+
+.cell.critical{
+animation:criticalPulse 1.4s infinite;
+}
+
+.restart-count{
+text-align:right;
+font-size:11px;
+font-weight:bold;
+color:#aab5c4;
+}
+
+.warning-text{
+color:var(--high);
+}
+
+.critical-text{
+color:var(--critical);
+}
+
+.legend{
+display:flex;
+justify-content:flex-end;
+gap:15px;
+padding:10px 0 18px;
+font-size:8px;
+color:var(--muted);
+}
+
+.legend span{
+display:flex;
+align-items:center;
+gap:5px;
+}
+
+.legend i{
+display:block;
+width:9px;
+height:9px;
+border-radius:3px;
+}
+
+.incident{
+display:grid;
+grid-template-columns:auto 1fr auto;
+align-items:center;
+gap:12px;
+padding:13px;
+border:1px solid rgba(244,63,94,.3);
+border-radius:12px;
+background:rgba(244,63,94,.06);
+}
+
+.incident-icon{
+display:flex;
+justify-content:center;
+align-items:center;
+width:30px;
+height:30px;
+border-radius:50%;
+background:rgba(244,63,94,.13);
+color:var(--critical);
+font-weight:bold;
+}
+
+.incident-content p{
+margin-bottom:3px;
+font-size:8px;
+letter-spacing:1px;
+color:var(--critical);
+}
+
+.incident-content h2{
+margin-bottom:3px;
+font-size:11px;
+}
+
+.incident-content span,
+.incident-meta span{
+font-size:8px;
+color:var(--muted);
+}
+
+.incident-meta{
+text-align:right;
+}
+
+.incident-meta strong{
+display:block;
+margin-bottom:4px;
+font-size:9px;
+color:#fda4af;
+}
+
+@keyframes boardEnter{
+from{
+opacity:0;
+transform:translateY(20px) scale(.98);
+}
+to{
+opacity:1;
+transform:none;
+}
+}
+
+@keyframes livePulse{
+50%{
+box-shadow:0 0 0 7px rgba(52,211,153,.08);
+}
+}
+
+@keyframes criticalPulse{
+50%{
+opacity:.55;
+box-shadow:0 0 10px rgba(244,63,94,.25);
+}
+}
+
+@media(max-width:650px){
+
+.restart-board{
+padding:20px;
+}
+
+.summary{
+grid-template-columns:repeat(2,1fr);
+}
+
+.heat-row{
+grid-template-columns:90px 1fr 25px;
+gap:8px;
+}
+
+.cells{
+gap:4px;
+}
+
+.cell{
+height:21px;
+}
+
+.legend{
+flex-wrap:wrap;
+justify-content:flex-start;
+}
+
+.incident{
+grid-template-columns:auto 1fr;
+}
+
+.incident-meta{
+grid-column:1 / -1;
+text-align:left;
+}
+
+header{
+align-items:flex-start;
+}
+
+h1{
+font-size:22px;
+}
+
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces **Ease Kubernetes Pod Restart Heatmap**, a responsive reliability component for visualizing pod restart activity across Kubernetes workloads.

### Type of Change

* [x] 🧩 New component
* [x] ✨ New animation / hover effect
* [ ] 🐛 Bug fix
* [ ] 📝 Documentation improvement

### Submission Checklist

* [x] All files are inside `submissions/examples/ease-kubernetes-pod-restart-heatmap-z1/`
* [x] Includes `demo.html`
* [x] Includes `style.css`
* [x] Includes `README.md`
* [x] No existing repository files were modified
* [x] One feature per pull request

### Feature Description

The component introduces a heatmap-based Kubernetes reliability interface for identifying pod restart patterns. Different intensity levels represent restart frequency, while critical animations and an incident panel highlight workloads experiencing repeated failures.

### Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [x] Safari

### Notes for Maintainer

* Built with semantic HTML5 and pure CSS.
* Includes heatmap cells, restart intensity states, critical pulse animations, hover interactions, incident information, and responsive behavior.
* No external JavaScript or UI libraries are required.
