### PR TITLE
Fix: prevent notification banner content from overflowing on narrow screens

### DIFF
--- a/submissions/examples/notification-banner-overflow-fix/README.md
+++ b/submissions/examples/notification-banner-overflow-fix/README.md
@@ -1,0 +1,41 @@
+﻿# Notification Banner — Overflow Fix
+
+Fixes #56742: notification banners with long messages and action buttons overflowing or becoming misaligned on narrow/mobile screens.
+
+## The Problem
+
+The original banner layout let long message text push the action button outside the container, or caused text clipping, because the container did not allow wrapping and the text had no minimum-width safeguard.
+
+## The Fix
+
+- `display: flex` plus `flex-wrap: wrap` on `.notification-banner` so content reflows instead of overflowing.
+- `.notification-banner__message` uses `flex: 1 1 220px` and `min-width: 0` so it can shrink and wrap instead of forcing the row wider than its container.
+- `overflow-wrap: break-word` and `word-break: break-word` on the message so unusually long words do not cause horizontal overflow.
+- `.notification-banner__actions` and each button use `flex-shrink: 0` and `white-space: nowrap` so buttons stay intact and visible rather than getting squeezed or clipped.
+- A `@media (max-width: 480px)` rule switches the banner to a vertical stack (`flex-direction: column`) and makes buttons full-width, so everything stays tappable and legible on small screens.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--nb-radius` | `8px` | Banner corner radius |
+| `--nb-gap` | `12px` | Gap between icon, message, and actions |
+| `--nb-padding` | `16px 20px` | Banner internal padding |
+| `--nb-font-size` | `0.95rem` | Message font size |
+| `--nb-info-bg` | `#eef6ff` | Info variant background |
+| `--nb-info-border` | `#2563eb` | Info variant left border/accent |
+| `--nb-warning-bg` | `#fff7ed` | Warning variant background |
+| `--nb-warning-border` | `#f59e0b` | Warning variant left border/accent |
+| `--nb-text-color` | `#1f2937` | Message text color |
+| `--nb-btn-radius` | `6px` | Button corner radius |
+
+## Usage
+
+1. Copy `style.css` into your project.
+2. Use the `.notification-banner` structure from `demo.html`: an optional icon, a `.notification-banner__message`, and a `.notification-banner__actions` wrapper containing one or more `.notification-banner__btn` elements.
+3. Apply a modifier class (e.g. `.notification-banner--warning`) for alternate variants.
+
+## Before and After
+
+- Before: long messages pushed the button outside the visible container or caused clipped text on mobile viewports.
+- After: message text wraps naturally within the banner, the buttons remain fully visible, and on screens 480px wide or less the banner stacks vertically with full-width buttons.

