### PR TITLE
feat: add release channel selector example

### DIFF
--- a/submissions/examples/release-channel-selector-kp/README.md
+++ b/submissions/examples/release-channel-selector-kp/README.md
@@ -1,0 +1,25 @@
+# Release Channel Selector KP
+
+## What does this do?
+
+Release Channel Selector KP adds a CSS-only stable, beta, and canary channel picker with an animated selection track and channel-specific release details.
+
+## How is it used?
+
+Place radio inputs and labels inside `channel-picker__controls`, then use the `channel-preview` elements to display the selected channel state.
+
+```html
+<div class="channel-picker__controls">
+  <span class="channel-picker__track" aria-hidden="true"></span>
+
+  <input type="radio" id="stable" name="channel" />
+  <label for="stable">
+    <strong>Stable</strong>
+    <small>Recommended</small>
+  </label>
+</div>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a practical settings pattern that turns a release preference into clear animated feedback while preserving keyboard access, responsive behavior, and reduced-motion support.

--- a/submissions/examples/release-channel-selector-kp/demo.html
+++ b/submissions/examples/release-channel-selector-kp/demo.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release Channel Selector KP</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="channel-card" aria-labelledby="channel-title">
+        <header class="channel-card__header">
+          <span class="product-mark" aria-hidden="true">A</span>
+          <div>
+            <span class="channel-card__eyebrow">Update preferences</span>
+            <h1 id="channel-title">Choose your release channel</h1>
+          </div>
+        </header>
+
+        <p class="channel-card__intro">
+          Control how early this workspace receives new product updates.
+        </p>
+
+        <fieldset class="channel-picker">
+          <legend>Release channel</legend>
+          <div class="channel-picker__controls">
+            <span class="channel-picker__track" aria-hidden="true"></span>
+
+            <input type="radio" id="stable" name="channel" />
+            <label for="stable">
+              <strong>Stable</strong>
+              <small>Recommended</small>
+            </label>
+
+            <input type="radio" id="beta" name="channel" checked />
+            <label for="beta">
+              <strong>Beta</strong>
+              <small>Early access</small>
+            </label>
+
+            <input type="radio" id="canary" name="channel" />
+            <label for="canary">
+              <strong>Canary</strong>
+              <small>Daily builds</small>
+            </label>
+          </div>
+        </fieldset>
+
+        <section class="channel-preview" aria-live="polite">
+          <div class="channel-preview__topline">
+            <span class="channel-preview__status">
+              <i aria-hidden="true"></i>
+            </span>
+            <span class="channel-preview__version"></span>
+          </div>
+
+          <h2 class="channel-preview__title"></h2>
+          <p class="channel-preview__copy"></p>
+
+          <div class="channel-preview__meter" aria-hidden="true">
+            <span></span>
+          </div>
+
+          <div class="channel-preview__meta">
+            <span>Update frequency</span>
+            <strong class="channel-preview__frequency"></strong>
+          </div>
+        </section>
+
+        <button class="save-button" type="button">Save channel</button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/release-channel-selector-kp/style.css
+++ b/submissions/examples/release-channel-selector-kp/style.css
@@ -1,0 +1,405 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #111417;
+  color: #f4f6f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 28px 18px;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    #111417;
+  background-size: 32px 32px;
+}
+
+.channel-card {
+  --channel-color: #7aa7ff;
+  --channel-soft: rgba(122, 167, 255, 0.12);
+  --channel-name: "Beta channel";
+  --channel-version: "v4.9.0-beta.3";
+  --channel-copy: "Preview polished features before the stable rollout.";
+  --channel-frequency: "Weekly";
+  --channel-progress: 68%;
+  width: min(100%, 650px);
+  padding: clamp(24px, 5vw, 44px);
+  border: 1px solid #30373d;
+  border-radius: 8px;
+  background: #1a1f23;
+  box-shadow: 0 24px 68px rgba(0, 0, 0, 0.35);
+}
+
+.channel-card:has(#stable:checked) {
+  --channel-color: #5de4ad;
+  --channel-soft: rgba(93, 228, 173, 0.12);
+  --channel-name: "Stable channel";
+  --channel-version: "v4.8.2";
+  --channel-copy: "Receive production-ready updates after full validation.";
+  --channel-frequency: "Monthly";
+  --channel-progress: 42%;
+}
+
+.channel-card:has(#canary:checked) {
+  --channel-color: #ffbd66;
+  --channel-soft: rgba(255, 189, 102, 0.13);
+  --channel-name: "Canary channel";
+  --channel-version: "v4.10.0-dev.18";
+  --channel-copy: "Test the newest experiments as soon as they are built.";
+  --channel-frequency: "Daily";
+  --channel-progress: 92%;
+}
+
+.channel-card__header {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.product-mark {
+  display: grid;
+  flex: 0 0 50px;
+  width: 50px;
+  height: 50px;
+  place-items: center;
+  border: 1px solid #414a51;
+  border-radius: 8px;
+  background: #242b30;
+  color: #f5f7f8;
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+.channel-card__eyebrow {
+  color: #8f9ba3;
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 5px 0 0;
+  color: #ffffff;
+  font-size: clamp(1.45rem, 4.8vw, 2rem);
+  line-height: 1.14;
+  letter-spacing: 0;
+}
+
+.channel-card__intro {
+  margin: 18px 0 0;
+  color: #a9b2b8;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.channel-picker {
+  margin: 28px 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.channel-picker legend {
+  margin-bottom: 10px;
+  color: #d9dee1;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.channel-picker__controls {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid #323a40;
+  border-radius: 8px;
+  background: #121619;
+}
+
+.channel-picker__track {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: calc((100% - 16px) / 3);
+  border: 1px solid var(--channel-color);
+  border-radius: 6px;
+  background: var(--channel-soft);
+  box-shadow: 0 8px 24px
+    color-mix(in srgb, var(--channel-color), transparent 82%);
+  transition:
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 220ms ease,
+    background-color 220ms ease;
+}
+
+.channel-card:has(#beta:checked) .channel-picker__track {
+  transform: translateX(calc(100% + 4px));
+}
+
+.channel-card:has(#canary:checked) .channel-picker__track {
+  transform: translateX(calc(200% + 8px));
+}
+
+.channel-picker input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.channel-picker label {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-width: 0;
+  min-height: 62px;
+  place-content: center;
+  gap: 3px;
+  border-radius: 6px;
+  color: #8f9aa1;
+  cursor: pointer;
+  text-align: center;
+  transition:
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.channel-picker label:hover {
+  color: #dce1e4;
+  transform: translateY(-1px);
+}
+
+.channel-picker label strong {
+  font-size: 0.88rem;
+}
+
+.channel-picker label small {
+  font-size: 0.68rem;
+}
+
+.channel-picker input:checked + label {
+  color: var(--channel-color);
+}
+
+.channel-picker input:focus-visible + label {
+  outline: 3px solid color-mix(in srgb, var(--channel-color), transparent 65%);
+  outline-offset: -2px;
+}
+
+.channel-preview {
+  margin-top: 16px;
+  padding: 22px;
+  border: 1px solid #343c42;
+  border-radius: 8px;
+  background: #14191c;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.channel-card:focus-within .channel-preview {
+  border-color: color-mix(in srgb, var(--channel-color), #343c42 45%);
+  box-shadow: inset 3px 0 0 var(--channel-color);
+}
+
+.channel-preview__topline,
+.channel-preview__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.channel-preview__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--channel-color);
+  font-size: 0.72rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.channel-preview__status::after {
+  content: var(--channel-name);
+}
+
+.channel-preview__status i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--channel-color);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--channel-color), transparent 50%);
+  animation: channel-pulse 1.8s ease-out infinite;
+}
+
+.channel-preview__version {
+  color: #7f8a91;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+}
+
+.channel-preview__version::after {
+  content: var(--channel-version);
+}
+
+.channel-preview__title {
+  margin: 20px 0 0;
+  color: #f6f7f8;
+  font-size: 1.25rem;
+  letter-spacing: 0;
+}
+
+.channel-preview__title::after {
+  content: var(--channel-name);
+}
+
+.channel-preview__copy {
+  min-height: 46px;
+  margin: 8px 0 0;
+  color: #9da8ae;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.channel-preview__copy::after {
+  content: var(--channel-copy);
+}
+
+.channel-preview__meter {
+  height: 6px;
+  margin-top: 18px;
+  overflow: hidden;
+  border-radius: 3px;
+  background: #2c3439;
+}
+
+.channel-preview__meter span {
+  display: block;
+  width: var(--channel-progress);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--channel-color);
+  transition:
+    width 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 220ms ease;
+}
+
+.channel-preview__meta {
+  margin-top: 12px;
+  color: #7f8a91;
+  font-size: 0.74rem;
+}
+
+.channel-preview__frequency {
+  color: var(--channel-color);
+}
+
+.channel-preview__frequency::after {
+  content: var(--channel-frequency);
+}
+
+.save-button {
+  width: 100%;
+  min-height: 46px;
+  margin-top: 18px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--channel-color);
+  color: #101417;
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 800;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 220ms ease;
+}
+
+.save-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px
+    color-mix(in srgb, var(--channel-color), transparent 75%);
+}
+
+.save-button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--channel-color), transparent 55%);
+  outline-offset: 3px;
+}
+
+@keyframes channel-pulse {
+  70% {
+    box-shadow: 0 0 0 7px transparent;
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+@media (max-width: 520px) {
+  .demo-shell {
+    align-items: start;
+    padding: 14px 10px;
+  }
+
+  .channel-card {
+    padding: 22px 16px;
+  }
+
+  .channel-card__header {
+    align-items: flex-start;
+  }
+
+  .channel-picker label {
+    min-height: 58px;
+  }
+
+  .channel-picker label small {
+    display: none;
+  }
+
+  .channel-preview {
+    padding: 18px 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained CSS-only stable, beta, and canary release-channel selector with an animated selection track and channel-specific preview details.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/release-channel-selector-kp/`
- [x] Includes a self-contained `demo.html`
- [x] Includes raw `style.css`
- [x] Includes a complete `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One focused feature

---

## Feature Description

**What does this add?**

A release preference control with stable, beta, and canary options whose preview, version, cadence, accent, and progress state update without JavaScript.

**How does a developer use it?**

```html
<div class="channel-picker__controls">
  <span class="channel-picker__track" aria-hidden="true"></span>
  <input type="radio" id="stable" name="channel" />
  <label for="stable">
    <strong>Stable</strong>
    <small>Recommended</small>
  </label>
</div>
```

**Why does it fit EaseMotion CSS?**

It turns a settings choice into clear motion-driven feedback while preserving semantic radio controls, keyboard focus, responsive behavior, and reduced-motion support.

---

## Demo

- [x] Direct-open demo visually verified at 1280x900 and 500x844
- [x] Beta-to-Canary state and preview update verified in Chrome

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Validation

- Prettier check passed for HTML, CSS, and Markdown.
- Staged diff contains exactly three new files.
- `git diff --cached --check` passed.
- Stylelint skips submission CSS through the repository ignore pattern.

---

## Notes for Maintainer

The component uses modern CSS `:has()`, custom properties, and `color-mix()` with a reduced-motion fallback.
