### PR TITLE
feat: add CSS scale-hover tabs for accessible web layouts

### DIFF
--- a/submissions/examples/css-scale-hover-tabs/README.md
+++ b/submissions/examples/css-scale-hover-tabs/README.md
@@ -1,0 +1,44 @@
+# CSS Scale-Hover Tabs
+
+A pure CSS tabs component styled as an account settings panel, with a scale-up hover on each tab trigger. No JavaScript, no dependencies.
+
+## How it works
+
+Tab switching uses three hidden radio inputs sharing the same `name`, so only one can be checked at a time — this is what makes the tabs mutually exclusive, unlike the checkbox hack used in an accordion where items can open independently.
+
+Each radio is paired with a `<label>` trigger, and `:checked ~` sibling selectors both style the active trigger and reveal the matching panel. On top of that, every trigger gets a `transform: scale()` transition on hover, independent of which tab is active.
+
+## Files
+
+- `demo.html` – a 3-tab settings panel (Profile, Notifications, Billing)
+- `style.css` – all styling, custom properties, tab-switching logic, and hover scale
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-tabs-duration` – 0.2s
+- `--ease-tabs-easing` – ease
+- `--ease-tabs-radius` – 8px
+- `--ease-tabs-bg` – panel background
+- `--ease-tabs-border` – border color
+- `--ease-tabs-text` – inactive tab text color
+- `--ease-tabs-active-text` – active tab / panel text color
+- `--ease-tabs-accent` – active tab underline color
+- `--ease-tabs-hover-scale` – how much a tab scales up on hover (1.06 = 6%)
+
+Example override:
+
+```css
+:root {
+  --ease-tabs-accent: #f97316;
+  --ease-tabs-hover-scale: 1.1;
+}
+```
+
+## Notes
+
+- Fully responsive, with breakpoints at 768px and 480px
+- Radio/label pairing means tabs are keyboard-navigable by default (arrow keys move between radios in the same group, Tab moves in and out)
+- Respects `prefers-reduced-motion` — hover scaling and the panel entrance animation are both disabled for users who have that set

--- a/submissions/examples/css-scale-hover-tabs/demo.html
+++ b/submissions/examples/css-scale-hover-tabs/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scale-Hover Tabs — Accessible Layout</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Account Settings</p>
+    <h1 class="ease-heading">Preferences</h1>
+    <p class="ease-subtitle">Pure CSS tabs, switched with radio inputs, no JavaScript.</p>
+
+    <div class="ease-tabs">
+
+      <input type="radio" name="ease-tabs-group" id="ease-tab-profile" class="ease-tabs-input" checked />
+      <input type="radio" name="ease-tabs-group" id="ease-tab-notifications" class="ease-tabs-input" />
+      <input type="radio" name="ease-tabs-group" id="ease-tab-billing" class="ease-tabs-input" />
+
+      <div class="ease-tabs-list" role="tablist">
+        <label for="ease-tab-profile" class="ease-tabs-trigger">Profile</label>
+        <label for="ease-tab-notifications" class="ease-tabs-trigger">Notifications</label>
+        <label for="ease-tab-billing" class="ease-tabs-trigger">Billing</label>
+      </div>
+
+      <div class="ease-tabs-panels">
+        <div class="ease-tabs-panel ease-tabs-panel-profile">
+          <h2>Profile</h2>
+          <p>Update your name, photo, and public bio here.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-notifications">
+          <h2>Notifications</h2>
+          <p>Choose which emails and alerts you want to receive.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-billing">
+          <h2>Billing</h2>
+          <p>Manage your plan, payment method, and invoices.</p>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-scale-hover-tabs/style.css
+++ b/submissions/examples/css-scale-hover-tabs/style.css
@@ -1,0 +1,175 @@
+:root {
+  --ease-tabs-duration: 0.2s;
+  --ease-tabs-easing: ease;
+  --ease-tabs-radius: 8px;
+  --ease-tabs-bg: #16181d;
+  --ease-tabs-border: #2a2d34;
+  --ease-tabs-text: #a8a8a8;
+  --ease-tabs-active-text: #f0f0f0;
+  --ease-tabs-accent: #6c63ff;
+  --ease-tabs-hover-scale: 1.06;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-tabs-active-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-tabs-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+/* hide the actual radios, keep them in the DOM for keyboard/focus */
+.ease-tabs-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-tabs-list {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--ease-tabs-border);
+  margin-bottom: 1.5rem;
+}
+
+.ease-tabs-trigger {
+  padding: 0.6rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--ease-tabs-text);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color var(--ease-tabs-duration) var(--ease-tabs-easing),
+              transform var(--ease-tabs-duration) var(--ease-tabs-easing);
+}
+
+.ease-tabs-trigger:hover {
+  color: var(--ease-tabs-active-text);
+  transform: scale(var(--ease-tabs-hover-scale));
+}
+
+.ease-tabs-input:focus-visible + .ease-tabs-list .ease-tabs-trigger {
+  outline: none;
+}
+
+.ease-tabs-panel {
+  display: none;
+  background: var(--ease-tabs-bg);
+  border: 1px solid var(--ease-tabs-border);
+  border-radius: var(--ease-tabs-radius);
+  padding: 1.25rem;
+}
+
+.ease-tabs-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.ease-tabs-panel p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #a8a8a8;
+  line-height: 1.5;
+}
+
+/* wire each radio to its label and its panel */
+#ease-tab-profile:checked ~ .ease-tabs-list label[for="ease-tab-profile"],
+#ease-tab-notifications:checked ~ .ease-tabs-list label[for="ease-tab-notifications"],
+#ease-tab-billing:checked ~ .ease-tabs-list label[for="ease-tab-billing"] {
+  color: var(--ease-tabs-active-text);
+  border-bottom-color: var(--ease-tabs-accent);
+}
+
+#ease-tab-profile:checked ~ .ease-tabs-panels .ease-tabs-panel-profile,
+#ease-tab-notifications:checked ~ .ease-tabs-panels .ease-tabs-panel-notifications,
+#ease-tab-billing:checked ~ .ease-tabs-panels .ease-tabs-panel-billing {
+  display: block;
+  animation: ease-tabs-panel-in 0.25s var(--ease-tabs-easing);
+}
+
+@keyframes ease-tabs-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-tabs-list {
+    gap: 0.25rem;
+  }
+
+  .ease-tabs-trigger {
+    padding: 0.5rem 0.7rem;
+    font-size: 0.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-trigger {
+    transition: none !important;
+  }
+
+  .ease-tabs-trigger:hover {
+    transform: none;
+  }
+
+  .ease-tabs-panel {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML scale-hover tabs component styled as an account settings panel, per issue #54212.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-scale-hover-tabs/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A tabs component using the radio-button hack for mutually exclusive switching, with a scale-up hover effect on each tab trigger.

**How does a developer use it?**
```html
<input type="radio" name="ease-tabs-group" id="ease-tab-profile" class="ease-tabs-input" checked />
<label for="ease-tab-profile" class="ease-tabs-trigger">Profile</label>
<div class="ease-tabs-panel ease-tabs-panel-profile">...</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-tabs-trigger`, `ease-tabs-panel`), zero dependencies, and it demonstrates a distinct pattern from other checkbox-based submissions — radio inputs enforce mutual exclusivity automatically, which is the correct primitive for tabs versus independently-toggleable content. Keyboard-navigable by default since it's built on native radio/label semantics.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Used radio inputs rather than checkboxes since tabs need mutual exclusivity — only one panel visible at a time. Hover scale and panel entrance both respect `prefers-reduced-motion`.