### PR TITLE
fix: prevent notification badge from overlapping icon at large counts (#56067)

### DIFF
--- a/submissions/examples/fix-badge-overlap-sah/README.md
+++ b/submissions/examples/fix-badge-overlap-sah/README.md
@@ -1,0 +1,16 @@
+# Notification Badge Icon Overlap Fix (`#56067`)
+
+## What does this do?
+Prevents numerical notification badges from overlapping or obscuring toolbar icons when displaying multi-digit numbers (like `99+`) using scalable pill geometry.
+
+## How is it used?
+Attach `ease-badge-count` (with optional `pill-fix` modifier for high-count triggers) directly to badge spans inside relatively positioned containers:
+```html
+<div style="position: relative;">
+  <span class="icon">🔔</span>
+  <span class="ease-badge-count danger pill-fix">99+</span>
+</div>
+```
+
+## Why is it useful?
+Solves issue #56067 by accommodating responsive content growth while protecting visual hierarchy across toolbars and navigation bells.

--- a/submissions/examples/fix-badge-overlap-sah/demo.html
+++ b/submissions/examples/fix-badge-overlap-sah/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Notification Badge Overflow Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="gallery">
+    <h1>Notification Badge Fix (<code>#56067</code>)</h1>
+    <p>Scalable pill-shape dimensions ensure triple-digit counts (like <code>99+</code>) extend outwards rather than overlapping trigger icons.</p>
+    
+    <div class="badge-row">
+      <div class="icon-box">
+        <span class="icon">🔔</span>
+        <span class="ease-badge-count">3</span>
+        <span class="label">Single Digit</span>
+      </div>
+
+      <div class="icon-box">
+        <span class="icon">💬</span>
+        <span class="ease-badge-count accent">24</span>
+        <span class="label">Double Digit</span>
+      </div>
+
+      <div class="icon-box">
+        <span class="icon">📫</span>
+        <span class="ease-badge-count danger pill-fix">99+</span>
+        <span class="label">Large Count (Fixed)</span>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fix-badge-overlap-sah/style.css
+++ b/submissions/examples/fix-badge-overlap-sah/style.css
@@ -1,0 +1,35 @@
+:root { --bg: #090d16; --surface: #131b2e; --text: #f8fafc; --danger: #ef4444; }
+* { box-sizing: border-box; margin: 0; padding: 0; font-family: system-ui, sans-serif; }
+body { background: var(--bg); color: var(--text); min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 2rem; }
+.gallery { background: var(--surface); padding: 3rem 2.5rem; border-radius: 16px; border: 1px solid rgba(255,255,255,0.08); box-shadow: 0 15px 35px rgba(0,0,0,0.5); text-align: center; max-width: 650px; width: 100%; }
+h1 { font-size: 1.6rem; color: #fff; margin-bottom: 0.5rem; }
+code { color: #f87171; background: rgba(239, 68, 68, 0.15); padding: 0.2rem 0.5rem; border-radius: 6px; font-family: monospace; }
+p { color: #94a3b8; font-size: 0.95rem; margin-bottom: 3rem; line-height: 1.5; }
+.badge-row { display: flex; justify-content: space-around; gap: 2rem; flex-wrap: wrap; }
+.icon-box { position: relative; background: #1e293b; width: 70px; height: 70px; border-radius: 16px; display: flex; align-items: center; justify-content: center; border: 1px solid rgba(255,255,255,0.1); box-shadow: 0 10px 20px rgba(0,0,0,0.3); margin-bottom: 2rem; }
+.icon { font-size: 2rem; }
+.label { position: absolute; bottom: -30px; font-size: 0.85rem; color: #cbd5e1; white-space: nowrap; font-weight: 600; }
+/* Fix #56067 Implementation: Pill scaling formatting prevents icon occlusion */
+.ease-badge-count {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background: #3b82f6;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 800;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--surface);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.4);
+  line-height: 1;
+}
+.ease-badge-count.accent { background: #8b5cf6; }
+.ease-badge-count.danger { background: var(--danger); }
+/* Pill-fix guarantees outwards right extension rather than internal icon overlap */
+.ease-badge-count.pill-fix { right: -14px; padding: 0 8px; font-size: 0.72rem; }


### PR DESCRIPTION
Resolves #56067.