### PR TITLE
fix: prevent chip component text clipping (#55881)

### DIFF
--- a/submissions/examples/55881-chip-text-clipping/README.md
+++ b/submissions/examples/55881-chip-text-clipping/README.md
@@ -1,0 +1,77 @@
+# Chip Component — Text Clipping Fix (#55881)
+
+A CSS-only fix for the bug where chip components with long text clip or overflow their container on smaller screens, making the content partially hidden and difficult to read.
+
+## The Bug
+
+Chip components with long text clip or overflow their container on smaller screens. As a result, the chip content becomes partially hidden and the layout looks inconsistent.
+
+## The Fix
+
+The solution uses three key CSS properties:
+
+### 1. Constrain to container width
+
+```css
+.chip {
+    max-width: 100%;  /* Prevents chip from exceeding container */
+}
+```
+
+### 2. Allow text wrapping
+
+```css
+.chip {
+    overflow-wrap: break-word;  /* Long words wrap to next line */
+    word-wrap: break-word;      /* Legacy browser support */
+}
+```
+
+### 3. Allow flex shrinking
+
+```css
+.chip {
+    min-width: 0;  /* Allows chip to shrink below content size in flex context */
+}
+```
+
+## How It Works
+
+- `max-width: 100%` ensures the chip never exceeds its container's width
+- `overflow-wrap: break-word` allows long words to wrap to the next line instead of overflowing
+- `word-wrap: break-word` provides legacy browser support for `overflow-wrap`
+- `min-width: 0` allows the chip to shrink when used inside a flex container
+
+## Features
+
+- Pure CSS implementation — no JavaScript
+- Text wraps gracefully instead of clipping
+- Works with short and long labels
+- Size variants (sm, default, lg) all respect the fix
+- Selected state maintains proper text visibility
+- Dark mode support
+- `prefers-reduced-motion` support
+- Full accessibility with ARIA labels
+
+## Files
+
+```text
+submissions/examples/55881-chip-text-clipping/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+1. Open `demo.html` in a modern web browser.
+2. Observe that all chip labels are fully visible, even with long text.
+3. Resize the browser window to see the responsive behavior.
+
+## Browser Support
+
+All modern browsers supporting:
+
+- CSS Flexbox
+- CSS `overflow-wrap`
+- CSS Custom Properties

--- a/submissions/examples/55881-chip-text-clipping/demo.html
+++ b/submissions/examples/55881-chip-text-clipping/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion CSS - Chip Text Clipping Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="demo-page">
+
+        <header class="demo-header">
+            <h1>Chip Component — Text Clipping Fix</h1>
+            <p>
+                Long chip labels no longer clip or overflow their container.
+                Chips use <code>max-width: 100%</code> with
+                <code>overflow-wrap: break-word</code> to ensure all text
+                remains visible on any screen size.
+            </p>
+        </header>
+
+        <!-- Short chips -->
+        <section class="demo-section">
+            <h2>Short Labels</h2>
+            <div class="chip-group" role="group" aria-label="Short label chips">
+                <span class="chip" role="listitem">CSS</span>
+                <span class="chip" role="listitem">HTML</span>
+                <span class="chip" role="listitem">JavaScript</span>
+                <span class="chip" role="listitem">React</span>
+            </div>
+        </section>
+
+        <!-- Long chips -->
+        <section class="demo-section">
+            <h2>Long Labels (This is where clipping happened before)</h2>
+            <div class="chip-group" role="group" aria-label="Long label chips">
+                <span class="chip" role="listitem">This is a very long chip label that demonstrates the text clipping issue on smaller screens</span>
+                <span class="chip" role="listitem">Another long chip that previously would overflow its container boundaries</span>
+                <span class="chip" role="listitem">Responsive Chip Component Fix</span>
+            </div>
+        </section>
+
+        <!-- Mixed chips -->
+        <section class="demo-section">
+            <h2>Mixed Sizes</h2>
+            <div class="chip-group" role="group" aria-label="Mixed size chips">
+                <span class="chip chip-sm" role="listitem">Small</span>
+                <span class="chip" role="listitem">Default</span>
+                <span class="chip chip-lg" role="listitem">Large chip with longer text that might clip without the fix applied</span>
+            </div>
+        </section>
+
+        <!-- Selected state -->
+        <section class="demo-section">
+            <h2>Selected State</h2>
+            <div class="chip-group" role="group" aria-label="Selected chip demo">
+                <span class="chip selected" role="listitem">Selected chip with long text that stays visible and does not clip on small screens</span>
+                <span class="chip" role="listitem">Unselected</span>
+            </div>
+        </section>
+
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/55881-chip-text-clipping/style.css
+++ b/submissions/examples/55881-chip-text-clipping/style.css
@@ -1,0 +1,192 @@
+/* ==========================================================================
+   Chip Component — Text Clipping Fix (#55881)
+   Prevents long chip labels from clipping or overflowing on small screens.
+   ========================================================================== */
+
+/* ── Custom Properties ───────────────────────────────────────────────────── */
+:root {
+    --bg: #f0f2f5;
+    --surface: #ffffff;
+    --primary: #4f46e5;
+    --text: #1e293b;
+    --text-muted: #64748b;
+    --border: #e2e8f0;
+    --chip-bg: #f3f4f6;
+    --chip-border: #d1d5db;
+    --chip-text: #374151;
+    --chip-selected-bg: #4f46e5;
+    --chip-selected-text: #ffffff;
+    --radius: 9999px;
+    --speed: 0.15s;
+    --ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Reset ───────────────────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+code {
+    background: rgba(79, 70, 229, 0.1);
+    color: var(--primary);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+/* ── Demo Page ───────────────────────────────────────────────────────────── */
+.demo-page {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.demo-header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.demo-header h1 {
+    font-size: clamp(1.5rem, 4vw, 2.25rem);
+    margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+    color: var(--text-muted);
+    max-width: 560px;
+    margin: 0 auto;
+    line-height: 1.7;
+}
+
+.demo-section {
+    margin-bottom: 2rem;
+}
+
+.demo-section h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+}
+
+/* ==========================================================================
+   THE FIX — Chip Component
+   ==========================================================================
+   Key CSS properties that prevent text clipping:
+
+   1. max-width: 100%          — constrains chip to container width
+   2. overflow-wrap: break-word — allows long words to wrap
+   3. min-width: 0             — allows flex child to shrink
+   4. word-wrap: break-word    — legacy support for overflow-wrap
+   ========================================================================== */
+
+/* ── Chip Group ──────────────────────────────────────────────────────────── */
+.chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+/* ── Base Chip ─────────────────────────────────────────────────────────────
+   THE FIX: max-width: 100% + overflow-wrap: break-word prevents long text
+   from clipping or overflowing the chip boundaries.                         */
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.875rem;
+    border-radius: var(--radius);
+    border: 1px solid var(--chip-border);
+    background: var(--chip-bg);
+    color: var(--chip-text);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1.4;
+
+    /* THE FIX — critical properties: */
+    max-width: 100%;               /* Constrain to container width */
+    overflow-wrap: break-word;     /* Allow long words to wrap */
+    word-wrap: break-word;         /* Legacy support */
+    min-width: 0;                  /* Allow shrinking in flex context */
+
+    transition:
+        background var(--speed) var(--ease),
+        border-color var(--speed) var(--ease),
+        color var(--speed) var(--ease),
+        transform var(--speed) var(--ease),
+        box-shadow var(--speed) var(--ease);
+}
+
+.chip:hover {
+    border-color: var(--primary);
+    background: #e5e7eb;
+    transform: translateY(-1px);
+}
+
+/* ── Selected State ──────────────────────────────────────────────────────── */
+.chip.selected {
+    background: var(--chip-selected-bg);
+    border-color: var(--chip-selected-bg);
+    color: var(--chip-selected-text);
+    box-shadow: 0 2px 8px rgba(79, 70, 229, 0.3);
+}
+
+.chip.selected:hover {
+    background: #4338ca;
+    border-color: #4338ca;
+}
+
+/* ── Size Variants ───────────────────────────────────────────────────────── */
+.chip-sm {
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+}
+
+.chip-lg {
+    padding: 0.5rem 1.125rem;
+    font-size: 0.9rem;
+}
+
+/* ── Dark Mode ───────────────────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --chip-bg: #374151;
+        --chip-border: #4b5563;
+        --chip-text: #f3f4f6;
+    }
+
+    .chip:hover {
+        background: #4b5563;
+        border-color: var(--primary);
+    }
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+    .demo-page {
+        padding: 1.5rem 1rem;
+    }
+}
+
+/* ── prefers-reduced-motion ──────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+        transition: none !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
## Fix: Chip Component Text Clipping (#55881)

### Problem
Chip components with long text clip or overflow their container on smaller screens. The chip content becomes partially hidden and the layout looks inconsistent.

### Solution
Self-contained CSS-only demo in `submissions/examples/55881-chip-text-clipping/` demonstrating the fix with three key CSS properties:

**1. Constrain to container width**
```css
.chip {
    max-width: 100%;  /* Prevents chip from exceeding container */
}