### PR TITLE
feat: add CSS zoom-out tabs for neumorphic soft layouts (#50280)

### DIFF
--- a/submissions/examples/zoom-out-tabs-neumorphic/README.md
+++ b/submissions/examples/zoom-out-tabs-neumorphic/README.md
@@ -1,0 +1,78 @@
+# CSS Zoom-Out Tabs (Neumorphic)
+
+Pure CSS tabs with a soft-UI (neumorphic) look. Switching tabs plays a zoom-out entrance on the panel content. No JavaScript.
+
+## How it works
+
+Tab state is driven by hidden radio inputs (`name="ease-tabs"`), not JavaScript. Each label toggles its input, and CSS shows the matching panel using a sibling selector:
+
+```css
+#ease-tab-overview:checked ~ .ease-tab-panels #panel-overview {
+  display: block;
+  animation: ease-tabs-zoom-out var(--ease-tabs-duration) var(--ease-tabs-easing);
+}
+```
+
+Because tab state lives on native radio inputs, arrow-key navigation between tabs and screen reader announcement of the selected tab work automatically, without any added ARIA state management.
+
+## Features
+
+- Pure CSS, no dependencies
+- Zoom-out panel transition via `@keyframes`
+- Neumorphic soft shadows on tabs and panel container
+- Keyboard accessible (native radio group behavior)
+- Responsive (tabs wrap on narrow screens)
+- Respects `prefers-reduced-motion`
+
+## Usage
+
+To add a tab, you need three pieces kept in sync by `id`/`for`/`name`:
+
+```html
+<input type="radio" name="ease-tabs" id="ease-tab-x" class="ease-tab-input">
+
+<label for="ease-tab-x" class="ease-tab-label">Tab X</label>
+
+<section id="panel-x" class="ease-tab-panel">Panel content</section>
+```
+
+Then add a matching CSS rule so the panel shows when its radio is checked:
+
+```css
+#ease-tab-x:checked ~ .ease-tab-panels #panel-x {
+  display: block;
+  animation: ease-tabs-zoom-out var(--ease-tabs-duration) var(--ease-tabs-easing);
+}
+```
+
+## Custom Properties
+
+Set in `:root` in `style.css`:
+
+```css
+--ease-tabs-duration      
+--ease-tabs-easing        
+--ease-tabs-scale         
+--ease-tabs-radius        
+--ease-tabs-gap           
+--ease-tabs-bg            
+--ease-tabs-text          
+--ease-tabs-accent        
+--ease-tabs-shadow-light 
+--ease-tabs-shadow-dark   
+```
+
+Override to reskin:
+
+```css
+:root {
+  --ease-tabs-accent: #f97316;
+  --ease-tabs-scale: 1.3;
+}
+```
+
+## Files
+
+- `demo.html` — three-tab example (Overview, Features, Pricing)
+- `style.css` — tab switching logic, neumorphic styling, and zoom-out keyframe
+- `README.md` — this file

--- a/submissions/examples/zoom-out-tabs-neumorphic/demo.html
+++ b/submissions/examples/zoom-out-tabs-neumorphic/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Zoom-Out Tabs — Neumorphic Soft</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Product Overview</p>
+    <h1 class="ease-heading">Neumorphic Tabs</h1>
+    <p class="ease-subtitle">Pure CSS tabs with a soft-UI look and a zoom-out panel transition.</p>
+
+    <div class="ease-tabs">
+      <input type="radio" name="ease-tabs" id="ease-tab-overview" class="ease-tab-input" checked>
+      <input type="radio" name="ease-tabs" id="ease-tab-features" class="ease-tab-input">
+      <input type="radio" name="ease-tabs" id="ease-tab-pricing" class="ease-tab-input">
+
+      <div class="ease-tab-nav" role="tablist" aria-label="Product information">
+        <label for="ease-tab-overview" class="ease-tab-label">Overview</label>
+        <label for="ease-tab-features" class="ease-tab-label">Features</label>
+        <label for="ease-tab-pricing" class="ease-tab-label">Pricing</label>
+      </div>
+
+      <div class="ease-tab-panels">
+        <section id="panel-overview" class="ease-tab-panel">
+          <h2>Overview</h2>
+          <p>A short summary of the product, its purpose, and who it's built for.</p>
+        </section>
+
+        <section id="panel-features" class="ease-tab-panel">
+          <h2>Features</h2>
+          <p>A breakdown of the core features, what problems they solve, and how they fit together.</p>
+        </section>
+
+        <section id="panel-pricing" class="ease-tab-panel">
+          <h2>Pricing</h2>
+          <p>Available plans, what's included at each tier, and how billing works.</p>
+        </section>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/zoom-out-tabs-neumorphic/style.css
+++ b/submissions/examples/zoom-out-tabs-neumorphic/style.css
@@ -1,0 +1,174 @@
+:root {
+  --ease-tabs-duration: 0.35s;
+  --ease-tabs-easing: ease-out;
+  --ease-tabs-scale: 1.15;
+  --ease-tabs-radius: 14px;
+  --ease-tabs-gap: 0.5rem;
+  --ease-tabs-bg: #e6e9ef;
+  --ease-tabs-text: #3a3f4b;
+  --ease-tabs-accent: #6c63ff;
+  --ease-tabs-shadow-light: #ffffff;
+  --ease-tabs-shadow-dark: #b8bcc7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-tabs-bg);
+  color: var(--ease-tabs-text);
+  padding: 5rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-tabs-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #6b7280;
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+/* Radios drive tab state but aren't shown directly - kept focusable for keyboard use */
+.ease-tab-input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.ease-tab-nav {
+  display: flex;
+  gap: var(--ease-tabs-gap);
+  margin-bottom: 1.5rem;
+}
+
+.ease-tab-label {
+  flex: 1;
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-radius: var(--ease-tabs-radius);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--ease-tabs-bg);
+  box-shadow:
+    6px 6px 12px var(--ease-tabs-shadow-dark),
+    -6px -6px 12px var(--ease-tabs-shadow-light);
+  transition: box-shadow var(--ease-tabs-duration) var(--ease-tabs-easing),
+              color var(--ease-tabs-duration) var(--ease-tabs-easing);
+}
+
+/* Focus outline for keyboard users tabbing/arrowing through the hidden radios */
+#ease-tab-overview:focus-visible ~ .ease-tab-nav label[for="ease-tab-overview"],
+#ease-tab-features:focus-visible ~ .ease-tab-nav label[for="ease-tab-features"],
+#ease-tab-pricing:focus-visible ~ .ease-tab-nav label[for="ease-tab-pricing"] {
+  outline: 2px solid var(--ease-tabs-accent);
+  outline-offset: 2px;
+}
+
+.ease-tab-panels {
+  background: var(--ease-tabs-bg);
+  border-radius: var(--ease-tabs-radius);
+  padding: 1.75rem;
+  box-shadow:
+    inset 4px 4px 10px var(--ease-tabs-shadow-dark),
+    inset -4px -4px 10px var(--ease-tabs-shadow-light);
+}
+
+.ease-tab-panel {
+  display: none;
+}
+
+.ease-tab-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.ease-tab-panel p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+@keyframes ease-tabs-zoom-out {
+  from {
+    opacity: 0;
+    transform: scale(var(--ease-tabs-scale));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Active tab: pressed-in shadow, accent text */
+#ease-tab-overview:checked ~ .ease-tab-nav label[for="ease-tab-overview"],
+#ease-tab-features:checked ~ .ease-tab-nav label[for="ease-tab-features"],
+#ease-tab-pricing:checked ~ .ease-tab-nav label[for="ease-tab-pricing"] {
+  color: var(--ease-tabs-accent);
+  box-shadow:
+    inset 3px 3px 8px var(--ease-tabs-shadow-dark),
+    inset -3px -3px 8px var(--ease-tabs-shadow-light);
+}
+
+/* Show the matching panel and play the zoom-out entrance */
+#ease-tab-overview:checked ~ .ease-tab-panels #panel-overview,
+#ease-tab-features:checked ~ .ease-tab-panels #panel-features,
+#ease-tab-pricing:checked ~ .ease-tab-panels #panel-pricing {
+  display: block;
+  animation: ease-tabs-zoom-out var(--ease-tabs-duration) var(--ease-tabs-easing);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  body {
+    padding: 3rem 1.25rem;
+  }
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+  .ease-tab-nav {
+    flex-wrap: wrap;
+  }
+  .ease-tab-label {
+    flex: 1 1 40%;
+    padding: 0.6rem 0.75rem;
+    font-size: 0.85rem;
+  }
+  .ease-tab-panels {
+    padding: 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tab-label,
+  .ease-tab-panel {
+    transition: none !important;
+  }
+  #ease-tab-overview:checked ~ .ease-tab-panels #panel-overview,
+  #ease-tab-features:checked ~ .ease-tab-panels #panel-features,
+  #ease-tab-pricing:checked ~ .ease-tab-panels #panel-pricing {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS zoom-out tabs component with a neumorphic soft-UI aesthetic, as requested in #50280. Closes #50280.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-out-tabs-neumorphic/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A three-tab component styled with neumorphic soft shadows, where switching tabs plays a zoom-out entrance on the panel content.

**How does a developer use it?**
```html
<input type="radio" name="ease-tabs" id="ease-tab-x" class="ease-tab-input">

<label for="ease-tab-x" class="ease-tab-label">Tab X</label>

<section id="panel-x" class="ease-tab-panel">Panel content</section>
```

**Why does it fit EaseMotion CSS?**
Tab switching is handled entirely with hidden radio inputs and a `:checked ~` sibling selector — zero JavaScript, and the markup stays readable enough that anyone can trace how a click becomes a visible panel change. Timing, easing, and the zoom-out scale factor are all exposed as custom properties, keeping it consistent with the library's animation-first, easily-reskinned philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Tab state is driven by native radio inputs rather than manual ARIA roles - arrow-key navigation and selection announcement come for free from the browser's radio group behavior, so I intentionally kept custom ARIA attributes minimal instead of layering on `aria-selected` state that would need JS to stay in sync. Happy to adjust the neumorphic shadow values if they read as too subtle/harsh on review.