### PR TITLE
Add CSS anchor position tooltip with fallback

### DIFF
--- a/submissions/examples/css-anchor-position-tooltip-55790/README.md
+++ b/submissions/examples/css-anchor-position-tooltip-55790/README.md
@@ -1,0 +1,101 @@
+# CSS Anchor Position Tooltip
+
+A tooltip component built on the native CSS Anchor Positioning API,
+with a plain absolute-position fallback for browsers that don't
+support it yet. No JavaScript is used for placement in either path.
+
+## How it works
+
+### The anchor relationship
+
+Anchor Positioning lets one element ("the anchor") give another
+element ("the positioned element") a named handle to attach to, even
+though they aren't nested in the DOM:
+
+```css
+/* The trigger becomes an anchor */
+#anchor-top {
+  anchor-name: --anchor-top;
+}
+
+/* The tooltip attaches to that anchor by name */
+#tip-top {
+  position: fixed;
+  position-anchor: --anchor-top;
+  position-area: top;
+}
+```
+
+`position-area: top` tells the browser to place the tooltip directly
+above whatever element declared `anchor-name: --anchor-top` —
+regardless of where the tooltip sits in the document. That's the
+whole positioning logic. No `getBoundingClientRect()`, no scroll
+listeners, no JS at all.
+
+### The fallback
+
+Anchor Positioning is a newer API, so everything is wrapped in:
+
+```css
+@supports (anchor-name: --a) {
+  /* anchor-positioning rules only apply here */
+}
+```
+
+Outside that block, the tooltip uses ordinary `position: absolute`
+inside a `position: relative` wrapper (`.anchor-wrap`), offset with
+plain `top`/`left`/`right`/`bottom`. Every browser gets a working,
+correctly placed tooltip — modern browsers just get the more robust,
+JS-free version that also handles edge-of-viewport flipping
+automatically (a native browser behavior of anchor positioning, not
+something this demo has to code manually).
+
+### Motion
+
+Both paths share the same fade + slight slide transition, driven by
+`opacity` and `transform` on `.tooltip`, triggered by `:hover` and
+`:focus-within` on the wrapper — so the entrance animation looks
+identical no matter which positioning path a browser takes.
+
+## Usage
+
+```html
+<div class="anchor-wrap">
+  <button class="anchor-btn" id="my-trigger" aria-describedby="my-tip">
+    Hover me
+  </button>
+  <div class="tooltip tooltip--top" id="my-tip" role="tooltip">
+    Tooltip content
+  </div>
+</div>
+```
+
+```css
+#my-trigger { anchor-name: --my-trigger; } /* inside @supports block */
+#my-tip     { position-anchor: --my-trigger; position-area: top; }
+```
+
+Four placement modifiers are included: `.tooltip--top`,
+`.tooltip--bottom`, `.tooltip--left`, `.tooltip--right`.
+
+## Why it fits EaseMotion CSS
+
+It's pure CSS with zero positioning JavaScript, demonstrates a modern
+browser capability, and degrades gracefully — matching EaseMotion's
+animation-first, lightweight, composable philosophy while still being
+usable in every browser today.
+
+## Accessibility
+
+- `role="tooltip"` and `aria-describedby` connect each trigger to its
+  tooltip for assistive technology.
+- `:focus-within` mirrors the hover reveal for keyboard users.
+- `@media (prefers-reduced-motion: reduce)` removes the fade/slide
+  transition; the tooltip still appears, just instantly.
+
+## Files
+
+- `demo.html` — four triggers demonstrating all four placements.
+- `style.css` — shared tooltip styling, the `@supports`-gated anchor
+  positioning rules, and the absolute-position fallback.
+- `README.md` — this file.

