### PR TITLE
feat: add CSS Morph-Glow Tabs for Accessible Web Layouts

### DIFF
--- a/submissions/examples/morph-glow-tabs-sathvika/README.md
+++ b/submissions/examples/morph-glow-tabs-sathvika/README.md
@@ -1,0 +1,25 @@
+﻿# CSS Morph-Glow Tabs
+
+Tabs with a sliding, pulsing-glow indicator that morphs its width/position between tabs with spring easing.
+
+## CSS Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| `--ease-tabs-glow` | `#4f46e5` | Indicator/glow color |
+| `--ease-tabs-duration` | `0.4s` | Text color transition duration |
+
+## Usage
+```html
+<div class="ease-tabs" role="tablist">
+  <div class="ease-tabs__indicator"></div>
+  <button class="ease-tabs__tab ease-tabs__tab--active" role="tab" aria-selected="true">Overview</button>
+  <button class="ease-tabs__tab" role="tab" aria-selected="false">Details</button>
+</div>
+```
+Minimal JS repositions/resizes the indicator via `offsetLeft`/`offsetWidth` on click; the morph and glow animation itself is CSS.
+
+## Accessibility
+`role="tablist"`/`tab`/`aria-selected` reflect state. `prefers-reduced-motion` disables the ambient glow pulse (the position transition remains, since it conveys state change).
+
+## Why it fits EaseMotion CSS
+Pure CSS spring-easing morph + glow pulse, `ease-` prefixed classes, themeable.

--- a/submissions/examples/morph-glow-tabs-sathvika/demo.html
+++ b/submissions/examples/morph-glow-tabs-sathvika/demo.html
@@ -1,0 +1,26 @@
+﻿<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" />
+<title>Morph-Glow Tabs Demo</title><link rel="stylesheet" href="style.css" />
+<style>body{font-family:-apple-system,sans-serif;background:#f9fafb;padding:60px;}</style>
+</head><body>
+<h2>CSS Morph-Glow Tabs</h2>
+<div class="ease-tabs" id="tabs" role="tablist">
+  <div class="ease-tabs__indicator" id="indicator"></div>
+  <button class="ease-tabs__tab ease-tabs__tab--active" role="tab" aria-selected="true" data-index="0">Overview</button>
+  <button class="ease-tabs__tab" role="tab" aria-selected="false" data-index="1">Details</button>
+  <button class="ease-tabs__tab" role="tab" aria-selected="false" data-index="2">Reviews</button>
+</div>
+<script>
+  const tabs = document.querySelectorAll('.ease-tabs__tab');
+  const indicator = document.getElementById('indicator');
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      tabs.forEach(t => { t.classList.remove('ease-tabs__tab--active'); t.setAttribute('aria-selected', 'false'); });
+      tab.classList.add('ease-tabs__tab--active');
+      tab.setAttribute('aria-selected', 'true');
+      indicator.style.transform = `translateX(${tab.offsetLeft - 6}px)`;
+      indicator.style.width = `${tab.offsetWidth}px`;
+    });
+  });
+  window.addEventListener('load', () => tabs[0].click());
+</script>
+</body></html>

--- a/submissions/examples/morph-glow-tabs-sathvika/style.css
+++ b/submissions/examples/morph-glow-tabs-sathvika/style.css
@@ -1,0 +1,27 @@
+﻿:root {
+  --ease-tabs-glow: #4f46e5;
+  --ease-tabs-duration: 0.4s;
+}
+.ease-tabs { position: relative; display: flex; gap: 4px; background: #f3f4f6; padding: 6px; border-radius: 12px; width: fit-content; }
+.ease-tabs__tab {
+  position: relative; z-index: 1; padding: 10px 20px; border: none; background: transparent;
+  cursor: pointer; font-size: 14px; font-weight: 600; color: #6b7280;
+  transition: color var(--ease-tabs-duration) ease;
+}
+.ease-tabs__tab--active { color: #ffffff; }
+.ease-tabs__indicator {
+  position: absolute; top: 6px; bottom: 6px; left: 6px; width: 100px;
+  background: var(--ease-tabs-glow); border-radius: 8px;
+  box-shadow: 0 0 0 rgba(79,70,229,0);
+  transition: transform var(--ease-tabs-duration) cubic-bezier(0.34,1.56,0.64,1),
+    width var(--ease-tabs-duration) cubic-bezier(0.34,1.56,0.64,1),
+    box-shadow var(--ease-tabs-duration) ease;
+  animation: ease-glow-pulse 2.4s ease-in-out infinite;
+}
+@keyframes ease-glow-pulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(79,70,229,0.4); }
+  50% { box-shadow: 0 0 18px rgba(79,70,229,0.7); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs__indicator { animation: none; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds pure CSS tabs with a sliding, pulsing-glow indicator that morphs its width/position between tabs, for accessible web layouts. Resolves #54220

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/examples/morph-glow-tabs-sathvika/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A tab navigation with a glowing indicator pill that morphs (repositions and resizes) with spring easing between tabs, while continuously pulsing.

**How does a developer use it?**
```html
<div class="ease-tabs" role="tablist">
  <div class="ease-tabs__indicator"></div>
  <button class="ease-tabs__tab ease-tabs__tab--active" role="tab" aria-selected="true">Overview</button>
</div>
```

**Why does it fit EaseMotion CSS?** Pure CSS spring-easing morph transition plus glow pulse keyframe, `ease-` prefixed classes, themeable.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Minimal JS only repositions/resizes the indicator via `offsetLeft`/`offsetWidth` on click — all animation styling is CSS. `role="tablist"`/`aria-selected` used for accessibility. `prefers-reduced-motion` disables the ambient glow pulse while keeping the position transition (since it conveys state change). Happy to adjust glow intensity if preferred.