### PR TITLE
feat(submission): Add slide-in-blurred demo (#56624)

### DIFF
--- a/submissions/examples/slide-in-blurred/README.md
+++ b/submissions/examples/slide-in-blurred/README.md
@@ -1,0 +1,16 @@
+# Slide-in Blurred
+
+**What does this do?**
+Introduces a new set of "slide-in-blurred" animations that combine translation and `filter: blur()` to create a cinematic, smooth reveal effect.
+
+**How is it used?**
+Use the classes on any element you want to animate on load or via JavaScript:
+```html
+<div class="slide-in-blurred-top-ag">I come from above</div>
+<div class="slide-in-blurred-bottom-ag">I come from below</div>
+<div class="slide-in-blurred-left-ag">I come from the left</div>
+<div class="slide-in-blurred-right-ag">I come from the right</div>
+```
+
+**Why is it useful?**
+It provides a cinematic entrance effect for cards, modals, or text blocks, adding depth to standard translations by utilizing CSS filters.

--- a/submissions/examples/slide-in-blurred/demo.html
+++ b/submissions/examples/slide-in-blurred/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slide-in Blurred Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f3f4f6;
+    }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+    }
+    .box {
+      width: 150px;
+      height: 150px;
+      background: #6366f1;
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body>
+  <div class="demo-grid">
+    <div class="box slide-in-blurred-top-ag">Top</div>
+    <div class="box slide-in-blurred-bottom-ag">Bottom</div>
+    <div class="box slide-in-blurred-left-ag">Left</div>
+    <div class="box slide-in-blurred-right-ag">Right</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/slide-in-blurred/style.css
+++ b/submissions/examples/slide-in-blurred/style.css
@@ -1,0 +1,64 @@
+@keyframes ease-kf-slide-in-blurred-top-ag {
+  from {
+    transform: translateY(-100%);
+    filter: blur(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-slide-in-blurred-bottom-ag {
+  from {
+    transform: translateY(100%);
+    filter: blur(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-slide-in-blurred-left-ag {
+  from {
+    transform: translateX(-100%);
+    filter: blur(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+@keyframes ease-kf-slide-in-blurred-right-ag {
+  from {
+    transform: translateX(100%);
+    filter: blur(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+.slide-in-blurred-top-ag {
+  animation: ease-kf-slide-in-blurred-top-ag 0.6s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.slide-in-blurred-bottom-ag {
+  animation: ease-kf-slide-in-blurred-bottom-ag 0.6s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.slide-in-blurred-left-ag {
+  animation: ease-kf-slide-in-blurred-left-ag 0.6s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.slide-in-blurred-right-ag {
+  animation: ease-kf-slide-in-blurred-right-ag 0.6s cubic-bezier(0.4, 0, 0.2, 1) both;
+}


### PR DESCRIPTION
## Fixes Issue #56624

### Description
Provides a set of 4 directional "slide-in-blurred" animations that combine translation and `filter: blur()` to create a cinematic entrance effect, submitted for review and integration.

### Submission Details
* **Location:** Added inside `submissions/examples/slide-in-blurred/`
* **Implementation:** Keyframes map translation offsets along with `blur(8px) -> blur(0)` to seamlessly fade and focus elements as they enter the screen.
* Includes required `demo.html`, `style.css`, and `README.md`.

### Notes for Reviewers
* This PR is contained in exactly **1 commit**.
* Strictly follows the contribution guidelines (no modifications to core files).