### PR TITLE
Add CSS zoom-in tooltip for creative portfolio layouts

### DIFF
--- a/submissions/examples/css-zoom-in-tooltip-portfolio/README.md
+++ b/submissions/examples/css-zoom-in-tooltip-portfolio/README.md
@@ -1,0 +1,46 @@
+# CSS Zoom-In Tooltip
+
+A pure CSS tooltip for portfolio "find me online" icons, with a zoom-in animation on hover or keyboard focus. No JavaScript required.
+
+## Features
+
+- Pure CSS, no dependencies
+- Zoom-in entrance via `@keyframes`
+- Keyboard accessible (`:focus-visible` + `aria-describedby`)
+- Fully responsive (breakpoints at 768px and 480px)
+- Respects `prefers-reduced-motion`
+
+## Usage
+
+Drop `demo.html` and `style.css` into your page. Copy a `.ease-tooltip-wrapper` block to add more icons — just update the glyph, tooltip text, and matching `id`/`aria-describedby` pair.
+
+## Custom Properties
+
+Set in `:root` in `style.css`:
+
+```css
+--ease-tooltip-duration     
+--ease-tooltip-easing      
+--ease-tooltip-radius      
+--ease-tooltip-gap          
+--ease-tooltip-bg          
+--ease-tooltip-border       
+--ease-tooltip-text        
+--ease-tooltip-popup-bg    
+--ease-tooltip-popup-text  
+```
+
+Override to reskin:
+
+```css
+:root {
+  --ease-tooltip-popup-bg: #f97316;
+  --ease-tooltip-duration: 0.15s;
+}
+```
+
+## Files
+
+- `demo.html` — four icon triggers with tooltips
+- `style.css` — styles, custom properties, and zoom-in keyframe
+- `README.md` — this file

