### PR TITLE
Add prefers-reduced-motion interactive demo example (prefers-reduced-…

### DIFF
--- a/submissions/examples/prefers-reduced-motion-demo-hr18/README.md
+++ b/submissions/examples/prefers-reduced-motion-demo-hr18/README.md
@@ -1,0 +1,89 @@
+# prefers-reduced-motion Demo (`prefers-reduced-motion-demo-hr18`)
+
+A demo/showcase example of respecting `prefers-reduced-motion` with
+EaseMotion-style animation classes, built for issue
+[#55958](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/55958).
+
+## A note on scope
+
+The framework's own site already documents `prefers-reduced-motion`
+support at the CSS level. What this issue actually asks for — per its
+title, "add prefers-reduced-motion demo example" — is a dedicated,
+interactive example that *teaches* the pattern rather than a new CSS
+mechanism, so that's what this submission builds: a page demonstrating
+the behavior live, with the exact global rule from the issue's own CSS
+snippet as the actual mechanism underneath.
+
+## What it does
+
+- **A live "Simulate reduced motion" toggle** that applies the identical
+  override this page uses for the real OS-level setting, so the effect is
+  visible immediately without needing to change any system preference —
+  useful for a reviewer checking this PR, and as a pattern other
+  submissions in this repo can reuse.
+- **Four animation demo cards** (fade-in, slide-up, bounce, hover-grow),
+  each replayable, so the "before vs after" is felt directly rather than
+  just described.
+- **A "reduced ≠ none" nuance example**: a purely decorative toast
+  (fully disabled under reduced motion) next to an essential one (a
+  payment-failure notice) that keeps a very short 120ms cross-fade even
+  under reduced motion, since its appearance *is* the notification —
+  removing that transition entirely would mean some users get no
+  indication anything happened at all, not just a less flashy one.
+- **A copy-ready CSS snippet** — the exact rule from the issue — with a
+  one-click copy button.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+The core mechanism is exactly the issue's proposed rule:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+Applied globally once, this makes every `ease-*` animation and transition
+in a project resolve instantly for anyone who's set that OS preference —
+no per-component opt-in required. This demo also shows the nuanced
+follow-up: if a specific transition is communicating that something
+happened (not just decorating that it happened), it's reasonable to
+scope it out of the blanket rule and keep a much shorter version of it,
+rather than treating "respect the preference" and "remove all motion
+everywhere without exception" as the same thing.
+
+## Accessibility notes
+
+- This entire submission *is* an accessibility feature demo, so the notes
+  above cover the substance — but worth stating directly: the "simulate"
+  toggle is additive, not a replacement for real support. The actual
+  `@media (prefers-reduced-motion: reduce)` rule works with zero
+  JavaScript and zero page interaction; the toggle only exists so this
+  specific demo page can be evaluated without changing system settings.
+- The toggle itself is a real, labeled checkbox with a visible
+  `:focus-visible` state, operable by keyboard.
+- The copy button announces success or failure through an
+  `aria-live="polite"` status region, and falls back to
+  `document.execCommand('copy')` for browsers without the async Clipboard
+  API.
+
+## Why this fits EaseMotion CSS
+
+`prefers-reduced-motion` support is directly aligned with the framework's
+stated accessibility goals, and this submission makes the behavior
+tangible and testable rather than just documented in prose — someone can
+open this one file and immediately understand, and verify, what "respects
+reduced motion" means for an `ease-*` class in practice.
+
+All classes and the folder itself use a `-hr18` suffix to avoid colliding
+with any other contributor's submission under `submissions/examples/`.

--- a/submissions/examples/prefers-reduced-motion-demo-hr18/demo.html
+++ b/submissions/examples/prefers-reduced-motion-demo-hr18/demo.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>prefers-reduced-motion Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="prm-hr18" id="prmRoot">
+  <div class="prm-wrap-hr18">
+
+    <header class="prm-header-hr18">
+      <h1>Respecting prefers-reduced-motion</h1>
+      <p>A demo of how EaseMotion-style animation classes should behave for
+        visitors who've asked their operating system to minimize motion —
+        with a live toggle below so you can see the effect without
+        changing any system settings.</p>
+    </header>
+
+    <!-- Live simulate toggle -->
+    <section class="prm-section-hr18">
+      <div class="prm-toggle-bar-hr18">
+        <span class="prm-switch-hr18">
+          <input type="checkbox" id="prmSimulateToggle" />
+          <span class="prm-switch-track-hr18" aria-hidden="true"></span>
+        </span>
+        <span class="prm-toggle-label-hr18">
+          <strong>Simulate prefers-reduced-motion: reduce</strong>
+          <span>Applies the exact same override this page uses for the real OS-level setting.</span>
+        </span>
+      </div>
+      <p class="prm-os-note-hr18">This also responds automatically to your actual OS setting
+        (macOS: System Settings &rarr; Accessibility &rarr; Display &rarr; Reduce motion;
+        Windows: Settings &rarr; Accessibility &rarr; Visual effects &rarr; Animation effects) —
+        the toggle above is just a faster way to preview it here.</p>
+    </section>
+
+    <!-- Demo animation cards -->
+    <section class="prm-section-hr18">
+      <h2>Try it</h2>
+      <p class="prm-lede-hr18">Flip the toggle above, then hit replay on any card —
+        with reduced motion on, everything below appears or updates instantly,
+        with no animation or transition at all.</p>
+
+      <div class="prm-grid-hr18">
+        <div class="prm-card-hr18">
+          <h3>ease-fade-in</h3>
+          <div class="prm-demo-box-hr18 prm-anim-fade-hr18" data-anim="prm-anim-fade-hr18">Fade in</div>
+          <button type="button" class="prm-replay-btn-hr18" data-target="0">Replay</button>
+        </div>
+
+        <div class="prm-card-hr18">
+          <h3>ease-slide-up</h3>
+          <div class="prm-demo-box-hr18 prm-anim-slide-hr18" data-anim="prm-anim-slide-hr18">Slide up</div>
+          <button type="button" class="prm-replay-btn-hr18" data-target="1">Replay</button>
+        </div>
+
+        <div class="prm-card-hr18">
+          <h3>ease-bounce</h3>
+          <div class="prm-demo-box-hr18 prm-anim-bounce-hr18" data-anim="prm-anim-bounce-hr18">Bounce</div>
+          <button type="button" class="prm-replay-btn-hr18" data-target="2">Replay</button>
+        </div>
+
+        <div class="prm-card-hr18">
+          <h3>ease-hover-grow</h3>
+          <div class="prm-demo-box-hr18 prm-anim-hover-grow-hr18">Hover me</div>
+          <span class="prm-replay-btn-hr18 prm-invisible-hr18" aria-hidden="true">Replay</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Reduced ≠ none nuance -->
+    <section class="prm-section-hr18">
+      <h2>"Reduced" doesn't always mean "none"</h2>
+      <p class="prm-lede-hr18">The blanket rule below is the right default for
+        decorative motion, but a state change that's communicated <em>only</em>
+        through motion can still need a very short, low-amplitude transition —
+        otherwise reduced-motion users lose the feedback entirely, not just the
+        flourish.</p>
+
+      <div class="prm-nuance-grid-hr18">
+        <div class="prm-nuance-card-hr18 decorative">
+          <h3>Decorative — fully removed</h3>
+          <p>A bounce or swoop that's purely for visual flair gets disabled
+            entirely under reduced motion. Nothing is lost by removing it.</p>
+          <div class="prm-toast-hr18" id="prmToastDecorative">Item added to cart</div>
+          <button type="button" class="prm-replay-btn-hr18" id="prmShowDecorative">Show toast</button>
+        </div>
+
+        <div class="prm-nuance-card-hr18 essential">
+          <h3>Essential — kept, just shorter</h3>
+          <p>This toast's appearance <em>is</em> the notification that
+            something happened. It keeps a brief 120ms cross-fade even in
+            reduced motion, instead of vanishing with no transition at all.</p>
+          <div class="prm-toast-hr18 prm-toast-essential-hr18" id="prmToastEssential">Payment failed &mdash; try again</div>
+          <button type="button" class="prm-replay-btn-hr18" id="prmShowEssential">Show toast</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Copy-ready snippet -->
+    <section class="prm-section-hr18">
+      <h2>Copy-ready CSS</h2>
+      <p class="prm-lede-hr18">Drop this in once, globally, and every
+        animation and transition in your project respects the user's
+        preference automatically.</p>
+
+      <div class="prm-snippet-card-hr18">
+        <div class="prm-snippet-head-hr18">
+          <span></span>
+          <button type="button" class="prm-copy-btn-hr18" id="prmCopyBtn">Copy CSS</button>
+        </div>
+        <pre class="prm-snippet-code-hr18" id="prmSnippetCode">@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}</pre>
+        <p class="prm-status-hr18" id="prmSnippetStatus" role="status" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <p class="prm-footnote-hr18">submissions/examples/prefers-reduced-motion-demo-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var root = document.getElementById("prmRoot");
+
+  // ---- Simulate toggle ----
+  document.getElementById("prmSimulateToggle").addEventListener("change", function (e) {
+    root.classList.toggle("prm-simulate-reduced-hr18", e.target.checked);
+  });
+
+  // ---- Replay buttons: remove the animation class, force a reflow, then
+  // re-add it so the @keyframes animation restarts from the top. Under
+  // reduced motion (real or simulated), the CSS override above means
+  // nothing visibly plays even when this runs. ----
+  var boxes = document.querySelectorAll(".prm-demo-box-hr18[data-anim]");
+  document.querySelectorAll(".prm-replay-btn-hr18[data-target]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var box = boxes[parseInt(btn.getAttribute("data-target"), 10)];
+      var animClass = box.getAttribute("data-anim");
+      box.classList.remove(animClass);
+      void box.offsetWidth;
+      box.classList.add(animClass);
+    });
+  });
+
+  // ---- Nuance example toasts ----
+  function wireToast(buttonId, toastId) {
+    var button = document.getElementById(buttonId);
+    var toast = document.getElementById(toastId);
+    button.addEventListener("click", function () {
+      toast.classList.remove("is-shown-hr18");
+      void toast.offsetWidth;
+      toast.classList.add("is-shown-hr18");
+    });
+  }
+  wireToast("prmShowDecorative", "prmToastDecorative");
+  wireToast("prmShowEssential", "prmToastEssential");
+
+  // ---- Copy snippet ----
+  var copyBtn = document.getElementById("prmCopyBtn");
+  var snippetCode = document.getElementById("prmSnippetCode");
+  var status = document.getElementById("prmSnippetStatus");
+
+  function announce(message) {
+    status.textContent = message;
+    window.setTimeout(function () {
+      status.textContent = "";
+    }, 3000);
+  }
+
+  function fallbackCopy(text) {
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    try {
+      var ok = document.execCommand("copy");
+      announce(ok ? "Copied to clipboard." : "Copy failed \u2014 select and copy manually.");
+    } catch (err) {
+      announce("Copy failed \u2014 select and copy manually.");
+    }
+    document.body.removeChild(textarea);
+  }
+
+  copyBtn.addEventListener("click", function () {
+    var text = snippetCode.textContent;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () {
+        announce("Copied to clipboard.");
+      }, function () {
+        fallbackCopy(text);
+      });
+    } else {
+      fallbackCopy(text);
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/prefers-reduced-motion-demo-hr18/style.css
+++ b/submissions/examples/prefers-reduced-motion-demo-hr18/style.css
@@ -1,0 +1,407 @@
+/* ==========================================================================
+   prefers-reduced-motion-demo-hr18 — style.css
+   A demo/showcase of respecting prefers-reduced-motion with EaseMotion-
+   style animation classes.
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.prm-hr18 {
+  --bg-hr18: #f6f7f5;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e2e4de;
+  --text-hr18: #171916;
+  --muted-hr18: #666a61;
+  --accent-hr18: #2f6b4f;
+  --accent-soft-hr18: #e3f0e8;
+  --warn-hr18: #b5651d;
+  --warn-soft-hr18: #f8ecdd;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  padding: 3rem 1.5rem 4.5rem;
+}
+
+.prm-hr18 * {
+  box-sizing: border-box;
+}
+
+.prm-wrap-hr18 {
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.prm-header-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.6rem, 2.6vw, 2.1rem);
+  margin: 0 0 0.6rem;
+}
+
+.prm-header-hr18 p {
+  margin: 0;
+  color: var(--muted-hr18);
+  font-size: 0.96rem;
+  line-height: 1.6;
+  max-width: 64ch;
+}
+
+.prm-section-hr18 {
+  margin-top: 2.5rem;
+}
+
+.prm-section-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem;
+}
+
+.prm-lede-hr18 {
+  color: var(--muted-hr18);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  max-width: 64ch;
+  margin: 0 0 1.1rem;
+}
+
+/* ---- Live simulate toggle ------------------------------------------------------------ */
+.prm-toggle-bar-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 14px;
+  padding: 1rem 1.2rem;
+}
+
+.prm-switch-hr18 {
+  position: relative;
+  width: 46px;
+  height: 26px;
+  flex-shrink: 0;
+}
+
+.prm-switch-hr18 input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.prm-switch-track-hr18 {
+  position: absolute;
+  inset: 0;
+  background: var(--border-hr18);
+  border-radius: 999px;
+  pointer-events: none;
+  transition: background 0.15s ease;
+}
+
+.prm-switch-track-hr18::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.15s ease;
+}
+
+.prm-switch-hr18 input:checked + .prm-switch-track-hr18 {
+  background: var(--accent-hr18);
+}
+
+.prm-switch-hr18 input:checked + .prm-switch-track-hr18::before {
+  transform: translateX(20px);
+}
+
+.prm-switch-hr18 input:focus-visible + .prm-switch-track-hr18 {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+.prm-toggle-label-hr18 strong {
+  display: block;
+  font-size: 0.92rem;
+}
+
+.prm-toggle-label-hr18 span {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--muted-hr18);
+  margin-top: 0.1rem;
+}
+
+.prm-os-note-hr18 {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Demo card grid --------------------------------------------------------------- */
+.prm-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.1rem;
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 560px) {
+  .prm-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.prm-card-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 14px;
+  padding: 1.2rem;
+}
+
+.prm-card-hr18 h3 {
+  font-size: 0.92rem;
+  margin: 0 0 0.7rem;
+}
+
+.prm-demo-box-hr18 {
+  height: 60px;
+  border-radius: 10px;
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.prm-replay-btn-hr18 {
+  margin-top: 0.8rem;
+  font-family: var(--font-body-hr18);
+  font-size: 0.78rem;
+  font-weight: 600;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  color: var(--text-hr18);
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.prm-replay-btn-hr18:hover {
+  border-color: var(--accent-hr18);
+  color: var(--accent-hr18);
+}
+
+/* A same-sized, invisible spacer where a card has no replay action (the
+   hover-grow example, which needs a real mouse hover instead), so every
+   card in the row stays the same height. */
+.prm-invisible-hr18 {
+  visibility: hidden;
+}
+
+/* ==========================================================================
+   The animation classes being demonstrated — deliberately similar to
+   EaseMotion's own ease-fade-in / ease-slide-up / ease-hover-grow /
+   ease-bounce naming, so this reads as a direct illustration of how those
+   classes behave under prefers-reduced-motion, not a different system.
+   ========================================================================== */
+
+.prm-anim-fade-hr18 {
+  animation: prmFade-hr18 550ms ease both;
+}
+
+.prm-anim-slide-hr18 {
+  animation: prmSlide-hr18 550ms ease both;
+}
+
+.prm-anim-bounce-hr18 {
+  animation: prmBounce-hr18 700ms ease both;
+}
+
+.prm-anim-hover-grow-hr18:hover {
+  transform: scale(1.06);
+  transition: transform 250ms ease;
+}
+
+@keyframes prmFade-hr18 {
+  from { opacity: 0.1; }
+  to { opacity: 1; }
+}
+
+@keyframes prmSlide-hr18 {
+  from { opacity: 0.1; transform: translateY(18px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes prmBounce-hr18 {
+  0% { transform: translateY(0); }
+  30% { transform: translateY(-14px); }
+  55% { transform: translateY(0); }
+  75% { transform: translateY(-6px); }
+  100% { transform: translateY(0); }
+}
+
+/* ==========================================================================
+   The actual feature: respecting prefers-reduced-motion. This mirrors the
+   issue's own proposed global rule exactly, plus the "simulate" class
+   below that lets this demo page apply the identical behavior on demand
+   without needing to change an OS setting to see it.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .prm-hr18 * {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Manual "simulate" override, scoped to this demo so a reviewer can see
+   the exact same behavior without changing their OS-level setting. */
+.prm-hr18.prm-simulate-reduced-hr18 * {
+  animation: none !important;
+  transition: none !important;
+  scroll-behavior: auto !important;
+}
+
+/* ---- The "reduced ≠ none" nuance example ----------------------------------------- */
+.prm-nuance-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.1rem;
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 560px) {
+  .prm-nuance-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.prm-nuance-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: 14px;
+  padding: 1.2rem;
+}
+
+.prm-nuance-card-hr18.decorative {
+  background: var(--warn-soft-hr18);
+  border-color: rgba(181, 101, 29, 0.3);
+}
+
+.prm-nuance-card-hr18.essential {
+  background: var(--accent-soft-hr18);
+  border-color: rgba(47, 107, 79, 0.3);
+}
+
+.prm-nuance-card-hr18 h3 {
+  font-size: 0.9rem;
+  margin: 0 0 0.4rem;
+}
+
+.prm-nuance-card-hr18 p {
+  margin: 0 0 0.8rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--muted-hr18);
+}
+
+.prm-toast-hr18 {
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 8px;
+  padding: 0.55rem 0.8rem;
+  font-size: 0.82rem;
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+.prm-toast-hr18.is-shown-hr18 {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+/* This particular transition is intentionally NOT wrapped in the
+   reduced-motion override above (see the :not() escape hatch in the
+   snippet section) — its job is to communicate that a state genuinely
+   changed, not to decorate the page, so a very short, low-amplitude
+   cross-fade is kept even under prefers-reduced-motion. Everything else
+   on this page follows the blanket "disable it" rule instead. */
+.prm-toast-essential-hr18.is-shown-hr18 {
+  transition-duration: 120ms;
+}
+
+/* ---- Copy-ready snippet ------------------------------------------------------------- */
+.prm-snippet-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: 14px;
+  background: #1a1c19;
+  overflow: hidden;
+}
+
+.prm-snippet-head-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid #2c2e29;
+}
+
+.prm-copy-btn-hr18 {
+  background: var(--accent-hr18);
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font-family: var(--font-body-hr18);
+  font-size: 0.76rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.prm-copy-btn-hr18:hover {
+  filter: brightness(1.08);
+}
+
+.prm-snippet-code-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8rem;
+  line-height: 1.65;
+  padding: 1rem;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: #eceee9;
+}
+
+.prm-status-hr18 {
+  padding: 0 1rem 0.85rem;
+  font-size: 0.76rem;
+  color: #7fd9a8;
+  min-height: 1.1em;
+}
+
+.prm-footnote-hr18 {
+  margin-top: 2rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+.prm-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Adds an interactive demo showcasing how EaseMotion-style animation
classes should behave under prefers-reduced-motion. A live "Simulate
reduced motion" toggle applies the exact same global override the page
uses for the real OS setting, so the effect is visible without changing
system preferences. Four replayable demo cards (fade-in, slide-up,
bounce, hover-grow) let visitors feel the before/after directly. A
"reduced ≠ none" section contrasts a fully-disabled decorative toast
against an essential one that keeps a very short 120ms cross-fade, since
its appearance is the notification itself. Includes a copy-ready CSS
snippet matching the issue's exact proposed rule.

Resolves #55958

---

## Type of Change
- [x] 📝 Documentation improvement

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/prefers-reduced-motion-demo-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An interactive, testable demo of prefers-reduced-motion support for
EaseMotion-style animation classes.

**How does a developer use it?**
```css
@media (prefers-reduced-motion: reduce) {
  * {
    animation: none !important;
    transition: none !important;
    scroll-behavior: auto !important;
  }
}
```

**Why does it fit EaseMotion CSS?**
Directly aligned with the framework's accessibility goals, and makes the
behavior tangible and verifiable rather than only documented in prose.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
No inline styles. The "simulate" toggle is purely additive for
reviewability — the actual @media rule works with zero JS. Tested the
toggle, all four replay buttons, both nuance toasts, and the copy button
in Chrome; haven't checked other browsers yet.