### PR TITLE
feat: add permission scope selector example

### DIFF
--- a/submissions/examples/permission-scope-selector-kp/README.md
+++ b/submissions/examples/permission-scope-selector-kp/README.md
@@ -1,0 +1,25 @@
+# Permission Scope Selector KP
+
+## What does this do?
+
+Permission Scope Selector KP adds an accessible integration-permission card with animated toggles, selected-state feedback, and a responsive access summary.
+
+## How is it used?
+
+Wrap each checkbox and its visible content in a `scope-item`, then add the `scope-switch` element for the animated control.
+
+```html
+<label class="scope-item">
+  <input type="checkbox" checked />
+  <span class="scope-item__icon" aria-hidden="true">P</span>
+  <span class="scope-item__copy">
+    <strong>View projects</strong>
+    <small>Read project names, status, and milestones</small>
+  </span>
+  <span class="scope-switch" aria-hidden="true"></span>
+</label>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a practical authorization pattern that communicates permission changes through focused motion while preserving keyboard access, responsive behavior, and reduced-motion support.

--- a/submissions/examples/permission-scope-selector-kp/demo.html
+++ b/submissions/examples/permission-scope-selector-kp/demo.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Permission Scope Selector KP</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="permission-card" aria-labelledby="permission-title">
+        <header class="permission-card__header">
+          <div class="app-mark" aria-hidden="true">N</div>
+          <div>
+            <span class="permission-card__eyebrow">Connect integration</span>
+            <h1 id="permission-title">Choose what Nimbus can access</h1>
+          </div>
+        </header>
+
+        <p class="permission-card__intro">
+          You can update these permissions at any time from workspace settings.
+        </p>
+
+        <fieldset class="scope-list">
+          <legend>Permission scopes</legend>
+
+          <label class="scope-item">
+            <input type="checkbox" checked />
+            <span class="scope-item__icon" aria-hidden="true">P</span>
+            <span class="scope-item__copy">
+              <strong>View projects</strong>
+              <small>Read project names, status, and milestones</small>
+            </span>
+            <span class="scope-switch" aria-hidden="true"></span>
+          </label>
+
+          <label class="scope-item">
+            <input type="checkbox" checked />
+            <span class="scope-item__icon" aria-hidden="true">T</span>
+            <span class="scope-item__copy">
+              <strong>Update tasks</strong>
+              <small>Create tasks and change their progress</small>
+            </span>
+            <span class="scope-switch" aria-hidden="true"></span>
+          </label>
+
+          <label class="scope-item">
+            <input type="checkbox" />
+            <span class="scope-item__icon" aria-hidden="true">M</span>
+            <span class="scope-item__copy">
+              <strong>Manage members</strong>
+              <small>Invite people and adjust workspace roles</small>
+            </span>
+            <span class="scope-switch" aria-hidden="true"></span>
+          </label>
+        </fieldset>
+
+        <footer class="permission-summary">
+          <span class="permission-summary__shield" aria-hidden="true"></span>
+          <span>
+            <strong>Granular access</strong>
+            <small>Only selected scopes will be shared</small>
+          </span>
+          <button type="button">Allow selected</button>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/permission-scope-selector-kp/style.css
+++ b/submissions/examples/permission-scope-selector-kp/style.css
@@ -1,0 +1,360 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #edf0f4;
+  color: #182026;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 28px 18px;
+  background:
+    linear-gradient(rgba(24, 32, 38, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(24, 32, 38, 0.045) 1px, transparent 1px),
+    #edf0f4;
+  background-size: 30px 30px;
+}
+
+.permission-card {
+  width: min(100%, 680px);
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid #cfd5dc;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 24px 64px rgba(35, 45, 55, 0.14);
+}
+
+.permission-card__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.app-mark {
+  display: grid;
+  flex: 0 0 52px;
+  width: 52px;
+  height: 52px;
+  place-items: center;
+  border-radius: 8px;
+  background: #182026;
+  color: #8df0ca;
+  font-size: 1.25rem;
+  font-weight: 800;
+  box-shadow: inset 0 0 0 1px #313d45;
+}
+
+.permission-card__eyebrow {
+  color: #177b5c;
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 5px 0 0;
+  color: #182026;
+  font-size: clamp(1.4rem, 4.8vw, 2rem);
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.permission-card__intro {
+  margin: 20px 0 0;
+  color: #60707a;
+  font-size: 0.96rem;
+  line-height: 1.6;
+}
+
+.scope-list {
+  display: grid;
+  gap: 10px;
+  margin: 28px 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.scope-list legend {
+  margin-bottom: 10px;
+  color: #394750;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.scope-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) 46px;
+  align-items: center;
+  gap: 14px;
+  min-height: 76px;
+  padding: 13px 15px;
+  border: 1px solid #d8dde3;
+  border-radius: 8px;
+  background: #fafbfc;
+  cursor: pointer;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.scope-item:hover {
+  transform: translateY(-2px);
+  border-color: #9ca8b0;
+  box-shadow: 0 8px 20px rgba(31, 44, 52, 0.08);
+}
+
+.scope-item:has(input:checked) {
+  border-color: #61caa4;
+  background: #f1fbf7;
+}
+
+.scope-item:has(input:focus-visible) {
+  outline: 3px solid rgba(21, 139, 100, 0.2);
+  outline-offset: 2px;
+}
+
+.scope-item input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.scope-item__icon {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid #d5dbe0;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #66757e;
+  font-size: 0.78rem;
+  font-weight: 800;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    transform 180ms ease;
+}
+
+.scope-item:has(input:checked) .scope-item__icon {
+  border-color: #8ad8bb;
+  color: #177b5c;
+  transform: scale(1.05);
+}
+
+.scope-item__copy {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.scope-item__copy strong {
+  color: #233039;
+  font-size: 0.94rem;
+}
+
+.scope-item__copy small {
+  overflow-wrap: anywhere;
+  color: #71808a;
+  font-size: 0.79rem;
+  line-height: 1.45;
+}
+
+.scope-switch {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  border-radius: 12px;
+  background: #c9d0d6;
+  transition:
+    background-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.scope-switch::after {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 2px 5px rgba(24, 32, 38, 0.24);
+  content: "";
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.scope-item input:checked ~ .scope-switch {
+  background: #168b64;
+  box-shadow: 0 0 0 4px rgba(22, 139, 100, 0.1);
+}
+
+.scope-item input:checked ~ .scope-switch::after {
+  transform: translateX(18px);
+}
+
+.permission-summary {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  margin-top: 24px;
+  padding-top: 22px;
+  border-top: 1px solid #e0e4e8;
+}
+
+.permission-summary__shield {
+  position: relative;
+  width: 27px;
+  height: 31px;
+  border: 2px solid #168b64;
+  border-radius: 12px 12px 16px 16px;
+  background: #eaf8f2;
+}
+
+.permission-summary__shield::after {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 7px;
+  height: 4px;
+  border-bottom: 2px solid #168b64;
+  border-left: 2px solid #168b64;
+  content: "";
+  transform: rotate(-45deg);
+}
+
+.permission-card:focus-within .permission-summary__shield {
+  animation: shield-ready 1.5s ease-in-out infinite;
+}
+
+.permission-summary > span:not(.permission-summary__shield) {
+  display: grid;
+  gap: 2px;
+}
+
+.permission-summary strong {
+  color: #26333b;
+  font-size: 0.86rem;
+}
+
+.permission-summary small {
+  color: #73818a;
+  font-size: 0.74rem;
+}
+
+.permission-summary button {
+  min-height: 42px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 6px;
+  background: #182026;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 700;
+  transition:
+    background-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.permission-summary button:hover {
+  transform: translateY(-2px);
+  background: #177b5c;
+  box-shadow: 0 8px 18px rgba(23, 123, 92, 0.2);
+}
+
+.permission-summary button:focus-visible {
+  outline: 3px solid rgba(23, 123, 92, 0.25);
+  outline-offset: 3px;
+}
+
+@keyframes shield-ready {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(22, 139, 100, 0.2);
+  }
+
+  50% {
+    box-shadow: 0 0 0 7px rgba(22, 139, 100, 0);
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-shell {
+    align-items: start;
+    padding: 16px 10px;
+  }
+
+  .permission-card {
+    padding: 22px 16px;
+  }
+
+  .permission-card__header {
+    align-items: flex-start;
+  }
+
+  .scope-item {
+    grid-template-columns: 38px minmax(0, 1fr) 42px;
+    gap: 10px;
+    padding: 12px 10px;
+  }
+
+  .scope-item__icon {
+    width: 38px;
+    height: 38px;
+  }
+
+  .permission-summary {
+    grid-template-columns: 30px minmax(0, 1fr);
+  }
+
+  .permission-summary button {
+    grid-column: 1 / -1;
+    width: 100%;
+    margin-top: 4px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained permission-scope selector with animated switches, clear selected states, keyboard focus, and a responsive access summary.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/permission-scope-selector-kp/`
- [x] Includes a self-contained `demo.html`
- [x] Includes raw `style.css`
- [x] Includes a complete `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One focused feature

---

## Feature Description

**What does this add?**

An integration-access card with selectable project, task, and member permission scopes.

**How does a developer use it?**

```html
<label class="scope-item">
  <input type="checkbox" checked />
  <span class="scope-item__icon" aria-hidden="true">P</span>
  <span class="scope-item__copy">
    <strong>View projects</strong>
    <small>Read project names, status, and milestones</small>
  </span>
  <span class="scope-switch" aria-hidden="true"></span>
</label>
```

**Why does it fit EaseMotion CSS?**

It gives authorization changes clear motion feedback while retaining semantic checkboxes, keyboard focus, responsive behavior, and reduced-motion support.

---

## Demo

- [x] Direct-open demo visually verified at 1280x900 and 500x844
- [x] Checkbox state transition verified in Chrome

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Validation

- Prettier check passed for HTML, CSS, and Markdown.
- Staged diff contains exactly three new files.
- `git diff --cached --check` passed.
- Stylelint skips submission CSS through the repository ignore pattern.

---

## Notes for Maintainer

The component uses modern CSS `:has()` for checked and focus states and includes a reduced-motion fallback.
