### PR TITLE
feat: add CSS Blur-Entrance Stepper for Accessible Web Layouts

### DIFF
--- a/submissions/examples/blur-entrance-stepper-sathvika/README.md
+++ b/submissions/examples/blur-entrance-stepper-sathvika/README.md
@@ -1,0 +1,25 @@
+﻿# CSS Blur-Entrance Stepper
+
+A step progress indicator where each step node blurs into focus on load, staggered slightly per step.
+
+## CSS Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| `--ease-stepper-duration` | `0.4s` | Entrance animation duration |
+| `--ease-stepper-blur` | `8px` | Starting blur amount |
+| `--ease-stepper-accent` | `#4f46e5` | Active step color |
+
+## Usage
+```html
+<div class="ease-stepper" role="list" aria-label="Progress steps">
+  <span class="ease-stepper__step ease-stepper__step--active" aria-current="step">1</span>
+  <span class="ease-stepper__connector"></span>
+  <span class="ease-stepper__step">2</span>
+</div>
+```
+
+## Accessibility
+`role="list"`/`listitem` and `aria-current="step"` on the active node communicate progress state to screen readers. `prefers-reduced-motion` removes the blur, using a fast opacity fade instead.
+
+## Why it fits EaseMotion CSS
+Pure CSS `filter: blur()` entrance technique, `ease-` prefixed classes, themeable, zero dependencies.

--- a/submissions/examples/blur-entrance-stepper-sathvika/demo.html
+++ b/submissions/examples/blur-entrance-stepper-sathvika/demo.html
@@ -1,0 +1,13 @@
+﻿<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" />
+<title>Blur-Entrance Stepper Demo</title><link rel="stylesheet" href="style.css" />
+<style>body{font-family:-apple-system,sans-serif;background:#f9fafb;padding:60px;}</style>
+</head><body>
+<h2>CSS Blur-Entrance Stepper</h2>
+<div class="ease-stepper" role="list" aria-label="Progress steps">
+  <span class="ease-stepper__step ease-stepper__step--active" role="listitem" aria-current="step">1</span>
+  <span class="ease-stepper__connector"></span>
+  <span class="ease-stepper__step" role="listitem">2</span>
+  <span class="ease-stepper__connector"></span>
+  <span class="ease-stepper__step" role="listitem">3</span>
+</div>
+</body></html>

--- a/submissions/examples/blur-entrance-stepper-sathvika/style.css
+++ b/submissions/examples/blur-entrance-stepper-sathvika/style.css
@@ -1,0 +1,22 @@
+﻿:root {
+  --ease-stepper-duration: 0.4s;
+  --ease-stepper-blur: 8px;
+  --ease-stepper-accent: #4f46e5;
+}
+.ease-stepper { display: flex; align-items: center; gap: 8px; }
+.ease-stepper__step {
+  display: flex; align-items: center; justify-content: center;
+  width: 36px; height: 36px; border-radius: 50%;
+  background: #e5e7eb; color: #6b7280; font-weight: 700; font-size: 14px;
+  filter: blur(var(--ease-stepper-blur)); opacity: 0;
+  animation: ease-step-in var(--ease-stepper-duration) ease forwards;
+}
+.ease-stepper__step:nth-child(1) { animation-delay: 0.1s; }
+.ease-stepper__step:nth-child(3) { animation-delay: 0.25s; }
+.ease-stepper__step:nth-child(5) { animation-delay: 0.4s; }
+@keyframes ease-step-in { to { filter: blur(0); opacity: 1; } }
+.ease-stepper__step--active { background: var(--ease-stepper-accent); color: #fff; }
+.ease-stepper__connector { width: 32px; height: 2px; background: #e5e7eb; }
+@media (prefers-reduced-motion: reduce) {
+  .ease-stepper__step { animation-duration: 0.15s; filter: none; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS step-progress indicator where each step blurs into focus on load with a staggered delay, for accessible web layouts. Resolves #54424

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/examples/blur-entrance-stepper-sathvika/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A stepper component where each step node animates from blurred/transparent to sharp/opaque on load, staggered per step index.

**How does a developer use it?**
```html
<div class="ease-stepper" role="list" aria-label="Progress steps">
  <span class="ease-stepper__step ease-stepper__step--active" aria-current="step">1</span>
  <span class="ease-stepper__connector"></span>
  <span class="ease-stepper__step">2</span>
</div>
```

**Why does it fit EaseMotion CSS?** Pure CSS `filter: blur()` entrance, `ease-` prefixed classes, themeable, zero dependencies.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Uses `role="list"`/`aria-current="step"` for accessibility. `prefers-reduced-motion` swaps the blur transition for a fast opacity fade. Happy to adjust stagger timing if preferred.