### PR TITLE
fix: prevent navbar link wrapping on small screens

### DIFF
--- a/submissions/examples/prevent-navbar-link-wrapping/README.md
+++ b/submissions/examples/prevent-navbar-link-wrapping/README.md
@@ -1,0 +1,14 @@
+# Prevent Navbar Link Wrapping
+
+## Description
+Fixes a responsive issue where navbar links wrapped onto multiple lines on smaller screens.
+
+## Features
+- Prevents link wrapping using `white-space: nowrap`.
+- Keeps links in a single row.
+- Enables horizontal scrolling when necessary.
+- Responsive across different screen sizes.
+
+## Files
+- `demo.html` – Demo page
+- `style.css` – Navbar styling

--- a/submissions/examples/prevent-navbar-link-wrapping/demo.html
+++ b/submissions/examples/prevent-navbar-link-wrapping/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prevent Navbar Link Wrapping</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav class="navbar">
+    <a href="#">Home</a>
+    <a href="#">About</a>
+    <a href="#">Services</a>
+    <a href="#">Portfolio</a>
+    <a href="#">Contact</a>
+</nav>
+
+</body>
+</html>

--- a/submissions/examples/prevent-navbar-link-wrapping/style.css
+++ b/submissions/examples/prevent-navbar-link-wrapping/style.css
@@ -1,0 +1,44 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, sans-serif;
+}
+
+.navbar {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 15px 20px;
+    background: #222;
+    overflow-x: auto;
+    white-space: nowrap;
+    scrollbar-width: none;
+}
+
+.navbar::-webkit-scrollbar {
+    display: none;
+}
+
+.navbar a {
+    color: #fff;
+    text-decoration: none;
+    white-space: nowrap;
+    flex-shrink: 0;
+    padding: 8px 12px;
+    transition: color 0.3s ease;
+}
+
+.navbar a:hover {
+    color: #00bcd4;
+}
+
+@media (max-width: 768px) {
+    .navbar {
+        gap: 12px;
+        padding: 12px;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a responsive issue where navbar links wrap onto multiple lines on smaller screens. The navbar now maintains a single-line layout using Flexbox and `white-space: nowrap`, with horizontal scrolling enabled when necessary for improved usability.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Fixes navbar link wrapping on small screens by keeping navigation links on a single line while allowing horizontal scrolling when needed.

**How does a developer use it?**

```html
<nav class="navbar">
  <a href="#">Home</a>
  <a href="#">About</a>
  <a href="#">Services</a>
  <a href="#">Portfolio</a>
  <a href="#">Contact</a>
</nav>