### PR TITLE
feat: add CSS fade in modal portfolio example

### DIFF
--- a/submissions/examples/fade-in-modals/README.md
+++ b/submissions/examples/fade-in-modals/README.md
@@ -1,0 +1,32 @@
+# CSS Fade-In Modal
+
+A responsive **Fade-In Modal** built with pure HTML and CSS for creative portfolio layouts.
+
+## Features
+
+- Pure HTML & CSS
+- Smooth fade-in animation
+- Responsive layout
+- Lightweight and reusable
+- Supports `prefers-reduced-motion`
+- Easy to customize using CSS variables
+
+## Files
+
+- demo.html
+- style.css
+
+## Usage
+
+Open `demo.html` directly in any modern browser.
+
+## CSS Variables
+
+```css
+:root{
+  --bg:#0f172a;
+  --card:#1e293b;
+  --accent:#38bdf8;
+  --text:#ffffff;
+}
+```

--- a/submissions/examples/fade-in-modals/demo.html
+++ b/submissions/examples/fade-in-modals/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fade-In Modal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+    <div class="modal">
+        <h2>Creative Portfolio</h2>
+        <p>
+            A simple Fade-In Modal built using pure HTML and CSS for creative portfolio layouts.
+        </p>
+        <a href="#" class="btn">Explore Projects</a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-modals/style.css
+++ b/submissions/examples/fade-in-modals/style.css
@@ -1,0 +1,87 @@
+:root{
+    --bg:#0f172a;
+    --card:#1e293b;
+    --accent:#38bdf8;
+    --text:#ffffff;
+}
+
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    min-height:100vh;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    padding:20px;
+    font-family:Arial,sans-serif;
+    background:linear-gradient(135deg,#0f172a,#1e293b);
+}
+
+.modal{
+    width:380px;
+    max-width:100%;
+    padding:35px;
+    background:var(--card);
+    color:var(--text);
+    border-radius:18px;
+    text-align:center;
+    box-shadow:0 15px 35px rgba(0,0,0,.35);
+    animation:fadeIn .8s ease forwards;
+    transition:transform .3s ease, box-shadow .3s ease;
+}
+
+.modal:hover{
+    transform:translateY(-6px);
+    box-shadow:0 20px 40px rgba(56,189,248,.35);
+}
+
+.modal h2{
+    margin-bottom:15px;
+}
+
+.modal p{
+    line-height:1.6;
+    margin-bottom:22px;
+}
+
+.btn{
+    display:inline-block;
+    padding:12px 24px;
+    border-radius:30px;
+    background:var(--accent);
+    color:#fff;
+    text-decoration:none;
+}
+
+@keyframes fadeIn{
+    from{
+        opacity:0;
+        transform:translateY(30px);
+    }
+    to{
+        opacity:1;
+        transform:translateY(0);
+    }
+}
+
+@media(max-width:600px){
+    .modal{
+        width:100%;
+        padding:25px;
+    }
+}
+
+@media(prefers-reduced-motion:reduce){
+    *{
+        animation:none!important;
+        transition:none!important;
+    }
+
+    .modal:hover{
+        transform:none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

**Fixes #54494**

This pull request adds a **CSS Fade-In Modal** example for creative portfolio layouts using pure HTML and CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/fade-in-modal/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

Adds a responsive **Fade-In Modal** with a smooth fade-in entrance animation for creative portfolio layouts.

### How does a developer use it?

```html
<div class="modal">
  <h2>Creative Portfolio</h2>
  <p>Pure HTML & CSS Fade-In Modal.</p>
  <a href="#" class="btn">Explore Projects</a>
</div>
```

### Why does it fit EaseMotion CSS?

This component aligns with EaseMotion CSS's animation-first philosophy by providing a lightweight, reusable modal built entirely with HTML and CSS. It is responsive, customizable, and supports `prefers-reduced-motion`.

---

## Demo

- [x] Demo added (`demo.html` opens directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(not tested)*

---

## Notes for Maintainer

- Built using pure HTML & CSS.
- Responsive across desktop, tablet, and mobile.
- Includes accessibility support with `prefers-reduced-motion`.

**Issue:** #54494