### PR TITLE
feat(submission): Add text-focus-in typography animation demo (#56625)

### DIFF
--- a/submissions/examples/text-focus-in/README.md
+++ b/submissions/examples/text-focus-in/README.md
@@ -1,0 +1,13 @@
+# Text Focus In
+
+**What does this do?**
+Adds a cinematic `text-focus-in` animation where typography transitions from a heavily blurred, spaced-out state into sharp focus.
+
+**How is it used?**
+Apply the utility class to any text element (e.g., headings or hero text):
+```html
+<h1 class="text-focus-in-ag">Cinematic Text Reveal</h1>
+```
+
+**Why is it useful?**
+It provides an extremely high-quality, professional typographic entrance effect typical in film titles and premium landing pages, requiring no JavaScript strings manipulation or heavy libraries.

--- a/submissions/examples/text-focus-in/demo.html
+++ b/submissions/examples/text-focus-in/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Focus In Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #0f172a;
+      color: #f8fafc;
+    }
+    h1 {
+      font-size: 4rem;
+      text-align: center;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+    .replay-btn {
+      margin-top: 3rem;
+      padding: 0.75rem 1.5rem;
+      font-size: 1rem;
+      border: none;
+      border-radius: 8px;
+      background: #3b82f6;
+      color: white;
+      cursor: pointer;
+      transition: background 0.3s ease;
+    }
+    .replay-btn:hover {
+      background: #2563eb;
+    }
+  </style>
+</head>
+<body>
+
+  <h1 id="demo-text" class="text-focus-in-ag">Cinematic Reveal</h1>
+
+  <button class="replay-btn" onclick="replay()">Replay Animation</button>
+
+  <script>
+    function replay() {
+      const el = document.getElementById('demo-text');
+      el.classList.remove('text-focus-in-ag');
+      void el.offsetWidth; // trigger reflow
+      el.classList.add('text-focus-in-ag');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/text-focus-in/style.css
+++ b/submissions/examples/text-focus-in/style.css
@@ -1,0 +1,16 @@
+@keyframes text-focus-in-kf-ag {
+  0% {
+    filter: blur(12px);
+    opacity: 0;
+    letter-spacing: -0.5em;
+  }
+  100% {
+    filter: blur(0px);
+    opacity: 1;
+    letter-spacing: normal;
+  }
+}
+
+.text-focus-in-ag {
+  animation: text-focus-in-kf-ag 1s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
+}


### PR DESCRIPTION
## Fixes Issue #56625

### Description
Provides a pure-CSS implementation of a cinematic `text-focus-in` typography entrance animation, submitted for review and integration.

### Submission Details
* **Location:** Added inside `submissions/examples/text-focus-in/`
* **Implementation:** 
  * Keyframes transition the element from `blur(12px)` with expanded `letter-spacing` and `0` opacity, into sharp focus with normal spacing and `1` opacity.
  * Uses a custom cubic-bezier timing function (`cubic-bezier(0.55, 0.085, 0.68, 0.53)`) for a dramatic easing effect.
* Includes required `demo.html`, `style.css`, and `README.md`.

### Notes for Reviewers
* This PR is contained in exactly **1 commit**.
* Strictly follows the contribution guidelines (no modifications to core files).