### PR TITLE
feature: add CSS-only star rating component

### DIFF
--- a/submissions/examples/star-rating-pr2145/README.md
+++ b/submissions/examples/star-rating-pr2145/README.md
@@ -1,0 +1,12 @@
+# CSS-only Star Rating
+
+## What does it do?
+
+Provides an accessible CSS-only star rating component with interactive and read-only variants.
+
+## Usage
+
+```html
+<div class="ease-stars">
+...
+</div>

--- a/submissions/examples/star-rating-pr2145/demo.html
+++ b/submissions/examples/star-rating-pr2145/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS-only Star Rating</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+
+    <h1>EaseMotion CSS-only Star Rating</h1>
+
+    <h2>Default</h2>
+
+    <div class="ease-stars" role="radiogroup" aria-label="Rating">
+
+        <input type="radio" id="star5" name="rating">
+        <label for="star5" class="ease-stars__star" aria-label="5 stars">★</label>
+
+        <input type="radio" id="star4" name="rating">
+        <label for="star4" class="ease-stars__star" aria-label="4 stars">★</label>
+
+        <input type="radio" id="star3" name="rating">
+        <label for="star3" class="ease-stars__star" aria-label="3 stars">★</label>
+
+        <input type="radio" id="star2" name="rating">
+        <label for="star2" class="ease-stars__star" aria-label="2 stars">★</label>
+
+        <input type="radio" id="star1" name="rating">
+        <label for="star1" class="ease-stars__star" aria-label="1 star">★</label>
+
+    </div>
+
+    <h2>Small</h2>
+
+    <div class="ease-stars ease-stars--sm">
+        ★★★★★
+    </div>
+
+    <h2>Large</h2>
+
+    <div class="ease-stars ease-stars--lg">
+        ★★★★★
+    </div>
+
+    <h2>Read Only (3.5)</h2>
+
+    <div
+        class="ease-stars--readonly"
+        style="--ease-stars-value:3.5"
+        aria-label="3.5 out of 5 stars">
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/star-rating-pr2145/style.css
+++ b/submissions/examples/star-rating-pr2145/style.css
@@ -1,0 +1,103 @@
+:root{
+    --ease-stars-color:#f59e0b;
+    --ease-stars-empty-color:#d1d5db;
+    --ease-stars-size:1.5rem;
+    --ease-stars-gap:.25rem;
+    --ease-stars-duration:.15s;
+}
+
+*{
+    box-sizing:border-box;
+}
+
+body{
+    font-family:Arial,Helvetica,sans-serif;
+    background:#f8fafc;
+    margin:0;
+    padding:40px;
+}
+
+.container{
+    max-width:700px;
+    margin:auto;
+}
+
+.ease-stars{
+    display:inline-flex;
+    flex-direction:row-reverse;
+    gap:var(--ease-stars-gap);
+}
+
+.ease-stars input{
+    position:absolute;
+    opacity:0;
+    pointer-events:none;
+}
+
+.ease-stars__star{
+    font-size:var(--ease-stars-size);
+    color:var(--ease-stars-empty-color);
+    cursor:pointer;
+    transition:color var(--ease-stars-duration);
+    user-select:none;
+}
+
+/* Hover */
+.ease-stars__star:hover,
+.ease-stars__star:hover ~ .ease-stars__star{
+    color:var(--ease-stars-color);
+}
+
+/* Selected */
+.ease-stars input:checked + label,
+.ease-stars input:checked + label ~ input + label{
+    color:var(--ease-stars-color);
+}
+
+/* Focus */
+.ease-stars input:focus + label{
+    outline:2px solid #2563eb;
+    outline-offset:4px;
+    border-radius:4px;
+}
+
+.ease-stars--sm{
+    --ease-stars-size:1rem;
+    color:var(--ease-stars-color);
+}
+
+.ease-stars--lg{
+    --ease-stars-size:2.5rem;
+    color:var(--ease-stars-color);
+}
+
+.ease-stars--readonly{
+    position:relative;
+    display:inline-block;
+    font-size:2rem;
+    line-height:1;
+}
+
+.ease-stars--readonly::before{
+    content:"★★★★★";
+    color:var(--ease-stars-empty-color);
+}
+
+.ease-stars--readonly::after{
+    content:"★★★★★";
+    color:var(--ease-stars-color);
+    position:absolute;
+    top:0;
+    left:0;
+    width:calc(var(--ease-stars-value) / 5 * 100%);
+    overflow:hidden;
+    white-space:nowrap;
+}
+
+@media (prefers-reduced-motion:reduce){
+
+.ease-stars__star{
+    transition:none;
+}
+
+}


### PR DESCRIPTION
## Description

This PR adds a reusable CSS-only Star Rating component.

### Features
- Interactive CSS-only star rating
- Read-only variant
- Small (`--sm`) and Large (`--lg`) size variants
- Customizable using CSS variables
- Smooth hover/fill transition
- Accessibility support with `role="radiogroup"` and labels
- `prefers-reduced-motion` support

Closes #55257