### PR TITLE
feat: add CSS morph-glow card grid for creative portfolios (issue #54…

### DIFF
--- a/submissions/examples/morph-glow-card-grid-ag/README.md
+++ b/submissions/examples/morph-glow-card-grid-ag/README.md
@@ -1,0 +1,60 @@
+# Morph-Glow Card Grid
+
+A pure CSS/HTML showcase example for creative portfolio layouts. Cards morph their border-radius into an organic blob shape and emit an animated conic-gradient glow on hover/focus — no JavaScript required.
+
+## Files
+
+- `demo.html` — Standalone showcase page with a responsive 6-card grid
+- `style.css` — All styling, morph keyframes, glow effect, and responsive/reduced-motion rules
+- `README.md` — This file
+
+## Usage
+
+Open `demo.html` directly in a browser, or copy the `.morph-*` classes and CSS custom properties into your own project.
+
+```html
+<article class="morph-card" tabindex="0">
+  <div class="morph-card__glow" aria-hidden="true"></div>
+  <div class="morph-card__inner">
+    <span class="morph-card__index">01</span>
+    <h2 class="morph-card__title">Card Title</h2>
+    <p class="morph-card__desc">Card description text.</p>
+    <span class="morph-card__tag">Tag</span>
+  </div>
+</article>
+```
+
+`tabindex="0"` is included so the morph/glow effect is also reachable and triggerable via keyboard (`:focus-visible`), not just mouse hover.
+
+## Customization (CSS Custom Properties)
+
+All defined on `:root`, scoped to this demo:
+
+| Property | Purpose | Default |
+|---|---|---|
+| `--morph-bg` | Page background | `#0f1117` |
+| `--morph-card-bg` | Card background | `#171a23` |
+| `--morph-card-border` | Card border color | `rgba(255,255,255,0.08)` |
+| `--morph-text` | Primary text color | `#f2f3f7` |
+| `--morph-text-muted` | Secondary text color | `#9aa0ac` |
+| `--morph-accent` | Primary glow/gradient color | `#7c5cff` |
+| `--morph-accent-2` | Secondary glow/gradient color | `#22d3ee` |
+| `--morph-radius-a` / `--morph-radius-b` | The two morph border-radius keyframe states | organic blob values |
+| `--morph-radius-rest` | Resting (non-hovered) border radius | `20px` |
+| `--morph-speed` | Morph cycle duration | `6s` |
+| `--morph-glow-size` | Blur radius of the glow layer | `60px` |
+
+Override any of these on `:root` or a parent selector to reskin the grid without touching the CSS rules themselves.
+
+## Features
+
+- Pure CSS/HTML — no JavaScript, no external frameworks
+- Organic `border-radius` morph animation cycling between two blob shapes on hover/focus
+- Animated conic-gradient glow using a blurred pseudo-layer, spinning behind the card
+- Fully keyboard-accessible: hover effects are mirrored via `:focus-visible` for `tabindex="0"` cards
+- Fully responsive: 3-column → 2-column → 1-column grid across desktop, tablet, and mobile
+- Respects `prefers-reduced-motion`: disables the morph and glow animations and falls back to a subtle `scale(1.02)` hover with no shape/border-radius change
+
+## Notes on scope
+
+No scope reduction was needed — all requirements in the issue (morph, glow, responsiveness, `prefers-reduced-motion`) are achievable in pure CSS and are implemented as specified.

--- a/submissions/examples/morph-glow-card-grid-ag/demo.html
+++ b/submissions/examples/morph-glow-card-grid-ag/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Morph-Glow Card Grid | EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="morph-page">
+  <header class="morph-header">
+    <h1>Morph-Glow Card Grid</h1>
+    <p>A pure CSS showcase for creative portfolio layouts — organic border-radius morphing paired with a soft animated glow.</p>
+  </header>
+
+  <section class="morph-grid" aria-label="Portfolio showcase grid">
+
+    <article class="morph-card" tabindex="0">
+      <div class="morph-card__glow" aria-hidden="true"></div>
+      <div class="morph-card__inner">
+        <span class="morph-card__index">01</span>
+        <h2 class="morph-card__title">Visual Design</h2>
+        <p class="morph-card__desc">Brand identity, illustration, and layout systems built for clarity and impact.</p>
+        <span class="morph-card__tag">Branding</span>
+      </div>
+    </article>
+
+    <article class="morph-card" tabindex="0">
+      <div class="morph-card__glow" aria-hidden="true"></div>
+      <div class="morph-card__inner">
+        <span class="morph-card__index">02</span>
+        <h2 class="morph-card__title">Front-End Dev</h2>
+        <p class="morph-card__desc">Interactive interfaces built with performance and accessibility in mind.</p>
+        <span class="morph-card__tag">Development</span>
+      </div>
+    </article>
+
+    <article class="morph-card" tabindex="0">
+      <div class="morph-card__glow" aria-hidden="true"></div>
+      <div class="morph-card__inner">
+        <span class="morph-card__index">03</span>
+        <h2 class="morph-card__title">Motion Design</h2>
+        <p class="morph-card__desc">Micro-interactions and animation systems that bring products to life.</p>
+        <span class="morph-card__tag">Animation</span>
+      </div>
+    </article>
+
+    <article class="morph-card" tabindex="0">
+      <div class="morph-card__glow" aria-hidden="true"></div>
+      <div class="morph-card__inner">
+        <span class="morph-card__index">04</span>
+        <h2 class="morph-card__title">3D & Illustration</h2>
+        <p class="morph-card__desc">Custom 3D renders and illustrative assets for standout digital experiences.</p>
+        <span class="morph-card__tag">Illustration</span>
+      </div>
+    </article>
+
+    <article class="morph-card" tabindex="0">
+      <div class="morph-card__glow" aria-hidden="true"></div>
+      <div class="morph-card__inner">
+        <span class="morph-card__index">05</span>
+        <h2 class="morph-card__title">UX Research</h2>
+        <p class="morph-card__desc">User interviews, journey mapping, and usability testing for informed design.</p>
+        <span class="morph-card__tag">Research</span>
+      </div>
+    </article>
+
+    <article class="morph-card" tabindex="0">
+      <div class="morph-card__glow" aria-hidden="true"></div>
+      <div class="morph-card__inner">
+        <span class="morph-card__index">06</span>
+        <h2 class="morph-card__title">Creative Direction</h2>
+        <p class="morph-card__desc">End-to-end creative strategy across campaigns and product launches.</p>
+        <span class="morph-card__tag">Strategy</span>
+      </div>
+    </article>
+
+  </section>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/morph-glow-card-grid-ag/style.css
+++ b/submissions/examples/morph-glow-card-grid-ag/style.css
@@ -1,0 +1,206 @@
+/* =========================================
+   Morph-Glow Card Grid
+   Pure CSS — no JS required
+   ========================================= */
+
+:root {
+  --morph-bg: #0f1117;
+  --morph-card-bg: #171a23;
+  --morph-card-border: rgba(255, 255, 255, 0.08);
+  --morph-text: #f2f3f7;
+  --morph-text-muted: #9aa0ac;
+  --morph-accent: #7c5cff;
+  --morph-accent-2: #22d3ee;
+
+  --morph-radius-a: 42% 58% 65% 35% / 45% 40% 60% 55%;
+  --morph-radius-b: 60% 40% 35% 65% / 55% 60% 40% 45%;
+  --morph-radius-rest: 20px;
+
+  --morph-speed: 6s;
+  --morph-glow-size: 60px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--morph-bg);
+  color: var(--morph-text);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+.morph-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 64px 24px 96px;
+}
+
+.morph-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.morph-header h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin: 0 0 12px;
+  background: linear-gradient(90deg, var(--morph-accent), var(--morph-accent-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.morph-header p {
+  color: var(--morph-text-muted);
+  max-width: 560px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.morph-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px;
+}
+
+@media (max-width: 900px) {
+  .morph-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 560px) {
+  .morph-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---- Card ---- */
+
+.morph-card {
+  position: relative;
+  isolation: isolate;
+  padding: 2px;
+  border-radius: var(--morph-radius-rest);
+  background: var(--morph-card-bg);
+  border: 1px solid var(--morph-card-border);
+  cursor: pointer;
+  outline: none;
+  transition: border-radius 0.6s ease, transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.morph-card:hover,
+.morph-card:focus-visible {
+  transform: translateY(-6px);
+  border-radius: var(--morph-radius-a);
+  animation: morphShape var(--morph-speed) ease-in-out infinite;
+  box-shadow:
+    0 20px 40px -20px rgba(0, 0, 0, 0.6),
+    0 0 0 1px var(--morph-card-border);
+}
+
+.morph-card:focus-visible {
+  box-shadow:
+    0 20px 40px -20px rgba(0, 0, 0, 0.6),
+    0 0 0 2px var(--morph-accent-2);
+}
+
+@keyframes morphShape {
+  0%, 100% { border-radius: var(--morph-radius-a); }
+  50% { border-radius: var(--morph-radius-b); }
+}
+
+/* ---- Glow layer ---- */
+
+.morph-card__glow {
+  position: absolute;
+  inset: -2px;
+  z-index: -1;
+  border-radius: inherit;
+  background: conic-gradient(
+    from 0deg,
+    var(--morph-accent),
+    var(--morph-accent-2),
+    var(--morph-accent)
+  );
+  opacity: 0;
+  filter: blur(var(--morph-glow-size));
+  transition: opacity 0.5s ease;
+}
+
+.morph-card:hover .morph-card__glow,
+.morph-card:focus-visible .morph-card__glow {
+  opacity: 0.55;
+  animation: morphSpin calc(var(--morph-speed) * 2) linear infinite;
+}
+
+@keyframes morphSpin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* ---- Card content ---- */
+
+.morph-card__inner {
+  position: relative;
+  height: 100%;
+  background: var(--morph-card-bg);
+  border-radius: inherit;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: border-radius 0.6s ease;
+}
+
+.morph-card__index {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--morph-accent-2);
+  letter-spacing: 0.08em;
+}
+
+.morph-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--morph-text);
+}
+
+.morph-card__desc {
+  margin: 0;
+  color: var(--morph-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.morph-card__tag {
+  align-self: flex-start;
+  margin-top: 8px;
+  font-size: 0.75rem;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--morph-card-border);
+  color: var(--morph-text-muted);
+}
+
+/* ---- Reduced motion fallback ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .morph-card,
+  .morph-card__inner,
+  .morph-card__glow {
+    animation: none !important;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  .morph-card:hover,
+  .morph-card:focus-visible {
+    border-radius: var(--morph-radius-rest);
+    transform: scale(1.02);
+  }
+
+  .morph-card__glow {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a CSS Morph-Glow Card Grid for creative portfolio layouts as requested in #54535.

## Changes
- New folder: `submissions/examples/morph-glow-card-grid-ag/`
- `demo.html` — Responsive 6-card showcase grid using EaseMotion-style markup
- `style.css` — Pure CSS morph (border-radius keyframe) + animated conic-gradient glow effect, fully responsive, `prefers-reduced-motion` support
- `README.md` — Usage instructions, CSS custom property reference, accessibility and customization notes

## Features
- Pure CSS/HTML — no JavaScript, no external frameworks
- Organic border-radius morph animation on hover/focus, cycling between two blob shapes
- Animated glow layer using a blurred conic-gradient pseudo-element
- Keyboard accessible via `:focus-visible` (cards are `tabindex="0"`)
- Fully responsive: 3-column → 2-column → 1-column across breakpoints
- Respects `prefers-reduced-motion`: disables morph/glow animations, falls back to a subtle scale hover

## Notes
No scope reduction was needed — all requirements (morph, glow, responsiveness, reduced-motion) are achievable in pure CSS and implemented as specified.

No existing files were modified or deleted — this PR only adds new files under `submissions/examples/`.

Closes #54535