### PR TITLE
Add CSS Zoom-In Stepper for Creative Portfolio Layouts

### DIFF
--- a/submissions/examples/zoom-in-portfolio-stepper/README.md
+++ b/submissions/examples/zoom-in-portfolio-stepper/README.md
@@ -1,0 +1,51 @@
+﻿# Zoom-In Stepper for Creative Portfolio Layouts
+
+A pure CSS/HTML step navigator that visually zooms in the active step and its content panel, no JavaScript required. Driven entirely by hidden radio inputs and the `:checked` pseudo-class.
+
+## Features
+
+- 4-step navigator (easily extendable) with numbered dots and labels
+- Active step zooms in (`scale(1.15)`) while inactive steps shrink slightly
+- Animated progress track that fills as you move through steps
+- Content panels reveal with a zoom-in + fade transition
+- Fully responsive, labels collapse on small screens, dots resize
+- Respects `prefers-reduced-motion` (all transforms/transitions disabled)
+- Zero JavaScript, works with just CSS `:checked` selectors
+
+## Usage
+
+1. Copy `style.css` into your project and link it in your HTML `<head>`.
+2. Copy the stepper markup from `demo.html`:
+   - A `<input type="radio">` per step (hidden, drives state)
+   - A `<label>` per step inside `.stepper__nav` (the visible dot)
+   - A `<section class="stepper__panel stepper__panel--N">` per step
+3. Add or remove steps by duplicating the radio/label/panel pattern and updating the nth panel width rule in `.stepper__progress`.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--stepper-primary` | `#6366f1` | Accent color for active step and progress bar |
+| `--stepper-primary-light` | `#a5b4fc` | Border/glow color on active step number |
+| `--stepper-bg` | `#0f0f1a` | Page background |
+| `--stepper-panel-bg` | `#1a1a2e` | Panel and dot background |
+| `--stepper-text` | `#f4f4f8` | Primary text color |
+| `--stepper-muted` | `#8b8ba7` | Secondary/muted text color |
+| `--stepper-dot-size` | `3rem` | Diameter of each step number circle |
+| `--stepper-zoom-inactive` | `0.85` | Scale applied to inactive step dots |
+| `--stepper-zoom-active` | `1.15` | Scale applied to the active step dot |
+| `--stepper-transition-duration` | `0.45s` | Duration for all zoom/fade transitions |
+| `--stepper-transition-ease` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Easing curve (gives a slight "pop") |
+
+Override any of these in your own stylesheet via `:root { --stepper-primary: #ff6b6b; }`.
+
+## Accessibility
+
+- Radio inputs are focusable and keyboard-navigable (arrow keys switch steps natively).
+- Labels are proper `<label for="...">` elements tied to inputs, screen readers announce them correctly.
+- All zoom/scale/opacity transitions are stripped under `prefers-reduced-motion: reduce`.
+
+## Responsive Behavior
+
+- Desktop/tablet: full labels visible beneath each numbered dot.
+- Mobile (max-width 640px): labels hidden to save space, dot size reduced, track insets tightened.

