### PR TITLE
Add infinite marquee tech stack logo carousel (infinite-marquee-carou…

### DIFF
--- a/submissions/examples/infinite-marquee-carousel-hr18/README.md
+++ b/submissions/examples/infinite-marquee-carousel-hr18/README.md
@@ -1,0 +1,107 @@
+# Infinite Marquee Tech Stack Carousel (`infinite-marquee-carousel-hr18`)
+
+A pure-CSS infinitely looping horizontal logo ticker, built for issue
+[#55695](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55695).
+
+## A note on naming
+
+The issue's own filenames (`index.html`, `styles.css`) and its suggested
+folder (`infinite-marquee-carousel-em`, no per-contributor suffix) don't
+match this repo's actual enforced submission convention —
+`demo.html` + `style.css` + `README.md`, in a uniquely-suffixed folder.
+This submission uses that convention instead, matching what the repo's
+automated submission validator checks for.
+
+## What it does
+
+A row of technology badges (React, Node.js, Docker, Figma, TypeScript,
+PostgreSQL, AWS, GraphQL) scrolls continuously to the left and loops
+seamlessly, with soft fade masks on both edges and a smooth pause on
+hover — no JavaScript involved anywhere.
+
+**How the seamless loop works:** the badge list appears twice in the
+markup, back to back, inside one flex track. The track only ever animates
+from `translateX(0)` to `translateX(-50%)` — exactly the width of one
+copy — so the instant it finishes, the second copy sits in precisely the
+position the first one started in. The animation then restarts (`infinite`)
+and the transition is invisible; there's no jump, reset, or visible seam.
+
+The edge fades use `mask-image: linear-gradient(...)` (with a
+`-webkit-mask-image` fallback) rather than solid gradient overlay `<div>`s,
+so they work over any background color without needing to match it.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<div class="ease-marquee-hr18" role="group" aria-label="Technology stack">
+  <div class="imc-track-hr18">
+    <!-- your items, once -->
+    <span class="imc-badge-hr18">React</span>
+    <span class="imc-badge-hr18">Node.js</span>
+
+    <!-- the exact same items again, marked aria-hidden -->
+    <span class="imc-badge-hr18" aria-hidden="true">React</span>
+    <span class="imc-badge-hr18" aria-hidden="true">Node.js</span>
+  </div>
+</div>
+```
+
+The second copy must be identical to the first (same items, same order)
+for the loop math to line up, and should carry `aria-hidden="true"` since
+it's a visual duplicate, not new content.
+
+### Tuning the marquee
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-marquee-duration-hr18` | `22s` | How long one full loop takes — lower is faster |
+| `--ease-marquee-gap-hr18` | `2.5rem` | Spacing between items |
+| `--ease-marquee-fade-width-hr18` | `12%` | How wide the edge fade masks are, as a percentage of the row's width |
+
+```css
+.ease-marquee-hr18.fast {
+  --ease-marquee-duration-hr18: 12s;
+}
+```
+
+## Accessibility notes
+
+- The visible copy of the badge list is real, readable content; the
+  duplicate copy needed for the seamless loop is marked
+  `aria-hidden="true"` so screen readers only announce the list once.
+- The whole row carries `role="group"` and a descriptive `aria-label`
+  ("Technology stack"), so it reads as one coherent unit rather than a
+  stream of unrelated items.
+- The scroll pauses on `:hover` **and** `:focus-within`, so keyboard users
+  tabbing through any focusable items in the row (if badges are made into
+  links) get the same "stop and read" behavior mouse users get from
+  hovering.
+- `@media (prefers-reduced-motion: reduce)` disables the scrolling
+  animation entirely, leaving a static row of badges — a continuously
+  moving ticker is exactly the kind of motion that preference is meant to
+  suppress.
+
+## Responsiveness
+
+The row's width is intrinsic to its content (`width: max-content`) inside
+an `overflow: hidden` frame that fills its container, so it scales cleanly
+at any viewport width without a media query — the same technique works
+identically on mobile and desktop.
+
+## Why this fits EaseMotion CSS
+
+A pure-CSS, zero-JavaScript animated component exactly as the issue
+requires — flexbox layout, one `@keyframes` translation, and
+`mask-image` for the fades — with every timing/spacing value exposed as a
+tunable custom property and `prefers-reduced-motion` respected as a
+first-class part of the design.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/infinite-marquee-carousel-hr18/demo.html
+++ b/submissions/examples/infinite-marquee-carousel-hr18/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Infinite Marquee Tech Stack Carousel</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="imc-hr18">
+  <div class="imc-wrap-hr18">
+
+    <h1>Built with tools you already trust</h1>
+    <p>Hover the row to pause it and read a name mid-scroll.</p>
+
+    <div class="ease-marquee-hr18" role="group" aria-label="Technology stack">
+      <div class="imc-track-hr18">
+
+        <!-- First copy of the badge list -->
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c1">R</span>React</span>
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c2">N</span>Node.js</span>
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c3">D</span>Docker</span>
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c4">F</span>Figma</span>
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c5">T</span>TypeScript</span>
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c6">P</span>PostgreSQL</span>
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c7">A</span>AWS</span>
+        <span class="imc-badge-hr18"><span class="imc-badge-icon-hr18 c8">G</span>GraphQL</span>
+
+        <!-- Second, identical copy — required so the loop has no seam.
+             aria-hidden since it's a visual duplicate of the row above,
+             not new content. -->
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c1">R</span>React</span>
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c2">N</span>Node.js</span>
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c3">D</span>Docker</span>
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c4">F</span>Figma</span>
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c5">T</span>TypeScript</span>
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c6">P</span>PostgreSQL</span>
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c7">A</span>AWS</span>
+        <span class="imc-badge-hr18" aria-hidden="true"><span class="imc-badge-icon-hr18 c8">G</span>GraphQL</span>
+
+      </div>
+    </div>
+
+    <div class="imc-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-marquee-duration-hr18</code></td><td><code>22s</code></td><td>How long one full loop takes &mdash; lower is faster.</td></tr>
+          <tr><td><code>--ease-marquee-gap-hr18</code></td><td><code>2.5rem</code></td><td>Spacing between badges.</td></tr>
+          <tr><td><code>--ease-marquee-fade-width-hr18</code></td><td><code>12%</code></td><td>How wide the edge fade masks are, as a percentage of the row's width.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="imc-footnote-hr18">submissions/examples/infinite-marquee-carousel-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/infinite-marquee-carousel-hr18/style.css
+++ b/submissions/examples/infinite-marquee-carousel-hr18/style.css
@@ -1,0 +1,210 @@
+/* ==========================================================================
+   infinite-marquee-carousel-hr18 — style.css
+   Infinite Marquee Tech Stack Logo Carousel
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.imc-hr18 {
+  --bg-hr18: #f6f7f9;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e3e6ec;
+  --text-hr18: #14161c;
+  --muted-hr18: #676d7c;
+  --accent-hr18: #3355ff;
+
+  /* Exposed marquee parameters. */
+  --ease-marquee-duration-hr18: 22s;
+  --ease-marquee-gap-hr18: 2.5rem;
+  --ease-marquee-fade-width-hr18: 12%;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3.5rem 1.5rem;
+}
+
+.imc-hr18 * {
+  box-sizing: border-box;
+}
+
+.imc-wrap-hr18 {
+  max-width: 760px;
+  width: 100%;
+  text-align: center;
+}
+
+.imc-wrap-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+  margin: 0 0 0.5rem;
+}
+
+.imc-wrap-hr18 p {
+  margin: 0 0 2rem;
+  color: var(--muted-hr18);
+  font-size: 0.92rem;
+}
+
+/* ==========================================================================
+   The reusable marquee component
+   ========================================================================== */
+
+/* Outer clipping frame. overflow: hidden keeps the doubled track from
+   spilling outside the visible row, and the mask-image below fades the
+   two edges to transparent. */
+.ease-marquee-hr18 {
+  position: relative;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 var(--ease-marquee-fade-width-hr18),
+    #000 calc(100% - var(--ease-marquee-fade-width-hr18)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 var(--ease-marquee-fade-width-hr18),
+    #000 calc(100% - var(--ease-marquee-fade-width-hr18)),
+    transparent 100%
+  );
+}
+
+/* The moving track. It contains the logo list TWICE in the markup
+   (identical copies back to back) — the animation only ever needs to
+   slide exactly one copy's width (-50% of the doubled track), so the
+   moment it finishes, the second copy is sitting in exactly the position
+   the first one started in. That's what makes the loop seamless with no
+   visible jump or reset. */
+.imc-track-hr18 {
+  display: flex;
+  align-items: center;
+  gap: var(--ease-marquee-gap-hr18);
+  width: max-content;
+  animation: ease-marquee-scroll-hr18 var(--ease-marquee-duration-hr18) linear infinite;
+}
+
+@keyframes ease-marquee-scroll-hr18 {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* Pausing on hover (or keyboard focus within, for anyone tabbing through
+   the logo links) lets a visitor actually read a name that's mid-scroll,
+   without needing any JavaScript. */
+.ease-marquee-hr18:hover .imc-track-hr18,
+.ease-marquee-hr18:focus-within .imc-track-hr18 {
+  animation-play-state: paused;
+}
+
+/* ---- Logo badges ------------------------------------------------------------------ */
+.imc-badge-hr18 {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 999px;
+  padding: 0.6rem 1.1rem;
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.imc-badge-icon-hr18 {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+/* Per-badge accent colors, kept as classes rather than inline styles. */
+.imc-badge-icon-hr18.c1 { background: #149eca; }
+.imc-badge-icon-hr18.c2 { background: #3c873a; }
+.imc-badge-icon-hr18.c3 { background: #0db7ed; }
+.imc-badge-icon-hr18.c4 { background: #a259ff; }
+.imc-badge-icon-hr18.c5 { background: #3178c6; }
+.imc-badge-icon-hr18.c6 { background: #336791; }
+.imc-badge-icon-hr18.c7 { background: #ff9900; }
+.imc-badge-icon-hr18.c8 { background: #e10098; }
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.imc-tuning-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.25rem 1.4rem;
+  text-align: left;
+}
+
+.imc-tuning-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1rem;
+  margin: 0 0 0.6rem;
+}
+
+.imc-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.imc-tuning-hr18 th,
+.imc-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.imc-tuning-hr18 th {
+  color: var(--muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.imc-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+}
+
+.imc-footnote-hr18 {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.imc-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .imc-track-hr18 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS infinitely looping horizontal logo ticker. A row of
technology badges scrolls left and loops seamlessly by duplicating the
badge list once in the markup and animating the doubled track exactly
-50% — the instant the animation finishes, the second copy sits where the
first started, so there's no visible seam or jump. Edge fades use
mask-image (with -webkit- fallback), and hovering (or focusing into) the
row pauses the scroll smoothly. Zero JavaScript.

Resolves #55695

Note for the maintainer: the issue's suggested filenames (index.html,
styles.css) and folder name (no per-contributor suffix) don't match this
repo's actual enforced convention, so I used demo.html/style.css and a
-hr18 suffix instead.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/infinite-marquee-carousel-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure-CSS infinite marquee logo carousel with edge fade masks and
pause-on-hover, tunable via custom properties.

**How does a developer use it?**
```html
<div class="ease-marquee-hr18" role="group" aria-label="Technology stack">
  <div class="imc-track-hr18">
    <span class="imc-badge-hr18">React</span>
    <!-- ...items, then the same items again with aria-hidden="true" -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
A pure-CSS, zero-JavaScript animated component exactly as the issue
requires, with every timing/spacing value exposed as a custom property
and prefers-reduced-motion respected by disabling the scroll entirely.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
No inline styles anywhere — per-badge icon colors are CSS classes
(c1–c8), not inline style attributes, to stay lint-friendly. Duplicate
badge copy is aria-hidden so screen readers only announce the list once.
Tested in Chrome, including the reduced-motion and hover-pause behavior;
haven't checked other browsers yet.