### PR TITLE
feat(submission): add css-only particle burst button on click (#55617)

### DIFF
--- a/submissions/examples/particle-burst-55617/README.md
+++ b/submissions/examples/particle-burst-55617/README.md
@@ -1,0 +1,16 @@
+# CSS-Only Particle Burst Button
+
+## What does this do?
+A button that shoots out a burst of "particles" or confetti when clicked. While this usually requires JavaScript, it can be achieved in pure CSS using the `:active` state and complex, multi-layered `box-shadow` animations that expand outward and fade.
+
+## How is it used?
+```html
+<button class="ease-btn-particle">Click Me 🎉</button>
+```
+
+## Why does it fit EaseMotion CSS?
+It relies entirely on the CSS `:active` pseudo-class and highly optimized `box-shadow` manipulations to create a gamified micro-interaction. It's extremely satisfying to click and delightfully avoids heavy canvas or DOM element injections for particles.
+
+## Tech Stack
+- HTML
+- CSS (No JavaScript)

--- a/submissions/examples/particle-burst-55617/demo.html
+++ b/submissions/examples/particle-burst-55617/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Particle Burst Button Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background-color: #f8fafc;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+    </style>
+</head>
+<body>
+    <button class="ease-btn-particle">Click Me 🎉</button>
+</body>
+</html>

--- a/submissions/examples/particle-burst-55617/style.css
+++ b/submissions/examples/particle-burst-55617/style.css
@@ -1,0 +1,61 @@
+.ease-btn-particle {
+  position: relative;
+  appearance: none;
+  background: #f43f5e;
+  padding: 12px 24px;
+  border: none;
+  color: white;
+  font-size: 1.1rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  outline: none;
+  z-index: 2;
+  transition: transform 0.1s ease;
+}
+
+.ease-btn-particle:active {
+  transform: scale(0.95);
+}
+
+.ease-btn-particle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  z-index: -1;
+  pointer-events: none;
+  background-color: transparent;
+  transition: all 0.3s ease;
+}
+
+.ease-btn-particle:active::before {
+  /* Complex box-shadow to simulate multiple particles flying out */
+  box-shadow: 
+    -30px -40px 0 0 rgba(244, 63, 94, 0.8),
+    40px -30px 0 0 rgba(244, 63, 94, 0.6),
+    35px 35px 0 0 rgba(244, 63, 94, 0.4),
+    -40px 30px 0 0 rgba(244, 63, 94, 0.7),
+    -10px -50px 0 0 rgba(244, 63, 94, 0.5),
+    50px 10px 0 0 rgba(244, 63, 94, 0.9),
+    10px 50px 0 0 rgba(244, 63, 94, 0.3),
+    -50px -10px 0 0 rgba(244, 63, 94, 0.8);
+  animation: ease-particle-burst 0.5s ease-out forwards;
+}
+
+@keyframes ease-particle-burst {
+  0% {
+    width: 100%;
+    height: 100%;
+    opacity: 1;
+  }
+  100% {
+    width: 200%;
+    height: 250%;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves #55617 by adding an `ease-btn-particle` component that utilizes an advanced `box-shadow` animation to simulate a gamified particle burst effect on click.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A button that shoots out a burst of "particles" or confetti when clicked. While this usually requires JavaScript, it can be achieved in pure CSS using the `:active` state and complex, multi-layered `box-shadow` animations that expand outward and fade.

**How does a developer use it?**

```html
<button class="ease-btn-particle">Click Me 🎉</button>