### PR TITLE
feat(submission): Add flip-in-diag 3D animation demo (#56626)

### DIFF
--- a/submissions/examples/flip-in-diag/README.md
+++ b/submissions/examples/flip-in-diag/README.md
@@ -1,0 +1,14 @@
+# Flip In Diagonal
+
+**What does this do?**
+Adds two new 3D flip-in entrance animations that rotate along the diagonal axes using the CSS `rotate3d()` function.
+
+**How is it used?**
+Apply the utility classes to the elements you want to flip into view:
+```html
+<div class="flip-in-diag-1-ag">Flips in along top-left to bottom-right axis</div>
+<div class="flip-in-diag-2-ag">Flips in along bottom-left to top-right axis</div>
+```
+
+**Why is it useful?**
+Most standard CSS libraries only provide flip-x and flip-y. Diagonal flipping provides a more complex, engaging 3D entrance effect for cards and modals.

--- a/submissions/examples/flip-in-diag/demo.html
+++ b/submissions/examples/flip-in-diag/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flip In Diagonal Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #e2e8f0;
+      gap: 2rem;
+    }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 3rem;
+    }
+    .box {
+      width: 150px;
+      height: 150px;
+      background: #10b981;
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: bold;
+      text-align: center;
+      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    }
+    .replay-btn {
+      padding: 0.75rem 1.5rem;
+      font-size: 1rem;
+      border: none;
+      border-radius: 8px;
+      background: #3b82f6;
+      color: white;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-grid" id="grid">
+    <div class="box flip-in-diag-1-ag">Diag 1<br>(Top-Left to Bottom-Right)</div>
+    <div class="box flip-in-diag-2-ag" style="background: #ef4444;">Diag 2<br>(Bottom-Left to Top-Right)</div>
+  </div>
+
+  <button class="replay-btn" onclick="replay()">Replay Animations</button>
+
+  <script>
+    function replay() {
+      const grid = document.getElementById('grid');
+      const clone = grid.cloneNode(true);
+      grid.parentNode.replaceChild(clone, grid);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/flip-in-diag/style.css
+++ b/submissions/examples/flip-in-diag/style.css
@@ -1,0 +1,55 @@
+@keyframes flip-in-diag-1-kf-ag {
+  0% {
+    transform: perspective(400px) rotate3d(1, 1, 0, 90deg);
+    animation-timing-function: ease-in;
+    opacity: 0;
+  }
+  40% {
+    transform: perspective(400px) rotate3d(1, 1, 0, -20deg);
+    animation-timing-function: ease-in;
+  }
+  60% {
+    transform: perspective(400px) rotate3d(1, 1, 0, 10deg);
+    opacity: 1;
+  }
+  80% {
+    transform: perspective(400px) rotate3d(1, 1, 0, -5deg);
+  }
+  100% {
+    transform: perspective(400px) rotate3d(1, 1, 0, 0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes flip-in-diag-2-kf-ag {
+  0% {
+    transform: perspective(400px) rotate3d(1, -1, 0, 90deg);
+    animation-timing-function: ease-in;
+    opacity: 0;
+  }
+  40% {
+    transform: perspective(400px) rotate3d(1, -1, 0, -20deg);
+    animation-timing-function: ease-in;
+  }
+  60% {
+    transform: perspective(400px) rotate3d(1, -1, 0, 10deg);
+    opacity: 1;
+  }
+  80% {
+    transform: perspective(400px) rotate3d(1, -1, 0, -5deg);
+  }
+  100% {
+    transform: perspective(400px) rotate3d(1, -1, 0, 0deg);
+    opacity: 1;
+  }
+}
+
+.flip-in-diag-1-ag {
+  backface-visibility: visible !important;
+  animation: flip-in-diag-1-kf-ag 1s ease-in-out both;
+}
+
+.flip-in-diag-2-ag {
+  backface-visibility: visible !important;
+  animation: flip-in-diag-2-kf-ag 1s ease-in-out both;
+}


### PR DESCRIPTION
## Fixes Issue #56626

### Description
Provides a pure-CSS implementation of two diagonal 3D flipping entrance animations utilizing the `rotate3d()` function, submitted for review and integration.

### Submission Details
* **Location:** Added inside `submissions/examples/flip-in-diag/`
* **Implementation:** 
  * `flip-in-diag-1-ag` animates along the `(1, 1, 0)` vector (top-left to bottom-right).
  * `flip-in-diag-2-ag` animates along the `(1, -1, 0)` vector (bottom-left to top-right).
  * Utilizes `perspective` and `backface-visibility` to ensure the 3D transforms render correctly in 3D space, with a built-in slight overshoot for a spring-like finish.
* Includes required `demo.html`, `style.css`, and `README.md`.

### Notes for Reviewers
* This PR is contained in exactly **1 commit**.
* Strictly follows the contribution guidelines (no modifications to core files).