### PR TITLE
fix: modal body scrolling on small screens (#55345)

### DIFF
--- a/submissions/examples/55345-modal-scroll-small-screens/README.md
+++ b/submissions/examples/55345-modal-scroll-small-screens/README.md
@@ -1,0 +1,66 @@
+# Scrollable Modal Fix for Small Screens (#55345)
+
+A CSS-only modal that correctly scrolls when its content exceeds the viewport height on small screens. Demonstrates the fix for the "Modal Cannot Be Scrolled on Small Screens" bug.
+
+## The Bug
+
+On small viewports, modal content that overflows the available height was not scrollable. The root cause is that in a `display: flex; flex-direction: column` container, flex children default to `min-height: auto`, which prevents them from shrinking below their content height. This means `overflow-y: auto` never activates.
+
+## The Fix
+
+The key CSS properties that enable scrolling:
+
+```css
+.modal-dialog {
+    max-height: 90vh;        /* Constrain to viewport */
+    display: flex;
+    flex-direction: column;
+}
+
+.modal-body {
+    flex: 1;                 /* Fill remaining space */
+    min-height: 0;           /* Override default min-height: auto */
+    overflow-y: auto;        /* Enable scroll when content overflows */
+}
+
+.modal-header,
+.modal-footer {
+    flex: 0 0 auto;          /* Don't shrink header/footer */
+}
+```
+
+The critical line is `min-height: 0` on `.modal-body`. Without it, the flex child refuses to shrink below its intrinsic content height, so `overflow-y: auto` never triggers.
+
+## Features
+
+- Pure HTML & CSS implementation (checkbox hack)
+- Smooth zoom-in animation
+- Fully responsive — works on 320px+ viewports
+- Accessibility: dialog role, ARIA labels, keyboard-friendly
+- `prefers-reduced-motion` support
+- No JavaScript required
+
+## Files
+
+```text
+submissions/examples/55345-modal-scroll-small-screens/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+1. Open `demo.html` in a modern web browser.
+2. Click **Open Long Modal** to see the modal with long content.
+3. On small screens, scroll through the modal body content.
+4. Click **Accept** / **Decline** or the **×** button to close.
+
+## Browser Support
+
+All modern browsers supporting:
+
+- CSS Custom Properties
+- Flexbox
+- `min-height` on flex children
+- CSS Transitions

--- a/submissions/examples/55345-modal-scroll-small-screens/demo.html
+++ b/submissions/examples/55345-modal-scroll-small-screens/demo.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS - Scrollable Modal Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="demo-page">
+
+        <section class="hero">
+            <h1>Scrollable Modal on Small Screens</h1>
+            <p>
+                A CSS-only modal that correctly scrolls when content exceeds the
+                viewport height on small screens. Uses flex layout with
+                <code>min-height: 0</code> on the body to enable overflow scrolling.
+            </p>
+            <label for="modal-toggle" class="btn btn-primary" role="button" tabindex="0">
+                Open Long Modal
+            </label>
+        </section>
+
+        <!-- Hidden checkbox toggle -->
+        <input
+            type="checkbox"
+            id="modal-toggle"
+            class="modal-checkbox"
+            aria-hidden="true"
+        >
+
+        <!-- Modal overlay -->
+        <div class="modal-overlay" role="presentation">
+
+            <div
+                class="modal-dialog"
+                role="dialog"
+                aria-labelledby="modal-heading"
+                aria-modal="true"
+            >
+
+                <header class="modal-header">
+                    <h2 id="modal-heading">Terms &amp; Conditions</h2>
+                    <label
+                        for="modal-toggle"
+                        class="modal-close"
+                        aria-label="Close modal"
+                    >
+                        &times;
+                    </label>
+                </header>
+
+                <div class="modal-body">
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        Sed do eiusmod tempor incididunt ut labore et dolore magna
+                        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    </p>
+                    <p>
+                        Duis aute irure dolor in reprehenderit in voluptate velit
+                        esse cillum dolore eu fugiat nulla pariatur. Excepteur
+                        sint occaecat cupidatat non proident, sunt in culpa qui
+                        officia deserunt mollit anim id est laborum.
+                    </p>
+                    <p>
+                        Sed ut perspiciatis unde omnis iste natus error sit
+                        voluptatem accusantium doloremque laudantium, totam rem
+                        aperiam, eaque ipsa quae ab illo inventore veritatis et
+                        quasi architecto beatae vitae dicta sunt explicabo.
+                    </p>
+                    <p>
+                        Nemo enim ipsam voluptatem quia voluptas sit aspernatur
+                        aut odit aut fugit, sed quia consequuntur magni dolores
+                        eos qui ratione voluptatem sequi nesciunt.
+                    </p>
+                    <p>
+                        Neque porro quisquam est, qui dolorem ipsum quia dolor sit
+                        amet, consectetur, adipisci velit, sed quia non numquam
+                        eius modi tempora incidunt ut labore et dolore magnam
+                        aliquam quaerat voluptatem.
+                    </p>
+                    <p>
+                        Ut enim ad minima veniam, quis nostrum exercitationem
+                        ullam corporis suscipit laboriosam, nisi ut aliquid ex ea
+                        commodi consequatur?
+                    </p>
+                    <p>
+                        Quis autem vel eum iure reprehenderit qui in ea voluptate
+                        velit esse quam nihil molestiae consequatur, vel illum
+                        qui dolorem eum fugiat quo voluptas nulla pariatur?
+                    </p>
+                    <p>
+                        At vero eos et accusamus et iusto odio dignissimos ducimus
+                        qui blanditiis praesentium voluptatum deleniti atque
+                        corrupti quos dolores et quas molestias excepturi sint
+                        occaecati cupiditate non provident.
+                    </p>
+                    <p>
+                        Similique sunt in culpa qui officia deserunt mollitia
+                        animi, id est laborum et dolorum fuga. Et harum quidem
+                        rerum facilis est et expedita distinctio.
+                    </p>
+                    <p>
+                        Nam libero tempore, cum soluta nobis est eligendi optio
+                        cumque nihil impedit quo minus id quod maxime placeat
+                        facere possimus, omnis voluptas assumenda est, omnis dolor
+                        repellendus.
+                    </p>
+                    <p>
+                        Temporibus autem quibusdam et aut officiis debitis aut
+                        rerum necessitatibus saepe eveniet ut et voluptates
+                        repudiandae sint et molestiae non recusandae.
+                    </p>
+                    <p>
+                        Itaque earum rerum hic tenetur a sapiente delectus, ut aut
+                        reiciendis voluptatibus maiores alias consequatur aut
+                        perferendis doloribus asperiores repellat.
+                    </p>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        Pellentesque habitant morbi tristique senectus et netus et
+                        malesuada fames ac turpis egestas.
+                    </p>
+                    <p>
+                        Vestibulum tortor quam, feugiat vitae, ultricies eget,
+                        tempor sit amet, ante. Donec eu libero sit amet quam
+                        egestas semper. Aenean ultricies mi vitae est.
+                    </p>
+                    <p>
+                        Mauris placerat electra enim. Nam tellus tortor, dignissim
+                        sit amet, porttitor ac, accumsan eget, enim. Maecenas
+                        mattis mauris eget purus.
+                    </p>
+                </div>
+
+                <footer class="modal-footer">
+                    <label
+                        for="modal-toggle"
+                        class="btn btn-outline"
+                        role="button"
+                        tabindex="0"
+                    >
+                        Decline
+                    </label>
+                    <label
+                        for="modal-toggle"
+                        class="btn btn-primary"
+                        role="button"
+                        tabindex="0"
+                    >
+                        Accept
+                    </label>
+                </footer>
+
+            </div>
+
+        </div>
+
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/55345-modal-scroll-small-screens/style.css
+++ b/submissions/examples/55345-modal-scroll-small-screens/style.css
@@ -1,0 +1,272 @@
+/* ==========================================================================
+   Scrollable Modal – Small Screen Fix (#55345)
+   Pure CSS modal with proper flex-based scrolling for small viewports.
+   ========================================================================== */
+
+/* ── Custom Properties ───────────────────────────────────────────────────── */
+:root {
+    --bg: #f0f2f5;
+    --surface: #ffffff;
+    --primary: #4f46e5;
+    --primary-hover: #4338ca;
+    --text: #1e293b;
+    --text-muted: #64748b;
+    --border: #e2e8f0;
+    --overlay: rgba(15, 23, 42, 0.6);
+    --radius: 12px;
+    --shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+    --speed: 0.3s;
+    --ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Reset ───────────────────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+code {
+    background: rgba(79, 70, 229, 0.1);
+    color: var(--primary);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+/* ── Demo Page ───────────────────────────────────────────────────────────── */
+.demo-page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+}
+
+.hero {
+    max-width: 600px;
+    text-align: center;
+}
+
+.hero h1 {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    margin-bottom: 1rem;
+}
+
+.hero p {
+    color: var(--text-muted);
+    margin-bottom: 2rem;
+    line-height: 1.7;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────────────────── */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    border: none;
+    transition:
+        background var(--speed) var(--ease),
+        transform var(--speed) var(--ease),
+        color var(--speed) var(--ease);
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: #fff;
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+    background: var(--primary-hover);
+    transform: translateY(-1px);
+}
+
+.btn-outline {
+    background: transparent;
+    color: var(--primary);
+    border: 2px solid var(--primary);
+}
+
+.btn-outline:hover,
+.btn-outline:focus-visible {
+    background: var(--primary);
+    color: #fff;
+}
+
+.btn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 3px;
+}
+
+/* ── Modal Checkbox (hidden) ─────────────────────────────────────────────── */
+.modal-checkbox {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* ── Modal Overlay ───────────────────────────────────────────────────────── */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    z-index: 1000;
+
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+
+    transition:
+        opacity var(--speed) var(--ease),
+        visibility var(--speed) var(--ease);
+}
+
+.modal-checkbox:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+/* ── Modal Dialog ──────────────────────────────────────────────────────────
+   KEY FIX: flex + min-height: 0 on body enables scrolling on small screens.
+   Without min-height: 0 the flex child cannot shrink below its content
+   height, so overflow-y: auto never triggers.                                */
+.modal-dialog {
+    background: var(--surface);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    width: min(520px, 100%);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+
+    transform: scale(0.9) translateY(20px);
+    opacity: 0;
+    transition:
+        transform var(--speed) var(--ease),
+        opacity var(--speed) var(--ease);
+}
+
+.modal-checkbox:checked ~ .modal-overlay .modal-dialog {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+}
+
+/* ── Modal Header ────────────────────────────────────────────────────────── */
+.modal-header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.modal-header h2 {
+    font-size: 1.125rem;
+    font-weight: 700;
+}
+
+.modal-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.5rem;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background var(--speed) var(--ease);
+}
+
+.modal-close:hover {
+    background: var(--border);
+    color: var(--text);
+}
+
+/* ── Modal Body ────────────────────────────────────────────────────────────
+   This is the critical fix: flex: 1 + min-height: 0 allows the body to
+   shrink within the flex column so overflow-y: auto activates properly.     */
+.modal-body {
+    flex: 1;
+    min-height: 0;
+    padding: 1.25rem;
+    overflow-y: auto;
+    color: var(--text-muted);
+    line-height: 1.7;
+}
+
+.modal-body p {
+    margin-bottom: 1rem;
+}
+
+.modal-body p:last-child {
+    margin-bottom: 0;
+}
+
+/* ── Modal Footer ────────────────────────────────────────────────────────── */
+.modal-footer {
+    flex: 0 0 auto;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-top: 1px solid var(--border);
+    background: #f8fafc;
+    border-radius: 0 0 var(--radius) var(--radius);
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+    .demo-page {
+        padding: 1rem;
+    }
+
+    .modal-dialog {
+        max-height: 95vh;
+    }
+
+    .modal-footer {
+        flex-direction: column-reverse;
+    }
+
+    .modal-footer .btn {
+        width: 100%;
+    }
+}
+
+/* ── prefers-reduced-motion ──────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+        transition: none !important;
+        scroll-behavior: auto !important;
+    }
+
+    .modal-dialog {
+        transform: none;
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
## Fix: Modal Cannot Be Scrolled on Small Screens

### Problem
On small viewports, modal content that overflows the available height was not scrollable. In a `display: flex; flex-direction: column` container, flex children default to `min-height: auto`, preventing them from shrinking below their content height — so `overflow-y: auto` never triggers.

### Solution
Created a self-contained CSS-only demo in `submissions/examples/55345-modal-scroll-small-screens/` that demonstrates the fix:

- `.modal-body` gets `flex: 1; min-height: 0;` so it fills remaining space and can shrink below content height
- `.modal-header` and `.modal-footer` get `flex: 0 0 auto;` so they don't shrink
- Combined with `overflow-y: auto`, the body now properly scrolls when content exceeds the viewport

### The Critical Fix
```css
.modal-body {
    flex: 1;
    min-height: 0;    /* Override default min-height: auto */
    overflow-y: auto;  /* Now triggers correctly */
}