### PR TITLE
[BUG FIX] .ease-masonry collapses completely on print media

### DIFF
--- a/submissions/examples/masonry-print-collapse-fix-ag/README.md
+++ b/submissions/examples/masonry-print-collapse-fix-ag/README.md
@@ -1,0 +1,15 @@
+# [BUG FIX] .ease-masonry collapses completely on print media
+
+## What does this do?
+Fixes grid/column masonry collapse on print by overriding layout properties to block styling inside @media print media queries.
+
+## How is it used?
+```html
+@media print { .masonry { display: block; } }
+```
+
+## Why is it useful?
+Implements standard fallback layout rules to guarantee print readability.
+
+## Fixes
+Fixes #9850

--- a/submissions/examples/masonry-print-collapse-fix-ag/demo.html
+++ b/submissions/examples/masonry-print-collapse-fix-ag/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Masonry Print Collapse Fix</title>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="container">
+    <header class="header">
+      <h1>Masonry Print Layout Fix</h1>
+      <p>This layout arranges cards cleanly. When printed (or viewed in Print Preview), it automatically switches to block layout to avoid overlap/collapse bugs.</p>
+      <button class="print-btn" onclick="window.print()">Print Page Preview</button>
+    </header>
+
+    <div class="masonry">
+      <div class="masonry-item item-short">Card Content 1</div>
+      <div class="masonry-item item-tall">Card Content 2 (Large Content Height)</div>
+      <div class="masonry-item item-medium">Card Content 3</div>
+      <div class="masonry-item item-short">Card Content 4</div>
+      <div class="masonry-item item-tall">Card Content 5 (Large Content Height)</div>
+      <div class="masonry-item item-medium">Card Content 6</div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/masonry-print-collapse-fix-ag/style.css
+++ b/submissions/examples/masonry-print-collapse-fix-ag/style.css
@@ -1,0 +1,93 @@
+/* Bug Fix: Masonry layout collapse on print
+   Issue #9850 */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  background: #090d16;
+  color: #f1f5f9;
+  padding: 3rem 2rem;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.header {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+.header h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #a78bfa 0%, #818cf8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.header p {
+  color: #94a3b8;
+  margin-bottom: 1.5rem;
+}
+
+.print-btn {
+  background: #818cf8;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.print-btn:hover {
+  background: #6c63ff;
+}
+
+/* Masonry via Column-count */
+.masonry {
+  column-count: 3;
+  column-gap: 1.5rem;
+}
+
+.masonry-item {
+  break-inside: avoid;
+  background: #0f172a;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #cbd5e1;
+}
+
+.item-short { height: 120px; }
+.item-medium { height: 180px; }
+.item-tall { height: 260px; }
+
+/* THE FIX: Avoid column wrapping bugs on print media */
+@media print {
+  body {
+    background: #fff !important;
+    color: #000 !important;
+  }
+  .header, .print-btn {
+    display: none !important;
+  }
+  .masonry {
+    display: block !important;
+    column-count: 1 !important;
+  }
+  .masonry-item {
+    display: block !important;
+    width: 100% !important;
+    border: 1px solid #ccc !important;
+    color: #000 !important;
+    background: #fff !important;
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+    margin-bottom: 1rem !important;
+    height: auto !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #9850
Fixes grid/column masonry collapse on print by overriding layout properties to block styling inside @media print media queries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/masonry-print-collapse-fix-ag/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Prevents grid masonry layout overlapping when printed.

**How does a developer use it?**
```html
@media print { .masonry { display: block; } }
```

**Why does it fit EaseMotion CSS?**
Implements standard fallback layout rules to guarantee print readability.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission only includes the fixed CSS in `submissions/examples/masonry-print-collapse-fix-ag/style.css` and a simple demo as per the new contribution guidelines. The original bug is documented in #9850.