--- a/submissions/examples/css-anchor-position-tooltip-55790/demo.html
+++ b/submissions/examples/css-anchor-position-tooltip-55790/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Anchor Position Tooltip</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <header class="demo-header">
+      <h1>CSS Anchor Position Tooltip</h1>
+      <p>
+        Hover or focus any button below. In browsers that support the
+        CSS Anchor Positioning API, the tooltip snaps to its anchor
+        automatically. Everywhere else, it falls back to simple
+        absolute positioning — no JavaScript either way.
+      </p>
+    </header>
+
+    <section class="demo-grid">
+
+      <div class="anchor-wrap">
+        <button class="anchor-btn" id="anchor-top" type="button" aria-describedby="tip-top">
+          Top
+        </button>
+        <div class="tooltip tooltip--top" id="tip-top" role="tooltip">
+          Tooltip placed above its anchor
+        </div>
+      </div>
+
+      <div class="anchor-wrap">
+        <button class="anchor-btn" id="anchor-bottom" type="button" aria-describedby="tip-bottom">
+          Bottom
+        </button>
+        <div class="tooltip tooltip--bottom" id="tip-bottom" role="tooltip">
+          Tooltip placed below its anchor
+        </div>
+      </div>
+
+      <div class="anchor-wrap">
+        <button class="anchor-btn" id="anchor-left" type="button" aria-describedby="tip-left">
+          Left
+        </button>
+        <div class="tooltip tooltip--left" id="tip-left" role="tooltip">
+          Tooltip placed left of anchor
+        </div>
+      </div>
+
+      <div class="anchor-wrap">
+        <button class="anchor-btn" id="anchor-right" type="button" aria-describedby="tip-right">
+          Right
+        </button>
+        <div class="tooltip tooltip--right" id="tip-right" role="tooltip">
+          Tooltip placed right of anchor
+        </div>
+      </div>
+
+    </section>
+
+    <footer class="demo-footer">
+      <p>
+        Pure CSS &middot; <code>anchor-name</code> / <code>position-anchor</code>
+        &middot; respects <code>prefers-reduced-motion</code>
+      </p>
+    </footer>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-anchor-position-tooltip-55790/style.css
+++ b/submissions/examples/css-anchor-position-tooltip-55790/style.css
@@ -1,0 +1,238 @@
+/* ==========================================================================
+   CSS Anchor Position Tooltip
+   Uses the native CSS Anchor Positioning API (anchor-name / position-anchor
+   / position-area) where supported, with a plain absolute-position
+   fallback for browsers that don't support it yet. No JavaScript.
+   ========================================================================== */
+
+:root {
+  --bg: #f5f6fa;
+  --surface: #1c1e26;
+  --text: #1a1b1f;
+  --tooltip-text: #f5f6fa;
+  --accent: #4f6df5;
+  --border: #dcdfe8;
+
+  --tip-duration: 220ms;
+  --tip-ease: ease-out;
+  --tip-offset: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+/* ---- Demo shell ------------------------------------------------------- */
+.demo {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3.5rem;
+}
+
+.demo-header h1 {
+  margin: 0 0 0.6rem;
+  font-size: 1.75rem;
+}
+
+.demo-header p {
+  color: #55586a;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 3.5rem 2rem;
+  justify-items: center;
+  padding: 2rem 0;
+}
+
+/* ---- Anchor wrapper: only needed for the fallback path ----------------- */
+.anchor-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+/* ---- Trigger button ----------------------------------------------------- */
+.anchor-btn {
+  padding: 0.6rem 1.4rem;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background-color: #ffffff;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.anchor-btn:hover,
+.anchor-btn:focus-visible {
+  border-color: var(--accent);
+}
+
+/* ---- Tooltip base styles (shared by both paths) ------------------------- */
+.tooltip {
+  position: absolute;
+  padding: 0.5rem 0.85rem;
+  background-color: var(--surface);
+  color: var(--tooltip-text);
+  font-size: 0.8rem;
+  border-radius: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+
+  opacity: 0;
+  transition: opacity var(--tip-duration) var(--tip-ease),
+              transform var(--tip-duration) var(--tip-ease);
+}
+
+/* ---- Fallback placement (no anchor positioning support) ---------------- */
+.tooltip--top {
+  bottom: calc(100% + var(--tip-offset));
+  left: 50%;
+  transform: translate(-50%, 4px);
+}
+
+.tooltip--bottom {
+  top: calc(100% + var(--tip-offset));
+  left: 50%;
+  transform: translate(-50%, -4px);
+}
+
+.tooltip--left {
+  right: calc(100% + var(--tip-offset));
+  top: 50%;
+  transform: translate(4px, -50%);
+}
+
+.tooltip--right {
+  left: calc(100% + var(--tip-offset));
+  top: 50%;
+  transform: translate(-4px, -50%);
+}
+
+/* Resting transform once visible, fallback path */
+.anchor-wrap:hover .tooltip--top,
+.anchor-wrap:focus-within .tooltip--top {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.anchor-wrap:hover .tooltip--bottom,
+.anchor-wrap:focus-within .tooltip--bottom {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.anchor-wrap:hover .tooltip--left,
+.anchor-wrap:focus-within .tooltip--left {
+  opacity: 1;
+  transform: translate(0, -50%);
+}
+
+.anchor-wrap:hover .tooltip--right,
+.anchor-wrap:focus-within .tooltip--right {
+  opacity: 1;
+  transform: translate(0, -50%);
+}
+
+/* ==========================================================================
+   NATIVE ANCHOR POSITIONING PATH
+   Only applied in browsers that understand `anchor-name`. Everything
+   above still works as the fallback for everyone else.
+   ========================================================================== */
+@supports (anchor-name: --a) {
+
+  #anchor-top    { anchor-name: --anchor-top; }
+  #anchor-bottom { anchor-name: --anchor-bottom; }
+  #anchor-left   { anchor-name: --anchor-left; }
+  #anchor-right  { anchor-name: --anchor-right; }
+
+  /* Anchored tooltips no longer need the relative wrapper's offsets —
+     they're positioned directly against the viewport, tied to their
+     anchor element via position-anchor. */
+  #tip-top,
+  #tip-bottom,
+  #tip-left,
+  #tip-right {
+    position: fixed;
+    inset: auto;
+    margin: 0;
+  }
+
+  #tip-top {
+    position-anchor: --anchor-top;
+    position-area: top;
+    margin-bottom: var(--tip-offset);
+    transform: translateY(4px);
+  }
+
+  #tip-bottom {
+    position-anchor: --anchor-bottom;
+    position-area: bottom;
+    margin-top: var(--tip-offset);
+    transform: translateY(-4px);
+  }
+
+  #tip-left {
+    position-anchor: --anchor-left;
+    position-area: left;
+    margin-right: var(--tip-offset);
+    transform: translateX(4px);
+  }
+
+  #tip-right {
+    position-anchor: --anchor-right;
+    position-area: right;
+    margin-left: var(--tip-offset);
+    transform: translateX(-4px);
+  }
+
+  .anchor-wrap:hover #tip-top,
+  .anchor-wrap:focus-within #tip-top,
+  .anchor-wrap:hover #tip-bottom,
+  .anchor-wrap:focus-within #tip-bottom {
+    transform: translateY(0);
+  }
+
+  .anchor-wrap:hover #tip-left,
+  .anchor-wrap:focus-within #tip-left,
+  .anchor-wrap:hover #tip-right,
+  .anchor-wrap:focus-within #tip-right {
+    transform: translateX(0);
+  }
+}
+
+/* ---- Footer -------------------------------------------------------------- */
+.demo-footer {
+  text-align: center;
+  color: #55586a;
+  font-size: 0.85rem;
+  margin-top: 2.5rem;
+}
+
+.demo-footer code {
+  background-color: #ffffff;
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+/* ---- Reduced motion: no slide/fade transition, snap instantly ----------- */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Pull Request Description

Adds a CSS Anchor Positioning tooltip component with four placement variants (top, bottom, left, right). Uses the native anchor-name / position-anchor / position-area API where supported, wrapped in @supports, with a plain absolute-position fallback everywhere else. No JavaScript for placement in either path. Addresses #55790.

Type of Change
 ✨ New animation / hover effect
 🧩 New component
Submission Checklist
 All changes are inside submissions/ (submissions/examples/css-anchor-position-tooltip-55790/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)
Feature Description

What does this add?
A JS-free tooltip that positions itself against a named anchor element using the CSS Anchor Positioning API, with graceful fallback for unsupported browsers.

How does a developer use it?

html
<div class="anchor-wrap">
  <button class="anchor-btn" id="trigger" aria-describedby="tip">Hover me</button>
  <div class="tooltip tooltip--top" id="tip" role="tooltip">Tooltip text</div>
</div>
css
#trigger { anchor-name: --trigger; } /* inside @supports (anchor-name: --a) */
#tip { position-anchor: --trigger; position-area: top; }

Why does it fit EaseMotion CSS?
Pure CSS, zero positioning JavaScript, demonstrates a modern browser capability while degrading gracefully for older browsers — matches EaseMotion's animation-first, lightweight, composable philosophy.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari
Notes for Maintainer

Anchor Positioning currently has partial browser support (strong in Chromium-based browsers) — the @supports fallback ensures the tooltip still works everywhere. Also assigned to @Devansh-18155, flagging in case of overlap. Opened as draft pending cross-browser check.

Closes #55790