### PR TITLE
feat: add nebula card variation with swirling cosmic clouds

### DIFF
--- a/submissions/examples/ease-nebula-card-av/README.md
+++ b/submissions/examples/ease-nebula-card-av/README.md
@@ -1,0 +1,136 @@
+# 🌌 Nebula Card – Cosmic Nebula Clouds Swirl Within
+
+> A space-themed card where six coloured nebula clouds swirl within on hover, turning a plain surface into a pocket of deep space.
+
+> **Note:** This is a parallel implementation of the nebula idea from #55905, kept in its own `-av` folder alongside the existing `ease-nebula-card`. It takes a different approach: a dark cosmic page rather than a light one, clouds that stay faintly visible at rest instead of fully hidden, a twinkling star layer, animations that stay paused until hover, and keyboard plus reduced-motion support.
+
+---
+
+## 📖 Description
+
+The **Nebula Card** is a space-themed UI component whose interior comes alive on hover. At rest the card reads as a still, dim patch of sky. The moment the pointer enters — or the card receives keyboard focus — six coloured nebula clouds brighten and begin to swirl, drifting, rotating and breathing across the surface like celestial gas clouds photographed by the Hubble Telescope.
+
+Each cloud is a blurred radial gradient with its own colour, size, anchor point, drift path and speed (3.5s through 5s). Because the speeds never divide evenly into one another, the clouds continuously fall in and out of phase, so the pattern never visibly loops — it feels organic rather than mechanical. A slow 24s rotation of the whole cloud layer adds the overall swirl, five stars twinkle in the background, and a vignette fades everything into darkness at the edges.
+
+All the motion is pure CSS. The animations sit paused while the card is idle, so an unhovered card costs nothing, and they resume from exactly where they stopped — there is no jump when the swirl starts.
+
+Perfect for space-themed interfaces, astronomy sites, sci-fi projects, and anywhere a card should feel like a window onto the universe.
+
+---
+
+## 🎯 Perfect For
+
+- ✅ **Space-themed interfaces** (cosmic, celestial, astronomical)
+- ✅ **Astronomy websites** (nebulae, stars, space exploration)
+- ✅ **Sci-fi projects** (futuristic, interstellar)
+- ✅ **Creative portfolios** (unique, memorable showcases)
+- ✅ **Science and planetarium sites** (space visualisation)
+- ✅ **Gaming interfaces** (cosmic, sci-fi HUDs)
+- ✅ **Music apps** (ambient, atmospheric)
+- ✅ **Interactive art** (generative, expressive visuals)
+- ✅ **Personal websites** (creative branding)
+
+---
+
+## ✨ Key Highlights
+
+| Feature | Description |
+|---------|-------------|
+| **Nebula Clouds** | 6 colour-graded clouds swirl on hover |
+| **Organic Drift** | 3 drift paths × 6 speeds (3.5s–5s) never re-sync |
+| **Twinkling Stars** | 5 stars pulse on their own timings |
+| **Cosmic Palette** | Violet, blue, pink, cyan over deep space |
+| **Smooth Motion** | `cubic-bezier` easing on every transition |
+| **Idle-Cheap** | Cloud animations stay paused until hover |
+| **Accessible** | `:focus-visible`, keyboard toggle, `prefers-reduced-motion` |
+| **Responsive** | Three breakpoints down to 380px |
+| **Zero Dependencies** | No CDN, no framework, no build step |
+
+---
+
+## 🔧 How It Is Used
+
+Drop the markup in and the card animates itself — the only JavaScript is a small optional handler that lets keyboard users toggle the swirl.
+
+```html
+<div class="nebula-card" tabindex="0" role="button" aria-label="Nebula card">
+  <div class="nebula-field" aria-hidden="true">
+    <span class="nebula-cloud cloud-1"></span>
+    <span class="nebula-cloud cloud-2"></span>
+    <span class="nebula-cloud cloud-3"></span>
+    <span class="nebula-cloud cloud-4"></span>
+    <span class="nebula-cloud cloud-5"></span>
+    <span class="nebula-cloud cloud-6"></span>
+  </div>
+
+  <div class="star-field" aria-hidden="true">
+    <span class="star star-1"></span>
+    <span class="star star-2"></span>
+    <span class="star star-3"></span>
+    <span class="star star-4"></span>
+    <span class="star star-5"></span>
+  </div>
+
+  <div class="nebula-content">
+    <span class="nebula-glyph" aria-hidden="true">✦</span>
+    <h2>Nebula</h2>
+    <p>Hover to wake the cosmic clouds</p>
+    <span class="nebula-tag">Deep Space</span>
+  </div>
+</div>
+```
+
+| Class | Role |
+|-------|------|
+| `.nebula-card` | The card shell — owns hover, focus and lift |
+| `.nebula-field` | Rotating layer that holds the clouds |
+| `.nebula-cloud` + `.cloud-1` … `.cloud-6` | One cloud each: colour, size, path, speed |
+| `.star-field` / `.star-1` … `.star-5` | Background twinkle layer |
+| `.nebula-content` | Foreground text, sits above the vignette |
+| `.is-active` | Applied by JS so keyboard users get the hover state |
+
+---
+
+## 🎨 Customising
+
+- **Cloud colours** — edit the `radial-gradient` colour stop in each `.cloud-N` rule.
+- **Swirl speed** — change `animation-duration` on `.cloud-N` (keep the values uneven so the loop stays hidden).
+- **Overall swirl** — change the `24s` on `.nebula-field`'s `nebula-spin`.
+- **Intensity** — adjust the hover `opacity` (`0.85`) and `filter: blur()` on `.nebula-cloud`.
+- **Density** — add or remove `.nebula-cloud` / `.star` elements; each just needs a position and a duration.
+
+---
+
+## 💡 Why It Fits EaseMotion
+
+EaseMotion is about motion that is declarative, cheap and readable. This card is a good example of all three: the whole effect is keyframes plus `animation-play-state`, with no per-frame JavaScript and nothing to initialise. The clouds compose their colours with `mix-blend-mode: screen` instead of stacked opacity hacks, the drift durations are the only knob needed to change the character of the effect, and `prefers-reduced-motion` turns the animation off while keeping the visual design intact.
+
+---
+
+## ♿ Accessibility
+
+- The card is reachable with <kbd>Tab</kbd> and shows a visible `:focus-visible` ring.
+- <kbd>Enter</kbd> or <kbd>Space</kbd> toggles the swirl, so keyboard users see the same effect as pointer users.
+- Decorative cloud and star layers are marked `aria-hidden="true"`.
+- `@media (prefers-reduced-motion: reduce)` disables all drifting, twinkling and rotation.
+
+---
+
+## 🚀 Quick Start
+
+1. Place `demo.html` and `style.css` in the same folder
+2. Open `demo.html` in your browser
+3. Hover over the card to watch the nebula swirl
+
+```bash
+/ease-nebula-card-av/
+├── demo.html       # HTML structure + small keyboard helper
+├── style.css       # All styles + animations
+└── README.md       # Documentation (this file)
+```
+
+---
+
+## 🌍 Browser Support
+
+Chrome, Edge, Firefox, Safari and Opera (current versions). Uses only `transform`, `filter`, `mix-blend-mode` and `@keyframes` — all widely supported.

