### PR TITLE
fix: prevent floating label overlap after autofill

### DIFF
--- a/submissions/examples/floating-label-autofill-fix/README.md
+++ b/submissions/examples/floating-label-autofill-fix/README.md
@@ -1,0 +1,35 @@
+# Floating Label Autofill Fix
+
+## Description
+
+This example fixes the issue where floating labels overlap autofilled input text. The label automatically moves above the field whenever the browser fills the input.
+
+## Features
+
+- Floating labels
+- Browser autofill support
+- Responsive design
+- Pure HTML & CSS
+- Smooth label transition
+
+## Usage
+
+```html
+<div class="input-group">
+    <input type="email" placeholder=" ">
+    <label>Email Address</label>
+</div>
+```
+
+## Fix Applied
+
+- Added support for `:-webkit-autofill`.
+- Floats the label when the browser autofills the input.
+- Preserves smooth transitions.
+- Keeps autofilled text readable.
+
+## Files
+
+- demo.html
+- style.css
+- README.md

--- a/submissions/examples/floating-label-autofill-fix/demo.html
+++ b/submissions/examples/floating-label-autofill-fix/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Floating Label Autofill Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="form-container">
+
+  <h2>Login</h2>
+
+  <form>
+
+    <div class="input-group">
+      <input
+        type="email"
+        id="email"
+        name="email"
+        placeholder=" "
+        autocomplete="email"
+        required
+      >
+      <label for="email">Email Address</label>
+    </div>
+
+    <div class="input-group">
+      <input
+        type="password"
+        id="password"
+        name="password"
+        placeholder=" "
+        autocomplete="current-password"
+        required
+      >
+      <label for="password">Password</label>
+    </div>
+
+    <button type="submit">Login</button>
+
+  </form>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/floating-label-autofill-fix/style.css
+++ b/submissions/examples/floating-label-autofill-fix/style.css
@@ -1,0 +1,100 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    font-family:Arial, Helvetica, sans-serif;
+    background:#f4f6fb;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    min-height:100vh;
+}
+
+.form-container{
+    width:360px;
+    background:#fff;
+    padding:35px;
+    border-radius:14px;
+    box-shadow:0 10px 25px rgba(0,0,0,.1);
+}
+
+h2{
+    text-align:center;
+    margin-bottom:30px;
+}
+
+.input-group{
+    position:relative;
+    margin-bottom:24px;
+}
+
+.input-group input{
+    width:100%;
+    padding:16px 14px;
+    border:2px solid #ccc;
+    border-radius:8px;
+    font-size:16px;
+    background:transparent;
+    outline:none;
+}
+
+.input-group label{
+    position:absolute;
+    left:14px;
+    top:16px;
+    background:#fff;
+    color:#777;
+    padding:0 4px;
+    transition:.25s ease;
+    pointer-events:none;
+}
+
+/* Float label when focused or filled */
+
+.input-group input:focus + label,
+.input-group input:not(:placeholder-shown) + label,
+.input-group input:-webkit-autofill + label{
+    top:-10px;
+    left:10px;
+    font-size:12px;
+    color:#2563eb;
+}
+
+.input-group input:focus{
+    border-color:#2563eb;
+}
+
+/* Autofill Fix */
+
+.input-group input:-webkit-autofill,
+.input-group input:-webkit-autofill:hover,
+.input-group input:-webkit-autofill:focus{
+    -webkit-text-fill-color:#222;
+    transition:background-color 9999s ease-in-out 0s;
+}
+
+button{
+    width:100%;
+    padding:14px;
+    border:none;
+    border-radius:8px;
+    background:#2563eb;
+    color:#fff;
+    font-size:16px;
+    cursor:pointer;
+}
+
+button:hover{
+    background:#1d4ed8;
+}
+
+@media(max-width:480px){
+
+    .form-container{
+        width:90%;
+    }
+
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes the issue where floating labels overlap autofilled input values. The implementation ensures that labels automatically transition to their active (floating) position whenever the browser autofills a field, improving readability and providing a consistent user experience.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/floating-label-autofill-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes floating label behavior so labels automatically move above autofilled input values instead of overlapping the text.

**How does a developer use it?**

```html
<div class="input-group">
  <input
    type="email"
    id="email"
    placeholder=" "
    autocomplete="email"
    required
  >
  <label for="email">Email Address</label>
</div>
```

**Why does it fit EaseMotion CSS?**

This fix improves the usability and accessibility of floating input fields while keeping the solution lightweight, reusable, responsive, and CSS-only. It ensures consistent behavior across manual input and browser autofill scenarios.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- Added support for browser autofill using `:-webkit-autofill`.
- Ensured floating labels remain in the active position after autofill.
- Preserved existing label animations and transitions.
- No changes were made outside the `submissions/` directory.

**Fixes #<issue-number>**