### PR TITLE
Add before/after comparison image slider (before-after-slider-hr18)

### DIFF
--- a/submissions/examples/before-after-slider-hr18/README.md
+++ b/submissions/examples/before-after-slider-hr18/README.md
@@ -1,0 +1,102 @@
+# Before/After Comparison Slider (`before-after-slider-hr18`)
+
+A draggable split-screen image comparison slider, built for issue
+[#55696](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55696).
+
+## A note on naming
+
+The issue's own filenames (`index.html`, `styles.css`) and its suggested
+folder (`before-after-comparison-slider-em`, no per-contributor suffix)
+don't match this repo's actual enforced submission convention —
+`demo.html` + `style.css` + `README.md`, in a uniquely-suffixed folder.
+This submission uses that convention, plus the `script.js` file the issue
+also explicitly asks for, matching what the repo's automated submission
+validator checks for.
+
+## What it does
+
+Two layers — a "before" scene and an "after" scene — sit exactly on top of
+each other inside one frame. The "before" layer is clipped with
+`clip-path` to reveal only its left portion, controlled entirely by one
+CSS custom property, `--bas-pos-hr18`. Dragging the slider (or clicking
+anywhere on the frame, or focusing it and pressing the arrow keys) updates
+that single property, which simultaneously moves the reveal clip, the
+divider line, and the round handle — all three are bound to the same
+variable, so they can never visually drift out of sync with each other.
+
+**The images here are CSS-painted placeholder gradients**, not real
+photos — this repo's submission guidelines don't provide a place to bundle
+binary image assets, so the demo stands in two solid "scenes" to
+illustrate the mechanism. Swapping in real `<img>` elements (or
+background images) is a drop-in change; see Usage below.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a local `style.css` and a local
+`script.js`; no build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<div class="ease-compare-slider-hr18">
+  <div class="bas-layer-hr18 bas-layer-after-hr18">
+    <!-- swap this background for your own "after" image -->
+    <span class="bas-layer-label-hr18">After</span>
+  </div>
+  <div class="bas-layer-hr18 bas-layer-before-hr18">
+    <!-- swap this background for your own "before" image -->
+    <span class="bas-layer-label-hr18">Before</span>
+  </div>
+  <div class="bas-divider-hr18" aria-hidden="true"></div>
+  <div class="bas-handle-hr18" aria-hidden="true">&#8646;</div>
+  <input type="range" class="bas-range-hr18" min="0" max="100" value="50" aria-label="Comparison slider" />
+</div>
+
+<script src="script.js"></script>
+```
+
+To use real photos instead of the placeholder gradients, replace each
+`.bas-layer-hr18`'s background with `background-image: url(...)` (and
+`background-size: cover`), or swap the `<div>` for an `<img>` styled to
+fill the frame (`position: absolute; inset: 0; object-fit: cover;`).
+
+`script.js` finds every `.ease-compare-slider-hr18` on the page
+automatically and wires up its range input — multiple sliders on one page
+work independently with no extra setup.
+
+## Accessibility notes
+
+- The actual interactive control is a native `<input type="range">`,
+  stretched invisibly over the whole frame — dragging, clicking, touch
+  gestures, and left/right arrow-key adjustment all work for free, since
+  they're native range-input behaviors, not custom pointer-event code.
+- The range input carries a descriptive `aria-label`
+  ("Comparison slider — drag to reveal before or after"), so its purpose
+  and current value are announced correctly by screen readers.
+- The visual-only divider line and handle icon are marked
+  `aria-hidden="true"`, since the range input is already the accessible
+  representation of the same state.
+- Focus is clearly visible via `:focus-visible` on the range input itself.
+- There's no ambient/automatic motion here — the divider only moves in
+  direct response to user input — so there's nothing for
+  `prefers-reduced-motion` to need to suppress; the stylesheet includes a
+  defensive rule disabling transitions under that preference regardless,
+  in case a future integration adds one.
+
+## Responsiveness
+
+The frame uses `aspect-ratio: 16 / 10` and fills its container's width, so
+it scales cleanly at any viewport size without a dedicated media query.
+
+## Why this fits EaseMotion CSS
+
+The entire reveal mechanism runs on one CSS custom property and a native
+form control — no custom drag-tracking math, no pointer-event listeners,
+just `range.addEventListener("input", ...)` setting one variable that CSS
+does the rest with. That's a small, readable, dependency-free
+implementation consistent with the framework's philosophy.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/before-after-slider-hr18/demo.html
+++ b/submissions/examples/before-after-slider-hr18/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Before/After Comparison Slider</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="bas-hr18">
+  <div class="bas-wrap-hr18">
+
+    <div class="bas-header-hr18">
+      <h1>Drag to compare</h1>
+      <p>Drag the handle, click anywhere on the frame, or focus it and use
+        the left/right arrow keys.</p>
+    </div>
+
+    <div class="ease-compare-slider-hr18">
+
+      <!-- "After" sits underneath, filling the whole frame. In a real
+           integration this would be an <img>; here it's a CSS-painted
+           placeholder scene so the demo needs no bundled image files. -->
+      <div class="bas-layer-hr18 bas-layer-after-hr18">
+        <span class="bas-layer-label-hr18">After</span>
+      </div>
+
+      <!-- "Before" sits on top, clipped by --bas-pos-hr18 to reveal only
+           its left portion. -->
+      <div class="bas-layer-hr18 bas-layer-before-hr18">
+        <span class="bas-layer-label-hr18">Before</span>
+      </div>
+
+      <div class="bas-divider-hr18" aria-hidden="true"></div>
+      <div class="bas-handle-hr18" aria-hidden="true">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 7 3 12 8 17"></polyline><polyline points="16 7 21 12 16 17"></polyline></svg>
+      </div>
+
+      <input
+        type="range"
+        class="bas-range-hr18"
+        min="0"
+        max="100"
+        value="50"
+        step="1"
+        aria-label="Comparison slider — drag to reveal before or after"
+      />
+    </div>
+
+    <div class="bas-tuning-hr18">
+      The reveal, divider position, and handle position are all driven by
+      one CSS custom property, <code>--bas-pos-hr18</code>, set from the
+      range input's value on every <code>input</code> event — no manual
+      pixel math or DOM measurement needed.
+    </div>
+
+    <p class="bas-footnote-hr18">submissions/examples/before-after-slider-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/before-after-slider-hr18/script.js
+++ b/submissions/examples/before-after-slider-hr18/script.js
@@ -1,0 +1,30 @@
+/* ==========================================================================
+   script.js — before-after-slider-hr18
+   Binds every .ease-compare-slider-hr18's range input to the
+   --bas-pos-hr18 custom property that drives the reveal clip-path,
+   divider line, and handle position (all defined in style.css).
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  function initSlider(root) {
+    var range = root.querySelector(".bas-range-hr18");
+    if (!range) return;
+
+    function apply() {
+      root.style.setProperty("--bas-pos-hr18", range.value + "%");
+    }
+
+    // 'input' fires continuously while dragging, clicking, or using the
+    // keyboard's arrow keys on a focused range input — a single listener
+    // covers mouse, touch, and keyboard interaction alike, since they all
+    // funnel through the same native <input type="range"> element.
+    range.addEventListener("input", apply);
+
+    // Set the initial position on load, in case the markup's starting
+    // value differs from the CSS default.
+    apply();
+  }
+
+  document.querySelectorAll(".ease-compare-slider-hr18").forEach(initSlider);
+})();

--- a/submissions/examples/before-after-slider-hr18/style.css
+++ b/submissions/examples/before-after-slider-hr18/style.css
@@ -1,0 +1,207 @@
+/* ==========================================================================
+   before-after-slider-hr18 — style.css
+   Interactive Comparison Image Slider (Before/After)
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.bas-hr18 {
+  --bg-hr18: #f6f7f5;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e2e4de;
+  --text-hr18: #171916;
+  --muted-hr18: #666a61;
+  --accent-hr18: #2f6b4f;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+}
+
+.bas-hr18 * {
+  box-sizing: border-box;
+}
+
+.bas-wrap-hr18 {
+  max-width: 560px;
+  width: 100%;
+}
+
+.bas-header-hr18 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.bas-header-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.3rem, 2.2vw, 1.7rem);
+  margin: 0 0 0.5rem;
+}
+
+.bas-header-hr18 p {
+  margin: 0;
+  color: var(--muted-hr18);
+  font-size: 0.9rem;
+}
+
+/* ==========================================================================
+   The reusable comparison slider component
+   ========================================================================== */
+
+.ease-compare-slider-hr18 {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid var(--border-hr18);
+  box-shadow: 0 1px 2px rgba(10, 15, 10, 0.04), 0 14px 30px rgba(10, 15, 10, 0.06);
+  user-select: none;
+}
+
+/* Both "images" fill the frame completely and sit exactly on top of each
+   other. In a real integration these would be actual <img> elements; here
+   they're CSS-painted placeholder scenes so the demo needs no bundled
+   image assets. */
+.bas-layer-hr18 {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 1rem;
+}
+
+.bas-layer-after-hr18 {
+  background: linear-gradient(135deg, #ffb703, #fb8500 45%, #e85d04);
+}
+
+.bas-layer-before-hr18 {
+  background: linear-gradient(135deg, #6b7280, #4b5563 45%, #374151);
+  /* The "before" layer sits on top and is clipped to reveal only its left
+     --bas-pos-hr18 percent, exposing the "after" layer underneath for the
+     rest of the frame. Updating one custom property moves the whole
+     reveal — no JavaScript needed to redraw anything. */
+  clip-path: inset(0 calc(100% - var(--bas-pos-hr18, 50%)) 0 0);
+}
+
+.bas-layer-label-hr18 {
+  font-family: var(--font-display-hr18);
+  font-weight: 700;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.28);
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+}
+
+/* ---- The divider line + handle, positioned to match --bas-pos-hr18 -------------- */
+.bas-divider-hr18 {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--bas-pos-hr18, 50%);
+  width: 3px;
+  background: #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.bas-handle-hr18 {
+  position: absolute;
+  top: 50%;
+  left: var(--bas-pos-hr18, 50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-hr18);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+/* ---- The actual control: a native range input, invisibly stretched over
+   the whole frame. Using a real <input type="range"> means dragging,
+   clicking, touch, and left/right arrow-key adjustment all work for
+   free, with no custom pointer-event handling required. ------------------ */
+.bas-range-hr18 {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: ew-resize;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.bas-range-hr18::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 100%;
+}
+
+.bas-range-hr18::-moz-range-thumb {
+  width: 1px;
+  height: 100%;
+  border: none;
+  background: transparent;
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.bas-tuning-hr18 {
+  margin-top: 1.5rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.1rem 1.3rem;
+  font-size: 0.85rem;
+  color: var(--muted-hr18);
+  line-height: 1.55;
+}
+
+.bas-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  color: var(--text-hr18);
+}
+
+.bas-footnote-hr18 {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+  text-align: center;
+}
+
+/* ---- Focus visibility: the range input itself is the focusable element,
+   so its own focus ring is what a keyboard user sees. -------------------- */
+.bas-range-hr18:focus-visible {
+  outline: 3px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+/* ---- Reduced motion: the slider's position change is driven by direct
+   user input (dragging/keys), not an ambient animation, so there is no
+   motion to disable here — this rule exists only in case a future
+   integration adds a transition to the divider's movement. -------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-compare-slider-hr18 * {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a draggable before/after comparison image slider. Two layers sit
exactly on top of each other; the top ("before") layer is clipped via
clip-path controlled by one CSS custom property, --bas-pos-hr18. The
actual control is a native <input type="range"> stretched invisibly over
the frame, so dragging, clicking, touch, and left/right arrow-key
adjustment all work natively — one 'input' listener sets the custom
property and CSS handles the reveal, divider line, and handle position
simultaneously, so they can never drift out of sync.

Resolves #55696

Note for the maintainer: the issue's suggested filenames (index.html,
styles.css) and folder name (no per-contributor suffix) don't match this
repo's actual enforced convention, so I used demo.html/style.css/script.js
and a -hr18 suffix instead. Images are CSS-painted placeholder gradients
since the submission format has no place to bundle real image assets —
README explains how to drop in real photos.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/before-after-slider-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A draggable, keyboard- and touch-accessible before/after image comparison
slider driven by one CSS custom property.

**How does a developer use it?**
```html
<div class="ease-compare-slider-hr18">
  <div class="bas-layer-hr18 bas-layer-after-hr18">...</div>
  <div class="bas-layer-hr18 bas-layer-before-hr18">...</div>
  <div class="bas-divider-hr18" aria-hidden="true"></div>
  <div class="bas-handle-hr18" aria-hidden="true"></div>
  <input type="range" class="bas-range-hr18" min="0" max="100" value="50" aria-label="Comparison slider" />
</div>
<script src="script.js"></script>
```

**Why does it fit EaseMotion CSS?**
The whole mechanism is one CSS custom property plus a native form
control — no custom drag-tracking math — a small, readable,
dependency-free implementation.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
No inline styles. script.js auto-discovers every
`.ease-compare-slider-hr18` on the page, so multiple sliders work
independently with no extra setup. Tested drag, click, and arrow-key
interaction in Chrome; haven't checked other browsers yet.