### PR TITLE
feat: add ease-card-interactive hover animation (fixes #39422)

### DIFF
--- a/submissions/examples-v1/39422-card-hover-animation/README.md
+++ b/submissions/examples-v1/39422-card-hover-animation/README.md
@@ -1,0 +1,18 @@
+# Card Hover Animation — fixes #39422
+
+This contribution adds the `.ease-card-interactive` utility class to provide a smooth, performant hover elevation effect for card components. It applies a subtle upward translation (`translateY(-6px)`), enhanced drop shadow, and brighter border color with a 250ms cubic-bezier transition, creating intuitive visual feedback without causing layout reflows. The class is composable and works seamlessly across flat, outlined, glassmorphism, and accent card variants.
+
+## Usage
+
+Simply add the `.ease-card-interactive` class alongside any existing `.ease-card` element:
+
+```html
+<div class="ease-card ease-card-interactive">
+  <h2>Card Title</h2>
+  <p>Card content goes here.</p>
+</div>
+```
+
+## Accessibility
+
+This animation fully respects user accessibility settings via `@media (prefers-reduced-motion: reduce)`. When reduced motion is enabled in the OS or browser settings, transforms and smooth transitions are disabled automatically.

--- a/submissions/examples-v1/39422-card-hover-animation/demo.html
+++ b/submissions/examples-v1/39422-card-hover-animation/demo.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Hover Animation Demo — Issue #39422</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    /* Demo Page Base Styles */
+    :root {
+      --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+      --text-main: #f8fafc;
+      --text-muted: #94a3b8;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg-gradient);
+      color: var(--text-main);
+      min-height: 100vh;
+      padding: 3rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    header {
+      text-align: center;
+      max-width: 650px;
+      margin-bottom: 3rem;
+    }
+
+    header h1 {
+      font-size: 2.25rem;
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      background: linear-gradient(to right, #818cf8, #c084fc);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    header p {
+      color: var(--text-muted);
+      font-size: 1.05rem;
+      line-height: 1.6;
+    }
+
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 2rem;
+      width: 100%;
+      max-width: 1100px;
+    }
+
+    /* Common Card Layout Base */
+    .ease-card {
+      border-radius: 1rem;
+      padding: 1.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .ease-card h2 {
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+
+    .ease-card p {
+      font-size: 0.95rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+
+    .card-tag {
+      display: inline-block;
+      align-self: flex-start;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 0.25rem 0.6rem;
+      border-radius: 9999px;
+    }
+
+    /* Card Variant Styles */
+    
+    /* 1. Flat Card Variant */
+    .card-flat {
+      background-color: #1e293b;
+      border: 1px solid #334155;
+    }
+    .card-flat .card-tag {
+      background: #312e81;
+      color: #a5b4fc;
+    }
+
+    /* 2. Outlined Card Variant */
+    .card-outlined {
+      background: transparent;
+      border: 2px solid #475569;
+    }
+    .card-outlined .card-tag {
+      background: #374151;
+      color: #d1d5db;
+    }
+
+    /* 3. Glassmorphism Card Variant */
+    .card-glass {
+      background: rgba(255, 255, 255, 0.05);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+    }
+    .card-glass .card-tag {
+      background: rgba(168, 85, 247, 0.2);
+      color: #e9d5ff;
+    }
+
+    /* 4. Accent Card Variant */
+    .card-accent {
+      background: linear-gradient(145deg, #1e1b4b, #311b92);
+      border: 1px solid #4338ca;
+    }
+    .card-accent .card-tag {
+      background: rgba(99, 102, 241, 0.3);
+      color: #c7d2fe;
+    }
+  </style>
+</head>
+<body>
+
+  <header>
+    <h1>Interactive Card Hover Animation</h1>
+    <p>Demonstrating composable hover elevation effect (<code>.ease-card-interactive</code>) applied across flat, outlined, glassmorphism, and accent card variants.</p>
+  </header>
+
+  <main class="card-grid">
+    <!-- Flat Card -->
+    <div class="ease-card card-flat ease-card-interactive">
+      <span class="card-tag">Flat Style</span>
+      <h2>Standard Card</h2>
+      <p>A classic surface card with subtle border and elevation on hover for smooth interactive feedback.</p>
+    </div>
+
+    <!-- Outlined Card -->
+    <div class="ease-card card-outlined ease-card-interactive">
+      <span class="card-tag">Outlined</span>
+      <h2>Minimal Outlined</h2>
+      <p>Clean border layout that lifts up and brightens its border tint seamlessly when targeted.</p>
+    </div>
+
+    <!-- Glassmorphism Card -->
+    <div class="ease-card card-glass ease-card-interactive">
+      <span class="card-tag">Glassmorphism</span>
+      <h2>Glass Surface</h2>
+      <p>Frosted glass card maintaining backdrop blur while elevating dynamically on cursor hover.</p>
+    </div>
+
+    <!-- Accent Card -->
+    <div class="ease-card card-accent ease-card-interactive">
+      <span class="card-tag">Accent</span>
+      <h2>Gradient Accent</h2>
+      <p>Rich gradient background card showcasing uniform transition timing without layout reflows.</p>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples-v1/39422-card-hover-animation/style.css
+++ b/submissions/examples-v1/39422-card-hover-animation/style.css
@@ -1,0 +1,33 @@
+/* ==========================================
+   EaseMotion CSS - Interactive Card Hover
+   Fixes Issue #39422
+   ========================================== */
+
+.ease-card-interactive {
+  cursor: pointer;
+  position: relative;
+  transition:
+    transform 250ms cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 250ms cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform, box-shadow, border-color;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ease-card-interactive:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 20px 30px -10px rgba(0, 0, 0, 0.15), 0 10px 15px -5px rgba(0, 0, 0, 0.08);
+    border-color: var(--ease-card-hover-border, #6366f1);
+    z-index: 2;
+  }
+}
+
+/* Accessibility: Respect user prefers-reduced-motion settings */
+@media (prefers-reduced-motion: reduce) {
+  .ease-card-interactive {
+    transition: none !important;
+  }
+  .ease-card-interactive:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a reusable `.ease-card-interactive` hover animation utility that provides consistent, smooth elevation feedback across all EaseMotion card variants (flat, outlined, glassmorphism, accent), addressing the inconsistent hover behavior reported in #39422.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples-v1/39422-card-hover-animation/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A composable `.ease-card-interactive` class that adds a smooth lift-and-glow hover effect to any card element.

**How does a developer use it?**
```html
<div class="ease-card ease-card-interactive">
  <h2>Card Title</h2>
  <p>Card content goes here.</p>
</div>
```

**Why does it fit EaseMotion CSS?**
It follows the framework's human-readable, animation-first philosophy — one clearly-named class (`ease-card-interactive`) adds intuitive, subtle motion feedback without any JS, and composes cleanly on top of any existing card variant (flat, outlined, glass, accent) rather than being tied to one specific style.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Fixes #39422. Chose a new class name (`.ease-card-interactive`) instead of reusing the existing `.ease-card-hover` in `components/cards.css`, since that class is opt-in per-card whereas this issue asked for consistent hover feedback composable across all card style variants. Fully respects `prefers-reduced-motion`. Happy to adjust timing/easing values if you'd prefer to match `.ease-card-hover`'s existing 300ms/cubic-bezier exactly.