### PR TITLE
Fix sidebar menu items overflowing on narrow screens

### DIFF
--- a/submissions/examples/core_changes-issue-56747/README.md
+++ b/submissions/examples/core_changes-issue-56747/README.md
@@ -1,0 +1,73 @@
+# Fix: Sidebar Menu Items Overflow on Narrow Screens
+
+Fixes **#56747** — long sidebar navigation labels overflowed their
+container, overlapped adjacent elements, or forced horizontal
+scrolling on narrow viewports.
+
+## Root cause
+
+The sidebar links had no defined text-wrapping behavior, and the
+sidebar container itself had no `min-width: 0`. By default, a
+flex item won't shrink below the natural width of its content's
+longest unbreakable run of text — so a label like "Analytics and
+Performance Reports" forced the whole sidebar wider than intended,
+overflowing its container.
+
+## The fix
+
+Three small, targeted CSS changes — no markup changes, no JavaScript:
+
+**1. `min-width: 0` on the sidebar.**
+```css
+.sidebar {
+  min-width: 0;
+}
+```
+This is the fix that matters most. Without it, a flexbox child
+refuses to shrink past its content's intrinsic width, no matter what
+`width` you set — which is the actual mechanism behind this bug.
+
+**2. Word wrapping on the links.**
+```css
+.sidebar a {
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+}
+```
+Long labels now wrap onto a second line inside the sidebar instead of
+pushing it wider.
+
+**3. A narrow-viewport layout adjustment.**
+```css
+@media (max-width: 480px) {
+  .demo-shell { flex-direction: column; }
+  .sidebar { width: 100%; }
+}
+```
+Below 480px, the sidebar stacks above the content and takes the full
+width, rather than staying pinned to a fixed width that no longer
+fits a phone-sized screen.
+
+## Why this approach
+
+This addresses the exact root cause (a flexbox min-width default)
+rather than papering over the symptom with `overflow: hidden` or
+`text-overflow: ellipsis`, which would hide part of every long label
+permanently instead of letting users read the full text on wrap.
+
+## How to verify
+
+Open `demo.html` and narrow the browser window (or view on a mobile
+device). The "Analytics and Performance Reports" and "User Management
+Settings" labels wrap onto a second line within the sidebar instead of
+overflowing it or triggering horizontal scroll. Below 480px, the
+sidebar stacks above the main content.
+
+## Files
+
+- `demo.html` — the exact sidebar markup from the issue report, in a
+  two-column demo layout.
+- `style.css` — the three-part fix, plus supporting demo layout
+  styling.
+- `README.md` — this file.

