### PR TITLE
fix: prevent browser crash when process is undefined (#52722)

### DIFF
--- a/easemotion/engine/runtime.js
+++ b/easemotion/engine/runtime.js
@@ -52,7 +52,7 @@ function processElement(el) {
 
   const ast = parse(value);
   if (!ast) {
-    if (process?.env?.NODE_ENV !== 'production') {
+    if (typeof process === 'undefined' || process.env?.NODE_ENV !== 'production') {
       console.warn(`[EaseMotion Engine] Could not parse em="${value}". Unknown animation name.`);
     }
     return;


### PR DESCRIPTION
## Fix: Browser Runtime Crash with `process` Not Defined (#52722)

### Problem
The EaseMotion JavaScript runtime crashes in native browser environments when it encounters an invalid or unsupported `em=""` animation value. The runtime references the Node.js `process` global while handling invalid animation tokens, causing a `ReferenceError` that terminates the Motion Engine.

### Root Cause
In `easemotion/engine/runtime.js:55`:
```js
if (process?.env?.NODE_ENV !== 'production') {