### PR TITLE
created CSS 3D-Flip Badge for Gaming Hub Layouts

### DIFF
--- a/submissions/examples/CSS 3D-Flip Badge for Gaming Hub Layouts/README.md
+++ b/submissions/examples/CSS 3D-Flip Badge for Gaming Hub Layouts/README.md
@@ -1,0 +1,134 @@
+# Gaming Hub 3D-Flip Rank Badge
+
+A pure CSS/HTML rank badge for gaming hub and profile layouts. On hover or
+keyboard focus, the badge performs a smooth 3D flip to reveal a HUD-style
+stats panel on the back — no JavaScript required.
+
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Standalone showcase page with a 6-tier badge wall |
+| `style.css` | All component styles, animations, and responsive rules |
+| `README.md` | This document |
+
+Open `demo.html` directly in a browser — there is no build step and no
+external JavaScript dependency.
+
+## How it works
+
+Each badge is two stacked faces inside a `perspective`-ed container. Hovering
+or focusing rotates the inner element `180deg` on the Y axis; `backface-visibility:
+hidden` keeps the correct face pointing at the viewer at all times.
+
+```html
+<div class="em-badge" data-tier="gold">
+  <button class="em-badge-flip" aria-label="Gold rank badge, flip for stats">
+    <div class="em-badge-face em-badge-face--front">...</div>
+    <div class="em-badge-face em-badge-face--back">...</div>
+  </button>
+</div>
+```
+
+The trigger is a real `<button>`, so the flip is reachable and operable with
+a keyboard (`Tab` + hover-equivalent `:focus-visible`) and announced properly
+by screen readers via `aria-label`. On touch devices, the flip fires on
+`:active` as a tap fallback.
+
+### Signature detail: the holo sheen
+
+The front face has an animated diagonal light sweep (`::before` with a
+`conic`-free linear gradient and `mix-blend-mode: overlay`), giving each
+badge the foil-card look familiar from trading-card and loot-drop UIs. This
+is the one deliberately eye-catching motion in the component; everything
+else (the flip, the meter fill) is quick and utilitarian by comparison.
+
+### Stat meters
+
+The back face includes a thin progress meter for the headline stat (win
+rate). It fills via `transform: scaleX()` on flip, driven by a per-badge
+`--fill` custom property set inline in the HTML:
+
+```html
+<div class="em-meter" style="--fill:71%">
+  <div class="em-meter__fill"></div>
+</div>
+```
+
+## CSS custom properties
+
+### Global tokens (set on `:root`)
+
+| Property | Default | Description |
+|---|---|---|
+| `--em-void` | `#0a0e1a` | Page background base |
+| `--em-void-raised` | `#10162a` | Badge surface background |
+| `--em-ink` | `#eef1fa` | Primary text color |
+| `--em-ink-dim` | `#8892ac` | Secondary/label text color |
+| `--em-holo-a` | `#2de2ff` | Sheen + focus-ring accent (cyan) |
+| `--em-holo-b` | `#ff3dad` | Title gradient accent (magenta) |
+| `--em-flip-duration` | `0.7s` | Duration of the 3D flip |
+| `--em-flip-ease` | `cubic-bezier(0.22, 1, 0.36, 1)` | Flip easing curve |
+| `--em-sheen-duration` | `3.2s` | Loop time of the holo sweep |
+| `--em-font-display` | `'Rajdhani', sans-serif` | Headline / tier name typeface |
+| `--em-font-body` | `'Inter', sans-serif` | Body typeface |
+| `--em-font-mono` | `'Share Tech Mono', monospace` | HUD data typeface |
+
+### Per-badge tokens (set on `.em-badge`, or via `data-tier`)
+
+| Property | Description |
+|---|---|
+| `--tier` | Badge accent color (ring, tier label, meter highlight) |
+| `--tier-deep` | Darker shade used for gradients/shadows |
+| `--tier-glow` | Translucent glow color behind the emblem |
+
+Six tiers ship out of the box via `data-tier`: `bronze`, `silver`, `gold`,
+`platinum`, `diamond`, `champion`. Add a new tier by setting the three
+tokens on any selector:
+
+```css
+.em-badge[data-tier="obsidian"] {
+  --tier: #b39dff;
+  --tier-deep: #4a2f9e;
+  --tier-glow: rgba(179, 157, 255, 0.4);
+}
+```
+
+## Features
+
+- **Pure CSS/HTML** — zero JavaScript, zero build tooling.
+- **Real 3D flip** — `transform-style: preserve-3d` + `backface-visibility`,
+  not an opacity crossfade (except under reduced motion, see below).
+- **Keyboard accessible** — the flip trigger is a native `<button>` with an
+  `aria-label`; `:focus-visible` drives the same flip as `:hover`.
+- **Touch-friendly** — `:active` fallback flips the badge on tap for coarse
+  pointers.
+- **Fully responsive** — a CSS Grid badge wall (`auto-fit`/`minmax`) reflows
+  from a multi-column desktop layout down to a 2-column mobile grid, with
+  `clamp()`-based fluid type throughout.
+- **`prefers-reduced-motion` support** — when reduced motion is requested,
+  the 3D rotation and holo-sheen animation are replaced with a quick,
+  gentle opacity crossfade so the same information is still revealed.
+
+## Customization examples
+
+**Slow the flip down for a heavier, more deliberate feel:**
+
+```css
+.em-badge { --em-flip-duration: 1.1s; }
+```
+
+**Recolor the whole component to a different brand accent:**
+
+```css
+:root {
+  --em-holo-a: #ffd23f;
+  --em-holo-b: #ff5757;
+}
+```
+
+**Reuse the badge outside the demo grid** — drop a single `.em-badge` block
+anywhere flex or grid layout is already in place; it has no dependency on
+the `.em-badge-grid` or `.em-hub` wrapper classes beyond needing a defined
+width/height (an `aspect-ratio` is set by default).