--- a/submissions/examples/core_changes-issue-56747/demo.html
+++ b/submissions/examples/core_changes-issue-56747/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fix: Sidebar Items Overflow on Narrow Screens (#56747)</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <header class="demo-header">
+      <h1>Sidebar Overflow Fix</h1>
+      <p>
+        Reproduces the exact markup from #56747 — a sidebar with long
+        navigation labels. Resize the window narrower (or view on
+        mobile); labels now wrap gracefully instead of overflowing or
+        forcing horizontal scroll.
+      </p>
+    </header>
+
+    <div class="demo-shell">
+
+      <!-- Reproduction markup, unchanged from the issue report -->
+      <aside class="sidebar">
+        <a href="#">Dashboard</a>
+        <a href="#">Analytics and Performance Reports</a>
+        <a href="#">User Management Settings</a>
+        <a href="#">Notifications</a>
+      </aside>
+
+      <div class="demo-content">
+        <p>Main content area. Narrow the viewport to see the sidebar labels wrap instead of overflowing.</p>
+      </div>
+
+    </div>
+
+    <footer class="demo-footer">
+      <p>See <code>README.md</code> for the root cause and the exact fix applied.</p>
+    </footer>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/core_changes-issue-56747/style.css
+++ b/submissions/examples/core_changes-issue-56747/style.css
@@ -1,0 +1,159 @@
+/* ==========================================================================
+   Fix: Sidebar Menu Items Overflow on Narrow Screens (#56747)
+
+   ROOT CAUSE
+   -----------
+   The sidebar links had no defined text-wrapping behavior and the
+   sidebar container had no `min-width: 0`. Flex/block children default
+   to a minimum content size based on their longest unbreakable word,
+   so a long label like "Analytics and Performance Reports" pushed the
+   sidebar wider than its intended width, overflowing its container or
+   forcing horizontal scroll on narrow viewports.
+
+   THE FIX
+   --------
+   1. `min-width: 0` on the sidebar — without this, a flex/grid item
+      will refuse to shrink below its content's natural width, which is
+      the single most common cause of this exact overflow bug.
+   2. `overflow-wrap: break-word` + `word-break: break-word` on the
+      links, so long labels wrap onto a second line instead of forcing
+      the container wider.
+   3. A responsive `max-width` + `flex-wrap` adjustment so the sidebar
+      itself reflows sensibly on narrow screens instead of staying
+      pinned to a fixed width that no longer fits.
+   ========================================================================== */
+
+:root {
+  --bg: #f6f7f9;
+  --surface: #ffffff;
+  --text: #1c1d21;
+  --text-muted: #6a6d74;
+  --accent: #2f6fed;
+  --border: #e2e4ea;
+
+  --sidebar-width: 220px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.demo {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.demo-header h1 {
+  margin: 0 0 0.6rem;
+  font-size: 1.6rem;
+}
+
+.demo-header p {
+  color: var(--text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* ---- Layout shell: sidebar + content, side by side ------------------------ */
+.demo-shell {
+  display: flex;
+  gap: 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: var(--surface);
+}
+
+/* ==========================================================================
+   THE FIX
+   ========================================================================== */
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+
+  /* Fix, part 1: without this, a flex item won't shrink below its
+     content's natural (unwrapped) width — the root cause of the
+     overflow. */
+  min-width: 0;
+
+  padding: 1rem 0.5rem;
+  background-color: var(--bg);
+  border-right: 1px solid var(--border);
+}
+
+.sidebar a {
+  display: block;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  line-height: 1.35;
+
+  /* Fix, part 2: let long labels wrap onto a second line instead of
+     pushing the sidebar wider or overflowing it. */
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.sidebar a:hover,
+.sidebar a:focus-visible {
+  background-color: var(--surface);
+  color: var(--accent);
+}
+
+.demo-content {
+  padding: 1.5rem 1.25rem 1.5rem 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+/* Fix, part 3: on narrow viewports, let the sidebar shrink further and
+   stack above the content instead of staying pinned to a fixed width
+   that no longer fits the screen. */
+@media (max-width: 480px) {
+  .demo-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .demo-content {
+    padding: 1.25rem;
+  }
+}
+
+/* ---- Footer ---------------------------------------------------------------- */
+.demo-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 2rem;
+}
+
+.demo-footer code {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
Pull Request Description

Fixes #56747 — long sidebar navigation labels overflowed their container, overlapped adjacent elements, or forced horizontal scrolling on narrow viewports. Root cause: the sidebar had no min-width: 0, so flexbox refused to shrink it below its longest label's natural width. Fix adds min-width: 0, word-wrapping on the links, and a narrow-viewport stacking layout.

Type of Change
 🐛 Bug fix in an existing submission
Submission Checklist
 All changes are inside submissions/ (submissions/examples/core_changes-issue-56747/)
 Includes demo.html — self-contained, opens in browser with no server
 Includes style.css — raw CSS for the proposed feature
 Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
 No changes to core/
 No changes to components/
 One feature per PR (no bundled unrelated changes)
Feature Description

What does this add?
A demonstrated fix for sidebar overflow: reproduces the issue's exact markup with long labels, with min-width: 0 and word-wrapping applied so labels wrap instead of overflowing.

How does a developer use it?

css
.sidebar { min-width: 0; }
.sidebar a { overflow-wrap: break-word; word-break: break-word; }

Why does it fit EaseMotion CSS?
Pure CSS, no JS, no markup changes — addresses the actual root cause (flexbox's default min-width) rather than masking it with overflow: hidden or ellipsis truncation.

Demo
 Demo added (demo.html works by opening directly in a browser)
Browser Testing
 Chrome
 Firefox
 Edge
 Safari

Closes#56747