### PR TITLE
50117 cyberpunk blur tabs

### DIFF
--- a/submissions/examples/cyberpunk-blur-tabs/README.md
+++ b/submissions/examples/cyberpunk-blur-tabs/README.md
@@ -1,0 +1,26 @@
+# CSS Cyberpunk Blur-Entrance Tabs
+
+A highly stylized, pure CSS tabbed interface designed for Cyberpunk and Sci-Fi neon layouts. It features striking neon glows, dynamic border color switching based on the active tab, and a high-tech blur-entrance animation.
+
+## 🚀 Features
+
+- **Pure CSS State Management:** Utilizes hidden `<input type="radio">` tags and CSS sibling combinators (`~`) to handle tab routing and dynamic panel styling entirely without JavaScript.
+- **Cyberpunk Aesthetic:** Features a stark dark theme, monospace typography, sharp borders, and glowing neon accents (Cyan, Magenta, Yellow) that dynamically update based on the user's selection.
+- **Digital Blur Animation:** When a tab is selected, the panel enters with a custom `@keyframes` animation that combines `filter: blur()`, `brightness`, and scaling to simulate a digital screen initializing.
+- **Accessible & Responsive:** Adapts to mobile screens by stacking tabs vertically. Fully keyboard navigable using `tabindex="0"` with dashed focus rings, and honors `@media (prefers-reduced-motion: reduce)` by bypassing the animation.
+
+## 🛠️ Usage
+
+Copy the HTML structure from `demo.html` and the styles from `style.css`. 
+
+### CSS Custom Properties
+Tweak the neon colors and animation timings in the `:root` pseudo-class to match your specific cyberpunk theme:
+
+```css
+:root {
+    --em-neon-cyan: #00f0ff;
+    --em-neon-magenta: #ff003c;
+    --em-neon-yellow: #fcee0a;
+    --em-blur-amount: 15px;         /* Intensity of the digital blur */
+    --em-transition-timing: 0.4s;   /* Animation speed */
+}

--- a/submissions/examples/cyberpunk-blur-tabs/demo.html
+++ b/submissions/examples/cyberpunk-blur-tabs/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Cyberpunk Blur-Entrance Tabs - EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="cyber-wrapper">
+        <header class="cyber-header">
+            <h1>NEXUS // TERMINAL</h1>
+            <p>Pure CSS tabs featuring a high-tech blur-entrance transition.</p>
+        </header>
+
+        <div class="em-tabs-container">
+            <!-- Hidden Radio Inputs for State Management -->
+            <input type="radio" id="em-tab-1" name="em-tabs" class="em-tab-input" checked>
+            <input type="radio" id="em-tab-2" name="em-tabs" class="em-tab-input">
+            <input type="radio" id="em-tab-3" name="em-tabs" class="em-tab-input">
+
+            <!-- Cyberpunk Tab Headers -->
+            <div class="em-tabs-header">
+                <label for="em-tab-1" class="em-tab-label" tabindex="0">
+                    <span class="cyber-bracket">[</span> MAINFRAME <span class="cyber-bracket">]</span>
+                </label>
+                <label for="em-tab-2" class="em-tab-label" tabindex="0">
+                    <span class="cyber-bracket">[</span> NEURAL NET <span class="cyber-bracket">]</span>
+                </label>
+                <label for="em-tab-3" class="em-tab-label" tabindex="0">
+                    <span class="cyber-bracket">[</span> OVERRIDE <span class="cyber-bracket">]</span>
+                </label>
+            </div>
+
+            <!-- Tab Content Panels -->
+            <div class="em-tabs-content">
+                <div class="em-tab-panel" id="em-panel-1">
+                    <h2>System Diagnostics</h2>
+                    <p>Core temperature nominal. Quantum routing protocols are currently active. Awaiting input for deep-dive packet analysis.</p>
+                    <button class="cyber-btn cyber-cyan">INITIATE SCAN</button>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-2">
+                    <h2>Synaptic Uplink</h2>
+                    <p>Connection established to the global grid. Warning: Unregistered ICE detected on subnet 4. Recommend rerouting through proxy servers immediately.</p>
+                    <button class="cyber-btn cyber-magenta">REROUTE SIGNAL</button>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-3">
+                    <h2>Manual Override</h2>
+                    <p>Authorization required. Engaging this protocol will bypass all security subroutines and grant root access to the physical hardware constraints.</p>
+                    <button class="cyber-btn cyber-yellow">BREACH FIREWALL</button>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-blur-tabs/style.css
+++ b/submissions/examples/cyberpunk-blur-tabs/style.css
@@ -1,0 +1,264 @@
+/* ==========================================================================
+   EaseMotion: Cyberpunk Neon Blur-Entrance Tabs
+   ========================================================================== */
+
+:root {
+    /* Cyberpunk Neon Palette */
+    --em-cyber-bg: #050510;
+    --em-cyber-panel: #0a0a1a;
+    --em-neon-cyan: #00f0ff;
+    --em-neon-magenta: #ff003c;
+    --em-neon-yellow: #fcee0a;
+    
+    /* Text Colors */
+    --em-text-main: #e0e0ff;
+    --em-text-muted: #6b6b8e;
+    
+    /* Animation Parameters */
+    --em-blur-amount: 15px;
+    --em-transition-timing: 0.4s;
+    --em-easing: cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Base Page Styling with Grid Background */
+body {
+    margin: 0;
+    font-family: 'Courier New', Courier, monospace; /* Monospace for that hacker feel */
+    background-color: var(--em-cyber-bg);
+    background-image: 
+        linear-gradient(rgba(0, 240, 255, 0.05) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 240, 255, 0.05) 1px, transparent 1px);
+    background-size: 30px 30px;
+    color: var(--em-text-main);
+    display: flex;
+    justify-content: center;
+    padding: 4rem 1rem;
+}
+
+.cyber-wrapper {
+    max-width: 750px;
+    width: 100%;
+}
+
+.cyber-header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+    text-transform: uppercase;
+}
+
+.cyber-header h1 {
+    margin: 0 0 0.5rem 0;
+    color: var(--em-neon-cyan);
+    text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
+    letter-spacing: 4px;
+}
+
+.cyber-header p {
+    color: var(--em-text-muted);
+    margin: 0;
+}
+
+/* ==========================================================================
+   Component: Tabs Container & Hidden Inputs
+   ========================================================================== */
+.em-tabs-container {
+    width: 100%;
+    position: relative;
+}
+
+/* Hide inputs visually, keep focusable in DOM */
+.em-tab-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+/* ==========================================================================
+   Component: Cyberpunk Tab Headers
+   ========================================================================== */
+.em-tabs-header {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.em-tab-label {
+    flex: 1;
+    text-align: center;
+    padding: 1rem;
+    cursor: pointer;
+    font-weight: bold;
+    font-size: 1rem;
+    color: var(--em-text-muted);
+    background-color: transparent;
+    border: 1px solid var(--em-text-muted);
+    text-transform: uppercase;
+    transition: all 0.3s ease;
+    user-select: none;
+    position: relative;
+    overflow: hidden;
+}
+
+.cyber-bracket {
+    opacity: 0.3;
+    transition: opacity 0.3s ease;
+}
+
+.em-tab-label:hover {
+    color: var(--em-text-main);
+    border-color: var(--em-neon-cyan);
+    box-shadow: inset 0 0 15px rgba(0, 240, 255, 0.1);
+}
+
+.em-tab-label:hover .cyber-bracket {
+    opacity: 1;
+    color: var(--em-neon-cyan);
+}
+
+/* ==========================================================================
+   Component: Tab Content Panels
+   ========================================================================== */
+.em-tabs-content {
+    background-color: var(--em-cyber-panel);
+    border: 1px solid var(--em-text-muted);
+    border-top: 3px solid var(--em-neon-cyan);
+    padding: 2.5rem;
+    min-height: 250px;
+    position: relative;
+}
+
+.em-tab-panel {
+    display: none; /* Hidden by default */
+}
+
+.em-tab-panel h2 {
+    margin-top: 0;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.em-tab-panel p {
+    line-height: 1.6;
+    color: var(--em-text-main);
+    margin-bottom: 2rem;
+}
+
+/* Cyberpunk Buttons */
+.cyber-btn {
+    background: transparent;
+    border: 1px solid currentColor;
+    color: inherit;
+    padding: 0.75rem 1.5rem;
+    font-family: 'Courier New', Courier, monospace;
+    font-weight: bold;
+    text-transform: uppercase;
+    cursor: pointer;
+    position: relative;
+    transition: all 0.2s ease;
+}
+
+.cyber-btn:hover {
+    background: currentColor;
+    color: var(--em-cyber-panel);
+    box-shadow: 0 0 15px currentColor;
+}
+
+.cyber-cyan { color: var(--em-neon-cyan); }
+.cyber-magenta { color: var(--em-neon-magenta); }
+.cyber-yellow { color: var(--em-neon-yellow); }
+
+/* ==========================================================================
+   Pure CSS Logic: Connecting Radios to Tabs & Panels
+   ========================================================================== */
+
+/* Active Tab Styling - Changing border colors based on the active tab */
+#em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"] {
+    color: var(--em-neon-cyan);
+    border-color: var(--em-neon-cyan);
+    box-shadow: 0 0 15px rgba(0, 240, 255, 0.3), inset 0 0 10px rgba(0, 240, 255, 0.2);
+}
+#em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"] {
+    color: var(--em-neon-magenta);
+    border-color: var(--em-neon-magenta);
+    box-shadow: 0 0 15px rgba(255, 0, 60, 0.3), inset 0 0 10px rgba(255, 0, 60, 0.2);
+}
+#em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"] {
+    color: var(--em-neon-yellow);
+    border-color: var(--em-neon-yellow);
+    box-shadow: 0 0 15px rgba(252, 238, 10, 0.3), inset 0 0 10px rgba(252, 238, 10, 0.2);
+}
+
+/* Make brackets glow on active */
+#em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"] .cyber-bracket,
+#em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"] .cyber-bracket,
+#em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"] .cyber-bracket {
+    opacity: 1;
+    text-shadow: 0 0 8px currentColor;
+}
+
+/* Dynamic Top Border color for content box based on active tab */
+#em-tab-1:checked ~ .em-tabs-content { border-top-color: var(--em-neon-cyan); }
+#em-tab-2:checked ~ .em-tabs-content { border-top-color: var(--em-neon-magenta); }
+#em-tab-3:checked ~ .em-tabs-content { border-top-color: var(--em-neon-yellow); }
+
+/* Title colors in panels */
+#em-tab-1:checked ~ .em-tabs-content #em-panel-1 h2 { color: var(--em-neon-cyan); }
+#em-tab-2:checked ~ .em-tabs-content #em-panel-2 h2 { color: var(--em-neon-magenta); }
+#em-tab-3:checked ~ .em-tabs-content #em-panel-3 h2 { color: var(--em-neon-yellow); }
+
+/* Keyboard Accessibility Focus Rings */
+.em-tab-label:focus-visible {
+    outline: 2px dashed var(--em-text-main);
+    outline-offset: 4px;
+}
+
+/* Show Active Panel & Trigger Blur Entrance Animation */
+#em-tab-1:checked ~ .em-tabs-content #em-panel-1,
+#em-tab-2:checked ~ .em-tabs-content #em-panel-2,
+#em-tab-3:checked ~ .em-tabs-content #em-panel-3 {
+    display: block;
+    animation: em-cyber-blur-in var(--em-transition-timing) var(--em-easing) forwards;
+}
+
+/* ==========================================================================
+   Keyframes: Digital Blur-Entrance
+   ========================================================================== */
+@keyframes em-cyber-blur-in {
+    0% {
+        opacity: 0;
+        filter: blur(var(--em-blur-amount)) brightness(2);
+        transform: scale(1.02) translateY(-10px);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0) brightness(1);
+        transform: scale(1) translateY(0);
+    }
+}
+
+/* ==========================================================================
+   Responsiveness
+   ========================================================================== */
+@media (max-width: 600px) {
+    .em-tabs-header {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+    .em-tabs-content {
+        padding: 1.5rem;
+    }
+}
+
+/* ==========================================================================
+   Accessibility: Prefers Reduced Motion
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .em-tab-panel {
+        animation: none !important; /* Disable blur and scale */
+        opacity: 1;
+        filter: none;
+        transform: none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #50117 by adding a purely CSS-driven Blur-Entrance Tabs component, intensely stylized for Cyberpunk Neon aesthetics within EaseMotion CSS.

**Key Implementations:**
* **HTML (`demo.html`)**: Built a robust, JavaScript-free state management system using the hidden radio-button technique. Styled the demo content with monospace fonts, terminal-style brackets, and thematic buttons.
* **CSS (`style.css`)**: Implemented a dynamic neon aesthetic. The active state logic not only shows the correct panel but dynamically changes the glowing box-shadows, text colors, and the main container's border-top color depending on the selected tab (Cyan, Magenta, Yellow). 
* **Animation**: Created a custom `em-cyber-blur-in` keyframe animation applying `filter: blur()`, increased `brightness`, and a slight `translateY` to simulate a futuristic display booting up.
* **Customization**: Centralized neon color codes, blur intensity, and animation timings into standard CSS variables within the `:root` selector.
* **Responsiveness**: The tab layout gracefully reflows from horizontal to vertical on viewports under `600px` to maintain large touch targets.
* **Accessibility**: Added `tabindex="0"` on the labels with distinct dashed `:focus-visible` rings for keyboard navigation. Implemented `prefers-reduced-motion` support to fall back to an instantaneous display for users with motion sensitivities.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📄 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (specifically under `submissions/examples/cyberpunk-blur-tabs/`)
- [x] Includes `demo.html` with a clean HTML5 showcase.
- [x] Includes `style.css` with pure CSS/HTML (No external JS frameworks).
- [x] Includes `README.md` with proper documentation.
- [x] Code is fully responsive across all viewports.
- [x] Code is accessible and includes `prefers-reduced-motion` support.

Closes #50117