### PR TITLE
feat: auto-update footer copyright year

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -764,10 +764,16 @@
         Built with ❤️ using <strong style="color:var(--ease-color-primary-light);">EaseMotion CSS</strong> — the
         animation-first, human-readable CSS framework.
       </p>
+      <p>© <span id="current-year"></span> EaseMotion CSS</p>
     </div>
   </footer>
 
   <!-- ── Scripts ────────────────────────────────────────── -->
+
+  <script>
+    //Auto-update footer copyright year
+    document.getElementById("current-year").textContent = new Date().getFullYear();
+  </script>
   <script>
     function replay(el, cls) {
       el.classList.remove(cls);


### PR DESCRIPTION
## Pull Request Description
## Summary

This PR --> Adds automatic rendering of the current year in the footer using JavaScript.

## Changes

- Added a `span` element to display the current year.
- Added a small JavaScript snippet to automatically update the footer year.
- Eliminates the need to manually update the copyright year annually.

## Why

This ensures the footer always displays the correct year without requiring future maintenance.
