### PR TITLE
feat: add calendar event lift example

### DIFF
--- a/submissions/examples/calendar-event-lift-kp/README.md
+++ b/submissions/examples/calendar-event-lift-kp/README.md
@@ -1,0 +1,36 @@
+# Calendar Event Lift KP
+
+A CSS-only agenda component that introduces scheduled events with a staggered rise and gives each event a clear hover or keyboard-focus lift.
+
+## What It Does
+
+The component combines an ordered event entrance, accent rails, an active-status pulse, and responsive interaction feedback in a compact daily agenda.
+
+## How to Use It
+
+Add the event card classes to semantic list items and set `--event-order` to control the stagger:
+
+```html
+<li class="event-card event-card--live" style="--event-order: 0">
+  <a class="event-card__link" href="#design-review">
+    <time class="event-card__time" datetime="2026-07-29T09:30">09:30 AM</time>
+    <span class="event-card__details">
+      <span class="event-card__title">Design review</span>
+      <span class="event-card__note">Motion system handoff</span>
+    </span>
+  </a>
+</li>
+```
+
+Open `demo.html` directly in a browser to view the complete example. No JavaScript, build step, CDN, or external framework is required.
+
+## Why It Is Useful
+
+Calendar interfaces contain dense time-based information. The motion makes the reading order easier to follow while hover and focus feedback keep every event visibly interactive, matching EaseMotion's readable, animation-first philosophy.
+
+## Accessibility
+
+- Semantic `ol`, `li`, `time`, and link elements preserve document meaning.
+- `:focus-visible` provides a strong keyboard focus state.
+- `prefers-reduced-motion` removes entrance and looping animation.
+- Text and status colors maintain clear contrast on the dark surface.

