### PR TITLE
docs: propose changelog automation workflow (#56793)

### DIFF
--- a/submissions/docs/changelog-automation/README.md
+++ b/submissions/docs/changelog-automation/README.md
@@ -1,0 +1,46 @@
+# Automated CHANGELOG.md Proposal & Guide
+
+## Description
+This documentation package serves as an official proposal and implementation guide for Issue #56793. Because the GSSoC bot restricts contributors from directly submitting Pull Requests that modify root repository files (like `package.json` and `.github/`), this proposal is submitted via the `submissions/docs/` directory.
+
+## Implementation Guide for Core Maintainers
+
+If this proposal is accepted, a repository maintainer can simply run the following steps to fully automate the generation of `CHANGELOG.md` based on Conventional Commits.
+
+### 1. Install Dependencies
+Run this in the repository root:
+```bash
+npm install --save-dev husky @commitlint/cli @commitlint/config-conventional standard-version
+```
+
+### 2. Configure Commitlint
+Create a `commitlint.config.js` in the root:
+```javascript
+module.exports = { extends: ['@commitlint/config-conventional'] };
+```
+
+### 3. Configure Husky
+Initialize Husky to lint commits before they happen:
+```bash
+npx husky install
+npx husky add .husky/commit-msg "npx --no -- commitlint --edit $1"
+```
+
+### 4. Update package.json
+Add the following to your `package.json` scripts:
+```json
+"scripts": {
+  "release": "standard-version"
+}
+```
+
+### Usage
+Once implemented, simply running `npm run release` will automatically:
+1. Bump the version in `package.json` based on the commits (major/minor/patch).
+2. Generate the `CHANGELOG.md` exactly as requested.
+3. Commit the changes and tag the release.
+
+## Files Provided
+- `demo.html` - A visual presentation of this proposal using EaseMotion components.
+- `style.css` - Custom styling for the proposal documentation.
+- `README.md` - This guide.

--- a/submissions/docs/changelog-automation/demo.html
+++ b/submissions/docs/changelog-automation/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Changelog Automation Proposal</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body style="background-color: #f8fafc; font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; padding: 2rem;">
+
+  <div class="ease-card" style="max-width: 800px; width: 100%;">
+    <h2 class="ease-card-title">Automated CHANGELOG.md Proposal</h2>
+    <p class="ease-card-subtitle">Using Semantic Release & Conventional Commits</p>
+    
+    <div class="ease-card-body doc-content">
+      <p>This documentation proposal outlines the integration of <code>semantic-release</code> and <code>commitlint</code> to automatically manage versioning and changelog generation for EaseMotion-css.</p>
+      
+      <h3>Why this is needed:</h3>
+      <ul>
+        <li>Removes the manual burden of updating <code>CHANGELOG.md</code>.</li>
+        <li>Standardizes commit messages across hundreds of GSSoC contributors.</li>
+        <li>Automatically determines the next semantic version number based on commit types (fix, feat, breaking change).</li>
+      </ul>
+
+      <h3>Proposed Toolchain:</h3>
+      <div style="display: flex; gap: 1rem; margin-top: 1rem; flex-wrap: wrap;">
+        <span class="ease-badge ease-badge-primary">Husky</span>
+        <span class="ease-badge ease-badge-secondary">Commitlint</span>
+        <span class="ease-badge ease-badge-success">Semantic Release</span>
+        <span class="ease-badge ease-badge-warning">GitHub Actions</span>
+      </div>
+
+      <div style="margin-top: 2rem; padding: 1rem; background: #f1f5f9; border-radius: 8px;">
+        <strong>Note for Maintainers:</strong> Because the GSSoC submission bot prevents contributors from directly modifying <code>package.json</code> or <code>.github/</code> files in pull requests, the full configuration scripts and instructions have been provided in the <code>README.md</code> of this submission directory. Maintainers can simply copy-paste the configuration into the repository root.
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/changelog-automation/style.css
+++ b/submissions/docs/changelog-automation/style.css
@@ -1,0 +1,28 @@
+/* Documentation specific styles */
+.doc-content {
+  color: #334155;
+  line-height: 1.6;
+}
+
+.doc-content h3 {
+  color: #0f172a;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.doc-content ul {
+  padding-left: 1.5rem;
+}
+
+.doc-content li {
+  margin-bottom: 0.5rem;
+}
+
+.doc-content code {
+  background-color: #e2e8f0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
Closes #56793

## Description
This PR addresses issue #56793 (Automating `CHANGELOG.md` generation). 

Since the GSSoC contribution guidelines strictly sandbox external contributors to the `submissions/` directory, I am unable to directly modify `package.json` to configure Husky and Semantic Release in the repository root.

To solve this while adhering to the guidelines, I have created a comprehensive **Implementation Guide and Proposal** inside `submissions/docs/changelog-automation/`.

## Changes Made
- Created `submissions/docs/changelog-automation/demo.html` detailing the rationale and workflow of the proposed toolchain (Commitlint + Husky + Semantic Release).
- Created `submissions/docs/changelog-automation/style.css` for documentation styling.
- Created `submissions/docs/changelog-automation/README.md` containing the exact `npm install` commands and configuration JSON required for maintainers to quickly copy-paste into the root repository.

## Why this matters
By providing the code and strategy inside the `submissions/docs` folder, we bypass the bot restrictions while handing the core team everything they need to implement automated versioning in under 2 minutes.

## How to Test
1. Check out this branch.
2. Open `submissions/docs/changelog-automation/demo.html` in your browser to view the proposal.
3. Maintainers can review `README.md` for the exact integration steps.