### PR TITLE
feat: add responsive statistics cards component (#55318)

### DIFF
--- a/submissions/examples/ease-stats-cards-hr18/README.md
+++ b/submissions/examples/ease-stats-cards-hr18/README.md
@@ -1,0 +1,65 @@
+# Responsive Statistics Cards
+
+## 1. What does this do?
+
+This is a self-contained component submission (resolves [#55318](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55318)) that adds a reusable statistics card component — an icon, a large number, and a short label, with a subtle lift-on-hover effect. It's the pattern used across SaaS landing pages, dashboards, and portfolio sites to surface key metrics like users, revenue, or uptime.
+
+It includes:
+
+- The **base `.stats-container` / `.stat-card` pair**, matching the structure proposed in the issue.
+- An optional **`.stat-icon`** slot for a leading icon.
+- An optional **`.stat-trend--up` / `.stat-trend--down`** badge for dashboard-style metrics that need a change indicator.
+- A **`.stats-container--fill`** modifier that stretches cards edge-to-edge instead of wrapping around a fixed card width, for rows that need to fill a dashboard column.
+
+## 2. How is it used?
+
+Open `demo.html` in a browser — no build step, no dependencies.
+
+The base pattern, matching the issue's proposed snippet:
+
+```html
+<div class="stats-container">
+  <div class="stat-card">
+    <h2>1.2K</h2>
+    <p>Users</p>
+  </div>
+</div>
+```
+
+```css
+.stats-container {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.stat-card {
+  width: 220px;
+  padding: 25px;
+  text-align: center;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-8px);
+}
+```
+
+Add an icon and a trend badge as needed — neither is required for the card to lay out correctly:
+
+```html
+<div class="stat-card">
+  <span class="stat-icon"><!-- svg icon --></span>
+  <h2>$48.2K</h2>
+  <p>Revenue</p>
+  <span class="stat-trend stat-trend--up">▲ 12.4%</span>
+</div>
+```
+
+## 3. Why is it useful?
+
+The issue's snippet already covers the core card — this submission keeps that exact structure and CSS, then adds the two pieces a real dashboard or landing page would need next: an icon slot for visual scanning, and a trend badge for metrics that change over time. Both are additive and optional, so a developer who only needs the plain number-and-label card from the issue gets it unchanged, while one building a fuller dashboard row can drop in the extra markup without switching components. It stays framework-appropriate — flexbox layout, one transition, zero JavaScript — and responsive by default, since `.stat-card` has a fixed width but the container wraps instead of forcing cards to overflow or compress on narrow screens.

--- a/submissions/examples/ease-stats-cards-hr18/demo.html
+++ b/submissions/examples/ease-stats-cards-hr18/demo.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Responsive Statistics Cards — EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A reusable, responsive statistics card component for dashboards, landing pages, and portfolios. Built with plain HTML and CSS."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="wrap">
+      <!-- ============ HERO ============ -->
+      <header class="hero">
+        <p class="eyebrow"><span class="dot"></span> submissions/examples · ease-stats-cards-hr18</p>
+        <h1 class="hero-title">
+          The numbers,<br />
+          <span class="hl">up front.</span>
+        </h1>
+        <p class="hero-sub">
+          A responsive row of statistic cards for dashboards, landing pages, and
+          portfolios — icon, big number, label, and a lift-on-hover effect, all in one
+          reusable class pair.
+        </p>
+      </header>
+
+      <!-- ============ SIGNATURE: BASE EXAMPLE ============ -->
+      <section class="demo-block" aria-labelledby="demo-1-title">
+        <div class="demo-head">
+          <h2 id="demo-1-title" class="demo-title">Base component</h2>
+          <span class="demo-tag">.stats-container · .stat-card</span>
+        </div>
+
+        <div class="stats-container">
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path d="M17 20v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2M11 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8Zm7 8a4 4 0 0 0 0-8" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <h2>1.2K</h2>
+            <p>Users</p>
+          </div>
+
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 19h16M7 15l3-4 3 2 4-6" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <h2>350</h2>
+            <p>Projects</p>
+          </div>
+
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path d="M20 6 9 17l-5-5" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <h2>98%</h2>
+            <p>Success rate</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ WITH TREND ============ -->
+      <section class="demo-block" aria-labelledby="demo-2-title">
+        <div class="demo-head">
+          <h2 id="demo-2-title" class="demo-title">With trend indicator</h2>
+          <span class="demo-tag">.stat-trend--up / --down</span>
+        </div>
+        <p class="demo-lede">
+          An optional trend badge drops into any card without changing the base layout —
+          useful for dashboard-style stat rows.
+        </p>
+
+        <div class="stats-container">
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path d="M3 3v18h18M7 15l3-3 3 3 5-6" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <h2>$48.2K</h2>
+            <p>Revenue</p>
+            <span class="stat-trend stat-trend--up">
+              <svg viewBox="0 0 24 24" width="12" height="12"><path d="M12 5v14M5 12l7-7 7 7" stroke="currentColor" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              12.4%
+            </span>
+          </div>
+
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="22" height="22"><path d="M12 3v6l4 2" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.8" fill="none"/></svg>
+            </span>
+            <h2>4.6d</h2>
+            <p>Avg. response time</p>
+            <span class="stat-trend stat-trend--down">
+              <svg viewBox="0 0 24 24" width="12" height="12"><path d="M12 19V5M5 12l7 7 7-7" stroke="currentColor" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              3.1%
+            </span>
+          </div>
+
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="22" height="22"><circle cx="12" cy="8" r="4" stroke="currentColor" stroke-width="1.8" fill="none"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round"/></svg>
+            </span>
+            <h2>12,904</h2>
+            <p>Followers</p>
+            <span class="stat-trend stat-trend--up">
+              <svg viewBox="0 0 24 24" width="12" height="12"><path d="M12 5v14M5 12l7-7 7 7" stroke="currentColor" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              5.8%
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ FULL WIDTH DASHBOARD ROW ============ -->
+      <section class="demo-block" aria-labelledby="demo-3-title">
+        <div class="demo-head">
+          <h2 id="demo-3-title" class="demo-title">Four-up dashboard row</h2>
+          <span class="demo-tag">.stats-container--fill</span>
+        </div>
+        <p class="demo-lede">
+          Adding one modifier stretches the cards to fill the container edge-to-edge
+          instead of wrapping around a fixed card width — useful when the row needs to
+          match a dashboard's full column width.
+        </p>
+
+        <div class="stats-container stats-container--fill">
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="20" height="20"><rect x="3" y="3" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="1.8" fill="none"/><rect x="14" y="3" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="1.8" fill="none"/><rect x="3" y="14" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="1.8" fill="none"/><rect x="14" y="14" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="1.8" fill="none"/></svg>
+            </span>
+            <h2>24</h2>
+            <p>Active modules</p>
+          </div>
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="20" height="20"><path d="M12 2 2 7l10 5 10-5-10-5Z" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linejoin="round"/><path d="M2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linejoin="round"/></svg>
+            </span>
+            <h2>7</h2>
+            <p>Integrations</p>
+          </div>
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="20" height="20"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linejoin="round"/></svg>
+            </span>
+            <h2>0.4s</h2>
+            <p>Avg. load time</p>
+          </div>
+          <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="20" height="20"><path d="M4.5 12.5 9 17l10.5-10.5" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <h2>99.9%</h2>
+            <p>Uptime</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ HOW IT WORKS ============ -->
+      <section class="how">
+        <h2 class="section-title">Structure</h2>
+        <div class="steps">
+          <div class="step">
+            <span class="step-no">1</span>
+            <h3>Container handles the row</h3>
+            <p>
+              <code>.stats-container</code> is a <code>flex-wrap</code> row that centers
+              and gaps its children — it doesn't care how many cards it holds.
+            </p>
+          </div>
+          <div class="step">
+            <span class="step-no">2</span>
+            <h3>Card is self-contained</h3>
+            <p>
+              <code>.stat-card</code> carries its own padding, radius, and shadow, so it
+              drops into any layout — grid, flex row, or sidebar — without depending on
+              its parent.
+            </p>
+          </div>
+          <div class="step">
+            <span class="step-no">3</span>
+            <h3>Optional pieces bolt on</h3>
+            <p>
+              <code>.stat-icon</code> and <code>.stat-trend</code> are both optional —
+              omit either and the card still lays out correctly with just a number and a
+              label.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ COPY-READY SNIPPET ============ -->
+      <section class="snippet-section">
+        <h2 class="section-title">Copy-ready markup</h2>
+        <div class="snippet-card">
+          <div class="snippet-head">
+            <span class="file-name">HTML</span>
+            <button class="copy-btn" onclick="copySnippet('snippet-markup', this)">Copy</button>
+          </div>
+          <pre class="code" id="snippet-markup"><code>&lt;div class="stats-container"&gt;
+  &lt;div class="stat-card"&gt;
+    &lt;h2&gt;1.2K&lt;/h2&gt;
+    &lt;p&gt;Users&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+
+      <!-- ============ CHECKLIST ============ -->
+      <section class="checklist">
+        <h2 class="section-title">Submission checklist</h2>
+        <ul class="check-list">
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Fully responsive</strong> — cards wrap onto new rows on narrow viewports instead of overflowing or shrinking unreadably.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Subtle hover lift</strong> on every card via <code>transform: translateY()</code>, no layout shift to siblings.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Icon and trend badge are optional</strong> — the base card works with just a number and label.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>No duplicate of an existing class</strong> — checked against current stat/metric components in the framework.</div>
+          </li>
+        </ul>
+      </section>
+
+      <footer class="footer">
+        <p>
+          Part of the <strong>EaseMotion CSS</strong> examples submissions ·
+          <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css">back to the repo</a>
+        </p>
+      </footer>
+    </main>
+
+    <script>
+      function copySnippet(id, btn) {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const text = el.innerText;
+
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            const original = btn.textContent;
+            btn.textContent = "Copied";
+            btn.classList.add("is-copied");
+            setTimeout(() => {
+              btn.textContent = original;
+              btn.classList.remove("is-copied");
+            }, 1500);
+          })
+          .catch(() => {
+            btn.textContent = "Select & copy";
+          });
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-stats-cards-hr18/style.css
+++ b/submissions/examples/ease-stats-cards-hr18/style.css
@@ -1,0 +1,432 @@
+/* Fonts */
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@500;600;700;800&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap");
+
+:root {
+  --ink: #0f1115;
+  --panel: #191b21;
+  --panel-2: #20232a;
+  --line: rgba(255, 255, 255, 0.09);
+  --text: #f3f4f7;
+  --muted: #9195a3;
+
+  --blue: #2563eb;
+  --blue-soft: rgba(37, 99, 235, 0.16);
+  --green: #22c55e;
+  --green-soft: rgba(34, 197, 94, 0.14);
+  --red: #f87171;
+  --red-soft: rgba(248, 113, 113, 0.14);
+
+  --font-display: "Manrope", sans-serif;
+  --font-body: "Inter", sans-serif;
+  --font-mono: "IBM Plex Mono", monospace;
+
+  --radius: 16px;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--ink);
+  background-image: radial-gradient(circle at 90% 0%, rgba(37, 99, 235, 0.1), transparent 45%);
+  color: var(--text);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  color: var(--blue);
+  background: var(--blue-soft);
+  padding: 0.1em 0.4em;
+  border-radius: 5px;
+}
+
+.wrap {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 72px 24px 100px;
+}
+
+/* ---------- Hero ---------- */
+.hero {
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 20px;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-soft);
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: clamp(2.2rem, 5.5vw, 3.4rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin-bottom: 20px;
+}
+
+.hero-title .hl {
+  color: var(--blue);
+}
+
+.hero-sub {
+  max-width: 58ch;
+  color: var(--muted);
+  font-size: 1.03rem;
+}
+
+/* ---------- Demo blocks ---------- */
+.demo-block {
+  margin-bottom: 56px;
+}
+
+.demo-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.demo-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+}
+
+.demo-tag {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.demo-lede {
+  color: var(--muted);
+  font-size: 0.92rem;
+  max-width: 62ch;
+  margin-bottom: 20px;
+}
+
+/* ---------- Signature component: stats-container / stat-card ---------- */
+.stats-container {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.stats-container--fill {
+  flex-wrap: nowrap;
+  justify-content: stretch;
+}
+
+.stats-container--fill .stat-card {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.stat-card {
+  width: 220px;
+  padding: 26px 24px;
+  text-align: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+  transition: transform 0.3s var(--ease), border-color 0.3s var(--ease);
+}
+
+.stat-card:hover {
+  transform: translateY(-8px);
+  border-color: rgba(37, 99, 235, 0.4);
+}
+
+.stat-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: var(--blue-soft);
+  color: var(--blue);
+  margin-bottom: 14px;
+}
+
+.stat-card h2 {
+  font-family: var(--font-display);
+  color: var(--blue);
+  font-size: 34px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.stat-card p {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.stat-trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 12px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.stat-trend--up {
+  color: var(--green);
+  background: var(--green-soft);
+}
+
+.stat-trend--down {
+  color: var(--red);
+  background: var(--red-soft);
+}
+
+/* ---------- Shared section styles ---------- */
+.section-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.5rem;
+  margin-bottom: 22px;
+}
+
+section {
+  margin-bottom: 64px;
+}
+
+/* ---------- How it works ---------- */
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.step {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.step-no {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--blue-soft);
+  color: var(--blue);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.step h3 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.step p {
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+.step code {
+  font-size: 0.82em;
+}
+
+/* ---------- Snippet ---------- */
+.snippet-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+
+.snippet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.file-name {
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+}
+
+.copy-btn {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--text);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 11px;
+  cursor: pointer;
+  transition: border-color 0.2s var(--ease), color 0.2s var(--ease);
+}
+
+.copy-btn:hover {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.copy-btn.is-copied {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.65;
+  background: #0a0b0e;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  color: #cbd0dc;
+}
+
+.code code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-size: 1em;
+}
+
+/* ---------- Checklist ---------- */
+.check-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.check-list li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.check-mark {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: var(--blue-soft);
+  color: var(--blue);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.check-list strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ---------- Footer ---------- */
+.footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.85rem;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+}
+
+.footer a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 720px) {
+  .wrap {
+    padding: 48px 18px 72px;
+  }
+
+  .steps {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-container--fill {
+    flex-wrap: wrap;
+  }
+
+  .stats-container--fill .stat-card {
+    flex: 1 1 45%;
+  }
+}
+
+@media (max-width: 420px) {
+  .stat-card {
+    width: 100%;
+  }
+
+  .stats-container--fill .stat-card {
+    flex: 1 1 100%;
+  }
+}
+
+/* ---------- Accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .stat-card {
+    transition-duration: 0.01ms;
+  }
+}
+
+:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a responsive statistics card component to `submissions/examples/`, resolving #55318. Displays a key metric with an icon, large number, and label, with a lift-on-hover effect — suitable for dashboards, landing pages, and portfolios.

---
## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-stats-cards-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A reusable statistics card (`.stats-container` / `.stat-card`) showing an icon, a large number, and a label, with optional trend badges and a full-width dashboard-row modifier.

**How does a developer use it?**
```html
<div class="stats-container">
  <div class="stat-card">
    <h2>1.2K</h2>
    <p>Users</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Keeps the exact base structure and CSS proposed in the issue, then adds two optional, additive pieces (an icon slot and a trend badge) so simple cards stay simple while dashboard-style cards get what they need — no JavaScript, fully responsive by default via `flex-wrap`.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Kept `.stats-container` / `.stat-card` naming and CSS from the issue snippet as-is. Added `.stat-icon`, `.stat-trend--up/--down`, and `.stats-container--fill` as optional extensions — happy to rename any of these per your conventions.

---
> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!