### PR TITLE
feat: add skew-active tooltip for creative portfolio layouts (issue #…

### DIFF
--- a/submissions/examples/skew-active-tooltip-ag/README.md
+++ b/submissions/examples/skew-active-tooltip-ag/README.md
@@ -1,0 +1,62 @@
+# Skew-Active Tooltip
+
+A pure CSS/HTML tooltip for creative portfolio layouts. The tooltip
+skews in from an angled, scaled-down resting state to its upright
+active state on hover or keyboard focus — no JavaScript required.
+
+## Files
+
+- `demo.html` — Standalone showcase page with a 4-item portfolio grid,
+  each card wired to a skew-active tooltip.
+- `style.css` — All styling and animation, driven by CSS custom
+  properties.
+- `README.md` — This file.
+
+## Usage
+
+Wrap any element with `.ease-skew-tooltip`, make it focusable
+(`tabindex="0"` if it isn't naturally interactive), and add a
+`.tooltip-bubble` child with your tooltip text:
+
+```html
+<div class="portfolio-card ease-skew-tooltip" tabindex="0">
+  <h2 class="card-title">Project Name</h2>
+  <span class="tooltip-bubble" role="tooltip">Short description</span>
+</div>
+```
+
+The tooltip activates on `:hover`, `:focus-visible`, and
+`:focus-within`, so it works with mouse, keyboard, and touch (via tap
++ focus on supporting browsers).
+
+## Customization
+
+All visuals are controlled through CSS custom properties on `:root`
+(override per-instance by redeclaring them on `.ease-skew-tooltip`):
+
+| Property              | Default                          | Purpose                          |
+|-----------------------|-----------------------------------|-----------------------------------|
+| `--tooltip-bg`         | `#1b1b1f`                        | Tooltip background color         |
+| `--tooltip-color`      | `#f5f5f7`                        | Tooltip text color                |
+| `--tooltip-accent`     | `#7c5cff`                        | Border / arrow accent color      |
+| `--skew-angle`         | `-10deg`                         | Resting skew angle               |
+| `--tooltip-offset`     | `14px`                           | Gap between trigger and tooltip  |
+| `--tooltip-duration`   | `320ms`                          | Transition duration              |
+| `--tooltip-easing`     | `cubic-bezier(0.22, 1, 0.36, 1)` | Transition easing                |
+| `--card-radius`        | `14px`                           | Portfolio card corner radius     |
+
+## Accessibility
+
+- Tooltip trigger elements are keyboard-focusable and respond to
+  `:focus-visible` / `:focus-within`, not just `:hover`.
+- `role="tooltip"` is set on the bubble for assistive technology.
+- Respects `prefers-reduced-motion`: transitions collapse to
+  near-instant and the tooltip appears in its final (unskewed) state
+  rather than animating.
+- Tooltip text wraps and constrains width on small viewports instead
+  of overflowing the screen.
+
+## Notes on scope
+
+None — hover/focus is sufficient to meet the issue's interactivity
+requirement in pure CSS, so no features were reduced or simplified.

--- a/submissions/examples/skew-active-tooltip-ag/demo.html
+++ b/submissions/examples/skew-active-tooltip-ag/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion CSS — Skew-Active Tooltip Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Skew-Active Tooltip</h1>
+    <p>Hover or focus a portfolio card to see the skew-in tooltip.</p>
+  </header>
+
+  <main class="portfolio-grid">
+
+    <div class="portfolio-card ease-skew-tooltip" tabindex="0">
+      <div class="card-thumb card-thumb--one"></div>
+      <h2 class="card-title">Nova Branding</h2>
+      <span class="tooltip-bubble" role="tooltip">
+        Identity design system, 2026
+      </span>
+    </div>
+
+    <div class="portfolio-card ease-skew-tooltip" tabindex="0">
+      <div class="card-thumb card-thumb--two"></div>
+      <h2 class="card-title">Aster Editorial</h2>
+      <span class="tooltip-bubble" role="tooltip">
+        Magazine layout &amp; typography
+      </span>
+    </div>
+
+    <div class="portfolio-card ease-skew-tooltip" tabindex="0">
+      <div class="card-thumb card-thumb--three"></div>
+      <h2 class="card-title">Fable Studio</h2>
+      <span class="tooltip-bubble" role="tooltip">
+        Motion reel, 2025–2026
+      </span>
+    </div>
+
+    <div class="portfolio-card ease-skew-tooltip" tabindex="0">
+      <div class="card-thumb card-thumb--four"></div>
+      <h2 class="card-title">Kite Interactive</h2>
+      <span class="tooltip-bubble" role="tooltip">
+        Web experience for a music label
+      </span>
+    </div>
+
+  </main>
+
+  <footer class="demo-footer">
+    <p>Part of <strong>EaseMotion CSS</strong> — pure CSS, no JavaScript.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-tooltip-ag/style.css
+++ b/submissions/examples/skew-active-tooltip-ag/style.css
@@ -1,0 +1,172 @@
+/* ==========================================================================
+   EaseMotion CSS — Skew-Active Tooltip
+   Pure CSS, no JavaScript. Triggered on hover / focus.
+   ========================================================================== */
+
+:root {
+  --tooltip-bg: #1b1b1f;
+  --tooltip-color: #f5f5f7;
+  --tooltip-accent: #7c5cff;
+  --skew-angle: -10deg;
+  --tooltip-offset: 14px;
+  --tooltip-duration: 320ms;
+  --tooltip-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --card-radius: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0f0f12;
+  color: #f5f5f7;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 20px;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.demo-header h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.demo-header p {
+  margin: 0;
+  color: #a3a3ad;
+}
+
+/* ---------- Grid ---------- */
+
+.portfolio-grid {
+  width: 100%;
+  max-width: 960px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 28px;
+}
+
+/* ---------- Card ---------- */
+
+.portfolio-card {
+  position: relative;
+  background: #17171c;
+  border: 1px solid #26262e;
+  border-radius: var(--card-radius);
+  padding: 18px;
+  cursor: pointer;
+  outline: none;
+  transition: transform var(--tooltip-duration) var(--tooltip-easing),
+              border-color var(--tooltip-duration) var(--tooltip-easing);
+}
+
+.portfolio-card:hover,
+.portfolio-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: var(--tooltip-accent);
+}
+
+.card-thumb {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 10px;
+  margin-bottom: 14px;
+  background: linear-gradient(135deg, #2a2a33, #3a3a46);
+}
+
+.card-thumb--one   { background: linear-gradient(135deg, #7c5cff, #3a2a80); }
+.card-thumb--two   { background: linear-gradient(135deg, #ff8a5c, #7a3220); }
+.card-thumb--three { background: linear-gradient(135deg, #5cffcf, #1f7a63); }
+.card-thumb--four  { background: linear-gradient(135deg, #ff5c8a, #7a1f42); }
+
+.card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+/* ---------- Skew-Active Tooltip ---------- */
+
+.tooltip-bubble {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + var(--tooltip-offset));
+  transform: translateX(-50%) skewX(var(--skew-angle)) scale(0.85);
+  transform-origin: bottom center;
+
+  background: var(--tooltip-bg);
+  color: var(--tooltip-color);
+  border: 1px solid var(--tooltip-accent);
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+
+  transition: opacity var(--tooltip-duration) var(--tooltip-easing),
+              transform var(--tooltip-duration) var(--tooltip-easing),
+              visibility 0s linear var(--tooltip-duration);
+}
+
+.tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) skewX(var(--skew-angle));
+  border: 6px solid transparent;
+  border-top-color: var(--tooltip-accent);
+}
+
+.ease-skew-tooltip:hover .tooltip-bubble,
+.ease-skew-tooltip:focus-visible .tooltip-bubble,
+.ease-skew-tooltip:focus-within .tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) skewX(0deg) scale(1);
+  transition: opacity var(--tooltip-duration) var(--tooltip-easing),
+              transform var(--tooltip-duration) var(--tooltip-easing),
+              visibility 0s linear 0s;
+}
+
+/* ---------- Footer ---------- */
+
+.demo-footer {
+  margin-top: 48px;
+  color: #6b6b76;
+  font-size: 0.85rem;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 480px) {
+  .tooltip-bubble {
+    white-space: normal;
+    max-width: 160px;
+    text-align: center;
+  }
+}
+
+/* ---------- Accessibility ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .portfolio-card,
+  .tooltip-bubble {
+    transition-duration: 0.01ms !important;
+  }
+  .tooltip-bubble {
+    transform: translateX(-50%) skewX(0deg) scale(1);
+  }
+}


### PR DESCRIPTION
## Description
Adds a CSS Skew-Active Tooltip for Creative Portfolio Layouts as requested in #54552.

## Changes
- New folder: `submissions/examples/skew-active-tooltip-ag/`
- `demo.html` — Standalone showcase page with a 4-item portfolio grid, each wired to a skew-active tooltip
- `style.css` — Pure CSS styling and skew-in animation, driven by CSS custom properties
- `README.md` — Usage, customization, and accessibility notes

## Features
- Tooltip skews in from an angled, scaled-down state to upright on hover/focus
- Triggered via `:hover`, `:focus-visible`, and `:focus-within` — works with mouse and keyboard, no JS
- Fully responsive grid and tooltip wrapping on small viewports
- Respects `prefers-reduced-motion`
- All colors, angle, offset, timing, and easing exposed as CSS custom properties

## Notes
No existing files were modified or deleted — this PR only adds new
files under `submissions/examples/`.

Closes #54552