### PR TITLE
fix: prevent accordion header text from overflowing on narrow screens

### DIFF
--- a/submissions/examples/accordion-header-overflow-mobile/README.md
+++ b/submissions/examples/accordion-header-overflow-mobile/README.md
@@ -1,0 +1,30 @@
+# Accordion Header Overflow Fix
+
+## Description
+
+This submission fixes an issue where long accordion header titles overflow or overlap the expand/collapse icon on smaller screens.
+
+## Features
+
+- Prevents header text overflow
+- Maintains icon alignment
+- Responsive layout for mobile devices
+- Pure CSS solution
+
+## Usage
+
+```html
+<div class="accordion">
+  <button class="accordion-header">
+    <span class="title">Long Accordion Title</span>
+    <span class="icon">+</span>
+  </button>
+</div>
+```
+
+## Benefits
+
+- Better readability
+- Responsive on all screen sizes
+- Prevents layout breaking
+- Easy to integrate with existing accordion components

--- a/submissions/examples/accordion-header-overflow-mobile/demo.html
+++ b/submissions/examples/accordion-header-overflow-mobile/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accordion Header Overflow Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="accordion">
+    <button class="accordion-header">
+      <span class="title">
+        This is a very long accordion header title that should remain readable on smaller screens without overflowing or overlapping the icon.
+      </span>
+      <span class="icon">+</span>
+    </button>
+
+    <div class="accordion-content">
+      <p>
+        This demonstrates how long accordion headers remain responsive and properly aligned.
+      </p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/accordion-header-overflow-mobile/style.css
+++ b/submissions/examples/accordion-header-overflow-mobile/style.css
@@ -1,0 +1,68 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  padding: 40px;
+}
+
+.accordion {
+  max-width: 500px;
+  margin: auto;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.accordion-header {
+  width: 100%;
+  padding: 16px;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.title {
+  flex: 1;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.icon {
+  flex-shrink: 0;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.accordion-content {
+  padding: 16px;
+  color: #444;
+  line-height: 1.5;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 20px;
+  }
+
+  .accordion-header {
+    padding: 12px;
+    font-size: 14px;
+    gap: 8px;
+  }
+
+  .icon {
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where long accordion header titles overflow or overlap the expand/collapse icon on narrow screens. The update improves responsiveness by ensuring proper text wrapping while keeping the toggle icon aligned.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/accordion-header-overflow-mobile/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Prevents accordion header text from overflowing or overlapping the toggle icon on smaller screens by improving responsive text wrapping and layout.

**How does a developer use it?**

```html
<div class="accordion">
  <button class="accordion-header">
    <span class="title">Long Accordion Title</span>
    <span class="icon">+</span>
  </button>
</div>
```

**Why does it fit EaseMotion CSS?**

This is a lightweight, reusable CSS improvement that enhances the responsiveness and usability of accordion components while following EaseMotion CSS's simple, composable design philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This fix uses standard CSS (`flex`, `overflow-wrap`, `word-break`, and responsive spacing) to ensure long accordion titles remain readable without affecting the layout. No changes were made to `core/` or `components/`.
```