### PR TITLE
fix: correct ease-pulse keyframe reference to ease-kf-pulse in connec…

### DIFF
--- a/submissions/examples/connection-status-fix-ag/README.md
+++ b/submissions/examples/connection-status-fix-ag/README.md
@@ -1,0 +1,35 @@
+# Connection Status — Bug Fix
+
+Fixes an incorrect animation keyframe reference in `components/connection-status.css`.
+
+## 🐛 What was wrong?
+
+Line 17 of `components/connection-status.css` referenced an undefined keyframe name:
+
+```css
+/* ❌ BEFORE — keyframe does not exist */
+animation: ease-pulse 2s infinite;
+```
+
+The `@keyframes ease-kf-pulse` rule is already defined in `core/animations.css`, but the component used the wrong name (`ease-pulse` instead of `ease-kf-pulse`). As a result, the offline status bar remained completely static instead of pulsing.
+
+## ✅ The Fix
+
+```css
+/* ✅ AFTER — correct keyframe name */
+animation: ease-kf-pulse 2s infinite;
+```
+
+## 🔎 How to reproduce the bug
+
+1. Link EaseMotion CSS in your project.
+2. Add `<div class="ease-connection-status is-offline">Connection lost.</div>` to your HTML.
+3. Open the page — the bar is visible but **does not pulse**.
+4. After the fix, the pulsing animation plays correctly.
+
+## 📁 Files
+
+| File        | Description                                 |
+| ----------- | ------------------------------------------- |
+| `style.css` | Corrected `connection-status` component CSS |
+| `demo.html` | Live demo showing the pulsing animation     |

