### PR TITLE
50279 cyberpunk zoom out tabs

### DIFF
--- a/submissions/examples/cyberpunk-zoom-out-tabs/README.md
+++ b/submissions/examples/cyberpunk-zoom-out-tabs/README.md
@@ -1,0 +1,24 @@
+# CSS Zoom-Out Tabs (Cyberpunk Neon)
+
+A striking, purely CSS-driven tabbed interface designed for Cyberpunk and Sci-Fi layouts. It features a dynamic Zoom-Out panel transition, bringing content from a scaled-up state into sharp, focused view, heavily inspired by futuristic UI terminals.
+
+## 🚀 Features
+
+- **Pure CSS State Management:** Leverages hidden `<input type="radio">` tags coupled with CSS general sibling combinators (`~`) to control active states flawlessly without any JavaScript.
+- **Dynamic Zoom-Out Animation:** Applies a custom `@keyframes` animation (`em-zoom-out`) to the inner panel contents, shifting from `scale(1.15)` down to `scale(1)` for a punchy, digital entry effect.
+- **Neon Aesthetic:** Stylized with dark backgrounds, monospace typography, and distinct, dynamic neon accents (Cyan, Magenta, Yellow) that adapt perfectly to the currently selected tab.
+- **Accessible Design:** Features hidden inputs that remain fully focusable for keyboard navigation (`tabindex="0"` on labels with explicit `:focus-visible` outlines), and automatically disables scaling animations for users with `@media (prefers-reduced-motion: reduce)`.
+
+## 🛠️ Usage
+
+Copy the HTML structure from `demo.html` and link the corresponding styles from `style.css`. 
+
+### CSS Custom Properties
+Tweak the zoom intensity and animation timing directly in the `:root` pseudo-class to match your app's tempo:
+
+```css
+:root {
+    --em-zoom-start-scale: 1.15;    /* How large the panel starts before zooming out */
+    --em-transition-timing: 0.45s;  /* Speed of the zoom effect */
+    --em-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275); /* Creates a snappy 'locking-in' feel */
+}

--- a/submissions/examples/cyberpunk-zoom-out-tabs/demo.html
+++ b/submissions/examples/cyberpunk-zoom-out-tabs/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Cyberpunk Zoom-Out Tabs - EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="cyber-wrapper">
+        <header class="cyber-header">
+            <h1>SYS // PROTOCOL</h1>
+            <p>Pure CSS tabs featuring a high-impact zoom-out transition.</p>
+        </header>
+
+        <div class="em-tabs-container">
+            <!-- Hidden Radio Inputs for State Management -->
+            <input type="radio" id="em-tab-1" name="em-tabs" class="em-tab-input" checked>
+            <input type="radio" id="em-tab-2" name="em-tabs" class="em-tab-input">
+            <input type="radio" id="em-tab-3" name="em-tabs" class="em-tab-input">
+
+            <!-- Cyberpunk Tab Headers -->
+            <div class="em-tabs-header">
+                <label for="em-tab-1" class="em-tab-label" tabindex="0">
+                    <span class="glitch-text">NETWORK</span>
+                </label>
+                <label for="em-tab-2" class="em-tab-label" tabindex="0">
+                    <span class="glitch-text">SECURITY</span>
+                </label>
+                <label for="em-tab-3" class="em-tab-label" tabindex="0">
+                    <span class="glitch-text">DATABANKS</span>
+                </label>
+            </div>
+
+            <!-- Tab Content Panels -->
+            <div class="em-tabs-content">
+                <div class="em-tab-panel" id="em-panel-1">
+                    <div class="panel-inner">
+                        <h2>Network Topography</h2>
+                        <p>Establishing secure handshake with the primary grid. All sub-nodes are currently broadcasting at optimal frequencies. Packet loss is within acceptable parameters.</p>
+                        <button class="cyber-btn btn-cyan">PING NODES</button>
+                    </div>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-2">
+                    <div class="panel-inner">
+                        <h2>Security Protocol</h2>
+                        <p>Firewall integrity is fluctuating. Unauthorized access attempts detected in Sector 4. Recommend immediate rotation of cryptographic keys.</p>
+                        <button class="cyber-btn btn-magenta">PURGE THREATS</button>
+                    </div>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-3">
+                    <div class="panel-inner">
+                        <h2>Databank Access</h2>
+                        <p>Accessing archived logs from standard cycle 2077. Data fragmentation detected. Initiating background defragmentation sequences.</p>
+                        <button class="cyber-btn btn-yellow">EXTRACT LOGS</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-zoom-out-tabs/style.css
+++ b/submissions/examples/cyberpunk-zoom-out-tabs/style.css
@@ -1,0 +1,283 @@
+/* ==========================================================================
+   EaseMotion: Cyberpunk Neon Zoom-Out Tabs
+   ========================================================================== */
+
+:root {
+    /* Cyberpunk Neon Palette */
+    --em-cyber-bg: #09090e;
+    --em-cyber-panel: #11111a;
+    --em-neon-cyan: #00f0ff;
+    --em-neon-magenta: #ff003c;
+    --em-neon-yellow: #fcee0a;
+    
+    /* Text Colors */
+    --em-text-main: #d4d4f7;
+    --em-text-muted: #5e5e7e;
+    
+    /* Zoom-Out Animation Parameters */
+    --em-zoom-start-scale: 1.15;
+    --em-transition-timing: 0.45s;
+    --em-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275); /* Snappy with slight bounce */
+}
+
+/* Base Page Styling with Grid Background */
+body {
+    margin: 0;
+    font-family: 'Courier New', Courier, monospace; 
+    background-color: var(--em-cyber-bg);
+    background-image: 
+        radial-gradient(circle at center, rgba(0, 240, 255, 0.03) 0%, transparent 60%),
+        linear-gradient(rgba(255, 0, 60, 0.02) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 0, 60, 0.02) 1px, transparent 1px);
+    background-size: 100% 100%, 40px 40px, 40px 40px;
+    color: var(--em-text-main);
+    display: flex;
+    justify-content: center;
+    padding: 5rem 1.5rem;
+}
+
+.cyber-wrapper {
+    max-width: 800px;
+    width: 100%;
+}
+
+.cyber-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    text-transform: uppercase;
+}
+
+.cyber-header h1 {
+    margin: 0 0 0.5rem 0;
+    color: var(--em-text-main);
+    text-shadow: 2px 2px 0px var(--em-neon-magenta), -2px -2px 0px var(--em-neon-cyan);
+    letter-spacing: 2px;
+}
+
+.cyber-header p {
+    color: var(--em-text-muted);
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+/* ==========================================================================
+   Component: Tabs Container & Hidden Inputs
+   ========================================================================== */
+.em-tabs-container {
+    width: 100%;
+    position: relative;
+}
+
+/* Hide inputs visually, keep focusable in DOM */
+.em-tab-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+/* ==========================================================================
+   Component: Cyberpunk Tab Headers
+   ========================================================================== */
+.em-tabs-header {
+    display: flex;
+    margin-bottom: 1.5rem;
+    background: #000;
+    border: 1px solid var(--em-text-muted);
+    padding: 0.25rem;
+}
+
+.em-tab-label {
+    flex: 1;
+    text-align: center;
+    padding: 1rem;
+    cursor: pointer;
+    font-weight: bold;
+    font-size: 1rem;
+    color: var(--em-text-muted);
+    background-color: transparent;
+    text-transform: uppercase;
+    transition: all 0.3s ease;
+    user-select: none;
+    position: relative;
+    z-index: 1;
+}
+
+.em-tab-label::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: currentColor;
+    opacity: 0;
+    z-index: -1;
+    transition: opacity 0.3s ease;
+}
+
+.em-tab-label:hover {
+    color: var(--em-text-main);
+}
+
+.em-tab-label:hover::before {
+    opacity: 0.1;
+}
+
+/* ==========================================================================
+   Component: Tab Content Panels
+   ========================================================================== */
+.em-tabs-content {
+    background-color: var(--em-cyber-panel);
+    border: 1px solid var(--em-text-muted);
+    min-height: 250px;
+    position: relative;
+    overflow: hidden; /* Crucial for keeping the zoom-out contained */
+}
+
+/* Panel Inner wrapper for scaling */
+.panel-inner {
+    padding: 3rem;
+}
+
+.em-tab-panel {
+    display: none; /* Hidden by default */
+}
+
+.em-tab-panel h2 {
+    margin-top: 0;
+    font-size: 1.6rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.em-tab-panel p {
+    line-height: 1.7;
+    color: var(--em-text-main);
+    margin-bottom: 2rem;
+}
+
+/* Cyberpunk Buttons */
+.cyber-btn {
+    background: transparent;
+    border: 2px solid currentColor;
+    color: inherit;
+    padding: 0.75rem 1.5rem;
+    font-family: inherit;
+    font-weight: bold;
+    text-transform: uppercase;
+    cursor: pointer;
+    position: relative;
+    transition: all 0.2s ease;
+    letter-spacing: 1px;
+}
+
+.cyber-btn:hover {
+    background: currentColor;
+    color: var(--em-cyber-panel);
+    box-shadow: 0 0 15px currentColor;
+}
+
+.btn-cyan { color: var(--em-neon-cyan); }
+.btn-magenta { color: var(--em-neon-magenta); }
+.btn-yellow { color: var(--em-neon-yellow); }
+
+/* ==========================================================================
+   Pure CSS Logic: Connecting Radios to Tabs & Panels
+   ========================================================================== */
+
+/* Active Tab Styling */
+#em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"] {
+    color: var(--em-neon-cyan);
+    text-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+}
+#em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"]::before {
+    opacity: 0.15;
+}
+
+#em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"] {
+    color: var(--em-neon-magenta);
+    text-shadow: 0 0 8px rgba(255, 0, 60, 0.5);
+}
+#em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"]::before {
+    opacity: 0.15;
+}
+
+#em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"] {
+    color: var(--em-neon-yellow);
+    text-shadow: 0 0 8px rgba(252, 238, 10, 0.5);
+}
+#em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"]::before {
+    opacity: 0.15;
+}
+
+/* Dynamic Borders for content box based on active tab */
+#em-tab-1:checked ~ .em-tabs-content { border-left: 4px solid var(--em-neon-cyan); }
+#em-tab-2:checked ~ .em-tabs-content { border-left: 4px solid var(--em-neon-magenta); }
+#em-tab-3:checked ~ .em-tabs-content { border-left: 4px solid var(--em-neon-yellow); }
+
+/* Title colors in panels */
+#em-tab-1:checked ~ .em-tabs-content #em-panel-1 h2 { color: var(--em-neon-cyan); }
+#em-tab-2:checked ~ .em-tabs-content #em-panel-2 h2 { color: var(--em-neon-magenta); }
+#em-tab-3:checked ~ .em-tabs-content #em-panel-3 h2 { color: var(--em-neon-yellow); }
+
+/* Keyboard Accessibility Focus Rings */
+.em-tab-label:focus-visible {
+    outline: 2px solid var(--em-text-main);
+    outline-offset: -4px;
+}
+
+/* Show Active Panel & Trigger Zoom-Out Animation */
+#em-tab-1:checked ~ .em-tabs-content #em-panel-1,
+#em-tab-2:checked ~ .em-tabs-content #em-panel-2,
+#em-tab-3:checked ~ .em-tabs-content #em-panel-3 {
+    display: block;
+}
+
+/* Apply animation to the inner content to prevent breaking the outer border container */
+#em-tab-1:checked ~ .em-tabs-content #em-panel-1 .panel-inner,
+#em-tab-2:checked ~ .em-tabs-content #em-panel-2 .panel-inner,
+#em-tab-3:checked ~ .em-tabs-content #em-panel-3 .panel-inner {
+    animation: em-zoom-out var(--em-transition-timing) var(--em-easing) forwards;
+}
+
+/* ==========================================================================
+   Keyframes: Zoom-Out
+   ========================================================================== */
+@keyframes em-zoom-out {
+    0% {
+        opacity: 0;
+        transform: scale(var(--em-zoom-start-scale));
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* ==========================================================================
+   Responsiveness
+   ========================================================================== */
+@media (max-width: 650px) {
+    .em-tabs-header {
+        flex-direction: column;
+        padding: 0;
+    }
+    .em-tab-label {
+        border-bottom: 1px solid var(--em-text-muted);
+    }
+    .em-tab-label:last-child {
+        border-bottom: none;
+    }
+    .panel-inner {
+        padding: 2rem 1.5rem;
+    }
+}
+
+/* ==========================================================================
+   Accessibility: Prefers Reduced Motion
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .panel-inner {
+        animation: none !important; /* Disable zoom-out scale */
+        opacity: 1;
+        transform: scale(1);
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #50279 by introducing a purely CSS-driven Zoom-Out Tabs component, styled intensely to fit the Cyberpunk Neon interface aesthetics for the EaseMotion CSS library.

**Key Implementations:**
* **HTML (`demo.html`)**: Built a resilient, JS-free state management system using the hidden radio-button hack. Structured the tabs as a futuristic system terminal featuring glitch-text placeholders and semantic structure.
* **CSS (`style.css`)**: 
  * Implemented a dynamic `em-zoom-out` keyframe animation targeting an inner `.panel-inner` wrapper. This approach ensures the outer container borders remain perfectly static while the text and buttons scale down from `1.15x` to `1x` seamlessly.
  * Designed complex CSS routing logic where the active tab dynamically dictates the glowing text-shadows, background opacity, and the left-border color of the main content container (using Cyan, Magenta, and Yellow themes).
* **Customization**: Centralized parameters for `--em-zoom-start-scale`, `--em-transition-timing`, and animation easing inside the `:root` variables.
* **Responsiveness**: The unified header bar breaks down gracefully into a stacked vertical list on viewports under `650px`, optimizing touch targets.
* **Accessibility**: Added `tabindex="0"` to the labels with custom `:focus-visible` styling for robust keyboard accessibility. Integrated `prefers-reduced-motion` support to fall back to an instantaneous display without the scaling effect.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📄 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (specifically under `submissions/examples/cyberpunk-zoom-out-tabs/`)
- [x] Includes `demo.html` with a clean HTML5 showcase.
- [x] Includes `style.css` with pure CSS/HTML (No external JS frameworks).
- [x] Includes `README.md` with proper documentation.
- [x] Code is fully responsive across all viewports.
- [x] Code is accessible and includes `prefers-reduced-motion` support.

closes #50279