### PR TITLE
Add text truncate utility with multi-line clamp companion (text-trunc…

### DIFF
--- a/submissions/examples/text-truncate-hr18/README.md
+++ b/submissions/examples/text-truncate-hr18/README.md
@@ -1,0 +1,108 @@
+# Text Truncate Utility (`text-truncate-hr18`)
+
+A lightweight, reusable utility class that truncates overflowing
+single-line text with an ellipsis, built for issue
+[#55875](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55875).
+
+## A note on naming
+
+The issue's own filenames (`index.html`, `styles.css`) don't match this
+repo's actual enforced submission convention — `demo.html` + `style.css`
++ `README.md`. This submission uses that convention instead. Per the
+issue's own checklist ("I understand my naming will be standardized by
+the maintainer"), the class is named `ease-text-truncate-hr18` — the
+`-hr18` suffix is only there to avoid colliding with any other
+contributor's submission for this issue; the maintainer is free to
+rename it to whatever the framework's final convention should be.
+
+## What it does
+
+```css
+.ease-text-truncate-hr18 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+}
+```
+
+This is the exact technique the issue itself specifies, with two small
+additions: `max-width: 100%` so the class behaves predictably as a flex
+or grid item without needing an extra wrapper, and a slightly taller
+`line-height: 1.4` — at very tight line-heights, this technique can read
+as clipping the descenders of letters like *g*, *y*, and *p* right at the
+ellipsis; a touch of breathing room avoids that without changing the
+truncation behavior itself.
+
+A second, related class is included as a natural companion:
+
+```css
+.ease-text-clamp-hr18 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--ease-clamp-lines-hr18, 2);
+  overflow: hidden;
+}
+```
+
+`ease-text-clamp-hr18` truncates after a configurable number of *lines*
+instead of stopping at a single line — useful for card descriptions,
+comment previews, and similar multi-line text that still needs a hard
+cutoff. The line count is genuinely per-use data (2 lines in one card,
+3 in another), so it's exposed as `--ease-clamp-lines-hr18` rather than
+baked into a fixed set of `.clamp-2` / `.clamp-3` classes.
+`-webkit-line-clamp` carries a vendor prefix in its name for historical
+reasons but is supported in all current evergreen browsers.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<div style="width: 220px;">
+  <p class="ease-text-truncate-hr18">
+    This is a very long line of text that will automatically be truncated
+    with an ellipsis when it exceeds the available width.
+  </p>
+</div>
+
+<p class="ease-text-clamp-hr18" style="--ease-clamp-lines-hr18: 3;">
+  A longer passage that will be cut off cleanly after exactly three lines,
+  wherever that ends up falling, with an ellipsis appended.
+</p>
+```
+
+The demo applies `ease-text-truncate-hr18` across the exact contexts the
+issue names — a card title, a button label, navigation links, a table
+cell, and a badge — to confirm it behaves correctly across each one, plus
+one example of the multi-line clamp companion.
+
+## Accessibility notes
+
+- Truncating text visually does not remove it from the accessible tree —
+  screen readers still read the full, untruncated text content, which is
+  the correct behavior (the full text simply isn't visible on screen).
+- Where the truncated text is the *only* content of an interactive
+  element (e.g. a nav link), consider pairing it with a `title` attribute
+  or `aria-label` carrying the full text, so sighted mouse users can also
+  see the complete string via a native tooltip on hover. This wasn't added
+  to the demo's own example markup by default, since whether a native
+  title tooltip is wanted is a per-project decision, not something the
+  utility class should force.
+
+## Why this fits EaseMotion CSS
+
+Exactly the kind of small, composable, zero-JavaScript utility the issue
+describes — solving a common layout problem with two plain CSS classes,
+no custom styling required per project, consistent with the framework's
+readable-class philosophy.
+
+The class name and the folder itself use a `-hr18` suffix to avoid
+colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/text-truncate-hr18/demo.html
+++ b/submissions/examples/text-truncate-hr18/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Text Truncate Utility</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ttc-hr18">
+  <div class="ttc-wrap-hr18">
+
+    <div class="ttc-header-hr18">
+      <h1>Text truncate utility</h1>
+      <p>A lightweight class that truncates overflowing single-line text
+        with an ellipsis, plus a multi-line clamp companion, applied here
+        across cards, buttons, nav links, table cells, and badges.</p>
+    </div>
+
+    <!-- Card title -->
+    <div class="ttc-example-hr18">
+      <span class="ttc-example-label-hr18">Card title</span>
+      <div class="ttc-card-hr18">
+        <h3 class="ease-text-truncate-hr18">Quarterly Planning and Roadmap Review Meeting Notes</h3>
+        <p>Card body text wraps normally &mdash; only the title is truncated.</p>
+      </div>
+    </div>
+
+    <!-- Button label -->
+    <div class="ttc-example-hr18">
+      <span class="ttc-example-label-hr18">Button label</span>
+      <button type="button" class="ttc-btn-hr18">
+        <span class="ease-text-truncate-hr18">Download the complete quarterly report</span>
+      </button>
+    </div>
+
+    <!-- Navigation links -->
+    <div class="ttc-example-hr18">
+      <span class="ttc-example-label-hr18">Navigation links</span>
+      <nav class="ttc-nav-hr18" aria-label="Example navigation">
+        <a href="#" class="ease-text-truncate-hr18">Dashboard Overview</a>
+        <a href="#" class="ease-text-truncate-hr18">Account Settings</a>
+        <a href="#" class="ease-text-truncate-hr18">Billing History</a>
+      </nav>
+    </div>
+
+    <!-- Table cell -->
+    <div class="ttc-example-hr18">
+      <span class="ttc-example-label-hr18">Table cell</span>
+      <table class="ttc-table-hr18">
+        <tbody>
+          <tr>
+            <td class="ease-text-truncate-hr18">Northwind Traders International Logistics Division</td>
+          </tr>
+          <tr>
+            <td class="ease-text-truncate-hr18">Acme Corporation Global Supply Chain Solutions</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Badge -->
+    <div class="ttc-example-hr18">
+      <span class="ttc-example-label-hr18">Badge</span>
+      <span class="ttc-badge-hr18">
+        <span class="ease-text-truncate-hr18">Enterprise Plan &mdash; Annual</span>
+      </span>
+    </div>
+
+    <!-- Multi-line clamp companion -->
+    <div class="ttc-example-hr18">
+      <span class="ttc-example-label-hr18">Multi-line clamp companion (ease-text-clamp-hr18)</span>
+      <div class="ttc-clamp-card-hr18">
+        <p class="ease-text-clamp-hr18" style="--ease-clamp-lines-hr18: 3;">
+          This paragraph is intentionally much longer than three lines of
+          text, so you can see it cut off cleanly with an ellipsis after
+          the third line instead of overflowing the card or being
+          truncated mid-line the way the single-line utility would handle
+          it, which wouldn't make sense for a full paragraph like this one.
+        </p>
+      </div>
+    </div>
+
+    <p class="ttc-footnote-hr18">submissions/examples/text-truncate-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/text-truncate-hr18/style.css
+++ b/submissions/examples/text-truncate-hr18/style.css
@@ -1,0 +1,201 @@
+/* ==========================================================================
+   text-truncate-hr18 — style.css
+   Text Truncate Utility (+ a multi-line clamp companion)
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.ttc-hr18 {
+  --bg-hr18: #f6f7f5;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e2e4de;
+  --text-hr18: #171916;
+  --muted-hr18: #666a61;
+  --accent-hr18: #2f6b4f;
+  --accent-soft-hr18: #e3f0e8;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.ttc-hr18 * {
+  box-sizing: border-box;
+}
+
+.ttc-wrap-hr18 {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.ttc-header-hr18 {
+  margin-bottom: 2rem;
+}
+
+.ttc-header-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  margin: 0 0 0.5rem;
+}
+
+.ttc-header-hr18 p {
+  margin: 0;
+  color: var(--muted-hr18);
+  font-size: 0.94rem;
+  line-height: 1.55;
+  max-width: 62ch;
+}
+
+/* ==========================================================================
+   The utility classes themselves
+   ========================================================================== */
+
+/* Single-line truncation with an ellipsis. Requires the element to have a
+   constrained width (or sit inside a flex/grid item that does) — text-
+   overflow only has an effect once overflow is actually possible. */
+.ease-text-truncate-hr18 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  /* A touch of extra line-height keeps descenders (g, y, p) from reading
+     as clipped right at the ellipsis, a common rough edge with this
+     technique at tight line-heights. */
+  line-height: 1.4;
+}
+
+/* Multi-line clamp companion: truncates after N lines instead of one,
+   using -webkit-line-clamp (now supported across all current evergreen
+   browsers despite the vendor prefix in its name). Line count is a real,
+   per-use choice, so it's exposed as a custom property rather than baked
+   into fixed line-count classes. */
+.ease-text-clamp-hr18 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--ease-clamp-lines-hr18, 2);
+  overflow: hidden;
+}
+
+/* ---- Demo context styling — not part of the utility itself -------------------------- */
+.ttc-example-hr18 {
+  margin-top: 1.75rem;
+}
+
+.ttc-example-label-hr18 {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--muted-hr18);
+  margin-bottom: 0.55rem;
+}
+
+.ttc-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
+  width: 260px;
+}
+
+.ttc-card-hr18 h3 {
+  font-family: var(--font-display-hr18);
+  font-size: 0.95rem;
+  margin: 0 0 0.3rem;
+}
+
+.ttc-card-hr18 p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--muted-hr18);
+}
+
+.ttc-btn-hr18 {
+  display: inline-flex;
+  max-width: 200px;
+  font-family: var(--font-body-hr18);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent-hr18);
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+}
+
+.ttc-nav-hr18 {
+  display: flex;
+  gap: 1rem;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  max-width: 420px;
+}
+
+.ttc-nav-hr18 a {
+  color: var(--text-hr18);
+  text-decoration: none;
+  font-size: 0.85rem;
+  max-width: 110px;
+}
+
+.ttc-table-hr18 {
+  width: 100%;
+  max-width: 420px;
+  border-collapse: collapse;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 10px;
+  overflow: hidden;
+  font-size: 0.82rem;
+}
+
+.ttc-table-hr18 td {
+  padding: 0.55rem 0.8rem;
+  border-bottom: 1px solid var(--border-hr18);
+  max-width: 160px;
+}
+
+.ttc-table-hr18 tr:last-child td {
+  border-bottom: none;
+}
+
+.ttc-badge-hr18 {
+  display: inline-flex;
+  max-width: 140px;
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+  font-size: 0.76rem;
+  font-weight: 600;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+}
+
+.ttc-clamp-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
+  max-width: 320px;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--muted-hr18);
+}
+
+.ttc-footnote-hr18 {
+  margin-top: 2.5rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+.ttc-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds ease-text-truncate-hr18, a single-line ellipsis truncation utility
matching the exact technique specified in the issue (overflow: hidden,
white-space: nowrap, text-overflow: ellipsis), plus a natural companion,
ease-text-clamp-hr18, for multi-line truncation via -webkit-line-clamp
with a configurable line count. Demo applies the truncate utility across
the exact contexts the issue names: card title, button label, nav links,
table cell, and badge.

Resolves #55875

Note for the maintainer: the issue's suggested filenames (index.html,
styles.css) don't match this repo's actual convention, so I used
demo.html/style.css instead. Per the issue's own checklist item about
naming being standardized, the class is suffixed -hr18 only to avoid
collision — happy for it to be renamed.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/text-truncate-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A single-line text-truncate utility plus a multi-line clamp companion,
both pure CSS with zero JavaScript.

**How does a developer use it?**
```html
<p class="ease-text-truncate-hr18">Long single-line text...</p>
<p class="ease-text-clamp-hr18" style="--ease-clamp-lines-hr18: 3;">Longer multi-line text...</p>
```

**Why does it fit EaseMotion CSS?**
A small, composable, zero-JavaScript utility solving a common layout
problem with two plain CSS classes — exactly the kind of contribution the
issue describes.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Added a slightly taller line-height (1.4) to the truncate class to avoid
a known rough edge where descenders (g/y/p) can read as clipped right at
the ellipsis under very tight line-heights. Tested across all 5 demo
contexts in Chrome; haven't checked other browsers yet.