### PR TITLE
fix: prevent navbar link wrapping on small screens

### DIFF
--- a/submissions/docs/55663-navbar-link-wrapping-fix-ds/README.md
+++ b/submissions/docs/55663-navbar-link-wrapping-fix-ds/README.md
@@ -1,0 +1,24 @@
+# Navbar Link Wrapping Fix
+
+A responsive CSS solution that prevents navigation links from wrapping onto multiple lines on smaller screen sizes.
+
+## 1. What does this do?
+
+This showcase demonstrates how to prevent navbar links from wrapping when the available width becomes limited. The fixed implementation keeps all navigation items on a single line by using a non-wrapping flex container with horizontal scrolling when necessary.
+
+## 2. How is it used?
+
+Open `demo.html` directly in any modern browser—no build step or server is required.
+
+The page includes two examples:
+
+- **Broken:** A navbar that allows links to wrap onto multiple lines on narrow viewports, causing layout inconsistencies.
+- **Fixed:** A navbar using `flex-wrap: nowrap`, `overflow-x: auto`, and `white-space: nowrap` so navigation links remain on a single line while staying accessible on smaller screens.
+
+To apply the solution in your own project, configure the navbar as a flex container with wrapping disabled and enable horizontal scrolling when required.
+
+## 3. Why is it useful?
+
+Navigation bars should remain consistent and easy to use across different screen sizes. Preventing link wrapping preserves the visual structure of the navigation, improves usability on mobile devices, and provides a cleaner responsive experience without hiding navigation items.
+
+Fixes #55663.

--- a/submissions/docs/55663-navbar-link-wrapping-fix-ds/demo.html
+++ b/submissions/docs/55663-navbar-link-wrapping-fix-ds/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Navbar Link Wrapping Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h1>Navbar Link Wrapping Fix Demo</h1>
+
+<p class="intro">
+Resize the page to a narrow width to compare the broken and fixed navigation bars.
+The broken version allows links to wrap onto multiple lines, while the fixed version
+keeps all links on a single line using a responsive flex layout.
+</p>
+
+<div class="demo-grid">
+
+  <section>
+    <h2>❌ Broken</h2>
+
+    <div class="mobile-frame">
+      <nav class="navbar navbar-broken">
+        <a href="#">Home</a>
+        <a href="#">About</a>
+        <a href="#">Services</a>
+        <a href="#">Portfolio</a>
+        <a href="#">Contact</a>
+      </nav>
+    </div>
+
+  </section>
+
+  <section>
+    <h2>✅ Fixed</h2>
+
+    <div class="mobile-frame">
+      <nav class="navbar navbar-fixed">
+        <a href="#">Home</a>
+        <a href="#">About</a>
+        <a href="#">Services</a>
+        <a href="#">Portfolio</a>
+        <a href="#">Contact</a>
+      </nav>
+    </div>
+
+  </section>
+
+</div>
+
+</body>
+</html>

--- a/submissions/docs/55663-navbar-link-wrapping-fix-ds/style.css
+++ b/submissions/docs/55663-navbar-link-wrapping-fix-ds/style.css
@@ -1,0 +1,80 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f1115;
+  color: #e7e9ee;
+  margin: 0;
+  padding: 32px 20px;
+}
+
+h1 {
+  margin-bottom: 8px;
+  font-size: 1.5rem;
+}
+
+.intro {
+  max-width: 700px;
+  color: #a5adba;
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+
+.demo-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+}
+
+.mobile-frame {
+  width: 260px;
+  border: 2px solid #313743;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #181b22;
+}
+
+/* Shared Navbar */
+
+.navbar {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  background: #232733;
+}
+
+.navbar a {
+  text-decoration: none;
+  background: #8b5cf6;
+  color: white;
+  padding: 8px 14px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+/* ---------------------------
+   Broken Example
+---------------------------- */
+
+.navbar-broken {
+  flex-wrap: wrap;
+}
+
+/* ---------------------------
+   Fixed Example
+---------------------------- */
+
+.navbar-fixed {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.navbar-fixed a {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+@media (max-width: 650px) {
+  .demo-grid {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
Adds a standalone documentation showcase demonstrating the navbar link wrapping issue and its responsive CSS fix. The demo compares the broken and fixed implementations, showing how `flex-wrap: nowrap` with horizontal scrolling keeps navigation links on a single line on smaller screens.

Fixes #55663

---

## Pull Request Description

This PR adds a documentation showcase under `submissions/docs/55663-navbar-link-wrapping-fix-ds/` demonstrating a common responsive navbar issue where navigation links wrap onto multiple lines on narrow viewports.

The showcase includes:
- A **Broken** example that reproduces the issue.
- A **Fixed** example using `flex-wrap: nowrap` and horizontal scrolling.
- A self-contained `demo.html`, `style.css`, and `README.md`.

---

## Type of Change

- [x] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A documentation showcase demonstrating how to prevent navbar links from wrapping onto multiple lines on smaller screens.

**How does a developer use it?**

```html
<nav class="navbar navbar-fixed">
  <a href="#">Home</a>
  <a href="#">About</a>
  <a href="#">Services</a>
  <a href="#">Portfolio</a>
  <a href="#">Contact</a>
</nav>
```

```css
.navbar {
  display: flex;
  flex-wrap: nowrap;
  overflow-x: auto;
}

.navbar a {
  flex: 0 0 auto;
  white-space: nowrap;
}
```

**Why does it fit EaseMotion CSS?**

It documents a practical CSS solution for a common responsive navigation problem using a standalone, browser-ready demo that aligns with EaseMotion CSS's documentation-first approach.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission is fully self-contained inside `submissions/docs/` and does not modify any core library files. Feedback and suggestions are welcome.