### PR TITLE
feat: add CSS blur-entrance navbar for gaming hub layouts (issue #56476)

### DIFF
--- a/submissions/examples/blur-navbar-gaming-hub-ag/README.md
+++ b/submissions/examples/blur-navbar-gaming-hub-ag/README.md
@@ -1,0 +1,71 @@
+# CSS Blur-Entrance Navbar for Gaming Hub Layouts
+
+A lightweight, pure CSS/HTML navbar for gaming hub style websites. On load, the
+navbar eases in with a blur-to-focus entrance animation — no JavaScript required.
+
+## Files
+
+- `demo.html` — Standalone showcase page with the navbar and sample content
+- `style.css` — All styling and animation logic
+- `README.md` — This file
+
+## Usage
+
+1. Copy `style.css` into your project (or link it as-is).
+2. Copy the `<nav class="gh-navbar">...</nav>` markup from `demo.html` into your page.
+3. Link the stylesheet in your `<head>`:
+```html
+   <link rel="stylesheet" href="style.css">
+```
+4. Reload the page to see the blur-entrance animation play on the navbar.
+
+## Features
+
+- **Blur-entrance animation** — the navbar fades in, slides down slightly, and
+  transitions from blurred to sharp using `filter: blur()` combined with
+  `opacity` and `transform`, driven entirely by a single `@keyframes` rule.
+- **Pulsing logo accent** — a small glowing dot beside the brand name, animated
+  with a subtle infinite pulse.
+- **Underline hover/focus indicator** on nav links, expanding from left to right.
+- **Fully responsive** — collapses to a wrapped, centered link layout on tablet
+  and mobile viewports.
+- **Sticky positioning** — the navbar stays pinned to the top of the viewport
+  while scrolling.
+
+## Customization
+
+All key values are exposed as CSS custom properties on `:root`:
+
+| Property | Description | Default |
+|---|---|---|
+| `--gh-bg` | Page background color | `#0d0f14` |
+| `--gh-bg-translucent` | Navbar background (translucent) | `rgba(13, 15, 20, 0.85)` |
+| `--gh-accent` | Accent color (logo dot, underline, glow) | `#7f5af0` |
+| `--gh-accent-glow` | Glow color behind the accent | `rgba(127, 90, 240, 0.55)` |
+| `--gh-text` | Primary text color | `#f5f5f7` |
+| `--gh-text-muted` | Muted text color (links, paragraphs) | `#a0a3ad` |
+| `--gh-navbar-height` | Navbar height on desktop | `72px` |
+| `--gh-blur-amount` | Starting blur intensity for the entrance | `14px` |
+| `--gh-entrance-duration` | Duration of the entrance animation | `900ms` |
+| `--gh-entrance-easing` | Easing curve for the entrance animation | `cubic-bezier(0.22, 1, 0.36, 1)` |
+
+Override any of these in your own stylesheet by redeclaring them on `:root`
+after importing `style.css`.
+
+## Accessibility
+
+- Respects `prefers-reduced-motion: reduce` — when set, the entrance animation,
+  logo pulse, and link transitions are all disabled and the navbar renders in
+  its final visible state immediately.
+- Link states are exposed via both `:hover` and `:focus-visible` for keyboard
+  navigation support.
+- Sufficient color contrast is maintained between text, background, and accent
+  colors for readability.
+
+## Notes on scope
+
+This submission is implemented in pure CSS/HTML with no JavaScript, per the
+issue's "pure CSS/HTML" requirement. There is no mobile hamburger toggle since
+that would require either JS or a checkbox/radio `:checked` hack; instead, the
+nav links wrap and center on narrower viewports to remain fully usable without
+any interactive toggle.

--- a/submissions/examples/blur-navbar-gaming-hub-ag/demo.html
+++ b/submissions/examples/blur-navbar-gaming-hub-ag/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Blur-Entrance Navbar | Gaming Hub</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav class="gh-navbar">
+  <div class="gh-navbar-brand">
+    <span class="gh-logo-dot"></span>
+    NexusPlay
+  </div>
+  <ul class="gh-navbar-links">
+    <li><a href="#home">Home</a></li>
+    <li><a href="#games">Games</a></li>
+    <li><a href="#tournaments">Tournaments</a></li>
+    <li><a href="#community">Community</a></li>
+    <li><a href="#store">Store</a></li>
+  </ul>
+</nav>
+
+<main class="gh-content">
+  <section class="gh-hero">
+    <h1>Blur-Entrance Navbar</h1>
+    <p>A lightweight, pure CSS navbar that eases in with a blur-to-focus effect — built for gaming hub style layouts.</p>
+  </section>
+
+  <section class="gh-info">
+    <h2>About this demo</h2>
+    <p>Scroll or reload the page to replay the entrance animation. Resize the browser to see the responsive nav collapse behavior on smaller viewports.</p>
+  </section>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/blur-navbar-gaming-hub-ag/style.css
+++ b/submissions/examples/blur-navbar-gaming-hub-ag/style.css
@@ -1,0 +1,212 @@
+/* ==========================================================================
+   CSS Blur-Entrance Navbar — Gaming Hub Layout
+   Pure CSS, no JS. Customize via the --gh- custom properties below.
+   ========================================================================== */
+
+:root {
+  --gh-bg: #0d0f14;
+  --gh-bg-translucent: rgba(13, 15, 20, 0.85);
+  --gh-accent: #7f5af0;
+  --gh-accent-glow: rgba(127, 90, 240, 0.55);
+  --gh-text: #f5f5f7;
+  --gh-text-muted: #a0a3ad;
+  --gh-navbar-height: 72px;
+  --gh-blur-amount: 14px;
+  --gh-entrance-duration: 900ms;
+  --gh-entrance-easing: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--gh-bg);
+  color: var(--gh-text);
+}
+
+/* ---------- Navbar shell ---------- */
+
+.gh-navbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--gh-navbar-height);
+  padding: 0 clamp(16px, 4vw, 48px);
+  background: var(--gh-bg-translucent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+
+  /* Blur-entrance animation */
+  animation: gh-navbar-entrance var(--gh-entrance-duration) var(--gh-entrance-easing) both;
+}
+
+.gh-navbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: var(--gh-text);
+}
+
+.gh-logo-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--gh-accent);
+  box-shadow: 0 0 12px 2px var(--gh-accent-glow);
+  animation: gh-dot-pulse 2.4s ease-in-out infinite;
+}
+
+.gh-navbar-links {
+  display: flex;
+  align-items: center;
+  gap: clamp(14px, 2.5vw, 32px);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.gh-navbar-links a {
+  position: relative;
+  color: var(--gh-text-muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 6px 2px;
+  transition: color 0.25s ease;
+}
+
+.gh-navbar-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: var(--gh-accent);
+  transition: width 0.3s ease;
+}
+
+.gh-navbar-links a:hover,
+.gh-navbar-links a:focus-visible {
+  color: var(--gh-text);
+}
+
+.gh-navbar-links a:hover::after,
+.gh-navbar-links a:focus-visible::after {
+  width: 100%;
+}
+
+/* ---------- Entrance keyframes ---------- */
+
+@keyframes gh-navbar-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(-18px);
+    filter: blur(var(--gh-blur-amount));
+  }
+  60% {
+    opacity: 1;
+    filter: blur(2px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+@keyframes gh-dot-pulse {
+  0%, 100% {
+    box-shadow: 0 0 8px 1px var(--gh-accent-glow);
+  }
+  50% {
+    box-shadow: 0 0 16px 4px var(--gh-accent-glow);
+  }
+}
+
+/* ---------- Page content (demo support only) ---------- */
+
+.gh-content {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: clamp(32px, 6vw, 72px) clamp(16px, 4vw, 48px);
+}
+
+.gh-hero h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  margin-bottom: 8px;
+}
+
+.gh-hero p,
+.gh-info p {
+  color: var(--gh-text-muted);
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+.gh-info {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* ---------- Responsive behavior ---------- */
+
+@media (max-width: 768px) {
+  .gh-navbar {
+    flex-direction: column;
+    height: auto;
+    padding: 14px clamp(16px, 5vw, 32px);
+    gap: 12px;
+  }
+
+  .gh-navbar-links {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px 20px;
+  }
+
+  .gh-navbar-links a {
+    font-size: 0.88rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .gh-navbar-brand {
+    font-size: 1.1rem;
+  }
+
+  .gh-navbar-links {
+    gap: 10px 16px;
+  }
+}
+
+/* ---------- Accessibility: reduced motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .gh-navbar {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+
+  .gh-logo-dot {
+    animation: none;
+  }
+
+  .gh-navbar-links a,
+  .gh-navbar-links a::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a CSS blur-entrance navbar for gaming hub layouts as requested in #56476.

## Changes
- New folder: `submissions/examples/blur-navbar-gaming-hub-ag/`
- `demo.html` — showcase page with navbar structure and content sections
- `style.css` — pure CSS blur-entrance animation, responsive layout, reduced-motion support
- `README.md` — usage, CSS custom properties, and accessibility notes

## Features
- Blur-to-focus entrance animation on page load using `@keyframes`
- Fully responsive across desktop, tablet, and mobile
- `prefers-reduced-motion` support for accessibility
- Customizable via CSS custom properties

## Notes
No existing files were modified or deleted — this PR only adds new files under `submissions/examples/`.

Closes #56476