### PR TITLE
fix(announce-bar): correct broken keyframe reference for entrance animation

### DIFF
--- a/components/announce-bar.css
+++ b/components/announce-bar.css
@@ -6,7 +6,7 @@
     color: #fff;
     text-align: center;
     font-size: 0.875rem;
-    animation: ease-slide-down 0.3s ease;
+    animation: ease-kf-slide-down 0.3s ease;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary

This PR fixes a broken animation in the `announce-bar` component by updating its `animation` property to reference the correct keyframe.

The change restores the intended slide-down entrance animation while keeping the implementation fully aligned with the framework's existing `ease-kf-*` naming convention.

---

## Problem

The announce bar references `ease-slide-down` as a keyframe name, but no keyframe with that name exists.

Instead, the framework defines the animation as `ease-kf-slide-down`. Because of this mismatch, browsers silently ignore the animation, causing the announce bar to appear instantly rather than animating into view.

---

## Solution

Updated the animation declaration to use the correct keyframe:

```css
animation: ease-kf-slide-down 0.3s ease;
```

This is a minimal, targeted fix that restores the intended behavior without affecting any existing APIs or component styling.

---

## Changes Made

- Fixed the announce bar's entrance animation keyframe reference
- Aligned the component with the framework's `ease-kf-*` keyframe naming convention
- Restored the intended slide-down animation
- No behavioral changes outside this bug fix

---

## Testing

- ✅ CSS lint passes
- ✅ Production build succeeds
- ✅ Smoke tests pass
- ✅ Engine tests pass
- ✅ Verified the correct keyframe exists in the generated build
- ✅ Confirmed the diff only contains the intended one-line fix

---

## Checklist

- [x] Lint passes
- [x] Tests pass
- [x] Build passes
- [x] No breaking changes
- [x] Minimal, focused fix