### PR TITLE
fix: card grid breaks with long titles (#55342)

### DIFF
--- a/submissions/examples/55342-card-grid-long-titles/README.md
+++ b/submissions/examples/55342-card-grid-long-titles/README.md
@@ -1,0 +1,77 @@
+# Card Grid — Long Titles Fix (#55342)
+
+A CSS-only fix for the bug where cards in a grid become misaligned when one or more cards contain long titles. Long titles now wrap gracefully without disrupting the visual consistency of the grid.
+
+## The Bug
+
+Cards with longer titles become taller than neighboring cards, causing uneven spacing and breaking the visual consistency of the grid layout.
+
+## The Fix
+
+The solution uses two key CSS techniques:
+
+### 1. CSS Grid with `align-items: stretch`
+
+```css
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    align-items: stretch; /* Force all cards in a row to equal height */
+}
+```
+
+`align-items: stretch` is the default for CSS Grid, but explicitly setting it ensures all cards in the same row stretch to match the tallest card.
+
+### 2. Flex-based card internals
+
+```css
+.card {
+    display: flex;
+    flex-direction: column;
+}
+
+.card-desc {
+    flex: 1; /* Pushes content to distribute space evenly */
+}
+
+.card-title {
+    min-height: 1.5em; /* Consistent minimum size for title area */
+    overflow-wrap: break-word; /* Long titles wrap instead of overflowing */
+}
+```
+
+Each card uses `flex-direction: column` so internal sections distribute space evenly. The `flex: 1` on the description ensures all cards have equal content height.
+
+## Features
+
+- Pure CSS implementation — no JavaScript
+- Responsive grid layout (auto-fill, minmax)
+- Equal-height cards regardless of title length
+- Long titles wrap gracefully with `overflow-wrap: break-word`
+- Smooth hover animation
+- `prefers-reduced-motion` support
+- Semantic HTML with ARIA labels
+
+## Files
+
+```text
+submissions/examples/55342-card-grid-long-titles/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+1. Open `demo.html` in a modern web browser.
+2. Observe that all cards in each row have equal height, regardless of title length.
+3. Resize the browser window to see the responsive grid reflow.
+
+## Browser Support
+
+All modern browsers supporting:
+
+- CSS Grid
+- Flexbox
+- CSS Custom Properties
+- CSS Transitions

--- a/submissions/examples/55342-card-grid-long-titles/demo.html
+++ b/submissions/examples/55342-card-grid-long-titles/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS - Card Grid Long Titles Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="demo-page">
+
+        <header class="demo-header">
+            <h1>Card Grid — Long Titles Fix</h1>
+            <p>
+                All cards maintain equal height regardless of title length.
+                Uses CSS Grid with <code>align-items: stretch</code> and flex-based
+                card internals so content distributes evenly across rows.
+            </p>
+        </header>
+
+        <!-- Card Grid -->
+        <div class="card-grid" role="list" aria-label="Feature cards">
+
+            <article class="card" role="listitem">
+                <div class="card-icon" aria-hidden="true">&#9881;</div>
+                <h2 class="card-title">Profile</h2>
+                <p class="card-desc">Short description.</p>
+            </article>
+
+            <article class="card" role="listitem">
+                <div class="card-icon" aria-hidden="true">&#9733;</div>
+                <h2 class="card-title">This is a very long card title that wraps onto multiple lines and increases the height of the card</h2>
+                <p class="card-desc">Another description.</p>
+            </article>
+
+            <article class="card" role="listitem">
+                <div class="card-icon" aria-hidden="true">&#9829;</div>
+                <h2 class="card-title">Analytics</h2>
+                <p class="card-desc">Track your performance metrics and gain insights into user behavior across all platforms.</p>
+            </article>
+
+            <article class="card" role="listitem">
+                <div class="card-icon" aria-hidden="true">&#9775;</div>
+                <h2 class="card-title">Notifications</h2>
+                <p class="card-desc">A medium length description that sits between the short and long examples.</p>
+            </article>
+
+            <article class="card" role="listitem">
+                <div class="card-icon" aria-hidden="true">&#9883;</div>
+                <h2 class="card-title">Dashboard</h2>
+                <p class="card-desc">Short.</p>
+            </article>
+
+            <article class="card" role="listitem">
+                <div class="card-icon" aria-hidden="true">&#10070;</div>
+                <h2 class="card-title">Settings &amp; Configuration Panel with Advanced Options for Customization and Theme Management</h2>
+                <p class="card-desc">Another description.</p>
+            </article>
+
+        </div>
+
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/55342-card-grid-long-titles/style.css
+++ b/submissions/examples/55342-card-grid-long-titles/style.css
@@ -1,0 +1,161 @@
+/* ==========================================================================
+   Card Grid — Long Titles Fix (#55342)
+   Demonstrates equal-height card grid using CSS Grid + flex internals.
+   ========================================================================== */
+
+/* ── Custom Properties ───────────────────────────────────────────────────── */
+:root {
+    --bg: #f0f2f5;
+    --surface: #ffffff;
+    --primary: #4f46e5;
+    --text: #1e293b;
+    --text-muted: #64748b;
+    --border: #e2e8f0;
+    --radius: 12px;
+    --shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.04);
+    --speed: 0.3s;
+    --ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Reset ───────────────────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+code {
+    background: rgba(79, 70, 229, 0.1);
+    color: var(--primary);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+/* ── Demo Page ───────────────────────────────────────────────────────────── */
+.demo-page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.demo-header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.demo-header h1 {
+    font-size: clamp(1.5rem, 4vw, 2.25rem);
+    margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+    color: var(--text-muted);
+    max-width: 560px;
+    margin: 0 auto;
+    line-height: 1.7;
+}
+
+/* ==========================================================================
+   THE FIX — Card Grid
+   ==========================================================================
+   Key points:
+   1. CSS Grid with `align-items: stretch` (default) forces all cards in a
+      row to match the tallest card's height.
+   2. Each card uses `display: flex; flex-direction: column` so internal
+      sections distribute space evenly.
+   3. `.card-title` has a `min-height` to prevent extremely short titles from
+      collapsing the card, while long titles wrap naturally.
+   ========================================================================== */
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+    align-items: stretch; /* Force equal heights per row */
+}
+
+/* ── Individual Card ─────────────────────────────────────────────────────── */
+.card {
+    display: flex;
+    flex-direction: column;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+    transition:
+        transform var(--speed) var(--ease),
+        box-shadow var(--speed) var(--ease);
+}
+
+.card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+/* ── Card Icon ───────────────────────────────────────────────────────────── */
+.card-icon {
+    font-size: 2rem;
+    line-height: 1;
+    margin-bottom: 0.75rem;
+}
+
+/* ── Card Title ────────────────────────────────────────────────────────────
+   min-height ensures the title area has a consistent minimum size, while
+   long titles wrap naturally without breaking the grid alignment.            */
+.card-title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    line-height: 1.4;
+    margin-bottom: 0.5rem;
+    min-height: 1.5em; /* At least ~1.5 lines of text */
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    hyphens: auto;
+}
+
+/* ── Card Description ──────────────────────────────────────────────────────
+   flex: 1 pushes the card content to stretch equally across all cards
+   in the same row.                                                          */
+.card-desc {
+    flex: 1;
+    color: var(--text-muted);
+    font-size: 0.9375rem;
+    line-height: 1.6;
+}
+
+.card-desc:last-child {
+    margin-bottom: 0;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+    .demo-page {
+        padding: 1.5rem 1rem;
+    }
+
+    .card-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ── prefers-reduced-motion ──────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+        transition: none !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
## Fix: Card Grid Breaks with Long Titles (#55342)

### Problem
Cards in the grid become misaligned when one or more cards contain long titles. The additional wrapped text increases the card height, resulting in an uneven and inconsistent grid layout.

### Solution
Self-contained CSS-only demo in `submissions/examples/55342-card-grid-long-titles/` demonstrating the fix with two key techniques:

**1. CSS Grid with `align-items: stretch`**
```css
.card-grid {
    display: grid;
    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
    align-items: stretch; /* Force equal height per row */
}