### PR TITLE
fix: modal body scrolling on small screens (#55345)

### DIFF
--- a/components/modals.css
+++ b/components/modals.css
@@ -78,6 +78,7 @@
   
   /* Modal Header */
   .ease-modal-header {
+    flex: 0 0 auto;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -123,6 +124,8 @@
 
   /* Modal Body */
   .ease-modal-body {
+    flex: 1;
+    min-height: 0;
     padding: var(--ease-space-6, 1.5rem);
     color: var(--ease-color-text-muted, #4b5563);
     line-height: 1.6;
@@ -139,6 +142,7 @@
 
   /* Modal Footer */
   .ease-modal-footer {
+    flex: 0 0 auto;
     display: flex;
     justify-content: flex-end;
     gap: var(--ease-space-3, 0.75rem);


### PR DESCRIPTION
## Fix: Modal Cannot Be Scrolled on Small Screens

### Problem
On small screens (≤640px), the modal body content was not scrollable when it exceeded the viewport height. The `.ease-modal` container had `max-height` and `overflow: auto`, but the flex children lacked proper constraints.

### Root Cause
`.ease-modal` uses `display: flex; flex-direction: column;`, but `.ease-modal-body` had no `flex` or `min-height` properties. Without `min-height: 0`, flex items default to `min-height: auto`, preventing them from shrinking below their content height — so `overflow-y: auto` never triggered.

### Fix (components/modals.css)
- **`.ease-modal-body`**: Added `flex: 1; min-height: 0;` so it fills remaining space and can scroll when content overflows
- **`.ease-modal-header`**: Added `flex: 0 0 auto;` to prevent shrinking
- **`.ease-modal-footer`**: Added `flex: 0 0 auto;` to prevent shrinking

### Testing
- Verified modal scrolls on 320px viewport with long content
- Verified modal still works correctly on desktop
- No visual regressions on existing modal styles