### PR TITLE
feat(submission): Add CSS-only carousel demo (#56643)

### DIFF
--- a/submissions/examples/carousel-scroll-snap/README.md
+++ b/submissions/examples/carousel-scroll-snap/README.md
@@ -1,0 +1,17 @@
+# CSS-Only Carousel
+
+**What does this do?**
+Creates a lightweight, pure-CSS carousel component using `scroll-snap-type` for smooth pagination and modern `animation-timeline: view()` for center-focused scale-up effects.
+
+**How is it used?**
+Use the wrapper class on your container and the slide class on your items:
+```html
+<div class="carousel-ag">
+  <div class="carousel-slide-ag">Slide 1</div>
+  <div class="carousel-slide-ag">Slide 2</div>
+  <div class="carousel-slide-ag">Slide 3</div>
+</div>
+```
+
+**Why is it useful?**
+Carousels usually require heavy JavaScript libraries like Swiper.js. This component provides 90% of the functionality (snapping, smooth scrolling, and dynamic scale-up/opacity effects based on scroll position) with 0 dependencies and pure CSS, making it incredibly performant. It gracefully degrades on older browsers (using hover/focus scale instead).

--- a/submissions/examples/carousel-scroll-snap/demo.html
+++ b/submissions/examples/carousel-scroll-snap/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Carousel with Snap & Scale</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f8fafc;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    h1 {
+      margin-bottom: 2rem;
+      color: #334155;
+    }
+    .carousel-container {
+      width: 100%;
+      max-width: 800px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>CSS Scroll-Snap Carousel</h1>
+
+  <div class="carousel-container">
+    <div class="carousel-ag">
+      <div class="carousel-slide-ag">Slide 1</div>
+      <div class="carousel-slide-ag" style="background: linear-gradient(135deg, #10b981, #34d399);">Slide 2</div>
+      <div class="carousel-slide-ag" style="background: linear-gradient(135deg, #f59e0b, #fbbf24);">Slide 3</div>
+      <div class="carousel-slide-ag" style="background: linear-gradient(135deg, #ef4444, #f87171);">Slide 4</div>
+      <div class="carousel-slide-ag" style="background: linear-gradient(135deg, #3b82f6, #60a5fa);">Slide 5</div>
+    </div>
+  </div>
+
+  <p style="margin-top: 2rem; color: #64748b;">Scroll horizontally to view the scale effect.</p>
+
+</body>
+</html>

--- a/submissions/examples/carousel-scroll-snap/style.css
+++ b/submissions/examples/carousel-scroll-snap/style.css
@@ -1,0 +1,71 @@
+/* CSS-Only Carousel with Scroll Snap & Scale Effects */
+
+.carousel-ag {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  gap: 1.5rem;
+  padding: 2rem calc(50% - 40%); /* Padding to center the first and last slides */
+  width: 100%;
+  box-sizing: border-box;
+  /* Hide scrollbar for a cleaner look */
+  scrollbar-width: none; 
+}
+.carousel-ag::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel-slide-ag {
+  flex: 0 0 80%;
+  height: 250px;
+  scroll-snap-align: center;
+  scroll-snap-stop: always;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  transform: scale(0.9); /* Default slightly scaled down */
+  opacity: 0.7;
+  transition: transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* Fallback for non-supporting browsers: scale up on hover or focus */
+.carousel-slide-ag:hover,
+.carousel-slide-ag:focus-within {
+  transform: scale(1.02);
+  opacity: 1;
+}
+
+/* Modern pure CSS scale-up based on scroll position using view-timeline */
+@supports (animation-timeline: view()) {
+  .carousel-slide-ag {
+    animation: auto linear slide-focus-ag both;
+    animation-timeline: view(inline);
+    /* Define the animation range so it peaks in the center of the scroll container */
+    animation-range: cover 0% cover 100%;
+  }
+
+  @keyframes slide-focus-ag {
+    0% {
+      transform: scale(0.85);
+      opacity: 0.5;
+    }
+    50% {
+      transform: scale(1.05);
+      opacity: 1;
+      box-shadow: 0 12px 24px rgba(108, 99, 255, 0.4);
+    }
+    100% {
+      transform: scale(0.85);
+      opacity: 0.5;
+    }
+  }
+}


### PR DESCRIPTION
## Fixes Issue #56643

### Description
Provides a pure-CSS implementation of a horizontal carousel utilizing native scroll-snapping and modern scroll-driven animations, submitted for review and integration.

### Submission Details
* **Location:** Added inside `submissions/examples/carousel-scroll-snap/`
* **Implementation:** 
  * Uses `scroll-snap-type: x mandatory` for fluid pagination.
  * Employs `animation-timeline: view(inline)` to automatically scale up the center slide based on scroll intersection, providing a dynamic 3D-like focus effect without JavaScript.
  * Includes graceful degradation (hover/focus scale fallback) for browsers lacking `animation-timeline` support.
* Includes required `demo.html`, `style.css`, and `README.md`.

### Notes for Reviewers
* This PR is contained in exactly **1 commit**.
* Strictly follows the contribution guidelines (no modifications to core files).