### PR TITLE
fix: prevent tooltip content from overflowing viewport

### DIFF
--- a/submissions/examples/tooltip-viewport-overflow/README.md
+++ b/submissions/examples/tooltip-viewport-overflow/README.md
@@ -1,0 +1,30 @@
+# Tooltip Viewport Overflow Fix
+
+## Description
+
+This submission fixes an issue where tooltips with long content overflow outside the viewport when displayed near the screen edges. The tooltip now wraps text and stays fully visible on desktop and mobile devices.
+
+## Features
+
+- Prevents tooltip overflow
+- Responsive maximum width
+- Automatic text wrapping
+- Pure CSS implementation
+
+## Usage
+
+```html
+<button class="tooltip-trigger">
+  Hover Me
+  <span class="tooltip">
+    Long tooltip message...
+  </span>
+</button>
+```
+
+## Benefits
+
+- Improves readability
+- Prevents clipped tooltip content
+- Responsive across different screen sizes
+- Easy to integrate with existing tooltip components

--- a/submissions/examples/tooltip-viewport-overflow/demo.html
+++ b/submissions/examples/tooltip-viewport-overflow/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Viewport Overflow Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+  <button class="tooltip-trigger">
+    Hover Me
+    <span class="tooltip">
+      This is a very long tooltip message that should stay inside the viewport without overflowing or being clipped on smaller screens.
+    </span>
+  </button>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/tooltip-viewport-overflow/style.css
+++ b/submissions/examples/tooltip-viewport-overflow/style.css
@@ -1,0 +1,64 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+  padding: 50px;
+}
+
+.container {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.tooltip-trigger {
+  position: relative;
+  padding: 10px 18px;
+  border: none;
+  border-radius: 6px;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 120%;
+  right: 0;
+  width: max-content;
+  max-width: min(260px, calc(100vw - 20px));
+  padding: 10px 12px;
+  background: #222;
+  color: #fff;
+  border-radius: 6px;
+  font-size: 14px;
+  line-height: 1.4;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 10;
+}
+
+.tooltip-trigger:hover .tooltip {
+  visibility: visible;
+  opacity: 1;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 20px;
+  }
+
+  .tooltip {
+    max-width: calc(100vw - 16px);
+    font-size: 13px;
+    right: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where tooltip content overflows the viewport when displayed near the edges of the screen. The update improves responsiveness by constraining the tooltip width, enabling text wrapping, and ensuring the tooltip remains fully visible across different screen sizes.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/tooltip-viewport-overflow/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Prevents tooltip content from overflowing outside the viewport by adding responsive width constraints and proper text wrapping.

**How does a developer use it?**

```html
<button class="tooltip-trigger">
  Hover Me
  <span class="tooltip">
    This is a long tooltip message that stays within the viewport.
  </span>
</button>
```

**Why does it fit EaseMotion CSS?**

This improvement enhances the usability and responsiveness of tooltip components while keeping the implementation lightweight, reusable, and aligned with EaseMotion CSS's human-readable and composable design philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The solution uses standard CSS properties such as `max-width`, `overflow-wrap`, `word-break`, and responsive spacing to keep tooltip content readable without affecting existing functionality. No modifications were made to `core/` or `components/`.
```