### PR TITLE
Add circular profile progress ring avatar component (profile-progress…

### DIFF
--- a/submissions/examples/profile-progress-avatar-hr18/README.md
+++ b/submissions/examples/profile-progress-avatar-hr18/README.md
@@ -1,0 +1,152 @@
+# Circular Profile Progress Ring Avatar (`profile-progress-avatar-hr18`)
+
+A circular user avatar encircled by an SVG progress ring, an online/away/
+offline status dot, and a hover/focus profile-breakdown tooltip, built for
+issue
+[#55700](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55700).
+
+## A note on this being a second submission
+
+This issue already shows an open PR (#55738) at the time of writing,
+likely from one of the other two assignees. I wasn't able to review its
+contents before building this, so there may be some overlap — flagging
+that directly in case the maintainer only needs one of the two merged.
+
+## A note on naming
+
+The issue's own filenames (`index.html`, `styles.css`) and its suggested
+folder (`profile-progress-avatar-em`, no per-contributor suffix) don't
+match this repo's actual enforced submission convention —
+`demo.html` + `style.css` + `README.md`, in a uniquely-suffixed folder.
+This submission uses that convention instead.
+
+## What it does
+
+Three example avatars, each combining:
+
+- A **circular SVG progress ring** showing profile-completion percentage
+- A **colored, initials-based avatar** in the center (no external image
+  assets required)
+- A **status dot** (online / away / offline)
+- A **hover/focus tooltip** breaking down exactly what is and isn't
+  complete on that profile
+
+## Ring stroke math
+
+The ring is two overlapping `<circle>` elements sharing the same center
+and radius: a static gray track, and a colored progress circle drawn on
+top of it.
+
+An SVG circle's `stroke-dasharray` and `stroke-dashoffset` let you control
+how much of its outline is drawn as a solid line versus a gap, by working
+in units of the circle's own circumference:
+
+```
+circumference = 2 × π × r
+```
+
+With `r = 40` (this component's radius):
+
+```
+circumference = 2 × π × 40 ≈ 251.33
+```
+
+Setting `stroke-dasharray: 251.33` makes the circle draw one full solid
+dash exactly as long as its own circumference — i.e. the whole ring.
+`stroke-dashoffset` then shifts where that dash *starts* along the path;
+offsetting it by some amount effectively hides that much of the dash from
+view, revealing a gap instead. To show `percent`% of the ring, the
+remaining `(100 - percent)`% needs to be hidden as gap, so:
+
+```
+stroke-dashoffset = circumference × (1 − percent / 100)
+```
+
+At `percent = 0`, `dashoffset = circumference` (fully hidden — no ring
+visible). At `percent = 100`, `dashoffset = 0` (nothing hidden — full
+ring visible). This component expresses that directly in CSS with one
+`calc()`:
+
+```css
+.epa-ring-progress-hr18 {
+  stroke-dasharray: 251.33;
+  stroke-dashoffset: calc(251.33 - (251.33 * var(--epa-percent-hr18, 0) / 100));
+}
+```
+
+The whole SVG is also rotated `-90deg`, since an SVG circle's path starts
+at the 3 o'clock position by default — rotating the container makes the
+ring fill starting from 12 o'clock instead, which is how progress rings
+are conventionally read.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<button
+  type="button"
+  class="ease-avatar-ring-hr18"
+  aria-label="Priya Nair — profile 72% complete, online"
+  style="--epa-percent-hr18: 72; --epa-ring-color-hr18: #22c55e;"
+>
+  <span class="epa-ring-frame-hr18">
+    <svg class="epa-ring-svg-hr18" viewBox="0 0 96 96" aria-hidden="true">
+      <circle class="epa-ring-track-hr18" cx="48" cy="48" r="40"></circle>
+      <circle class="epa-ring-progress-hr18" cx="48" cy="48" r="40"></circle>
+    </svg>
+    <span class="epa-avatar-hr18 c1">PN</span>
+    <span class="epa-status-dot-hr18 online" aria-hidden="true"></span>
+  </span>
+  <span class="epa-name-hr18">Priya Nair</span>
+  <span class="epa-percent-label-hr18">72% complete</span>
+  <span class="epa-tooltip-hr18" role="tooltip">
+    <!-- breakdown content -->
+  </span>
+</button>
+```
+
+`--epa-percent-hr18` is set inline per instance deliberately — unlike this
+component's other, decorative custom properties, the percentage is real,
+per-profile data, so it belongs directly on the element it describes
+(the same reasoning a native `<progress value="72">` sets its value as an
+attribute rather than in a stylesheet).
+
+## Accessibility notes
+
+- Each avatar is a real `<button>`, so it's reachable and its tooltip
+  revealable by keyboard, with a descriptive `aria-label` summarizing the
+  name, percentage, and status in one string — useful even for someone who
+  never opens the tooltip.
+- The tooltip appears on `:hover`, `:focus-visible`, and `:focus-within`,
+  so keyboard users get identical access to mouse users.
+- The status dot and the SVG ring are marked `aria-hidden="true"`, since
+  their information (status, percentage) is already conveyed through the
+  button's `aria-label` and the visible percent-complete text label.
+- The tooltip's checklist uses `✓`/`✗` characters alongside color, not
+  color alone, so complete-vs-missing items are distinguishable without
+  relying on the green checkmark color being perceivable.
+- The ring's fill transition and tooltip fade both shorten to effectively
+  instant under `@media (prefers-reduced-motion: reduce)`.
+
+## Responsiveness
+
+The row of avatars wraps onto additional lines on narrow viewports via
+`flex-wrap`, and each avatar's fixed 96px size stays comfortable down to
+mobile widths without needing a dedicated breakpoint.
+
+## Why this fits EaseMotion CSS
+
+A self-contained, reusable component combining SVG and CSS with no
+JavaScript and no external image assets, with its one genuinely dynamic
+value (`--epa-percent-hr18`) exposed as a real per-instance CSS custom
+property rather than baked into a fixed class — consistent with the
+framework's readable, class-driven approach.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/profile-progress-avatar-hr18/demo.html
+++ b/submissions/examples/profile-progress-avatar-hr18/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Profile Progress Ring Avatar</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="epa-hr18">
+  <div class="epa-wrap-hr18">
+
+    <h1>Team members</h1>
+    <p>Hover or tab to any avatar for a profile completion breakdown.</p>
+
+    <div class="epa-row-hr18">
+
+      <!-- 35% complete, offline -->
+      <button
+        type="button"
+        class="ease-avatar-ring-hr18"
+        aria-label="Priya Nair — profile 35% complete, offline"
+        style="--epa-percent-hr18: 35; --epa-ring-color-hr18: #f97316;"
+      >
+        <span class="epa-ring-frame-hr18">
+          <svg class="epa-ring-svg-hr18" viewBox="0 0 96 96" aria-hidden="true">
+            <circle class="epa-ring-track-hr18" cx="48" cy="48" r="40"></circle>
+            <circle class="epa-ring-progress-hr18" cx="48" cy="48" r="40"></circle>
+          </svg>
+          <span class="epa-avatar-hr18 c1">PN</span>
+          <span class="epa-status-dot-hr18 offline" aria-hidden="true"></span>
+        </span>
+        <span class="epa-name-hr18">Priya Nair</span>
+        <span class="epa-percent-label-hr18">35% complete</span>
+
+        <span class="epa-tooltip-hr18" role="tooltip">
+          <span class="epa-tooltip-title-hr18">Profile 35% complete</span>
+          <span class="epa-tooltip-list-hr18">
+            <span class="done">Photo added</span>
+            <span class="pending">Bio missing</span>
+            <span class="pending">Skills missing</span>
+          </span>
+        </span>
+      </button>
+
+      <!-- 72% complete, away -->
+      <button
+        type="button"
+        class="ease-avatar-ring-hr18"
+        aria-label="Devon Okafor — profile 72% complete, away"
+        style="--epa-percent-hr18: 72; --epa-ring-color-hr18: #eab308;"
+      >
+        <span class="epa-ring-frame-hr18">
+          <svg class="epa-ring-svg-hr18" viewBox="0 0 96 96" aria-hidden="true">
+            <circle class="epa-ring-track-hr18" cx="48" cy="48" r="40"></circle>
+            <circle class="epa-ring-progress-hr18" cx="48" cy="48" r="40"></circle>
+          </svg>
+          <span class="epa-avatar-hr18 c2">DO</span>
+          <span class="epa-status-dot-hr18 away" aria-hidden="true"></span>
+        </span>
+        <span class="epa-name-hr18">Devon Okafor</span>
+        <span class="epa-percent-label-hr18">72% complete</span>
+
+        <span class="epa-tooltip-hr18" role="tooltip">
+          <span class="epa-tooltip-title-hr18">Profile 72% complete</span>
+          <span class="epa-tooltip-list-hr18">
+            <span class="done">Photo added</span>
+            <span class="done">Bio added</span>
+            <span class="pending">Skills missing</span>
+          </span>
+        </span>
+      </button>
+
+      <!-- 100% complete, online -->
+      <button
+        type="button"
+        class="ease-avatar-ring-hr18"
+        aria-label="Mei Lin — profile 100% complete, online"
+        style="--epa-percent-hr18: 100; --epa-ring-color-hr18: #22c55e;"
+      >
+        <span class="epa-ring-frame-hr18">
+          <svg class="epa-ring-svg-hr18" viewBox="0 0 96 96" aria-hidden="true">
+            <circle class="epa-ring-track-hr18" cx="48" cy="48" r="40"></circle>
+            <circle class="epa-ring-progress-hr18" cx="48" cy="48" r="40"></circle>
+          </svg>
+          <span class="epa-avatar-hr18 c3">ML</span>
+          <span class="epa-status-dot-hr18 online" aria-hidden="true"></span>
+        </span>
+        <span class="epa-name-hr18">Mei Lin</span>
+        <span class="epa-percent-label-hr18">100% complete</span>
+
+        <span class="epa-tooltip-hr18" role="tooltip">
+          <span class="epa-tooltip-title-hr18">Profile 100% complete</span>
+          <span class="epa-tooltip-list-hr18">
+            <span class="done">Photo added</span>
+            <span class="done">Bio added</span>
+            <span class="done">Skills added</span>
+          </span>
+        </span>
+      </button>
+
+    </div>
+
+    <div class="epa-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Set to</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--epa-percent-hr18</code></td><td>a number, 0&ndash;100</td><td>How much of the ring is filled &mdash; real per-profile data, so it's set inline per avatar.</td></tr>
+          <tr><td><code>--epa-ring-color-hr18</code></td><td>any CSS color</td><td>The progress arc's stroke color.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="epa-footnote-hr18">submissions/examples/profile-progress-avatar-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/profile-progress-avatar-hr18/style.css
+++ b/submissions/examples/profile-progress-avatar-hr18/style.css
@@ -1,0 +1,282 @@
+/* ==========================================================================
+   profile-progress-avatar-hr18 — style.css
+   Circular Profile Progress Ring Avatar Component
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.epa-hr18 {
+  --bg-hr18: #f5f6f8;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e2e4ea;
+  --text-hr18: #14161c;
+  --muted-hr18: #676c7a;
+  --track-hr18: #e6e8ee;
+
+  --status-online-hr18: #22c55e;
+  --status-away-hr18: #eab308;
+  --status-offline-hr18: #94a3b8;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3.5rem 1.5rem;
+}
+
+.epa-hr18 * {
+  box-sizing: border-box;
+}
+
+.epa-wrap-hr18 {
+  max-width: 640px;
+  width: 100%;
+  text-align: center;
+}
+
+.epa-wrap-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+  margin: 0 0 0.5rem;
+}
+
+.epa-wrap-hr18 > p {
+  margin: 0 0 2.25rem;
+  color: var(--muted-hr18);
+  font-size: 0.92rem;
+}
+
+.epa-row-hr18 {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2.5rem;
+}
+
+/* ==========================================================================
+   The reusable progress-ring avatar component
+   ========================================================================== */
+
+.ease-avatar-ring-hr18 {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.7rem;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: default;
+  font-family: inherit;
+}
+
+.epa-ring-frame-hr18 {
+  position: relative;
+  width: 96px;
+  height: 96px;
+}
+
+/* The SVG ring: a static track circle underneath, and a progress circle
+   on top whose stroke-dashoffset is driven by --epa-percent-hr18 (a
+   number from 0–100, set per-instance since it's real data, not a
+   decorative choice). The circle is rotated -90deg so the arc starts at
+   12 o'clock rather than 3 o'clock, matching how progress rings are
+   conventionally read. */
+.epa-ring-svg-hr18 {
+  position: absolute;
+  inset: 0;
+  transform: rotate(-90deg);
+}
+
+.epa-ring-track-hr18 {
+  fill: none;
+  stroke: var(--track-hr18);
+  stroke-width: 6;
+}
+
+.epa-ring-progress-hr18 {
+  fill: none;
+  stroke: var(--epa-ring-color-hr18, #3355ff);
+  stroke-width: 6;
+  stroke-linecap: round;
+  /* Circumference for r=40: 2 * π * 40 ≈ 251.33 */
+  stroke-dasharray: 251.33;
+  stroke-dashoffset: calc(251.33 - (251.33 * var(--epa-percent-hr18, 0) / 100));
+  transition: stroke-dashoffset 700ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---- Avatar circle, sitting inside the ring's inner radius ---------------------- */
+.epa-avatar-hr18 {
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display-hr18);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #fff;
+}
+
+.epa-avatar-hr18.c1 { background: linear-gradient(135deg, #6366f1, #8b5cf6); }
+.epa-avatar-hr18.c2 { background: linear-gradient(135deg, #06b6d4, #0ea5e9); }
+.epa-avatar-hr18.c3 { background: linear-gradient(135deg, #f59e0b, #f97316); }
+
+/* ---- Status dot ------------------------------------------------------------------- */
+.epa-status-dot-hr18 {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 3px solid var(--bg-hr18);
+}
+
+.epa-status-dot-hr18.online { background: var(--status-online-hr18); }
+.epa-status-dot-hr18.away { background: var(--status-away-hr18); }
+.epa-status-dot-hr18.offline { background: var(--status-offline-hr18); }
+
+.epa-name-hr18 {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.epa-percent-label-hr18 {
+  font-size: 0.76rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Hover/focus tooltip: profile breakdown --------------------------------------- */
+.epa-tooltip-hr18 {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  width: 190px;
+  background: var(--text-hr18);
+  color: #fff;
+  border-radius: 10px;
+  padding: 0.75rem 0.85rem;
+  text-align: left;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  box-shadow: 0 16px 34px rgba(10, 15, 25, 0.22);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 180ms ease, transform 180ms ease, visibility 180ms;
+  z-index: 20;
+}
+
+.epa-tooltip-hr18::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--text-hr18);
+}
+
+.ease-avatar-ring-hr18:hover .epa-tooltip-hr18,
+.ease-avatar-ring-hr18:focus-visible .epa-tooltip-hr18,
+.ease-avatar-ring-hr18:focus-within .epa-tooltip-hr18 {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.epa-tooltip-title-hr18 {
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.epa-tooltip-list-hr18 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.2rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.epa-tooltip-list-hr18 .done::before {
+  content: "\2713  ";
+  color: var(--status-online-hr18);
+}
+
+.epa-tooltip-list-hr18 .pending::before {
+  content: "\2717  ";
+  color: rgba(255, 255, 255, 0.4);
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.epa-tuning-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.25rem 1.4rem;
+  text-align: left;
+}
+
+.epa-tuning-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1rem;
+  margin: 0 0 0.6rem;
+}
+
+.epa-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.epa-tuning-hr18 th,
+.epa-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.epa-tuning-hr18 th {
+  color: var(--muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.epa-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+}
+
+.epa-footnote-hr18 {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.epa-hr18 :focus-visible {
+  outline: 2px solid #3355ff;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .epa-ring-progress-hr18 {
+    transition: none;
+  }
+  .epa-tooltip-hr18 {
+    transition: opacity 1ms linear;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a circular profile avatar with an SVG progress ring, an online/away/
offline status dot, and a hover/focus tooltip breaking down profile
completion. The ring uses stroke-dasharray/stroke-dashoffset math (full
derivation in README) driven by one real per-instance CSS custom
property, --epa-percent-hr18. Three example avatars at 35%/72%/100%
complete, each with a different status.

Resolves #55700

Note for the maintainer: this issue already shows an open PR (#55738) at
time of writing, likely from another assignee — wasn't able to review its
contents before building this, so there may be overlap. Flagging in case
only one needs to be merged. Also: the issue's suggested filenames
(index.html, styles.css) and folder name (no per-contributor suffix)
don't match this repo's actual enforced convention, so I used
demo.html/style.css and a -hr18 suffix instead.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/profile-progress-avatar-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable circular avatar with an SVG completion-progress ring, status
dot, and profile-breakdown tooltip.

**How does a developer use it?**
```html
<button type="button" class="ease-avatar-ring-hr18" aria-label="Priya Nair — profile 72% complete, online" style="--epa-percent-hr18: 72; --epa-ring-color-hr18: #22c55e;">
  <!-- ring SVG, avatar initials, status dot, tooltip — see README -->
</button>
```

**Why does it fit EaseMotion CSS?**
A self-contained SVG+CSS component with no JavaScript and no external
image assets, exposing its one genuinely dynamic value as a real
per-instance custom property rather than baking it into a class.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Ring stroke-dasharray/dashoffset math is fully documented in the README,
per the issue's "document ring stroke calculation math" requirement.
Tested keyboard focus/tooltip reveal and hover in Chrome; haven't checked
other browsers yet.