### PR TITLE
docs: propose global @media print stylesheets (#56796)

### DIFF
--- a/submissions/docs/print-stylesheets/README.md
+++ b/submissions/docs/print-stylesheets/README.md
@@ -1,0 +1,80 @@
+# Accessibility: Global Print Stylesheets Proposal
+
+## Description
+This documentation package serves as an official architectural proposal and implementation guide for Issue #56796. Because the GSSoC bot restricts contributors from modifying core framework files, this accessibility upgrade is submitted via the `submissions/docs/` directory.
+
+## Implementation Guide for Core Maintainers
+
+To dramatically improve Print Accessibility and ensure EaseMotion interfaces are usable when rendered onto physical paper, the framework should include a dedicated `_print.scss` core file.
+
+### 1. Create `core/_print.scss`
+Copy and paste this code into a new file located at `core/_print.scss`.
+
+```scss
+/* 
+ * Global Print Accessibility Defaults 
+ * Strips colors, removes animations, and ensures high contrast for physical paper.
+ */
+
+@media print {
+  // Strip backgrounds, colors, and shadows globally for ink-saving
+  *,
+  *::before,
+  *::after {
+    background: transparent !important;
+    color: #000 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  // Ensure backgrounds are strictly white
+  body {
+    background-color: #fff !important;
+  }
+
+  // Flatten the ease-card component
+  .ease-card {
+    border: 1px solid #000 !important;
+    page-break-inside: avoid;
+  }
+
+  // Disable all animations and transitions
+  * {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  // Expand links so they are readable on paper
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+  
+  a[href]::after {
+    content: " (" attr(href) ")";
+  }
+
+  // Hide links that are just fragments or javascript
+  a[href^="#"]::after,
+  a[href^="javascript:"]::after {
+    content: "";
+  }
+
+  // Utility class to easily hide navbars/buttons from the print view
+  .ease-hide-print {
+    display: none !important;
+  }
+}
+```
+
+### 2. Import into `easemotion.scss`
+Add the import statement to the main framework entry point:
+```scss
+// easemotion.scss
+@import "core/print";
+```
+
+## Files Provided
+- `demo.html` - A visual presentation of this proposal, including a live print demonstration. (Press Ctrl+P/Cmd+P while viewing it to see it in action!)
+- `style.css` - Custom styling and the actual print preview logic for the proposal documentation.
+- `README.md` - This guide.

--- a/submissions/docs/print-stylesheets/demo.html
+++ b/submissions/docs/print-stylesheets/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Print Accessibility Proposal</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body style="background-color: #f8fafc; font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; padding: 2rem;">
+
+  <div class="ease-card" style="max-width: 800px; width: 100%;">
+    <h2 class="ease-card-title">Global Print Stylesheets Proposal</h2>
+    <p class="ease-card-subtitle">Enhancing Accessibility for Physical Media</p>
+    
+    <div class="ease-card-body doc-content">
+      <p>This documentation proposes an accessibility upgrade for the framework: implementing a global <code>@media print</code> configuration to ensure EaseMotion interfaces look perfect when printed onto physical paper.</p>
+      
+      <div class="ease-hide-print ease-announce-bar" style="background: #ef4444; color: white; padding: 1rem; border-radius: 4px; margin: 1rem 0;">
+        ⚠️ This banner should automatically hide when printing! Try pressing Ctrl+P / Cmd+P to see.
+      </div>
+
+      <h3>Why Print Styles Matter:</h3>
+      <ul>
+        <li><strong>Readability:</strong> Dark modes, glassmorphism, and neon colors waste printer ink and are illegible on paper.</li>
+        <li><strong>Clutter Reduction:</strong> Utility classes like <code>.ease-hide-print</code> allow developers to effortlessly hide navigation bars, footers, and interactive elements.</li>
+        <li><strong>Professional Output:</strong> Dashboards built with EaseMotion will generate clean, ink-friendly invoices and reports.</li>
+      </ul>
+
+      <div style="margin-top: 2rem; padding: 1rem; background: #f1f5f9; border-radius: 8px;">
+        <strong>Note for Maintainers:</strong> Because the GSSoC submission bot prevents contributors from modifying core framework files in pull requests, the full CSS implementation for the <code>_print.scss</code> file has been provided in the <code>README.md</code> of this submission directory.
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/print-stylesheets/style.css
+++ b/submissions/docs/print-stylesheets/style.css
@@ -1,0 +1,51 @@
+/* Documentation specific styles */
+.doc-content {
+  color: #334155;
+  line-height: 1.6;
+}
+
+.doc-content h3 {
+  color: #0f172a;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.doc-content ul {
+  padding-left: 1.5rem;
+}
+
+.doc-content li {
+  margin-bottom: 0.5rem;
+}
+
+.doc-content code {
+  background-color: #e2e8f0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+/* DEMONSTRATION OF PROPOSAL */
+@media print {
+  body {
+    background-color: white !important;
+  }
+  
+  .ease-hide-print {
+    display: none !important;
+  }
+  
+  .ease-card {
+    box-shadow: none !important;
+    border: 1px solid #000 !important;
+    background: transparent !important;
+  }
+  
+  * {
+    color: black !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+}


### PR DESCRIPTION
Closes #56796

## Description
This PR addresses issue #56796 (Implementing global `@media print` stylesheets for print accessibility).

Since the GSSoC contribution guidelines strictly sandbox external contributors to the `submissions/` directory, I am unable to directly add the new `_print.scss` to the `core/` directory in the repository root.

To successfully close this issue while adhering to the guidelines, I have created a comprehensive **Architectural Proposal and Implementation Guide** inside `submissions/docs/print-stylesheets/`.

## Changes Made
- Created `submissions/docs/print-stylesheets/demo.html` detailing the rationale for stripping colors, removing shadows, and flattening UI components specifically for printer output.
- Created `submissions/docs/print-stylesheets/style.css` which includes an actual live demonstration of the `@media print` code applied to the proposal itself.
- Created `submissions/docs/print-stylesheets/README.md` containing the fully authored `_print.scss` code block, allowing maintainers to easily copy-paste the logic into the core framework.

## Why this matters
By providing the completed SCSS logic and strategy inside the `submissions/docs` folder, we bypass the bot restrictions while handing the core team the exact code they need to upgrade their accessibility standards in under a minute.

## How to Test
1. Check out this branch.
2. Open `submissions/docs/print-stylesheets/demo.html` in your browser.
3. Try printing the page (`Ctrl+P` or `Cmd+P`). You will see the UI flatten, the red banner completely disappear, and the borders collapse into clean ink-friendly black lines!
4. Maintainers can review `README.md` for the exact integration steps.