### PR TITLE
fix: prevent chip component text clipping

### DIFF
--- a/submissions/examples/chip-text-clipping/README.md
+++ b/submissions/examples/chip-text-clipping/README.md
@@ -1,0 +1,30 @@
+# Chip Text Clipping Fix
+
+## Description
+
+This example prevents long chip labels from being clipped on smaller screens by allowing the chip to wrap its content while remaining responsive.
+
+## Problem
+
+Chip components with lengthy text may clip or overflow on narrow screens, making labels difficult to read.
+
+## Solution
+
+Use a responsive chip with wrapping enabled.
+
+```css
+.chip {
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+```
+
+## Benefits
+
+- Prevents text clipping
+- Fully responsive
+- Supports long labels
+- Pure CSS implementation
+- Reusable across chips, tags, and badges

--- a/submissions/examples/chip-text-clipping/demo.html
+++ b/submissions/examples/chip-text-clipping/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip Text Clipping Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+  <h2>Responsive Chip Component</h2>
+
+  <div class="chip">
+    This is a very long chip label that automatically wraps instead of being clipped on smaller screens.
+  </div>
+
+  <div class="chip">
+    EaseMotion CSS
+  </div>
+
+  <div class="chip">
+    Responsive Design Utility
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/chip-text-clipping/style.css
+++ b/submissions/examples/chip-text-clipping/style.css
@@ -1,0 +1,46 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  padding: 40px;
+}
+
+.container {
+  max-width: 500px;
+  margin: auto;
+}
+
+h2 {
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  margin: 8px;
+  padding: 10px 16px;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 999px;
+  font-size: 14px;
+  line-height: 1.4;
+
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+@media (max-width: 480px) {
+  .chip {
+    display: flex;
+    width: 100%;
+    margin: 8px 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Added a CSS-only bug fix example that prevents chip component text from being clipped on smaller screens. The update ensures long chip labels remain fully visible by allowing responsive wrapping while preserving the chip's appearance.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a responsive fix that prevents chip component text from being clipped when labels are longer than the available width.

**How does a developer use it?**

```html
<div class="chip">
  This is a very long chip label that wraps instead of being clipped.
</div>
```

```css
.chip {
  max-width: 100%;
  white-space: normal;
  overflow-wrap: break-word;
  word-break: break-word;
}
```

**Why does it fit EaseMotion CSS?**

This is a lightweight, reusable CSS improvement that enhances the usability of chip components without modifying the core framework. It follows EaseMotion CSS's philosophy of providing simple, responsive, and developer-friendly styling utilities.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(not tested)*

---

## Notes for Maintainer

The fix relies on standard CSS properties (`max-width`, `overflow-wrap`, and `word-break`) to ensure chip labels remain readable on all screen sizes. No changes were made to the `core/` or `components/` directories.