--- a/submissions/examples/css-zoom-in-tooltip-portfolio/demo.html
+++ b/submissions/examples/css-zoom-in-tooltip-portfolio/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Zoom-In Tooltip — Creative Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Get In Touch</p>
+    <h1 class="ease-heading">Find Me Online</h1>
+    <p class="ease-subtitle">A pure CSS zoom-in tooltip, styled for a creative portfolio page.</p>
+
+    <div class="ease-tooltip-group">
+
+      <span class="ease-tooltip-wrapper" tabindex="0" aria-describedby="ease-tip-email">
+        <span class="ease-tooltip-trigger" aria-hidden="true">✉</span>
+        <span class="ease-tooltip" role="tooltip" id="ease-tip-email">Email me</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0" aria-describedby="ease-tip-linkedin">
+        <span class="ease-tooltip-trigger" aria-hidden="true">in</span>
+        <span class="ease-tooltip" role="tooltip" id="ease-tip-linkedin">LinkedIn</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0" aria-describedby="ease-tip-github">
+        <span class="ease-tooltip-trigger" aria-hidden="true">GH</span>
+        <span class="ease-tooltip" role="tooltip" id="ease-tip-github">GitHub</span>
+      </span>
+
+      <span class="ease-tooltip-wrapper" tabindex="0" aria-describedby="ease-tip-portfolio">
+        <span class="ease-tooltip-trigger" aria-hidden="true">🖼</span>
+        <span class="ease-tooltip" role="tooltip" id="ease-tip-portfolio">Portfolio</span>
+      </span>
+
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-zoom-in-tooltip-portfolio/style.css
+++ b/submissions/examples/css-zoom-in-tooltip-portfolio/style.css
@@ -1,0 +1,179 @@
+:root {
+  --ease-tooltip-duration: 0.2s;
+  --ease-tooltip-easing: ease;
+  --ease-tooltip-radius: 8px;
+  --ease-tooltip-gap: 1rem;
+  --ease-tooltip-bg: #16181d;
+  --ease-tooltip-border: #2a2d34;
+  --ease-tooltip-text: #f0f0f0;
+  --ease-tooltip-popup-bg: #6c63ff;
+  --ease-tooltip-popup-text: #0f1115;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-tooltip-text);
+  padding: 5rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-tooltip-popup-bg);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 3rem;
+  font-size: 0.95rem;
+}
+
+.ease-tooltip-group {
+  display: flex;
+  gap: var(--ease-tooltip-gap);
+}
+
+.ease-tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.ease-tooltip-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid var(--ease-tooltip-border);
+  background: var(--ease-tooltip-bg);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color var(--ease-tooltip-duration) var(--ease-tooltip-easing);
+}
+
+.ease-tooltip-wrapper:hover .ease-tooltip-trigger,
+.ease-tooltip-wrapper:focus-visible .ease-tooltip-trigger {
+  border-color: var(--ease-tooltip-popup-bg);
+}
+
+/* Tooltip bubble: hidden by default, zoomed-in entrance on hover/focus */
+.ease-tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.6);
+  transform-origin: bottom center;
+  background: var(--ease-tooltip-popup-bg);
+  color: var(--ease-tooltip-popup-text);
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--ease-tooltip-radius);
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--ease-tooltip-duration) var(--ease-tooltip-easing),
+    opacity var(--ease-tooltip-duration) var(--ease-tooltip-easing);
+}
+
+.ease-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--ease-tooltip-popup-bg);
+}
+
+/* Keyframe zoom-in, applied once the tooltip becomes visible */
+@keyframes ease-tooltip-zoom-in {
+  from {
+    transform: translateX(-50%) scale(0.6);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(-50%) scale(1);
+    opacity: 1;
+  }
+}
+
+.ease-tooltip-wrapper:hover .ease-tooltip,
+.ease-tooltip-wrapper:focus-visible .ease-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+  animation: ease-tooltip-zoom-in var(--ease-tooltip-duration) var(--ease-tooltip-easing) forwards;
+}
+
+.ease-tooltip-wrapper:focus-visible {
+  outline: none;
+}
+
+.ease-tooltip-wrapper:focus-visible .ease-tooltip-trigger {
+  outline: 2px solid var(--ease-tooltip-popup-bg);
+  outline-offset: 2px;
+}
+
+/* Responsive breakpoints */
+@media (max-width: 768px) {
+  body {
+    padding: 3rem 1.25rem;
+  }
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+  .ease-tooltip-group {
+    gap: 0.75rem;
+  }
+  .ease-tooltip-trigger {
+    width: 42px;
+    height: 42px;
+    font-size: 0.75rem;
+  }
+}
+
+/* Respect reduced motion: no zoom, no keyframe, instant show/hide */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip {
+    transition: none !important;
+  }
+  .ease-tooltip-wrapper:hover .ease-tooltip,
+  .ease-tooltip-wrapper:focus-visible .ease-tooltip {
+    animation: none !important;
+    transform: translateX(-50%) scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS zoom-in tooltip component styled for creative portfolio "find me online" icon rows, as requested in #54556. Closes #54556.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-in-tooltip-portfolio/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A zoom-in tooltip that scales and fades in on hover or keyboard focus, anchored to circular icon triggers in a portfolio contact row.

**How does a developer use it?**
```html
<span class="ease-tooltip-wrapper" tabindex="0" aria-describedby="ease-tip-email">
  <span class="ease-tooltip-trigger" aria-hidden="true">✉</span>
  <span class="ease-tooltip" role="tooltip" id="ease-tip-email">Email me</span>
</span>
```

**Why does it fit EaseMotion CSS?**
It's pure CSS, animation-first (`@keyframes` zoom-in with a `transform-origin` anchor for a natural "grows from the source" feel), uses the `ease-` class convention, and stays human-readable — no JS, no build step, just semantic classes anyone can drop in and reskin via custom properties.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Includes `aria-describedby` wiring between each trigger and its tooltip, `:focus-visible` (not plain `:focus`) so the tooltip only shows on keyboard nav, and full `prefers-reduced-motion` support disabling both the transition and the keyframe animation.