### PR TITLE
feat: add CSS Zoom-In Tabs example (#54211)

### DIFF
--- a/submissions/examples/zoom-in-tabs/README.md
+++ b/submissions/examples/zoom-in-tabs/README.md
@@ -1,0 +1,45 @@
+# Zoom-In Tabs
+
+A responsive **Zoom-In Tabs** component built using pure HTML and CSS.
+
+## Features
+
+- Pure HTML & CSS
+- Smooth zoom hover effect
+- Responsive design
+- Keyboard accessible
+- `prefers-reduced-motion` support
+- No JavaScript required
+
+## Folder Structure
+
+```
+zoom-in-tabs/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## CSS Variables
+
+```css
+--primary
+--background
+--text
+--radius
+--duration
+```
+
+## Accessibility
+
+- Keyboard focus support
+- Responsive layout
+- Reduced motion support
+
+## License
+
+MIT

--- a/submissions/examples/zoom-in-tabs/demo.html
+++ b/submissions/examples/zoom-in-tabs/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zoom-In Tabs</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="tabs">
+    <button class="tab active">Home</button>
+    <button class="tab">About</button>
+    <button class="tab">Services</button>
+    <button class="tab">Contact</button>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-tabs/style.css
+++ b/submissions/examples/zoom-in-tabs/style.css
@@ -1,0 +1,65 @@
+:root{
+    --primary:#2563eb;
+    --background:#f4f7ff;
+    --text:#222;
+    --radius:12px;
+    --duration:.3s;
+}
+
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    min-height:100vh;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    background:var(--background);
+    font-family:Arial,sans-serif;
+}
+
+.tabs{
+    display:flex;
+    gap:1rem;
+    flex-wrap:wrap;
+}
+
+.tab{
+    border:none;
+    cursor:pointer;
+    padding:14px 28px;
+    border-radius:var(--radius);
+    background:#fff;
+    color:var(--text);
+    transition:transform var(--duration), background var(--duration), color var(--duration);
+}
+
+.tab:hover,
+.tab:focus-visible{
+    transform:scale(1.12);
+    background:var(--primary);
+    color:#fff;
+}
+
+.tab.active{
+    background:var(--primary);
+    color:#fff;
+}
+
+@media(max-width:600px){
+    .tabs{
+        justify-content:center;
+    }
+}
+
+@media(prefers-reduced-motion:reduce){
+    *,
+    *::before,
+    *::after{
+        animation:none!important;
+        transition:none!important;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

### Summary

This PR adds a **CSS Zoom-In Tabs** example for accessible web layouts using pure HTML and CSS.

### Changes Made

- Added `demo.html`
- Added `style.css`
- Added `README.md`
- Smooth zoom-in hover animation
- Responsive design
- Keyboard accessibility
- `prefers-reduced-motion` support

### Folder Structure

```
submissions/
└── examples/
    └── zoom-in-tabs/
        ├── demo.html
        ├── style.css
        └── README.md
```

### Checklist

- [x] Pure HTML & CSS
- [x] Responsive layout
- [x] Accessible interactions
- [x] Reduced motion support
- [x] Documentation included

Fixes #54211