### PR TITLE
feat: add idempotency request ledger example

### DIFF
--- a/submissions/examples/idempotency-request-ledger-kp/README.md
+++ b/submissions/examples/idempotency-request-ledger-kp/README.md
@@ -1,0 +1,31 @@
+# Idempotency Request Ledger KP
+
+## What does this do?
+
+Idempotency Request Ledger KP adds a responsive operational component for tracing how repeated API writes resolve to one safe response. It includes status filters, animated request-to-key flows, processed and replayed states, ledger metrics, and a compact mobile layout.
+
+## How is it used?
+
+Use semantic radio inputs to drive the ledger filters, then compose each request from a summary, resolution flow, and footer.
+
+```html
+<input type="radio" name="request-filter" id="filter-replayed" />
+
+<span class="filter-tabs" role="group" aria-label="Filter requests">
+  <label for="filter-replayed">Replayed <i>1</i></label>
+</span>
+
+<article class="request-row request-row--replayed">
+  <span class="resolution-flow">
+    <span class="flow-node">Received again</span>
+    <span class="flow-line flow-line--replay" aria-hidden="true"><i></i></span>
+    <span class="flow-node flow-node--key">Matching key</span>
+    <span class="flow-line flow-line--replay" aria-hidden="true"><i></i></span>
+    <span class="flow-node flow-node--replay">Cached response</span>
+  </span>
+</article>
+```
+
+## Why is it useful?
+
+The component turns an abstract backend guarantee into an inspectable UI pattern. Motion clarifies request resolution, color distinguishes new and replayed responses, and semantic controls preserve keyboard focus while CSS-only filtering, responsive layouts, and reduced-motion support keep the example practical.

