### PR TITLE
fix: prevent progress bar percentage label from overflowing at 100% (#56076)

### DIFF
--- a/submissions/examples/fix-progress-label-sah/README.md
+++ b/submissions/examples/fix-progress-label-sah/README.md
@@ -1,0 +1,17 @@
+# Progress Bar Percentage Label Overflow Fix (`#56076`)
+
+## What does this do?
+Prevents percentage text tags from overflowing or popping outside progress bars when reaching 100% capacity by enclosing labels inside an inner flex-clamped boundary.
+
+## How is it used?
+Embed the label within the filling bar and attach the `clamped` modifier class:
+```html
+<div class="ease-progress-bar">
+  <div class="progress-fill" style="width: 100%;">
+    <span class="progress-label clamped">100% ✓</span>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Resolves issue #56076 by maintaining spotless visual alignment across progress feedback dashboards without requiring external JavaScript calculation hacks.

--- a/submissions/examples/fix-progress-label-sah/demo.html
+++ b/submissions/examples/fix-progress-label-sah/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Progress Bar Label Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="progress-showcase">
+    <h1>Progress Bar Label Fix (<code>#56076</code>)</h1>
+    <p class="subtitle">Ensures percentage labels never burst out of container boundaries at full 100% capacity.</p>
+    
+    <div class="progress-card">
+      <div class="bar-group">
+        <span class="bar-title">Initial Load (45%)</span>
+        <div class="ease-progress-bar">
+          <div class="progress-fill" style="width: 45%;">
+            <span class="progress-label">45%</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="bar-group">
+        <span class="bar-title">Near Complete (85%)</span>
+        <div class="ease-progress-bar">
+          <div class="progress-fill accent" style="width: 85%;">
+            <span class="progress-label">85%</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="bar-group">
+        <span class="bar-title">Fully Complete (100%) - Zero Overflow Fix</span>
+        <div class="ease-progress-bar">
+          <div class="progress-fill success" style="width: 100%;">
+            <span class="progress-label clamped">100% ✓</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-progress-label-sah/style.css
+++ b/submissions/examples/fix-progress-label-sah/style.css
@@ -1,0 +1,37 @@
+:root { --bg: #090d16; --card: #131b2e; --text: #f8fafc; }
+* { box-sizing: border-box; margin: 0; padding: 0; font-family: system-ui, sans-serif; }
+body { background: var(--bg); color: var(--text); min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 2rem 1.5rem; }
+.progress-showcase { max-width: 650px; width: 100%; }
+h1 { font-size: 1.6rem; color: #fff; margin-bottom: 0.5rem; }
+code { color: #10b981; background: rgba(16, 185, 129, 0.15); padding: 0.2rem 0.5rem; border-radius: 6px; font-family: monospace; }
+.subtitle { color: #94a3b8; font-size: 0.95rem; margin-bottom: 2.5rem; }
+.progress-card { background: var(--card); padding: 2.5rem; border-radius: 16px; border: 1px solid rgba(255,255,255,0.08); box-shadow: 0 15px 35px rgba(0,0,0,0.4); display: flex; flex-direction: column; gap: 2rem; }
+.bar-group { display: flex; flex-direction: column; gap: 0.6rem; }
+.bar-title { font-size: 0.9rem; font-weight: 600; color: #cbd5e1; }
+/* Fix #56076 Implementation: Internal clamped labels to prevent overflow at 100% */
+.ease-progress-bar {
+  width: 100%;
+  height: 24px;
+  background: #0b1120;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.06);
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.5);
+  position: relative;
+}
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #3b82f6, #60a5fa);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 12px;
+  transition: width 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+  position: relative;
+}
+.progress-fill.accent { background: linear-gradient(90deg, #8b5cf6, #a78bfa); }
+.progress-fill.success { background: linear-gradient(90deg, #059669, #10b981); }
+.progress-label { font-size: 0.75rem; font-weight: 700; color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.5); white-space: nowrap; }
+/* Clamped modifier ensures inner-right safety margin regardless of bar width */
+.progress-label.clamped { padding-left: 8px; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }


### PR DESCRIPTION
Resolves #56076.