### PR TITLE
fix: prevent social icons from overflowing card on small screens (#55…

### DIFF
--- a/submissions/examples/social-icons-overflow-fix/README.md
+++ b/submissions/examples/social-icons-overflow-fix/README.md
@@ -1,0 +1,19 @@
+# Fix: Social Icons Overflow on Small Screens
+
+## Issue
+
+Fixes #55313 - Social media icons inside the Team Member Card were overflowing outside the container on screens narrower than 320px.
+
+## Root Cause
+
+The `.social-links` container lacked `flex-wrap`, forcing all icons onto a single line that exceeded the card's width.
+
+## Fix
+
+- Added `display: flex; flex-wrap: wrap; justify-content: center; gap: 8px;` to `.social-links`
+- Added `max-width: 100%; overflow: hidden;` to `.team-card`
+- Added a media query for extra-small screens (≤320px)
+
+## Testing
+
+Verified in Chrome DevTools responsive mode at 320px, 280px, and 240px widths.

--- a/submissions/examples/social-icons-overflow-fix/demo.html
+++ b/submissions/examples/social-icons-overflow-fix/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Team Member Card - Social Icons Fix</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div class="team-card">
+  <h3>Team Member Name</h3>
+  <div class="social-links">
+    <a href="#">GitHub</a>
+    <a href="#">LinkedIn</a>
+    <a href="#">Twitter</a>
+    <a href="#">Instagram</a>
+    <a href="#">Facebook</a>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/social-icons-overflow-fix/style.css
+++ b/submissions/examples/social-icons-overflow-fix/style.css
@@ -1,0 +1,42 @@
+.team-card {
+  max-width: 300px;
+  width: 100%;
+  margin: 20px auto;
+  padding: 16px;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  box-sizing: border-box;
+  overflow: hidden;
+  text-align: center;
+}
+
+.social-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  max-width: 100%;
+}
+
+.social-links a {
+  flex: 0 1 auto;
+  padding: 6px 10px;
+  font-size: 14px;
+  text-decoration: none;
+  border-radius: 6px;
+  background: #f5f5f5;
+  color: #333;
+  white-space: nowrap;
+}
+
+@media (max-width: 320px) {
+  .social-links {
+    gap: 6px;
+  }
+  .social-links a {
+    padding: 5px 8px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
 ## Description
This PR fixes the issue where social media icons inside the Team Member Card were overflowing outside the card container on small screens (below 320px width).

Fixes #55313

## Root Cause
The `.social-links` container did not have `flex-wrap` set, which forced all social icons onto a single line. On narrow screens, this caused the icons to overflow beyond the card's boundaries instead of wrapping.

## Fix
- Added `display: flex; flex-wrap: wrap; justify-content: center; gap: 8px;` to `.social-links`
- Added `max-width: 100%; overflow: hidden;` to `.team-card` for extra safety
- Added a media query for screens ≤320px to slightly reduce padding/font-size for a cleaner fit

## Files Changed
- `submissions/examples/social-icons-overflow-fix/demo.html`
- `submissions/examples/social-icons-overflow-fix/style.css`
- `submissions/examples/social-icons-overflow-fix/README.md`

## Testing
Tested locally in Chrome DevTools responsive mode at 320px, 280px, and 240px widths. Icons now wrap to a new line and stay within the card boundary instead of overflowing.

## Screenshot (After Fix)

<img width="1366" height="768" alt="Screenshot (417)" src="https://github.com/user-attachments/assets/19939812-74fa-4538-aee5-1c0a491e637c" />


<img width="1366" height="768" alt="Screenshot (418)" src="https://github.com/user-attachments/assets/08b0e703-9f87-4779-9fed-3311416ec8d2" />


[Paste screenshot here]