### PR TITLE
feat: add fade-in dashboard stepper

### DIFF
--- a/submissions/examples/fade-in-dashboard-stepper/README.md
+++ b/submissions/examples/fade-in-dashboard-stepper/README.md
@@ -1,0 +1,34 @@
+# CSS Fade-In Stepper for Responsive Dashboard Layouts
+
+A pure HTML/CSS dashboard stepper that uses staggered fade-in motion to show progress across a release workflow.
+
+## Features
+
+- Five-step dashboard workflow with complete, active, queued, and next states.
+- Staggered CSS-only fade-in animation using per-step `--delay` values.
+- Horizontal desktop layout that collapses into a readable vertical mobile timeline.
+- Accessible semantics with an ordered list, section labels, and `aria-current="step"`.
+- `prefers-reduced-motion` support for users who prefer minimal animation.
+
+## Files
+
+- `demo.html`: semantic dashboard progress markup.
+- `style.css`: responsive layout, visual treatment, and fade-in animation.
+- `README.md`: usage notes and implementation summary.
+
+## Usage
+
+Copy the `fade-stepper` ordered list into a dashboard page and adjust each step's text, status class, and `--delay` value.
+
+```html
+<li class="step is-active" style="--delay: 240ms;" aria-current="step">
+  <span class="step-marker" aria-hidden="true">03</span>
+  <div class="step-content">
+    <span class="step-kicker">In progress</span>
+    <h2>Review Dashboard</h2>
+    <p>QA the responsive cards, empty states, and motion timing.</p>
+  </div>
+</li>
+```
+
+Use `is-complete` for completed steps and `is-active` for the current step.

