### PR TITLE
feat: add CSS Rotate-Fade Carousel for Gaming Hub Layouts

### DIFF
--- a/submissions/examples/rotate-fade-carousel-sathvika/README.md
+++ b/submissions/examples/rotate-fade-carousel-sathvika/README.md
@@ -1,0 +1,24 @@
+﻿# CSS Rotate-Fade Carousel
+
+A carousel where each slide rotates in on the Y-axis (like a page turn) while fading in, using CSS `perspective` and `rotateY`.
+
+## CSS Custom Properties
+| Property | Default | Description |
+|---|---|---|
+| `--ease-carousel-duration` | `0.5s` | Slide transition duration |
+| `--ease-carousel-easing` | `cubic-bezier(0.4, 0, 0.2, 1)` | Transition easing curve |
+
+## Usage
+```html
+<div class="ease-carousel">
+  <div class="ease-carousel__slide ease-carousel__slide--active">Slide 1</div>
+  <div class="ease-carousel__slide">Slide 2</div>
+</div>
+```
+Minimal JS toggles the `ease-carousel__slide--active` class per dot click; all animation is CSS.
+
+## Accessibility
+Nav dots use `aria-label` per slide. `prefers-reduced-motion` shortens the transition duration significantly.
+
+## Why it fits EaseMotion CSS
+Pure CSS 3D `rotateY` + opacity transition, `ease-` prefixed classes, themeable.

--- a/submissions/examples/rotate-fade-carousel-sathvika/demo.html
+++ b/submissions/examples/rotate-fade-carousel-sathvika/demo.html
@@ -1,0 +1,28 @@
+﻿<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" />
+<title>Rotate-Fade Carousel Demo</title><link rel="stylesheet" href="style.css" />
+<style>body{font-family:-apple-system,sans-serif;background:#f9fafb;padding:60px;}</style>
+</head><body>
+<h2>CSS Rotate-Fade Carousel</h2>
+<div class="ease-carousel" id="carousel">
+  <div class="ease-carousel__slide ease-carousel__slide--active">Slide 1</div>
+  <div class="ease-carousel__slide">Slide 2</div>
+  <div class="ease-carousel__slide">Slide 3</div>
+</div>
+<div class="ease-carousel__nav" id="nav">
+  <button class="ease-carousel__dot ease-carousel__dot--active" data-index="0" aria-label="Go to slide 1"></button>
+  <button class="ease-carousel__dot" data-index="1" aria-label="Go to slide 2"></button>
+  <button class="ease-carousel__dot" data-index="2" aria-label="Go to slide 3"></button>
+</div>
+<script>
+  const slides = document.querySelectorAll('.ease-carousel__slide');
+  const dots = document.querySelectorAll('.ease-carousel__dot');
+  dots.forEach(dot => {
+    dot.addEventListener('click', () => {
+      const i = parseInt(dot.dataset.index, 10);
+      slides.forEach((s, idx) => s.classList.toggle('ease-carousel__slide--active', idx === i));
+      dots.forEach(d => d.classList.remove('ease-carousel__dot--active'));
+      dot.classList.add('ease-carousel__dot--active');
+    });
+  });
+</script>
+</body></html>

--- a/submissions/examples/rotate-fade-carousel-sathvika/style.css
+++ b/submissions/examples/rotate-fade-carousel-sathvika/style.css
@@ -1,0 +1,23 @@
+﻿:root {
+  --ease-carousel-duration: 0.5s;
+  --ease-carousel-easing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+.ease-carousel { position: relative; width: 100%; max-width: 480px; height: 220px; perspective: 1000px; }
+.ease-carousel__slide {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  color: #fff; font-size: 22px; font-weight: 700; border-radius: 14px;
+  transform: rotateY(90deg); opacity: 0;
+  transition: transform var(--ease-carousel-duration) var(--ease-carousel-easing),
+    opacity var(--ease-carousel-duration) ease;
+  pointer-events: none;
+}
+.ease-carousel__slide--active { transform: rotateY(0deg); opacity: 1; pointer-events: auto; }
+.ease-carousel__slide:nth-child(1) { background: #4f46e5; }
+.ease-carousel__slide:nth-child(2) { background: #ec4899; }
+.ease-carousel__slide:nth-child(3) { background: #22c55e; }
+.ease-carousel__nav { display: flex; justify-content: center; gap: 8px; margin-top: 12px; }
+.ease-carousel__dot { width: 10px; height: 10px; border-radius: 50%; border: none; background: #d1d5db; cursor: pointer; }
+.ease-carousel__dot--active { background: #4f46e5; }
+@media (prefers-reduced-motion: reduce) {
+  .ease-carousel__slide { transition-duration: 0.15s; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS carousel where slides rotate in on the Y-axis like a page turn while fading, for gaming hub layouts. Resolves #56387

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/examples/rotate-fade-carousel-sathvika/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A dot-navigated carousel where each slide rotates in via `perspective` + `rotateY` combined with an opacity fade, resembling a page turn.

**How does a developer use it?**
```html
<div class="ease-carousel">
  <div class="ease-carousel__slide ease-carousel__slide--active">Slide 1</div>
  <div class="ease-carousel__slide">Slide 2</div>
</div>
```

**Why does it fit EaseMotion CSS?** Pure CSS 3D `rotateY` + opacity transition, `ease-` prefixed classes, themeable; minimal JS only toggles which slide is active.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Dot buttons carry `aria-label` per slide. `prefers-reduced-motion` shortens the transition duration significantly. Happy to add autoplay or swipe navigation if preferred.
