### PR TITLE
Added copyright year at the bottom of the demo page

### DIFF
--- a/submissions/docs/copyright-year-issue/README.md
+++ b/submissions/docs/copyright-year-issue/README.md
@@ -1,0 +1,21 @@
+# Automated Copyright Year
+
+1. What does this do? Automatically displays the current copyright year in the footer below existing branding text without manual updates.
+2. How is it used? Add `<span id="year"></span>` inside your copyright paragraph and populate it dynamically using `document.getElementById('year').textContent = new Date().getFullYear()`.
+3. Why is it useful? Keeps footer copyright notices automatically accurate every year with zero manual maintenance.
+
+## Example
+
+```html
+<footer class="footer">
+  <!-- Branding text -->
+  <p class="branding">Built with ❤️ using <strong>EaseMotion CSS</strong></p>
+
+  <!-- Automated copyright line below branding text -->
+  <p class="copyright">&copy; <span id="year"></span> EaseMotion CSS</p>
+</footer>
+
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+```

--- a/submissions/docs/copyright-year-issue/demo.html
+++ b/submissions/docs/copyright-year-issue/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Automated Copyright Year</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <footer class="footer">
+    <!-- Existing branding text -->
+    <p class="branding">Built with ❤️ using <strong>EaseMotion CSS</strong></p>
+
+    <!-- Automated copyright line below branding text -->
+    <p class="copyright">&copy; <span id="year"></span> EaseMotion CSS</p>
+  </footer>
+
+  <script>
+    // Automatically set the current year without manual edits
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/submissions/docs/copyright-year-issue/style.css
+++ b/submissions/docs/copyright-year-issue/style.css
@@ -1,0 +1,44 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  line-height: 1.5;
+}
+
+.footer {
+  width: 100%;
+  background: #1e293b;
+  border-top: 1px solid #334155;
+  padding: 24px 20px;
+  text-align: center;
+}
+
+.branding {
+  font-size: 1rem;
+  color: #cbd5e1;
+  margin-bottom: 8px;
+}
+
+.branding strong {
+  color: #ffffff;
+}
+
+.copyright {
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+#year {
+  color: #38bdf8;
+  font-weight: 600;
+}


### PR DESCRIPTION
------  Pull Request Description -------
Adds a copyright year line to the demo footer in documentation.

------- Type of Change  ------
[x] 📝 Documentation improvement

  ----- Checklist -----
[x] Changes inside submissions/docs/copyright-year-issue/

[x] Includes demo.html, style.css, README.md

[x] No changes to core/ or components/

[x] One feature per PR

Feature Description
What does this add?  
A footer line showing:
© 2026 EaseMotion CSS
Why?  
Completes the footer and makes copyright visible in demos.

Demo
[x] Demo works in browser

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
