### PR TITLE
Add responsive statistics cards with count-up animation (responsive-s…

### DIFF
--- a/submissions/examples/responsive-stat-cards-hr18/README.md
+++ b/submissions/examples/responsive-stat-cards-hr18/README.md
@@ -1,0 +1,88 @@
+# Responsive Statistics Cards (`responsive-stat-cards-hr18`)
+
+A responsive row of statistic cards — icon, big number, label, hover lift
+— with a count-up entrance animation, built for issue
+[#55318](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55318).
+
+## A note on naming
+
+The issue's own filenames (`index.html`, `styles.css`) don't match this
+repo's actual enforced submission convention — `demo.html` + `style.css`
++ `README.md`. This submission uses that convention instead.
+
+## What it does
+
+Four stat cards (Active users, Downloads today, Monthly revenue, Customer
+satisfaction), each with an icon badge, a large number, and a short label.
+Hovering a card lifts it with a soft shadow, per the issue's spec. Beyond
+the literal starter snippet, each number **counts up from 0** to its
+final value once the card scrolls into view, rather than appearing
+instantly — a small addition in keeping with the framework's
+animation-first philosophy, since a static number felt like a missed
+opportunity for motion in an otherwise animated card.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<div class="ease-stats-container-hr18">
+  <div class="ease-stat-card-hr18">
+    <span class="rsc-icon-hr18" aria-hidden="true"><!-- icon SVG --></span>
+    <h2><span class="rsc-count-hr18" data-target="12.4" data-decimals="1">0</span>K</h2>
+    <p>Active users</p>
+  </div>
+  <!-- more cards -->
+</div>
+```
+
+`.ease-stats-container-hr18` is a wrapping flex row; `.ease-stat-card-hr18`
+is the individual card, with its hover-lift transition defined entirely in
+CSS. The count-up itself is handled by a small script in `demo.html`:
+
+- `data-target` on the `.rsc-count-hr18` span holds the final numeric
+  value (e.g. `12.4`, `350`, `98`)
+- `data-decimals` controls how many decimal places to display
+- Any prefix/suffix (`$`, `K`, `%`) is written as plain static text
+  directly around the span in the markup, so the animated part is only
+  ever the number itself
+
+An `IntersectionObserver` triggers each card's count-up once, the first
+time it's at least 40% visible, using `requestAnimationFrame` and an
+eased curve (`easeOutCubic`) rather than a linear count, so the animation
+feels like it settles into place instead of ticking mechanically.
+
+## Accessibility notes
+
+- `font-variant-numeric: tabular-nums` on the number keeps each digit the
+  same width, so the card doesn't visibly reflow or jitter as the count-up
+  animation changes how many characters are displayed.
+- `@media (prefers-reduced-motion: reduce)` is checked before the
+  animation ever starts — if set, every number jumps straight to its
+  final value with no count-up at all, and the card's hover-lift
+  `transition` is also disabled.
+- The icon badges are marked `aria-hidden="true"`, since they're purely
+  decorative next to a text label that already conveys the same
+  information.
+
+## Responsiveness
+
+Cards wrap onto additional rows via `flex-wrap` as the viewport narrows,
+and below `480px` each card switches from a fixed width to a
+`max-width`-constrained full-width block, so there's never an awkward
+half-width card left dangling at the end of a row on a phone.
+
+## Why this fits EaseMotion CSS
+
+A self-contained, reusable component matching the issue's exact spec
+(icon, number, label, hover lift, responsive), with one small,
+purposeful animation addition — a count-up gated behind
+`prefers-reduced-motion` — that reflects the framework's animation-first
+character rather than presenting static numbers.
+
+All classes and the folder itself use a `-hr18` suffix to avoid colliding
+with any other contributor's submission under `submissions/examples/`.

--- a/submissions/examples/responsive-stat-cards-hr18/demo.html
+++ b/submissions/examples/responsive-stat-cards-hr18/demo.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Responsive Statistics Cards</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="rsc-hr18">
+  <div class="rsc-wrap-hr18">
+
+    <h1>Trusted by teams everywhere</h1>
+    <p>Scroll the numbers into view (or reload the page) to see them count up.</p>
+
+    <div class="ease-stats-container-hr18">
+
+      <div class="ease-stat-card-hr18">
+        <span class="rsc-icon-hr18" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>
+        </span>
+        <h2><span class="rsc-count-hr18" data-target="12.4" data-decimals="1">0</span>K</h2>
+        <p>Active users</p>
+      </div>
+
+      <div class="ease-stat-card-hr18">
+        <span class="rsc-icon-hr18" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+        </span>
+        <h2><span class="rsc-count-hr18" data-target="350" data-decimals="0">0</span></h2>
+        <p>Downloads today</p>
+      </div>
+
+      <div class="ease-stat-card-hr18">
+        <span class="rsc-icon-hr18" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"></line><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg>
+        </span>
+        <h2>$<span class="rsc-count-hr18" data-target="89" data-decimals="0">0</span>K</h2>
+        <p>Monthly revenue</p>
+      </div>
+
+      <div class="ease-stat-card-hr18">
+        <span class="rsc-icon-hr18" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+        </span>
+        <h2><span class="rsc-count-hr18" data-target="98" data-decimals="0">0</span>%</h2>
+        <p>Customer satisfaction</p>
+      </div>
+
+    </div>
+
+    <div class="rsc-tuning-hr18">
+      <h2>How the count-up works</h2>
+      <p>Each number's final value lives in a <code>data-target</code>
+        attribute on its <code>.rsc-count-hr18</code> span. A small
+        IntersectionObserver-based script animates from 0 to that target
+        once the card scrolls into view, using
+        <code>requestAnimationFrame</code> and an eased curve — the card
+        itself stays plain, static markup otherwise, and the hover-lift
+        transition is handled entirely by CSS.</p>
+    </div>
+
+    <p class="rsc-footnote-hr18">submissions/examples/responsive-stat-cards-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  function easeOutCubic(t) {
+    return 1 - Math.pow(1 - t, 3);
+  }
+
+  function animateCount(el) {
+    var target = parseFloat(el.getAttribute("data-target"));
+    var decimals = parseInt(el.getAttribute("data-decimals"), 10) || 0;
+    var duration = 1200;
+    var start = null;
+
+    function step(timestamp) {
+      if (start === null) start = timestamp;
+      var elapsed = timestamp - start;
+      var progress = Math.min(elapsed / duration, 1);
+      var eased = easeOutCubic(progress);
+      var current = target * eased;
+      el.textContent = current.toFixed(decimals);
+      if (progress < 1) {
+        window.requestAnimationFrame(step);
+      } else {
+        el.textContent = target.toFixed(decimals);
+      }
+    }
+
+    window.requestAnimationFrame(step);
+  }
+
+  var counts = document.querySelectorAll(".rsc-count-hr18");
+  var prefersReducedMotion =
+    window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  if (prefersReducedMotion) {
+    // Respect the preference by jumping straight to the final values
+    // instead of running the count-up animation at all.
+    counts.forEach(function (el) {
+      var target = parseFloat(el.getAttribute("data-target"));
+      var decimals = parseInt(el.getAttribute("data-decimals"), 10) || 0;
+      el.textContent = target.toFixed(decimals);
+    });
+    return;
+  }
+
+  if (!("IntersectionObserver" in window)) {
+    counts.forEach(animateCount);
+    return;
+  }
+
+  var observer = new IntersectionObserver(
+    function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          animateCount(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.4 }
+  );
+
+  counts.forEach(function (el) {
+    observer.observe(el);
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/responsive-stat-cards-hr18/style.css
+++ b/submissions/examples/responsive-stat-cards-hr18/style.css
@@ -1,0 +1,166 @@
+/* ==========================================================================
+   responsive-stat-cards-hr18 — style.css
+   Responsive Statistics Cards
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.rsc-hr18 {
+  --bg-hr18: #f4f6fb;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e4e8f2;
+  --text-hr18: #14161f;
+  --muted-hr18: #676c7f;
+  --accent-hr18: #2563eb;
+  --accent-soft-hr18: #e9efff;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  padding: 3.5rem 1.5rem;
+}
+
+.rsc-hr18 * {
+  box-sizing: border-box;
+}
+
+.rsc-wrap-hr18 {
+  max-width: 880px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.rsc-wrap-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  margin: 0 0 0.5rem;
+}
+
+.rsc-wrap-hr18 > p {
+  margin: 0 0 2.25rem;
+  color: var(--muted-hr18);
+  font-size: 0.92rem;
+}
+
+/* ==========================================================================
+   The reusable stat card component
+   ========================================================================== */
+
+.ease-stats-container-hr18 {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.ease-stat-card-hr18 {
+  width: 200px;
+  padding: 1.6rem 1.4rem;
+  text-align: center;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 16px;
+  box-shadow: 0 1px 2px rgba(15, 20, 40, 0.03), 0 10px 24px rgba(15, 20, 40, 0.06);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-stat-card-hr18:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 1px 2px rgba(15, 20, 40, 0.04), 0 20px 34px rgba(15, 20, 40, 0.1);
+}
+
+.rsc-icon-hr18 {
+  width: 44px;
+  height: 44px;
+  margin: 0 auto 0.9rem;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+}
+
+.ease-stat-card-hr18 h2 {
+  margin: 0;
+  color: var(--accent-hr18);
+  font-family: var(--font-display-hr18);
+  font-size: 2.1rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.ease-stat-card-hr18 p {
+  margin-top: 0.5rem;
+  color: var(--muted-hr18);
+  font-size: 0.86rem;
+}
+
+/* ---- The count-up number: styling only. The animation from 0 up to the
+   card's target value is handled by the small script in demo.html, which
+   rewrites this element's text content on each frame — no CSS animation
+   can read an arbitrary numeric target out of markup on its own. --------- */
+.rsc-count-hr18 {
+  display: inline;
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.rsc-tuning-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.25rem 1.4rem;
+  text-align: left;
+}
+
+.rsc-tuning-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1rem;
+  margin: 0 0 0.6rem;
+}
+
+.rsc-tuning-hr18 p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted-hr18);
+  line-height: 1.55;
+}
+
+.rsc-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+}
+
+.rsc-footnote-hr18 {
+  margin-top: 1.75rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Responsive: cards shrink to fill a single column on very narrow
+   screens rather than relying on wrapping alone, so there's no
+   awkward half-width leftover card on a phone. ---------------------------- */
+@media (max-width: 480px) {
+  .ease-stat-card-hr18 {
+    width: 100%;
+    max-width: 280px;
+  }
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.rsc-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stat-card-hr18 {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a responsive row of statistic cards (icon, big number, label,
hover-lift) matching the issue's spec, plus a count-up entrance
animation — each number animates from 0 to its final value once the card
scrolls into view (IntersectionObserver + requestAnimationFrame with an
eased curve), rather than appearing instantly. Four example cards: Active
users, Downloads today, Monthly revenue, Customer satisfaction.

Resolves #55318

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/responsive-stat-cards-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Responsive statistics cards with icon, count-up number, label, and
hover-lift, built from a reusable container + card class pair.

**How does a developer use it?**
```html
<div class="ease-stats-container-hr18">
  <div class="ease-stat-card-hr18">
    <span class="rsc-icon-hr18" aria-hidden="true"><!-- icon SVG --></span>
    <h2><span class="rsc-count-hr18" data-target="12.4" data-decimals="1">0</span>K</h2>
    <p>Active users</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Matches the issue's exact spec (icon, number, label, hover lift,
responsive) with one purposeful animation addition — a count-up gated
behind prefers-reduced-motion — reflecting the framework's
animation-first character rather than static numbers.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
font-variant-numeric: tabular-nums keeps digit width stable during the
count-up so cards don't jitter. prefers-reduced-motion is checked before
the animation starts — if set, numbers jump straight to their final
value and the hover-lift transition is disabled too. Tested scroll-reveal
and reduced-motion behavior in Chrome; haven't checked other browsers yet.