--- a/submissions/examples/ease-nebula-card-av/demo.html
+++ b/submissions/examples/ease-nebula-card-av/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nebula Card · Cosmic Nebula Clouds Swirl Within</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+    <div class="page">
+        <h1>🌌 Nebula Card</h1>
+        <p class="sub">cosmic nebula clouds swirl within on hover</p>
+
+        <!-- === NEBULA CARD === -->
+        <div class="nebula-card" id="nebulaCard" tabindex="0" role="button"
+             aria-label="Nebula card. Hover or focus to swirl the cosmic clouds.">
+
+            <!-- Six coloured nebula clouds -->
+            <div class="nebula-field" aria-hidden="true">
+                <span class="nebula-cloud cloud-1"></span>
+                <span class="nebula-cloud cloud-2"></span>
+                <span class="nebula-cloud cloud-3"></span>
+                <span class="nebula-cloud cloud-4"></span>
+                <span class="nebula-cloud cloud-5"></span>
+                <span class="nebula-cloud cloud-6"></span>
+            </div>
+
+            <!-- Five twinkling background stars -->
+            <div class="star-field" aria-hidden="true">
+                <span class="star star-1"></span>
+                <span class="star star-2"></span>
+                <span class="star star-3"></span>
+                <span class="star star-4"></span>
+                <span class="star star-5"></span>
+            </div>
+
+            <div class="nebula-content">
+                <span class="nebula-glyph" aria-hidden="true">✦</span>
+                <h2>Nebula</h2>
+                <p>Hover to wake the cosmic clouds</p>
+                <span class="nebula-tag">Deep Space</span>
+            </div>
+        </div>
+
+        <p class="hint">Hover, or press <kbd>Tab</kbd> then <kbd>Enter</kbd> · watch the nebula swirl</p>
+    </div>
+
+    <script>
+        (function () {
+            'use strict';
+
+            var card = document.getElementById('nebulaCard');
+
+            // Keyboard users get the same swirl as hover, toggled on Enter / Space.
+            card.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    card.classList.toggle('is-active');
+                }
+            });
+
+            card.addEventListener('blur', function () {
+                card.classList.remove('is-active');
+            });
+
+            card.addEventListener('click', function () {
+                card.classList.add('is-pulsing');
+                setTimeout(function () {
+                    card.classList.remove('is-pulsing');
+                }, 400);
+            });
+        })();
+    </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-nebula-card-av/style.css
+++ b/submissions/examples/ease-nebula-card-av/style.css
@@ -1,0 +1,380 @@
+/* ----- style.css - Nebula Card: cosmic nebula clouds swirl within on hover ----- */
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 2rem 1.25rem;
+    background:
+        radial-gradient(circle at 15% 10%, #171334 0%, transparent 55%),
+        radial-gradient(circle at 85% 90%, #1a1038 0%, transparent 50%),
+        #05030f;
+    font-family: 'Segoe UI', Roboto, system-ui, sans-serif;
+    color: #cdd4f0;
+}
+
+.page {
+    text-align: center;
+    max-width: 560px;
+    width: 100%;
+}
+
+h1 {
+    font-size: 1.75rem;
+    font-weight: 600;
+    letter-spacing: -0.3px;
+    margin-bottom: 0.35rem;
+}
+
+.sub {
+    color: #8b93bd;
+    font-size: 0.95rem;
+    margin-bottom: 2.25rem;
+}
+
+.hint {
+    margin-top: 2rem;
+    font-size: 0.8rem;
+    color: #6b739b;
+}
+
+kbd {
+    font-family: inherit;
+    font-size: 0.75rem;
+    padding: 1px 6px;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* ===== N E B U L A   C A R D ===== */
+.nebula-card {
+    position: relative;
+    width: 300px;
+    height: 380px;
+    margin: 0 auto;
+    border-radius: 22px;
+    overflow: hidden;
+    cursor: pointer;
+    isolation: isolate;
+    background:
+        radial-gradient(ellipse at 50% 120%, #1c1546 0%, transparent 60%),
+        linear-gradient(160deg, #0b0820 0%, #120d2e 55%, #08061a 100%);
+    border: 1px solid rgba(148, 130, 255, 0.14);
+    box-shadow: 0 18px 50px rgba(0, 0, 0, 0.6);
+    transition:
+        transform 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+        box-shadow 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+        border-color 0.6s ease;
+}
+
+.nebula-card:hover,
+.nebula-card:focus-visible,
+.nebula-card.is-active {
+    transform: translateY(-8px);
+    border-color: rgba(168, 85, 247, 0.45);
+    box-shadow:
+        0 28px 70px rgba(0, 0, 0, 0.7),
+        0 0 80px rgba(124, 58, 237, 0.28);
+}
+
+.nebula-card:focus-visible {
+    outline: 2px solid #a855f7;
+    outline-offset: 4px;
+}
+
+/* --- The swirling cloud layer --- */
+.nebula-field {
+    position: absolute;
+    inset: -20%;
+    animation: nebula-spin 24s linear infinite;
+    animation-play-state: paused;
+}
+
+.nebula-card:hover .nebula-field,
+.nebula-card:focus-visible .nebula-field,
+.nebula-card.is-active .nebula-field {
+    animation-play-state: running;
+}
+
+.nebula-cloud {
+    position: absolute;
+    border-radius: 50%;
+    mix-blend-mode: screen;
+    filter: blur(26px);
+    opacity: 0.22;
+    animation-play-state: paused;
+    animation-iteration-count: infinite;
+    animation-timing-function: cubic-bezier(0.45, 0.05, 0.55, 0.95);
+    transition:
+        opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+        filter 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.nebula-card:hover .nebula-cloud,
+.nebula-card:focus-visible .nebula-cloud,
+.nebula-card.is-active .nebula-cloud {
+    opacity: 0.85;
+    filter: blur(20px);
+    animation-play-state: running;
+}
+
+/* Each cloud: own colour, size, anchor, drift path and speed (3.5s -> 5s) */
+.cloud-1 {
+    top: 30%;
+    left: 28%;
+    width: 240px;
+    height: 200px;
+    background: radial-gradient(circle at 38% 42%, #8b5cf6 0%, rgba(139, 92, 246, 0.35) 45%, transparent 72%);
+    animation-name: nebula-drift-a;
+    animation-duration: 3.5s;
+}
+
+.cloud-2 {
+    top: 62%;
+    left: 60%;
+    width: 260px;
+    height: 215px;
+    background: radial-gradient(circle at 60% 38%, #3b82f6 0%, rgba(59, 130, 246, 0.3) 45%, transparent 72%);
+    animation-name: nebula-drift-b;
+    animation-duration: 3.9s;
+}
+
+.cloud-3 {
+    top: 26%;
+    left: 72%;
+    width: 200px;
+    height: 170px;
+    background: radial-gradient(circle at 42% 58%, #ec4899 0%, rgba(236, 72, 153, 0.3) 45%, transparent 72%);
+    animation-name: nebula-drift-c;
+    animation-duration: 4.2s;
+}
+
+.cloud-4 {
+    top: 72%;
+    left: 26%;
+    width: 190px;
+    height: 165px;
+    background: radial-gradient(circle at 55% 45%, #22d3ee 0%, rgba(34, 211, 238, 0.25) 45%, transparent 72%);
+    animation-name: nebula-drift-a;
+    animation-duration: 4.5s;
+    animation-direction: reverse;
+}
+
+.cloud-5 {
+    top: 48%;
+    left: 46%;
+    width: 225px;
+    height: 190px;
+    background: radial-gradient(circle at 45% 50%, #a855f7 0%, rgba(168, 85, 247, 0.3) 45%, transparent 72%);
+    animation-name: nebula-drift-b;
+    animation-duration: 4.7s;
+}
+
+.cloud-6 {
+    top: 18%;
+    left: 46%;
+    width: 165px;
+    height: 145px;
+    background: radial-gradient(circle at 50% 40%, #f472b6 0%, rgba(244, 114, 182, 0.28) 45%, transparent 72%);
+    animation-name: nebula-drift-c;
+    animation-duration: 5s;
+    animation-direction: reverse;
+}
+
+/* --- Cloud drift paths --- */
+@keyframes nebula-drift-a {
+    0% { transform: translate(-50%, -50%) rotate(0deg) scale(1); }
+    35% { transform: translate(-38%, -62%) rotate(130deg) scale(1.18); }
+    70% { transform: translate(-64%, -44%) rotate(245deg) scale(0.88); }
+    100% { transform: translate(-50%, -50%) rotate(360deg) scale(1); }
+}
+
+@keyframes nebula-drift-b {
+    0% { transform: translate(-50%, -50%) rotate(0deg) scale(1.05); }
+    40% { transform: translate(-60%, -38%) rotate(-140deg) scale(0.85); }
+    75% { transform: translate(-42%, -60%) rotate(-260deg) scale(1.2); }
+    100% { transform: translate(-50%, -50%) rotate(-360deg) scale(1.05); }
+}
+
+@keyframes nebula-drift-c {
+    0% { transform: translate(-50%, -50%) rotate(0deg) scale(0.95); }
+    30% { transform: translate(-56%, -58%) rotate(100deg) scale(1.22); }
+    65% { transform: translate(-44%, -40%) rotate(215deg) scale(0.9); }
+    100% { transform: translate(-50%, -50%) rotate(360deg) scale(0.95); }
+}
+
+/* --- Slow rotation of the whole cloud layer --- */
+@keyframes nebula-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* --- Twinkling stars --- */
+.star-field {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.star {
+    position: absolute;
+    width: 2px;
+    height: 2px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 0 6px 1px rgba(255, 255, 255, 0.7);
+    animation: star-twinkle 3s ease-in-out infinite;
+}
+
+.star-1 { top: 14%; left: 18%; animation-duration: 2.2s; }
+.star-2 { top: 24%; left: 78%; animation-duration: 2.8s; animation-delay: 0.4s; }
+.star-3 { top: 55%; left: 12%; animation-duration: 3.1s; animation-delay: 0.9s; }
+.star-4 { top: 68%; left: 84%; animation-duration: 2.5s; animation-delay: 1.3s; }
+.star-5 { top: 86%; left: 46%; animation-duration: 3.4s; animation-delay: 0.6s; }
+
+.nebula-card:hover .star,
+.nebula-card:focus-visible .star,
+.nebula-card.is-active .star {
+    box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.9);
+}
+
+@keyframes star-twinkle {
+    0%, 100% { opacity: 0.25; transform: scale(0.8); }
+    50% { opacity: 1; transform: scale(1.35); }
+}
+
+/* --- Card content --- */
+.nebula-content {
+    position: relative;
+    z-index: 2;
+    height: 100%;
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: #eef0ff;
+    text-shadow: 0 2px 18px rgba(5, 3, 15, 0.8);
+}
+
+.nebula-glyph {
+    font-size: 2.25rem;
+    line-height: 1;
+    margin-bottom: 0.9rem;
+    color: #d8b4fe;
+    transition: transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.nebula-card:hover .nebula-glyph,
+.nebula-card:focus-visible .nebula-glyph,
+.nebula-card.is-active .nebula-glyph {
+    transform: scale(1.15) rotate(180deg);
+}
+
+.nebula-content h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.35rem;
+}
+
+.nebula-content p {
+    font-size: 0.85rem;
+    color: #b4bbe0;
+    margin-bottom: 1.1rem;
+}
+
+.nebula-tag {
+    font-size: 0.7rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    padding: 4px 14px;
+    border-radius: 999px;
+    color: #e9d5ff;
+    background: rgba(168, 85, 247, 0.14);
+    border: 1px solid rgba(168, 85, 247, 0.3);
+    transition: background 0.6s ease, border-color 0.6s ease;
+}
+
+.nebula-card:hover .nebula-tag,
+.nebula-card:focus-visible .nebula-tag,
+.nebula-card.is-active .nebula-tag {
+    background: rgba(168, 85, 247, 0.3);
+    border-color: rgba(216, 180, 254, 0.6);
+}
+
+/* --- Vignette so the clouds fade into deep space at the edges --- */
+.nebula-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    background: radial-gradient(ellipse at center, transparent 45%, rgba(5, 3, 15, 0.75) 100%);
+}
+
+/* --- Click feedback: the clouds flare, without interrupting the drift --- */
+.nebula-card.is-pulsing .nebula-cloud {
+    opacity: 1;
+    filter: blur(14px) brightness(1.4);
+    transition-duration: 0.2s;
+}
+
+/* --- Responsive --- */
+@media (max-width: 520px) {
+    h1 { font-size: 1.45rem; }
+
+    .nebula-card {
+        width: 260px;
+        height: 330px;
+    }
+
+    .nebula-glyph { font-size: 1.9rem; }
+
+    .nebula-content h2 { font-size: 1.3rem; }
+}
+
+@media (max-width: 380px) {
+    .nebula-card {
+        width: 100%;
+        max-width: 230px;
+        height: 300px;
+    }
+
+    .nebula-content { padding: 1.25rem; }
+
+    .nebula-content p { font-size: 0.78rem; }
+}
+
+/* --- Motion-sensitive users get the colours without the swirl --- */
+@media (prefers-reduced-motion: reduce) {
+    .nebula-field,
+    .nebula-cloud,
+    .star {
+        animation: none !important;
+    }
+
+    .nebula-card,
+    .nebula-cloud,
+    .nebula-glyph,
+    .nebula-tag {
+        transition-duration: 0.01ms;
+    }
+
+    .nebula-card:hover .nebula-glyph,
+    .nebula-card:focus-visible .nebula-glyph,
+    .nebula-card.is-active .nebula-glyph {
+        transform: none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Adds **Nebula Card (av)**, a space-themed card whose interior comes alive on hover: six coloured nebula clouds brighten and swirl across the surface like celestial gas clouds, over a slowly rotating cloud layer and five twinkling stars.

This is a **parallel implementation** of the nebula idea from #55905, submitted in its own `ease-nebula-card-av` folder alongside the existing `ease-nebula-card` rather than replacing it, following the contribution guide's naming policy and its note that *"the project encourages creative variations and parallel implementations rather than overwriting existing contributor work."* Nothing in the existing submission is touched.

How this one differs from the merged `ease-nebula-card`:

| | `ease-nebula-card` | this submission |
|---|---|---|
| Page treatment | Light page, dark card | Dark cosmic page and card |
| Idle state | Clouds fully hidden | Clouds faintly visible, dim nebula |
| Star layer | — | 5 stars twinkling on their own timings |
| Idle cost | Animations always running | Animations paused until hover |
| Keyboard | Focus ring | Focus ring + Enter/Space toggles the swirl |
| Reduced motion | — | Full `prefers-reduced-motion` support |
| Dependencies | Font Awesome CDN | None |

Related to #55905

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

All three files live in `submissions/examples/ease-nebula-card-av/`. Branch is rebased onto current `main`, so the diff is three added files and nothing else — no deletions, no modifications to existing code, no folder-name collision.

---

## Feature Description

**What does this add?**

A card that stays a dim, still patch of sky at rest and, on hover or keyboard focus, wakes six colour-graded nebula clouds that drift, rotate and breathe within it.

**How does a developer use it?**

```html
<div class="nebula-card" tabindex="0" role="button" aria-label="Nebula card">
  <div class="nebula-field" aria-hidden="true">
    <span class="nebula-cloud cloud-1"></span>
    <span class="nebula-cloud cloud-2"></span>
    <span class="nebula-cloud cloud-3"></span>
    <span class="nebula-cloud cloud-4"></span>
    <span class="nebula-cloud cloud-5"></span>
    <span class="nebula-cloud cloud-6"></span>
  </div>

  <div class="star-field" aria-hidden="true">
    <span class="star star-1"></span>
    <span class="star star-2"></span>
    <span class="star star-3"></span>
    <span class="star star-4"></span>
    <span class="star star-5"></span>
  </div>

  <div class="nebula-content">
    <span class="nebula-glyph" aria-hidden="true">✦</span>
    <h2>Nebula</h2>
    <p>Hover to wake the cosmic clouds</p>
    <span class="nebula-tag">Deep Space</span>
  </div>
</div>
```

Drop the markup in and the card animates itself. The only JavaScript is a short optional handler that toggles `.is-active` so keyboard users get the same swirl as pointer users.

**Why does it fit EaseMotion CSS?**

The whole effect is keyframes plus `animation-play-state` — no per-frame JavaScript, no initialisation step, nothing to import. The clouds compose their colours with `mix-blend-mode: screen` rather than stacked opacity hacks, and the drift durations are the single knob that changes the character of the effect, which keeps it readable and easy to restyle into `ease-*` naming.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

No CDN, no external fonts, no framework, no build step — `demo.html` and `style.css` in the same folder is all it needs.

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- **Why a second nebula card.** My earlier PR for this used the folder name `ease-nebula-card`, which collided with the submission merged in `f75c5522f0` while I was working, and the auto-merge bot closed it on an add/add conflict. This resubmission is rebased onto current `main` under a unique `-av` folder so it sits beside that work rather than competing with it. Happy to close this if you'd rather keep just the one nebula card.
- **Idle cost is zero.** The cloud and layer animations sit at `animation-play-state: paused` and only switch to `running` on `:hover`, `:focus-visible` or `.is-active`. Since a paused animation resumes from where it stopped, the swirl also starts without any jump.
- **Timings.** The six clouds run at 3.5s, 3.9s, 4.2s, 4.5s, 4.7s and 5s across three drift paths. The unevenness is deliberate — the cycles never re-sync, so the pattern has no visible loop. Feel free to retune if they're fast or slow for the framework's defaults.
- **Click feedback** is a brightness/opacity transition rather than a keyframe on purpose: re-declaring the `animation` shorthand on the cloud layer would have restarted the 24s rotation and snapped it back to 0°.
- **Accessibility.** Tabbable with a visible `:focus-visible` ring, <kbd>Enter</kbd>/<kbd>Space</kbd> toggles the swirl, decorative layers are `aria-hidden="true"`, and `@media (prefers-reduced-motion: reduce)` disables all drifting, twinkling and rotation while keeping the visual design intact.
- Tested in Chromium (so Chrome and Edge should both be fine); I haven't verified Firefox or Safari. The only slightly less common properties are `mix-blend-mode` and `filter: blur()`, both widely supported.