### PR TITLE
feat: add skew active tooltip portfolio example (#54552)

### DIFF
--- a/submissions/examples/skew-active-tooltip/README.md
+++ b/submissions/examples/skew-active-tooltip/README.md
@@ -1,16 +1,77 @@
-# Skew-Active Tooltip (Accessible Web Layouts)
+# Creative Portfolio Card with Skew-Active Tooltip
 
-A modern kinetic CSS animation pattern that uses micro-skew transitions without depending on JavaScript engines. It is completely structured around modern web accessibility requirements.
+A lightweight, high-performance Creative Portfolio Card featuring a kinetic **Skew-Active Tooltip** micro-interaction. Built strictly with pure HTML5 and modern CSS3 (no JavaScript, no external frameworks).
 
-## Design Concept
-Upon activation, the element transitions dynamically from an idle skew angle (`-12deg`) to a flattened base alignment (`0deg`). This introduces a rapid visual snap-to-place motion.
+## Overview
 
-## Optimization Configuration
+This example demonstrates how to create a production-ready portfolio showcase card with interactive action triggers that reveal tooltips using smooth skew, scale, and fade transitions. The card itself elevates slightly on hover to deliver a layered depth effect.
 
-Configurations are isolated within the CSS properties block:
+## Features
 
-| Property | Default Value | Functional Usage |
-| :--- | :--- | :--- |
-| `--tooltip-skew-start` | `-12deg` | Initial distortion offset on the X-axis prior to focus |
-| `--tooltip-scale-start` | `0.85` | Lower bounds of scaling interpolation before component focus |
-| `--tooltip-duration` | `0.25s` | Window performance curve timing length |
+- **Pure HTML & CSS**: Zero JavaScript runtime overhead or external dependencies.
+- **Skew-Active Tooltip Animation**: Hardware-accelerated entrance transition combining `skewX()`, `scale()`, `translateY()`, and `opacity`.
+- **Card Elevate Micro-Interaction**: Smooth vertical lift with dynamic shadow expansion on hover.
+- **Tooltip Arrow**: Pure CSS triangular pointer anchored cleanly beneath the tooltip.
+- **Responsive Layout**: Seamlessly adapts across desktop, tablet, and mobile screens.
+- **Keyboard Accessible**: Full support for keyboard navigation using `:focus-visible` focus rings and standard ARIA attributes (`aria-describedby`, `role="tooltip"`).
+- **Reduced Motion Ready**: Honors user accessibility settings via `@media (prefers-reduced-motion: reduce)`.
+
+## Folder Structure
+
+```text
+submissions/examples/skew-active-tooltip/
+├── demo.html       # Self-contained working HTML demo
+├── style.css       # Raw CSS implementation & design system tokens
+└── README.md       # Documentation & technical guide
+```
+
+## How to Use
+
+1. **HTML Markup**:
+   Wrap your action trigger (e.g. `<button>`) and tooltip `<div>` inside a container with `.tooltip-wrapper`:
+
+   ```html
+   <div class="tooltip-wrapper">
+     <button type="button" class="action-btn" aria-describedby="tooltip-id">
+       Trigger Label
+     </button>
+     <div id="tooltip-id" class="skew-tooltip" role="tooltip">
+       <span class="tooltip-heading">Category</span>
+       <p class="tooltip-content">Detailed tooltip message content.</p>
+     </div>
+   </div>
+   ```
+
+2. **CSS Integration**:
+   Link `style.css` in your HTML `<head>` or import the CSS rules into your stylesheet.
+
+## CSS Variables
+
+Customization is driven by CSS variables defined in `:root`:
+
+| Variable                | Default Value                   | Description                                       |
+| ----------------------- | ------------------------------- | ------------------------------------------------- |
+| `--skew-duration`       | `0.35s`                         | Duration of the skew-active tooltip entrance/exit |
+| `--skew-easing`         | `cubic-bezier(0.16, 1, 0.3, 1)` | Easing curve for kinetic motion                   |
+| `--skew-angle-initial`  | `-10deg`                        | Starting skew angle before activation             |
+| `--skew-scale-initial`  | `0.94`                          | Starting scale transform                          |
+| `--skew-offset-y`       | `12px`                          | Vertical slide offset                             |
+| `--card-hover-duration` | `0.3s`                          | Card elevation transition duration                |
+| `--card-bg`             | `#121824`                       | Background color of the portfolio card            |
+| `--tooltip-bg`          | `#1e293b`                       | Tooltip container background color                |
+| `--tooltip-border`      | `#334155`                       | Tooltip border color                              |
+| `--accent-cyan`         | `#06b6d4`                       | Highlight accent color for badges & titles        |
+| `--focus-ring`          | `#38bdf8`                       | Visible keyboard focus ring color                 |
+
+## Browser Compatibility
+
+- **Chrome / Edge**: 88+
+- **Firefox**: 85+
+- **Safari**: 14+
+- **Mobile Browsers**: iOS Safari, Chrome for Android
+
+## Accessibility Notes
+
+- **Keyboard Focus**: Interactive elements include explicit `:focus-visible` styling with distinct outline rings for keyboard users.
+- **ARIA Semantics**: Tooltips use `role="tooltip"` and are referenced via `aria-describedby` on trigger buttons.
+- **Reduced Motion**: Under `@media (prefers-reduced-motion: reduce)`, all transforms and skew animations are disabled, displaying tooltips instantly without motion.

--- a/submissions/examples/skew-active-tooltip/demo.html
+++ b/submissions/examples/skew-active-tooltip/demo.html
@@ -1,29 +1,170 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CSS Skew-Active Tooltip (Accessible Layout) - EaseMotion</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Creative Portfolio Card with Skew-Active Tooltip</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="portfolio-container">
+      <!-- Creative Portfolio Card -->
+      <article class="portfolio-card">
+        <!-- Header Section -->
+        <header class="portfolio-card-header">
+          <div class="artist-profile">
+            <div class="artist-avatar" aria-hidden="true">
+              <span class="avatar-initials">KV</span>
+            </div>
+            <div class="artist-meta">
+              <h1 class="artist-name">Kira Vance</h1>
+              <p class="artist-role">Lead Motion & UI Designer</p>
+            </div>
+          </div>
+          <span class="availability-badge">
+            <span class="badge-dot" aria-hidden="true"></span>
+            Available
+          </span>
+        </header>
 
-  <main class="accessible-panel">
-    <h2 style="margin-top: 0; font-size: 1.25rem;">Server Infrastructure</h2>
-    <p style="color: #64748b; font-size: 0.9rem; margin-bottom: 1.5rem;">
-      Hover or keyboard tab to view deployment configurations safely.
-    </p>
+        <!-- Card Body / Project Highlight -->
+        <div class="portfolio-card-body">
+          <div class="project-preview">
+            <span class="project-tag">Featured Case Study</span>
+            <h2 class="project-title">Aura Interactive Studio</h2>
+            <p class="project-description">
+              A next-generation design showcase blending kinetic motion,
+              glassmorphism, and responsive micro-interactions.
+            </p>
+          </div>
 
-    <div class="tooltip-wrapper">
-      <button class="tooltip-trigger" aria-describedby="skew-tooltip-desc">
-        Check Node Storage
-      </button>
-      
-      <div class="tooltip-box" id="skew-tooltip-desc" role="tooltip">
-        <strong>Storage Capacity:</strong> 84% allocated across 12 distributed edge clusters.
-      </div>
-    </div>
-  </main>
+          <!-- Action Metrics / Buttons with Skew-Active Tooltips -->
+          <div class="portfolio-actions-grid">
+            <!-- Feature 1 -->
+            <div class="tooltip-wrapper">
+              <button
+                type="button"
+                class="action-btn"
+                aria-describedby="tooltip-motion"
+              >
+                <svg
+                  class="btn-icon"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polygon
+                    points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"
+                  ></polygon>
+                </svg>
+                <span>60 FPS Motion</span>
+              </button>
+              <div id="tooltip-motion" class="skew-tooltip" role="tooltip">
+                <span class="tooltip-heading">Kinetic Engine</span>
+                <p class="tooltip-content">
+                  GPU-accelerated CSS transitions with dynamic skew
+                  interpolation on entry.
+                </p>
+              </div>
+            </div>
 
-</body>
+            <!-- Feature 2 -->
+            <div class="tooltip-wrapper">
+              <button
+                type="button"
+                class="action-btn"
+                aria-describedby="tooltip-design"
+              >
+                <svg
+                  class="btn-icon"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="3" y="3" width="7" height="7"></rect>
+                  <rect x="14" y="3" width="7" height="7"></rect>
+                  <rect x="14" y="14" width="7" height="7"></rect>
+                  <rect x="3" y="14" width="7" height="7"></rect>
+                </svg>
+                <span>42 Components</span>
+              </button>
+              <div id="tooltip-design" class="skew-tooltip" role="tooltip">
+                <span class="tooltip-heading">Design Tokens</span>
+                <p class="tooltip-content">
+                  Modular cards, glass popups, responsive grids, and accessible
+                  components.
+                </p>
+              </div>
+            </div>
+
+            <!-- Feature 3 -->
+            <div class="tooltip-wrapper">
+              <button
+                type="button"
+                class="action-btn"
+                aria-describedby="tooltip-a11y"
+              >
+                <svg
+                  class="btn-icon"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+                </svg>
+                <span>A11y Verified</span>
+              </button>
+              <div id="tooltip-a11y" class="skew-tooltip" role="tooltip">
+                <span class="tooltip-heading">Accessibility</span>
+                <p class="tooltip-content">
+                  Keyboard focusable, WCAG AA contrast ratio, and reduced motion
+                  compliant.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card Footer -->
+        <footer class="portfolio-card-footer">
+          <a href="#case-study" class="cta-link">
+            <span>Explore Case Study</span>
+            <svg
+              class="link-arrow"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="5" y1="12" x2="19" y2="12"></line>
+              <polyline points="12 5 19 12 12 19"></polyline>
+            </svg>
+          </a>
+        </footer>
+      </article>
+    </main>
+  </body>
 </html>

--- a/submissions/examples/skew-active-tooltip/style.css
+++ b/submissions/examples/skew-active-tooltip/style.css
@@ -1,100 +1,333 @@
-/* ==========================================================================
-   CSS Custom Properties (Parameters)
-   ========================================================================== */
+/* =========================================================================
+   Custom Properties (Design System & Motion Tokens)
+   ========================================================================= */
 :root {
-  /* Animation Parameters */
-  --tooltip-duration: 0.25s;
-  --tooltip-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  --tooltip-skew-start: -12deg;
-  --tooltip-scale-start: 0.85;
-  
-  /* Interface Themes (Accessible UI) */
-  --bg-app: #f8fafc;
-  --bg-tooltip: #0f172a;
-  --border-focus: #2563eb;
-  --text-tooltip: #ffffff;
-  --text-dark: #1e293b;
-  --shadow-standard: 0 4px 12px rgba(15, 23, 42, 0.15);
+  /* Skew Motion Tokens */
+  --skew-duration: 0.35s;
+  --skew-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --skew-angle-initial: -10deg;
+  --skew-scale-initial: 0.94;
+  --skew-offset-y: 12px;
+
+  /* Card Transition Tokens */
+  --card-hover-duration: 0.3s;
+  --card-hover-easing: cubic-bezier(0.2, 0.8, 0.2, 1);
+
+  /* Creative Portfolio Color Palette */
+  --bg-main: #0a0d14;
+  --card-bg: #121824;
+  --card-border: #1e293b;
+  --card-border-hover: #38bdf8;
+
+  --accent-purple: #8b5cf6;
+  --accent-cyan: #06b6d4;
+  --accent-gradient: linear-gradient(135deg, #8b5cf6 0%, #06b6d4 100%);
+
+  --tooltip-bg: #1e293b;
+  --tooltip-border: #334155;
+  --tooltip-text-primary: #f8fafc;
+  --tooltip-text-secondary: #94a3b8;
+
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #64748b;
+
+  --focus-ring: #38bdf8;
+  --card-shadow: 0 12px 32px -8px rgba(0, 0, 0, 0.5);
+  --card-shadow-hover: 0 24px 48px -12px rgba(56, 189, 248, 0.25);
+  --tooltip-shadow: 0 16px 32px -6px rgba(0, 0, 0, 0.45);
+
+  /* Radius & Spacing System */
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-pill: 9999px;
+
+  --space-xs: 6px;
+  --space-sm: 12px;
+  --space-md: 20px;
+  --space-lg: 28px;
 }
 
-/* Demo Container */
+/* =========================================================================
+   Base Layout Canvas
+   ========================================================================= */
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  padding: 0;
-  font-family: system-ui, -apple-system, sans-serif;
-  background-color: var(--bg-app);
-  color: var(--text-dark);
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 100vh;
+  background-color: var(--bg-main);
+  background-image: radial-gradient(
+    circle at 50% 30%,
+    rgba(139, 92, 246, 0.12) 0%,
+    transparent 60%
+  );
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  color: var(--text-primary);
+  padding: var(--space-md);
 }
 
-.accessible-panel {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  padding: 2rem;
-  border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-  text-align: center;
+.portfolio-container {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  justify-content: center;
 }
 
-/* ==========================================================================
-   Tooltip Layout & Skew Interaction
-   ========================================================================== */
+/* =========================================================================
+   Portfolio Card Component (Lifts on Hover)
+   ========================================================================= */
+.portfolio-card {
+  width: 100%;
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  box-shadow: var(--card-shadow);
+  transform: translateY(0);
+  transition:
+    transform var(--card-hover-duration) var(--card-hover-easing),
+    border-color var(--card-hover-duration) var(--card-hover-easing),
+    box-shadow var(--card-hover-duration) var(--card-hover-easing);
+}
+
+.portfolio-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--card-border-hover);
+  box-shadow: var(--card-shadow-hover);
+}
+
+/* =========================================================================
+   Header Section & Artist Metadata
+   ========================================================================= */
+.portfolio-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.artist-profile {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.artist-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-gradient);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+}
+
+.avatar-initials {
+  letter-spacing: 0.05em;
+}
+
+.artist-meta {
+  display: flex;
+  flex-direction: column;
+}
+
+.artist-name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.artist-role {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* Availability Badge & Pulse Keyframe */
+.availability-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  background-color: rgba(16, 185, 129, 0.1);
+  color: #10b981;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background-color: #10b981;
+  animation: pulse-dot 2s infinite ease-in-out;
+}
+
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(1.3);
+  }
+}
+
+/* =========================================================================
+   Project Preview Section
+   ========================================================================= */
+.portfolio-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.project-tag {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-cyan);
+  margin-bottom: var(--space-xs);
+}
+
+.project-title {
+  margin: 0 0 var(--space-xs) 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.project-description {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* =========================================================================
+   Action Grid & Skew-Active Tooltips
+   ========================================================================= */
+.portfolio-actions-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+
 .tooltip-wrapper {
   position: relative;
-  display: inline-block;
+  display: flex;
+  justify-content: center;
 }
 
-/* Trigger Element */
-.tooltip-trigger {
-  background-color: #2563eb;
-  color: #ffffff;
-  border: none;
-  padding: 0.75rem 1.5rem;
-  font-size: 0.95rem;
+/* Action Trigger Buttons */
+.action-btn {
+  width: 100%;
+  padding: 10px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background-color: rgba(30, 41, 59, 0.6);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
   font-weight: 600;
-  border-radius: 6px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  outline: none;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
 }
 
-.tooltip-trigger:hover,
-.tooltip-trigger:focus {
-  background-color: #1d4ed8;
-  outline: 3px solid #93c5fd;
-  outline-offset: 2px;
+.action-btn:hover {
+  background-color: rgba(30, 41, 59, 0.95);
+  border-color: var(--accent-cyan);
+  color: var(--text-primary);
 }
 
-/* Skew Tooltip Box */
-.tooltip-box {
+.action-btn:focus-visible {
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.3);
+  color: var(--text-primary);
+}
+
+.btn-icon {
+  stroke: var(--accent-purple);
+  transition: stroke 0.2s ease;
+}
+
+.action-btn:hover .btn-icon,
+.action-btn:focus-visible .btn-icon {
+  stroke: var(--accent-cyan);
+}
+
+/* =========================================================================
+   Skew-Active Tooltip Box Layout
+   ========================================================================= */
+.skew-tooltip {
   position: absolute;
-  bottom: 135%;
+  bottom: calc(100% + 12px);
   left: 50%;
-  /* Combines centering offset, initial scale, and active-ready skew angle */
-  transform: translateX(-50%) translateY(8px) skewX(var(--tooltip-skew-start)) scale(var(--tooltip-scale-start));
-  transform-origin: bottom center;
-  background-color: var(--bg-tooltip);
-  color: var(--text-tooltip);
-  padding: 10px 14px;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  width: 200px;
-  box-shadow: var(--shadow-standard);
-  
-  /* Hidden Initialization */
-  opacity: 0;
+  width: max-content;
+  max-width: 210px;
+  padding: 10px 12px;
+  background-color: var(--tooltip-bg);
+  border: 1px solid var(--tooltip-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--tooltip-shadow);
+  z-index: 100;
   pointer-events: none;
-  
-  /* Transitions */
-  transition: 
-    opacity var(--tooltip-duration) var(--tooltip-easing),
-    transform var(--tooltip-duration) var(--tooltip-easing);
+  transform-origin: bottom center;
+
+  /* Hidden Initial State (Skewed, Scaled down, and Offset) */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%) translateY(var(--skew-offset-y))
+    scale(var(--skew-scale-initial)) skewX(var(--skew-angle-initial));
+
+  /* Smooth 60fps composite transition */
+  transition:
+    opacity var(--skew-duration) var(--skew-easing),
+    visibility var(--skew-duration) var(--skew-easing),
+    transform var(--skew-duration) var(--skew-easing);
 }
 
-/* Tooltip Connector Arrow */
-.tooltip-box::after {
+/* Arrow Pointer (Content fill) */
+.skew-tooltip::after {
   content: "";
   position: absolute;
   top: 100%;
@@ -102,27 +335,131 @@ body {
   transform: translateX(-50%);
   border-width: 6px;
   border-style: solid;
-  border-color: var(--bg-tooltip) transparent transparent transparent;
+  border-color: var(--tooltip-bg) transparent transparent transparent;
 }
 
-/* ==========================================================================
-   Triggered States (Hover & Keyboard Focus Within)
-   ========================================================================== */
-.tooltip-wrapper:hover .tooltip-box,
-.tooltip-wrapper:focus-within .tooltip-box {
+/* Arrow Pointer (Border outline silhouette) */
+.skew-tooltip::before {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 7px;
+  border-style: solid;
+  border-color: var(--tooltip-border) transparent transparent transparent;
+  z-index: -1;
+}
+
+.tooltip-heading {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent-cyan);
+  margin-bottom: 3px;
+}
+
+.tooltip-content {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: var(--tooltip-text-secondary);
+}
+
+/* =========================================================================
+   Interaction Engine: Skew-Active Trigger Logic
+   ========================================================================= */
+.action-btn:hover + .skew-tooltip,
+.action-btn:focus-visible + .skew-tooltip {
   opacity: 1;
-  pointer-events: auto;
-  /* Snaps back to 0deg skew and full scale when deployed */
-  transform: translateX(-50%) translateY(0) skewX(0deg) scale(1);
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1) skewX(0deg);
 }
 
-/* ==========================================================================
-   Accessibility: Reduced Motion Guardrail
-   ========================================================================== */
+/* =========================================================================
+   Footer & CTA Link
+   ========================================================================= */
+.portfolio-card-footer {
+  padding-top: var(--space-xs);
+}
+
+.cta-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent-cyan);
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.cta-link:hover {
+  color: var(--accent-purple);
+}
+
+.cta-link:focus-visible {
+  outline: none;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.4);
+}
+
+.link-arrow {
+  transition: transform 0.2s ease;
+}
+
+.cta-link:hover .link-arrow {
+  transform: translateX(4px);
+}
+
+/* =========================================================================
+   Responsive Adaptations (Tablet & Mobile)
+   ========================================================================= */
+@media (max-width: 480px) {
+  .portfolio-card {
+    padding: var(--space-md);
+  }
+
+  .portfolio-actions-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .action-btn {
+    flex-direction: row;
+    padding: 12px 14px;
+    justify-content: flex-start;
+  }
+
+  .skew-tooltip {
+    max-width: 260px;
+  }
+}
+
+/* =========================================================================
+   Accessibility: Reduced Motion Preference
+   ========================================================================= */
 @media (prefers-reduced-motion: reduce) {
-  .tooltip-box {
-    /* Instantly strips out all transform skew updates */
-    transform: translateX(-50%) translateY(0) skewX(0deg) scale(1) !important;
-    transition: opacity 0.1s linear !important;
+  .badge-dot {
+    animation: none;
+  }
+
+  .portfolio-card,
+  .action-btn,
+  .btn-icon,
+  .skew-tooltip,
+  .cta-link,
+  .link-arrow {
+    transition: none;
+  }
+
+  .portfolio-card:hover {
+    transform: none;
+  }
+
+  .action-btn:hover + .skew-tooltip,
+  .action-btn:focus-visible + .skew-tooltip {
+    transform: translateX(-50%) translateY(0);
   }
 }


### PR DESCRIPTION
Closes #54552

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/skew-active-tooltip/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

Adds a modern **Skew-Active Tooltip** example for creative portfolio layouts using only HTML and CSS.

### How does a developer use it?

```html
<link rel="stylesheet" href="style.css">