### PR TITLE
feat(submission): CSS-only snowfall/particle background (#56645)

### DIFF
--- a/submissions/examples/snowfall-particle-background/index.html
+++ b/submissions/examples/snowfall-particle-background/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion - Particle/Snowfall Background</title>
+<style>
+/* ================================================
+   EaseMotion CSS - Snowfall / Particle Background
+   Pure CSS, zero dependencies, zero JavaScript.
+   
+   Three depth layers with parallax drift.
+   Uses box-shadow for particles, @keyframes for
+   vertical fall + slight horizontal sway.
+   ================================================ */
+
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: #0b0e17;
+  overflow: hidden;
+  font-family: system-ui, sans-serif;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ---------- snowfall container ---------- */
+.ease-snowfall {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.ease-snowfall__layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* --- Layer 1: far background — small, slow, dense --- */
+.ease-snowfall__layer--back::before {
+  content: '';
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: transparent;
+  top: -10px;
+  box-shadow:
+    24px 0 #ffffff40,   78px 12px #ffffff30,  135px 8px #ffffff50,
+    200px 20px #ffffff25, 260px 5px #ffffff45,  330px 18px #ffffff35,
+    400px 2px #ffffff30,  470px 15px #ffffff40, 540px 7px #ffffff20,
+    610px 22px #ffffff45, 680px 10px #ffffff35, 750px 3px #ffffff50,
+    50px 120px #ffffff30,  120px 90px #ffffff40,  190px 150px #ffffff25,
+    270px 80px #ffffff35,  350px 130px #ffffff45, 430px 100px #ffffff30,
+    510px 140px #ffffff20, 590px 70px #ffffff40,  670px 160px #ffffff35,
+    30px 250px #ffffff45,  100px 220px #ffffff30, 180px 280px #ffffff50,
+    250px 200px #ffffff25, 340px 260px #ffffff40, 420px 230px #ffffff35,
+    500px 290px #ffffff30, 580px 210px #ffffff45, 660px 270px #ffffff20;
+  animation: ease-snowfall-fall-back 20s linear infinite;
+}
+
+/* --- Layer 2: mid ground — medium --- */
+.ease-snowfall__layer--mid::before {
+  content: '';
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: transparent;
+  top: -10px;
+  box-shadow:
+    40px 0 #ffffff50,   110px 15px #ffffff40,  195px 5px #ffffff60,
+    280px 20px #ffffff35, 370px 10px #ffffff55,  460px 8px #ffffff45,
+    550px 18px #ffffff30, 640px 3px #ffffff50,   720px 12px #ffffff40,
+    60px 100px #ffffff45,  150px 80px #ffffff55,  240px 120px #ffffff35,
+    335px 90px #ffffff50,  425px 110px #ffffff40, 515px 70px #ffffff60,
+    605px 130px #ffffff30, 700px 95px #ffffff45;
+  animation: ease-snowfall-fall-mid 14s linear infinite;
+}
+
+/* --- Layer 3: foreground — large, fast --- */
+.ease-snowfall__layer--front::before {
+  content: '';
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: transparent;
+  top: -10px;
+  box-shadow:
+    55px 0 #ffffff70,   160px 10px #ffffff50,  290px 5px #ffffff65,
+    410px 15px #ffffff55, 530px 8px #ffffff60,   660px 20px #ffffff45,
+    80px 80px #ffffff55,  210px 60px #ffffff65,  350px 90px #ffffff50,
+    480px 70px #ffffff60, 620px 85px #ffffff45;
+  animation: ease-snowfall-fall-front 9s linear infinite;
+}
+
+/* Diagonal drift: fall down + slight horizontal sway */
+@keyframes ease-snowfall-fall-back {
+  0%   { transform: translateY(0)      translateX(0); }
+  50%  { transform: translateY(50vh)   translateX(15px); }
+  100% { transform: translateY(100vh)  translateX(0); }
+}
+
+@keyframes ease-snowfall-fall-mid {
+  0%   { transform: translateY(0)      translateX(0); }
+  50%  { transform: translateY(50vh)   translateX(-20px); }
+  100% { transform: translateY(100vh)  translateX(0); }
+}
+
+@keyframes ease-snowfall-fall-front {
+  0%   { transform: translateY(0)      translateX(0); }
+  50%  { transform: translateY(50vh)   translateX(25px); }
+  100% { transform: translateY(100vh)  translateX(0); }
+}
+
+/* ---------- demo content ---------- */
+.demo-content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+}
+
+.demo-content h1 {
+  font-size: 2rem;
+  font-weight: 300;
+  letter-spacing: 2px;
+  margin-bottom: 8px;
+}
+
+.demo-content p {
+  font-size: 0.9rem;
+  opacity: 0.6;
+}
+</style>
+</head>
+<body>
+
+<div class="ease-snowfall">
+  <div class="ease-snowfall__layer ease-snowfall__layer--back"></div>
+  <div class="ease-snowfall__layer ease-snowfall__layer--mid"></div>
+  <div class="ease-snowfall__layer ease-snowfall__layer--front"></div>
+</div>
+
+<div class="demo-content">
+  <h1>Snowfall</h1>
+  <p>pure CSS · zero dependencies · three depth layers</p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #56645

## What this adds

A pure CSS snowfall/particle background animation demo.

### Implementation
- Three depth layers (back/mid/front) using `::before` pseudo-elements
- Particles rendered with `box-shadow` — no extra DOM elements needed
- Each layer has different particle sizes (2px/3px/4px), opacities, and animation speeds (20s/14s/9s) to create parallax depth
- Diagonal drift via `translateX` sway in keyframes — not purely vertical
- Zero JavaScript, zero dependencies
- `pointer-events: none` so the overlay doesn't block interaction

### File
`submissions/examples/snowfall-particle-background/index.html`

Self-contained single HTML file with inline CSS. Ready to open in any browser.