### PR TITLE
feat: add CSS 3D-Flip Popover for Gaming Hub Layouts

### DIFF
--- a/submissions/examples/3d-flip-popover-sathvika/README.md
+++ b/submissions/examples/3d-flip-popover-sathvika/README.md
@@ -1,0 +1,24 @@
+﻿# CSS 3D-Flip Popover
+
+A popover that flips into view like a hinged flap, using a 3D `rotateX` transform anchored at the top edge.
+
+## CSS Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| `--ease-popover-duration` | `0.5s` | Transition duration |
+| `--ease-popover-easing` | `cubic-bezier(0.4, 0, 0.2, 1)` | Transition easing curve |
+| `--ease-popover-bg` | `#111827` | Popover background |
+
+## Usage
+```html
+<div class="ease-popover-wrapper">
+  <button class="ease-popover-trigger" aria-describedby="popoverContent">Show Info</button>
+  <div class="ease-popover" id="popoverContent" role="tooltip">Content</div>
+</div>
+```
+
+## Accessibility
+`role="tooltip"` and `aria-describedby` link trigger to content. Clicking outside closes the popover. `prefers-reduced-motion` shortens transition duration.
+
+## Why it fits EaseMotion CSS
+Pure CSS 3D `rotateX` flip transition using `perspective`, `ease-` prefixed classes, themeable.

--- a/submissions/examples/3d-flip-popover-sathvika/demo.html
+++ b/submissions/examples/3d-flip-popover-sathvika/demo.html
@@ -1,0 +1,22 @@
+﻿<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" />
+<title>3D-Flip Popover Demo</title><link rel="stylesheet" href="style.css" />
+<style>body{font-family:-apple-system,sans-serif;background:#f9fafb;padding:100px;}</style>
+</head><body>
+<h2>CSS 3D-Flip Popover</h2>
+<div class="ease-popover-wrapper">
+  <button class="ease-popover-trigger" id="triggerBtn" aria-describedby="popoverContent">Show Info</button>
+  <div class="ease-popover" id="popoverContent" role="tooltip">
+    This popover flips down into view like a hinged flap using a 3D rotateX transform.
+  </div>
+</div>
+<script>
+  const trigger = document.getElementById('triggerBtn');
+  const popover = document.getElementById('popoverContent');
+  trigger.addEventListener('click', () => popover.classList.toggle('ease-popover--open'));
+  document.addEventListener('click', (e) => {
+    if (!trigger.contains(e.target) && !popover.contains(e.target)) {
+      popover.classList.remove('ease-popover--open');
+    }
+  });
+</script>
+</body></html>

--- a/submissions/examples/3d-flip-popover-sathvika/style.css
+++ b/submissions/examples/3d-flip-popover-sathvika/style.css
@@ -1,0 +1,21 @@
+﻿:root {
+  --ease-popover-duration: 0.5s;
+  --ease-popover-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-popover-bg: #111827;
+}
+.ease-popover-wrapper { position: relative; display: inline-block; perspective: 800px; }
+.ease-popover-trigger { padding: 10px 20px; border-radius: 8px; border: none; background: #4f46e5; color: #fff; font-size: 14px; font-weight: 600; cursor: pointer; }
+.ease-popover {
+  position: absolute; top: calc(100% + 10px); left: 0; width: 220px;
+  background: var(--ease-popover-bg); color: #f9fafb; padding: 14px 16px;
+  border-radius: 10px; font-size: 13px; line-height: 1.5;
+  transform: rotateX(-90deg); transform-origin: top center;
+  opacity: 0; pointer-events: none;
+  transition: transform var(--ease-popover-duration) var(--ease-popover-easing),
+    opacity var(--ease-popover-duration) ease;
+  z-index: 10;
+}
+.ease-popover--open { transform: rotateX(0deg); opacity: 1; pointer-events: auto; }
+@media (prefers-reduced-motion: reduce) {
+  .ease-popover { transition-duration: 0.15s; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS popover that flips into view like a hinged flap using a 3D rotateX transform, for gaming hub layouts. Resolves #56415

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/examples/3d-flip-popover-sathvika/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A popover that flips down into view around its top edge using `perspective` + `rotateX`, resembling a hinged flap opening.

**How does a developer use it?**
```html
<div class="ease-popover-wrapper">
  <button class="ease-popover-trigger" aria-describedby="popoverContent">Show Info</button>
  <div class="ease-popover" id="popoverContent" role="tooltip">Content</div>
</div>
```

**Why does it fit EaseMotion CSS?** Pure CSS 3D `rotateX` flip transition, `ease-` prefixed classes, themeable.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
`transform-origin: top center` anchors the rotation at the hinge edge. `role="tooltip"`/`aria-describedby` for accessibility; clicking outside closes it. `prefers-reduced-motion` shortens the transition. Happy to adjust the flip angle if preferred.