### PR TITLE
feat: add elastic-slide badge for gaming hub layouts (closes #56509)

### DIFF
--- a/submissions/examples/elastic-slide-gaming-badge/README.md
+++ b/submissions/examples/elastic-slide-gaming-badge/README.md
@@ -1,0 +1,88 @@
+# Elastic-Slide Badge for Gaming Hub Layouts
+
+A pure CSS/HTML rank-badge component that slides in from off-screen with a
+springy, elastic overshoot, then settles into a soft ambient pulse. Built for
+gaming hub / dashboard layouts (player ranks, achievement rows, leaderboards).
+
+No JavaScript is required — the entrance, stagger, progress-bar fill, and
+idle pulse are all driven by CSS keyframes.
+
+## Files
+
+- `demo.html` — standalone showcase page with five example badges
+- `style.css` — the component styles
+- `README.md` — this file
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<article class="em-badge em-badge--gold" style="--em-badge-delay: 140ms;" tabindex="0">
+  <div class="em-badge__icon" aria-hidden="true">🥇</div>
+  <div class="em-badge__body">
+    <span class="em-badge__tier">Gold II</span>
+    <span class="em-badge__meta">410 XP to next rank</span>
+    <div class="em-badge__progress"><span style="--em-progress: 78%;"></span></div>
+  </div>
+</article>
+```
+
+Wrap several badges in `.em-badge-grid` for a responsive auto-fit layout, and
+give each one an increasing `--em-badge-delay` (e.g. `0ms`, `140ms`, `280ms`)
+to stagger their entrance.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--em-badge-delay` | `0ms` | Per-badge entrance delay, used to stagger a group |
+| `--em-progress` | `60%` | Fill amount of the badge's progress bar |
+| `--em-slide-distance` | `140px` | Distance the badge travels in from |
+| `--em-slide-duration` | `900ms` | Duration of the elastic entrance animation |
+| `--em-slide-ease` | `cubic-bezier(0.16, 1.4, 0.3, 1)` | Overshoot/elastic easing curve |
+| `--em-stagger-step` | `140ms` | Suggested spacing between staggered delays |
+| `--em-glow-duration` | `2.4s` | Period of the idle icon pulse |
+| `--em-badge-accent` | `var(--em-cyan)` | Accent color for icon, glow, and progress fill |
+| `--em-badge-accent-soft` | `rgba(38,229,209,.18)` | Soft background tint derived from the accent |
+
+## Tier variants
+
+Five ready-made accent variants are included, each overriding
+`--em-badge-accent` / `--em-badge-accent-soft`:
+
+- `.em-badge--bronze`
+- `.em-badge--silver`
+- `.em-badge--gold`
+- `.em-badge--diamond`
+- `.em-badge--legend`
+
+Add your own tier by setting the two custom properties on any class or
+inline `style` attribute — no CSS edits required.
+
+## Features
+
+- **Elastic slide-in**: badges enter from the left with a bounce/overshoot,
+  driven entirely by a custom cubic-bezier curve — no external animation library.
+- **Trailing streak**: a soft gradient sweep trails the badge as it slides in,
+  reinforcing the sense of motion and momentum.
+- **Staggered groups**: each badge accepts its own `--em-badge-delay`, so a
+  row of badges can cascade in one after another.
+- **Animated progress bar**: the XP/progress bar fills in right as the badge
+  settles into place.
+- **Ambient idle pulse**: once settled, each badge's icon emits a slow,
+  subtle glow so the hub still feels alive.
+- **Interactive re-trigger**: hovering or focusing a badge replays a quick
+  directional nudge, giving keyboard and mouse users the same feedback.
+- **Fully responsive**: the grid auto-fits from a multi-column hub down to a
+  single column on mobile, and the slide distance shortens on small screens.
+- **Accessible by default**: badges are focusable (`tabindex="0"`) with a
+  visible focus ring, and a `prefers-reduced-motion` query disables all
+  motion (entrance, streak, pulse, nudge) in favor of an instant, static state.
+
+## Browser support
+
+Uses `color-mix()` for accent-derived borders/fills, supported in all
+current evergreen browsers (Chrome/Edge 111+, Firefox 113+, Safari 16.2+).
+On older browsers the borders simply fall back to the accent color at full
+opacity — the component still renders and animates correctly.

--- a/submissions/examples/elastic-slide-gaming-badge/demo.html
+++ b/submissions/examples/elastic-slide-gaming-badge/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Elastic-Slide Badge — Gaming Hub Layouts | EaseMotion CSS</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<main class="em-hub" tabindex="-1">
+  <p class="em-hub__eyebrow">EaseMotion CSS · Showcase</p>
+  <h1 class="em-hub__title">Elastic-Slide Badge<br />for Gaming Hub Layouts</h1>
+  <p class="em-hub__subtitle">
+    Rank badges slide in from off-screen with a springy, elastic overshoot,
+    then settle into an ambient idle pulse — built with pure CSS keyframes,
+    no JavaScript required.
+  </p>
+
+  <section class="em-badge-grid" aria-label="Player rank badges">
+
+    <article class="em-badge em-badge--bronze" style="--em-badge-delay: 0ms;" tabindex="0">
+      <div class="em-badge__icon" aria-hidden="true">🥉</div>
+      <div class="em-badge__body">
+        <span class="em-badge__tier">Bronze III</span>
+        <span class="em-badge__meta">1,240 XP to next rank</span>
+        <div class="em-badge__progress"><span style="--em-progress: 42%;"></span></div>
+      </div>
+    </article>
+
+    <article class="em-badge em-badge--silver" style="--em-badge-delay: 140ms;" tabindex="0">
+      <div class="em-badge__icon" aria-hidden="true">🥈</div>
+      <div class="em-badge__body">
+        <span class="em-badge__tier">Silver I</span>
+        <span class="em-badge__meta">860 XP to next rank</span>
+        <div class="em-badge__progress"><span style="--em-progress: 61%;"></span></div>
+      </div>
+    </article>
+
+    <article class="em-badge em-badge--gold" style="--em-badge-delay: 280ms;" tabindex="0">
+      <div class="em-badge__icon" aria-hidden="true">🥇</div>
+      <div class="em-badge__body">
+        <span class="em-badge__tier">Gold II</span>
+        <span class="em-badge__meta">410 XP to next rank</span>
+        <div class="em-badge__progress"><span style="--em-progress: 78%;"></span></div>
+      </div>
+    </article>
+
+    <article class="em-badge em-badge--diamond" style="--em-badge-delay: 420ms;" tabindex="0">
+      <div class="em-badge__icon" aria-hidden="true">💎</div>
+      <div class="em-badge__body">
+        <span class="em-badge__tier">Diamond</span>
+        <span class="em-badge__meta">95 XP to next rank</span>
+        <div class="em-badge__progress"><span style="--em-progress: 94%;"></span></div>
+      </div>
+    </article>
+
+    <article class="em-badge em-badge--legend" style="--em-badge-delay: 560ms;" tabindex="0">
+      <div class="em-badge__icon" aria-hidden="true">👑</div>
+      <div class="em-badge__body">
+        <span class="em-badge__tier">Legend</span>
+        <span class="em-badge__meta">Max rank achieved</span>
+        <div class="em-badge__progress"><span style="--em-progress: 100%;"></span></div>
+      </div>
+    </article>
+
+  </section>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/elastic-slide-gaming-badge/style.css
+++ b/submissions/examples/elastic-slide-gaming-badge/style.css
@@ -1,0 +1,288 @@
+/* =========================================================
+   EaseMotion CSS — Elastic-Slide Badge (Gaming Hub Layouts)
+   Pure CSS/HTML. No JavaScript, no external frameworks.
+   ========================================================= */
+
+:root {
+  /* Palette */
+  --em-bg: #0b0e14;
+  --em-surface: #131826;
+  --em-surface-alt: #182036;
+  --em-border: #232b40;
+  --em-text: #e7ecf5;
+  --em-text-muted: #7d879e;
+  --em-violet: #7c5cfc;
+  --em-cyan: #26e5d1;
+  --em-amber: #ffb84d;
+  --em-rose: #ff5c7c;
+
+  /* Badge tier accents (override per-badge via inline style or class) */
+  --em-badge-accent: var(--em-cyan);
+  --em-badge-accent-soft: rgba(38, 229, 209, 0.18);
+
+  /* Motion */
+  --em-slide-distance: 140px;
+  --em-slide-duration: 900ms;
+  --em-slide-ease: cubic-bezier(0.16, 1.4, 0.3, 1); /* elastic overshoot */
+  --em-stagger-step: 140ms;
+  --em-glow-duration: 2.4s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% -10%, rgba(124, 92, 252, 0.16), transparent 55%),
+    radial-gradient(circle at 100% 10%, rgba(38, 229, 209, 0.10), transparent 45%),
+    var(--em-bg);
+  color: var(--em-text);
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  padding: 4rem 1.5rem 6rem;
+}
+
+.em-hub {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.em-hub__eyebrow {
+  font-family: "Rajdhani", "Inter", sans-serif;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--em-cyan);
+  margin: 0 0 0.5rem;
+}
+
+.em-hub__title {
+  font-family: "Rajdhani", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3.1rem);
+  line-height: 1.05;
+  margin: 0 0 0.75rem;
+}
+
+.em-hub__subtitle {
+  color: var(--em-text-muted);
+  max-width: 46ch;
+  margin: 0 0 3rem;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.em-badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+/* ---------- The Badge ---------- */
+
+.em-badge {
+  --em-badge-accent: var(--em-cyan);
+  --em-badge-accent-soft: rgba(38, 229, 209, 0.18);
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.1rem 1.25rem;
+  background: linear-gradient(155deg, var(--em-surface-alt), var(--em-surface));
+  border: 1px solid var(--em-border);
+  border-radius: 14px;
+  overflow: hidden;
+  isolation: isolate;
+
+  /* Elastic slide-in on load */
+  opacity: 0;
+  transform: translateX(calc(-1 * var(--em-slide-distance)));
+  animation: em-slide-in var(--em-slide-duration) var(--em-slide-ease) forwards;
+  animation-delay: var(--em-badge-delay, 0ms);
+}
+
+.em-badge::before {
+  /* trailing streak that draws alongside the slide */
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--em-badge-accent-soft), transparent 60%);
+  opacity: 0;
+  transform: translateX(-40%);
+  animation: em-streak var(--em-slide-duration) var(--em-slide-ease) forwards;
+  animation-delay: var(--em-badge-delay, 0ms);
+  z-index: -1;
+}
+
+.em-badge__icon {
+  flex: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  background: var(--em-badge-accent-soft);
+  color: var(--em-badge-accent);
+  border: 1px solid color-mix(in srgb, var(--em-badge-accent) 45%, transparent);
+}
+
+.em-badge__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.em-badge__tier {
+  font-family: "Rajdhani", "Inter", sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-size: 1.05rem;
+  color: var(--em-text);
+}
+
+.em-badge__meta {
+  font-size: 0.82rem;
+  color: var(--em-text-muted);
+}
+
+.em-badge__progress {
+  margin-top: 0.55rem;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.em-badge__progress > span {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--em-badge-accent), color-mix(in srgb, var(--em-badge-accent) 60%, white));
+  width: var(--em-progress, 60%);
+  transform-origin: left;
+  transform: scaleX(0);
+  animation: em-progress-fill 700ms ease-out forwards;
+  animation-delay: calc(var(--em-badge-delay, 0ms) + var(--em-slide-duration) * 0.55);
+}
+
+/* Idle ambient pulse on the icon, independent of the slide-in */
+.em-badge__icon {
+  animation: em-badge-pulse var(--em-glow-duration) ease-in-out infinite;
+  animation-delay: calc(var(--em-badge-delay, 0ms) + var(--em-slide-duration));
+}
+
+/* Re-trigger a subtle bounce on hover/focus, for interactivity beyond page load */
+.em-badge:hover,
+.em-badge:focus-within {
+  animation: em-badge-nudge 520ms var(--em-slide-ease);
+}
+
+.em-badge:focus-within {
+  outline: 2px solid var(--em-badge-accent);
+  outline-offset: 3px;
+}
+
+/* Tier color variants */
+.em-badge--bronze { --em-badge-accent: var(--em-amber); --em-badge-accent-soft: rgba(255, 184, 77, 0.18); }
+.em-badge--silver { --em-badge-accent: #b9c4d6; --em-badge-accent-soft: rgba(185, 196, 214, 0.18); }
+.em-badge--gold   { --em-badge-accent: #ffd166; --em-badge-accent-soft: rgba(255, 209, 102, 0.2); }
+.em-badge--diamond{ --em-badge-accent: var(--em-cyan); --em-badge-accent-soft: rgba(38, 229, 209, 0.18); }
+.em-badge--legend { --em-badge-accent: var(--em-rose); --em-badge-accent-soft: rgba(255, 92, 124, 0.18); }
+
+/* ---------- Keyframes ---------- */
+
+@keyframes em-slide-in {
+  0% {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--em-slide-distance)));
+  }
+  60% {
+    opacity: 1;
+    transform: translateX(3%);
+  }
+  80% {
+    transform: translateX(-1.5%);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes em-streak {
+  0% {
+    opacity: 0.9;
+    transform: translateX(-40%);
+  }
+  70% {
+    opacity: 0.35;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(0%);
+  }
+}
+
+@keyframes em-progress-fill {
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes em-badge-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 var(--em-badge-accent-soft);
+  }
+  50% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+}
+
+@keyframes em-badge-nudge {
+  0% { transform: translateX(0); }
+  40% { transform: translateX(6px); }
+  70% { transform: translateX(-2px); }
+  100% { transform: translateX(0); }
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 640px) {
+  .em-badge-grid {
+    grid-template-columns: 1fr;
+  }
+  :root {
+    --em-slide-distance: 70px;
+  }
+}
+
+/* ---------- Accessibility: prefers-reduced-motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .em-badge,
+  .em-badge::before,
+  .em-badge__progress > span,
+  .em-badge__icon {
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+  }
+  .em-badge {
+    opacity: 1;
+    transform: none;
+  }
+  .em-badge::before {
+    opacity: 0;
+  }
+  .em-badge__progress > span {
+    transform: scaleX(1);
+  }
+  .em-badge:hover,
+  .em-badge:focus-within {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new pure-CSS showcase example: an Elastic-Slide Badge for Gaming Hub Layouts (closes #56509). Rank badges (Bronze → Legend) slide in from off-screen with a springy, elastic overshoot, then settle into a soft ambient pulse — no JavaScript required.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/elastic-slide-gaming-badge/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A rank/achievement badge component that elastic-slides in on load (with a trailing gradient streak and staggered group entrance), then idles with a subtle glow pulse — built for gaming hub, leaderboard, and player-dashboard layouts.

**How does a developer use it?**
```html
<link rel="stylesheet" href="style.css" />

<article class="em-badge em-badge--gold" style="--em-badge-delay: 140ms;" tabindex="0">
  <div class="em-badge__icon" aria-hidden="true">🥇</div>
  <div class="em-badge__body">
    <span class="em-badge__tier">Gold II</span>
    <span class="em-badge__meta">410 XP to next rank</span>
    <div class="em-badge__progress"><span style="--em-progress: 78%;"></span></div>
  </div>
</article>
```
Wrap multiple badges in `.em-badge-grid` and increase each one's `--em-badge-delay` to stagger the entrance across a group.

**Why does it fit EaseMotion CSS?**
It's entirely CSS-driven (custom-property-based, no JS), human-readable class names (`em-badge`, `em-badge__tier`, `em-badge--gold`), and animation-first — the entrance, stagger, progress fill, and idle pulse are all expressed as keyframes and easing curves rather than JS-toggled states.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Uses `color-mix()` for accent-derived borders (supported in all current evergreen browsers — Chrome/Edge 111+, Firefox 113+, Safari 16.2+). On older browsers it falls back gracefully to the accent color at full opacity, so nothing breaks. `prefers-reduced-motion` is fully respected — all entrance/pulse/streak animations collapse to an instant static state. Happy to adjust the elastic easing curve or slide distance if it feels too bouncy for the maintainer's taste.