### PR TITLE
feat: add CSS Float-Drift Drawer for Creative Portfolio Layouts

### DIFF
--- a/submissions/examples/float-drift-drawer-sathvika/README.md
+++ b/submissions/examples/float-drift-drawer-sathvika/README.md
@@ -1,0 +1,28 @@
+﻿# CSS Float-Drift Drawer
+
+A side drawer that slides in and then gently drifts in place with a slow floating motion.
+
+## CSS Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| `--ease-drawer-duration` | `0.45s` | Slide-in transition duration |
+| `--ease-drawer-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Slide-in easing |
+| `--ease-drawer-width` | `320px` | Drawer width |
+| `--ease-drawer-bg` | `#ffffff` | Drawer background |
+
+## Usage
+```html
+<button class="ease-drawer-trigger" id="openBtn">Open Drawer</button>
+<div class="ease-drawer-overlay" id="overlay" role="dialog" aria-modal="true">
+  <div class="ease-drawer" tabindex="-1">
+    <button class="ease-drawer__close" id="closeBtn" aria-label="Close">✕</button>
+    Content
+  </div>
+</div>
+```
+
+## Accessibility
+`role="dialog"`, `aria-modal`, Escape-to-close, backdrop click, focus moves to close button on open. `prefers-reduced-motion` disables the drift loop.
+
+## Why it fits EaseMotion CSS
+Pure CSS slide + ambient drift animation, `ease-` prefixed classes, themeable, zero dependencies.

--- a/submissions/examples/float-drift-drawer-sathvika/demo.html
+++ b/submissions/examples/float-drift-drawer-sathvika/demo.html
@@ -1,0 +1,25 @@
+﻿<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" />
+<title>Float-Drift Drawer Demo</title><link rel="stylesheet" href="style.css" />
+<style>body{font-family:-apple-system,sans-serif;background:#f9fafb;padding:60px;}</style>
+</head><body>
+<h2>CSS Float-Drift Drawer</h2>
+<button class="ease-drawer-trigger" id="openBtn">Open Drawer</button>
+<div class="ease-drawer-overlay" id="overlay" role="dialog" aria-modal="true">
+  <div class="ease-drawer" tabindex="-1">
+    <button class="ease-drawer__close" id="closeBtn" aria-label="Close">✕</button>
+    <h3>Drawer Content</h3>
+    <p>This drawer gently drifts once open, evoking a floating sensation.</p>
+  </div>
+</div>
+<script>
+  const overlay = document.getElementById('overlay');
+  const openBtn = document.getElementById('openBtn');
+  const closeBtn = document.getElementById('closeBtn');
+  function open() { overlay.classList.add('ease-drawer-overlay--open'); closeBtn.focus(); }
+  function close() { overlay.classList.remove('ease-drawer-overlay--open'); openBtn.focus(); }
+  openBtn.addEventListener('click', open);
+  closeBtn.addEventListener('click', close);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+</script>
+</body></html>

--- a/submissions/examples/float-drift-drawer-sathvika/style.css
+++ b/submissions/examples/float-drift-drawer-sathvika/style.css
@@ -1,0 +1,39 @@
+﻿:root {
+  --ease-drawer-duration: 0.45s;
+  --ease-drawer-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-drawer-width: 320px;
+  --ease-drawer-bg: #ffffff;
+}
+.ease-drawer-trigger {
+  padding: 10px 20px; border-radius: 8px; border: none;
+  background: #4f46e5; color: #fff; font-size: 14px; font-weight: 600; cursor: pointer;
+}
+.ease-drawer-overlay {
+  position: fixed; inset: 0; background: rgba(17,24,39,0.5);
+  opacity: 0; visibility: hidden; pointer-events: none;
+  transition: opacity var(--ease-drawer-duration) var(--ease-drawer-easing),
+    visibility 0s linear var(--ease-drawer-duration);
+  z-index: 999;
+}
+.ease-drawer-overlay--open { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+.ease-drawer {
+  position: fixed; top: 0; right: 0; height: 100%; width: var(--ease-drawer-width);
+  background: var(--ease-drawer-bg); box-shadow: -10px 0 30px rgba(0,0,0,0.15);
+  padding: 24px; transform: translateX(30px);
+  opacity: 0;
+  transition: transform var(--ease-drawer-duration) var(--ease-drawer-easing),
+    opacity var(--ease-drawer-duration) var(--ease-drawer-easing);
+  animation: none;
+}
+.ease-drawer-overlay--open .ease-drawer {
+  transform: translateX(0); opacity: 1;
+  animation: ease-drift-float 3s ease-in-out infinite 0.5s;
+}
+@keyframes ease-drift-float {
+  0%, 100% { transform: translateX(0) translateY(0); }
+  50% { transform: translateX(-4px) translateY(-3px); }
+}
+.ease-drawer__close { position: absolute; top: 16px; right: 16px; width: 32px; height: 32px; border: none; border-radius: 50%; background: #f3f4f6; cursor: pointer; font-size: 16px; }
+@media (prefers-reduced-motion: reduce) {
+  .ease-drawer-overlay--open .ease-drawer { animation: none; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS side drawer that slides in and then gently drifts in place with a slow floating motion, for creative portfolio layouts. Resolves #54521

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/examples/float-drift-drawer-sathvika/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A slide-in drawer that, once open, gently drifts (translateX/Y micro-motion) in a slow ambient loop, giving a floating sensation.

**How does a developer use it?**
```html
<button class="ease-drawer-trigger" id="openBtn">Open Drawer</button>
<div class="ease-drawer-overlay" id="overlay" role="dialog" aria-modal="true">
  <div class="ease-drawer" tabindex="-1">Content</div>
</div>
```

**Why does it fit EaseMotion CSS?** Pure CSS slide + ambient drift, `ease-` prefixed classes, themeable via custom properties.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Drift animation starts 0.5s after slide-in completes, and is disabled under `prefers-reduced-motion`. Happy to adjust drift amplitude/speed if preferred.