### PR TITLE
feat: add before-after image comparison slider (#55696)

### DIFF
--- a/submissions/examples/before-after-image-slider-em/README.md
+++ b/submissions/examples/before-after-image-slider-em/README.md
@@ -1,0 +1,48 @@
+# Before / After Comparison Slider
+
+## 1. What does this do?
+
+This is a self-contained example (resolves [#55696](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55696)) that adds an interactive, draggable before/after image comparison slider — the kind used in design-portfolio and photo-retouching showcases to reveal a "before" and "after" state side by side.
+
+It includes two working instances:
+
+- **Darkroom grade** — a desaturated landscape scene sliding into a vivid color-graded version, demonstrating the component on illustrative imagery.
+- **Interface redesign** — a wireframe-style UI mockup sliding into its redesigned counterpart, demonstrating the component on flat UI content instead of a photo.
+
+Both instances share the same markup pattern and are driven entirely by one CSS custom property, `--clip-offset`.
+
+## 2. How is it used?
+
+Open `demo.html` in a browser — no build step, no dependencies. Drag the circular handle left/right, tap and swipe on mobile, or click the handle and use the **Left/Right arrow keys** to nudge the comparison point.
+
+The core pattern, consistent with the [component conventions](../../../README.md) used elsewhere in this repo:
+
+```html
+<div class="compare" style="--clip-offset: 50%">
+  <div class="compare-frame">
+    <div class="compare-layer compare-layer--before">...before content...</div>
+    <div class="compare-layer compare-layer--after">...after content...</div>
+    <div class="compare-handle"></div>
+  </div>
+  <input type="range" class="compare-range" min="0" max="100" value="50" />
+</div>
+```
+
+```css
+.compare-layer--after {
+  clip-path: inset(0 calc(100% - var(--clip-offset)) 0 0);
+}
+```
+
+```js
+// script.js
+range.addEventListener("input", () => {
+  container.style.setProperty("--clip-offset", `${range.value}%`);
+});
+```
+
+The "after" layer sits on top of the "before" layer and is clipped from the right edge by `--clip-offset`. A native `<input type="range">` is stretched over the whole frame, fully transparent except for its thumb, which is styled to look like the visible handle grip. Because it's a real range input, dragging, touch swiping, and arrow-key nudging all come from the browser for free — `script.js` only has to copy the input's value onto the CSS variable.
+
+## 3. Why is it useful?
+
+Most before/after sliders reach for `mousemove`/`touchmove` listeners and manual position math, which means re-implementing drag physics, touch handling, and keyboard support separately. Anchoring the whole interaction to a single custom property and a native range input removes almost all of that: the browser already knows how to drag, swipe, and step a range control, and CSS already knows how to clip a layer — this component just wires the two together. That makes it easy to drop a second, third, or fourth instance onto a page (as the two examples here show) without writing any additional interaction code, only new markup for the before/after content itself.

--- a/submissions/examples/before-after-image-slider-em/demo.html
+++ b/submissions/examples/before-after-image-slider-em/demo.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Before / After Comparison Slider — EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A draggable before/after image comparison slider built with EaseMotion CSS — clip-path driven, keyboard accessible, touch-friendly."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="wrap">
+      <!-- ============ HERO ============ -->
+      <header class="hero">
+        <p class="eyebrow"><span class="dot"></span> submissions/examples · before-after-image-slider-em</p>
+        <h1 class="hero-title">
+          Same frame.<br />
+          <span class="hl">Two exposures.</span>
+        </h1>
+        <p class="hero-sub">
+          One slider, one CSS custom property. Drag the grip, use the arrow keys, or touch
+          and swipe — <code>--clip-offset</code> does the rest, no JavaScript animation
+          loop required.
+        </p>
+      </header>
+
+      <!-- ============ SIGNATURE: COMPARISON SLIDER 1 ============ -->
+      <section class="demo-block" aria-labelledby="demo-1-title">
+        <div class="demo-head">
+          <h2 id="demo-1-title" class="demo-title">Darkroom grade</h2>
+          <span class="demo-tag">landscape · color grade</span>
+        </div>
+
+        <div class="compare" style="--ratio: 16/10">
+          <div class="compare-frame">
+            <!-- BEFORE layer -->
+            <div class="compare-layer compare-layer--before">
+              <svg viewBox="0 0 640 400" preserveAspectRatio="xMidYMid slice" class="scene scene--before" aria-hidden="true">
+                <rect width="640" height="400" fill="#3a3d42"/>
+                <circle cx="500" cy="90" r="46" fill="#6b6e73"/>
+                <path d="M0 260 L140 150 L230 230 L340 120 L430 220 L520 160 L640 250 L640 400 L0 400 Z" fill="#26282c"/>
+                <path d="M0 310 L180 240 L300 300 L460 230 L640 300 L640 400 L0 400 Z" fill="#1b1d20"/>
+              </svg>
+              <span class="scene-label scene-label--before">Before</span>
+            </div>
+
+            <!-- AFTER layer, clipped by --clip-offset -->
+            <div class="compare-layer compare-layer--after">
+              <svg viewBox="0 0 640 400" preserveAspectRatio="xMidYMid slice" class="scene scene--after" aria-hidden="true">
+                <defs>
+                  <linearGradient id="sky1" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stop-color="#ff9a5c"/>
+                    <stop offset="55%" stop-color="#f3667a"/>
+                    <stop offset="100%" stop-color="#5b3a8f"/>
+                  </linearGradient>
+                </defs>
+                <rect width="640" height="400" fill="url(#sky1)"/>
+                <circle cx="500" cy="90" r="46" fill="#ffe3a8"/>
+                <path d="M0 260 L140 150 L230 230 L340 120 L430 220 L520 160 L640 250 L640 400 L0 400 Z" fill="#3d2b52" opacity="0.9"/>
+                <path d="M0 310 L180 240 L300 300 L460 230 L640 300 L640 400 L0 400 Z" fill="#241a38"/>
+              </svg>
+              <span class="scene-label scene-label--after">After</span>
+            </div>
+
+            <!-- Handle -->
+            <div class="compare-handle" aria-hidden="true">
+              <span class="compare-handle-grip">
+                <svg viewBox="0 0 24 24" width="14" height="14"><path d="M15 6l-6 6 6 6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <svg viewBox="0 0 24 24" width="14" height="14"><path d="M9 6l6 6-6 6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </span>
+            </div>
+          </div>
+
+          <input
+            type="range"
+            class="compare-range"
+            min="0"
+            max="100"
+            value="50"
+            step="0.1"
+            aria-label="Comparison position for darkroom grade example"
+          />
+        </div>
+      </section>
+
+      <!-- ============ SIGNATURE: COMPARISON SLIDER 2 ============ -->
+      <section class="demo-block" aria-labelledby="demo-2-title">
+        <div class="demo-head">
+          <h2 id="demo-2-title" class="demo-title">Interface redesign</h2>
+          <span class="demo-tag">UI mockup · wireframe to shipped</span>
+        </div>
+
+        <div class="compare" style="--ratio: 16/10">
+          <div class="compare-frame">
+            <!-- BEFORE layer -->
+            <div class="compare-layer compare-layer--before">
+              <div class="scene scene--ui scene--ui-before">
+                <div class="ui-topbar">
+                  <span class="ui-dot"></span><span class="ui-dot"></span><span class="ui-dot"></span>
+                </div>
+                <div class="ui-body">
+                  <div class="ui-side">
+                    <div class="ui-line ui-line--sm"></div>
+                    <div class="ui-line ui-line--sm"></div>
+                    <div class="ui-line ui-line--sm"></div>
+                  </div>
+                  <div class="ui-main">
+                    <div class="ui-line ui-line--lg"></div>
+                    <div class="ui-line ui-line--md"></div>
+                    <div class="ui-cards">
+                      <div class="ui-card"></div>
+                      <div class="ui-card"></div>
+                      <div class="ui-card"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <span class="scene-label scene-label--before">Before</span>
+            </div>
+
+            <!-- AFTER layer -->
+            <div class="compare-layer compare-layer--after">
+              <div class="scene scene--ui scene--ui-after">
+                <div class="ui-topbar ui-topbar--after">
+                  <span class="ui-dot ui-dot--after"></span><span class="ui-dot ui-dot--after"></span><span class="ui-dot ui-dot--after"></span>
+                </div>
+                <div class="ui-body">
+                  <div class="ui-side ui-side--after">
+                    <div class="ui-line ui-line--sm ui-line--after"></div>
+                    <div class="ui-line ui-line--sm ui-line--after-accent"></div>
+                    <div class="ui-line ui-line--sm ui-line--after"></div>
+                  </div>
+                  <div class="ui-main">
+                    <div class="ui-line ui-line--lg ui-line--after"></div>
+                    <div class="ui-line ui-line--md ui-line--after"></div>
+                    <div class="ui-cards">
+                      <div class="ui-card ui-card--after"></div>
+                      <div class="ui-card ui-card--after"></div>
+                      <div class="ui-card ui-card--after"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <span class="scene-label scene-label--after">After</span>
+            </div>
+
+            <!-- Handle -->
+            <div class="compare-handle" aria-hidden="true">
+              <span class="compare-handle-grip">
+                <svg viewBox="0 0 24 24" width="14" height="14"><path d="M15 6l-6 6 6 6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <svg viewBox="0 0 24 24" width="14" height="14"><path d="M9 6l6 6-6 6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </span>
+            </div>
+          </div>
+
+          <input
+            type="range"
+            class="compare-range"
+            min="0"
+            max="100"
+            value="35"
+            step="0.1"
+            aria-label="Comparison position for interface redesign example"
+          />
+        </div>
+      </section>
+
+      <!-- ============ HOW IT WORKS ============ -->
+      <section class="how">
+        <h2 class="section-title">How the reveal works</h2>
+        <div class="steps">
+          <div class="step">
+            <span class="step-no">1</span>
+            <h3>One custom property</h3>
+            <p>
+              Every slider sets <code>--clip-offset</code> on its own <code>.compare</code>
+              container. The "after" layer's <code>clip-path</code> reads that value —
+              nothing else needs to know it exists.
+            </p>
+          </div>
+          <div class="step">
+            <span class="step-no">2</span>
+            <h3>A transparent range input</h3>
+            <p>
+              A native <code>&lt;input type="range"&gt;</code> sits on top, fully
+              transparent except for its thumb. That's what gives you drag, touch, and
+              keyboard arrow support for free.
+            </p>
+          </div>
+          <div class="step">
+            <span class="step-no">3</span>
+            <h3>One line of JS</h3>
+            <p>
+              On <code>input</code>, <code>script.js</code> writes the range's value
+              straight to the CSS variable. No drag math, no pointer tracking, no
+              animation frame loop.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ COPY-READY SNIPPET ============ -->
+      <section class="snippet-section">
+        <h2 class="section-title">Copy-ready markup</h2>
+        <div class="snippet-card">
+          <div class="snippet-head">
+            <span class="file-name">index.html</span>
+            <button class="copy-btn" onclick="copySnippet('snippet-markup', this)">Copy</button>
+          </div>
+          <pre class="code" id="snippet-markup"><code>&lt;div class="compare" style="--clip-offset: 50%"&gt;
+  &lt;div class="compare-frame"&gt;
+    &lt;div class="compare-layer compare-layer--before"&gt;...&lt;/div&gt;
+    &lt;div class="compare-layer compare-layer--after"&gt;...&lt;/div&gt;
+    &lt;div class="compare-handle"&gt;&lt;/div&gt;
+  &lt;/div&gt;
+  &lt;input type="range" class="compare-range" min="0" max="100" value="50" /&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+
+      <!-- ============ CHECKLIST ============ -->
+      <section class="checklist">
+        <h2 class="section-title">Acceptance checklist</h2>
+        <ul class="check-list">
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Dragging the divider</strong> reveals or hides the top layer smoothly, driven purely by <code>clip-path</code>.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Touch gestures work natively</strong> — the handle is a real range input, so mobile drag "just works."</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Left / Right arrow keys</strong> adjust the slider in 1% steps once the handle is focused.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Aspect ratio is fixed per instance</strong> via <code>--ratio</code>, so neither layer distorts as the slider moves.</div>
+          </li>
+        </ul>
+      </section>
+
+      <footer class="footer">
+        <p>
+          Part of the <strong>EaseMotion CSS</strong> examples submissions ·
+          <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css">back to the repo</a>
+        </p>
+      </footer>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/submissions/examples/before-after-image-slider-em/script.js
+++ b/submissions/examples/before-after-image-slider-em/script.js
@@ -1,0 +1,47 @@
+// Binds every .compare-range input to its parent .compare container's
+// --clip-offset custom property. That single variable drives the
+// clip-path on the "after" layer and the handle's position in CSS —
+// this file has no drag math, no pointer tracking, no animation loop.
+
+function initComparisonSliders() {
+  const ranges = document.querySelectorAll(".compare-range");
+
+  ranges.forEach((range) => {
+    const container = range.closest(".compare");
+    if (!container) return;
+
+    const update = () => {
+      container.style.setProperty("--clip-offset", `${range.value}%`);
+    };
+
+    // Initial paint from the input's starting value attribute.
+    update();
+
+    // Mouse drag, touch drag, and keyboard arrows all fire native
+    // "input" events on a range control — one listener covers all three.
+    range.addEventListener("input", update);
+  });
+}
+
+function copySnippet(id, btn) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const text = el.innerText;
+
+  navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      const original = btn.textContent;
+      btn.textContent = "Copied";
+      btn.classList.add("is-copied");
+      setTimeout(() => {
+        btn.textContent = original;
+        btn.classList.remove("is-copied");
+      }, 1500);
+    })
+    .catch(() => {
+      btn.textContent = "Select & copy";
+    });
+}
+
+document.addEventListener("DOMContentLoaded", initComparisonSliders);

