### PR TITLE
fix: resolve dropdown closing on scrollbar click

### DIFF
--- a/submissions/examples/dropdown-scrollbar-fix/README.md
+++ b/submissions/examples/dropdown-scrollbar-fix/README.md
@@ -1,0 +1,29 @@
+# Dropdown Scrollbar Fix
+
+## Description
+
+This example demonstrates a scrollable dropdown menu that remains open while users interact with its scrollbar.
+
+## Problem
+
+Scrollable dropdowns may close unexpectedly when users try to scroll through long lists, making item selection difficult.
+
+## Solution
+
+- Added a scrollable dropdown using:
+  ```css
+  max-height: 180px;
+  overflow-y: auto;
+  ```
+- Kept the dropdown open during interactions inside the dropdown.
+- Closed the dropdown only when clicking outside it.
+
+## Usage
+
+Open `demo.html` in a browser and click the button to view the scrollable dropdown.
+
+## Benefits
+
+- Better usability
+- Improved handling of long option lists
+- Responsive and lightweight implementation

--- a/submissions/examples/dropdown-scrollbar-fix/demo.html
+++ b/submissions/examples/dropdown-scrollbar-fix/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown Scrollbar Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="dropdown">
+  <button class="dropdown-btn" onclick="toggleDropdown()">
+    Select Option
+  </button>
+
+  <div class="dropdown-menu" id="dropdownMenu">
+    <div class="item">Option 1</div>
+    <div class="item">Option 2</div>
+    <div class="item">Option 3</div>
+    <div class="item">Option 4</div>
+    <div class="item">Option 5</div>
+    <div class="item">Option 6</div>
+    <div class="item">Option 7</div>
+    <div class="item">Option 8</div>
+    <div class="item">Option 9</div>
+    <div class="item">Option 10</div>
+    <div class="item">Option 11</div>
+    <div class="item">Option 12</div>
+  </div>
+</div>
+
+<script>
+const dropdown = document.getElementById("dropdownMenu");
+
+function toggleDropdown() {
+  dropdown.classList.toggle("show");
+}
+
+document.addEventListener("click", function (e) {
+  if (!e.target.closest(".dropdown")) {
+    dropdown.classList.remove("show");
+  }
+});
+</script>
+
+</body>
+</html>

--- a/submissions/examples/dropdown-scrollbar-fix/style.css
+++ b/submissions/examples/dropdown-scrollbar-fix/style.css
@@ -1,0 +1,50 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  padding: 40px;
+}
+
+.dropdown {
+  position: relative;
+  width: 220px;
+}
+
+.dropdown-btn {
+  width: 100%;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+
+  width: 100%;
+  max-height: 180px;
+
+  overflow-y: auto;
+
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+
+  z-index: 1000;
+}
+
+.dropdown-menu.show {
+  display: block;
+}
+
+.item {
+  padding: 10px;
+  cursor: pointer;
+}
+
+.item:hover {
+  background: #f5f5f5;
+}


### PR DESCRIPTION
## Pull Request Description

Added a bug fix example demonstrating a scrollable dropdown that remains open while users interact with its scrollbar. This improves usability for long dropdown menus and prevents accidental closure during scrolling.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a scrollable dropdown example that supports long option lists without interrupting user interaction.

**How does a developer use it?**

```html
<div class="dropdown">
  <button class="dropdown-btn">Open Menu</button>

  <div class="dropdown-menu">
    <div class="item">Option 1</div>
    <div class="item">Option 2</div>
    <div class="item">Option 3</div>
    <!-- More items -->
  </div>
</div>