### PR TITLE
fix: single-open accordion behavior (#56060)

### DIFF
--- a/submissions/examples/ease-accordion-single-open/README.md
+++ b/submissions/examples/ease-accordion-single-open/README.md
@@ -1,0 +1,18 @@
+# ease-accordion-single-open
+
+Fixes #56060 - accordion sections now close automatically when another
+section is opened, so only one section is expanded at a time.
+
+## Behavior
+
+- Clicking a closed section opens it and closes any other open section
+  in the same accordion.
+- Clicking the currently open section closes it (standard toggle).
+- Uses a .active class + max-height transition, consistent with
+  EaseMotion existing animation approach (no external dependencies).
+
+## Files
+
+- demo.html - usage example matching the markup from issue #56060
+- style.css - accordion styles + collapse/expand transition
+- script.js - single-open toggle logic

--- a/submissions/examples/ease-accordion-single-open/demo.html
+++ b/submissions/examples/ease-accordion-single-open/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion CSS - Single-Open Accordion Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="accordion">
+  <div class="accordion-item">
+    <button class="accordion-trigger">Section 1</button>
+    <div class="accordion-content">Content 1</div>
+  </div>
+
+  <div class="accordion-item">
+    <button class="accordion-trigger">Section 2</button>
+    <div class="accordion-content">Content 2</div>
+  </div>
+
+  <div class="accordion-item">
+    <button class="accordion-trigger">Section 3</button>
+    <div class="accordion-content">Content 3</div>
+  </div>
+</div>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/ease-accordion-single-open/script.js
+++ b/submissions/examples/ease-accordion-single-open/script.js
@@ -1,0 +1,15 @@
+document.querySelectorAll('.accordion-trigger').forEach((trigger) => {
+  trigger.addEventListener('click', () => {
+    const item = trigger.closest('.accordion-item');
+    const accordion = item.closest('.accordion');
+    const isActive = item.classList.contains('active');
+
+    accordion.querySelectorAll('.accordion-item.active').forEach((openItem) => {
+      openItem.classList.remove('active');
+    });
+
+    if (!isActive) {
+      item.classList.add('active');
+    }
+  });
+});

--- a/submissions/examples/ease-accordion-single-open/style.css
+++ b/submissions/examples/ease-accordion-single-open/style.css
@@ -1,0 +1,43 @@
+.accordion {
+  max-width: 500px;
+  margin: 2rem auto;
+  border: 1px solid var(--ease-color-border, #e2e2e2);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  overflow: hidden;
+  font-family: sans-serif;
+}
+
+.accordion-item {
+  border-bottom: 1px solid var(--ease-color-border, #e2e2e2);
+}
+
+.accordion-item:last-child {
+  border-bottom: none;
+}
+
+.accordion-trigger {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.accordion-trigger:hover {
+  background: var(--ease-color-hover-bg, #f5f5f5);
+}
+
+.accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--ease-speed-medium, 400ms) ease;
+  padding: 0 1rem;
+}
+
+.accordion-item.active .accordion-content {
+  max-height: 500px;
+  padding: 0.5rem 1rem 1rem;
+}


### PR DESCRIPTION
Fixes #56060

Adds a self-contained accordion example under submissions/examples/
where opening one section automatically closes any other open
section, so only one section is expanded at a time.

Files:
- demo.html — usage example matching the issue's markup
- style.css — accordion styles + collapse/expand transition
- script.js — single-open toggle logic
- README.md — behavior notes