### PR TITLE
feat: add profile completion ring example

### DIFF
--- a/submissions/examples/profile-completion-ring-kp/README.md
+++ b/submissions/examples/profile-completion-ring-kp/README.md
@@ -1,0 +1,29 @@
+# Profile Completion Ring KP
+
+## What does this do?
+
+Profile Completion Ring KP adds an animated account setup card with a conic progress ring, staggered checklist entrance, and interactive lift states.
+
+## How is it used?
+
+Add the `completion-ring`, `setup-list`, and `setup-item` classes to a small profile setup card.
+
+```html
+<div
+  class="completion-ring"
+  role="img"
+  aria-label="Profile setup is 78 percent complete"
+>
+  <span class="completion-ring__value">78%</span>
+  <span class="completion-ring__label">complete</span>
+</div>
+
+<ul class="setup-list">
+  <li class="setup-item setup-item--done">Photo uploaded</li>
+  <li class="setup-item">Add availability</li>
+</ul>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a practical onboarding pattern that combines progress feedback, task motion, hover response, and reduced-motion support without requiring JavaScript.

--- a/submissions/examples/profile-completion-ring-kp/demo.html
+++ b/submissions/examples/profile-completion-ring-kp/demo.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Profile Completion Ring KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="profile-stage" aria-labelledby="profile-title">
+      <section class="profile-panel">
+        <div class="profile-overview">
+          <div
+            class="completion-ring"
+            role="img"
+            aria-label="Profile setup is 78 percent complete"
+          >
+            <span class="completion-ring__value">78%</span>
+            <span class="completion-ring__label">complete</span>
+          </div>
+
+          <div class="profile-copy">
+            <p class="profile-copy__eyebrow">Workspace setup</p>
+            <h1 id="profile-title">Finish your profile</h1>
+            <p>
+              Keep the account card moving with a progress ring, sliding task
+              list, and focused calls to action.
+            </p>
+          </div>
+        </div>
+
+        <ul class="setup-list" aria-label="Profile setup checklist">
+          <li class="setup-item setup-item--done">
+            <span class="setup-item__status" aria-hidden="true"></span>
+            <div>
+              <strong>Photo uploaded</strong>
+              <span>Helps teammates recognize your updates.</span>
+            </div>
+          </li>
+          <li class="setup-item setup-item--done">
+            <span class="setup-item__status" aria-hidden="true"></span>
+            <div>
+              <strong>Role selected</strong>
+              <span>Personalizes shortcuts and default views.</span>
+            </div>
+          </li>
+          <li class="setup-item">
+            <span class="setup-item__status" aria-hidden="true"></span>
+            <div>
+              <strong>Add availability</strong>
+              <span>Shows when collaborators can reach you.</span>
+            </div>
+          </li>
+        </ul>
+
+        <button class="profile-action" type="button">
+          Continue setup
+          <span aria-hidden="true">-></span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/profile-completion-ring-kp/style.css
+++ b/submissions/examples/profile-completion-ring-kp/style.css
@@ -1,0 +1,315 @@
+:root {
+  color-scheme: light;
+  --surface: #fffdf8;
+  --ink: #16211a;
+  --muted: #65706a;
+  --line: #dde6df;
+  --accent: #11a36a;
+  --accent-strong: #08784e;
+  --warm: #f2b84b;
+  --sky: #67a6ff;
+  --shadow: 0 24px 70px rgba(25, 47, 36, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(17, 163, 106, 0.1), transparent 36%),
+    linear-gradient(315deg, rgba(103, 166, 255, 0.16), transparent 34%), #f6f0e5;
+}
+
+.profile-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 32px;
+  place-items: center;
+}
+
+.profile-panel {
+  width: min(100%, 760px);
+  padding: clamp(24px, 5vw, 42px);
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid rgba(22, 33, 26, 0.08);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+  animation: card-arrive 720ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.profile-overview {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: clamp(22px, 4vw, 36px);
+  align-items: center;
+}
+
+.completion-ring {
+  position: relative;
+  display: grid;
+  width: 180px;
+  aspect-ratio: 1;
+  place-items: center;
+  isolation: isolate;
+}
+
+.completion-ring::before,
+.completion-ring::after {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  border-radius: 50%;
+}
+
+.completion-ring::before {
+  background: conic-gradient(
+    from -90deg,
+    var(--accent) 0deg,
+    var(--accent) 281deg,
+    #e7eee9 281deg,
+    #e7eee9 360deg
+  );
+  animation: ring-pop 880ms cubic-bezier(0.19, 1, 0.22, 1) both;
+}
+
+.completion-ring::after {
+  inset: 15px;
+  background:
+    radial-gradient(
+      circle at 42% 28%,
+      rgba(255, 255, 255, 0.95),
+      transparent 40%
+    ),
+    var(--surface);
+  box-shadow: inset 0 0 0 1px rgba(22, 33, 26, 0.08);
+}
+
+.completion-ring__value,
+.completion-ring__label {
+  display: block;
+  text-align: center;
+}
+
+.completion-ring__value {
+  margin-top: 18px;
+  font-size: clamp(2.15rem, 6vw, 3.1rem);
+  font-weight: 800;
+  line-height: 0.9;
+}
+
+.completion-ring__label {
+  margin-top: 58px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.profile-copy__eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: var(--accent-strong);
+  text-transform: uppercase;
+}
+
+.profile-copy h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.6rem);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.profile-copy p:last-child {
+  max-width: 44rem;
+  margin: 16px 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.setup-list {
+  display: grid;
+  gap: 14px;
+  padding: 0;
+  margin: 34px 0;
+  list-style: none;
+}
+
+.setup-item {
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 14px;
+  align-items: center;
+  min-height: 76px;
+  padding: 16px;
+  background: #f9faf4;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  animation: task-slide 620ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.setup-item:nth-child(2) {
+  animation-delay: 110ms;
+}
+
+.setup-item:nth-child(3) {
+  animation-delay: 220ms;
+}
+
+.setup-item:hover,
+.setup-item:focus-within {
+  border-color: rgba(17, 163, 106, 0.34);
+  box-shadow: 0 14px 34px rgba(25, 47, 36, 0.1);
+  transform: translateY(-3px);
+}
+
+.setup-item__status {
+  width: 34px;
+  aspect-ratio: 1;
+  border: 2px solid var(--warm);
+  border-radius: 50%;
+  background: #fff8e7;
+  box-shadow: inset 0 0 0 7px var(--surface);
+  animation: status-pulse 1700ms ease-in-out infinite;
+}
+
+.setup-item--done .setup-item__status {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: inset 0 0 0 8px var(--surface);
+  animation: none;
+}
+
+.setup-item strong,
+.setup-item span {
+  display: block;
+}
+
+.setup-item strong {
+  font-size: 1rem;
+}
+
+.setup-item div > span {
+  margin-top: 4px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.profile-action {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  min-height: 48px;
+  padding: 0 20px;
+  font: inherit;
+  font-weight: 800;
+  color: #ffffff;
+  cursor: pointer;
+  background: var(--ink);
+  border: 0;
+  border-radius: 999px;
+  box-shadow: 0 12px 28px rgba(22, 33, 26, 0.22);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease;
+}
+
+.profile-action:hover,
+.profile-action:focus-visible {
+  background: var(--accent-strong);
+  box-shadow: 0 16px 34px rgba(8, 120, 78, 0.28);
+  transform: translateY(-2px);
+}
+
+@keyframes card-arrive {
+  from {
+    transform: translateY(22px) scale(0.98);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes ring-pop {
+  from {
+    transform: scale(0.88) rotate(-10deg);
+    opacity: 0;
+  }
+
+  to {
+    transform: scale(1) rotate(0);
+    opacity: 1;
+  }
+}
+
+@keyframes task-slide {
+  from {
+    transform: translateX(-18px);
+    opacity: 0;
+  }
+}
+
+@keyframes status-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow:
+      inset 0 0 0 7px var(--surface),
+      0 0 0 0 rgba(242, 184, 75, 0);
+  }
+
+  50% {
+    transform: scale(1.08);
+    box-shadow:
+      inset 0 0 0 7px var(--surface),
+      0 0 0 10px rgba(242, 184, 75, 0.16);
+  }
+}
+
+@media (max-width: 640px) {
+  .profile-stage {
+    padding: 18px;
+  }
+
+  .profile-panel {
+    border-radius: 22px;
+  }
+
+  .profile-overview {
+    grid-template-columns: 1fr;
+  }
+
+  .completion-ring {
+    width: min(170px, 64vw);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a self-contained Profile Completion Ring KP example under `submissions/examples/profile-completion-ring-kp/`
- Include a direct-open HTML demo, polished CSS-only motion states, and a README with usage notes
- Cover progress feedback, staggered checklist motion, hover/focus lift, responsive layout, and reduced-motion support

## Validation
- `npx prettier --check submissions/examples/profile-completion-ring-kp/**/*.{html,css,md}`
- `npx stylelint submissions/examples/profile-completion-ring-kp/**/*.css` reports the submission CSS is ignored by the repo stylelint ignore pattern
- `git diff --cached --name-status` showed exactly three added files before commit
- `git diff --cached --check`
- Chrome headless direct-open screenshots at 1280x900 and 500x844 verified no visible overlap or cropped content

## Checklist
- [x] My submission is inside an allowed `submissions/` subdirectory
- [x] My standard-track submission includes exactly `demo.html`, `style.css`, and `README.md`
- [x] I did not modify core framework files, workflows, configs, or existing examples
- [x] The demo works by opening `demo.html` directly in a browser
- [x] The feature name includes a short unique identifier