--- a/submissions/examples/connection-status-fix-ag/demo.html
+++ b/submissions/examples/connection-status-fix-ag/demo.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Connection Status Fix Demo | EaseMotion CSS</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- EaseMotion core (provides @keyframes ease-kf-pulse) -->
+    <link rel="stylesheet" href="../../../easemotion.min.css" />
+    <!-- Fixed component styles -->
+    <link rel="stylesheet" href="./style.css" />
+
+    <style>
+      body {
+        margin: 0;
+        font-family: var(--ease-font-sans);
+        background-color: var(--ease-color-neutral-900);
+        color: var(--ease-color-neutral-100);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: var(--ease-space-8);
+        padding: var(--ease-space-8);
+      }
+
+      .demo-card {
+        background: var(--ease-glass-bg);
+        border: 1px solid var(--ease-glass-border);
+        border-radius: var(--ease-radius-xl);
+        padding: var(--ease-space-8);
+        max-width: 560px;
+        width: 100%;
+        backdrop-filter: blur(16px);
+        -webkit-backdrop-filter: blur(16px);
+      }
+
+      h1 {
+        font-size: var(--ease-text-2xl);
+        font-weight: 700;
+        margin: 0 0 var(--ease-space-2) 0;
+        color: white;
+      }
+
+      p {
+        font-size: var(--ease-text-sm);
+        color: var(--ease-color-neutral-400);
+        line-height: var(--ease-leading-normal);
+        margin: 0 0 var(--ease-space-6) 0;
+      }
+
+      .diff-block {
+        background: var(--ease-color-neutral-800);
+        border-radius: var(--ease-radius-md);
+        padding: var(--ease-space-4);
+        font-family: monospace;
+        font-size: 0.8rem;
+        line-height: 1.6;
+        margin-bottom: var(--ease-space-6);
+      }
+
+      .diff-removed {
+        color: #f87171;
+        background: rgba(248, 113, 113, 0.1);
+        display: block;
+        padding: 0 var(--ease-space-2);
+        border-radius: 2px;
+      }
+
+      .diff-added {
+        color: #4ade80;
+        background: rgba(74, 222, 128, 0.1);
+        display: block;
+        padding: 0 var(--ease-space-2);
+        border-radius: 2px;
+      }
+
+      .label {
+        font-size: var(--ease-text-xs);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--ease-color-neutral-500);
+        margin-bottom: var(--ease-space-2);
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- 
+      The offline status bar — now animates correctly with ease-kf-pulse.
+      Before the fix, it was static because `ease-pulse` keyframe does not exist.
+    -->
+    <div class="ease-connection-status is-offline" id="status-bar">
+      <span class="ease-connection-status-icon"></span>
+      Connection lost. Retrying…
+    </div>
+
+    <div class="demo-card ease-fade-in">
+      <h1>🐛 Bug Fix: Connection Status</h1>
+      <p>
+        The offline status bar above now correctly pulses using
+        <code>ease-kf-pulse</code>. Previously, the component referenced the
+        non-existent keyframe name <code>ease-pulse</code>, causing the
+        animation to fail silently and the bar to remain static.
+      </p>
+
+      <span class="label"
+        >The one-line fix (components/connection-status.css)</span
+      >
+      <div class="diff-block">
+        <span class="diff-removed">
+          - animation: ease-pulse 2s infinite; /* ❌ undefined keyframe */
+        </span>
+        <span class="diff-added">
+          + animation: ease-kf-pulse 2s infinite; /* ✅ correct keyframe */
+        </span>
+      </div>
+
+      <p>
+        The <code>@keyframes ease-kf-pulse</code> rule is already defined in
+        <code>core/animations.css</code>. This fix simply corrects the reference
+        so the animation plays as intended.
+      </p>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/connection-status-fix-ag/style.css
+++ b/submissions/examples/connection-status-fix-ag/style.css
@@ -1,0 +1,65 @@
+/* =========================================================================
+   Connection Status Component — Bug Fix Demo
+   Fixes: animation name `ease-pulse` → `ease-kf-pulse` (line 17 in
+   components/connection-status.css).
+
+   The @keyframes rule is defined as `ease-kf-pulse` in core/animations.css.
+   The original component incorrectly referenced `ease-pulse`, causing the
+   offline status bar to remain static instead of pulsing.
+   ========================================================================= */
+
+@layer easemotion-components {
+  .ease-connection-status {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    padding: 0.5rem 1rem;
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transform: translateY(-100%);
+    transition: transform 0.3s ease;
+  }
+
+  /* FIX: was `animation: ease-pulse 2s infinite` — incorrect keyframe name.
+     The actual keyframe is `ease-kf-pulse` defined in core/animations.css. */
+  .ease-connection-status.is-offline {
+    transform: translateY(0);
+    background: #ef4444;
+    color: #fff;
+    animation: ease-kf-pulse 2s infinite;
+  }
+
+  .ease-connection-status.is-online {
+    transform: translateY(0);
+    background: #10b981;
+    color: #fff;
+  }
+
+  .ease-connection-status.is-online-delay {
+    transform: translateY(0);
+    background: #10b981;
+    color: #fff;
+    animation: none;
+  }
+
+  .ease-connection-status-icon {
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 9999px;
+    margin-right: 0.375rem;
+    vertical-align: middle;
+  }
+
+  .ease-connection-status.is-offline .ease-connection-status-icon {
+    background: #fff;
+  }
+
+  .ease-connection-status.is-online .ease-connection-status-icon {
+    background: #fff;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #55578 under gssoc'26, the bug reported in the issue where the `ease-connection-status.is-offline` element remains static instead of pulsing.

**Root cause:** Line 17 of `components/connection-status.css` references `ease-pulse` — a keyframe name that does not exist. The actual keyframe defined in `core/animations.css` is `ease-kf-pulse`.

**The fix:**
```diff
- animation: ease-pulse 2s infinite;   /* ❌ undefined — animation silently fails */
+ animation: ease-kf-pulse 2s infinite; /* ✅ correct keyframe name */
```

This submission places the corrected CSS and a visual demo inside `submissions/examples/connection-status-fix-ag/` following the repository's contribution guidelines.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — corrected CSS for the component
- [x] Includes `README.md` — describes root cause, the fix, and how to reproduce
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One fix per PR (no bundled unrelated changes)

---

## Steps to Reproduce (from the issue)

1. Link EaseMotion CSS in your project.
2. Add `<div class="ease-connection-status is-offline">Connection lost. Retrying...</div>`.
3. Open the page — the bar appears but **does not pulse**.

## Expected Behavior

The offline status bar pulses using `@keyframes ease-kf-pulse` already defined in `core/animations.css`.

## Demo

- [x] Demo added — `demo.html` visually shows the fix with a diff block and the live pulsing bar.

## Notes for Maintainer

The fix is a single animation name correction. The `@keyframes ease-kf-pulse` rule is already present in `core/animations.css` — no new keyframes were added. The component simply needed to reference the correct name.
```