### PR TITLE
fix: remove unreachable dead code in modal.js

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -25,10 +25,6 @@
 
           const modal = overlay.querySelector('.ease-modal');
           if (modal) {
-            if (!overlay.classList.contains('is-active')) {
-              previousFocusedElement = document.activeElement;
-            }
-
             modal.setAttribute('tabindex', '-1');
             modal.focus();
           }


### PR DESCRIPTION
## 📝 Description

This PR removes an unreachable dead code block from the `checkModal()` function in `modal.js`.

The removed conditional could never execute because the `is-active` class is added to the overlay immediately before the check, making the condition always evaluate to `false`. Additionally, `previousFocusedElement` had already been assigned earlier in the function, making the reassignment unnecessary.

## 🔧 Changes Made

- Removed unreachable conditional block in `checkModal()`.
- Eliminated redundant assignment to `previousFocusedElement`.
- Removed the unnecessary blank line left after the deletion.
- Preserved all existing modal functionality.

## 🐛 Issue Fixed

### Problem

The following code was unreachable:

```javascript
if (!overlay.classList.contains('is-active')) {
  previousFocusedElement = document.activeElement;
}
```

### Root Cause

- `overlay.classList.add('is-active')` is called immediately before this condition.
- Therefore, `overlay.classList.contains('is-active')` always returns `true`.
- `previousFocusedElement` was already assigned before adding the class.

## ✅ Impact

- Removes dead code.
- Improves readability and maintainability.
- No functional or behavioral changes.

## 🧪 Testing

- [x] Project builds successfully.
- [x] Modal functionality remains unchanged.
- [x] No new files were added.
- [x] Existing behavior verified after the cleanup.

## 📷 Screenshots

N/A (code cleanup only).

## Checklist

- [x] Code follows the project's coding style.
- [x] No new files created.
- [x] No breaking changes introduced.
- [x] Changes are minimal and focused.