### PR TITLE
feat: add hover reveal text utility (#55309)

### DIFF
--- a/submissions/examples/ease-hover-reveal-text-hr18/README.md
+++ b/submissions/examples/ease-hover-reveal-text-hr18/README.md
@@ -1,0 +1,62 @@
+# Hover Reveal Text Utility
+
+## 1. What does this do?
+
+This is a self-contained utility submission (resolves [#55309](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55309)) that swaps a primary line of text for a secondary one on hover, with the primary text sliding up and fading out while the secondary text slides in from below to take its place.
+
+It includes:
+
+- The **base `.hover-reveal-text` utility**, matching the structure proposed in the issue.
+- **Three applied examples**: a button ("Add to Cart" → price), a card action ("View details" → stock status), and a nav link ("Pricing" → "See plans"), to confirm the utility drops onto real elements without extra wrapper markup.
+- **Keyboard support** — the reveal also triggers on `:focus-within`, not only `:hover`, so it isn't mouse-only.
+- A **`prefers-reduced-motion`** override that shortens the transition instead of removing the effect outright.
+
+## 2. How is it used?
+
+Open `demo.html` in a browser — no build step, no dependencies. Hover (or tab to, then focus) any of the labels to see the swap.
+
+The base pattern, matching the issue's proposed snippet:
+
+```html
+<span class="hover-reveal-text">
+  <span class="primary-text">Hover Me</span>
+  <span class="secondary-text">Welcome!</span>
+</span>
+```
+
+```css
+.hover-reveal-text {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+}
+
+.primary-text,
+.secondary-text {
+  display: block;
+  transition: all 0.35s ease;
+}
+
+.secondary-text {
+  position: absolute;
+  left: 0;
+  top: 100%;
+  opacity: 0;
+}
+
+.hover-reveal-text:hover .primary-text {
+  transform: translateY(-100%);
+  opacity: 0;
+}
+
+.hover-reveal-text:hover .secondary-text {
+  top: 0;
+  opacity: 1;
+}
+```
+
+Because the wrapper only needs `overflow: hidden` and `position: relative`, it works the same way inside a `<button>`, a card, or an `<a>` tag — nothing about the surrounding element needs to change.
+
+## 3. Why is it useful?
+
+The issue's own snippet already describes the whole mechanism, so this submission keeps that CSS as-is and focuses on proving it out in context: `demo.html` shows the same `.hover-reveal-text` span unmodified inside a button, a product card, and a nav link, which is the fastest way to confirm it doesn't fight existing padding or alignment. The one addition beyond the original snippet is triggering the reveal on `:focus-within` as well as `:hover`, so keyboard users get the same secondary-text disclosure that mouse users do — a small addition that keeps the utility usable rather than purely decorative. It stays CSS-only, with a single shared transition doing both the fade and the slide.

--- a/submissions/examples/ease-hover-reveal-text-hr18/demo.html
+++ b/submissions/examples/ease-hover-reveal-text-hr18/demo.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hover Reveal Text Utility — EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A CSS-only hover utility that swaps primary text for secondary text with a fade-and-slide reveal. No JavaScript required."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="wrap">
+      <!-- ============ HERO ============ -->
+      <header class="hero">
+        <p class="eyebrow"><span class="dot"></span> submissions/examples · ease-hover-reveal-text-hr18</p>
+        <h1 class="hero-title">
+          Say one thing.<br />
+          <span class="hl">Reveal another.</span>
+        </h1>
+        <p class="hero-sub">
+          Hover any label below — the primary text slides up and fades out while a
+          second line slides in to replace it. One wrapper, two spans, zero JavaScript.
+        </p>
+      </header>
+
+      <!-- ============ SIGNATURE: BASE EXAMPLE ============ -->
+      <section class="demo-block" aria-labelledby="demo-1-title">
+        <div class="demo-head">
+          <h2 id="demo-1-title" class="demo-title">Base utility</h2>
+          <span class="demo-tag">.hover-reveal-text</span>
+        </div>
+
+        <div class="stage">
+          <span class="hover-reveal-text">
+            <span class="primary-text">Hover Me</span>
+            <span class="secondary-text">Welcome!</span>
+          </span>
+        </div>
+      </section>
+
+      <!-- ============ APPLIED EXAMPLES ============ -->
+      <section class="demo-block" aria-labelledby="demo-2-title">
+        <div class="demo-head">
+          <h2 id="demo-2-title" class="demo-title">Applied to real elements</h2>
+          <span class="demo-tag">button · card label · nav link</span>
+        </div>
+        <p class="demo-lede">
+          The utility only needs <code>overflow: hidden</code> and relative
+          positioning on its wrapper, so it drops onto a button, a card footer, or a
+          nav link without any extra markup around it.
+        </p>
+
+        <div class="grid-3">
+          <button class="btn" type="button">
+            <span class="hover-reveal-text">
+              <span class="primary-text">Add to Cart</span>
+              <span class="secondary-text">$42.00 →</span>
+            </span>
+          </button>
+
+          <article class="card">
+            <div class="card-thumb" aria-hidden="true"></div>
+            <h3>Midnight Desk Lamp</h3>
+            <span class="hover-reveal-text">
+              <span class="primary-text">View details</span>
+              <span class="secondary-text">In stock — ships today</span>
+            </span>
+          </article>
+
+          <nav class="nav-demo" aria-label="Example navigation">
+            <a href="#" class="nav-link">
+              <span class="hover-reveal-text">
+                <span class="primary-text">Pricing</span>
+                <span class="secondary-text">See plans →</span>
+              </span>
+            </a>
+          </nav>
+        </div>
+      </section>
+
+      <!-- ============ HOW IT WORKS ============ -->
+      <section class="how">
+        <h2 class="section-title">How the reveal works</h2>
+        <div class="steps">
+          <div class="step">
+            <span class="step-no">1</span>
+            <h3>Wrapper clips the swap</h3>
+            <p>
+              <code>.hover-reveal-text</code> is <code>position: relative</code> with
+              <code>overflow: hidden</code>, so anything sliding outside its own height
+              is simply cut off.
+            </p>
+          </div>
+          <div class="step">
+            <span class="step-no">2</span>
+            <h3>Secondary text waits below</h3>
+            <p>
+              <code>.secondary-text</code> starts <code>position: absolute; top:
+              100%; opacity: 0</code> — parked just under the visible area, invisible
+              until hover.
+            </p>
+          </div>
+          <div class="step">
+            <span class="step-no">3</span>
+            <h3>Both animate on :hover</h3>
+            <p>
+              On hover, the primary text slides up out of view while the secondary text
+              slides from <code>top: 100%</code> to <code>top: 0</code> — a single
+              synchronized transition, no keyframes needed.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ COPY-READY SNIPPET ============ -->
+      <section class="snippet-section">
+        <h2 class="section-title">Copy-ready markup</h2>
+        <div class="snippet-card">
+          <div class="snippet-head">
+            <span class="file-name">HTML</span>
+            <button class="copy-btn" onclick="copySnippet('snippet-markup', this)">Copy</button>
+          </div>
+          <pre class="code" id="snippet-markup"><code>&lt;span class="hover-reveal-text"&gt;
+  &lt;span class="primary-text"&gt;Hover Me&lt;/span&gt;
+  &lt;span class="secondary-text"&gt;Welcome!&lt;/span&gt;
+&lt;/span&gt;</code></pre>
+        </div>
+      </section>
+
+      <!-- ============ CHECKLIST ============ -->
+      <section class="checklist">
+        <h2 class="section-title">Submission checklist</h2>
+        <ul class="check-list">
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>CSS-only</strong> — no JavaScript is used or required for the reveal itself.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Keyboard accessible</strong> — the reveal also triggers on <code>:focus-within</code>, not just mouse hover.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Works inside buttons, cards, and links</strong> without extra wrapper markup or layout changes to the parent.</div>
+          </li>
+          <li>
+            <span class="check-mark">✓</span>
+            <div><strong>Respects <code>prefers-reduced-motion</code></strong> by shortening the transition instead of removing the effect entirely.</div>
+          </li>
+        </ul>
+      </section>
+
+      <footer class="footer">
+        <p>
+          Part of the <strong>EaseMotion CSS</strong> examples submissions ·
+          <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css">back to the repo</a>
+        </p>
+      </footer>
+    </main>
+
+    <script>
+      function copySnippet(id, btn) {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const text = el.innerText;
+
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            const original = btn.textContent;
+            btn.textContent = "Copied";
+            btn.classList.add("is-copied");
+            setTimeout(() => {
+              btn.textContent = original;
+              btn.classList.remove("is-copied");
+            }, 1500);
+          })
+          .catch(() => {
+            btn.textContent = "Select & copy";
+          });
+      }
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-hover-reveal-text-hr18/style.css
+++ b/submissions/examples/ease-hover-reveal-text-hr18/style.css
@@ -1,0 +1,445 @@
+/* Fonts */
+@import url("https://fonts.googleapis.com/css2?family=Sora:wght@500;600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap");
+
+:root {
+  --ink: #101114;
+  --panel: #1a1b1f;
+  --panel-2: #212227;
+  --line: rgba(255, 255, 255, 0.09);
+  --text: #f2f1ef;
+  --muted: #93939a;
+
+  --coral: #fb7185;
+  --coral-soft: rgba(251, 113, 133, 0.15);
+  --teal: #2dd4bf;
+
+  --font-display: "Sora", sans-serif;
+  --font-body: "Inter", sans-serif;
+  --font-mono: "IBM Plex Mono", monospace;
+
+  --radius: 14px;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--ink);
+  background-image: radial-gradient(circle at 12% 100%, rgba(251, 113, 133, 0.08), transparent 45%);
+  color: var(--text);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  color: var(--coral);
+  background: var(--coral-soft);
+  padding: 0.1em 0.4em;
+  border-radius: 5px;
+}
+
+.wrap {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 72px 24px 100px;
+}
+
+/* ---------- Hero ---------- */
+.hero {
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 20px;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--coral);
+  box-shadow: 0 0 0 3px var(--coral-soft);
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.2rem, 5.5vw, 3.4rem);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin-bottom: 20px;
+}
+
+.hero-title .hl {
+  color: var(--coral);
+}
+
+.hero-sub {
+  max-width: 58ch;
+  color: var(--muted);
+  font-size: 1.03rem;
+}
+
+/* ---------- Demo blocks ---------- */
+.demo-block {
+  margin-bottom: 56px;
+}
+
+.demo-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.demo-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.3rem;
+}
+
+.demo-tag {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.demo-lede {
+  color: var(--muted);
+  font-size: 0.92rem;
+  max-width: 62ch;
+  margin-bottom: 20px;
+}
+
+.stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 56px 24px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  font-size: 1.4rem;
+  font-family: var(--font-display);
+  font-weight: 600;
+}
+
+/* ---------- Signature component: hover-reveal-text ---------- */
+.hover-reveal-text {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+}
+
+.primary-text,
+.secondary-text {
+  display: block;
+  transition: transform 0.35s var(--ease), opacity 0.35s var(--ease), top 0.35s var(--ease);
+}
+
+.secondary-text {
+  position: absolute;
+  left: 0;
+  top: 100%;
+  opacity: 0;
+  color: var(--teal);
+  white-space: nowrap;
+}
+
+.hover-reveal-text:hover .primary-text,
+.hover-reveal-text:focus-within .primary-text {
+  transform: translateY(-100%);
+  opacity: 0;
+}
+
+.hover-reveal-text:hover .secondary-text,
+.hover-reveal-text:focus-within .secondary-text {
+  top: 0;
+  opacity: 1;
+}
+
+/* ---------- Applied examples ---------- */
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  align-items: stretch;
+}
+
+.btn {
+  border: none;
+  border-radius: 12px;
+  background: var(--coral);
+  color: #1a0d10;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 16px 20px;
+  cursor: pointer;
+}
+
+.btn .secondary-text {
+  color: #1a0d10;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card-thumb {
+  height: 90px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #2dd4bf, #0f766e);
+}
+
+.card h3 {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.card .hover-reveal-text {
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+.nav-demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.nav-link {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 16px 20px;
+}
+
+/* ---------- Shared section styles ---------- */
+.section-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.5rem;
+  margin-bottom: 22px;
+}
+
+section {
+  margin-bottom: 64px;
+}
+
+/* ---------- How it works ---------- */
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.step {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.step-no {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--coral-soft);
+  color: var(--coral);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.step h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.step p {
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+.step code {
+  font-size: 0.82em;
+}
+
+/* ---------- Snippet ---------- */
+.snippet-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+
+.snippet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.file-name {
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+}
+
+.copy-btn {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--text);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 11px;
+  cursor: pointer;
+  transition: border-color 0.2s var(--ease), color 0.2s var(--ease);
+}
+
+.copy-btn:hover {
+  border-color: var(--coral);
+  color: var(--coral);
+}
+
+.copy-btn.is-copied {
+  border-color: var(--coral);
+  color: var(--coral);
+}
+
+.code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.65;
+  background: #0a0a0c;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  color: #cbd0dc;
+}
+
+.code code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-size: 1em;
+}
+
+/* ---------- Checklist ---------- */
+.check-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.check-list li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.check-mark {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: var(--coral-soft);
+  color: var(--coral);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.check-list strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ---------- Footer ---------- */
+.footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.85rem;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+}
+
+.footer a {
+  color: var(--coral);
+  text-decoration: none;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 720px) {
+  .wrap {
+    padding: 48px 18px 72px;
+  }
+
+  .grid-3,
+  .steps {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .primary-text,
+  .secondary-text {
+    transition-duration: 0.01ms;
+  }
+}
+
+:focus-visible {
+  outline: 2px solid var(--coral);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS-only hover text-reveal utility to `submissions/examples/`, resolving #55309. Swaps a primary line of text for a secondary line on hover, with a synchronized slide-and-fade transition and no JavaScript.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-hover-reveal-text-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A `.hover-reveal-text` utility that slides the primary text up and out while a secondary line slides in from below, triggered on both hover and keyboard focus.

**How does a developer use it?**
```html
<span class="hover-reveal-text">
  <span class="primary-text">Hover Me</span>
  <span class="secondary-text">Welcome!</span>
</span>
```

**Why does it fit EaseMotion CSS?**
Keeps the exact mechanism from the issue snippet (absolute-positioned secondary text, overflow-hidden wrapper, single transition), then proves it out inside a button, card, and nav link so it's clear it works on real elements. Added `:focus-within` alongside `:hover` so keyboard users get the same disclosure — CSS-only, one shared transition, no JavaScript.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Kept `.hover-reveal-text` / `.primary-text` / `.secondary-text` naming exactly as proposed in the issue. Only addition beyond the snippet is `:focus-within` support for keyboard accessibility. Happy to adjust naming or timing per your conventions.

---
> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!