--- a/submissions/examples/fade-in-dashboard-stepper/demo.html
+++ b/submissions/examples/fade-in-dashboard-stepper/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Fade-In Stepper for Responsive Dashboard Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="dashboard-shell">
+    <section class="hero-panel" aria-labelledby="stepper-title">
+      <p class="eyebrow">Release command center</p>
+      <div class="hero-grid">
+        <div>
+          <h1 id="stepper-title">CSS Fade-In Stepper for Responsive Dashboard Layouts</h1>
+          <p class="intro">
+            Track a dashboard deployment from intake to launch with staggered fade-in
+            steps, responsive layout shifts, and accessible reduced-motion behavior.
+          </p>
+        </div>
+        <aside class="status-card" aria-label="Deployment summary">
+          <span class="status-label">Current phase</span>
+          <strong>QA Review</strong>
+          <span class="status-meta">4 of 5 milestones ready</span>
+        </aside>
+      </div>
+    </section>
+
+    <section class="stepper-panel" aria-label="Dashboard deployment progress">
+      <ol class="fade-stepper">
+        <li class="step is-complete" style="--delay: 0ms;">
+          <span class="step-marker" aria-hidden="true">01</span>
+          <div class="step-content">
+            <span class="step-kicker">Complete</span>
+            <h2>Collect Signals</h2>
+            <p>Import product metrics, user feedback, and release blockers into the dashboard.</p>
+          </div>
+        </li>
+        <li class="step is-complete" style="--delay: 120ms;">
+          <span class="step-marker" aria-hidden="true">02</span>
+          <div class="step-content">
+            <span class="step-kicker">Complete</span>
+            <h2>Validate Data</h2>
+            <p>Confirm schema health, freshness windows, and alert thresholds before sign-off.</p>
+          </div>
+        </li>
+        <li class="step is-active" style="--delay: 240ms;" aria-current="step">
+          <span class="step-marker" aria-hidden="true">03</span>
+          <div class="step-content">
+            <span class="step-kicker">In progress</span>
+            <h2>Review Dashboard</h2>
+            <p>QA the responsive cards, empty states, and motion timing with stakeholders.</p>
+          </div>
+        </li>
+        <li class="step" style="--delay: 360ms;">
+          <span class="step-marker" aria-hidden="true">04</span>
+          <div class="step-content">
+            <span class="step-kicker">Queued</span>
+            <h2>Publish Release</h2>
+            <p>Ship the final build once accessibility checks and visual regression checks pass.</p>
+          </div>
+        </li>
+        <li class="step" style="--delay: 480ms;">
+          <span class="step-marker" aria-hidden="true">05</span>
+          <div class="step-content">
+            <span class="step-kicker">Next</span>
+            <h2>Monitor Adoption</h2>
+            <p>Watch engagement, response times, and operational notes after launch.</p>
+          </div>
+        </li>
+      </ol>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fade-in-dashboard-stepper/style.css
+++ b/submissions/examples/fade-in-dashboard-stepper/style.css
@@ -1,0 +1,271 @@
+:root {
+  --bg: #0d1b16;
+  --panel: #f6efe1;
+  --panel-soft: #fff8eb;
+  --ink: #13231d;
+  --muted: #66736b;
+  --line: rgba(19, 35, 29, 0.16);
+  --accent: #d57a1f;
+  --accent-deep: #844817;
+  --mint: #4ebf8d;
+  --shadow: 0 28px 80px rgba(3, 14, 10, 0.34);
+  --radius-xl: 34px;
+  --radius-md: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Space Grotesk", "Trebuchet MS", sans-serif;
+  background:
+    radial-gradient(circle at 12% 14%, rgba(78, 191, 141, 0.36), transparent 30rem),
+    radial-gradient(circle at 82% 5%, rgba(213, 122, 31, 0.28), transparent 28rem),
+    linear-gradient(145deg, #0d1b16 0%, #183126 54%, #0a120f 100%);
+}
+
+.dashboard-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 56px 0;
+}
+
+.hero-panel,
+.stepper-panel {
+  border: 1px solid rgba(255, 248, 235, 0.24);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+}
+
+.hero-panel {
+  padding: clamp(28px, 5vw, 56px);
+  color: var(--panel-soft);
+  background:
+    linear-gradient(135deg, rgba(255, 248, 235, 0.14), rgba(255, 248, 235, 0.04)),
+    rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1fr minmax(220px, 300px);
+  gap: 28px;
+  align-items: end;
+}
+
+.eyebrow,
+.step-kicker,
+.status-label,
+.status-meta {
+  margin: 0;
+  color: #f4c98b;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 760px;
+  margin: 12px 0 0;
+  font-size: clamp(2.3rem, 7vw, 5.4rem);
+  line-height: 0.94;
+  letter-spacing: -0.08em;
+}
+
+.intro {
+  max-width: 660px;
+  margin: 24px 0 0;
+  color: rgba(255, 248, 235, 0.74);
+  font-size: clamp(1rem, 2vw, 1.18rem);
+  line-height: 1.7;
+}
+
+.status-card {
+  display: grid;
+  gap: 8px;
+  padding: 22px;
+  border: 1px solid rgba(255, 248, 235, 0.24);
+  border-radius: 24px;
+  background: rgba(255, 248, 235, 0.11);
+}
+
+.status-card strong {
+  color: #ffffff;
+  font-size: 1.8rem;
+}
+
+.status-meta {
+  color: rgba(255, 248, 235, 0.68);
+  letter-spacing: 0.04em;
+}
+
+.stepper-panel {
+  margin-top: 24px;
+  padding: clamp(20px, 4vw, 34px);
+  background: var(--panel);
+}
+
+.fade-stepper {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.step {
+  position: relative;
+  display: grid;
+  align-content: start;
+  gap: 18px;
+  min-height: 260px;
+  padding: 22px;
+  border-right: 1px solid var(--line);
+  opacity: 0;
+  transform: translateY(24px);
+  animation: step-fade-in 680ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: var(--delay);
+}
+
+.step:last-child {
+  border-right: 0;
+}
+
+.step::before {
+  position: absolute;
+  top: 42px;
+  right: -12px;
+  z-index: 1;
+  width: 24px;
+  height: 24px;
+  border: 5px solid var(--panel);
+  border-radius: 999px;
+  background: #d4c8b4;
+  content: "";
+}
+
+.step:last-child::before {
+  display: none;
+}
+
+.step.is-complete::before,
+.step.is-active::before {
+  background: var(--mint);
+}
+
+.step-marker {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  color: var(--accent-deep);
+  font-weight: 800;
+  background: var(--panel-soft);
+}
+
+.is-active .step-marker {
+  color: #ffffff;
+  background: var(--accent);
+  box-shadow: 0 14px 34px rgba(213, 122, 31, 0.32);
+}
+
+.step-content {
+  display: grid;
+  gap: 12px;
+}
+
+.step-content h2 {
+  margin: 0;
+  font-size: clamp(1.16rem, 2vw, 1.42rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.step-content p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.94rem;
+  line-height: 1.62;
+}
+
+.is-active .step-content {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: var(--panel-soft);
+}
+
+.is-active .step-kicker {
+  color: var(--accent-deep);
+}
+
+@keyframes step-fade-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 860px) {
+  .hero-grid,
+  .fade-stepper {
+    grid-template-columns: 1fr;
+  }
+
+  .step {
+    min-height: auto;
+    grid-template-columns: 64px 1fr;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .step:last-child {
+    border-bottom: 0;
+  }
+
+  .step::before {
+    top: auto;
+    right: auto;
+    bottom: -12px;
+    left: 37px;
+  }
+}
+
+@media (max-width: 520px) {
+  .dashboard-shell {
+    width: min(100% - 20px, 1120px);
+    padding: 20px 0;
+  }
+
+  .hero-panel,
+  .stepper-panel {
+    border-radius: 24px;
+  }
+
+  .step {
+    grid-template-columns: 1fr;
+    padding: 20px 10px;
+  }
+
+  .step::before {
+    left: 24px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Added a pure HTML/CSS fade-in dashboard stepper example.
- Included responsive desktop-to-mobile layout behavior.
- Added accessible ordered-list semantics, `aria-current="step"`, and reduced-motion support.

## Validation
- `git diff --check -- submissions/examples/fade-in-dashboard-stepper`
- `npx.cmd htmlhint submissions/examples/fade-in-dashboard-stepper/demo.html --config .github/workflows/htmlhint.config.json`
- `npx.cmd stylelint submissions/examples/fade-in-dashboard-stepper/style.css --config .github/workflows/stylelint.config.json`

Fixes #54164
