### PR TITLE
Fix tooltip hidden behind nearby elements (stacking context)

### DIFF
--- a/submissions/examples/core_changes-issue-56062/README.md
+++ b/submissions/examples/core_changes-issue-56062/README.md
@@ -1,0 +1,90 @@
+# Fix: Tooltip Gets Hidden Behind Nearby Elements
+
+Fixes **#56062** — tooltips rendering behind neighboring elements when
+used inside containers with overlapping content or differing stacking
+contexts.
+
+## Root cause
+
+The original tooltip relied on a high `z-index` on the tooltip element
+alone. That's not enough. `z-index` only ranks elements **within the
+same stacking context** — and a child's `z-index`, however high,
+cannot lift it above a sibling of its *parent* if the parent itself
+doesn't out-rank that sibling.
+
+Concretely, in the reported reproduction:
+
+```html
+<div class="card">
+  <button class="tooltip-trigger">
+    Hover Me
+    <span class="tooltip">Tooltip Content</span>
+  </button>
+</div>
+```
+
+If `.card` has no stacking context of its own (no `position` +
+`z-index`), and a neighboring `.card` happens to paint after it in DOM
+order or overlaps it visually, the neighbor's entire box can render on
+top of the first card's contents — tooltip included — regardless of
+the tooltip's own `z-index`.
+
+## The fix
+
+Three changes, all in `style.css`:
+
+**1. Give each card its own stacking context at rest.**
+```css
+.card {
+  position: relative;
+  z-index: 1;
+}
+```
+
+**2. Raise the whole card — not just the tooltip — on hover/focus.**
+```css
+.card:hover,
+.card:focus-within {
+  z-index: 50;
+}
+```
+This is the actual fix. Lifting the entire card's stacking context
+above its siblings brings everything inside it, including the
+tooltip, above any neighboring card in one step — a high z-index on
+the tooltip alone can't do this on its own.
+
+**3. Keep a locally high z-index on the tooltip itself.**
+```css
+.tooltip {
+  z-index: 100;
+}
+```
+This ensures the tooltip still wins against other content *inside*
+its own (now-lifted) card.
+
+No `overflow: hidden` is used anywhere in the ancestor chain, since
+that would clip the tooltip regardless of z-index.
+
+## Why this approach
+
+It's a pure-CSS fix with no JavaScript and no structural changes to
+existing markup — any project already using `.tooltip-trigger` /
+`.tooltip` gets the fix by updating the stylesheet alone. It also
+doesn't require `position: fixed` (which has its own edge cases with
+scrolling and JS-measured positioning), keeping the component fully
+static and CSS-only, in line with EaseMotion's philosophy.
+
+## How to verify
+
+Open `demo.html`. Two cards sit side by side with a deliberate visual
+overlap, reproducing the layout described in the issue. Hover the
+"Hover Me" button in the first card — the tooltip now renders fully
+above the second, overlapping card.
+
+## Files
+
+- `demo.html` — reproduces the issue's exact card/tooltip scenario,
+  with the fix applied.
+- `style.css` — the fixed tooltip and card styling, with the root
+  cause and each fix step documented inline.
+- `README.md` — this file.

