### PR TITLE
fix: prevent breadcrumb text wrapping unexpectedly

### DIFF
--- a/submissions/examples/breadcrump-text-wrapping/README.md
+++ b/submissions/examples/breadcrump-text-wrapping/README.md
@@ -1,0 +1,43 @@
+# Breadcrumb Text Wrapping Fix
+
+## Description
+
+This example prevents breadcrumb navigation from wrapping onto multiple lines when long labels are present. Instead, long items are truncated with an ellipsis while the breadcrumb remains on a single line.
+
+## Usage
+
+```html
+<nav class="breadcrumb">
+  <a href="#">Home</a>
+  <span>/</span>
+  <a href="#" class="truncate">
+    Very Long Breadcrumb Item
+  </a>
+</nav>
+```
+
+## CSS
+
+```css
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.truncate {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+```
+
+## Benefits
+
+- Prevents unexpected line wrapping
+- Keeps breadcrumb navigation readable
+- Handles long labels gracefully
+- Responsive and mobile-friendly
+- Pure CSS solution

--- a/submissions/examples/breadcrump-text-wrapping/demo.html
+++ b/submissions/examples/breadcrump-text-wrapping/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumb Wrapping Fix</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <h2>Responsive Breadcrumb</h2>
+
+  <nav class="breadcrumb">
+    <a href="#">Home</a>
+    <span>/</span>
+    <a href="#">Components</a>
+    <span>/</span>
+    <a href="#" class="truncate">
+      Very Long Breadcrumb Item That Should Not Break the Layout
+    </a>
+    <span>/</span>
+    <span class="current">Current Page</span>
+  </nav>
+
+</body>
+</html>

--- a/submissions/examples/breadcrump-text-wrapping/style.css
+++ b/submissions/examples/breadcrump-text-wrapping/style.css
@@ -1,0 +1,54 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  padding: 40px;
+}
+
+h2 {
+  margin-bottom: 20px;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 600px;
+  padding: 12px 16px;
+  background: #fff;
+  border-radius: 8px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.breadcrumb a,
+.breadcrumb span {
+  color: #333;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.truncate {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.current {
+  font-weight: bold;
+}
+
+.breadcrumb::-webkit-scrollbar {
+  height: 6px;
+}
+
+.breadcrumb::-webkit-scrollbar-thumb {
+  background: #bbb;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Pull Request Description

Added a CSS-only fix that prevents breadcrumb navigation from wrapping unexpectedly when long labels are present. The solution keeps breadcrumbs on a single line, gracefully truncates lengthy items with an ellipsis, and allows horizontal scrolling on smaller screens to preserve readability.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/breadcrumb-text-wrapping/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a responsive fix that prevents breadcrumb items from wrapping onto multiple lines while handling long labels gracefully.

**How does a developer use it?**

```html
<nav class="breadcrumb">
  <a href="#">Home</a>
  <span>/</span>
  <a href="#" class="truncate">
    Very Long Breadcrumb Item
  </a>
  <span>/</span>
  <span>Current Page</span>
</nav>
```

**Why does it fit EaseMotion CSS?**

This fix improves the responsiveness and usability of breadcrumb navigation using lightweight, reusable CSS. It aligns with EaseMotion CSS's philosophy of providing clean, composable, and developer-friendly UI utilities without introducing unnecessary complexity.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(not tested)*

---

## Notes for Maintainer

This submission uses standard CSS (`flex`, `white-space`, `overflow-x`, and `text-overflow`) to maintain a clean single-line breadcrumb layout while supporting long labels on smaller screens. No modifications were made to the `core/` or `components/` directories.