### PR TITLE
Add cyberpunk glitch effect header banner (cyberpunk-glitch-header-hr18)

### DIFF
--- a/submissions/examples/cyberpunk-glitch-header-hr18/README.md
+++ b/submissions/examples/cyberpunk-glitch-header-hr18/README.md
@@ -1,0 +1,91 @@
+# Cyberpunk Glitch Header Banner (`cyberpunk-glitch-header-hr18`)
+
+A retro-futuristic CSS glitch-effect hero title banner, built for issue
+[#55699](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55699).
+
+## A note on naming
+
+The issue's own filenames (`index.html`, `styles.css`) and its suggested
+folder (`cyberpunk-glitch-header-em`, no per-contributor suffix) don't
+match this repo's actual enforced submission convention —
+`demo.html` + `style.css` + `README.md`, in a uniquely-suffixed folder.
+This submission uses `demo.html` / `style.css` and the folder
+`cyberpunk-glitch-header-hr18` to match what the repo's automated
+submission validator actually checks for.
+
+## What it does
+
+A hero banner with an RGB-split glitch title (`SYSTEM ONLINE`), a subtle
+scanline overlay drifting slowly down the banner, and a pulsing neon
+accent line beneath the title — all built with the classic
+`data-text` / `::before` / `::after` glitch technique, entirely in CSS.
+
+The title text is duplicated by its two pseudo-elements
+(`content: attr(data-text)`), each tinted toward one channel of an RGB
+split (cyan and magenta/red) and blended with `mix-blend-mode: screen` so
+they read as neutral white where they overlap. Two independent
+`@keyframes` sequences — deliberately out of phase with each other —
+spend most of their time at rest and only briefly jump to an offset
+`clip-path` slice with a hard, un-eased cut, which reads as a digital
+glitch rather than a smooth wobble.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<header class="cgh-hero-hr18">
+  <div class="cgh-scanlines-hr18" aria-hidden="true"></div>
+  <h1 class="cgh-glitch-title-hr18" data-text="YOUR TITLE HERE">YOUR TITLE HERE</h1>
+  <div class="cgh-neon-line-hr18" aria-hidden="true"></div>
+</header>
+```
+
+The `data-text` attribute value must exactly match the element's own text
+content — the pseudo-elements read it via `attr(data-text)` to generate
+the two colored glitch layers on top of the real text.
+
+### Tuning the glitch
+
+```css
+.cgh-hr18 {
+  --ease-glitch-duration-hr18: 3.2s; /* how long one full glitch cycle takes */
+  --ease-glitch-offset-hr18: 3px;    /* how far each layer jumps during a glitch */
+}
+```
+
+## Accessibility notes
+
+- The real, readable title text lives directly in the `<h1>` — the
+  pseudo-element layers are purely decorative color duplicates sitting on
+  top of it, not a replacement for it.
+- The scanline overlay and neon line are marked `aria-hidden="true"`,
+  since they carry no information beyond visual styling.
+- `@media (prefers-reduced-motion: reduce)` disables the glitch jumps and
+  the scanline drift entirely, leaving a clean, static, subtly-tinted
+  title — motion is never forced on someone who's asked their system not
+  to show it.
+- Per the issue's own acceptance criteria, the glitch keyframes spend the
+  large majority of each cycle at full legibility (0 offset, no clip),
+  with only brief, occasional jumps — the title is designed to always be
+  readable, not obscured by constant distortion.
+
+## Responsiveness
+
+The title uses `clamp()` for its font size, scaling smoothly between
+mobile and desktop widths, and the hero card's padding tightens under a
+`480px` viewport.
+
+## Why this fits EaseMotion CSS
+
+A pure-CSS, zero-JavaScript animated effect, exactly as the issue
+requires, using only `@keyframes`, pseudo-elements, and `clip-path` — no
+framework, no build step, and respecting `prefers-reduced-motion` as a
+first-class part of the design rather than an afterthought.
+
+All classes and the folder itself use a `-hr18` suffix to avoid colliding
+with any other contributor's submission under `submissions/examples/`.

--- a/submissions/examples/cyberpunk-glitch-header-hr18/demo.html
+++ b/submissions/examples/cyberpunk-glitch-header-hr18/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Cyberpunk Glitch Header Banner</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cgh-hr18">
+  <header class="cgh-hero-hr18">
+    <div class="cgh-scanlines-hr18" aria-hidden="true"></div>
+
+    <span class="cgh-eyebrow-hr18">EaseMotion-css &middot; example</span>
+
+    <h1 class="cgh-glitch-title-hr18" data-text="SYSTEM ONLINE">SYSTEM ONLINE</h1>
+
+    <div class="cgh-neon-line-hr18" aria-hidden="true"></div>
+
+    <p class="cgh-subtext-hr18">A retro-futuristic glitch title banner for gaming
+      sites, web3 apps, and creative portfolio hero headers &mdash; RGB-split
+      distortion layers, a scanline overlay, and a pulsing neon accent line,
+      all pure CSS.</p>
+  </header>
+</div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-glitch-header-hr18/style.css
+++ b/submissions/examples/cyberpunk-glitch-header-hr18/style.css
@@ -1,0 +1,246 @@
+/* ==========================================================================
+   cyberpunk-glitch-header-hr18 — style.css
+   CSS Glitch Effect Cyberpunk Header Banner
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.cgh-hr18 {
+  --bg-hr18: #06060a;
+  --bg-glow-hr18: #12081c;
+  --text-hr18: #f2f0f7;
+  --muted-hr18: #9490a8;
+  --neon-a-hr18: #ff2a72;
+  --neon-b-hr18: #05f2db;
+
+  /* Exposed glitch parameters. */
+  --ease-glitch-duration-hr18: 3.2s;
+  --ease-glitch-offset-hr18: 3px;
+
+  --font-display-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 42, 114, 0.16), transparent 45%),
+    radial-gradient(circle at 80% 70%, rgba(5, 242, 219, 0.12), transparent 45%),
+    var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+}
+
+.cgh-hr18 * {
+  box-sizing: border-box;
+}
+
+/* ---- Hero shell ---------------------------------------------------------------- */
+.cgh-hero-hr18 {
+  position: relative;
+  max-width: 720px;
+  width: 100%;
+  text-align: center;
+  padding: 3.5rem 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+}
+
+/* ---- Scanline overlay: thin repeating horizontal lines drifting slowly
+   downward, giving the whole banner a CRT-screen feel. Purely decorative,
+   so it's marked aria-hidden and sits behind the text via z-index. ------ */
+.cgh-scanlines-hr18 {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.05) 0px,
+    rgba(255, 255, 255, 0.05) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  animation: cgh-scanline-drift-hr18 6s linear infinite;
+  z-index: 0;
+}
+
+@keyframes cgh-scanline-drift-hr18 {
+  from { background-position: 0 0; }
+  to { background-position: 0 60px; }
+}
+
+/* ---- Eyebrow + subtext ----------------------------------------------------------- */
+.cgh-eyebrow-hr18 {
+  position: relative;
+  z-index: 1;
+  display: inline-block;
+  font-family: var(--font-display-hr18);
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--neon-b-hr18);
+  margin-bottom: 1rem;
+}
+
+.cgh-subtext-hr18 {
+  position: relative;
+  z-index: 1;
+  margin: 1.1rem auto 0;
+  max-width: 46ch;
+  color: var(--muted-hr18);
+  font-size: 0.94rem;
+  line-height: 1.6;
+}
+
+/* ==========================================================================
+   The glitch title itself
+   ========================================================================== */
+
+.cgh-glitch-title-hr18 {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-family: var(--font-display-hr18);
+  font-size: clamp(2rem, 7vw, 3.6rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-hr18);
+}
+
+/* The two duplicate text layers, positioned exactly over the real text via
+   attr(data-text), each tinted toward one side of an RGB split and blended
+   additively (screen) so overlapping color reads as white/neutral where
+   they line up, and as a color fringe where the keyframes offset them. */
+.cgh-glitch-title-hr18::before,
+.cgh-glitch-title-hr18::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  mix-blend-mode: screen;
+}
+
+.cgh-glitch-title-hr18::before {
+  color: var(--neon-b-hr18);
+  animation: cgh-glitch-1-hr18 var(--ease-glitch-duration-hr18) infinite linear;
+}
+
+.cgh-glitch-title-hr18::after {
+  color: var(--neon-a-hr18);
+  animation: cgh-glitch-2-hr18 var(--ease-glitch-duration-hr18) infinite linear;
+}
+
+/* Both keyframes spend most of their time at rest (0 offset, full-height
+   clip) so the title stays fully legible, with brief, sudden jumps —
+   no easing between steps — that read as a digital glitch rather than a
+   smooth wobble. The two layers are deliberately out of sync with each
+   other so they never jump at exactly the same moment. */
+@keyframes cgh-glitch-1-hr18 {
+  0%, 78% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+  }
+  79% {
+    clip-path: inset(10% 0 60% 0);
+    transform: translate(calc(var(--ease-glitch-offset-hr18) * -1), 0);
+  }
+  80% {
+    clip-path: inset(55% 0 20% 0);
+    transform: translate(var(--ease-glitch-offset-hr18), 0);
+  }
+  81%, 87% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+  }
+  88% {
+    clip-path: inset(70% 0 5% 0);
+    transform: translate(calc(var(--ease-glitch-offset-hr18) * -1), 0);
+  }
+  89%, 100% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes cgh-glitch-2-hr18 {
+  0%, 30% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+  }
+  31% {
+    clip-path: inset(20% 0 45% 0);
+    transform: translate(var(--ease-glitch-offset-hr18), 0);
+  }
+  32% {
+    clip-path: inset(65% 0 10% 0);
+    transform: translate(calc(var(--ease-glitch-offset-hr18) * -1), 0);
+  }
+  33%, 62% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+  }
+  63% {
+    clip-path: inset(5% 0 80% 0);
+    transform: translate(var(--ease-glitch-offset-hr18), 0);
+  }
+  64%, 100% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+  }
+}
+
+/* ---- Neon accent line beneath the title ------------------------------------------ */
+.cgh-neon-line-hr18 {
+  position: relative;
+  z-index: 1;
+  width: 140px;
+  height: 3px;
+  margin: 1.5rem auto 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--neon-a-hr18), var(--neon-b-hr18));
+  box-shadow: 0 0 12px var(--neon-a-hr18), 0 0 20px var(--neon-b-hr18);
+  animation: cgh-neon-pulse-hr18 2.4s ease-in-out infinite;
+}
+
+@keyframes cgh-neon-pulse-hr18 {
+  0%, 100% { opacity: 0.75; width: 140px; }
+  50% { opacity: 1; width: 190px; }
+}
+
+/* ---- Reduced motion: disable the glitch and scanline drift entirely,
+   leaving a clean, static neon-styled title. The neon line keeps a
+   gentle non-jarring presence but stops pulsing. -------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .cgh-glitch-title-hr18::before,
+  .cgh-glitch-title-hr18::after {
+    animation: none;
+    clip-path: inset(0 0 0 0);
+    transform: none;
+    opacity: 0.35;
+  }
+  .cgh-scanlines-hr18 {
+    animation: none;
+  }
+  .cgh-neon-line-hr18 {
+    animation: none;
+  }
+}
+
+/* ---- Focus visibility (in case a link/button is added inside the hero) ----------- */
+.cgh-hr18 :focus-visible {
+  outline: 2px solid var(--neon-b-hr18);
+  outline-offset: 3px;
+}
+
+/* ---- Responsive ------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .cgh-hero-hr18 {
+    padding: 2.5rem 1.1rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a retro-futuristic CSS glitch-effect hero title banner. Uses the
classic data-text / ::before / ::after glitch technique — two duplicated,
RGB-tinted text layers blended with mix-blend-mode: screen, each with an
independent @keyframes sequence that spends most of its cycle at rest and
only briefly jumps to an offset clip-path slice for a genuine digital
glitch feel rather than a smooth wobble. Includes a scanline overlay and
a pulsing neon accent line. Pure CSS, zero JavaScript.

Resolves #55699

Note for the maintainer: the issue's suggested filenames (index.html,
styles.css) and folder name (no per-contributor suffix) don't match this
repo's actual enforced convention, so I used demo.html/style.css and a
-hr18 suffix instead, matching what the automated validator checks for.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/cyberpunk-glitch-header-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure-CSS cyberpunk glitch-effect hero header with RGB-split title text,
a scanline overlay, and a neon accent line.

**How does a developer use it?**
```html
<header class="cgh-hero-hr18">
  <div class="cgh-scanlines-hr18" aria-hidden="true"></div>
  <h1 class="cgh-glitch-title-hr18" data-text="YOUR TITLE HERE">YOUR TITLE HERE</h1>
  <div class="cgh-neon-line-hr18" aria-hidden="true"></div>
</header>
```

**Why does it fit EaseMotion CSS?**
A pure-CSS, zero-JavaScript animated effect exactly as the issue
requires, respecting prefers-reduced-motion as a first-class part of the
design.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Glitch keyframes spend ~85%+ of each cycle at full legibility with only
brief, un-eased jumps, per the issue's "text remains legible" acceptance
criterion. prefers-reduced-motion disables the glitch and scanline drift
entirely. Tested in Chrome; haven't checked other browsers yet.