### PR TITLE
feat(submission): add stacked deck card fan-out reveal on hover (#55613)

### DIFF
--- a/submissions/examples/stacked-cards-55613/README.md
+++ b/submissions/examples/stacked-cards-55613/README.md
@@ -1,0 +1,21 @@
+# Stacked Deck Card Fan-Out Reveal
+
+## What does this do?
+Creates a component where 3 cards are stacked on top of each other (like a deck of playing cards). When the user hovers over the container, the cards beautifully fan out radially using `transform: rotate()` and `translate()`.
+
+## How is it used?
+```html
+<div class="ease-stacked-container">
+    <div class="ease-stacked-card">3</div>
+    <div class="ease-stacked-card">2</div>
+    <div class="ease-stacked-card">1</div>
+</div>
+```
+*(Note: Because of absolute positioning, the last element in the DOM appears on top).*
+
+## Why does it fit EaseMotion CSS?
+It provides a highly tactile, engaging interaction perfect for highlighting portfolios or testimonials. Using `nth-child` selectors and `cubic-bezier` transitions, it requires no JS state management to handle complex overlapping hover states.
+
+## Tech Stack
+- HTML
+- CSS (No JavaScript)

--- a/submissions/examples/stacked-cards-55613/demo.html
+++ b/submissions/examples/stacked-cards-55613/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stacked Deck Fan-Out Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background-color: #f1f5f9;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="ease-stacked-container">
+        <!-- Bottom Card (index 3 visually) -->
+        <div class="ease-stacked-card">3</div>
+        
+        <!-- Middle Card (index 2 visually) -->
+        <div class="ease-stacked-card">2</div>
+        
+        <!-- Top Card (index 1 visually) -->
+        <div class="ease-stacked-card">1</div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/stacked-cards-55613/style.css
+++ b/submissions/examples/stacked-cards-55613/style.css
@@ -1,0 +1,62 @@
+.ease-stacked-container {
+  position: relative;
+  width: 200px;
+  height: 280px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.ease-stacked-card {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.4s ease;
+  transform-origin: bottom center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  color: white;
+  font-weight: bold;
+}
+
+/* Base un-hovered stack state */
+.ease-stacked-card:nth-child(1) {
+  background: linear-gradient(135deg, #f43f5e, #fb923c);
+  z-index: 3;
+  transform: rotate(0deg) translateY(0);
+}
+
+.ease-stacked-card:nth-child(2) {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  z-index: 2;
+  transform: rotate(4deg) translateY(-5px) scale(0.95);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.ease-stacked-card:nth-child(3) {
+  background: linear-gradient(135deg, #10b981, #3b82f6);
+  z-index: 1;
+  transform: rotate(8deg) translateY(-10px) scale(0.9);
+  box-shadow: 0 4px 5px rgba(0, 0, 0, 0.02);
+}
+
+/* Hovered fan-out state */
+.ease-stacked-container:hover .ease-stacked-card:nth-child(1) {
+  transform: rotate(-15deg) translateY(-10px) translateX(-20px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+.ease-stacked-container:hover .ease-stacked-card:nth-child(2) {
+  transform: rotate(0deg) translateY(-20px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+.ease-stacked-container:hover .ease-stacked-card:nth-child(3) {
+  transform: rotate(15deg) translateY(-10px) translateX(20px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves #55613 by adding an `ease-stacked-container` component that seamlessly fans out overlapping cards radially upon hover using pure CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Creates a component where 3 cards are stacked on top of each other (like a deck of playing cards). When the user hovers over the container, the cards beautifully fan out radially using `transform: rotate()` and `translate()`.

**How does a developer use it?**

```html
<div class="ease-stacked-container">
    <div class="ease-stacked-card">3</div>
    <div class="ease-stacked-card">2</div>
    <div class="ease-stacked-card">1</div>
</div>