### PR TITLE
[BUG FIX] .ease-btn-group border radius breaks with mixed height buttons

### DIFF
--- a/submissions/examples/btn-group-radius-fix-ag/README.md
+++ b/submissions/examples/btn-group-radius-fix-ag/README.md
@@ -1,0 +1,15 @@
+# [BUG FIX] .ease-btn-group border radius breaks with mixed height buttons
+
+## What does this do?
+Fixes border-radius distortion in button groups containing different height buttons by enforcing stretch layout and targeted child border resets.
+
+## How is it used?
+```html
+<div class="btn-group"><button>A</button><button>B</button></div>
+```
+
+## Why is it useful?
+Corrects broken visual designs in button group utilities.
+
+## Fixes
+Fixes #9854

--- a/submissions/examples/btn-group-radius-fix-ag/demo.html
+++ b/submissions/examples/btn-group-radius-fix-ag/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Button Group Radius Fix</title>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Button Group Radius Fix</h1>
+    <p>Inside this group, buttons contain varying font sizes (and native heights), but the group container forces stretch rendering, ensuring the border corners align correctly.</p>
+    
+    <div class="demo-box">
+      <!-- THE FIX: Flex row btn group with stretch -->
+      <div class="btn-group">
+        <button class="grp-btn">Small</button>
+        <button class="grp-btn main-btn">Medium Bold</button>
+        <button class="grp-btn">Large Text</button>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/btn-group-radius-fix-ag/style.css
+++ b/submissions/examples/btn-group-radius-fix-ag/style.css
@@ -1,0 +1,78 @@
+/* Bug Fix: Button group border radius alignment
+   Issue #9854 */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  background: #090d16;
+  color: #f1f5f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.demo-container {
+  max-width: 500px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #a78bfa 0%, #818cf8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+p {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.demo-box {
+  background: #0f172a;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+/* THE FIX: Flex container stretching buttons to equal height */
+.btn-group {
+  display: inline-flex;
+  align-items: stretch; /* Forces equal heights */
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+}
+
+.grp-btn {
+  background: #1e293b;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.grp-btn:not(:last-child) {
+  border-right: none;
+}
+
+/* Mixed sizes to trigger issue */
+.main-btn {
+  font-size: 1.2rem;
+  font-weight: 700;
+  padding: 0.75rem 1.25rem;
+  background: #818cf8;
+}
+
+.grp-btn:hover {
+  filter: brightness(1.1);
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #9854
Fixes border-radius distortion in button groups containing different height buttons by enforcing stretch layout and targeted child border resets.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/btn-group-radius-fix-ag/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Aligns buttons perfectly and preserves outer border corners in button groups.

**How does a developer use it?**
```html
<div class="btn-group"><button>A</button><button>B</button></div>
```

**Why does it fit EaseMotion CSS?**
Corrects broken visual designs in button group utilities.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission only includes the fixed CSS in `submissions/examples/btn-group-radius-fix-ag/style.css` and a simple demo as per the new contribution guidelines. The original bug is documented in #9854.
