### PR TITLE
feat: add CSS slide-up progress bar for responsive dashboard layouts

### DIFF
--- a/submissions/examples/css-slide-up-progress-bar/README.md
+++ b/submissions/examples/css-slide-up-progress-bar/README.md
@@ -1,0 +1,49 @@
+# CSS Slide-Up Progress Bar
+
+A pure CSS progress bar set styled for a dashboard "project status" section. Each bar slides up into view, then fills to its target value. No JavaScript, no dependencies.
+
+## How it works
+
+Two animations run in sequence per bar:
+
+1. The whole `.ease-progress-item` (label + track) slides up and fades in on load, staggered per item with `animation-delay`.
+2. Once that settles, `.ease-progress-fill` animates its `width` from 0 to a target value, read from a `--ease-progress-value` custom property set inline per bar (e.g. `style="--ease-progress-value: 90%;"`).
+
+Splitting the value into a CSS custom property set inline on each bar means the same `@keyframes` rule works for every bar regardless of its target percentage, instead of writing a separate keyframe per value.
+
+## Files
+
+- `demo.html` – four progress bars representing project stages
+- `style.css` – all styling, custom properties, and both animations
+- `README.md` – this file
+
+## Custom properties
+
+Global ones live on `:root` in `style.css`:
+
+- `--ease-progress-duration` – 0.8s
+- `--ease-progress-easing` – ease-out
+- `--ease-progress-radius` – 999px (pill shape)
+- `--ease-progress-gap` – spacing between bars
+- `--ease-progress-track-bg` – track background
+- `--ease-progress-track-height` – bar thickness
+- `--ease-progress-text` – label text color
+- `--ease-progress-muted-text` – percentage text color
+- `--ease-progress-fill-start` / `--ease-progress-fill-end` – gradient colors for the fill
+
+Per-bar, `--ease-progress-value` is set inline on each `.ease-progress-fill` to control its target width.
+
+Example override:
+
+```css
+:root {
+  --ease-progress-fill-start: #22c55e;
+  --ease-progress-fill-end: #4ade80;
+}
+```
+
+## Notes
+
+- `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` on the track for screen reader support
+- Fully responsive, with breakpoints at 768px and 480px
+- Respects `prefers-reduced-motion` — bars appear instantly at their final position and fill width, no animation

--- a/submissions/examples/css-slide-up-progress-bar/demo.html
+++ b/submissions/examples/css-slide-up-progress-bar/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Slide-Up Progress Bar — Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Project Status</p>
+    <h1 class="ease-heading">Current Progress</h1>
+    <p class="ease-subtitle">Pure CSS progress bars that slide up into view and fill on load.</p>
+
+    <div class="ease-progress-stack">
+
+      <div class="ease-progress-item">
+        <div class="ease-progress-label">
+          <span>Design</span>
+          <span>90%</span>
+        </div>
+        <div class="ease-progress-track" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
+          <div class="ease-progress-fill" style="--ease-progress-value: 90%;"></div>
+        </div>
+      </div>
+
+      <div class="ease-progress-item">
+        <div class="ease-progress-label">
+          <span>Development</span>
+          <span>65%</span>
+        </div>
+        <div class="ease-progress-track" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100">
+          <div class="ease-progress-fill" style="--ease-progress-value: 65%;"></div>
+        </div>
+      </div>
+
+      <div class="ease-progress-item">
+        <div class="ease-progress-label">
+          <span>Testing</span>
+          <span>40%</span>
+        </div>
+        <div class="ease-progress-track" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100">
+          <div class="ease-progress-fill" style="--ease-progress-value: 40%;"></div>
+        </div>
+      </div>
+
+      <div class="ease-progress-item">
+        <div class="ease-progress-label">
+          <span>Launch Prep</span>
+          <span>15%</span>
+        </div>
+        <div class="ease-progress-track" role="progressbar" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100">
+          <div class="ease-progress-fill" style="--ease-progress-value: 15%;"></div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-slide-up-progress-bar/style.css
+++ b/submissions/examples/css-slide-up-progress-bar/style.css
@@ -1,0 +1,155 @@
+:root {
+  --ease-progress-duration: 0.8s;
+  --ease-progress-easing: ease-out;
+  --ease-progress-radius: 999px;
+  --ease-progress-gap: 1.25rem;
+  --ease-progress-track-bg: #1c1f26;
+  --ease-progress-track-height: 10px;
+  --ease-progress-text: #f0f0f0;
+  --ease-progress-muted-text: #a8a8a8;
+  --ease-progress-fill-start: #6c63ff;
+  --ease-progress-fill-end: #a78bfa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-progress-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-progress-fill-start);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-progress-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-progress-gap);
+}
+
+.ease-progress-item {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: ease-progress-slide-up 0.5s var(--ease-progress-easing) both;
+}
+
+.ease-progress-item:nth-child(1) { animation-delay: 0.05s; }
+.ease-progress-item:nth-child(2) { animation-delay: 0.15s; }
+.ease-progress-item:nth-child(3) { animation-delay: 0.25s; }
+.ease-progress-item:nth-child(4) { animation-delay: 0.35s; }
+
+.ease-progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  margin-bottom: 0.4rem;
+}
+
+.ease-progress-label span:last-child {
+  color: var(--ease-progress-muted-text);
+}
+
+.ease-progress-track {
+  width: 100%;
+  height: var(--ease-progress-track-height);
+  background: var(--ease-progress-track-bg);
+  border-radius: var(--ease-progress-radius);
+  overflow: hidden;
+}
+
+.ease-progress-fill {
+  height: 100%;
+  width: 0;
+  border-radius: var(--ease-progress-radius);
+  background: linear-gradient(90deg, var(--ease-progress-fill-start), var(--ease-progress-fill-end));
+  animation: ease-progress-fill-bar var(--ease-progress-duration) var(--ease-progress-easing) forwards;
+  animation-delay: 0.4s;
+}
+
+@keyframes ease-progress-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-progress-fill-bar {
+  from {
+    width: 0;
+  }
+  to {
+    width: var(--ease-progress-value);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-progress-label {
+    font-size: 0.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-progress-item {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+
+  .ease-progress-fill {
+    animation: none !important;
+    width: var(--ease-progress-value);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML slide-up progress bar component styled as a dashboard "project status" section, per issue #54180.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-slide-up-progress-bar/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A set of progress bars that slide up into view on load, then fill to a target percentage using a CSS custom property.

**How does a developer use it?**
```html
<div class="ease-progress-track" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
  <div class="ease-progress-fill" style="--ease-progress-value: 90%;"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-progress-track`, `ease-progress-fill`), zero dependencies, and it uses a single reusable `@keyframes` rule for every bar regardless of target value, by reading the fill amount from an inline custom property instead of hardcoding separate keyframes per percentage. Includes proper `role="progressbar"` ARIA attributes for screen readers.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Fill animation is driven by a `--ease-progress-value` custom property set inline per bar, so the same keyframe works for any percentage without needing per-value keyframes. Respects `prefers-reduced-motion`.