--- a/submissions/examples/core_changes-issue-56062/demo.html
+++ b/submissions/examples/core_changes-issue-56062/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fix: Tooltip Hidden Behind Nearby Elements (#56062)</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <header class="demo-header">
+      <h1>Tooltip Stacking-Context Fix</h1>
+      <p>
+        Reproduces the exact scenario from #56062 — a tooltip trigger
+        inside a card, with a second overlapping card next to it.
+        Hover the button below; the tooltip now renders above the
+        neighboring card instead of behind it.
+      </p>
+    </header>
+
+    <section class="card-row">
+
+      <!-- The card containing the tooltip trigger -->
+      <div class="card">
+        <p class="card-title">Card A</p>
+        <p class="card-body">This card holds the tooltip trigger.</p>
+        <button class="tooltip-trigger" type="button">
+          Hover Me
+          <span class="tooltip">Tooltip Content</span>
+        </button>
+      </div>
+
+      <!-- The overlapping neighbor that used to sit on top of the tooltip -->
+      <div class="card card--overlap">
+        <p class="card-title">Card B</p>
+        <p class="card-body">
+          This card overlaps Card A slightly and used to sit above the
+          tooltip, hiding it. It no longer does.
+        </p>
+      </div>
+
+    </section>
+
+    <footer class="demo-footer">
+      <p>See <code>README.md</code> for the root cause and the exact fix applied.</p>
+    </footer>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-56062/style.css
+++ b/submissions/examples/core_changes-issue-56062/style.css
@@ -1,0 +1,175 @@
+/* ==========================================================================
+   Fix: Tooltip Gets Hidden Behind Nearby Elements (#56062)
+
+   ROOT CAUSE
+   -----------
+   The tooltip was given a high `z-index`, but that only wins within its
+   OWN stacking context. If the tooltip's parent (`.card`) does not have
+   an explicit stacking context of its own, and a NEIGHBORING card happens
+   to paint after it in DOM order (or has any transform/opacity/z-index
+   of its own), the neighbor's entire box — including its background —
+   can paint on top of the tooltip, no matter how high the tooltip's own
+   z-index is set. A high z-index on a child cannot escape a low
+   stacking position on its ancestor.
+
+   THE FIX
+   --------
+   1. Give the tooltip's containing card a real stacking context
+      (`position: relative` + `z-index: 1` at rest).
+   2. On hover/focus, raise that card's z-index well above its siblings
+      (`z-index: 50`) — this lifts the ENTIRE card, tooltip included,
+      above every neighboring card in one step.
+   3. Ensure no ancestor clips with `overflow: hidden` (removed here;
+      `.card` uses default visible overflow).
+   4. Keep the tooltip itself at a high z-index too, so it also wins
+      against any other elements inside the same lifted card.
+   ========================================================================== */
+
+:root {
+  --bg: #f4f5f8;
+  --surface: #ffffff;
+  --text: #1d1f24;
+  --text-muted: #666b76;
+  --accent: #2f2f38;
+  --border: #e1e3ea;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.demo {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-header h1 {
+  margin: 0 0 0.6rem;
+  font-size: 1.6rem;
+}
+
+.demo-header p {
+  color: var(--text-muted);
+  max-width: 460px;
+  margin: 0 auto;
+}
+
+/* ---- Card layout: cards overlap slightly via negative margin, to
+        reproduce the "overlapping content" scenario from the issue ------- */
+.card-row {
+  display: flex;
+}
+
+.card {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem;
+  width: 220px;
+
+  /* THE FIX, part 1: give this card its own stacking context so its
+     z-index (and its tooltip descendant) can be reliably raised. */
+  position: relative;
+  z-index: 1;
+}
+
+.card--overlap {
+  margin-left: -40px;
+  margin-top: 30px;
+}
+
+.card-title {
+  font-weight: 700;
+  margin: 0 0 0.4rem;
+}
+
+.card-body {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin: 0 0 0.75rem;
+}
+
+/* THE FIX, part 2: on hover/focus of anything inside the card, lift the
+   WHOLE card's stacking context above every sibling card. This is what
+   actually solves the bug — raising only the tooltip's own z-index is
+   not enough if its ancestor doesn't out-rank the neighboring card. */
+.card:hover,
+.card:focus-within {
+  z-index: 50;
+}
+
+/* ---- Tooltip trigger ------------------------------------------------- */
+.tooltip-trigger {
+  position: relative;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background-color: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+}
+
+/* ---- The tooltip itself ------------------------------------------------ */
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+
+  background-color: var(--accent);
+  color: #ffffff;
+  font-size: 0.8rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  white-space: nowrap;
+
+  /* THE FIX, part 3: still set a high z-index locally, so the tooltip
+     also wins against other content inside its own (now-lifted) card. */
+  z-index: 100;
+
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease-out, transform 180ms ease-out;
+}
+
+.tooltip-trigger:hover .tooltip,
+.tooltip-trigger:focus-visible .tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ---- Footer ------------------------------------------------------------- */
+.demo-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 3rem;
+}
+
+.demo-footer code {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+/* ---- Reduced motion ------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Pull Request Description

Fixes #56062 — tooltips rendering behind neighboring elements when used inside containers with overlapping content or differing stacking contexts. Root cause: the tooltip's own z-index can't outrank a sibling card if its parent container has no stacking context of its own. Fix lifts the whole trigger's containing card above its siblings on hover/focus, rather than relying on the tooltip's z-index alone.

Type of Change
 🐛 Bug fix in an existing submission
Submission Checklist
 All changes are inside submissions/ (submissions/examples/core_changes-issue-56062/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)
Feature Description

What does this add?
A demonstrated fix for the tooltip stacking-context bug: reproduces the exact overlapping-card scenario from the issue, with the corrected CSS applied.

How does a developer use it?

css
.card { position: relative; z-index: 1; }
.card:hover, .card:focus-within { z-index: 50; }
.tooltip { z-index: 100; }

Why does it fit EaseMotion CSS?
Pure CSS, no JS, no markup changes required — any existing tooltip using this pattern gets the fix by updating the stylesheet alone.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari
Notes for Maintainer

Also assigned to @aparna24bce11388 (reporter) and @SAPTARSHI-coder — flagging in case of overlap. The fix raises the entire trigger's containing element's z-index on hover rather than only the tooltip's, since that's the actual mechanism needed to escape a lower-ranked ancestor stacking context. Opened as draft pending cross-browser check.

Closes #56062