### PR TITLE
feat(submission): Add slit-in-vertical entrance animation demo (#56630)

### DIFF
--- a/submissions/examples/slit-in-vertical/README.md
+++ b/submissions/examples/slit-in-vertical/README.md
@@ -1,0 +1,13 @@
+# Slit In Vertical
+
+**What does this do?**
+Provides a 3D entrance animation where the element rotates in along the Y-axis from an obscured, deep Z-index perspective, creating an effect like a slit opening or a door swinging open into view.
+
+**How is it used?**
+Apply the class to a card or modal. Note: for the 3D effect to render correctly, the parent container should have `perspective` defined.
+```html
+<div class="slit-in-vertical-ag">I swing in vertically</div>
+```
+
+**Why is it useful?**
+3D perspective entrances provide a dynamic alternative to flat 2D translations, giving modals and dialog boxes a physical presence within the UI.

--- a/submissions/examples/slit-in-vertical/demo.html
+++ b/submissions/examples/slit-in-vertical/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slit In Vertical Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f3f4f6;
+      /* Add perspective to the container to ensure 3D transforms render correctly */
+      perspective: 1000px;
+    }
+    .box {
+      width: 250px;
+      height: 250px;
+      background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+      border-radius: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: 700;
+      font-size: 1.5rem;
+      text-align: center;
+      box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    }
+    .replay-btn {
+      margin-top: 3rem;
+      padding: 0.75rem 1.5rem;
+      font-size: 1rem;
+      border: none;
+      border-radius: 8px;
+      background: #1f2937;
+      color: white;
+      cursor: pointer;
+      transition: background 0.3s ease;
+    }
+    .replay-btn:hover {
+      background: #111827;
+    }
+  </style>
+</head>
+<body>
+
+  <div id="demo-box" class="box slit-in-vertical-ag">Slit In<br>Vertical</div>
+
+  <button class="replay-btn" onclick="replay()">Replay Animation</button>
+
+  <script>
+    function replay() {
+      const el = document.getElementById('demo-box');
+      el.classList.remove('slit-in-vertical-ag');
+      void el.offsetWidth; // trigger reflow
+      el.classList.add('slit-in-vertical-ag');
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/slit-in-vertical/style.css
+++ b/submissions/examples/slit-in-vertical/style.css
@@ -1,0 +1,19 @@
+@keyframes slit-in-vertical-kf-ag {
+  0% {
+    transform: translateZ(-800px) rotateY(90deg);
+    opacity: 0;
+  }
+  54% {
+    transform: translateZ(-160px) rotateY(87deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateZ(0) rotateY(0);
+    opacity: 1;
+  }
+}
+
+.slit-in-vertical-ag {
+  backface-visibility: hidden;
+  animation: slit-in-vertical-kf-ag 0.6s ease-out both;
+}


### PR DESCRIPTION
## Fixes Issue #56630

### Description
Provides a pure-CSS implementation of a 3D `slit-in-vertical` entrance animation, simulating a physical shutter swinging open on the Y-axis into view, submitted for review and integration.

### Submission Details
* **Location:** Added inside `submissions/examples/slit-in-vertical/`
* **Implementation:** 
  * Starts at a deep Z-index (`translateZ(-800px)`) and a 90-degree Y-rotation (making it invisible edge-on).
  * Smoothly animates forward and flattens out to `rotateY(0deg)` while fading in.
  * Uses `backface-visibility: hidden` to prevent visual glitches during the 3D rotation.
* Includes required `demo.html`, `style.css`, and `README.md`.

### Notes for Reviewers
* This PR is contained in exactly **1 commit**.
* Strictly follows the contribution guidelines (no modifications to core files).