### PR TITLE
docs: propose official PurgeCSS configuration (#56790)

### DIFF
--- a/submissions/docs/purgecss-configuration/README.md
+++ b/submissions/docs/purgecss-configuration/README.md
@@ -1,0 +1,47 @@
+# PurgeCSS Production Optimization Guide
+
+## Description
+This documentation package serves as an official architectural proposal and implementation guide for Issue #56790. Because the GSSoC bot restricts contributors from modifying the root `README.md` directly, this documentation proposal is submitted via the `submissions/docs/` directory.
+
+## Implementation Guide for Core Maintainers
+
+To dramatically improve Production Performance, EaseMotion needs an official `PurgeCSS` configuration block that users can copy-paste into their webpack, vite, or postcss configs.
+
+### Proposed Documentation Addition
+Please append the following Markdown block to the **"Production"** section of the root `README.md`:
+
+```markdown
+## Optimizing for Production (PurgeCSS)
+
+EaseMotion ships with hundreds of utility classes. To ensure your production CSS bundle remains as small as possible, we highly recommend using [PurgeCSS](https://purgecss.com/).
+
+### Standard Configuration
+
+If you are using PostCSS, add the following to your `postcss.config.js`:
+
+\`\`\`javascript
+const purgecss = require('@fullhuman/postcss-purgecss')
+
+module.exports = {
+  plugins: [
+    purgecss({
+      content: ['./src/**/*.html', './src/**/*.js', './src/**/*.jsx', './src/**/*.vue'],
+      defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || [],
+      // Safelist dynamic animation classes that might be injected via JS
+      safelist: {
+        standard: [/^ease-/],
+        deep: [/ease-animate-/, /ease-transition-/]
+      }
+    })
+  ]
+}
+\`\`\`
+
+**Why Safelist?**
+Because some EaseMotion animations (like scroll reveals) dynamically inject classes like `.ease-fade-in` using JavaScript, PurgeCSS might accidentally delete them during the build process since they don't appear directly in your HTML strings. The `safelist` configuration above ensures that any class starting with `ease-` is protected from deletion!
+```
+
+## Files Provided
+- `demo.html` - A visual presentation of this proposal.
+- `style.css` - Custom styling for the proposal documentation.
+- `README.md` - This guide.

--- a/submissions/docs/purgecss-configuration/demo.html
+++ b/submissions/docs/purgecss-configuration/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PurgeCSS Configuration Proposal</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body style="background-color: #f8fafc; font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; padding: 2rem;">
+
+  <div class="ease-card" style="max-width: 800px; width: 100%;">
+    <h2 class="ease-card-title">Production Optimization via PurgeCSS</h2>
+    <p class="ease-card-subtitle">Shipping only what you use.</p>
+    
+    <div class="ease-card-body doc-content">
+      <p>This documentation proposes an official PurgeCSS configuration for EaseMotion, allowing users to strip thousands of unused utility classes from the final production bundle.</p>
+      
+      <h3>Why Provide Official Configuration?</h3>
+      <ul>
+        <li><strong>Bundle Size:</strong> Utility frameworks ship with massive CSS files. PurgeCSS can reduce a 150KB CSS file down to 10KB.</li>
+        <li><strong>Animation Safety:</strong> Dynamic classes (like <code>.ease-fade-in-on-scroll</code> added via Intersection Observers) are often accidentally deleted by bundlers. An official config ensures these are safely allowlisted.</li>
+      </ul>
+
+      <div style="margin-top: 2rem; padding: 1rem; background: #f1f5f9; border-radius: 8px;">
+        <strong>Note for Maintainers:</strong> Because the GSSoC submission bot prevents contributors from modifying the root <code>README.md</code>, the full official PurgeCSS configuration block to be appended to the root documentation has been provided in the <code>README.md</code> of this submission directory.
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/purgecss-configuration/style.css
+++ b/submissions/docs/purgecss-configuration/style.css
@@ -1,0 +1,28 @@
+/* Documentation specific styles */
+.doc-content {
+  color: #334155;
+  line-height: 1.6;
+}
+
+.doc-content h3 {
+  color: #0f172a;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.doc-content ul {
+  padding-left: 1.5rem;
+}
+
+.doc-content li {
+  margin-bottom: 0.5rem;
+}
+
+.doc-content code {
+  background-color: #e2e8f0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
Closes #56790

## Description
This PR addresses issue #56790 (Adding official PurgeCSS configuration and documentation for production).

Since the GSSoC contribution guidelines strictly sandbox external contributors to the `submissions/` directory, I am unable to directly append this configuration block to the root `README.md` without the bot rejecting the PR.

To successfully close this issue while adhering to the guidelines, I have created a comprehensive **Architectural Proposal and Implementation Guide** inside `submissions/docs/purgecss-configuration/`.

## Changes Made
- Created `submissions/docs/purgecss-configuration/demo.html` detailing the critical importance of bundle size optimization and safely allowing dynamic animation classes during the purge process.
- Created `submissions/docs/purgecss-configuration/style.css` for documentation styling.
- Created `submissions/docs/purgecss-configuration/README.md` containing the fully authored PurgeCSS configuration code block (using `postcss-purgecss`), complete with a `safelist` that prevents dynamically injected `.ease-*` animation classes from being accidentally stripped out by the bundler.

## Why this matters
By providing the completed PurgeCSS configuration and Markdown block inside the `submissions/docs` folder, we bypass the bot restrictions while handing the core team the exact code they need to copy-paste into the main README.

## How to Test
1. Check out this branch.
2. Open `submissions/docs/purgecss-configuration/demo.html` in your browser to view the proposal.
3. Maintainers can review `README.md` for the exact Markdown block to append to the root documentation.