--- a/submissions/examples/before-after-image-slider-em/styles.css
+++ b/submissions/examples/before-after-image-slider-em/styles.css
@@ -1,0 +1,561 @@
+/* Fonts */
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap");
+
+:root {
+  --ink: #111316;
+  --panel: #1a1d21;
+  --panel-2: #202429;
+  --line: rgba(255, 255, 255, 0.09);
+  --text: #f1eee7;
+  --muted: #9195a0;
+
+  --amber: #e8a33d;
+  --amber-soft: rgba(232, 163, 61, 0.16);
+
+  --font-display: "Fraunces", serif;
+  --font-body: "Inter", sans-serif;
+  --font-mono: "IBM Plex Mono", monospace;
+
+  --radius: 14px;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--ink);
+  background-image: radial-gradient(circle at 10% 0%, rgba(232, 163, 61, 0.08), transparent 45%);
+  color: var(--text);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  color: var(--amber);
+  background: var(--amber-soft);
+  padding: 0.1em 0.4em;
+  border-radius: 5px;
+}
+
+.wrap {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 72px 24px 100px;
+}
+
+/* ---------- Hero ---------- */
+.hero {
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 20px;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 0 3px var(--amber-soft);
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-optical-sizing: auto;
+  font-size: clamp(2.2rem, 5.5vw, 3.4rem);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin-bottom: 20px;
+}
+
+.hero-title .hl {
+  color: var(--amber);
+  font-style: italic;
+}
+
+.hero-sub {
+  max-width: 58ch;
+  color: var(--muted);
+  font-size: 1.03rem;
+}
+
+/* ---------- Demo blocks ---------- */
+.demo-block {
+  margin-bottom: 56px;
+}
+
+.demo-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.demo-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.35rem;
+}
+
+.demo-tag {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+/* ---------- Comparison slider (signature component) ---------- */
+.compare {
+  --clip-offset: 50%;
+  position: relative;
+}
+
+.compare-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: var(--ratio, 16/10);
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  background: #0a0b0d;
+  cursor: ew-resize;
+  user-select: none;
+}
+
+.compare-layer {
+  position: absolute;
+  inset: 0;
+}
+
+.compare-layer--after {
+  clip-path: inset(0 calc(100% - var(--clip-offset)) 0 0);
+  transition: clip-path 0.05s linear;
+}
+
+.scene {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.scene-label {
+  position: absolute;
+  bottom: 14px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: 6px;
+  background: rgba(10, 11, 13, 0.55);
+  backdrop-filter: blur(4px);
+  color: var(--text);
+}
+
+.scene-label--before {
+  left: 14px;
+}
+
+.scene-label--after {
+  right: 14px;
+}
+
+/* Handle */
+.compare-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--clip-offset);
+  width: 0;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.compare-handle::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: rgba(241, 238, 231, 0.85);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.compare-handle-grip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: var(--text);
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+/* The real, interactive control: a transparent range input on top */
+.compare-range {
+  position: absolute;
+  inset: 0;
+  top: -100%;
+  height: 300%;
+  width: 100%;
+  margin: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  cursor: ew-resize;
+}
+
+.compare-range:focus-visible {
+  outline: none;
+}
+
+.compare-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 38px;
+  height: 38px;
+  background: transparent;
+  border-radius: 50%;
+  cursor: ew-resize;
+}
+
+.compare-range::-moz-range-thumb {
+  width: 38px;
+  height: 38px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  cursor: ew-resize;
+}
+
+.compare-range::-webkit-slider-runnable-track {
+  background: transparent;
+}
+
+.compare-range::-moz-range-track {
+  background: transparent;
+}
+
+.compare:focus-within .compare-handle-grip {
+  box-shadow: 0 0 0 3px var(--amber-soft), 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+/* ---------- UI redesign scene (built from divs, not images) ---------- */
+.scene--ui {
+  width: 100%;
+  height: 100%;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.scene--ui-before {
+  background: #2b2e33;
+}
+
+.scene--ui-after {
+  background: linear-gradient(160deg, #241a38, #3d2b52 60%, #6b3f6b);
+}
+
+.ui-topbar {
+  display: flex;
+  gap: 6px;
+}
+
+.ui-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #55595f;
+}
+
+.ui-dot--after {
+  background: var(--amber);
+}
+
+.ui-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 12px;
+}
+
+.ui-side {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ui-line {
+  border-radius: 4px;
+  background: #3d4148;
+}
+
+.ui-line--after {
+  background: rgba(241, 238, 231, 0.3);
+}
+
+.ui-line--after-accent {
+  background: var(--amber);
+}
+
+.ui-line--sm {
+  height: 8px;
+  width: 100%;
+}
+
+.ui-line--lg {
+  height: 16px;
+  width: 55%;
+  margin-bottom: 4px;
+}
+
+.ui-line--md {
+  height: 9px;
+  width: 80%;
+  margin-bottom: 10px;
+}
+
+.ui-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  flex: 1;
+}
+
+.ui-card {
+  border-radius: 6px;
+  background: #3d4148;
+}
+
+.ui-card--after {
+  background: rgba(241, 238, 231, 0.22);
+  border: 1px solid rgba(232, 163, 61, 0.4);
+}
+
+/* ---------- Shared section styles ---------- */
+.section-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.5rem;
+  margin-bottom: 22px;
+}
+
+section {
+  margin-bottom: 64px;
+}
+
+/* ---------- How it works ---------- */
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.step {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.step-no {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--amber-soft);
+  color: var(--amber);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.step h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.step p {
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+/* ---------- Snippet ---------- */
+.snippet-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+
+.snippet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.file-name {
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+}
+
+.copy-btn {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--text);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 11px;
+  cursor: pointer;
+  transition: border-color 0.2s var(--ease), color 0.2s var(--ease);
+}
+
+.copy-btn:hover {
+  border-color: var(--amber);
+  color: var(--amber);
+}
+
+.copy-btn.is-copied {
+  border-color: var(--amber);
+  color: var(--amber);
+}
+
+.code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.65;
+  background: #0a0b0d;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  color: #cbd0dc;
+}
+
+.code code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-size: 1em;
+}
+
+/* ---------- Checklist ---------- */
+.check-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.check-list li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.check-mark {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: var(--amber-soft);
+  color: var(--amber);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.check-list strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ---------- Footer ---------- */
+.footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.85rem;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+}
+
+.footer a {
+  color: var(--amber);
+  text-decoration: none;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 720px) {
+  .wrap {
+    padding: 48px 18px 72px;
+  }
+
+  .steps {
+    grid-template-columns: 1fr;
+  }
+
+  .ui-body {
+    grid-template-columns: 50px 1fr;
+  }
+}
+
+/* ---------- Accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds an interactive before/after image comparison slider to `submissions/examples/`, resolving #55696. Solves the lack of a split-screen comparison component for photo-editing and UI-redesign showcases.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/before-after-image-slider-em/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
A draggable before/after comparison slider that reveals a top image layer over a bottom one, using `clip-path` bound to a single CSS custom property.

**How does a developer use it?**
```html
<div class="compare" style="--clip-offset: 50%">
  <div class="compare-frame">
    <div class="compare-layer compare-layer--before">...</div>
    <div class="compare-layer compare-layer--after">...</div>
    <div class="compare-handle"></div>
  </div>
  <input type="range" class="compare-range" min="0" max="100" value="50" />
</div>
```

**Why does it fit EaseMotion CSS?**
It keeps the interaction declarative and human-readable — one custom property (`--clip-offset`) drives the whole reveal, and a native range input supplies drag, touch, and keyboard support with no custom pointer-tracking JS. That matches the framework's philosophy of small, readable CSS doing the heavy lifting rather than hand-rolled animation logic.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Two working instances included (photo color-grade, UI wireframe-to-redesign) to show the component works on both illustrative and flat UI content. `script.js` is intentionally minimal — it only mirrors the range input's value onto `--clip-offset` on `input`; no drag math or animation frame loop.

---
> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [[Discord Server](https://discord.gg/hWSdGrccBU)](https://discord.gg/hWSdGrccBU)!