### PR TITLE
Add CSS fade-in stepper for creative portfolio layouts (#56351)

### DIFF
--- a/submissions/examples/fade-in-portfolio-stepper/README.md
+++ b/submissions/examples/fade-in-portfolio-stepper/README.md
@@ -1,0 +1,50 @@
+﻿# Fade-In Stepper for Creative Portfolio Layouts
+
+A pure CSS/HTML tabbed stepper for case-study style portfolio content, where each step's content fades and rises in with a staggered, sequential reveal. No JavaScript, driven entirely by hidden radio inputs and `:checked`.
+
+## Features
+
+- 4-step tab navigation with a sliding underline indicator
+- Each panel's child elements (eyebrow, heading, paragraph, tags) fade in with a staggered delay for a polished sequential reveal
+- Smooth active-tab color transition and indicator slide
+- Fully responsive, tabs become horizontally scrollable on small screens
+- Respects `prefers-reduced-motion` (stagger/fade/rise fully disabled, content shown instantly)
+- Zero JavaScript
+
+## Usage
+
+1. Copy `style.css` into your project and link it in your HTML `<head>`.
+2. Copy the stepper markup from `demo.html`:
+   - One hidden `<input type="radio">` per step
+   - One `<label>` per step inside `.fstepper__nav` (the tab)
+   - One `<section class="fstepper__panel fstepper__panel--N">` per step, with each direct piece of content wrapped in `.fstepper__item .fstepper__item--N` (N = stagger order, 1 through however many elements you have)
+3. To add a step, duplicate the radio/tab/panel pattern, add a new `.fstepper__indicator` transform rule, and set width on `.fstepper__indicator` to 100% divided by total steps.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--fstepper-primary` | `#10b981` | Active tab underline color |
+| `--fstepper-primary-light` | `#6ee7b7` | Eyebrow text and active tab index color |
+| `--fstepper-bg` | `#0d1117` | Page background |
+| `--fstepper-panel-bg` | `#161b22` | Panel background |
+| `--fstepper-border` | `rgba(255,255,255,0.08)` | Panel and tab borders |
+| `--fstepper-text` | `#e6edf3` | Primary text color |
+| `--fstepper-muted` | `#8b949e` | Secondary/muted text color |
+| `--fstepper-fade-duration` | `0.5s` | Duration of each item's fade-in animation |
+| `--fstepper-fade-ease` | `ease-out` | Easing curve for fade-in |
+| `--fstepper-stagger-step` | `0.12s` | Delay increment between each staggered item |
+| `--fstepper-rise-distance` | `14px` | Vertical distance items rise while fading in |
+
+Override any of these via `:root { --fstepper-primary: #f43f5e; }` in your own stylesheet.
+
+## Accessibility
+
+- Radio inputs are keyboard-navigable (arrow keys switch tabs natively via native radio group behavior).
+- Labels are proper `<label for="...">` elements tied to inputs for correct screen reader announcement.
+- Under `prefers-reduced-motion: reduce`, all animations and transitions are removed and content is shown immediately at full opacity.
+
+## Responsive Behavior
+
+- Desktop/tablet: tabs share available width evenly.
+- Mobile (max-width 640px): tabs shrink to content width and the nav becomes horizontally scrollable.

--- a/submissions/examples/fade-in-portfolio-stepper/demo.html
+++ b/submissions/examples/fade-in-portfolio-stepper/demo.html
@@ -1,0 +1,82 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fade-In Stepper — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="fshowcase">
+    <h1 class="fshowcase__title">Creative Portfolio — Case Study Walkthrough</h1>
+    <p class="fshowcase__subtitle">Pure CSS staggered fade-in stepper. No JavaScript.</p>
+
+    <div class="fstepper">
+      <input type="radio" name="fstep" id="fstep-1" class="fstepper__radio" checked>
+      <input type="radio" name="fstep" id="fstep-2" class="fstepper__radio">
+      <input type="radio" name="fstep" id="fstep-3" class="fstepper__radio">
+      <input type="radio" name="fstep" id="fstep-4" class="fstepper__radio">
+
+      <nav class="fstepper__nav" aria-label="Case study steps">
+        <label for="fstep-1" class="fstepper__tab">
+          <span class="fstepper__tab-index">01</span>
+          <span class="fstepper__tab-label">Research</span>
+        </label>
+        <label for="fstep-2" class="fstepper__tab">
+          <span class="fstepper__tab-index">02</span>
+          <span class="fstepper__tab-label">Wireframe</span>
+        </label>
+        <label for="fstep-3" class="fstepper__tab">
+          <span class="fstepper__tab-index">03</span>
+          <span class="fstepper__tab-label">Visual Design</span>
+        </label>
+        <label for="fstep-4" class="fstepper__tab">
+          <span class="fstepper__tab-index">04</span>
+          <span class="fstepper__tab-label">Handoff</span>
+        </label>
+        <div class="fstepper__indicator" aria-hidden="true"></div>
+      </nav>
+
+      <div class="fstepper__stage">
+        <section class="fstepper__panel fstepper__panel--1">
+          <span class="fstepper__eyebrow fstepper__item fstepper__item--1">Phase 01</span>
+          <h2 class="fstepper__item fstepper__item--2">User &amp; Market Research</h2>
+          <p class="fstepper__item fstepper__item--3">Interviews, competitor audits, and analytics review to uncover what the audience actually needs before any pixel is placed.</p>
+          <ul class="fstepper__tags fstepper__item fstepper__item--4">
+            <li>Interviews</li><li>Surveys</li><li>Analytics</li>
+          </ul>
+        </section>
+
+        <section class="fstepper__panel fstepper__panel--2">
+          <span class="fstepper__eyebrow fstepper__item fstepper__item--1">Phase 02</span>
+          <h2 class="fstepper__item fstepper__item--2">Low-Fidelity Wireframes</h2>
+          <p class="fstepper__item fstepper__item--3">Rough layout structures to validate information hierarchy and user flow before visual styling begins.</p>
+          <ul class="fstepper__tags fstepper__item fstepper__item--4">
+            <li>Sitemaps</li><li>Flows</li><li>Sketches</li>
+          </ul>
+        </section>
+
+        <section class="fstepper__panel fstepper__panel--3">
+          <span class="fstepper__eyebrow fstepper__item fstepper__item--1">Phase 03</span>
+          <h2 class="fstepper__item fstepper__item--2">Visual Design System</h2>
+          <p class="fstepper__item fstepper__item--3">Typography, color, and component design brought together into a cohesive, reusable visual language.</p>
+          <ul class="fstepper__tags fstepper__item fstepper__item--4">
+            <li>Typography</li><li>Color</li><li>Components</li>
+          </ul>
+        </section>
+
+        <section class="fstepper__panel fstepper__panel--4">
+          <span class="fstepper__eyebrow fstepper__item fstepper__item--1">Phase 04</span>
+          <h2 class="fstepper__item fstepper__item--2">Developer Handoff</h2>
+          <p class="fstepper__item fstepper__item--3">Specs, assets, and documentation packaged for a smooth build phase with zero ambiguity.</p>
+          <ul class="fstepper__tags fstepper__item fstepper__item--4">
+            <li>Specs</li><li>Assets</li><li>Docs</li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-portfolio-stepper/style.css
+++ b/submissions/examples/fade-in-portfolio-stepper/style.css
@@ -1,0 +1,239 @@
+﻿/* =========================================
+   Fade-In Stepper — EaseMotion CSS
+   Pure CSS, radio-driven, staggered fade-in
+   ========================================= */
+
+:root {
+  --fstepper-primary: #10b981;
+  --fstepper-primary-light: #6ee7b7;
+  --fstepper-bg: #0d1117;
+  --fstepper-panel-bg: #161b22;
+  --fstepper-border: rgba(255, 255, 255, 0.08);
+  --fstepper-text: #e6edf3;
+  --fstepper-muted: #8b949e;
+  --fstepper-fade-duration: 0.5s;
+  --fstepper-fade-ease: ease-out;
+  --fstepper-stagger-step: 0.12s;
+  --fstepper-rise-distance: 14px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--fstepper-bg);
+  color: var(--fstepper-text);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.fshowcase {
+  width: 100%;
+  max-width: 760px;
+}
+
+.fshowcase__title {
+  margin-bottom: 0.25rem;
+  font-size: clamp(1.4rem, 4vw, 2rem);
+}
+
+.fshowcase__subtitle {
+  color: var(--fstepper-muted);
+  margin-bottom: 2.5rem;
+}
+
+.fstepper__radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.fstepper__nav {
+  position: relative;
+  display: flex;
+  border-bottom: 1px solid var(--fstepper-border);
+  margin-bottom: 2rem;
+  overflow-x: auto;
+}
+
+.fstepper__tab {
+  flex: 1 1 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--fstepper-muted);
+  transition: color var(--fstepper-fade-duration) var(--fstepper-fade-ease);
+}
+
+.fstepper__tab-index {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--fstepper-muted);
+  transition: color var(--fstepper-fade-duration) var(--fstepper-fade-ease);
+}
+
+.fstepper__tab-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.fstepper__indicator {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  width: 25%;
+  background: var(--fstepper-primary);
+  transition: transform var(--fstepper-fade-duration) var(--fstepper-fade-ease);
+}
+
+#fstep-1:checked ~ .fstepper__nav label[for="fstep-1"],
+#fstep-2:checked ~ .fstepper__nav label[for="fstep-2"],
+#fstep-3:checked ~ .fstepper__nav label[for="fstep-3"],
+#fstep-4:checked ~ .fstepper__nav label[for="fstep-4"] {
+  color: var(--fstepper-text);
+}
+
+#fstep-1:checked ~ .fstepper__nav label[for="fstep-1"] .fstepper__tab-index,
+#fstep-2:checked ~ .fstepper__nav label[for="fstep-2"] .fstepper__tab-index,
+#fstep-3:checked ~ .fstepper__nav label[for="fstep-3"] .fstepper__tab-index,
+#fstep-4:checked ~ .fstepper__nav label[for="fstep-4"] .fstepper__tab-index {
+  color: var(--fstepper-primary-light);
+}
+
+#fstep-1:checked ~ .fstepper__nav .fstepper__indicator { transform: translateX(0%); }
+#fstep-2:checked ~ .fstepper__nav .fstepper__indicator { transform: translateX(100%); }
+#fstep-3:checked ~ .fstepper__nav .fstepper__indicator { transform: translateX(200%); }
+#fstep-4:checked ~ .fstepper__nav .fstepper__indicator { transform: translateX(300%); }
+
+.fstepper__stage {
+  position: relative;
+  min-height: 220px;
+}
+
+.fstepper__panel {
+  position: absolute;
+  inset: 0;
+  background: var(--fstepper-panel-bg);
+  border: 1px solid var(--fstepper-border);
+  border-radius: 10px;
+  padding: 1.75rem;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0s linear 0.2s;
+}
+
+#fstep-1:checked ~ .fstepper__stage .fstepper__panel--1,
+#fstep-2:checked ~ .fstepper__stage .fstepper__panel--2,
+#fstep-3:checked ~ .fstepper__stage .fstepper__panel--3,
+#fstep-4:checked ~ .fstepper__stage .fstepper__panel--4 {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+  position: relative;
+  transition: opacity 0.2s ease;
+}
+
+.fstepper__item {
+  opacity: 0;
+  transform: translateY(var(--fstepper-rise-distance));
+}
+
+#fstep-1:checked ~ .fstepper__stage .fstepper__panel--1 .fstepper__item,
+#fstep-2:checked ~ .fstepper__stage .fstepper__panel--2 .fstepper__item,
+#fstep-3:checked ~ .fstepper__stage .fstepper__panel--3 .fstepper__item,
+#fstep-4:checked ~ .fstepper__stage .fstepper__panel--4 .fstepper__item {
+  animation: fstepperFadeRise var(--fstepper-fade-duration) var(--fstepper-fade-ease) forwards;
+}
+
+.fstepper__item--1 { animation-delay: calc(var(--fstepper-stagger-step) * 1); }
+.fstepper__item--2 { animation-delay: calc(var(--fstepper-stagger-step) * 2); }
+.fstepper__item--3 { animation-delay: calc(var(--fstepper-stagger-step) * 3); }
+.fstepper__item--4 { animation-delay: calc(var(--fstepper-stagger-step) * 4); }
+
+@keyframes fstepperFadeRise {
+  from {
+    opacity: 0;
+    transform: translateY(var(--fstepper-rise-distance));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fstepper__eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fstepper-primary-light);
+  margin-bottom: 0.5rem;
+}
+
+.fstepper__panel h2 {
+  margin: 0 0 0.75rem;
+}
+
+.fstepper__panel p {
+  margin: 0 0 1rem;
+  color: var(--fstepper-muted);
+  line-height: 1.6;
+}
+
+.fstepper__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fstepper__tags li {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--fstepper-border);
+  color: var(--fstepper-muted);
+}
+
+@media (max-width: 640px) {
+  .fstepper__nav {
+    justify-content: flex-start;
+  }
+  .fstepper__tab {
+    flex: 0 0 auto;
+    padding: 0.75rem 0.85rem;
+  }
+  .fstepper__tab-label {
+    font-size: 0.85rem;
+  }
+  .fstepper__panel {
+    padding: 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fstepper__tab,
+  .fstepper__tab-index,
+  .fstepper__indicator,
+  .fstepper__panel,
+  .fstepper__item {
+    transition: none !important;
+    animation: none !important;
+  }
+  .fstepper__item {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #56351

## What this adds
A pure CSS/HTML tabbed stepper for case-study style portfolio content. Each panel's content (eyebrow, heading, paragraph, tags) fades and rises in with a staggered sequential reveal, no JS.

## Files
- `submissions/examples/fade-in-portfolio-stepper/demo.html`
- `submissions/examples/fade-in-portfolio-stepper/style.css`
- `submissions/examples/fade-in-portfolio-stepper/README.md`

## Features
- 4-tab navigation with sliding underline indicator
- Staggered fade + rise animation for each content item within the active panel
- Fully responsive (horizontally scrollable tabs on mobile)
- `prefers-reduced-motion` support
- Documented CSS custom properties for theming
- Zero JavaScript

## Checklist
- [x] Pure CSS/HTML, no external JS frameworks
- [x] Smooth transitions and keyframe animation
- [x] Responsive across desktop/tablet/mobile
- [x] `prefers-reduced-motion` support
- [x] Files placed under `submissions/examples/`