### PR TITLE
feat: add search suggestion tray example

### DIFF
--- a/submissions/examples/search-suggestion-tray/README.md
+++ b/submissions/examples/search-suggestion-tray/README.md
@@ -1,0 +1,19 @@
+# Search Suggestion Tray
+
+A CSS-only search surface with an animated input focus ring, sliding suggestion tray, and staggered result cards.
+
+## Features
+
+- Search input with glow and lift states on focus.
+- Staggered suggestion tray reveal using CSS custom properties.
+- Keyboard-friendly links and visible focus outlines.
+- Responsive layout with reduced-motion support.
+
+## Files
+
+- `demo.html` - semantic search form and suggestion list markup.
+- `style.css` - search card layout, focus animation, tray reveal, and responsive styles.
+
+## How to Use
+
+Open `demo.html` in a browser, then focus the search field or suggestion links to preview the interaction states.

--- a/submissions/examples/search-suggestion-tray/demo.html
+++ b/submissions/examples/search-suggestion-tray/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Search Suggestion Tray</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="search-shell">
+    <section class="search-card" aria-label="Search suggestion tray demo">
+      <p class="eyebrow">Command Search</p>
+      <h1>Search Suggestion Tray</h1>
+      <p class="intro">A focused search surface with a glowing input state, staggered suggestions, and keyboard-friendly actions.</p>
+
+      <form class="search-box" role="search">
+        <label class="visually-hidden" for="query">Search workspace</label>
+        <input id="query" type="search" value="motion" aria-label="Search workspace">
+        <button type="button">Search</button>
+      </form>
+
+      <div class="suggestions" aria-label="Suggested results">
+        <a class="suggestion" href="#" style="--index: 0">
+          <span class="icon" aria-hidden="true">UI</span>
+          <span>
+            <strong>Motion tokens</strong>
+            <small>Design system utilities</small>
+          </span>
+        </a>
+        <a class="suggestion" href="#" style="--index: 1">
+          <span class="icon" aria-hidden="true">FX</span>
+          <span>
+            <strong>Hover transitions</strong>
+            <small>Interaction examples</small>
+          </span>
+        </a>
+        <a class="suggestion" href="#" style="--index: 2">
+          <span class="icon" aria-hidden="true">CSS</span>
+          <span>
+            <strong>Animation presets</strong>
+            <small>Reusable easing patterns</small>
+          </span>
+        </a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/search-suggestion-tray/style.css
+++ b/submissions/examples/search-suggestion-tray/style.css
@@ -1,0 +1,235 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 16% 18%, rgba(14, 165, 233, 0.24), transparent 25rem),
+    radial-gradient(circle at 84% 18%, rgba(245, 158, 11, 0.2), transparent 23rem),
+    linear-gradient(135deg, #f8fafc 0%, #e0f2fe 48%, #fff7ed 100%);
+  color: #172033;
+}
+
+.search-shell {
+  width: min(92vw, 820px);
+  padding: 36px 0;
+}
+
+.search-card {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 5vw, 48px);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(18px);
+}
+
+.search-card::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, transparent 0 34%, rgba(255, 255, 255, 0.58) 48%, transparent 62%),
+    radial-gradient(circle at 92% 14%, rgba(20, 184, 166, 0.18), transparent 16rem);
+  opacity: 0.6;
+  transform: translateX(-18%);
+  transition: opacity 720ms ease, transform 720ms ease;
+}
+
+.search-card:focus-within::before,
+.search-card:hover::before {
+  opacity: 0.9;
+  transform: translateX(12%);
+}
+
+.eyebrow {
+  position: relative;
+  margin: 0;
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  position: relative;
+  margin: 8px 0 10px;
+  font-size: clamp(2.1rem, 5vw, 4rem);
+  line-height: 1;
+}
+
+.intro {
+  position: relative;
+  max-width: 58ch;
+  margin: 0 0 30px;
+  color: #475569;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.search-box {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 22px;
+  background: rgba(248, 250, 252, 0.86);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  transition:
+    border-color 260ms ease,
+    box-shadow 260ms ease,
+    transform 260ms ease;
+}
+
+.search-box:focus-within {
+  border-color: rgba(20, 184, 166, 0.38);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    0 18px 34px rgba(20, 184, 166, 0.16);
+  transform: translateY(-2px);
+}
+
+input {
+  min-height: 50px;
+  width: 100%;
+  border: 0;
+  border-radius: 16px;
+  background: #ffffff;
+  color: #0f172a;
+  font: inherit;
+  font-size: 1rem;
+  font-weight: 750;
+  padding: 0 18px;
+  outline: none;
+}
+
+button {
+  min-height: 50px;
+  padding: 0 20px;
+  border: 0;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #14b8a6, #22c55e);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 850;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(20, 184, 166, 0.22);
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  box-shadow: 0 16px 30px rgba(20, 184, 166, 0.28);
+  outline: none;
+  transform: translateY(-2px);
+}
+
+.suggestions {
+  position: relative;
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.suggestion {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  padding: 15px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  color: inherit;
+  text-decoration: none;
+  opacity: 0;
+  transform: translateY(14px) scale(0.98);
+  animation: suggestion-rise 560ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: calc(var(--index) * 90ms + 140ms);
+  transition:
+    border-color 240ms ease,
+    box-shadow 240ms ease,
+    transform 240ms ease;
+}
+
+.suggestion:hover,
+.suggestion:focus-visible {
+  border-color: rgba(20, 184, 166, 0.36);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  outline: none;
+  transform: translateY(-3px);
+}
+
+.icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: rgba(20, 184, 166, 0.12);
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+strong,
+small {
+  display: block;
+}
+
+strong {
+  margin-bottom: 4px;
+}
+
+small {
+  color: #64748b;
+  line-height: 1.4;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@keyframes suggestion-rise {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 640px) {
+  .search-box {
+    grid-template-columns: 1fr;
+    border-radius: 18px;
+  }
+
+  button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add the Search Suggestion Tray CSS-only example
- include a focused search form with animated suggestion cards and accessible focus states
- document the files and usage in the example README

## Validation
- git diff --cached --name-status
- git diff --cached --check