--- a/submissions/examples/calendar-event-lift-kp/demo.html
+++ b/submissions/examples/calendar-event-lift-kp/demo.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A CSS-only agenda card with staggered event entrance and accessible lift states."
+    />
+    <title>Calendar Event Lift</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="agenda" aria-labelledby="agenda-title">
+        <header class="agenda__header">
+          <div>
+            <p class="agenda__eyebrow">Wednesday, July 29</p>
+            <h1 id="agenda-title">Today's agenda</h1>
+          </div>
+          <span class="agenda__count" aria-label="Three scheduled events"
+            >3 events</span
+          >
+        </header>
+
+        <ol class="event-list">
+          <li class="event-card event-card--live" style="--event-order: 0">
+            <a class="event-card__link" href="#design-review">
+              <time class="event-card__time" datetime="2026-07-29T09:30">
+                <strong>09:30</strong>
+                <span>AM</span>
+              </time>
+              <span class="event-card__details">
+                <span class="event-card__meta">
+                  <span class="event-card__status">In progress</span>
+                  <span>45 min</span>
+                </span>
+                <span class="event-card__title" id="design-review"
+                  >Design review</span
+                >
+                <span class="event-card__note">Motion system handoff</span>
+              </span>
+              <span class="event-card__action" aria-hidden="true">&rarr;</span>
+            </a>
+          </li>
+
+          <li class="event-card event-card--focus" style="--event-order: 1">
+            <a class="event-card__link" href="#prototype-session">
+              <time class="event-card__time" datetime="2026-07-29T11:15">
+                <strong>11:15</strong>
+                <span>AM</span>
+              </time>
+              <span class="event-card__details">
+                <span class="event-card__meta">
+                  <span class="event-card__tag">Deep work</span>
+                  <span>60 min</span>
+                </span>
+                <span class="event-card__title" id="prototype-session">
+                  Prototype session
+                </span>
+                <span class="event-card__note">Calendar interactions</span>
+              </span>
+              <span class="event-card__action" aria-hidden="true">&rarr;</span>
+            </a>
+          </li>
+
+          <li class="event-card event-card--sync" style="--event-order: 2">
+            <a class="event-card__link" href="#team-sync">
+              <time class="event-card__time" datetime="2026-07-29T14:00">
+                <strong>02:00</strong>
+                <span>PM</span>
+              </time>
+              <span class="event-card__details">
+                <span class="event-card__meta">
+                  <span class="event-card__tag">Team</span>
+                  <span>30 min</span>
+                </span>
+                <span class="event-card__title" id="team-sync"
+                  >Weekly sync</span
+                >
+                <span class="event-card__note">Studio room 2</span>
+              </span>
+              <span class="event-card__action" aria-hidden="true">&rarr;</span>
+            </a>
+          </li>
+        </ol>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/calendar-event-lift-kp/style.css
+++ b/submissions/examples/calendar-event-lift-kp/style.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #0f1217;
+  color: #f5f7fa;
+  letter-spacing: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    #0f1217;
+  background-size: 32px 32px;
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  padding: 32px 18px;
+  place-items: center;
+}
+
+.agenda {
+  width: min(100%, 620px);
+  padding: 26px;
+  overflow: hidden;
+  background: #171b22;
+  border: 1px solid #2b313b;
+  border-radius: 8px;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+}
+
+.agenda__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 22px;
+}
+
+.agenda__eyebrow {
+  margin: 0 0 7px;
+  color: #ff9b84;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.65rem, 4vw, 2.15rem);
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.agenda__count {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  color: #bcc5d1;
+  font-size: 0.78rem;
+  font-weight: 650;
+  background: #20252d;
+  border: 1px solid #343b47;
+  border-radius: 6px;
+}
+
+.event-list {
+  display: grid;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.event-card {
+  --event-accent: #91a0b4;
+  position: relative;
+  opacity: 0;
+  background: #1d222a;
+  border: 1px solid #303743;
+  border-radius: 7px;
+  transform: translateY(18px);
+  animation: calendar-event-arrive 560ms cubic-bezier(0.2, 0.8, 0.2, 1)
+    calc(120ms + var(--event-order) * 90ms) forwards;
+}
+
+.event-card::before {
+  position: absolute;
+  inset: 10px auto 10px 0;
+  width: 3px;
+  content: "";
+  background: var(--event-accent);
+  border-radius: 0 3px 3px 0;
+  transform: scaleY(0.45);
+  transition: transform 240ms ease;
+}
+
+.event-card--live {
+  --event-accent: #65d6ad;
+}
+
+.event-card--focus {
+  --event-accent: #ff9b84;
+}
+
+.event-card--sync {
+  --event-accent: #efc96d;
+}
+
+.event-card__link {
+  display: grid;
+  grid-template-columns: 68px minmax(0, 1fr) 30px;
+  gap: 16px;
+  align-items: center;
+  min-height: 104px;
+  padding: 15px 15px 15px 20px;
+  color: inherit;
+  text-decoration: none;
+  border-radius: inherit;
+  transition:
+    background-color 220ms ease,
+    transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 220ms ease;
+}
+
+.event-card__link:hover,
+.event-card__link:focus-visible {
+  background: #242a33;
+  outline: none;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
+  transform: translateY(-4px);
+}
+
+.event-card:has(.event-card__link:hover)::before,
+.event-card:has(.event-card__link:focus-visible)::before {
+  transform: scaleY(1);
+}
+
+.event-card__link:focus-visible {
+  box-shadow:
+    0 0 0 3px rgba(255, 155, 132, 0.35),
+    0 12px 26px rgba(0, 0, 0, 0.22);
+}
+
+.event-card__time {
+  display: grid;
+  gap: 2px;
+  padding-right: 13px;
+  text-align: right;
+  border-right: 1px solid #353d49;
+}
+
+.event-card__time strong {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.event-card__time span {
+  color: #8f9aaa;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.event-card__details {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.event-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #8f9aaa;
+  font-size: 0.72rem;
+}
+
+.event-card__status,
+.event-card__tag {
+  color: var(--event-accent);
+  font-weight: 750;
+}
+
+.event-card__status {
+  position: relative;
+  padding-left: 12px;
+}
+
+.event-card__status::before {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 6px;
+  height: 6px;
+  content: "";
+  background: currentColor;
+  border-radius: 50%;
+  box-shadow: 0 0 0 0 rgba(101, 214, 173, 0.5);
+  transform: translateY(-50%);
+  animation: calendar-status-pulse 1.8s ease-out infinite;
+}
+
+.event-card__title {
+  overflow: hidden;
+  font-size: 1rem;
+  font-weight: 750;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-card__note {
+  overflow: hidden;
+  color: #aab3c0;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-card__action {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  color: #9aa5b3;
+  font-size: 1.1rem;
+  border: 1px solid #3c4552;
+  border-radius: 6px;
+  place-items: center;
+  transition:
+    color 220ms ease,
+    border-color 220ms ease,
+    transform 220ms ease;
+}
+
+.event-card__link:hover .event-card__action,
+.event-card__link:focus-visible .event-card__action {
+  color: var(--event-accent);
+  border-color: var(--event-accent);
+  transform: translateX(3px);
+}
+
+@keyframes calendar-event-arrive {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes calendar-status-pulse {
+  70%,
+  100% {
+    box-shadow: 0 0 0 8px rgba(101, 214, 173, 0);
+  }
+}
+
+@media (max-width: 520px) {
+  .agenda {
+    padding: 20px 14px;
+  }
+
+  .agenda__header {
+    align-items: flex-start;
+  }
+
+  .event-card__link {
+    grid-template-columns: 54px minmax(0, 1fr) 28px;
+    gap: 11px;
+    min-height: 98px;
+    padding-left: 15px;
+  }
+
+  .event-card__time {
+    padding-right: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .event-card {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+
+  .event-card__status::before {
+    animation: none;
+  }
+
+  .event-card__link,
+  .event-card__action,
+  .event-card::before {
+    transition-duration: 0.01ms;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only daily agenda component with staggered event entrances, colored accent rails, active-status pulse, and lift feedback for pointer and keyboard users.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/calendar-event-lift-kp/`
- [x] Includes `demo.html` - self-contained and opens without a server
- [x] Includes `style.css` - raw CSS for the component
- [x] Includes `README.md` - what it does, how to use it, and why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A responsive agenda card whose events enter in sequence and lift on hover or keyboard focus.

**How does a developer use it?**

```html
<li class="event-card event-card--live" style="--event-order: 0">
  <a class="event-card__link" href="#design-review">...</a>
</li>
```

**Why does it fit EaseMotion CSS?**

It gives a familiar scheduling interface readable motion cues while remaining CSS-only, dependency-free, responsive, and respectful of reduced-motion preferences.

---

## Demo

- [x] `demo.html` works by opening directly in a browser

---

## Browser Testing

- [x] Chrome (1280px desktop and 500px mobile breakpoint)
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Validation

- `npx prettier --check "submissions/examples/calendar-event-lift-kp/*.{html,css,md}"`
- `git diff --cached --check`
- Verified exactly three new files and no existing-file modifications