--- a/submissions/examples/CSS 3D-Flip Badge for Gaming Hub Layouts/demo.html
+++ b/submissions/examples/CSS 3D-Flip Badge for Gaming Hub Layouts/demo.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion — Gaming Hub 3D-Flip Rank Badge</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body class="em-hub">
+
+  <header class="em-hub__header">
+    <span class="em-hub__eyebrow">EaseMotion · Gaming Hub</span>
+    <h1 class="em-hub__title">Rank Badge Wall</h1>
+    <p class="em-hub__subtitle">
+      Hover or focus a badge to flip it in 3D and reveal the player's season
+      stats. Built with pure CSS — no JavaScript required.
+    </p>
+  </header>
+
+  <main class="em-badge-grid">
+
+    <!-- Bronze -->
+    <div class="em-badge" data-tier="bronze">
+      <button class="em-badge-flip" aria-label="Bronze rank badge, flip for stats">
+        <div class="em-badge-face em-badge-face--front">
+          <div class="em-badge-ring"><span class="em-badge-ring__icon">🛡️</span></div>
+          <h2 class="em-badge-tier">Bronze</h2>
+          <p class="em-badge-rank">RANK #4,812</p>
+          <span class="em-badge-hint">Hover to flip</span>
+        </div>
+        <div class="em-badge-face em-badge-face--back">
+          <h3 class="em-badge-back__title">Season Stats</h3>
+          <ul class="em-badge-stats">
+            <li><span class="em-label">Win rate</span><span class="em-value">41%</span>
+              <div class="em-meter" style="--fill:41%"><div class="em-meter__fill"></div></div>
+            </li>
+            <li><span class="em-label">Matches</span><span class="em-value">128</span></li>
+            <li><span class="em-label">Win streak</span><span class="em-value">2</span></li>
+            <li><span class="em-label">Level</span><span class="em-value">12</span></li>
+          </ul>
+          <div class="em-badge-back__footer"><span>PLAYER_04812</span><span>S6</span></div>
+        </div>
+      </button>
+    </div>
+
+    <!-- Silver -->
+    <div class="em-badge" data-tier="silver">
+      <button class="em-badge-flip" aria-label="Silver rank badge, flip for stats">
+        <div class="em-badge-face em-badge-face--front">
+          <div class="em-badge-ring"><span class="em-badge-ring__icon">⚔️</span></div>
+          <h2 class="em-badge-tier">Silver</h2>
+          <p class="em-badge-rank">RANK #2,203</p>
+          <span class="em-badge-hint">Hover to flip</span>
+        </div>
+        <div class="em-badge-face em-badge-face--back">
+          <h3 class="em-badge-back__title">Season Stats</h3>
+          <ul class="em-badge-stats">
+            <li><span class="em-label">Win rate</span><span class="em-value">49%</span>
+              <div class="em-meter" style="--fill:49%"><div class="em-meter__fill"></div></div>
+            </li>
+            <li><span class="em-label">Matches</span><span class="em-value">241</span></li>
+            <li><span class="em-label">Win streak</span><span class="em-value">4</span></li>
+            <li><span class="em-label">Level</span><span class="em-value">27</span></li>
+          </ul>
+          <div class="em-badge-back__footer"><span>PLAYER_02203</span><span>S6</span></div>
+        </div>
+      </button>
+    </div>
+
+    <!-- Gold -->
+    <div class="em-badge" data-tier="gold">
+      <button class="em-badge-flip" aria-label="Gold rank badge, flip for stats">
+        <div class="em-badge-face em-badge-face--front">
+          <div class="em-badge-ring"><span class="em-badge-ring__icon">👑</span></div>
+          <h2 class="em-badge-tier">Gold</h2>
+          <p class="em-badge-rank">RANK #614</p>
+          <span class="em-badge-hint">Hover to flip</span>
+        </div>
+        <div class="em-badge-face em-badge-face--back">
+          <h3 class="em-badge-back__title">Season Stats</h3>
+          <ul class="em-badge-stats">
+            <li><span class="em-label">Win rate</span><span class="em-value">58%</span>
+              <div class="em-meter" style="--fill:58%"><div class="em-meter__fill"></div></div>
+            </li>
+            <li><span class="em-label">Matches</span><span class="em-value">356</span></li>
+            <li><span class="em-label">Win streak</span><span class="em-value">7</span></li>
+            <li><span class="em-label">Level</span><span class="em-value">44</span></li>
+          </ul>
+          <div class="em-badge-back__footer"><span>PLAYER_00614</span><span>S6</span></div>
+        </div>
+      </button>
+    </div>
+
+    <!-- Platinum -->
+    <div class="em-badge" data-tier="platinum">
+      <button class="em-badge-flip" aria-label="Platinum rank badge, flip for stats">
+        <div class="em-badge-face em-badge-face--front">
+          <div class="em-badge-ring"><span class="em-badge-ring__icon">💠</span></div>
+          <h2 class="em-badge-tier">Platinum</h2>
+          <p class="em-badge-rank">RANK #187</p>
+          <span class="em-badge-hint">Hover to flip</span>
+        </div>
+        <div class="em-badge-face em-badge-face--back">
+          <h3 class="em-badge-back__title">Season Stats</h3>
+          <ul class="em-badge-stats">
+            <li><span class="em-label">Win rate</span><span class="em-value">63%</span>
+              <div class="em-meter" style="--fill:63%"><div class="em-meter__fill"></div></div>
+            </li>
+            <li><span class="em-label">Matches</span><span class="em-value">412</span></li>
+            <li><span class="em-label">Win streak</span><span class="em-value">9</span></li>
+            <li><span class="em-label">Level</span><span class="em-value">58</span></li>
+          </ul>
+          <div class="em-badge-back__footer"><span>PLAYER_00187</span><span>S6</span></div>
+        </div>
+      </button>
+    </div>
+
+    <!-- Diamond -->
+    <div class="em-badge" data-tier="diamond">
+      <button class="em-badge-flip" aria-label="Diamond rank badge, flip for stats">
+        <div class="em-badge-face em-badge-face--front">
+          <div class="em-badge-ring"><span class="em-badge-ring__icon">🔷</span></div>
+          <h2 class="em-badge-tier">Diamond</h2>
+          <p class="em-badge-rank">RANK #42</p>
+          <span class="em-badge-hint">Hover to flip</span>
+        </div>
+        <div class="em-badge-face em-badge-face--back">
+          <h3 class="em-badge-back__title">Season Stats</h3>
+          <ul class="em-badge-stats">
+            <li><span class="em-label">Win rate</span><span class="em-value">71%</span>
+              <div class="em-meter" style="--fill:71%"><div class="em-meter__fill"></div></div>
+            </li>
+            <li><span class="em-label">Matches</span><span class="em-value">503</span></li>
+            <li><span class="em-label">Win streak</span><span class="em-value">14</span></li>
+            <li><span class="em-label">Level</span><span class="em-value">72</span></li>
+          </ul>
+          <div class="em-badge-back__footer"><span>PLAYER_00042</span><span>S6</span></div>
+        </div>
+      </button>
+    </div>
+
+    <!-- Champion -->
+    <div class="em-badge" data-tier="champion">
+      <button class="em-badge-flip" aria-label="Champion rank badge, flip for stats">
+        <div class="em-badge-face em-badge-face--front">
+          <div class="em-badge-ring"><span class="em-badge-ring__icon">🏆</span></div>
+          <h2 class="em-badge-tier">Champion</h2>
+          <p class="em-badge-rank">RANK #1</p>
+          <span class="em-badge-hint">Hover to flip</span>
+        </div>
+        <div class="em-badge-face em-badge-face--back">
+          <h3 class="em-badge-back__title">Season Stats</h3>
+          <ul class="em-badge-stats">
+            <li><span class="em-label">Win rate</span><span class="em-value">86%</span>
+              <div class="em-meter" style="--fill:86%"><div class="em-meter__fill"></div></div>
+            </li>
+            <li><span class="em-label">Matches</span><span class="em-value">647</span></li>
+            <li><span class="em-label">Win streak</span><span class="em-value">21</span></li>
+            <li><span class="em-label">Level</span><span class="em-value">99</span></li>
+          </ul>
+          <div class="em-badge-back__footer"><span>PLAYER_00001</span><span>S6</span></div>
+        </div>
+      </button>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/CSS 3D-Flip Badge for Gaming Hub Layouts/style.css
+++ b/submissions/examples/CSS 3D-Flip Badge for Gaming Hub Layouts/style.css
@@ -1,0 +1,412 @@
+/* ==========================================================================
+   EaseMotion — Gaming Hub 3D-Flip Rank Badge
+   Pure CSS, no JS. Hover / focus flips the badge to reveal live stats.
+   ========================================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&family=Inter:wght@400;500;600&family=Share+Tech+Mono&display=swap');
+
+/* --------------------------------------------------------------------------
+   1. Design tokens
+   -------------------------------------------------------------------------- */
+:root {
+  /* arena surface */
+  --em-void: #0a0e1a;
+  --em-void-raised: #10162a;
+  --em-grid-line: rgba(120, 150, 220, 0.07);
+
+  /* text */
+  --em-ink: #eef1fa;
+  --em-ink-dim: #8892ac;
+
+  /* signature duotone accent (holo sweep + focus ring) */
+  --em-holo-a: #2de2ff;
+  --em-holo-b: #ff3dad;
+
+  /* tier colors — each badge overrides --tier / --tier-deep / --tier-glow */
+  --tier: #ffcf5c;
+  --tier-deep: #a86c1a;
+  --tier-glow: rgba(255, 207, 92, 0.45);
+
+  /* motion */
+  --em-flip-duration: 0.7s;
+  --em-flip-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --em-sheen-duration: 3.2s;
+
+  /* type */
+  --em-font-display: 'Rajdhani', 'Arial Narrow', sans-serif;
+  --em-font-body: 'Inter', system-ui, sans-serif;
+  --em-font-mono: 'Share Tech Mono', 'Courier New', monospace;
+}
+
+/* --------------------------------------------------------------------------
+   2. Page shell (demo scaffolding — not required by consumers of the badge)
+   -------------------------------------------------------------------------- */
+* { box-sizing: border-box; }
+
+body.em-hub {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    linear-gradient(var(--em-grid-line) 1px, transparent 1px) 0 0 / 48px 48px,
+    linear-gradient(90deg, var(--em-grid-line) 1px, transparent 1px) 0 0 / 48px 48px,
+    radial-gradient(ellipse at 50% -10%, #16203f 0%, var(--em-void) 55%);
+  color: var(--em-ink);
+  font-family: var(--em-font-body);
+  padding: clamp(24px, 5vw, 72px) clamp(16px, 4vw, 48px) 80px;
+}
+
+.em-hub__header {
+  max-width: 960px;
+  margin: 0 auto clamp(32px, 6vw, 56px);
+  text-align: center;
+}
+
+.em-hub__eyebrow {
+  display: inline-block;
+  font-family: var(--em-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--em-holo-a);
+  border: 1px solid rgba(45, 226, 255, 0.35);
+  padding: 5px 14px;
+  border-radius: 999px;
+  margin-bottom: 18px;
+}
+
+.em-hub__title {
+  font-family: var(--em-font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  letter-spacing: 0.01em;
+  margin: 0 0 12px;
+  background: linear-gradient(90deg, #fff 0%, var(--em-holo-a) 55%, var(--em-holo-b) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.em-hub__subtitle {
+  color: var(--em-ink-dim);
+  font-size: clamp(0.95rem, 1.6vw, 1.05rem);
+  max-width: 52ch;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* --------------------------------------------------------------------------
+   3. Badge grid
+   -------------------------------------------------------------------------- */
+.em-badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(20px, 3vw, 32px);
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+/* --------------------------------------------------------------------------
+   4. The flip card
+   -------------------------------------------------------------------------- */
+.em-badge {
+  position: relative;
+  aspect-ratio: 3 / 4;
+  perspective: 1400px;
+  font-family: var(--em-font-body);
+}
+
+.em-badge-flip {
+  /* reset <button> defaults so it behaves as a plain flip surface */
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  transition: transform var(--em-flip-duration) var(--em-flip-ease);
+  transform-style: preserve-3d;
+  cursor: pointer;
+  border-radius: 20px;
+  outline-offset: 6px;
+}
+
+.em-badge-flip:focus-visible {
+  outline: 2px solid var(--em-holo-a);
+}
+
+/* hover OR keyboard focus flips the card */
+.em-badge:hover .em-badge-flip,
+.em-badge-flip:focus-visible,
+.em-badge-flip:focus-within {
+  transform: rotateY(180deg);
+}
+
+/* touch devices: tapping toggles via :focus (card is a <button>), and we
+   also support a checkbox-free "sticky hover" fallback for coarse pointers */
+@media (hover: none) {
+  .em-badge-flip:active {
+    transform: rotateY(180deg);
+  }
+}
+
+.em-badge-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--em-void-raised);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow:
+    0 18px 40px -18px rgba(0, 0, 0, 0.65),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+/* --------------------------------------------------------------------------
+   5. Front face — emblem + tier
+   -------------------------------------------------------------------------- */
+.em-badge-face--front {
+  background:
+    radial-gradient(circle at 50% 18%, var(--tier-glow), transparent 60%),
+    linear-gradient(160deg, var(--em-void-raised) 0%, #0c1120 100%);
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  text-align: center;
+}
+
+/* holographic sweep — the signature motion of this component */
+.em-badge-face--front::before {
+  content: '';
+  position: absolute;
+  inset: -40%;
+  background: linear-gradient(
+    115deg,
+    transparent 40%,
+    rgba(255, 255, 255, 0.16) 48%,
+    var(--em-holo-a) 50%,
+    rgba(255, 255, 255, 0.16) 52%,
+    transparent 60%
+  );
+  animation: em-sheen var(--em-sheen-duration) linear infinite;
+  mix-blend-mode: overlay;
+  pointer-events: none;
+}
+
+@keyframes em-sheen {
+  0%   { transform: translateX(-30%) translateY(-30%) rotate(0deg); }
+  100% { transform: translateX(30%) translateY(30%) rotate(0deg); }
+}
+
+.em-badge-ring {
+  position: relative;
+  width: clamp(64px, 22%, 96px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: conic-gradient(from -90deg, var(--tier), var(--tier-deep), var(--tier));
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.05), 0 0 26px var(--tier-glow);
+  margin-bottom: 16px;
+}
+
+.em-badge-ring::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  background: var(--em-void-raised);
+}
+
+.em-badge-ring__icon {
+  position: relative;
+  z-index: 1;
+  font-size: clamp(1.4rem, 4vw, 1.9rem);
+  line-height: 1;
+}
+
+.em-badge-tier {
+  font-family: var(--em-font-display);
+  font-weight: 700;
+  font-size: clamp(1.15rem, 2.4vw, 1.5rem);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--tier);
+  margin: 0;
+}
+
+.em-badge-rank {
+  font-family: var(--em-font-mono);
+  font-size: 0.78rem;
+  color: var(--em-ink-dim);
+  margin: 6px 0 0;
+  letter-spacing: 0.06em;
+}
+
+.em-badge-hint {
+  position: absolute;
+  bottom: 14px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-family: var(--em-font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--em-ink-dim);
+  opacity: 0.7;
+}
+
+/* --------------------------------------------------------------------------
+   6. Back face — HUD stat readout
+   -------------------------------------------------------------------------- */
+.em-badge-face--back {
+  transform: rotateY(180deg);
+  background: linear-gradient(160deg, #141a30 0%, #0a0e1a 100%);
+  padding: 18px 18px 16px;
+  justify-content: space-between;
+}
+
+.em-badge-back__title {
+  font-family: var(--em-font-display);
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--em-ink);
+  margin: 0 0 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.em-badge-stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  flex: 1;
+}
+
+.em-badge-stats li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+}
+
+.em-badge-stats .em-label {
+  color: var(--em-ink-dim);
+}
+
+.em-badge-stats .em-value {
+  font-family: var(--em-font-mono);
+  color: var(--em-ink);
+}
+
+.em-meter {
+  grid-column: 1 / -1;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.em-meter__fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--tier-deep), var(--tier));
+  width: var(--fill, 50%);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.9s var(--em-flip-ease) 0.15s;
+}
+
+.em-badge:hover .em-meter__fill,
+.em-badge-flip:focus-visible .em-meter__fill,
+.em-badge-flip:focus-within .em-meter__fill {
+  transform: scaleX(1);
+}
+
+.em-badge-back__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--em-font-mono);
+  font-size: 0.68rem;
+  color: var(--em-holo-a);
+  letter-spacing: 0.08em;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --------------------------------------------------------------------------
+   7. Tier color assignments (override the --tier tokens per badge)
+   -------------------------------------------------------------------------- */
+.em-badge[data-tier="bronze"]   { --tier: #d98b4c; --tier-deep: #7a4a1f; --tier-glow: rgba(217, 139, 76, 0.4); }
+.em-badge[data-tier="silver"]   { --tier: #d7deec; --tier-deep: #7c869c; --tier-glow: rgba(215, 222, 236, 0.35); }
+.em-badge[data-tier="gold"]     { --tier: #ffcf5c; --tier-deep: #a86c1a; --tier-glow: rgba(255, 207, 92, 0.45); }
+.em-badge[data-tier="platinum"] { --tier: #7fe8d6; --tier-deep: #21857a; --tier-glow: rgba(127, 232, 214, 0.4); }
+.em-badge[data-tier="diamond"]  { --tier: #8fc9ff; --tier-deep: #2c5fa8; --tier-glow: rgba(143, 201, 255, 0.4); }
+.em-badge[data-tier="champion"] { --tier: #ff8fd8; --tier-deep: #a83c86; --tier-glow: rgba(255, 143, 216, 0.45); }
+
+/* --------------------------------------------------------------------------
+   8. Responsive tuning
+   -------------------------------------------------------------------------- */
+@media (max-width: 720px) {
+  .em-badge-grid { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 16px; }
+  .em-badge { aspect-ratio: 4 / 5; }
+}
+
+@media (max-width: 420px) {
+  .em-badge-grid { grid-template-columns: repeat(2, 1fr); }
+  .em-badge-hint { display: none; }
+}
+
+/* --------------------------------------------------------------------------
+   9. Accessibility — respect reduced-motion preference
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .em-badge-flip {
+    transition: none;
+  }
+
+  /* swap the 3D rotation for a gentle crossfade instead of disabling
+     the interaction entirely */
+  .em-badge-face { transition: opacity 0.25s ease; }
+  .em-badge-face--back { transform: none; position: absolute; opacity: 0; }
+  .em-badge-face--front { position: absolute; opacity: 1; }
+
+  .em-badge:hover .em-badge-flip,
+  .em-badge-flip:focus-visible,
+  .em-badge-flip:focus-within {
+    transform: none;
+  }
+
+  .em-badge:hover .em-badge-face--front,
+  .em-badge-flip:focus-visible .em-badge-face--front,
+  .em-badge-flip:focus-within .em-badge-face--front {
+    opacity: 0;
+  }
+
+  .em-badge:hover .em-badge-face--back,
+  .em-badge-flip:focus-visible .em-badge-face--back,
+  .em-badge-flip:focus-within .em-badge-face--back {
+    opacity: 1;
+  }
+
+  .em-badge-face--front::before { animation: none; }
+  .em-meter__fill { transition: none; transform: scaleX(1); }
+}


### PR DESCRIPTION
**Pull Request: Add CSS 3D-Flip Rank Badge for Gaming Hub Layouts**

_Summary_
Closes the request to expand EaseMotion CSS with a new showcase example: a pure CSS/HTML 3D-Flip Rank Badge for gaming hub layouts. Hovering or focusing a badge performs a smooth 3D flip to reveal a HUD-style stats panel on the back — no JavaScript involved.

_What's included_
New submission folder: submissions/examples/CSS 3D-Flip Badge for Gaming Hub Layouts/

1. demo.html — standalone showcase page with a 6-tier badge wall (Bronze, Silver, Gold, Platinum, Diamond, Champion)
2. style.css — all component styles, animations, and responsive rules
3. README.md — usage docs, full CSS custom-property reference, and customization examples

_How it works_ 
Each badge is two stacked faces (.em-badge-face--front / --back) inside a perspective-ed <button>. Hover or :focus-visible rotates the inner element 180deg on the Y axis; backface-visibility: hidden keeps the right face forward at all times. Per-badge tier color is controlled via data-tier, which overrides three custom properties (--tier, --tier-deep, --tier-glow) — new tiers can be added without touching the component CSS.

_Testing performed_

- Verified flip behavior via mouse hover, keyboard Tab + focus, and touch :active fallback

- Verified prefers-reduced-motion: reduce fallback in browser dev tools emulation

- Verified responsive reflow at desktop, tablet (≤720px), and mobile (≤420px) breakpoints

- Verified all 6 tiers render distinct colors via data-tier without editing base component CSS