--- a/submissions/examples/notification-banner-overflow-fix/demo.html
+++ b/submissions/examples/notification-banner-overflow-fix/demo.html
@@ -1,0 +1,40 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Notification Banner — Overflow Fix</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="nbdemo">
+    <h1 class="nbdemo__title">Notification Banner — Overflow Fix</h1>
+    <p class="nbdemo__subtitle">Resize the window to see the banner wrap and stack gracefully instead of overflowing.</p>
+
+    <div class="notification-banner notification-banner--info">
+      <span class="notification-banner__icon" aria-hidden="true">i</span>
+      <p class="notification-banner__message">
+        This is a very long notification message that demonstrates how the content
+        used to overflow on smaller screens, pushing the action button outside the
+        container or causing text clipping.
+      </p>
+      <div class="notification-banner__actions">
+        <button class="notification-banner__btn notification-banner__btn--primary">Dismiss</button>
+      </div>
+    </div>
+
+    <div class="notification-banner notification-banner--warning">
+      <span class="notification-banner__icon" aria-hidden="true">!</span>
+      <p class="notification-banner__message">
+        Short message with two actions.
+      </p>
+      <div class="notification-banner__actions">
+        <button class="notification-banner__btn notification-banner__btn--ghost">Undo</button>
+        <button class="notification-banner__btn notification-banner__btn--primary">Dismiss</button>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/notification-banner-overflow-fix/style.css
+++ b/submissions/examples/notification-banner-overflow-fix/style.css
@@ -1,0 +1,141 @@
+﻿/* =========================================
+   Notification Banner — Overflow Fix
+   Prevents content overflow/clipping on
+   narrow screens using flexbox + wrapping
+   ========================================= */
+
+:root {
+  --nb-radius: 8px;
+  --nb-gap: 12px;
+  --nb-padding: 16px 20px;
+  --nb-font-size: 0.95rem;
+  --nb-info-bg: #eef6ff;
+  --nb-info-border: #2563eb;
+  --nb-warning-bg: #fff7ed;
+  --nb-warning-border: #f59e0b;
+  --nb-text-color: #1f2937;
+  --nb-btn-radius: 6px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f4f6f8;
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.nbdemo {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.nbdemo__title {
+  margin-bottom: 0.25rem;
+  font-size: clamp(1.3rem, 4vw, 1.8rem);
+  color: #111827;
+}
+
+.nbdemo__subtitle {
+  color: #6b7280;
+  margin-bottom: 2rem;
+}
+
+.notification-banner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--nb-gap);
+  padding: var(--nb-padding);
+  border-radius: var(--nb-radius);
+  border-left: 5px solid var(--nb-info-border);
+  background: var(--nb-info-bg);
+  margin-bottom: 1.5rem;
+  max-width: 100%;
+}
+
+.notification-banner--warning {
+  border-left-color: var(--nb-warning-border);
+  background: var(--nb-warning-bg);
+}
+
+.notification-banner__icon {
+  flex-shrink: 0;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.notification-banner__message {
+  flex: 1 1 220px;
+  min-width: 0;
+  margin: 0;
+  color: var(--nb-text-color);
+  font-size: var(--nb-font-size);
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.notification-banner__actions {
+  flex-shrink: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.notification-banner__btn {
+  flex-shrink: 0;
+  white-space: nowrap;
+  padding: 0.55rem 1rem;
+  border: none;
+  border-radius: var(--nb-btn-radius);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, opacity 0.2s ease;
+}
+
+.notification-banner__btn--primary {
+  background: #2563eb;
+  color: #fff;
+}
+
+.notification-banner__btn--primary:hover {
+  background: #1d4ed8;
+}
+
+.notification-banner__btn--ghost {
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  color: var(--nb-text-color);
+}
+
+.notification-banner__btn--ghost:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+@media (max-width: 480px) {
+  .notification-banner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .notification-banner__message {
+    flex-basis: auto;
+  }
+
+  .notification-banner__actions {
+    justify-content: flex-end;
+  }
+
+  .notification-banner__btn {
+    flex: 1 1 auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notification-banner__btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Fixes #56742

## The Bug
Notification banners with long messages and action buttons overflowed or became misaligned on narrow/mobile screens — long text pushed the button outside the container or got clipped instead of wrapping.

## The Fix
- `display: flex` + `flex-wrap: wrap` on `.notification-banner` so content reflows instead of overflowing
- `.notification-banner__message` uses `flex: 1 1 220px` and `min-width: 0` so it shrinks and wraps instead of forcing the row wider than its container
- `overflow-wrap: break-word` / `word-break: break-word` prevents long words from causing horizontal overflow
- Buttons use `flex-shrink: 0` and `white-space: nowrap` so they stay intact and visible
- `@media (max-width: 480px)` stacks the banner vertically with full-width buttons on small screens

## Files
- `submissions/examples/notification-banner-overflow-fix/demo.html`
- `submissions/examples/notification-banner-overflow-fix/style.css`
- `submissions/examples/notification-banner-overflow-fix/README.md`

## Checklist
- [x] Reproduces and resolves the exact scenario from the issue
- [x] Pure CSS/HTML, no external JS frameworks
- [x] Fully responsive (tested at narrow/mobile widths)
- [x] Files placed under `submissions/examples/`