### PR TITLE
feat: add CSS fade-in card grid for creative portfolio layouts (#54524)

### DIFF
--- a/submissions/examples/fade-in-card-grid/README.md
+++ b/submissions/examples/fade-in-card-grid/README.md
@@ -1,0 +1,44 @@
+# CSS Fade-In Card Grid
+
+A pure CSS portfolio grid where each card fades in and settles into place on load, one after another. No JavaScript, no dependencies.
+
+## How it works
+
+Each `.ease-card` runs the same `@keyframes` fade-up animation, but `nth-child` selectors give each one a slightly later `animation-delay`, so instead of all six cards appearing at once, they roll in left to right, row by row.
+
+Thumbnails use a CSS gradient instead of real images, since this is meant as a drop-in placeholder — swap `.ease-card-thumb` for an `<img>` in real use.
+
+## Files
+
+- `demo.html` – a 6-card portfolio grid
+- `style.css` – grid layout, custom properties, and the stagger animation
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-grid-duration` – 0.6s
+- `--ease-grid-easing` – ease-out
+- `--ease-grid-radius` – 12px
+- `--ease-grid-gap` – space between cards
+- `--ease-grid-bg` – card background
+- `--ease-grid-border` – card border color
+- `--ease-grid-text` – title text color
+- `--ease-grid-muted-text` – description text color
+- `--ease-grid-thumb-start` / `--ease-grid-thumb-end` – gradient colors for the thumbnail placeholder
+
+Example override:
+
+```css
+:root {
+  --ease-grid-thumb-start: #f97316;
+  --ease-grid-thumb-end: #7c2d12;
+}
+```
+
+## Notes
+
+- Grid drops from 3 columns to 2 at 768px, and to 1 at 480px
+- Respects `prefers-reduced-motion` — cards appear instantly at full opacity with no stagger for users who have that set
+- Dark theme matches the rest of the portfolio-style submissions in this batch, and is fully re-themeable through the custom properties above

--- a/submissions/examples/fade-in-card-grid/demo.html
+++ b/submissions/examples/fade-in-card-grid/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Fade-In Card Grid — Creative Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Selected Work</p>
+    <h1 class="ease-heading">Portfolio Grid</h1>
+    <p class="ease-subtitle">Cards fade in one after another on load, pure CSS.</p>
+
+    <div class="ease-card-grid">
+      <article class="ease-card">
+        <div class="ease-card-thumb"></div>
+        <h2 class="ease-card-title">Brand Identity</h2>
+        <p class="ease-card-desc">Visual identity system for a design studio.</p>
+      </article>
+
+      <article class="ease-card">
+        <div class="ease-card-thumb"></div>
+        <h2 class="ease-card-title">Mobile App</h2>
+        <p class="ease-card-desc">UI and interaction design for a fitness app.</p>
+      </article>
+
+      <article class="ease-card">
+        <div class="ease-card-thumb"></div>
+        <h2 class="ease-card-title">Web Platform</h2>
+        <p class="ease-card-desc">Marketing site and dashboard redesign.</p>
+      </article>
+
+      <article class="ease-card">
+        <div class="ease-card-thumb"></div>
+        <h2 class="ease-card-title">Packaging</h2>
+        <p class="ease-card-desc">Product packaging concept for a retail launch.</p>
+      </article>
+
+      <article class="ease-card">
+        <div class="ease-card-thumb"></div>
+        <h2 class="ease-card-title">Illustration</h2>
+        <p class="ease-card-desc">Editorial illustration series for print.</p>
+      </article>
+
+      <article class="ease-card">
+        <div class="ease-card-thumb"></div>
+        <h2 class="ease-card-title">Motion Reel</h2>
+        <p class="ease-card-desc">Short-form motion graphics showcase.</p>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fade-in-card-grid/style.css
+++ b/submissions/examples/fade-in-card-grid/style.css
@@ -1,0 +1,137 @@
+:root {
+  --ease-grid-duration: 0.6s;
+  --ease-grid-easing: ease-out;
+  --ease-grid-radius: 12px;
+  --ease-grid-gap: 1.25rem;
+  --ease-grid-bg: #16181d;
+  --ease-grid-border: #2a2d34;
+  --ease-grid-text: #f0f0f0;
+  --ease-grid-muted-text: #a8a8a8;
+  --ease-grid-thumb-start: #6c63ff;
+  --ease-grid-thumb-end: #3730a3;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-grid-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-grid-thumb-start);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--ease-grid-gap);
+}
+
+.ease-card {
+  border: 1px solid var(--ease-grid-border);
+  border-radius: var(--ease-grid-radius);
+  background: var(--ease-grid-bg);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: ease-grid-fade-in var(--ease-grid-duration) var(--ease-grid-easing) both;
+}
+
+.ease-card-thumb {
+  height: 120px;
+  background: linear-gradient(135deg, var(--ease-grid-thumb-start), var(--ease-grid-thumb-end));
+}
+
+.ease-card-title {
+  margin: 1rem 1rem 0.25rem;
+  font-size: 1rem;
+}
+
+.ease-card-desc {
+  margin: 0 1rem 1rem;
+  font-size: 0.85rem;
+  color: var(--ease-grid-muted-text);
+  line-height: 1.5;
+}
+
+/* stagger each card's entrance a bit after the last */
+.ease-card:nth-child(1) { animation-delay: 0.05s; }
+.ease-card:nth-child(2) { animation-delay: 0.15s; }
+.ease-card:nth-child(3) { animation-delay: 0.25s; }
+.ease-card:nth-child(4) { animation-delay: 0.35s; }
+.ease-card:nth-child(5) { animation-delay: 0.45s; }
+.ease-card:nth-child(6) { animation-delay: 0.55s; }
+
+@keyframes ease-grid-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .ease-card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-card {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML fade-in card grid component styled as a "selected work" portfolio section, per issue #54524.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-fade-in-card-grid/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A responsive portfolio card grid where each card fades and slides up into place on load, staggered one after another.

**How does a developer use it?**
```html
<div class="ease-card-grid">
  <article class="ease-card">
    <div class="ease-card-thumb"></div>
    <h2 class="ease-card-title">Project Title</h2>
    <p class="ease-card-desc">Short description.</p>
  </article>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-card-grid`, `ease-card-thumb`), zero dependencies, and the staggered entrance is a reusable `@keyframes` pattern driven purely through `nth-child` delays. Fully theme-able through CSS custom properties, and the grid collapses responsively from 3 to 2 to 1 columns.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Thumbnails use a CSS gradient as a placeholder rather than real images, since this is meant as a drop-in template — swap `.ease-card-thumb` for an `<img>` in real use. Respects `prefers-reduced-motion`.