### PR TITLE
[BUG FIX] .ease-loader spinner inherits transparent color in primary button

### DIFF
--- a/submissions/examples/loader-btn-color-fix-ag/README.md
+++ b/submissions/examples/loader-btn-color-fix-ag/README.md
@@ -1,0 +1,15 @@
+# [BUG FIX] .ease-loader spinner inherits transparent color in primary button
+
+## What does this do?
+Fixes spinner invisible state inside primary buttons by setting default border colors to inherit button text color values.
+
+## How is it used?
+```html
+<button class="btn btn-primary"><span class="loader"></span></button>
+```
+
+## Why is it useful?
+Prevents loading spinner symbols from going invisible inside primary styling options.
+
+## Fixes
+Fixes #9855

--- a/submissions/examples/loader-btn-color-fix-ag/demo.html
+++ b/submissions/examples/loader-btn-color-fix-ag/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loader Button Color Fix</title>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Visible Loader inside Primary Button</h1>
+    <p>The spinner inherits the contrast color of the parent button (white text), ensuring it is fully visible against dark background states.</p>
+    
+    <div class="demo-box">
+      <!-- FIXED LOADER INSIDE BUTTON -->
+      <button class="btn btn-primary">
+        <span class="loader"></span>
+        Loading Content
+      </button>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/loader-btn-color-fix-ag/style.css
+++ b/submissions/examples/loader-btn-color-fix-ag/style.css
@@ -1,0 +1,70 @@
+/* Bug Fix: Loader color inheritance inside buttons
+   Issue #9855 */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  background: #090d16;
+  color: #f1f5f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.demo-container {
+  max-width: 450px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #a78bfa 0%, #818cf8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+p {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.demo-box {
+  background: #0f172a;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+.btn-primary {
+  background: #818cf8;
+  color: #ffffff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* THE FIX: Spinner color uses currentColor (inherits white from button text) */
+.loader {
+  width: 18px;
+  height: 18px;
+  border: 2px solid currentColor;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes #9855
Fixes spinner invisible state inside primary buttons by setting default border colors to inherit button text color values.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/examples/loader-btn-color-fix-ag/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Updates loader spinner to inherit currentColor, resolving transparency overrides.

**How does a developer use it?**
```html
<button class="btn btn-primary"><span class="loader"></span></button>
```

**Why does it fit EaseMotion CSS?**
Prevents loading spinner symbols from going invisible inside primary styling options.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission only includes the fixed CSS in `submissions/examples/loader-btn-color-fix-ag/style.css` and a simple demo as per the new contribution guidelines. The original bug is documented in #9855.
