### PR TITLE
Add animated progress bars with scroll-triggered fill

### DIFF
--- a/submissions/examples/progress-bars-gb-55784/README.md
+++ b/submissions/examples/progress-bars-gb-55784/README.md
@@ -1,0 +1,84 @@
+# Animated Progress Bars
+
+Scroll-triggered progress bars for dashboards, skill sections, and
+form validation summaries. Each bar fills — and its percentage label
+counts up — only once it scrolls into view, using
+`IntersectionObserver`. The fill motion itself is a pure CSS
+transition.
+
+## How it works
+
+### Markup
+
+Each bar declares its target percentage as a data attribute — nothing
+else needs to be precomputed:
+
+```html
+<div class="progress-bar" data-progress data-value="72">
+  <div class="progress-bar__label">
+    <span>JavaScript</span>
+    <span class="progress-bar__percent" data-percent>0%</span>
+  </div>
+  <div class="progress-bar__track">
+    <div class="progress-bar__fill" data-fill></div>
+  </div>
+</div>
+```
+
+### Scroll trigger
+
+One `IntersectionObserver` watches every `[data-progress]` element. The
+first time a bar crosses 40% into view, its fill width is set to the
+target percentage (which CSS then animates via `transition: width`),
+and the observer stops watching that bar — so scrolling past it again
+doesn't replay the animation:
+
+```js
+var observer = new IntersectionObserver(function (entries) {
+  entries.forEach(function (entry) {
+    if (!entry.isIntersecting) return;
+    var bar = entry.target;
+    var value = bar.getAttribute("data-value");
+    bar.querySelector("[data-fill]").style.width = value + "%";
+    observer.unobserve(bar);
+  });
+}, { threshold: 0.4 });
+```
+
+### Counting label
+
+The percentage label counts up from 0 to its target value over the
+same duration as the fill, using `requestAnimationFrame` — this is the
+only piece of custom JS animation in the demo; everything visual
+(the fill itself) stays in CSS.
+
+## Usage
+
+Add a new bar by copying the markup block above and changing three
+things: the `data-value`, the label text, and nothing else — the
+script auto-discovers every `[data-progress]` element on the page.
+
+## Why it fits EaseMotion CSS
+
+The fill motion — the actual visual animation — is a single CSS
+`transition` on `width`. JavaScript only decides *when* to reveal each
+bar and *what* value to count toward; it never animates anything
+itself. That mirrors EaseMotion's separation of orchestration (JS) from
+motion (CSS), and the component is a single composable block with no
+external dependencies.
+
+## Accessibility
+
+- `@media (prefers-reduced-motion: reduce)` disables the fill
+  transition and skips the counting animation — the bar and label jump
+  straight to their final values instead.
+- Bars use plain semantic markup with visible text labels, so screen
+  readers announce both the skill name and its percentage as normal
+  page content.
+
+## Files
+
+- `demo.html` — four sample skill bars, a scroll spacer to demonstrate
+  the trigger, and the `IntersectionObserver` + counting-label script.
+- `style.css` — track, fill, gradient, and label styling.
+- `README.md` — this file.

