### PR TITLE
feat(submission): add floating action button (FAB) with menu reveal 

### DIFF
--- a/submissions/examples/fab-radial-menu-55584/README.md
+++ b/submissions/examples/fab-radial-menu-55584/README.md
@@ -1,0 +1,22 @@
+# Floating Action Button (FAB) with Menu Reveal
+
+## What does this do?
+Provides a CSS-only Floating Action Button that stays fixed at the bottom right of the screen. When hovered, the main button rotates into a close icon (`+` to `x`), and smoothly reveals a vertical menu of secondary action buttons cascading upwards.
+
+## How is it used?
+```html
+<div class="ease-fab-container">
+    <button class="ease-fab-main">+</button>
+    <div class="ease-fab-menu">
+        <button class="ease-fab-item">A</button>
+        <button class="ease-fab-item">B</button>
+    </div>
+</div>
+```
+
+## Why does it fit EaseMotion CSS?
+Floating Action Buttons (FABs) are a staple of modern web applications. This implementation relies entirely on CSS hover states and `cubic-bezier` transitions to create an organic, bouncy reveal effect without any JavaScript state management.
+
+## Tech Stack
+- HTML
+- CSS (No JavaScript)

--- a/submissions/examples/fab-radial-menu-55584/demo.html
+++ b/submissions/examples/fab-radial-menu-55584/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FAB Radial Menu Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background-color: #f8fafc;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hover the bottom-right button</h1>
+
+    <div class="ease-fab-container">
+        <!-- Main Button -->
+        <button class="ease-fab-main">+</button>
+
+        <!-- Menu Items -->
+        <div class="ease-fab-menu">
+            <button class="ease-fab-item">A</button>
+            <button class="ease-fab-item">B</button>
+            <button class="ease-fab-item">C</button>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/fab-radial-menu-55584/style.css
+++ b/submissions/examples/fab-radial-menu-55584/style.css
@@ -1,0 +1,69 @@
+.ease-fab-container {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 50;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: 1rem;
+}
+
+.ease-fab-main {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #6366f1;
+  color: white;
+  border: none;
+  box-shadow: 0 4px 10px rgba(99, 102, 241, 0.4);
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 24px;
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  z-index: 2;
+}
+
+.ease-fab-container:hover .ease-fab-main {
+  transform: rotate(45deg);
+  background: #4f46e5;
+}
+
+.ease-fab-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(20px) scale(0.8);
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.ease-fab-container:hover .ease-fab-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+.ease-fab-item {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: white;
+  color: #333;
+  border: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 18px;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.ease-fab-item:hover {
+  transform: scale(1.1);
+  background: #f8fafc;
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves #55584 by adding a CSS-only Floating Action Button (`ease-fab-container`) that stays fixed to the screen and smoothly reveals a vertical menu of secondary action buttons on hover.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Provides a CSS-only Floating Action Button that stays fixed at the bottom right of the screen. When hovered, the main button rotates into a close icon (`+` to `x`), and smoothly reveals a vertical menu of secondary action buttons cascading upwards.

**How does a developer use it?**

```html
<div class="ease-fab-container">
    <button class="ease-fab-main">+</button>
    <div class="ease-fab-menu">
        <button class="ease-fab-item">A</button>
        <button class="ease-fab-item">B</button>
    </div>
</div>