### PR TITLE
docs: report unclosed code fence corrupting README rendering

### DIFF
--- a/submissions/docs/readme-unclosed-code-fence-ks/README.md
+++ b/submissions/docs/readme-unclosed-code-fence-ks/README.md
@@ -1,0 +1,33 @@
+# Bug: Unclosed Code Fence Breaks README Rendering
+
+## What does this do?
+
+Identifies and documents a missing closing ` ``` ` code fence in `README.md` at line 712 that causes the `### Animations`, `### Duration Helpers` sections and all their content (lines 714–742) to render incorrectly as raw code instead of formatted markdown on GitHub.
+
+## How is it used?
+
+The bug is visible when viewing the `## Usage and Examples` section on GitHub or any markdown viewer. The broken section starts here:
+
+```markdown
+### Development
+Use the non-minified version for debugging and development:
+
+```html
+<link rel="stylesheet" href="easemotion.css" />
+[PSYCHE: NO CLOSING FENCE — remaining lines 713–741 are consumed]
+```
+
+Expected:
+```html
+<link rel="stylesheet" href="easemotion.css" />
+```
+
+## Why is it useful?
+
+- The Animations, Duration Helpers, Duration Table, and Looping Animation examples (30 lines of documentation) are invisible to readers browsing the README on GitHub
+- This is the `## Usage and Examples` section — the primary way users learn to use the framework
+- Fix is a single line addition with zero risk of breaking anything else
+
+## Files to update in core:
+
+- `README.md` — add ` ``` ` closing fence after line 712 (between the `<link>` tag and `### Animations`)

--- a/submissions/docs/readme-unclosed-code-fence-ks/demo.html
+++ b/submissions/docs/readme-unclosed-code-fence-ks/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>README Unclosed Code Fence — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>README Unclosed Code Fence Bug</h1>
+
+    <section class="card">
+      <h2>Location</h2>
+      <p><code>README.md</code>, lines 706–742, under <code>## Usage and Examples</code></p>
+    </section>
+
+    <section class="card">
+      <h2>Bug</h2>
+      <p>A <code>```html</code> code fence at line 711 never receives a closing <code>```</code> fence. This causes the <code>### Animations</code> heading, <code>### Duration Helpers</code> heading, all entrance animation HTML examples, the Duration Table, and the Looping animation examples — <strong>30 lines of documentation</strong> — to render as raw code rather than formatted markdown.</p>
+    </section>
+
+    <section class="card">
+      <h2>Before (Broken)</h2>
+      <pre>### Development
+Use the non-minified version for debugging and development:
+
+```html
+&lt;link rel="stylesheet" href="easemotion.css" /&gt;
+<span class="highlight">← MISSING ```</span>
+
+### Animations
+(All content below renders as code)</pre>
+    </section>
+
+    <section class="card">
+      <h2>After (Fixed)</h2>
+      <pre>### Development
+Use the non-minified version for debugging and development:
+
+```html
+&lt;link rel="stylesheet" href="easemotion.css" /&gt;
+```
+<span class="highlight">← ADD THIS LINE</span>
+
+### Animations
+
+```html
+&lt;h1 class="ease-fade-in"&gt;Fade in&lt;/h1&gt;
+...</pre>
+    </section>
+
+    <section class="card">
+      <h2>Affected Content</h2>
+      <ul>
+        <li>### Animations heading (line 714)</li>
+        <li>9 entrance animation HTML examples (lines 716–723)</li>
+        <li>Staggered sequence examples (lines 725–728)</li>
+        <li>### Duration Helpers heading (line 731)</li>
+        <li>Duration HTML examples (lines 733–736)</li>
+        <li>Duration reference table (lines 738–742)</li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>Impact</h2>
+      <p>This is the primary <strong>Usage and Examples</strong> section that users land on when learning EaseMotion CSS. The broken rendering hides critical documentation from all GitHub visitors and documentation site builds.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/docs/readme-unclosed-code-fence-ks/style.css
+++ b/submissions/docs/readme-unclosed-code-fence-ks/style.css
@@ -1,0 +1,100 @@
+/* README Code Fence Bug Report Styles */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 800px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  color: #a78bfa;
+}
+
+h2 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  color: #c4b5fd;
+}
+
+.card {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card p {
+  line-height: 1.7;
+  margin-bottom: 0.75rem;
+}
+
+.card p:last-child {
+  margin-bottom: 0;
+}
+
+pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 1rem 0;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.6;
+}
+
+.highlight {
+  color: #fbbf24;
+  font-weight: 600;
+}
+
+code {
+  background: rgba(99, 102, 241, 0.15);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  color: #c4b5fd;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+}
+
+ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
+
+li {
+  line-height: 1.7;
+  margin-bottom: 0.25rem;
+  color: #94a3b8;
+}
+
+strong {
+  color: #fbbf24;
+}


### PR DESCRIPTION
## Summary

This PR adds a documentation submission reporting a Markdown formatting issue in the project's README. The report identifies an unclosed code fence that causes part of the Usage section to render incorrectly on GitHub.

## Problem

A missing closing code fence in the README causes subsequent headings, examples, and reference tables to be rendered as part of the same code block, making an important section of the documentation difficult to read.

To comply with the repository's contribution policy, this issue is documented under the `submissions/` directory instead of modifying maintainer-owned files directly.

## Solution

Added a documentation submission containing:

- A description of the rendering issue
- Root cause analysis
- Exact location of the problem
- Suggested fix
- A visual demonstration of the issue

## Changes Made

- Added `submissions/docs/readme-unclosed-code-fence-ks/README.md`
- Added `submissions/docs/readme-unclosed-code-fence-ks/demo.html`
- Added `submissions/docs/readme-unclosed-code-fence-ks/style.css`
- No production or documentation files outside `submissions/` were modified.

## Testing

- Verified the Markdown rendering issue on GitHub.
- Confirmed the reported fix resolves the formatting problem.
- Ensured the submission follows the repository's contribution guidelines.

## Checklist

- [x] Contribution is inside `submissions/`
- [x] No core project files modified
- [x] Includes README, demo, and styles
- [x] Documents a reproducible issue
- [x] No breaking changes