### PR TITLE
feat: add rating meter glow example

### DIFF
--- a/submissions/examples/rating-meter-glow-kp/README.md
+++ b/submissions/examples/rating-meter-glow-kp/README.md
@@ -1,0 +1,26 @@
+# Rating Meter Glow KP
+
+## What does this do?
+
+Rating Meter Glow KP adds a CSS-only five-star feedback selector with animated selection, a color-responsive progress meter, and contextual rating feedback.
+
+## How is it used?
+
+Place radio inputs and their labels inside the `rating-panel` and `rating-stars` classes, then add the meter and feedback elements.
+
+```html
+<fieldset class="rating-panel">
+  <div class="rating-stars">
+    <input type="radio" id="rating-1" name="rating" value="1" />
+    <label for="rating-1" aria-label="1 star"><span>1</span></label>
+  </div>
+
+  <div class="rating-meter" aria-hidden="true">
+    <span class="rating-meter__fill"></span>
+  </div>
+</fieldset>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a practical feedback pattern with visible state changes, keyboard focus, responsive sizing, and reduced-motion support without JavaScript or external dependencies.

--- a/submissions/examples/rating-meter-glow-kp/demo.html
+++ b/submissions/examples/rating-meter-glow-kp/demo.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rating Meter Glow KP</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="rating-card" aria-labelledby="rating-title">
+        <div class="rating-card__intro">
+          <span class="rating-card__eyebrow">Quick feedback</span>
+          <h1 id="rating-title">How was your workspace setup?</h1>
+          <p>Your rating helps us improve the next setup experience.</p>
+        </div>
+
+        <fieldset class="rating-panel">
+          <legend>Choose a rating from 1 to 5 stars</legend>
+
+          <div class="rating-stars">
+            <input type="radio" id="rating-1" name="rating" value="1" />
+            <label for="rating-1" aria-label="1 star"><span>1</span></label>
+
+            <input type="radio" id="rating-2" name="rating" value="2" />
+            <label for="rating-2" aria-label="2 stars"><span>2</span></label>
+
+            <input type="radio" id="rating-3" name="rating" value="3" />
+            <label for="rating-3" aria-label="3 stars"><span>3</span></label>
+
+            <input type="radio" id="rating-4" name="rating" value="4" checked />
+            <label for="rating-4" aria-label="4 stars"><span>4</span></label>
+
+            <input type="radio" id="rating-5" name="rating" value="5" />
+            <label for="rating-5" aria-label="5 stars"><span>5</span></label>
+          </div>
+
+          <div class="rating-meter" aria-hidden="true">
+            <span class="rating-meter__fill"></span>
+          </div>
+
+          <div class="rating-feedback" aria-live="polite">
+            <span class="rating-feedback__score">4.0</span>
+            <span class="rating-feedback__copy">Great experience</span>
+          </div>
+        </fieldset>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/rating-meter-glow-kp/style.css
+++ b/submissions/examples/rating-meter-glow-kp/style.css
@@ -1,0 +1,356 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #101315;
+  color: #f7f8f8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 32px 20px;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    #101315;
+  background-size: 32px 32px;
+}
+
+.rating-card {
+  width: min(100%, 660px);
+  padding: clamp(24px, 5vw, 48px);
+  border: 1px solid #30383b;
+  border-radius: 8px;
+  background: #191e20;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+}
+
+.rating-card__intro {
+  max-width: 520px;
+}
+
+.rating-card__eyebrow {
+  display: inline-block;
+  margin-bottom: 12px;
+  color: #67e8b4;
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(1.7rem, 5vw, 2.45rem);
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+p {
+  margin: 14px 0 0;
+  color: #aab4b7;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.rating-panel {
+  --rating-progress: 80%;
+  --rating-color: #67e8b4;
+  position: relative;
+  margin: 32px 0 0;
+  padding: 26px;
+  border: 1px solid #343d40;
+  border-radius: 8px;
+  background: #131719;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.rating-panel:focus-within {
+  border-color: color-mix(in srgb, var(--rating-color), #ffffff 18%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--rating-color), transparent 82%);
+}
+
+.rating-panel:has(#rating-1:checked) {
+  --rating-progress: 20%;
+  --rating-color: #ff6b6b;
+}
+
+.rating-panel:has(#rating-2:checked) {
+  --rating-progress: 40%;
+  --rating-color: #ff9f43;
+}
+
+.rating-panel:has(#rating-3:checked) {
+  --rating-progress: 60%;
+  --rating-color: #ffd166;
+}
+
+.rating-panel:has(#rating-4:checked) {
+  --rating-progress: 80%;
+  --rating-color: #67e8b4;
+}
+
+.rating-panel:has(#rating-5:checked) {
+  --rating-progress: 100%;
+  --rating-color: #58c8ff;
+}
+
+.rating-panel legend {
+  padding: 0 8px;
+  color: #dce2e4;
+  font-size: 0.88rem;
+  font-weight: 650;
+}
+
+.rating-stars {
+  display: flex;
+  width: 100%;
+  gap: clamp(7px, 2vw, 14px);
+}
+
+.rating-stars input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.rating-stars label {
+  position: relative;
+  display: grid;
+  flex: 1 1 0;
+  aspect-ratio: 1;
+  min-width: 0;
+  place-items: center;
+  border: 1px solid #3b4548;
+  border-radius: 8px;
+  color: #657175;
+  cursor: pointer;
+  font-size: clamp(1.45rem, 7vw, 2.35rem);
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.rating-stars label::before {
+  content: "\2605";
+}
+
+.rating-stars label span {
+  position: absolute;
+  right: 5px;
+  bottom: 4px;
+  color: #7f8b8e;
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.rating-stars label:hover {
+  transform: translateY(-4px);
+  border-color: #889497;
+  color: #e4ebed;
+}
+
+.rating-stars input:focus-visible + label {
+  outline: 3px solid color-mix(in srgb, var(--rating-color), transparent 55%);
+  outline-offset: 3px;
+}
+
+.rating-stars input:checked + label {
+  border-color: var(--rating-color);
+  color: var(--rating-color);
+  background: color-mix(in srgb, var(--rating-color), transparent 91%);
+  box-shadow: 0 8px 30px
+    color-mix(in srgb, var(--rating-color), transparent 77%);
+  transform: translateY(-5px) scale(1.04);
+  animation: rating-star-set 380ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.rating-meter {
+  height: 7px;
+  margin-top: 26px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: #2b3336;
+}
+
+.rating-meter__fill {
+  display: block;
+  width: var(--rating-progress);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--rating-color);
+  box-shadow: 0 0 20px var(--rating-color);
+  transition:
+    width 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 220ms ease;
+}
+
+.rating-feedback {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 15px;
+}
+
+.rating-feedback__score {
+  color: var(--rating-color);
+  font-size: 1.65rem;
+  font-weight: 800;
+  transition: color 220ms ease;
+}
+
+.rating-feedback__copy {
+  color: #aab4b7;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: right;
+}
+
+.rating-panel:has(#rating-1:checked) .rating-feedback__score {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-1:checked) .rating-feedback__score::after {
+  content: "1.0";
+  font-size: 1.65rem;
+}
+
+.rating-panel:has(#rating-1:checked) .rating-feedback__copy {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-1:checked) .rating-feedback__copy::after {
+  content: "Needs improvement";
+  font-size: 0.9rem;
+}
+
+.rating-panel:has(#rating-2:checked) .rating-feedback__score {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-2:checked) .rating-feedback__score::after {
+  content: "2.0";
+  font-size: 1.65rem;
+}
+
+.rating-panel:has(#rating-2:checked) .rating-feedback__copy {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-2:checked) .rating-feedback__copy::after {
+  content: "Could be smoother";
+  font-size: 0.9rem;
+}
+
+.rating-panel:has(#rating-3:checked) .rating-feedback__score {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-3:checked) .rating-feedback__score::after {
+  content: "3.0";
+  font-size: 1.65rem;
+}
+
+.rating-panel:has(#rating-3:checked) .rating-feedback__copy {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-3:checked) .rating-feedback__copy::after {
+  content: "Solid experience";
+  font-size: 0.9rem;
+}
+
+.rating-panel:has(#rating-5:checked) .rating-feedback__score {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-5:checked) .rating-feedback__score::after {
+  content: "5.0";
+  font-size: 1.65rem;
+}
+
+.rating-panel:has(#rating-5:checked) .rating-feedback__copy {
+  font-size: 0;
+}
+
+.rating-panel:has(#rating-5:checked) .rating-feedback__copy::after {
+  content: "Outstanding";
+  font-size: 0.9rem;
+}
+
+@keyframes rating-star-set {
+  0% {
+    transform: translateY(0) scale(0.84);
+  }
+
+  58% {
+    transform: translateY(-7px) scale(1.12);
+  }
+
+  100% {
+    transform: translateY(-5px) scale(1.04);
+  }
+}
+
+@media (max-width: 520px) {
+  .demo-shell {
+    align-items: start;
+    padding: 18px 12px;
+  }
+
+  .rating-card {
+    padding: 24px 18px;
+  }
+
+  .rating-panel {
+    margin-top: 26px;
+    padding: 20px 14px;
+  }
+
+  .rating-stars {
+    gap: 6px;
+  }
+
+  .rating-stars label span {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained CSS-only rating meter with animated star selection, a responsive progress glow, and contextual feedback states.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/rating-meter-glow-kp/`
- [x] Includes `demo.html` and opens directly with no server
- [x] Includes `style.css` with raw CSS
- [x] Includes `README.md` covering purpose, usage, and fit
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One focused feature

---

## Feature Description

**What does this add?**

A five-star feedback selector whose selected state, meter width, accent color, score, and feedback copy respond without JavaScript.

**How does a developer use it?**

```html
<fieldset class="rating-panel">
  <div class="rating-stars">
    <input type="radio" id="rating-1" name="rating" value="1" />
    <label for="rating-1" aria-label="1 star"><span>1</span></label>
  </div>
  <div class="rating-meter" aria-hidden="true">
    <span class="rating-meter__fill"></span>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**

It turns a familiar feedback control into a clear motion-driven state change while retaining keyboard focus, responsive sizing, and reduced-motion support.

---

## Demo

- [x] Direct-open demo added and visually verified at 1280x900 and 500x844

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Validation

- Prettier check passed for HTML, CSS, and Markdown.
- Staged diff contains exactly three new files.
- `git diff --cached --check` passed.
- Stylelint skips submission CSS through the repository ignore pattern.

---

## Notes for Maintainer

The example uses modern CSS `:has()` and `color-mix()` for state-driven styling and includes a reduced-motion fallback.