--- a/submissions/examples/progress-bars-gb-55784/demo.html
+++ b/submissions/examples/progress-bars-gb-55784/demo.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Animated Progress Bars</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <header class="demo-header">
+      <h1>Animated Progress Bars</h1>
+      <p>Scroll down — each bar fills only once it enters view, with the percentage label counting up alongside it.</p>
+    </header>
+
+    <!-- Spacer so the bars start below the fold, proving the scroll trigger -->
+    <div class="scroll-spacer">
+      <p>Scroll down to trigger the bars &darr;</p>
+    </div>
+
+    <section class="bar-group" aria-label="Skill progress">
+
+      <div class="progress-bar" data-progress data-value="90">
+        <div class="progress-bar__label">
+          <span>HTML &amp; CSS</span>
+          <span class="progress-bar__percent" data-percent>0%</span>
+        </div>
+        <div class="progress-bar__track">
+          <div class="progress-bar__fill" data-fill></div>
+        </div>
+      </div>
+
+      <div class="progress-bar" data-progress data-value="72">
+        <div class="progress-bar__label">
+          <span>JavaScript</span>
+          <span class="progress-bar__percent" data-percent>0%</span>
+        </div>
+        <div class="progress-bar__track">
+          <div class="progress-bar__fill" data-fill></div>
+        </div>
+      </div>
+
+      <div class="progress-bar" data-progress data-value="55">
+        <div class="progress-bar__label">
+          <span>Design Systems</span>
+          <span class="progress-bar__percent" data-percent>0%</span>
+        </div>
+        <div class="progress-bar__track">
+          <div class="progress-bar__fill" data-fill></div>
+        </div>
+      </div>
+
+      <div class="progress-bar" data-progress data-value="38">
+        <div class="progress-bar__label">
+          <span>Backend Basics</span>
+          <span class="progress-bar__percent" data-percent>0%</span>
+        </div>
+        <div class="progress-bar__track">
+          <div class="progress-bar__fill" data-fill></div>
+        </div>
+      </div>
+
+    </section>
+
+    <footer class="demo-footer">
+      <p>Scroll-triggered via <code>IntersectionObserver</code> &middot; respects <code>prefers-reduced-motion</code></p>
+    </footer>
+  </main>
+
+  <script>
+    (function () {
+      var reduceMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+      ).matches;
+
+      var bars = document.querySelectorAll("[data-progress]");
+
+      /* Animate the percentage label counting up in sync with the fill.
+         Skipped entirely under reduced motion — the label just jumps
+         straight to its final value. */
+      function animateCount(el, target, duration) {
+        if (reduceMotion) {
+          el.textContent = target + "%";
+          return;
+        }
+        var start = 0;
+        var startTime = null;
+
+        function step(timestamp) {
+          if (!startTime) startTime = timestamp;
+          var progress = Math.min((timestamp - startTime) / duration, 1);
+          var current = Math.round(progress * target);
+          el.textContent = current + "%";
+          if (progress < 1) {
+            requestAnimationFrame(step);
+          }
+        }
+        requestAnimationFrame(step);
+      }
+
+      var observer = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (!entry.isIntersecting) return;
+
+            var bar = entry.target;
+            var value = bar.getAttribute("data-value");
+            var fill = bar.querySelector("[data-fill]");
+            var percent = bar.querySelector("[data-percent]");
+            var duration = reduceMotion ? 0 : 1100;
+
+            fill.style.width = value + "%";
+            animateCount(percent, parseInt(value, 10), duration);
+
+            observer.unobserve(bar);
+          });
+        },
+        { threshold: 0.4 }
+      );
+
+      bars.forEach(function (bar) {
+        observer.observe(bar);
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/progress-bars-gb-55784/style.css
+++ b/submissions/examples/progress-bars-gb-55784/style.css
@@ -1,0 +1,132 @@
+/* ==========================================================================
+   Animated Progress Bars
+   Fill width is set inline by JS once IntersectionObserver confirms the
+   bar is in view; the actual fill motion is a pure CSS transition.
+   ========================================================================== */
+
+:root {
+  --bg: #fafafa;
+  --surface: #ffffff;
+  --text: #202124;
+  --text-muted: #676a6f;
+  --track: #e9eaee;
+  --accent: #3a7bfd;
+  --accent-2: #6dd3c8;
+  --border: #e3e4e8;
+
+  --fill-duration: 1100ms;
+  --fill-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+/* ---- Demo shell --------------------------------------------------------- */
+.demo {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.demo-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+}
+
+.demo-header p {
+  color: var(--text-muted);
+  max-width: 460px;
+  margin: 0 auto;
+}
+
+/* Just to push the bars below the fold so the scroll trigger is visible */
+.scroll-spacer {
+  height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  margin-bottom: 2rem;
+}
+
+/* ---- Bar group ----------------------------------------------------------- */
+.bar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.progress-bar {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+}
+
+.progress-bar__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.progress-bar__percent {
+  font-weight: 700;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- The bar itself ------------------------------------------------------- */
+.progress-bar__track {
+  height: 10px;
+  background-color: var(--track);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  width: 0%;
+  border-radius: 999px;
+  background-image: linear-gradient(90deg, var(--accent), var(--accent-2));
+  transition: width var(--fill-duration) var(--fill-ease);
+}
+
+/* ---- Footer ---------------------------------------------------------------- */
+.demo-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 2.5rem;
+}
+
+.demo-footer code {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+/* ---- Reduced motion: fill jumps to final width instantly ------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .progress-bar__fill {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Pull Request Description

Adds animated, scroll-triggered progress bars for dashboards, skill sections, and form validation summaries. Each bar's fill and percentage label animate only once it scrolls into view, using IntersectionObserver. Addresses #55784.

Type of Change
 ✨ New animation / hover effect
 🧩 New component
Submission Checklist
 All changes are inside submissions/ (submissions/examples/progress-bars-gb-55784/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)
Feature Description

What does this add?
Scroll-triggered progress bars that fill and count up their percentage label only once visible, via IntersectionObserver.

How does a developer use it?

html
<div class="progress-bar" data-progress data-value="72">
  <div class="progress-bar__label">
    <span>JavaScript</span>
    <span class="progress-bar__percent" data-percent>0%</span>
  </div>
  <div class="progress-bar__track">
    <div class="progress-bar__fill" data-fill></div>
  </div>
</div>

Why does it fit EaseMotion CSS?
JS only decides when to reveal a bar and what value to count toward — the actual fill motion is a single CSS transition on width. Matches EaseMotion's separation of orchestration from motion, and respects prefers-reduced-motion.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari
Notes for Maintainer

Also assigned to @scriptedbyshivam, who has an existing PR (#55785) open on this issue — flagging in case of overlap. Opened as draft pending cross-browser check.

Closes #55784