### PR TITLE
feat: add CSS Glitch-Flicker Tabs for Creative Portfolio Layouts

### DIFF
--- a/submissions/examples/glitch-flicker-tabs-sathvika/README.md
+++ b/submissions/examples/glitch-flicker-tabs-sathvika/README.md
@@ -1,0 +1,23 @@
+﻿# CSS Glitch-Flicker Tabs
+
+A tab navigation where hovering a tab briefly triggers a glitch-style RGB text-shadow flicker.
+
+## CSS Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| `--ease-tabs-glitch-color` | `#ec4899` | Primary glitch shadow color |
+| `--ease-tabs-accent` | `#4f46e5` | Active tab underline/text color |
+
+## Usage
+```html
+<div class="ease-tabs" role="tablist">
+  <button class="ease-tabs__tab ease-tabs__tab--active" role="tab" aria-selected="true">Overview</button>
+  <button class="ease-tabs__tab" role="tab" aria-selected="false">Details</button>
+</div>
+```
+
+## Accessibility
+`role="tablist"`/`tab` and `aria-selected` reflect state to screen readers. The glitch effect is purely visual and doesn't affect readability of the text itself; `prefers-reduced-motion` disables it.
+
+## Why it fits EaseMotion CSS
+Pure CSS `text-shadow` glitch technique using `steps()` timing, `ease-` prefixed classes, themeable, zero dependencies.

--- a/submissions/examples/glitch-flicker-tabs-sathvika/demo.html
+++ b/submissions/examples/glitch-flicker-tabs-sathvika/demo.html
@@ -1,0 +1,11 @@
+﻿<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" />
+<title>Glitch-Flicker Tabs Demo</title><link rel="stylesheet" href="style.css" />
+<style>body{font-family:-apple-system,sans-serif;background:#f9fafb;padding:60px;}</style>
+</head><body>
+<h2>CSS Glitch-Flicker Tabs</h2>
+<div class="ease-tabs" role="tablist">
+  <button class="ease-tabs__tab ease-tabs__tab--active" role="tab" aria-selected="true">Overview</button>
+  <button class="ease-tabs__tab" role="tab" aria-selected="false">Details</button>
+  <button class="ease-tabs__tab" role="tab" aria-selected="false">Reviews</button>
+</div>
+</body></html>

--- a/submissions/examples/glitch-flicker-tabs-sathvika/style.css
+++ b/submissions/examples/glitch-flicker-tabs-sathvika/style.css
@@ -1,0 +1,27 @@
+﻿:root {
+  --ease-tabs-glitch-color: #ec4899;
+  --ease-tabs-accent: #4f46e5;
+}
+.ease-tabs { display: flex; gap: 4px; border-bottom: 2px solid #e5e7eb; }
+.ease-tabs__tab {
+  padding: 12px 18px; border: none; background: transparent; cursor: pointer;
+  font-size: 14px; font-weight: 600; color: #6b7280; position: relative;
+}
+.ease-tabs__tab--active { color: var(--ease-tabs-accent); }
+.ease-tabs__tab--active::after {
+  content: ''; position: absolute; bottom: -2px; left: 0; right: 0; height: 2px;
+  background: var(--ease-tabs-accent);
+}
+.ease-tabs__tab:hover {
+  animation: ease-glitch-flicker 0.4s steps(2, end);
+}
+@keyframes ease-glitch-flicker {
+  0% { text-shadow: none; }
+  20% { text-shadow: -2px 0 var(--ease-tabs-glitch-color), 2px 0 #22d3ee; }
+  40% { text-shadow: 2px 0 var(--ease-tabs-glitch-color), -2px 0 #22d3ee; }
+  60% { text-shadow: -1px 0 var(--ease-tabs-glitch-color), 1px 0 #22d3ee; }
+  100% { text-shadow: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs__tab:hover { animation: none; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS tab navigation where hovering a tab triggers a brief RGB-glitch text-shadow flicker, for creative portfolio layouts. Resolves #54473

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/examples/glitch-flicker-tabs-sathvika/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** Tab buttons that flicker with a glitch-style dual-color text-shadow on hover, using `steps()` timing for a jittery, non-smooth feel appropriate to the glitch aesthetic.

**How does a developer use it?**
```html
<div class="ease-tabs" role="tablist">
  <button class="ease-tabs__tab ease-tabs__tab--active" role="tab" aria-selected="true">Overview</button>
  <button class="ease-tabs__tab" role="tab" aria-selected="false">Details</button>
</div>
```

**Why does it fit EaseMotion CSS?** Pure CSS `text-shadow` + `steps()` glitch technique, `ease-` prefixed classes, themeable.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
`role="tablist"`/`tab`/`aria-selected` used for accessibility; the glitch effect doesn't affect text legibility and is disabled under `prefers-reduced-motion`. Happy to adjust glitch color pairing if preferred.