--- a/submissions/examples/idempotency-request-ledger-kp/demo.html
+++ b/submissions/examples/idempotency-request-ledger-kp/demo.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Idempotency Request Ledger KP</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="ledger-shell" aria-labelledby="ledger-title">
+        <input
+          class="filter-input"
+          type="radio"
+          name="request-filter"
+          id="filter-all"
+          checked
+        />
+        <input
+          class="filter-input"
+          type="radio"
+          name="request-filter"
+          id="filter-processed"
+        />
+        <input
+          class="filter-input"
+          type="radio"
+          name="request-filter"
+          id="filter-replayed"
+        />
+
+        <header class="ledger-header">
+          <span class="product-mark" aria-hidden="true">IL</span>
+          <span class="header-copy">
+            <small>PAYMENTS INFRASTRUCTURE</small>
+            <strong id="ledger-title">Idempotency request ledger</strong>
+            <span
+              >Trace how duplicate writes resolve to one safe response.</span
+            >
+          </span>
+          <span class="environment-badge">
+            <i aria-hidden="true"></i>
+            Production
+          </span>
+        </header>
+
+        <section class="overview" aria-label="Request overview">
+          <span class="metric">
+            <small>Requests today</small>
+            <strong>18,492</strong>
+            <em>+8.4%</em>
+          </span>
+          <span class="metric">
+            <small>Replay rate</small>
+            <strong>0.7%</strong>
+            <em>129 protected</em>
+          </span>
+          <span class="metric">
+            <small>Cache hit</small>
+            <strong>42 ms</strong>
+            <em>p50 latency</em>
+          </span>
+          <span class="health">
+            <span class="health-ring" aria-hidden="true">
+              <i></i>
+            </span>
+            <span>
+              <small>Ledger health</small>
+              <strong>99.99%</strong>
+            </span>
+          </span>
+        </section>
+
+        <div class="toolbar">
+          <span class="filter-tabs" role="group" aria-label="Filter requests">
+            <label for="filter-all">
+              All
+              <i>3</i>
+            </label>
+            <label for="filter-processed">
+              Processed
+              <i>2</i>
+            </label>
+            <label for="filter-replayed">
+              Replayed
+              <i>1</i>
+            </label>
+          </span>
+
+          <span class="live-status">
+            <i aria-hidden="true"></i>
+            Live events
+          </span>
+        </div>
+
+        <section class="request-list" aria-label="Recent idempotent requests">
+          <article class="request-row request-row--processed">
+            <span class="request-summary">
+              <span class="method method--post">POST</span>
+              <span>
+                <strong>/v1/payment_intents</strong>
+                <small>req_8fc2a41d</small>
+              </span>
+              <time datetime="2026-07-27T10:23:18+05:30">10:23:18</time>
+            </span>
+
+            <span class="resolution-flow">
+              <span class="flow-node">
+                <i class="node-icon">R</i>
+                <span>
+                  <small>Received</small>
+                  <strong>INR 4,850</strong>
+                </span>
+              </span>
+              <span class="flow-line" aria-hidden="true"><i></i></span>
+              <span class="flow-node flow-node--key">
+                <i class="node-icon">K</i>
+                <span>
+                  <small>Idempotency key</small>
+                  <strong>order_8472_pay</strong>
+                </span>
+              </span>
+              <span class="flow-line" aria-hidden="true"><i></i></span>
+              <span class="flow-node flow-node--success">
+                <i class="node-icon">OK</i>
+                <span>
+                  <small>New response</small>
+                  <strong>200 Processed</strong>
+                </span>
+              </span>
+            </span>
+
+            <footer class="request-footer">
+              <span><i></i> Stored for 24 hours</span>
+              <span>312 ms</span>
+            </footer>
+          </article>
+
+          <article class="request-row request-row--replayed">
+            <span class="request-summary">
+              <span class="method method--post">POST</span>
+              <span>
+                <strong>/v1/refunds</strong>
+                <small>req_b19e0d72</small>
+              </span>
+              <time datetime="2026-07-27T10:22:54+05:30">10:22:54</time>
+            </span>
+
+            <span class="resolution-flow">
+              <span class="flow-node">
+                <i class="node-icon">R</i>
+                <span>
+                  <small>Received again</small>
+                  <strong>INR 1,200</strong>
+                </span>
+              </span>
+              <span class="flow-line flow-line--replay" aria-hidden="true"
+                ><i></i
+              ></span>
+              <span class="flow-node flow-node--key">
+                <i class="node-icon">K</i>
+                <span>
+                  <small>Matching key</small>
+                  <strong>refund_1902</strong>
+                </span>
+              </span>
+              <span class="flow-line flow-line--replay" aria-hidden="true"
+                ><i></i
+              ></span>
+              <span class="flow-node flow-node--replay">
+                <i class="node-icon">RT</i>
+                <span>
+                  <small>Cached response</small>
+                  <strong>200 Replayed</strong>
+                </span>
+              </span>
+            </span>
+
+            <footer class="request-footer">
+              <span><i></i> Duplicate write prevented</span>
+              <span>38 ms</span>
+            </footer>
+          </article>
+
+          <article class="request-row request-row--processed">
+            <span class="request-summary">
+              <span class="method method--patch">PATCH</span>
+              <span>
+                <strong>/v1/subscriptions</strong>
+                <small>req_d77391bc</small>
+              </span>
+              <time datetime="2026-07-27T10:21:39+05:30">10:21:39</time>
+            </span>
+
+            <span class="resolution-flow">
+              <span class="flow-node">
+                <i class="node-icon">R</i>
+                <span>
+                  <small>Received</small>
+                  <strong>Plan change</strong>
+                </span>
+              </span>
+              <span class="flow-line" aria-hidden="true"><i></i></span>
+              <span class="flow-node flow-node--key">
+                <i class="node-icon">K</i>
+                <span>
+                  <small>Idempotency key</small>
+                  <strong>sub_702_upgrade</strong>
+                </span>
+              </span>
+              <span class="flow-line" aria-hidden="true"><i></i></span>
+              <span class="flow-node flow-node--success">
+                <i class="node-icon">OK</i>
+                <span>
+                  <small>New response</small>
+                  <strong>200 Processed</strong>
+                </span>
+              </span>
+            </span>
+
+            <footer class="request-footer">
+              <span><i></i> Stored for 24 hours</span>
+              <span>276 ms</span>
+            </footer>
+          </article>
+        </section>
+
+        <p class="empty-state">No requests match this filter.</p>
+
+        <footer class="ledger-footer">
+          <span>
+            <i aria-hidden="true"></i>
+            Responses are encrypted at rest
+          </span>
+          <button type="button">Export ledger</button>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/idempotency-request-ledger-kp/style.css
+++ b/submissions/examples/idempotency-request-ledger-kp/style.css
@@ -1,0 +1,856 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #0a0e10;
+  color: #eef2f1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.page-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 52px 20px;
+  background:
+    linear-gradient(rgba(116, 135, 132, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(116, 135, 132, 0.08) 1px, transparent 1px),
+    #0a0e10;
+  background-size: 32px 32px;
+}
+
+.ledger-shell {
+  position: relative;
+  width: min(100%, 1040px);
+  overflow: hidden;
+  border: 1px solid #2d3839;
+  border-radius: 8px;
+  background: #141a1c;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.42);
+}
+
+.filter-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ledger-header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 24px 28px;
+  border-bottom: 1px solid #293234;
+  background: #171e20;
+}
+
+.product-mark {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid #31564d;
+  border-radius: 6px;
+  background: #17332d;
+  color: #7ee6c4;
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.header-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.header-copy small {
+  color: #76ddbc;
+  font-size: 0.63rem;
+  font-weight: 800;
+}
+
+.header-copy strong {
+  overflow: hidden;
+  color: #f1f5f4;
+  font-size: 1.15rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-copy > span {
+  overflow: hidden;
+  color: #8f9d9d;
+  font-size: 0.73rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.environment-badge,
+.live-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #a9b5b3;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.environment-badge {
+  padding: 8px 10px;
+  border: 1px solid #30413e;
+  border-radius: 5px;
+  background: #192321;
+}
+
+.environment-badge i,
+.live-status i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #69dfb8;
+  box-shadow: 0 0 0 0 rgba(105, 223, 184, 0.36);
+  animation: live-pulse 1.8s ease-out infinite;
+}
+
+.overview {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) minmax(150px, 0.9fr);
+  gap: 1px;
+  margin: 0 28px;
+  border-right: 1px solid #2b3537;
+  border-bottom: 1px solid #2b3537;
+  border-left: 1px solid #2b3537;
+  background: #2b3537;
+}
+
+.metric,
+.health {
+  min-width: 0;
+  min-height: 88px;
+  padding: 17px 18px;
+  background: #111719;
+}
+
+.metric {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-content: center;
+  gap: 5px 10px;
+}
+
+.metric small {
+  grid-column: 1 / -1;
+  color: #768586;
+  font-size: 0.63rem;
+}
+
+.metric strong {
+  color: #e7eceb;
+  font-size: 1.1rem;
+}
+
+.metric em {
+  align-self: center;
+  overflow: hidden;
+  color: #76dcbc;
+  font-size: 0.61rem;
+  font-style: normal;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.health {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.health-ring {
+  position: relative;
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(#73dfbd 0 91%, #2b3937 91% 100%);
+}
+
+.health-ring::before {
+  width: 32px;
+  height: 32px;
+  border-radius: inherit;
+  background: #111719;
+  content: "";
+}
+
+.health-ring i {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #73dfbd;
+  animation: ring-orbit 3s linear infinite;
+  transform-origin: 0 0;
+}
+
+.health > span:last-child {
+  display: grid;
+  gap: 4px;
+}
+
+.health small {
+  color: #768586;
+  font-size: 0.61rem;
+}
+
+.health strong {
+  color: #e7eceb;
+  font-size: 0.9rem;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 22px 28px 14px;
+}
+
+.filter-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid #2c3739;
+  border-radius: 6px;
+  background: #101618;
+}
+
+.filter-tabs label {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 11px;
+  border-radius: 4px;
+  color: #869495;
+  cursor: pointer;
+  font-size: 0.68rem;
+  font-weight: 750;
+  transition:
+    background-color 170ms ease,
+    color 170ms ease,
+    transform 170ms ease;
+}
+
+.filter-tabs label:hover {
+  color: #dce3e1;
+  transform: translateY(-1px);
+}
+
+.filter-tabs label i {
+  display: grid;
+  min-width: 18px;
+  height: 18px;
+  place-items: center;
+  border-radius: 4px;
+  background: #253033;
+  color: #93a1a2;
+  font-size: 0.58rem;
+  font-style: normal;
+}
+
+#filter-all:focus-visible ~ .toolbar label[for="filter-all"],
+#filter-processed:focus-visible ~ .toolbar label[for="filter-processed"],
+#filter-replayed:focus-visible ~ .toolbar label[for="filter-replayed"] {
+  outline: 3px solid rgba(114, 222, 187, 0.28);
+  outline-offset: 2px;
+}
+
+#filter-all:checked ~ .toolbar label[for="filter-all"],
+#filter-processed:checked ~ .toolbar label[for="filter-processed"],
+#filter-replayed:checked ~ .toolbar label[for="filter-replayed"] {
+  background: #263531;
+  color: #e7f3ef;
+}
+
+#filter-all:checked ~ .toolbar label[for="filter-all"] i,
+#filter-processed:checked ~ .toolbar label[for="filter-processed"] i,
+#filter-replayed:checked ~ .toolbar label[for="filter-replayed"] i {
+  background: #315b4f;
+  color: #85e9c7;
+}
+
+.request-list {
+  display: grid;
+  gap: 10px;
+  padding: 0 28px 24px;
+}
+
+.request-row {
+  overflow: hidden;
+  border: 1px solid #2d383a;
+  border-radius: 7px;
+  background: #101618;
+  animation: row-enter 420ms both;
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.request-row:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.request-row:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.request-row:hover {
+  border-color: #405050;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.17);
+  transform: translateY(-2px);
+}
+
+.request-row--replayed {
+  border-color: #55483a;
+  background: #171715;
+}
+
+.request-row--replayed:hover {
+  border-color: #6b5943;
+}
+
+.request-summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid #273133;
+}
+
+.method {
+  display: grid;
+  min-width: 48px;
+  min-height: 24px;
+  place-items: center;
+  border-radius: 4px;
+  font-size: 0.56rem;
+  font-weight: 850;
+}
+
+.method--post {
+  background: #17372f;
+  color: #77dfbd;
+}
+
+.method--patch {
+  background: #293047;
+  color: #aebaf5;
+}
+
+.request-summary > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 9px;
+}
+
+.request-summary strong {
+  overflow: hidden;
+  color: #dde4e2;
+  font-size: 0.71rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.request-summary small {
+  color: #657476;
+  font-family: SFMono-Regular, Consolas, monospace;
+  font-size: 0.59rem;
+}
+
+.request-summary time {
+  color: #758385;
+  font-family: SFMono-Regular, Consolas, monospace;
+  font-size: 0.6rem;
+}
+
+.resolution-flow {
+  display: grid;
+  grid-template-columns:
+    minmax(150px, 1fr) minmax(42px, 0.32fr) minmax(170px, 1.1fr)
+    minmax(42px, 0.32fr) minmax(150px, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 14px;
+}
+
+.flow-node {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  align-items: center;
+  min-width: 0;
+  gap: 9px;
+  padding: 10px;
+  border: 1px solid #2e393b;
+  border-radius: 6px;
+  background: #182022;
+}
+
+.flow-node > span {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.flow-node small {
+  color: #718082;
+  font-size: 0.57rem;
+}
+
+.flow-node strong {
+  overflow: hidden;
+  color: #d7dfdd;
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border-radius: 5px;
+  background: #283438;
+  color: #b9c4c3;
+  font-size: 0.58rem;
+  font-style: normal;
+  font-weight: 850;
+}
+
+.flow-node--key {
+  border-color: #395348;
+  background: #17231f;
+}
+
+.flow-node--key .node-icon {
+  background: #24453a;
+  color: #7fe3c1;
+}
+
+.flow-node--success {
+  border-color: #2e5449;
+  background: #14251f;
+}
+
+.flow-node--success .node-icon {
+  background: #1f5746;
+  color: #8cf0ce;
+}
+
+.flow-node--replay {
+  border-color: #66523b;
+  background: #282219;
+}
+
+.flow-node--replay .node-icon {
+  background: #5d472d;
+  color: #ffd195;
+}
+
+.flow-line {
+  position: relative;
+  height: 1px;
+  background: #3b504b;
+}
+
+.flow-line::after {
+  position: absolute;
+  top: -3px;
+  right: 0;
+  width: 6px;
+  height: 6px;
+  border-top: 1px solid #72dcbc;
+  border-right: 1px solid #72dcbc;
+  content: "";
+  transform: rotate(45deg);
+}
+
+.flow-line i {
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #72dcbc;
+  box-shadow: 0 0 8px rgba(114, 220, 188, 0.7);
+  animation: request-travel 1.8s ease-in-out infinite;
+}
+
+.flow-line--replay {
+  background: #624e39;
+}
+
+.flow-line--replay::after {
+  border-color: #eebc78;
+}
+
+.flow-line--replay i {
+  background: #f1bd76;
+  box-shadow: 0 0 8px rgba(241, 189, 118, 0.6);
+}
+
+.request-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 14px;
+  border-top: 1px solid #273133;
+  color: #718082;
+  font-size: 0.58rem;
+}
+
+.request-footer > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.request-footer i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #65d6b2;
+}
+
+.request-row--replayed .request-footer i {
+  background: #efb76f;
+}
+
+#filter-processed:checked ~ .request-list .request-row--replayed,
+#filter-replayed:checked ~ .request-list .request-row--processed {
+  display: none;
+}
+
+.empty-state {
+  display: none;
+  margin: 0 28px 24px;
+  padding: 28px;
+  border: 1px dashed #344143;
+  border-radius: 7px;
+  color: #819092;
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+.ledger-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 28px;
+  border-top: 1px solid #293234;
+  background: #111719;
+}
+
+.ledger-footer > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #718082;
+  font-size: 0.62rem;
+}
+
+.ledger-footer > span i {
+  position: relative;
+  width: 10px;
+  height: 9px;
+  border: 1px solid #62cfae;
+  border-radius: 2px;
+}
+
+.ledger-footer > span i::before {
+  position: absolute;
+  top: -6px;
+  left: 1px;
+  width: 6px;
+  height: 6px;
+  border: 1px solid #62cfae;
+  border-bottom: 0;
+  border-radius: 6px 6px 0 0;
+  content: "";
+}
+
+.ledger-footer button {
+  min-height: 36px;
+  padding: 0 14px;
+  border: 1px solid #3b4a4c;
+  border-radius: 5px;
+  background: #20292b;
+  color: #d6dfdd;
+  cursor: pointer;
+  font-size: 0.66rem;
+  font-weight: 750;
+  transition:
+    border-color 170ms ease,
+    background-color 170ms ease,
+    transform 170ms ease;
+}
+
+.ledger-footer button:hover {
+  border-color: #598378;
+  background: #263432;
+  transform: translateY(-1px);
+}
+
+.ledger-footer button:focus-visible {
+  outline: 3px solid rgba(114, 222, 187, 0.28);
+  outline-offset: 2px;
+}
+
+@keyframes row-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}
+
+@keyframes request-travel {
+  0% {
+    opacity: 0;
+    transform: translateX(0);
+  }
+
+  18% {
+    opacity: 1;
+  }
+
+  82% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateX(calc(100% + 34px));
+  }
+}
+
+@keyframes live-pulse {
+  70% {
+    box-shadow: 0 0 0 7px rgba(105, 223, 184, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(105, 223, 184, 0);
+  }
+}
+
+@keyframes ring-orbit {
+  from {
+    transform: rotate(0deg) translateY(-18px);
+  }
+
+  to {
+    transform: rotate(360deg) translateY(-18px);
+  }
+}
+
+@media (max-width: 840px) {
+  .overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .resolution-flow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .flow-line {
+    width: 1px;
+    height: 25px;
+    margin-left: 30px;
+  }
+
+  .flow-line::after {
+    top: auto;
+    right: -3px;
+    bottom: 0;
+    transform: rotate(135deg);
+  }
+
+  .flow-line i {
+    top: 0;
+    left: -2px;
+    animation-name: request-travel-mobile;
+  }
+}
+
+@media (max-width: 600px) {
+  .page-shell {
+    align-items: start;
+    padding: 10px;
+  }
+
+  .ledger-header {
+    grid-template-columns: auto minmax(0, 1fr);
+    padding: 18px 16px;
+  }
+
+  .environment-badge {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .header-copy strong,
+  .header-copy > span {
+    white-space: normal;
+  }
+
+  .overview {
+    grid-template-columns: 1fr 1fr;
+    margin: 0 16px;
+  }
+
+  .metric,
+  .health {
+    min-height: 80px;
+    padding: 14px;
+  }
+
+  .metric {
+    grid-template-columns: 1fr;
+  }
+
+  .metric em {
+    text-align: left;
+  }
+
+  .toolbar {
+    display: grid;
+    padding: 18px 16px 12px;
+  }
+
+  .filter-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .filter-tabs label {
+    justify-content: center;
+    min-width: 0;
+    padding: 0 5px;
+  }
+
+  .live-status {
+    justify-self: end;
+  }
+
+  .request-list {
+    padding: 0 16px 18px;
+  }
+
+  .request-summary {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .request-summary > span:nth-child(2) {
+    display: grid;
+    gap: 3px;
+  }
+
+  .request-summary time {
+    grid-column: 2;
+  }
+
+  .ledger-footer {
+    display: grid;
+    padding: 16px;
+  }
+
+  .ledger-footer button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 420px) {
+  .overview {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-tabs label {
+    gap: 4px;
+    font-size: 0.61rem;
+  }
+
+  .filter-tabs label i {
+    min-width: 16px;
+    height: 16px;
+  }
+
+  .request-footer {
+    align-items: flex-start;
+  }
+}
+
+@keyframes request-travel-mobile {
+  0% {
+    opacity: 0;
+    transform: translateY(0);
+  }
+
+  18% {
+    opacity: 1;
+  }
+
+  82% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained idempotency request ledger for inspecting how duplicate API writes resolve to one safe response. The component combines semantic status filters, animated request-to-key resolution flows, processed and replayed states, operational metrics, and a compact mobile layout without JavaScript.

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive operational ledger that visualizes idempotency-key resolution across received, matched, processed, and replayed API request states.

**How does a developer use it?**

```html
<input type="radio" name="request-filter" id="filter-replayed" />
<label for="filter-replayed">Replayed</label>

<article class="request-row request-row--replayed">
  <span class="flow-node">Received again</span>
  <span class="flow-line flow-line--replay" aria-hidden="true"><i></i></span>
  <span class="flow-node flow-node--key">Matching key</span>
  <span class="flow-line flow-line--replay" aria-hidden="true"><i></i></span>
  <span class="flow-node flow-node--replay">Cached response</span>
</article>
```

**Why does it fit EaseMotion CSS?**

Motion explains request resolution rather than decorating it. The implementation stays CSS-only and human-readable while semantic controls, keyboard focus, responsive flow direction, compact data states, and reduced-motion support make it practical.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome (Playwright Chromium at desktop and mobile viewports)
- [ ] Firefox
- [ ] Edge
- [ ] Safari (optional but appreciated)

---

## Notes for Maintainer

Validated with Prettier, Stylelint through stdin (the repository ignore file excludes submissions), `git diff --cached --check`, and Playwright interaction tests. Verified all/processed/replayed keyboard filtering, expected row counts, focus state, responsive horizontal-to-vertical flows, and zero horizontal overflow at 1280px and 500px widths.
