### PR TITLE
fix: prevent card footer buttons from overflowing on small screens

### DIFF
--- a/submissions/docs/55659-card-footer-overflow-fix-ds/README.md
+++ b/submissions/docs/55659-card-footer-overflow-fix-ds/README.md
@@ -1,0 +1,40 @@
+# Card Footer Overflow Fix
+
+A fix for card footer action buttons overflowing outside the card
+boundary on smaller screens.
+
+## 1. What does this do?
+
+Fixes the card footer layout so that multiple action buttons (e.g.
+Edit / Preview / Download / Share) wrap onto additional rows instead
+of overflowing past the card's edge when the available width is too
+narrow to fit them all on one line.
+
+## 2. How is it used?
+
+Open `demo.html` directly in any browser — no build step or server
+required. It shows two cards side by side:
+
+- **Broken**: reproduces the original issue using the exact markup
+  from the bug report — a `.card-footer-broken` with no `flex-wrap`,
+  so the buttons overflow past the card edge.
+- **Fixed**: the corrected version using `.card-footer` with
+  `flex-wrap: wrap` on the container and `flex: 1 1 auto; min-width: 0;`
+  on each button, so buttons wrap onto a new row and shrink instead of
+  spilling outside the card.
+
+To apply the fix in your own project, give the footer container
+`display: flex; flex-wrap: wrap; gap: <spacing>;` and give each footer
+button `flex: 1 1 auto; min-width: 0;` so buttons can shrink and wrap
+instead of forcing horizontal overflow.
+
+## 3. Why is it useful?
+
+Cards with multiple footer actions are a common UI pattern, and this
+overflow bug breaks usability on any narrow viewport — buttons become
+partially hidden or impossible to tap. The fix keeps every action
+visible and reachable at any screen size without changing the visual
+design of the buttons themselves, which fits EaseMotion CSS's goal of
+components that stay usable and consistent across breakpoints.
+
+Fixes #55659.

--- a/submissions/docs/55659-card-footer-overflow-fix-ds/demo.html
+++ b/submissions/docs/55659-card-footer-overflow-fix-ds/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Card Footer Overflow Fix — Before &amp; After</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<h1>Card Footer Button Overflow — Fix Demo</h1>
+<p class="intro">
+  Resize this page (or open it on a narrow viewport) to see the difference.
+  The "Broken" card lets its footer buttons overflow past the card edge on
+  small screens. The "Fixed" card wraps the buttons so they always stay
+  inside the card boundary.
+</p>
+
+<div class="demo-grid">
+
+  <section>
+    <h2>❌ Broken</h2>
+    <div class="card card-broken" style="max-width:320px;">
+      <div class="card-body">
+        <h3>Product Card</h3>
+        <p>This card contains multiple footer actions.</p>
+      </div>
+      <div class="card-footer card-footer-broken">
+        <button>Edit</button>
+        <button>Preview</button>
+        <button>Download</button>
+        <button>Share</button>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>✅ Fixed</h2>
+    <div class="card" style="max-width:320px;">
+      <div class="card-body">
+        <h3>Product Card</h3>
+        <p>This card contains multiple footer actions.</p>
+      </div>
+      <div class="card-footer">
+        <button>Edit</button>
+        <button>Preview</button>
+        <button>Download</button>
+        <button>Share</button>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+</body>
+</html>

--- a/submissions/docs/55659-card-footer-overflow-fix-ds/style.css
+++ b/submissions/docs/55659-card-footer-overflow-fix-ds/style.css
@@ -1,0 +1,116 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f1115;
+  color: #e7e9ee;
+  padding: 32px 20px;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+.intro {
+  color: #a3a8b5;
+  max-width: 640px;
+  margin-bottom: 32px;
+  line-height: 1.5;
+}
+
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+}
+
+.demo-grid h2 {
+  font-size: 1rem;
+  margin-bottom: 12px;
+}
+
+.card {
+  background: #1a1d24;
+  border: 1px solid #2a2e38;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.card-body {
+  padding: 16px;
+}
+
+.card-body h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.card-body p {
+  margin: 0;
+  color: #a3a8b5;
+  font-size: 0.85rem;
+}
+
+/* --- BROKEN: original reported behavior ---
+   No wrapping and no width constraint on the footer's flex items,
+   so buttons overflow past the card edge on narrow viewports. */
+.card-footer-broken {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid #2a2e38;
+}
+
+.card-footer-broken button {
+  flex-shrink: 0;
+  white-space: nowrap;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid #3a3f4b;
+  background: #232733;
+  color: #e7e9ee;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+/* Force the broken example to visibly overflow at any width,
+   so the failure mode is reproducible without a real narrow device. */
+.card-broken {
+  max-width: 320px !important;
+}
+
+.card-broken .card-footer-broken {
+  width: max-content;
+}
+
+/* --- FIXED ---
+   Buttons wrap onto additional lines instead of overflowing,
+   and each button can shrink/grow to share the available row width. */
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid #2a2e38;
+}
+
+.card-footer button {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid #3a3f4b;
+  background: #232733;
+  color: #e7e9ee;
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 480px) {
+  .demo-grid {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
Adds a documentation showcase demonstrating the card footer button overflow issue and its responsive CSS fix. The demo compares the broken and fixed implementations side by side, showing how `flex-wrap: wrap` and flexible button sizing prevent footer actions from overflowing on smaller screens.

Fixes #55659

---

## Pull Request Description

This PR adds a standalone documentation showcase under `submissions/docs/55659-card-footer-overflow-fix-ds/` demonstrating a common responsive layout issue where multiple footer action buttons overflow the card on narrow viewports.

The showcase includes:
- A **Broken** example that reproduces the issue.
- A **Fixed** example using `flex-wrap: wrap` and flexible button sizing.
- A README explaining the problem, solution, and usage.

---

## Type of Change

- [x] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A documentation showcase demonstrating a responsive fix for card footer button overflow using CSS Flexbox.

### How does a developer use it?

```html
<div class="card-footer">
  <button>Edit</button>
  <button>Preview</button>
  <button>Download</button>
  <button>Share</button>
</div>
```

Apply the following CSS to keep footer actions responsive:

```css
.card-footer {
  display: flex;
  flex-wrap: wrap;
  gap: 8px;
}

.card-footer button {
  flex: 1 1 auto;
  min-width: 0;
}
```

### Why does it fit EaseMotion CSS?

It provides a simple, reusable CSS solution for a common responsive UI issue while following EaseMotion CSS's documentation-first approach with a standalone, easy-to-understand demo.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional)*

---

## Notes for Maintainer

This submission is completely self-contained within `submissions/docs/` and does not modify any core library files. Feedback or suggestions for improving the demonstration are welcome.