### PR TITLE
feat(submission): add css-only hover magnifying glass (#56026)

### DIFF
--- a/submissions/examples/magnifying-glass-56026/README.md
+++ b/submissions/examples/magnifying-glass-56026/README.md
@@ -1,0 +1,17 @@
+# CSS-Only Hover Magnifying Glass
+
+## What does this do?
+When hovering over an image container, a circular lens area appears and scales up the image strictly within that circle, simulating a magnifying glass.
+
+## How is it used?
+```html
+<div class="ease-magnify-container"></div>
+```
+*(Note: Ensure the container has a background image set either inline or in your CSS).*
+
+## Why does it fit EaseMotion CSS?
+Magnifying glasses on product images usually require bulky JavaScript to track the mouse coordinates and adjust the background position. This component takes a CSS-only approach, placing a beautifully styled, bouncy lens directly in the center on hover, allowing users to inspect the center details without any JS overhead.
+
+## Tech Stack
+- HTML
+- CSS (No JavaScript)

--- a/submissions/examples/magnifying-glass-56026/demo.html
+++ b/submissions/examples/magnifying-glass-56026/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS-Only Hover Magnifying Glass</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background-color: #f1f5f9;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+        
+        .gallery-wrap {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 15px;
+        }
+        
+        .gallery-wrap p {
+            color: #64748b;
+            margin: 0;
+            font-size: 0.95rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="gallery-wrap">
+        <div class="ease-magnify-container"></div>
+        <p>Hover over the image to inspect closely.</p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/magnifying-glass-56026/style.css
+++ b/submissions/examples/magnifying-glass-56026/style.css
@@ -1,0 +1,45 @@
+.ease-magnify-container {
+  position: relative;
+  width: 400px;
+  height: 300px;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 10px 20px rgba(0,0,0,0.15);
+  cursor: zoom-in;
+  
+  /* The base image */
+  background-image: url('https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=2564&auto=format&fit=crop');
+  background-size: cover;
+  background-position: center;
+}
+
+/* The Magnifying Glass Lens */
+.ease-magnify-container::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.5);
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  
+  /* The zoomed version of the same image */
+  background-image: inherit;
+  background-size: 800px 600px; /* 2x the container size for zoom */
+  background-position: center;
+  
+  /* Lens styling */
+  box-shadow: inset 0 0 20px rgba(0,0,0,0.5), 0 5px 15px rgba(0,0,0,0.3);
+  border: 4px solid rgba(255, 255, 255, 0.8);
+  
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* On hover, pop the lens in */
+.ease-magnify-container:hover::after {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves #56026 by adding an `ease-magnify-container` component that elegantly creates a CSS-only zoomed magnifying glass effect on hover.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

When hovering over an image container, a circular lens area appears and scales up the image strictly within that circle, simulating a magnifying glass.

**How does a developer use it?**

```html
<div class="ease-magnify-container"></div>