### PR TITLE
Add shimmer skeleton loading card demo (shimmer-skeleton-loader-hr18)

### DIFF
--- a/submissions/examples/shimmer-skeleton-loader-hr18/README.md
+++ b/submissions/examples/shimmer-skeleton-loader-hr18/README.md
@@ -1,0 +1,84 @@
+# Shimmer Skeleton Loading Card (`shimmer-skeleton-loader-hr18`)
+
+A self-contained HTML/CSS demo of a modern skeleton loading card with a
+shimmering gradient sweep, built for issue
+[#55712](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55712).
+
+## A note on naming
+
+The issue asks for the demo under `submissions/examples/shimmer-skeleton-loader/`
+with `index.html` and `style.css` — this submission uses those exact
+filenames, but with a `-hr18` folder suffix
+(`shimmer-skeleton-loader-hr18`) rather than the bare name. Three people
+are assigned to this issue, including the reporter, who may well submit
+under the exact literal folder name from their own issue text — the suffix
+here just avoids a collision with that. `README.md` is added on top of the
+two requested files for consistency with the rest of this repo's
+submissions.
+
+## What it does
+
+Two skeleton card variants — a product-card layout (rectangular thumbnail,
+title, subtitle, price line, button) and a profile-card layout (circular
+avatar, centered title/subtitle, button) — each built from reusable
+placeholder "bone" shapes. Every bone carries a moving shimmer: a gradient
+band three times the element's own width, animated by sliding its
+`background-position` from one edge to the other, so only a thin bright
+highlight is ever visible sweeping across the shape at once.
+
+## Installation
+
+Nothing to install — `index.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+Apply `ssl-bone-hr18 ssl-shimmer-hr18` to any placeholder shape, then a
+sizing class for that shape:
+
+```html
+<div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-thumb-hr18"></div>
+<div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 title"></div>
+<div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 subtitle"></div>
+<div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-button-hr18"></div>
+```
+
+`ssl-bone-hr18` sets the flat placeholder color and rounded corners;
+`ssl-shimmer-hr18` adds the animated gradient sweep on top. They're kept
+separate so a bone can be used without the shimmer (e.g. for a
+`prefers-reduced-motion` fallback) without duplicating any rules.
+
+### Customizing the look
+
+```css
+.ssl-hr18 {
+  --ssl-bone-hr18: #2a2a32;   /* placeholder color */
+  --ssl-shine-hr18: #3a3a44;  /* the sweeping highlight */
+  --ssl-shimmer-duration-hr18: 1200ms;
+}
+```
+
+## Accessibility notes
+
+- Each card carries `role="status"` and a descriptive `aria-label` (e.g.
+  "Loading product"), so screen readers announce that content is loading
+  rather than presenting a wall of unlabeled empty boxes.
+- `@media (prefers-reduced-motion: reduce)` disables the shimmer animation
+  entirely rather than just slowing it down — a sweeping gradient is
+  exactly the kind of motion that preference is meant to suppress. The
+  bones remain visible as flat color blocks, which still clearly reads as
+  a loading state without any movement.
+
+## Responsiveness
+
+The two cards sit in a wrapping flex row, so they sit side by side on
+wider viewports and stack on narrow ones without any media query needed
+for the layout itself.
+
+## Why this fits EaseMotion CSS
+
+A clean, well-commented, dependency-free CSS animation example — exactly
+what the issue asks for — using only plain HTML/CSS with no JavaScript at
+all, consistent with the framework's zero-dependency, readable-class
+philosophy.

--- a/submissions/examples/shimmer-skeleton-loader-hr18/index.html
+++ b/submissions/examples/shimmer-skeleton-loader-hr18/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Shimmer Skeleton Loading Card</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ssl-hr18">
+
+  <div class="ssl-heading-hr18">
+    <h1>Shimmer skeleton loading card</h1>
+    <p>A modern placeholder card with a shimmering sweep of light,
+      standing in for content that hasn't loaded yet.</p>
+  </div>
+
+  <div class="ssl-row-hr18">
+
+    <!-- Product-card style skeleton -->
+    <div class="ssl-card-hr18" role="status" aria-label="Loading product">
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-thumb-hr18"></div>
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 title"></div>
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 subtitle"></div>
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 price"></div>
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-button-hr18"></div>
+    </div>
+
+    <!-- Profile-card style skeleton -->
+    <div class="ssl-card-hr18 ssl-card-centered-hr18" role="status" aria-label="Loading profile">
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-avatar-hr18"></div>
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 title ssl-line-centered-hr18"></div>
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 subtitle ssl-line-centered-hr18"></div>
+      <div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-button-hr18"></div>
+    </div>
+
+  </div>
+
+</div>
+</body>
+</html>

--- a/submissions/examples/shimmer-skeleton-loader-hr18/style.css
+++ b/submissions/examples/shimmer-skeleton-loader-hr18/style.css
@@ -1,0 +1,179 @@
+/* ==========================================================================
+   shimmer-skeleton-loader-hr18 — style.css
+   Shimmer Skeleton Loading Card demo
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+/* ---- Page shell — just enough to present the card nicely ----------------- */
+.ssl-hr18 {
+  --ssl-bg-hr18: #f5f6f8;
+  --ssl-card-bg-hr18: #ffffff;
+  --ssl-border-hr18: #e4e6ec;
+  --ssl-text-hr18: #14161c;
+  --ssl-muted-hr18: #6b7080;
+
+  /* The skeleton "bone" color and the lighter shimmer highlight that
+     sweeps across it. Change these two to re-theme the whole effect. */
+  --ssl-bone-hr18: #e4e6ec;
+  --ssl-shine-hr18: #f4f5f8;
+
+  /* How long one shimmer sweep takes, and how it paces itself. */
+  --ssl-shimmer-duration-hr18: 1600ms;
+  --ssl-shimmer-easing-hr18: ease-in-out;
+
+  --ssl-font-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--ssl-bg-hr18);
+  color: var(--ssl-text-hr18);
+  font-family: var(--ssl-font-hr18);
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 3rem 1.25rem;
+}
+
+.ssl-hr18 * {
+  box-sizing: border-box;
+}
+
+.ssl-heading-hr18 {
+  text-align: center;
+  max-width: 46ch;
+}
+
+.ssl-heading-hr18 h1 {
+  margin: 0 0 0.4rem;
+  font-size: 1.4rem;
+}
+
+.ssl-heading-hr18 p {
+  margin: 0;
+  color: var(--ssl-muted-hr18);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* Cards laid out in a responsive row that wraps on small screens. */
+.ssl-row-hr18 {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 720px;
+}
+
+/* ==========================================================================
+   The skeleton card itself
+   ========================================================================== */
+
+.ssl-card-hr18 {
+  width: 220px;
+  background: var(--ssl-card-bg-hr18);
+  border: 1px solid var(--ssl-border-hr18);
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 1px 2px rgba(10, 15, 25, 0.04), 0 10px 24px rgba(10, 15, 25, 0.05);
+}
+
+/* Every placeholder "bone" shares this base look: a flat color block with
+   rounded corners. The shimmer itself is added separately below so it can
+   be reused on any shape (rectangle, circle, pill) without repeating the
+   animation rules on each one. */
+.ssl-bone-hr18 {
+  background-color: var(--ssl-bone-hr18);
+  border-radius: 8px;
+}
+
+/* The shimmer effect: a wide gradient band (bone → shine → bone) that's
+   3x the element's own width, animated by sliding its background-position
+   from fully left to fully right. Because the gradient is much wider than
+   the element, only a thin bright band is ever visible at once, which is
+   what reads as a "sweep" of light passing across the shape. */
+.ssl-shimmer-hr18 {
+  background-image: linear-gradient(
+    100deg,
+    var(--ssl-bone-hr18) 30%,
+    var(--ssl-shine-hr18) 50%,
+    var(--ssl-bone-hr18) 70%
+  );
+  background-size: 300% 100%;
+  background-position: 100% 0;
+  animation: ssl-shimmer-sweep-hr18 var(--ssl-shimmer-duration-hr18) var(--ssl-shimmer-easing-hr18) infinite;
+}
+
+@keyframes ssl-shimmer-sweep-hr18 {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+/* ---- The individual placeholder shapes making up the card ----------------- */
+
+.ssl-thumb-hr18 {
+  width: 100%;
+  height: 120px;
+  margin-bottom: 0.9rem;
+  border-radius: 10px;
+}
+
+.ssl-line-hr18 {
+  height: 12px;
+  margin-bottom: 0.55rem;
+}
+
+.ssl-line-hr18.title {
+  width: 80%;
+  height: 14px;
+}
+
+.ssl-line-hr18.subtitle {
+  width: 55%;
+}
+
+.ssl-line-hr18.price {
+  width: 35%;
+  margin-top: 0.7rem;
+  margin-bottom: 0;
+}
+
+.ssl-button-hr18 {
+  width: 100%;
+  height: 34px;
+  margin-top: 0.9rem;
+  border-radius: 999px;
+}
+
+/* ---- Profile-card variant: a centered circular avatar instead of a
+   rectangular thumbnail, with its text lines centered to match. ---------- */
+.ssl-card-centered-hr18 {
+  text-align: center;
+}
+
+.ssl-avatar-hr18 {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 0.9rem;
+  border-radius: 50%;
+}
+
+.ssl-line-centered-hr18 {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ---- Reduced motion: a shimmering page is exactly the kind of motion
+   prefers-reduced-motion is meant to suppress, so it's disabled here
+   rather than merely slowed down. The bones stay visible as flat color,
+   which still reads clearly as "loading" without any movement. ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ssl-shimmer-hr18 {
+    animation: none;
+    background-image: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a self-contained shimmer skeleton loading card demo — two card
variants (product-card and profile-card layouts) built from reusable
placeholder "bone" shapes, each with a shimmering gradient sweep animated
via background-position. Well-commented CSS explains how the shimmer
technique works. No JavaScript, no dependencies.

Resolves #55712

Note for the maintainer: the issue's folder name (`shimmer-skeleton-loader`)
has no per-contributor suffix, and 3 people are assigned including the
reporter — used `shimmer-skeleton-loader-hr18` to avoid a folder collision
with their likely submission under the literal name. Filenames
(`index.html`, `style.css`) match the issue's explicit request rather than
this repo's usual `demo.html` convention; added `README.md` on top for
consistency with other submissions.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/shimmer-skeleton-loader-hr18/`)
- [x] Includes `index.html` — self-contained, opens in browser with no server (per issue's explicit filename request, in place of demo.html)
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Two skeleton loading card variants with a reusable, well-commented CSS
shimmer sweep effect.

**How does a developer use it?**
```html
<div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-thumb-hr18"></div>
<div class="ssl-bone-hr18 ssl-shimmer-hr18 ssl-line-hr18 title"></div>
```

**Why does it fit EaseMotion CSS?**
A clean, well-commented, dependency-free CSS animation example — exactly
what the issue asks for — using plain HTML/CSS only, no JavaScript,
consistent with the framework's readable-class philosophy.

---

## Demo
- [x] Demo added (`index.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
No inline styles — every visual variant (e.g. the circular avatar) is a
proper CSS class, to stay lint-friendly per the issue's "passes npm run
lint" acceptance criterion. `prefers-reduced-motion` disables the shimmer
entirely rather than slowing it, since a sweeping gradient is exactly the
motion that preference targets. Tested in Chrome; haven't run the repo's
actual lint script locally, so flagging in case it catches something I
can't see from here.