### PR TITLE
Add Scale-Hover tooltip component for gaming hub layouts (scale-hover…

### DIFF
--- a/submissions/examples/scale-hover-tooltip-hr18/README.md
+++ b/submissions/examples/scale-hover-tooltip-hr18/README.md
@@ -1,0 +1,82 @@
+# Scale-Hover Tooltip (`scale-hover-tooltip-hr18`)
+
+A pure-CSS animated tooltip with a "Scale-Hover" entrance, styled for
+gaming hub inventory layouts, built for issue
+[#56489](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/56489).
+
+## What it does
+
+Hovering — or tabbing to, with a keyboard — an inventory item reveals a
+stat tooltip that springs open from `scale(0.4)` to `scale(1)` with a
+slight overshoot, rather than just fading or growing linearly into place.
+Both the show/hide behavior and the scale animation are pure CSS, driven
+by `:hover`/`:focus-within` and a single `transform`/`opacity` transition
+— no JavaScript anywhere in this component.
+
+The demo applies it to a 5-item inventory grid with rarity-colored items
+(Common, Rare, Epic) and per-item stat breakdowns in each tooltip.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<span class="sht-item-wrap-hr18">
+  <span class="sht-item-hr18" tabindex="0">&#9876;</span>
+  <span class="ease-tooltip-scale-hr18" role="tooltip">
+    <span class="sht-tooltip-name-hr18">Frost Blade</span>
+    <span class="sht-tooltip-rarity-hr18">Rare</span>
+    <span class="sht-tooltip-stat-hr18"><span>Damage</span><span>+42</span></span>
+  </span>
+</span>
+```
+
+`tabindex="0"` on the trigger is what makes it focusable by keyboard when
+it isn't already a naturally interactive element like a `<button>` — if
+your trigger already is one, the `tabindex` isn't needed.
+
+### Tuning the animation
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-scale-duration-hr18` | `260ms` | How long the scale-in takes |
+| `--ease-scale-easing-hr18` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | The overshoot curve that gives it a slight spring |
+
+```css
+.sht-item-wrap-hr18.snappy {
+  --ease-scale-duration-hr18: 140ms;
+}
+```
+
+## Accessibility notes
+
+- The tooltip shows on `:focus-within` as well as `:hover`, so keyboard
+  users see the same content sighted mouse users do.
+- The tooltip carries `role="tooltip"`.
+- Rarity is conveyed through text ("Common" / "Rare" / "Epic") in
+  addition to color, so it's never communicated by color alone.
+- The tooltip contains only text — no interactive content — matching the
+  WAI-ARIA tooltip pattern's expectations.
+- `@media (prefers-reduced-motion: reduce)` shortens the transition to a
+  near-instant opacity fade with no scaling motion, so feedback is
+  preserved without any movement.
+
+## Responsiveness
+
+The inventory grid runs 5 columns wide, dropping to 3 under a `480px`
+viewport width so items stay a comfortable tap size on a phone.
+
+## Why this fits EaseMotion CSS
+
+A pure-CSS, zero-JavaScript component — a single transition rule — with
+its timing and easing exposed as tunable custom properties, matching the
+issue's "no external JS frameworks" and "smooth CSS transitions and
+keyframe animations" requirements directly.
+
+All classes, custom properties, and the folder itself use a `-hr18`
+suffix to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/scale-hover-tooltip-hr18/demo.html
+++ b/submissions/examples/scale-hover-tooltip-hr18/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Scale-Hover Tooltip — gaming hub demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="sht-hr18">
+  <div class="sht-wrap-hr18">
+
+    <h1>Inventory</h1>
+    <p>Hover or tab to any item &mdash; its tooltip springs open from zero
+      with a slight overshoot, instead of just fading in.</p>
+
+    <div class="sht-grid-hr18">
+
+      <span class="sht-item-wrap-hr18">
+        <span class="sht-item-hr18" tabindex="0">&#9876;</span>
+        <span class="ease-tooltip-scale-hr18" role="tooltip">
+          <span class="sht-tooltip-name-hr18">Frost Blade</span>
+          <span class="sht-tooltip-rarity-hr18">Rare</span>
+          <span class="sht-tooltip-stat-hr18"><span>Damage</span><span>+42</span></span>
+          <span class="sht-tooltip-stat-hr18"><span>Speed</span><span>+8</span></span>
+        </span>
+      </span>
+
+      <span class="sht-item-wrap-hr18">
+        <span class="sht-item-hr18 epic" tabindex="0">&#128737;</span>
+        <span class="ease-tooltip-scale-hr18" role="tooltip">
+          <span class="sht-tooltip-name-hr18">Voidplate Helm</span>
+          <span class="sht-tooltip-rarity-hr18 epic">Epic</span>
+          <span class="sht-tooltip-stat-hr18"><span>Armor</span><span>+120</span></span>
+          <span class="sht-tooltip-stat-hr18"><span>HP</span><span>+300</span></span>
+        </span>
+      </span>
+
+      <span class="sht-item-wrap-hr18">
+        <span class="sht-item-hr18" tabindex="0">&#127993;</span>
+        <span class="ease-tooltip-scale-hr18" role="tooltip">
+          <span class="sht-tooltip-name-hr18">Elixir of Haste</span>
+          <span class="sht-tooltip-rarity-hr18">Common</span>
+          <span class="sht-tooltip-stat-hr18"><span>Speed</span><span>+15</span></span>
+          <span class="sht-tooltip-stat-hr18"><span>Duration</span><span>30s</span></span>
+        </span>
+      </span>
+
+      <span class="sht-item-wrap-hr18">
+        <span class="sht-item-hr18 epic" tabindex="0">&#128142;</span>
+        <span class="ease-tooltip-scale-hr18" role="tooltip">
+          <span class="sht-tooltip-name-hr18">Shard of Eternity</span>
+          <span class="sht-tooltip-rarity-hr18 epic">Epic</span>
+          <span class="sht-tooltip-stat-hr18"><span>All stats</span><span>+18</span></span>
+          <span class="sht-tooltip-stat-hr18"><span>Crit</span><span>+6%</span></span>
+        </span>
+      </span>
+
+      <span class="sht-item-wrap-hr18">
+        <span class="sht-item-hr18" tabindex="0">&#128737;&#65039;</span>
+        <span class="ease-tooltip-scale-hr18" role="tooltip">
+          <span class="sht-tooltip-name-hr18">Guard's Buckler</span>
+          <span class="sht-tooltip-rarity-hr18">Rare</span>
+          <span class="sht-tooltip-stat-hr18"><span>Block</span><span>+22%</span></span>
+          <span class="sht-tooltip-stat-hr18"><span>Armor</span><span>+40</span></span>
+        </span>
+      </span>
+
+    </div>
+
+    <div class="sht-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-scale-duration-hr18</code></td><td><code>260ms</code></td><td>How long the scale-in takes.</td></tr>
+          <tr><td><code>--ease-scale-easing-hr18</code></td><td><code>cubic-bezier(0.34, 1.56, 0.64, 1)</code></td><td>The overshoot curve that gives it a slight spring.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="sht-footnote-hr18">submissions/examples/scale-hover-tooltip-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/scale-hover-tooltip-hr18/style.css
+++ b/submissions/examples/scale-hover-tooltip-hr18/style.css
@@ -1,0 +1,239 @@
+/* ==========================================================================
+   scale-hover-tooltip-hr18 — style.css
+   CSS Scale-Hover Tooltip for Gaming Hub Layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.sht-hr18 {
+  --bg-hr18: #0b0c12;
+  --panel-hr18: #14151e;
+  --border-hr18: #262838;
+  --text-hr18: #eceefb;
+  --muted-hr18: #8b8fa3;
+  --neon-hr18: #7cf7c4;
+  --rarity-epic-hr18: #b98bff;
+
+  /* Exposed animation parameters. */
+  --ease-scale-duration-hr18: 260ms;
+  --ease-scale-easing-hr18: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-mono-hr18: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  background:
+    radial-gradient(circle at 20% 10%, rgba(124, 247, 196, 0.08), transparent 45%),
+    radial-gradient(circle at 85% 40%, rgba(185, 139, 255, 0.08), transparent 45%),
+    var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  padding: 3.5rem 1.5rem;
+}
+
+.sht-hr18 * {
+  box-sizing: border-box;
+}
+
+.sht-wrap-hr18 {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.sht-wrap-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  margin: 0 0 0.5rem;
+}
+
+.sht-wrap-hr18 > p {
+  margin: 0 0 2.25rem;
+  color: var(--muted-hr18);
+  font-size: 0.92rem;
+}
+
+/* ==========================================================================
+   The inventory grid — context for the tooltip, not the component itself
+   ========================================================================== */
+
+.sht-grid-hr18 {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.9rem;
+}
+
+@media (max-width: 480px) {
+  .sht-grid-hr18 {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* ==========================================================================
+   The reusable tooltip component
+   ========================================================================== */
+
+.sht-item-wrap-hr18 {
+  position: relative;
+}
+
+.sht-item-hr18 {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display-hr18);
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--neon-hr18);
+  cursor: default;
+  transition: border-color 180ms ease;
+}
+
+.sht-item-hr18:hover,
+.sht-item-hr18:focus-visible {
+  border-color: var(--neon-hr18);
+}
+
+.sht-item-hr18.epic {
+  color: var(--rarity-epic-hr18);
+}
+
+.sht-item-hr18.epic:hover,
+.sht-item-hr18.epic:focus-visible {
+  border-color: var(--rarity-epic-hr18);
+}
+
+/* The tooltip bubble: scaled to nothing and invisible at rest, growing
+   to full size with a springy overshoot on hover/focus. Anchored to
+   scale from its bottom edge, since it sits above the trigger. */
+.ease-tooltip-scale-hr18 {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  width: 170px;
+  background: var(--panel-hr18);
+  border: 1px solid var(--border-hr18);
+  border-radius: 10px;
+  padding: 0.7rem 0.85rem;
+  text-align: left;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  visibility: hidden;
+  opacity: 0;
+  transform: translateX(-50%) scale(0.4);
+  transform-origin: bottom center;
+  z-index: 20;
+}
+
+.sht-item-wrap-hr18:hover .ease-tooltip-scale-hr18,
+.sht-item-wrap-hr18:focus-within .ease-tooltip-scale-hr18 {
+  visibility: visible;
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+  transition: transform var(--ease-scale-duration-hr18) var(--ease-scale-easing-hr18),
+    opacity var(--ease-scale-duration-hr18) ease,
+    visibility var(--ease-scale-duration-hr18);
+}
+
+.sht-tooltip-name-hr18 {
+  font-weight: 700;
+  font-size: 0.82rem;
+  margin-bottom: 0.2rem;
+}
+
+.sht-tooltip-rarity-hr18 {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--neon-hr18);
+  margin-bottom: 0.4rem;
+}
+
+.sht-tooltip-rarity-hr18.epic {
+  color: var(--rarity-epic-hr18);
+}
+
+.sht-tooltip-stat-hr18 {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.74rem;
+  color: var(--muted-hr18);
+  padding: 0.1rem 0;
+}
+
+.sht-tooltip-stat-hr18 span:last-child {
+  color: var(--text-hr18);
+  font-family: var(--font-mono-hr18);
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.sht-tuning-hr18 {
+  margin-top: 2.5rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.25rem 1.4rem;
+  text-align: left;
+}
+
+.sht-tuning-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1rem;
+  margin: 0 0 0.6rem;
+}
+
+.sht-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.sht-tuning-hr18 th,
+.sht-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.sht-tuning-hr18 th {
+  color: var(--muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.sht-tuning-hr18 code {
+  font-family: var(--font-mono-hr18);
+  font-size: 0.8em;
+  color: var(--neon-hr18);
+}
+
+.sht-footnote-hr18 {
+  margin-top: 1.75rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.sht-hr18 :focus-visible {
+  outline: 2px solid var(--neon-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sht-item-wrap-hr18:hover .ease-tooltip-scale-hr18,
+  .sht-item-wrap-hr18:focus-within .ease-tooltip-scale-hr18 {
+    transition: opacity 120ms ease, visibility 120ms;
+    transform: translateX(-50%) scale(1);
+  }
+  .ease-tooltip-scale-hr18 {
+    transform: translateX(-50%) scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated Tooltip with a "Scale-Hover" entrance, styled
for gaming hub inventory layouts. Hovering or focusing an inventory item
springs its stat tooltip open from scale(0.4) to scale(1) with a slight
overshoot, rather than a linear fade. Show/hide and the scale animation
are both pure CSS (:hover/:focus-within + one transition rule) — zero
JavaScript. Demo applies it to a 5-item inventory grid with
rarity-colored items (Common/Rare/Epic) and per-item stats.

Resolves #56489

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/scale-hover-tooltip-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS scale-hover tooltip with tunable timing/easing via
custom properties.

**How does a developer use it?**
```html
<span class="sht-item-wrap-hr18">
  <span class="sht-item-hr18" tabindex="0">⚔</span>
  <span class="ease-tooltip-scale-hr18" role="tooltip">...</span>
</span>
```

**Why does it fit EaseMotion CSS?**
A pure-CSS, zero-JavaScript component with timing/easing exposed as
tunable custom properties, matching the issue's "no external JS
frameworks" requirement directly.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Rarity conveyed through text, not color alone. prefers-reduced-motion
shortens the transition to a near-instant opacity fade with no scale.
Tested keyboard focus and hover in Chrome; haven't checked other browsers
yet.