### PR TITLE
Add Ripple-Wave navbar component for gaming hub layouts (ripple-wave-…

### DIFF
--- a/submissions/examples/ripple-wave-navbar-hr18/README.md
+++ b/submissions/examples/ripple-wave-navbar-hr18/README.md
@@ -1,0 +1,91 @@
+# Ripple-Wave Navbar (`ripple-wave-navbar-hr18`)
+
+A pure-CSS navbar combining a per-link hover ripple with a continuous
+ambient wave, styled for gaming hub layouts, built for issue
+[#56481](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/56481).
+
+## What it does
+
+Two motions work together to earn the "Ripple-Wave" name:
+
+- **Ripple** — hovering or focusing any nav link expands a soft radial
+  glow outward from the link's own center via a `::before` pseudo-element
+  scaling from `0` to `14`, then fading. This needs no click-coordinate
+  tracking or JavaScript — it's centered on the element itself, not a
+  cursor position, so it works identically for a mouse hover and a
+  keyboard `Tab`.
+- **Wave** — a slim, two-tone gradient band along the bottom edge of the
+  bar drifts continuously via an animated `background-position`, giving
+  the whole navbar a subtle sense of motion even before anyone interacts
+  with it.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<nav class="ease-navbar-ripple-wave-hr18" aria-label="Gaming hub">
+  <span class="rwn-logo-hr18">NEONFRAG</span>
+  <div class="rwn-links-hr18">
+    <a href="#" class="rwn-link-hr18 is-active-hr18">Home</a>
+    <a href="#" class="rwn-link-hr18">Store</a>
+    <a href="#" class="rwn-link-hr18">Leaderboard</a>
+  </div>
+</nav>
+```
+
+Add `is-active-hr18` to whichever link represents the current page — it
+gets a filled background and a small glowing dot underneath, independent
+of the ripple/wave motion.
+
+### Tuning the animation
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-ripple-duration-hr18` | `900ms` | How long each link's hover ripple takes to fully expand |
+| `--ease-wave-duration-hr18` | `5s` | How long one full cycle of the ambient wave drift takes |
+
+```css
+.ease-navbar-ripple-wave-hr18.snappy {
+  --ease-ripple-duration-hr18: 400ms;
+  --ease-wave-duration-hr18: 3s;
+}
+```
+
+## Accessibility notes
+
+- Links are real `<a>` elements, and the ripple triggers on
+  `:focus-visible` as well as `:hover`, so keyboard users see identical
+  feedback to mouse users.
+- The ripple pseudo-element uses `z-index: -1` with `isolation: isolate`
+  on the link, so it never sits visually above the link's own text and
+  never intercepts clicks.
+- The navbar itself carries `aria-label="Gaming hub"` so it's announced
+  as a distinct landmark.
+- `@media (prefers-reduced-motion: reduce)` disables the ambient wave
+  drift entirely and turns the ripple into a simple, near-instant opacity
+  fade with no scaling motion — feedback on hover/focus is preserved,
+  just without any movement.
+
+## Responsiveness
+
+Below `560px`, the bar switches from a single row to a stacked layout
+(logo above links), and the links themselves space out to fill the full
+width with smaller padding, so the navbar stays usable on a phone rather
+than cramming everything into one overflowing row.
+
+## Why this fits EaseMotion CSS
+
+A pure-CSS, zero-JavaScript component — both the ripple and the wave are
+plain `@keyframes`/transition rules — with every timing value exposed as
+a tunable custom property, matching the issue's "no external JS
+frameworks" and "smooth CSS transitions and keyframe animations"
+requirements directly.
+
+All classes, custom properties, and the folder itself use a `-hr18`
+suffix to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/ripple-wave-navbar-hr18/demo.html
+++ b/submissions/examples/ripple-wave-navbar-hr18/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Ripple-Wave Navbar — gaming hub demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="rwn-hr18">
+  <div class="rwn-page-hr18">
+
+    <nav class="ease-navbar-ripple-wave-hr18" aria-label="Gaming hub">
+      <span class="rwn-logo-hr18">NEONFRAG</span>
+      <div class="rwn-links-hr18">
+        <a href="#" class="rwn-link-hr18 is-active-hr18">Home</a>
+        <a href="#" class="rwn-link-hr18">Store</a>
+        <a href="#" class="rwn-link-hr18">Leaderboard</a>
+        <a href="#" class="rwn-link-hr18">Profile</a>
+      </div>
+    </nav>
+
+    <h1>Ripple-Wave Navbar</h1>
+    <p>Hover or tab to any link &mdash; a ripple pulses out from its center,
+      while a continuous neon wave drifts slowly along the bar's bottom
+      edge underneath everything, giving the whole navbar a sense of
+      motion even at rest.</p>
+
+    <div class="rwn-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-ripple-duration-hr18</code></td><td><code>900ms</code></td><td>How long each link's hover ripple takes to fully expand.</td></tr>
+          <tr><td><code>--ease-wave-duration-hr18</code></td><td><code>5s</code></td><td>How long one full cycle of the ambient wave drift takes.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="rwn-footnote-hr18">submissions/examples/ripple-wave-navbar-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ripple-wave-navbar-hr18/style.css
+++ b/submissions/examples/ripple-wave-navbar-hr18/style.css
@@ -1,0 +1,266 @@
+/* ==========================================================================
+   ripple-wave-navbar-hr18 — style.css
+   CSS Ripple-Wave Navbar for Gaming Hub Layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.rwn-hr18 {
+  --bg-hr18: #090a10;
+  --panel-hr18: #12131b;
+  --border-hr18: #23242e;
+  --text-hr18: #eceefb;
+  --muted-hr18: #8b8fa3;
+  --neon-a-hr18: #00e5ff;
+  --neon-b-hr18: #ff2e88;
+
+  /* Exposed animation parameters. */
+  --ease-ripple-duration-hr18: 900ms;
+  --ease-wave-duration-hr18: 5s;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background:
+    radial-gradient(circle at 15% 0%, rgba(0, 229, 255, 0.08), transparent 45%),
+    radial-gradient(circle at 85% 30%, rgba(255, 46, 136, 0.08), transparent 45%),
+    var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+}
+
+.rwn-hr18 * {
+  box-sizing: border-box;
+}
+
+.rwn-page-hr18 {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 5rem;
+}
+
+.rwn-page-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  margin: 2.5rem 0 0.6rem;
+}
+
+.rwn-page-hr18 p {
+  margin: 0;
+  color: var(--muted-hr18);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  max-width: 60ch;
+}
+
+/* ==========================================================================
+   The reusable navbar component
+   ========================================================================== */
+
+.ease-navbar-ripple-wave-hr18 {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 16px;
+  padding: 0.9rem 1.4rem;
+  overflow: hidden;
+}
+
+/* The continuous "wave": a soft, animated gradient band drifting slowly
+   along the bottom edge of the bar, giving the whole navbar a subtle
+   sense of motion even before anyone interacts with it. */
+.ease-navbar-ripple-wave-hr18::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--neon-a-hr18) 0,
+    var(--neon-a-hr18) 40px,
+    var(--neon-b-hr18) 40px,
+    var(--neon-b-hr18) 80px
+  );
+  background-size: 160px 100%;
+  opacity: 0.7;
+  animation: ease-wave-drift-hr18 var(--ease-wave-duration-hr18) linear infinite;
+}
+
+@keyframes ease-wave-drift-hr18 {
+  from { background-position: 0 0; }
+  to { background-position: 160px 0; }
+}
+
+.rwn-logo-hr18 {
+  font-family: var(--font-display-hr18);
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  background: linear-gradient(90deg, var(--neon-a-hr18), var(--neon-b-hr18));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  white-space: nowrap;
+}
+
+.rwn-links-hr18 {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+/* Each nav link is its own ripple surface: a radial ::before pseudo-
+   element sits centered on the link, scaled to nothing and invisible at
+   rest, then scales up and fades out on hover/focus — a self-contained
+   "ripple" that needs no click-coordinate tracking or JavaScript. */
+.rwn-link-hr18 {
+  position: relative;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted-hr18);
+  text-decoration: none;
+  font-size: 0.86rem;
+  font-weight: 600;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  isolation: isolate;
+}
+
+.rwn-link-hr18::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(0, 229, 255, 0.55), rgba(255, 46, 136, 0.35) 60%, transparent 75%);
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  z-index: -1;
+  transition: transform var(--ease-ripple-duration-hr18) cubic-bezier(0.22, 1, 0.36, 1),
+    opacity var(--ease-ripple-duration-hr18) ease;
+}
+
+.rwn-link-hr18:hover,
+.rwn-link-hr18:focus-visible {
+  color: var(--text-hr18);
+}
+
+.rwn-link-hr18:hover::before,
+.rwn-link-hr18:focus-visible::before {
+  transform: translate(-50%, -50%) scale(14);
+  opacity: 1;
+}
+
+.rwn-link-hr18.is-active-hr18 {
+  color: var(--text-hr18);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.rwn-link-hr18.is-active-hr18::after {
+  content: "";
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--neon-a-hr18);
+  box-shadow: 0 0 8px var(--neon-a-hr18);
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.rwn-tuning-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.25rem 1.4rem;
+}
+
+.rwn-tuning-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1rem;
+  margin: 0 0 0.6rem;
+}
+
+.rwn-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.rwn-tuning-hr18 th,
+.rwn-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.rwn-tuning-hr18 th {
+  color: var(--muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.rwn-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+  color: var(--neon-a-hr18);
+}
+
+.rwn-footnote-hr18 {
+  margin-top: 2rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Responsive: links wrap and shrink their padding on narrow screens ------------- */
+@media (max-width: 560px) {
+  .ease-navbar-ripple-wave-hr18 {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+  .rwn-links-hr18 {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .rwn-link-hr18 {
+    padding: 0.5rem 0.7rem;
+    font-size: 0.8rem;
+  }
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.rwn-hr18 :focus-visible {
+  outline: 2px solid var(--neon-a-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-navbar-ripple-wave-hr18::after {
+    animation: none;
+  }
+  .rwn-link-hr18::before {
+    transition: opacity 120ms ease;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  .rwn-link-hr18:hover::before,
+  .rwn-link-hr18:focus-visible::before {
+    transform: translate(-50%, -50%) scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS navbar combining a per-link hover ripple with a
continuous ambient wave, styled for gaming hub layouts. Each nav link
expands a soft radial glow from its own center on hover/focus (no
click-coordinate tracking needed), while a slim two-tone gradient band
drifts continuously along the bar's bottom edge. Both effects are plain
CSS keyframes/transitions with no JavaScript.

Resolves #56481

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ripple-wave-navbar-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure-CSS navbar with a per-link hover ripple and a continuous ambient
wave, tunable via custom properties.

**How does a developer use it?**
```html
<nav class="ease-navbar-ripple-wave-hr18" aria-label="Gaming hub">
  <span class="rwn-logo-hr18">NEONFRAG</span>
  <div class="rwn-links-hr18">
    <a href="#" class="rwn-link-hr18 is-active-hr18">Home</a>
    <a href="#" class="rwn-link-hr18">Store</a>
  </div>
</nav>
```

**Why does it fit EaseMotion CSS?**
A pure-CSS, zero-JavaScript component with every timing value exposed as
a tunable custom property, matching the issue's "no external JS
frameworks" and "smooth CSS transitions and keyframe animations"
requirements directly.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Ripple triggers on :focus-visible as well as :hover for keyboard parity.
prefers-reduced-motion disables the wave drift entirely and reduces the
ripple to a simple opacity fade with no scaling, preserving feedback
without motion. Tested keyboard focus and hover in Chrome; haven't
checked other browsers yet.