--- a/submissions/examples/zoom-in-portfolio-stepper/demo.html
+++ b/submissions/examples/zoom-in-portfolio-stepper/demo.html
@@ -1,0 +1,64 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zoom-In Stepper — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="showcase">
+    <h1 class="showcase__title">Creative Portfolio — Project Journey</h1>
+    <p class="showcase__subtitle">Pure CSS zoom-in stepper. No JavaScript.</p>
+
+    <div class="stepper">
+      <input type="radio" name="step" id="step-1" class="stepper__radio" checked>
+      <input type="radio" name="step" id="step-2" class="stepper__radio">
+      <input type="radio" name="step" id="step-3" class="stepper__radio">
+      <input type="radio" name="step" id="step-4" class="stepper__radio">
+
+      <nav class="stepper__nav" aria-label="Project steps">
+        <label for="step-1" class="stepper__dot">
+          <span class="stepper__number">1</span>
+          <span class="stepper__label">Concept</span>
+        </label>
+        <label for="step-2" class="stepper__dot">
+          <span class="stepper__number">2</span>
+          <span class="stepper__label">Design</span>
+        </label>
+        <label for="step-3" class="stepper__dot">
+          <span class="stepper__number">3</span>
+          <span class="stepper__label">Build</span>
+        </label>
+        <label for="step-4" class="stepper__dot">
+          <span class="stepper__number">4</span>
+          <span class="stepper__label">Launch</span>
+        </label>
+        <div class="stepper__track"></div>
+        <div class="stepper__progress"></div>
+      </nav>
+
+      <div class="stepper__panels">
+        <section class="stepper__panel stepper__panel--1">
+          <h2>Concept</h2>
+          <p>Sketch the idea, define the audience, and set the creative direction for the portfolio piece.</p>
+        </section>
+        <section class="stepper__panel stepper__panel--2">
+          <h2>Design</h2>
+          <p>Build wireframes and a visual language — typography, color, spacing — before touching code.</p>
+        </section>
+        <section class="stepper__panel stepper__panel--3">
+          <h2>Build</h2>
+          <p>Translate the design into semantic HTML and CSS, keeping performance and accessibility in mind.</p>
+        </section>
+        <section class="stepper__panel stepper__panel--4">
+          <h2>Launch</h2>
+          <p>Ship it. Gather feedback, iterate, and add the finished piece to the portfolio.</p>
+        </section>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-portfolio-stepper/style.css
+++ b/submissions/examples/zoom-in-portfolio-stepper/style.css
@@ -1,0 +1,232 @@
+﻿/* =========================================
+   Zoom-In Stepper — EaseMotion CSS
+   Pure CSS, radio-driven, zoom-in transitions
+   ========================================= */
+
+:root {
+  --stepper-primary: #6366f1;
+  --stepper-primary-light: #a5b4fc;
+  --stepper-bg: #0f0f1a;
+  --stepper-panel-bg: #1a1a2e;
+  --stepper-text: #f4f4f8;
+  --stepper-muted: #8b8ba7;
+  --stepper-dot-size: 3rem;
+  --stepper-zoom-inactive: 0.85;
+  --stepper-zoom-active: 1.15;
+  --stepper-transition-duration: 0.45s;
+  --stepper-transition-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--stepper-bg);
+  color: var(--stepper-text);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.showcase {
+  width: 100%;
+  max-width: 800px;
+  text-align: center;
+}
+
+.showcase__title {
+  margin-bottom: 0.25rem;
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.showcase__subtitle {
+  color: var(--stepper-muted);
+  margin-bottom: 3rem;
+}
+
+.stepper__radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.stepper__nav {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 2.5rem;
+  padding: 0 1rem;
+}
+
+.stepper__track {
+  position: absolute;
+  top: calc(var(--stepper-dot-size) / 2);
+  left: 2rem;
+  right: 2rem;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  z-index: 0;
+}
+
+.stepper__progress {
+  position: absolute;
+  top: calc(var(--stepper-dot-size) / 2);
+  left: 2rem;
+  height: 3px;
+  width: 0%;
+  background: var(--stepper-primary);
+  z-index: 1;
+  transition: width var(--stepper-transition-duration) var(--stepper-transition-ease);
+}
+
+.stepper__dot {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  transform: scale(var(--stepper-zoom-inactive));
+  transition: transform var(--stepper-transition-duration) var(--stepper-transition-ease);
+}
+
+.stepper__number {
+  width: var(--stepper-dot-size);
+  height: var(--stepper-dot-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--stepper-panel-bg);
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  font-weight: 700;
+  transition: background var(--stepper-transition-duration) var(--stepper-transition-ease),
+              border-color var(--stepper-transition-duration) var(--stepper-transition-ease),
+              box-shadow var(--stepper-transition-duration) var(--stepper-transition-ease);
+}
+
+.stepper__label {
+  font-size: 0.85rem;
+  color: var(--stepper-muted);
+  transition: color var(--stepper-transition-duration) ease;
+}
+
+#step-1:checked ~ .stepper__nav label[for="step-1"],
+#step-2:checked ~ .stepper__nav label[for="step-2"],
+#step-3:checked ~ .stepper__nav label[for="step-3"],
+#step-4:checked ~ .stepper__nav label[for="step-4"] {
+  transform: scale(var(--stepper-zoom-active));
+}
+
+#step-1:checked ~ .stepper__nav label[for="step-1"] .stepper__number,
+#step-2:checked ~ .stepper__nav label[for="step-2"] .stepper__number,
+#step-3:checked ~ .stepper__nav label[for="step-3"] .stepper__number,
+#step-4:checked ~ .stepper__nav label[for="step-4"] .stepper__number {
+  background: var(--stepper-primary);
+  border-color: var(--stepper-primary-light);
+  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.2);
+}
+
+#step-1:checked ~ .stepper__nav label[for="step-1"] .stepper__label,
+#step-2:checked ~ .stepper__nav label[for="step-2"] .stepper__label,
+#step-3:checked ~ .stepper__nav label[for="step-3"] .stepper__label,
+#step-4:checked ~ .stepper__nav label[for="step-4"] .stepper__label {
+  color: var(--stepper-text);
+}
+
+#step-1:checked ~ .stepper__nav .stepper__progress { width: 0%; }
+#step-2:checked ~ .stepper__nav .stepper__progress { width: 33%; }
+#step-3:checked ~ .stepper__nav .stepper__progress { width: 66%; }
+#step-4:checked ~ .stepper__nav .stepper__progress { width: 100%; }
+
+.stepper__panels {
+  position: relative;
+  min-height: 140px;
+}
+
+.stepper__panel {
+  position: absolute;
+  inset: 0;
+  background: var(--stepper-panel-bg);
+  border-radius: 12px;
+  padding: 1.75rem;
+  opacity: 0;
+  transform: scale(0.8);
+  pointer-events: none;
+  transition: opacity var(--stepper-transition-duration) var(--stepper-transition-ease),
+              transform var(--stepper-transition-duration) var(--stepper-transition-ease);
+}
+
+.stepper__panel h2 {
+  margin-top: 0;
+  color: var(--stepper-primary-light);
+}
+
+.stepper__panel p {
+  margin-bottom: 0;
+  color: var(--stepper-muted);
+  line-height: 1.6;
+}
+
+#step-1:checked ~ .stepper__panels .stepper__panel--1,
+#step-2:checked ~ .stepper__panels .stepper__panel--2,
+#step-3:checked ~ .stepper__panels .stepper__panel--3,
+#step-4:checked ~ .stepper__panels .stepper__panel--4 {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+  position: relative;
+}
+
+@media (max-width: 640px) {
+  .stepper__nav {
+    padding: 0;
+  }
+  .stepper__label {
+    display: none;
+  }
+  .stepper__track,
+  .stepper__progress {
+    left: 1.5rem;
+    right: 1.5rem;
+  }
+  :root {
+    --stepper-dot-size: 2.25rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .stepper__panel {
+    padding: 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stepper__dot,
+  .stepper__number,
+  .stepper__label,
+  .stepper__progress,
+  .stepper__panel {
+    transition: none !important;
+    transform: none !important;
+  }
+
+  #step-1:checked ~ .stepper__nav label[for="step-1"],
+  #step-2:checked ~ .stepper__nav label[for="step-2"],
+  #step-3:checked ~ .stepper__nav label[for="step-3"],
+  #step-4:checked ~ .stepper__nav label[for="step-4"] {
+    transform: none;
+  }
+
+  #step-1:checked ~ .stepper__panels .stepper__panel--1,
+  #step-2:checked ~ .stepper__panels .stepper__panel--2,
+  #step-3:checked ~ .stepper__panels .stepper__panel--3,
+  #step-4:checked ~ .stepper__panels .stepper__panel--4 {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #56353

## What this adds
A pure CSS/HTML zoom-in stepper for showcasing project phases in creative portfolio layouts. Built with radio-input-driven state (no JS) — active step and its content panel zoom in via `:checked` selectors.

## Files
- `submissions/examples/zoom-in-portfolio-stepper/demo.html`
- `submissions/examples/zoom-in-portfolio-stepper/style.css`
- `submissions/examples/zoom-in-portfolio-stepper/README.md`

## Features
- 4-step navigator with numbered dots, labels, and animated progress track
- Zoom-in + fade reveal on active step/panel
- Fully responsive (labels collapse, dots resize on mobile)
- `prefers-reduced-motion` support
- Documented CSS custom properties for easy theming
- Zero JavaScript

## Checklist
- [x] Pure CSS/HTML, no external JS frameworks
- [x] Smooth transitions and keyframe-style animation
- [x] Responsive across desktop/tablet/mobile
- [x] `prefers-reduced-motion` support
- [x] Files placed under `submissions/examples/`