### PR TITLE
Add avatar aspect ratio bug fix reference (avatar-aspect-ratio-fix-hr18)

### DIFF
--- a/submissions/examples/avatar-aspect-ratio-fix-hr18/README.md
+++ b/submissions/examples/avatar-aspect-ratio-fix-hr18/README.md
@@ -1,0 +1,93 @@
+# Avatar Aspect Ratio Fix (`avatar-aspect-ratio-fix-hr18`)
+
+A reference fix for a reported bug in EaseMotion's shipped `.avatar`
+class, built for issue
+[#56065](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/56065).
+
+## A note on scope
+
+The reported bug is in the framework's real, shipped CSS (the issue's own
+repro links the actual CDN stylesheet), which lives in `core/`. This
+repo's README currently states that core-file PRs are temporarily
+restricted while the framework stabilizes, so this submission doesn't
+edit `core/` directly. Instead, it provides a corrected, working
+`.ease-avatar-fixed-hr18` class the maintainer (or a future core
+contributor) can lift directly into the real `.avatar` rule, plus a
+side-by-side demo reproducing the original bug so the fix can be verified
+visually rather than just described.
+
+## What it does
+
+- **Reproduces the bug exactly**: a `.aaf-avatar-broken-hr18` class with
+  fixed `width`/`height` and no `object-fit` — a non-square image gets
+  stretched to fill both dimensions, matching the reported behavior.
+- **Demonstrates the fix**: `.ease-avatar-fixed-hr18` wraps an `<img>` in
+  a fixed-size, `overflow: hidden` container, with the image itself set
+  to `width: 100%; height: 100%; object-fit: cover;` — cropping cleanly
+  to fill the circle instead of distorting.
+- **Confirms it generalizes**: the fixed class applied to a wide (16:9), a
+  tall (3:4), and a square (1:1) source image, all rendering as clean,
+  undistorted circles.
+
+All three source "photos" in this demo are self-contained inline SVG data
+URIs (simple abstract scenes), so nothing here depends on external image
+files or a CDN.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<span class="ease-avatar-fixed-hr18">
+  <img src="your-photo.jpg" alt="A person's name" />
+</span>
+```
+
+```css
+.ease-avatar-fixed-hr18 {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0; /* keeps it from being squeezed inside a flex row */
+}
+
+.ease-avatar-fixed-hr18 img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+```
+
+**Why the container needs its own fixed size and `overflow: hidden`, in
+addition to `object-fit: cover` on the image:** `object-fit` only
+controls how the image fills *its own* box — it does nothing on its own
+if the box itself is sized by the image's natural (and possibly
+non-square) dimensions. The `overflow: hidden` on the container is what
+actually clips the parts of the cropped image that fall outside the
+circular frame once `border-radius: 50%` is applied.
+
+## Accessibility notes
+
+- Every avatar image keeps a real, descriptive `alt` attribute — cropping
+  the image doesn't change what needs to be conveyed to someone who can't
+  see it.
+- `object-position: center` is used rather than a corner, so the crop
+  favors the middle of the source image by default, which is the safest
+  general-purpose choice for a face photo without per-image tuning.
+
+## Why this fits EaseMotion CSS
+
+A minimal, correct fix for a real visual bug, expressed the same way the
+framework's own components are — a couple of small CSS rules, no
+JavaScript, no dependencies — while respecting the current restriction on
+`core/` edits by staying entirely in `submissions/`.
+
+All classes and the folder itself use a `-hr18` suffix to avoid colliding
+with any other contributor's submission under `submissions/examples/`.

--- a/submissions/examples/avatar-aspect-ratio-fix-hr18/demo.html
+++ b/submissions/examples/avatar-aspect-ratio-fix-hr18/demo.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Avatar Aspect Ratio Fix</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="aaf-hr18">
+  <div class="aaf-wrap-hr18">
+
+    <header class="aaf-header-hr18">
+      <h1>Avatar aspect ratio fix</h1>
+      <p>A reference fix for the reported bug: when an avatar is given a
+        non-square image, it gets visibly squashed to fit the circular
+        frame instead of being cropped cleanly. Both source images below
+        are self-contained inline SVGs (a 16:9 "landscape" scene and a
+        3:4 "portrait" scene) so this demo needs no external image files.</p>
+    </header>
+
+    <section class="aaf-section-hr18">
+      <h2>The bug, reproduced</h2>
+      <p class="aaf-lede-hr18">The class on the left is deliberately
+        missing <code>object-fit</code> &mdash; matching the reported
+        behavior exactly.</p>
+
+      <div class="aaf-compare-grid-hr18">
+
+        <article class="aaf-compare-card-hr18 bad">
+          <div class="aaf-compare-head-hr18">&#10007; BEFORE &mdash; stretched</div>
+          <div class="aaf-compare-body-hr18">
+            <img
+              class="aaf-avatar-broken-hr18"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 225'%3E%3Crect width='400' height='225' fill='%23a8d8f0'/%3E%3Ccircle cx='320' cy='55' r='30' fill='%23ffd166'/%3E%3Cpath d='M0 160 L100 90 L180 150 L260 100 L400 170 L400 225 L0 225 Z' fill='%234a7c59'/%3E%3C/svg%3E"
+              alt="A wide landscape scene, incorrectly squashed into a circle"
+            />
+          </div>
+          <pre class="aaf-compare-code-hr18">.avatar-broken {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  /* no object-fit — image is
+     stretched to fill both
+     dimensions exactly */
+}</pre>
+        </article>
+
+        <article class="aaf-compare-card-hr18 good">
+          <div class="aaf-compare-head-hr18">&#10003; AFTER &mdash; cropped correctly</div>
+          <div class="aaf-compare-body-hr18">
+            <span class="ease-avatar-fixed-hr18">
+              <img
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 225'%3E%3Crect width='400' height='225' fill='%23a8d8f0'/%3E%3Ccircle cx='320' cy='55' r='30' fill='%23ffd166'/%3E%3Cpath d='M0 160 L100 90 L180 150 L260 100 L400 170 L400 225 L0 225 Z' fill='%234a7c59'/%3E%3C/svg%3E"
+                alt="The same landscape scene, correctly cropped into a circle"
+              />
+            </span>
+          </div>
+          <pre class="aaf-compare-code-hr18">.ease-avatar-fixed-hr18 {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  overflow: hidden;
+}
+.ease-avatar-fixed-hr18 img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}</pre>
+        </article>
+
+      </div>
+    </section>
+
+    <section class="aaf-section-hr18">
+      <h2>Works for any source aspect ratio</h2>
+      <p class="aaf-lede-hr18">The same fixed class, applied to a wide
+        image, a tall image, and a square image &mdash; all render as
+        clean, undistorted circles.</p>
+
+      <div class="aaf-row-hr18">
+
+        <div class="aaf-row-item-hr18">
+          <span class="ease-avatar-fixed-hr18">
+            <img
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 225'%3E%3Crect width='400' height='225' fill='%23a8d8f0'/%3E%3Ccircle cx='320' cy='55' r='30' fill='%23ffd166'/%3E%3Cpath d='M0 160 L100 90 L180 150 L260 100 L400 170 L400 225 L0 225 Z' fill='%234a7c59'/%3E%3C/svg%3E"
+              alt="Wide landscape source image, 16:9"
+            />
+          </span>
+          <span>16:9 source</span>
+        </div>
+
+        <div class="aaf-row-item-hr18">
+          <span class="ease-avatar-fixed-hr18">
+            <img
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 400'%3E%3Crect width='300' height='400' fill='%23f4d9c6'/%3E%3Ccircle cx='150' cy='150' r='70' fill='%23e8a17c'/%3E%3Crect x='60' y='230' width='180' height='170' rx='30' fill='%23d98a5f'/%3E%3C/svg%3E"
+              alt="Tall portrait source image, 3:4"
+            />
+          </span>
+          <span>3:4 source</span>
+        </div>
+
+        <div class="aaf-row-item-hr18">
+          <span class="ease-avatar-fixed-hr18">
+            <img
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Crect width='200' height='200' fill='%23d8e0f4'/%3E%3Ccircle cx='100' cy='85' r='55' fill='%23a9bcec'/%3E%3Crect x='30' y='140' width='140' height='80' rx='24' fill='%237e97d8'/%3E%3C/svg%3E"
+              alt="Square source image, 1:1"
+            />
+          </span>
+          <span>1:1 source</span>
+        </div>
+
+      </div>
+    </section>
+
+    <p class="aaf-footnote-hr18">submissions/examples/avatar-aspect-ratio-fix-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/avatar-aspect-ratio-fix-hr18/style.css
+++ b/submissions/examples/avatar-aspect-ratio-fix-hr18/style.css
@@ -1,0 +1,203 @@
+/* ==========================================================================
+   avatar-aspect-ratio-fix-hr18 — style.css
+   Fix reference for: Avatar Image Appears Stretched (non-square images)
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.aaf-hr18 {
+  --bg-hr18: #f6f7f5;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e2e4de;
+  --text-hr18: #171916;
+  --muted-hr18: #666a61;
+  --bad-hr18: #b5432f;
+  --bad-soft-hr18: #fbeae6;
+  --good-hr18: #2f6b4f;
+  --good-soft-hr18: #e3f0e8;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.aaf-hr18 * {
+  box-sizing: border-box;
+}
+
+.aaf-wrap-hr18 {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.aaf-header-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  margin: 0 0 0.6rem;
+}
+
+.aaf-header-hr18 p {
+  margin: 0;
+  color: var(--muted-hr18);
+  font-size: 0.94rem;
+  line-height: 1.6;
+  max-width: 62ch;
+}
+
+.aaf-section-hr18 {
+  margin-top: 2.25rem;
+}
+
+.aaf-section-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1.05rem;
+  margin: 0 0 0.5rem;
+}
+
+.aaf-lede-hr18 {
+  color: var(--muted-hr18);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  max-width: 62ch;
+  margin: 0 0 1.1rem;
+}
+
+/* ---- Comparison grid ------------------------------------------------------------ */
+.aaf-compare-grid-hr18 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 560px) {
+  .aaf-compare-grid-hr18 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.aaf-compare-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--panel-hr18);
+}
+
+.aaf-compare-card-hr18.bad {
+  border-color: rgba(181, 67, 47, 0.35);
+}
+
+.aaf-compare-card-hr18.good {
+  border-color: rgba(47, 107, 79, 0.35);
+}
+
+.aaf-compare-head-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.74rem;
+  font-weight: 700;
+  padding: 0.6rem 0.9rem;
+}
+
+.aaf-compare-card-hr18.bad .aaf-compare-head-hr18 {
+  background: var(--bad-soft-hr18);
+  color: var(--bad-hr18);
+}
+
+.aaf-compare-card-hr18.good .aaf-compare-head-hr18 {
+  background: var(--good-soft-hr18);
+  color: var(--good-hr18);
+}
+
+.aaf-compare-body-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.aaf-compare-code-hr18 {
+  border-top: 1px solid var(--border-hr18);
+  padding: 0.8rem 0.9rem;
+  font-family: var(--font-mono-hr18);
+  font-size: 0.74rem;
+  line-height: 1.6;
+  white-space: pre;
+  overflow-x: auto;
+  color: var(--text-hr18);
+  margin: 0;
+}
+
+/* ==========================================================================
+   The bug, reproduced exactly as the issue describes: a fixed-size
+   circular avatar with no object-fit rule, so a non-square source image
+   is squashed to fit the box. This class exists ONLY to demonstrate the
+   problem — do not use it for anything real.
+   ========================================================================== */
+.aaf-avatar-broken-hr18 {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  /* Deliberately missing: object-fit. The browser's default for a
+     replaced element with mismatched intrinsic and rendered aspect
+     ratios is to stretch to fill both dimensions exactly. */
+}
+
+/* ==========================================================================
+   The fix: object-fit: cover, explicit fixed dimensions, and
+   overflow: hidden on the container. This is the class meant to be
+   lifted into core/'s real .avatar rule once core contributions reopen.
+   ========================================================================== */
+.ease-avatar-fixed-hr18 {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.ease-avatar-fixed-hr18 img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+/* ---- Real-world usage row: several fixed avatars at different natural
+   image aspect ratios, all rendering as clean circles. -------------------- */
+.aaf-row-hr18 {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.aaf-row-item-hr18 {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.aaf-row-item-hr18 span {
+  font-size: 0.72rem;
+  color: var(--muted-hr18);
+  font-family: var(--font-mono-hr18);
+}
+
+.aaf-footnote-hr18 {
+  margin-top: 2rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+.aaf-hr18 :focus-visible {
+  outline: 2px solid var(--good-hr18);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Pull Request Description
Fixes the reported bug where a non-square avatar image gets stretched
instead of cropped. Reproduces the bug exactly (fixed width/height, no
object-fit — matching the shipped .avatar behavior), then demonstrates
the fix: a fixed-size, overflow: hidden container wrapping an <img> set
to object-fit: cover. Confirmed working across wide (16:9), tall (3:4),
and square (1:1) source images, all self-contained inline SVGs so the
demo needs no external image files.

Resolves #56065

Note for the maintainer: the actual bug lives in core/'s real .avatar
class, which is off-limits to contributor PRs right now per the repo's
current restriction policy. This submission provides a corrected,
working class (.ease-avatar-fixed-hr18) meant to be lifted directly into
the real .avatar rule once core contributions reopen, rather than editing
core/ directly.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/avatar-aspect-ratio-fix-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A corrected avatar class fixing the non-square image stretching bug, with
a side-by-side before/after demo.

**How does a developer use it?**
```html
<span class="ease-avatar-fixed-hr18">
  <img src="your-photo.jpg" alt="A person's name" />
</span>
```

**Why does it fit EaseMotion CSS?**
A minimal, correct fix for a real visual bug — a couple of small CSS
rules, no JavaScript, no dependencies — matching how the framework's own
components are built.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
README explains why both object-fit: cover AND overflow: hidden on the
container are needed (object-fit alone doesn't clip anything if the box
itself isn't already the right size). Tested in Chrome; haven't checked
other browsers yet.