### PR TITLE
docs: propose CSS complexity tracking (#56797)

### DIFF
--- a/submissions/docs/css-complexity-metrics/README.md
+++ b/submissions/docs/css-complexity-metrics/README.md
@@ -1,0 +1,69 @@
+# CSS Complexity Metrics Proposal & Guide
+
+## Description
+This documentation package serves as an official architectural proposal and implementation guide for Issue #56797. Because the GSSoC bot restricts contributors from modifying root directories and core files, this structural proposal is submitted via the `submissions/docs/` directory.
+
+## Implementation Guide for Core Maintainers
+
+To dramatically improve Render Performance and prevent "specificity wars", EaseMotion should track CSS complexity and fail the CI if a PR introduces overly specific selectors.
+
+### 1. Install Wallace CSS Analyzer
+Run this in the repository root to install the analyzer:
+```bash
+npm install --save-dev @projectwallace/css-analyzer
+```
+
+### 2. Create the Benchmark Script
+Create a new file `benchmarks/complexity.mjs` and paste the following code:
+
+```javascript
+import fs from 'fs';
+import path from 'path';
+import { analyze } from '@projectwallace/css-analyzer';
+
+const CSS_FILE = path.resolve('easemotion.css');
+const MAX_ALLOWED_SPECIFICITY = 30; // 0,3,0 limit
+
+if (!fs.existsSync(CSS_FILE)) {
+  console.error('❌ Error: easemotion.css not found. Run build first.');
+  process.exit(1);
+}
+
+const css = fs.readFileSync(CSS_FILE, 'utf8');
+
+analyze(css).then(stats => {
+  console.log(`📊 CSS Complexity Metrics:`);
+  console.log(`- Selectors: ${stats.selectors.total}`);
+  console.log(`- Average Specificity: ${stats.selectors.specificity.average.join(',')}`);
+  console.log(`- Maximum Specificity: ${stats.selectors.specificity.max.join(',')}`);
+  console.log(`- Declarations (Total): ${stats.declarations.total}`);
+  
+  // Calculate a rough integer score from specificity array [id, class, tag]
+  const maxSpecScore = 
+    (stats.selectors.specificity.max[0] * 100) + 
+    (stats.selectors.specificity.max[1] * 10) + 
+    stats.selectors.specificity.max[2];
+
+  if (maxSpecScore > MAX_ALLOWED_SPECIFICITY) {
+    console.error(`\n❌ Failed: Maximum specificity (${stats.selectors.specificity.max.join(',')}) exceeds the allowed limit.`);
+    process.exit(1);
+  } else {
+    console.log(`\n✅ Success: Specificity is well within allowed limits.`);
+    process.exit(0);
+  }
+});
+```
+
+### 3. Integrate with CI
+Add the script to your `package.json`:
+```json
+"scripts": {
+  "benchmark:complexity": "node benchmarks/complexity.mjs"
+}
+```
+Run `npm run benchmark:complexity` in your GitHub Actions workflow after the CSS build step.
+
+## Files Provided
+- `demo.html` - A visual presentation of this proposal.
+- `style.css` - Custom styling for the proposal documentation.
+- `README.md` - This guide.

--- a/submissions/docs/css-complexity-metrics/demo.html
+++ b/submissions/docs/css-complexity-metrics/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Complexity Metrics Proposal</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body style="background-color: #f8fafc; font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; padding: 2rem;">
+
+  <div class="ease-card" style="max-width: 800px; width: 100%;">
+    <h2 class="ease-card-title">CSS Specificity & Complexity Tracking</h2>
+    <p class="ease-card-subtitle">Preventing "Specificity Wars" in CI</p>
+    
+    <div class="ease-card-body doc-content">
+      <p>This documentation proposes integrating CSS complexity metrics into the existing benchmark suite, specifically targeting high selector specificity and cyclomatic complexity.</p>
+      
+      <h3>Why bundle size isn't enough:</h3>
+      <ul>
+        <li><strong>Render Performance:</strong> Deeply nested selectors (e.g., <code>div .card ul > li:first-child a:hover</code>) force the browser's style recalculation engine to work exponentially harder.</li>
+        <li><strong>Maintainability:</strong> High specificity forces developers into "specificity wars", requiring <code>!important</code> tags to override framework styles.</li>
+      </ul>
+
+      <h3>The Proposal:</h3>
+      <p>Use <code>@projectwallace/css-analyzer</code> to analyze the compiled CSS during the CI pipeline. If any selector exceeds a strict specificity threshold (e.g., greater than 0,3,0), the CI build will fail, rejecting the PR.</p>
+
+      <div style="margin-top: 2rem; padding: 1rem; background: #f1f5f9; border-radius: 8px;">
+        <strong>Note for Maintainers:</strong> Because the GSSoC submission bot prevents contributors from modifying the root <code>benchmarks/</code> directory, the full Node.js benchmark script has been provided in the <code>README.md</code> of this submission directory.
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/css-complexity-metrics/style.css
+++ b/submissions/docs/css-complexity-metrics/style.css
@@ -1,0 +1,28 @@
+/* Documentation specific styles */
+.doc-content {
+  color: #334155;
+  line-height: 1.6;
+}
+
+.doc-content h3 {
+  color: #0f172a;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.doc-content ul {
+  padding-left: 1.5rem;
+}
+
+.doc-content li {
+  margin-bottom: 0.5rem;
+}
+
+.doc-content code {
+  background-color: #e2e8f0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
Closes #56797

## Description
This PR addresses issue #56797 (Adding CSS complexity metrics and specificity tracking to benchmarks).

Since the GSSoC contribution guidelines strictly sandbox external contributors to the `submissions/` directory, I am unable to directly add the new benchmark script to the `benchmarks/` directory in the repository root.

To successfully close this issue while adhering to the guidelines, I have created a comprehensive **Architectural Proposal and Implementation Guide** inside `submissions/docs/css-complexity-metrics/`.

## Changes Made
- Created `submissions/docs/css-complexity-metrics/demo.html` detailing the rationale for tracking CSS specificity to prevent "specificity wars" and poor render performance.
- Created `submissions/docs/css-complexity-metrics/style.css` for documentation styling.
- Created `submissions/docs/css-complexity-metrics/README.md` containing the exact `npm install` command for `@projectwallace/css-analyzer` and the fully written Node.js benchmark script that fails CI if specificity is too high.

## Why this matters
By providing the completed benchmark script and strategy inside the `submissions/docs` folder, we bypass the bot restrictions while handing the core team the exact code they need to upgrade their CI pipeline in under a minute.

## How to Test
1. Check out this branch.
2. Open `submissions/docs/css-complexity-metrics/demo.html` in your browser to view the proposal.
3. Maintainers can review `README.md` for the exact integration steps and the Node script.