### PR TITLE
feat: add CSS Ripple Wave Tabs example (#54219)

### DIFF
--- a/submissions/examples/ripple-wave-tabs/README.md
+++ b/submissions/examples/ripple-wave-tabs/README.md
@@ -1,0 +1,45 @@
+# Ripple Wave Tabs
+
+A responsive Ripple Wave Tabs component built using only HTML and CSS.
+
+## Features
+
+- Pure HTML & CSS
+- Ripple-wave hover animation
+- Responsive layout
+- Keyboard accessible
+- `prefers-reduced-motion` support
+- No JavaScript required
+
+## Folder Structure
+
+```
+ripple-wave-tabs/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+Open `demo.html` in your browser and hover or focus on the tabs.
+
+## CSS Variables
+
+```css
+--primary
+--bg
+--text
+--radius
+--duration
+```
+
+## Accessibility
+
+- Keyboard focus support
+- Responsive design
+- Reduced motion support
+
+## License
+
+MIT

--- a/submissions/examples/ripple-wave-tabs/demo.html
+++ b/submissions/examples/ripple-wave-tabs/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ripple Wave Tabs</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="tabs">
+  <button class="tab active">Home</button>
+  <button class="tab">Services</button>
+  <button class="tab">Portfolio</button>
+  <button class="tab">Contact</button>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/ripple-wave-tabs/style.css
+++ b/submissions/examples/ripple-wave-tabs/style.css
@@ -1,0 +1,81 @@
+:root{
+    --primary:#2563eb;
+    --bg:#f3f6ff;
+    --text:#222;
+    --radius:12px;
+    --duration:.35s;
+  }
+  
+  *{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+  }
+  
+  body{
+    font-family:Arial,sans-serif;
+    background:var(--bg);
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    min-height:100vh;
+  }
+  
+  .tabs{
+    display:flex;
+    gap:1rem;
+    flex-wrap:wrap;
+  }
+  
+  .tab{
+    position:relative;
+    overflow:hidden;
+    border:none;
+    cursor:pointer;
+    padding:14px 28px;
+    border-radius:var(--radius);
+    background:#fff;
+    color:var(--text);
+    transition:all var(--duration);
+  }
+  
+  .tab::before{
+    content:"";
+    position:absolute;
+    width:0;
+    height:0;
+    border-radius:50%;
+    background:rgba(37,99,235,.25);
+    top:50%;
+    left:50%;
+    transform:translate(-50%,-50%);
+    transition:.55s;
+  }
+  
+  .tab:hover::before,
+  .tab:focus-visible::before{
+    width:260px;
+    height:260px;
+  }
+  
+  .tab:hover,
+  .tab:focus-visible,
+  .tab.active{
+    color:#fff;
+    background:var(--primary);
+  }
+  
+  @media(max-width:600px){
+    .tabs{
+      justify-content:center;
+    }
+  }
+  
+  @media(prefers-reduced-motion:reduce){
+    *,
+    *::before,
+    *::after{
+      animation:none!important;
+      transition:none!important;
+    }
+  }


### PR DESCRIPTION
## Pull Request Description

### Summary
This PR adds a **CSS Ripple-Wave Tabs** example for accessible web layouts using only HTML and CSS.

### Changes Made
- Added `demo.html` showcasing Ripple-Wave Tabs.
- Added `style.css` with a smooth ripple-wave hover animation.
- Added `README.md` with usage instructions, CSS custom properties, features, and accessibility notes.

### Features
- Pure HTML & CSS (No JavaScript)
- Smooth ripple-wave hover/focus animation
- Responsive design
- Keyboard accessible
- `prefers-reduced-motion` support
- Lightweight and reusable component

### Folder Structure

```
submissions/
└── examples/
    └── ripple-wave-tabs/
        ├── demo.html
        ├── style.css
        └── README.md
```

### Checklist

- [x] Pure HTML & CSS
- [x] Responsive
- [x] Accessible
- [x] Reduced motion support
- [x] Documentation included

Fixes #54219