### PR TITLE
created CSS Float-Drift Navbar for Gaming Hub Layouts

### DIFF
--- a/submissions/examples/CSS Float-Drift Navbar for Gaming Hub Layouts/README.md
+++ b/submissions/examples/CSS Float-Drift Navbar for Gaming Hub Layouts/README.md
@@ -1,0 +1,159 @@
+# Gaming Hub Float-Drift Navbar
+
+A pure CSS/HTML navigation bar for gaming hub and launcher layouts. The
+navbar floats as a detached glass dock above the page, its icons idle in a
+gentle asynchronous float, and its active-tab indicator drifts smoothly to
+whichever tab is selected — entirely in CSS, no JavaScript.
+
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Standalone showcase page with a full navbar (brand, 5 tabs, actions) |
+| `style.css` | All component styles, animations, and responsive rules |
+| `README.md` | This document |
+
+Open `demo.html` directly in a browser — there is no build step and no
+external JavaScript dependency.
+
+## How it works
+
+**Floating dock.** The navbar is `position: fixed`, detached from the
+viewport edge with margin, and rendered as a translucent, blurred glass
+panel (`backdrop-filter: blur()`), so it reads as a HUD console hovering
+over the page rather than a docked bar.
+
+**Idle float.** Each nav icon runs its own `translateY` keyframe loop
+(`em-float`), with a negative `animation-delay` staggered per item via
+`:nth-of-type`, so the icons bob independently instead of in lockstep —
+this is what gives the bar its "alive" feel at rest.
+
+**Drifting active indicator, in pure CSS.** Tab selection is implemented
+with the classic hidden-radio-input pattern (no JS): each tab is a
+`<label>` bound to a visually-hidden `<input type="radio">`. The indicator
+pill's horizontal position is driven by a CSS custom property, `--active`,
+which is set per tab using the modern `:has()` selector:
+
+```css
+.em-navbar__nav:has(#nav-store:checked) { --active: 1; }
+```
+
+```css
+.em-nav-indicator {
+  transform: translateX(calc(var(--active, 0) * 100%));
+  transition: transform var(--em-indicator-duration) var(--em-indicator-ease);
+}
+```
+
+Because the indicator's own width equals one tab's width, `translateX(N *
+100%)` lands it exactly on the Nth tab, and because `transform` is
+animatable, the move glides rather than jumps. Browsers without `:has()`
+support simply keep the indicator hidden (`@supports not selector(:has(a))`)
+— the checked tab is still clearly marked by its text color, so navigation
+never breaks, only the extra glide is skipped.
+
+## HTML structure
+
+```html
+<nav class="em-navbar" aria-label="Primary">
+  <div class="em-navbar__brand">...</div>
+
+  <div class="em-navbar__nav" style="--em-tab-count:5">
+    <input type="radio" name="em-nav" id="nav-home" class="em-nav-radio" checked>
+    <label for="nav-home" class="em-nav-item">
+      <span class="em-nav-item__icon" aria-hidden="true">🏠</span>
+      <span class="em-nav-item__label">Home</span>
+    </label>
+    <!-- ...repeat per tab... -->
+    <span class="em-nav-indicator" aria-hidden="true"></span>
+  </div>
+
+  <div class="em-navbar__actions">...</div>
+</nav>
+```
+
+Set `--em-tab-count` on `.em-navbar__nav` to however many tabs you have —
+it's used to size the indicator to exactly `1 / count` of the track width.
+If you change the tab count, also add/remove the matching
+`:has(#id:checked) { --active: N; }` rule for the new tab's index.
+
+> **Real apps:** swap the `<label for>` / `<input>` pattern for your
+> router's active-link mechanism (e.g. render the `checked` attribute or an
+> `is-active` class server-side) — the indicator math works the same way
+> either way, since it only depends on `--active` and `--em-tab-count`.
+
+## CSS custom properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--em-abyss` | `#061412` | Page background base |
+| `--em-abyss-deep` | `#030907` | Text color on bright accent surfaces (indicator, badge, avatar) |
+| `--em-panel` | `rgba(14, 36, 32, 0.66)` | Navbar glass background |
+| `--em-panel-border` | `rgba(255,255,255,0.09)` | Navbar hairline border |
+| `--em-ink` | `#eafff5` | Primary text color |
+| `--em-ink-dim` | `#7fa89c` | Inactive tab / secondary text color |
+| `--em-drift-a` | `#33e6a6` | Primary accent — brand orb, indicator, focus rings |
+| `--em-drift-b` | `#ffb84d` | Secondary accent — notification badge, avatar |
+| `--em-radius` | `999px` | Corner radius used throughout (pill shapes) |
+| `--em-navbar-height` | `62px` | Height of the navbar; also used to reserve page top padding |
+| `--em-float-duration` | `3.6s` | Duration of one idle icon float cycle |
+| `--em-float-amplitude` | `4px` | Vertical travel distance of the idle float |
+| `--em-glow-duration` | `9s` | Loop time of the ambient border-glow drift |
+| `--em-indicator-duration` | `0.5s` | How long the active indicator takes to glide |
+| `--em-indicator-ease` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Overshoot easing for the indicator glide |
+| `--em-font-display` | `'Orbitron', sans-serif` | Brand wordmark typeface |
+| `--em-font-body` | `'Inter', sans-serif` | Nav labels, body text |
+| `--em-font-mono` | `'JetBrains Mono', monospace` | Notification count / data readouts |
+
+## Features
+
+- **Pure CSS/HTML** — zero JavaScript, zero build tooling; tab switching
+  uses the native radio-input pattern.
+- **Smooth, performant animation** — every animated property is `transform`,
+  `opacity`, or a masked gradient position; nothing triggers layout, so the
+  float and drift stay smooth even with the `backdrop-filter` blur active.
+- **Fully responsive** — the dock repositions from a centered top bar on
+  desktop to a full-width bottom tab bar at `860px`, and drops text labels
+  in favor of icon-only tabs at `560px` for comfortable thumb reach.
+- **`prefers-reduced-motion` support** — the idle icon float, brand-orb
+  pulse, notification-badge pulse, and ambient border glow are all disabled
+  under reduced motion; the indicator glide is kept (it's a direct response
+  to a click, not ambient motion) but its transition is shortened to be
+  effectively instant.
+- **Keyboard & screen-reader friendly** — tabs are real, labelled form
+  controls reachable with `Tab`/arrow keys with a visible focus ring
+  (`:focus-visible`); decorative icons and the indicator are `aria-hidden`.
+
+## Customization examples
+
+**Change how many tabs you have:**
+
+```html
+<div class="em-navbar__nav" style="--em-tab-count:4">
+```
+```css
+.em-navbar__nav:has(#nav-new-tab:checked) { --active: 3; }
+```
+
+**Calmer, less bouncy indicator:**
+
+```css
+.em-navbar__nav { --em-indicator-ease: ease-out; --em-indicator-duration: 0.3s; }
+```
+
+**Recolor to a different brand accent:**
+
+```css
+:root {
+  --em-drift-a: #4dd2ff;
+  --em-drift-b: #ff5fae;
+}
+```
+
+**Turn off the idle float entirely** (e.g. for a calmer admin-style hub)
+while keeping the indicator glide:
+
+```css
+.em-nav-item__icon { animation: none; }
+```

--- a/submissions/examples/CSS Float-Drift Navbar for Gaming Hub Layouts/demo.html
+++ b/submissions/examples/CSS Float-Drift Navbar for Gaming Hub Layouts/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion — Gaming Hub Float-Drift Navbar</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body class="em-hub">
+
+  <nav class="em-navbar" aria-label="Primary">
+
+    <div class="em-navbar__brand">
+      <span class="em-navbar__brand-orb" aria-hidden="true"></span>
+      NEXUS
+    </div>
+
+    <div class="em-navbar__nav" style="--em-tab-count:5">
+      <input type="radio" name="em-nav" id="nav-home" class="em-nav-radio" checked>
+      <label for="nav-home" class="em-nav-item">
+        <span class="em-nav-item__icon" aria-hidden="true">🏠</span>
+        <span class="em-nav-item__label">Home</span>
+      </label>
+
+      <input type="radio" name="em-nav" id="nav-store" class="em-nav-radio">
+      <label for="nav-store" class="em-nav-item">
+        <span class="em-nav-item__icon" aria-hidden="true">🛒</span>
+        <span class="em-nav-item__label">Store</span>
+      </label>
+
+      <input type="radio" name="em-nav" id="nav-inventory" class="em-nav-radio">
+      <label for="nav-inventory" class="em-nav-item">
+        <span class="em-nav-item__icon" aria-hidden="true">🎒</span>
+        <span class="em-nav-item__label">Inventory</span>
+      </label>
+
+      <input type="radio" name="em-nav" id="nav-squad" class="em-nav-radio">
+      <label for="nav-squad" class="em-nav-item">
+        <span class="em-nav-item__icon" aria-hidden="true">👥</span>
+        <span class="em-nav-item__label">Squad</span>
+      </label>
+
+      <input type="radio" name="em-nav" id="nav-events" class="em-nav-radio">
+      <label for="nav-events" class="em-nav-item">
+        <span class="em-nav-item__icon" aria-hidden="true">🎮</span>
+        <span class="em-nav-item__label">Events</span>
+      </label>
+
+      <span class="em-nav-indicator" aria-hidden="true"></span>
+    </div>
+
+    <div class="em-navbar__actions">
+      <button class="em-icon-btn" type="button" aria-label="Search">🔍</button>
+      <button class="em-icon-btn" type="button" aria-label="Notifications, 3 unread">
+        🔔
+        <span class="em-icon-btn__badge" aria-hidden="true">3</span>
+      </button>
+      <button class="em-avatar" type="button" aria-label="Open profile menu">KP</button>
+    </div>
+
+  </nav>
+
+  <main class="em-hub__content">
+    <span class="em-hub__eyebrow">EaseMotion · Gaming Hub</span>
+    <h1 class="em-hub__title">Float-Drift Navbar</h1>
+    <p class="em-hub__subtitle">
+      A detached glass dock that idles like a HUD console: icons gently
+      float, and the active-tab indicator drifts to whichever tab you pick —
+      all in pure CSS, no JavaScript. Click a tab above to see it glide.
+      Resize the window to watch the dock relocate to the bottom on
+      smaller screens.
+    </p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/CSS Float-Drift Navbar for Gaming Hub Layouts/style.css
+++ b/submissions/examples/CSS Float-Drift Navbar for Gaming Hub Layouts/style.css
@@ -1,0 +1,390 @@
+
+
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@500&display=swap');
+
+
+:root {
+  /* surface */
+  --em-abyss: #061412;
+  --em-abyss-deep: #030907;
+  --em-panel: rgba(14, 36, 32, 0.66);
+  --em-panel-border: rgba(255, 255, 255, 0.09);
+
+  /* text */
+  --em-ink: #eafff5;
+  --em-ink-dim: #7fa89c;
+
+  /* signature duotone accent — "drifting embers over dark water" */
+  --em-drift-a: #33e6a6;   /* emerald glow: brand, indicator, focus ring */
+  --em-drift-b: #ffb84d;   /* ember amber: notification badge, highlights */
+
+  /* geometry */
+  --em-radius: 999px;
+  --em-navbar-height: 62px;
+
+  /* motion */
+  --em-float-duration: 3.6s;
+  --em-float-amplitude: 4px;
+  --em-glow-duration: 9s;
+  --em-indicator-duration: 0.5s;
+  --em-indicator-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* type */
+  --em-font-display: 'Orbitron', 'Arial Narrow', sans-serif;
+  --em-font-body: 'Inter', system-ui, sans-serif;
+  --em-font-mono: 'JetBrains Mono', 'Courier New', monospace;
+}
+
+* { box-sizing: border-box; }
+
+/* --------------------------------------------------------------------------
+   2. Page shell (demo scaffolding — not required by consumers of the navbar)
+   -------------------------------------------------------------------------- */
+body.em-hub {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(ellipse 900px 500px at 20% 0%, rgba(51, 230, 166, 0.10), transparent 60%),
+    radial-gradient(ellipse 900px 500px at 85% 30%, rgba(255, 184, 77, 0.07), transparent 55%),
+    var(--em-abyss);
+  color: var(--em-ink);
+  font-family: var(--em-font-body);
+  padding-top: calc(var(--em-navbar-height) + 56px);
+  padding-bottom: 96px;
+}
+
+.em-hub__content {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 clamp(16px, 4vw, 32px);
+  text-align: center;
+}
+
+.em-hub__eyebrow {
+  display: inline-block;
+  font-family: var(--em-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--em-drift-a);
+  border: 1px solid rgba(51, 230, 166, 0.3);
+  padding: 5px 14px;
+  border-radius: var(--em-radius);
+  margin-bottom: 18px;
+}
+
+.em-hub__title {
+  font-family: var(--em-font-display);
+  font-weight: 700;
+  font-size: clamp(1.9rem, 5vw, 3.1rem);
+  margin: 0 0 14px;
+  background: linear-gradient(90deg, #fff 0%, var(--em-drift-a) 60%, var(--em-drift-b) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.em-hub__subtitle {
+  color: var(--em-ink-dim);
+  font-size: clamp(0.95rem, 1.6vw, 1.05rem);
+  line-height: 1.7;
+  max-width: 54ch;
+  margin: 0 auto 8px;
+}
+
+/* --------------------------------------------------------------------------
+   3. The floating navbar shell
+   -------------------------------------------------------------------------- */
+.em-navbar {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 2vw, 28px);
+
+  height: var(--em-navbar-height);
+  padding: 0 10px 0 18px;
+  max-width: calc(100% - 32px);
+
+  background: var(--em-panel);
+  border: 1px solid var(--em-panel-border);
+  border-radius: var(--em-radius);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  box-shadow:
+    0 16px 40px -18px rgba(0, 0, 0, 0.7),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+/* ambient drifting glow behind the whole dock — the "drift" of the name */
+.em-navbar::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(120deg, transparent 20%, rgba(51, 230, 166, 0.5) 50%, transparent 80%);
+  background-size: 300% 100%;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: em-glow-drift var(--em-glow-duration) ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes em-glow-drift {
+  0%, 100% { background-position: 0% 0%; }
+  50%      { background-position: 100% 0%; }
+}
+
+/* --------------------------------------------------------------------------
+   4. Brand mark
+   -------------------------------------------------------------------------- */
+.em-navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-shrink: 0;
+  font-family: var(--em-font-display);
+  font-weight: 700;
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  color: var(--em-ink);
+  white-space: nowrap;
+}
+
+.em-navbar__brand-orb {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #d4fff0, var(--em-drift-a) 55%, #0d6b4c 100%);
+  box-shadow: 0 0 14px rgba(51, 230, 166, 0.65);
+  animation: em-pulse 2.6s ease-in-out infinite;
+}
+
+@keyframes em-pulse {
+  0%, 100% { box-shadow: 0 0 10px rgba(51, 230, 166, 0.5); }
+  50%      { box-shadow: 0 0 20px rgba(51, 230, 166, 0.85); }
+}
+
+/* --------------------------------------------------------------------------
+   5. Nav item group + drifting active indicator
+   -------------------------------------------------------------------------- */
+.em-navbar__nav {
+  position: relative;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  align-items: center;
+  height: 44px;
+  border-radius: var(--em-radius);
+  background: rgba(0, 0, 0, 0.18);
+  padding: 3px;
+}
+
+.em-nav-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.em-nav-item {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  height: 100%;
+  padding: 0 clamp(10px, 1.6vw, 18px);
+  border-radius: var(--em-radius);
+  cursor: pointer;
+  color: var(--em-ink-dim);
+  font-size: 0.86rem;
+  font-weight: 500;
+  white-space: nowrap;
+  user-select: none;
+  transition: color 0.25s ease;
+}
+
+.em-nav-radio:checked + .em-nav-item {
+  color: var(--em-abyss-deep);
+  font-weight: 600;
+}
+
+.em-nav-radio:focus-visible + .em-nav-item {
+  outline: 2px solid var(--em-drift-a);
+  outline-offset: 2px;
+}
+
+.em-nav-item__icon {
+  display: inline-block;
+  font-size: 1rem;
+  line-height: 1;
+  animation: em-float var(--em-float-duration) ease-in-out infinite;
+}
+
+/* stagger the idle float so icons feel independently alive, not synced */
+label.em-nav-item:nth-of-type(1) .em-nav-item__icon { animation-delay: 0s; }
+label.em-nav-item:nth-of-type(2) .em-nav-item__icon { animation-delay: -0.6s; }
+label.em-nav-item:nth-of-type(3) .em-nav-item__icon { animation-delay: -1.2s; }
+label.em-nav-item:nth-of-type(4) .em-nav-item__icon { animation-delay: -1.8s; }
+label.em-nav-item:nth-of-type(5) .em-nav-item__icon { animation-delay: -2.4s; }
+
+@keyframes em-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(calc(var(--em-float-amplitude) * -1)); }
+}
+
+.em-nav-item__label {
+  font-family: var(--em-font-body);
+}
+
+/* the drifting pill that glides to the checked tab */
+.em-nav-indicator {
+  position: absolute;
+  inset: 3px auto 3px 3px;
+  width: calc((100% - 6px) / var(--em-tab-count, 5));
+  border-radius: var(--em-radius);
+  background: linear-gradient(120deg, var(--em-drift-a), #8ef7cf);
+  box-shadow: 0 6px 18px -6px rgba(51, 230, 166, 0.7);
+  transform: translateX(calc(var(--active, 0) * 100%));
+  transition: transform var(--em-indicator-duration) var(--em-indicator-ease);
+  z-index: 0;
+}
+
+/* graceful fallback where :has() isn't supported: hide the indicator,
+   keep the (still fully functional) color-based active state */
+@supports not selector(:has(a)) {
+  .em-nav-indicator { display: none; }
+}
+
+.em-navbar__nav:has(#nav-home:checked)      { --active: 0; }
+.em-navbar__nav:has(#nav-store:checked)     { --active: 1; }
+.em-navbar__nav:has(#nav-inventory:checked) { --active: 2; }
+.em-navbar__nav:has(#nav-squad:checked)     { --active: 3; }
+.em-navbar__nav:has(#nav-events:checked)    { --active: 4; }
+
+/* --------------------------------------------------------------------------
+   6. Right-side actions
+   -------------------------------------------------------------------------- */
+.em-navbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.em-icon-btn {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--em-ink-dim);
+  font-size: 1.05rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.em-icon-btn:hover,
+.em-icon-btn:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--em-ink);
+}
+
+.em-icon-btn:focus-visible {
+  outline: 2px solid var(--em-drift-a);
+  outline-offset: 2px;
+}
+
+.em-icon-btn__badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  border-radius: var(--em-radius);
+  background: var(--em-drift-b);
+  color: var(--em-abyss-deep);
+  font-family: var(--em-font-mono);
+  font-size: 0.6rem;
+  line-height: 15px;
+  text-align: center;
+  animation: em-pulse-amber 2.4s ease-in-out infinite;
+}
+
+@keyframes em-pulse-amber {
+  0%, 100% { box-shadow: 0 0 0 rgba(255, 184, 77, 0); }
+  50%      { box-shadow: 0 0 10px rgba(255, 184, 77, 0.75); }
+}
+
+.em-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(150deg, var(--em-drift-b), #a85a1c);
+  color: var(--em-abyss-deep);
+  font-family: var(--em-font-display);
+  font-weight: 700;
+  font-size: 0.72rem;
+  cursor: pointer;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+}
+
+/* --------------------------------------------------------------------------
+   7. Responsive: top dock -> bottom dock
+   -------------------------------------------------------------------------- */
+@media (max-width: 860px) {
+  .em-navbar {
+    top: auto;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 24px);
+    justify-content: space-between;
+  }
+
+  .em-navbar__brand { display: none; }
+}
+
+@media (max-width: 560px) {
+  .em-navbar {
+    padding: 0 8px;
+    gap: 4px;
+  }
+
+  .em-nav-item__label { display: none; }
+  .em-nav-item { padding: 0 12px; }
+  .em-nav-item__icon { font-size: 1.2rem; }
+  .em-navbar__actions .em-icon-btn:nth-of-type(1) { display: none; } /* hide search on very small screens */
+}
+
+/* --------------------------------------------------------------------------
+   8. Accessibility — respect reduced-motion preference
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .em-nav-item__icon,
+  .em-navbar__brand-orb,
+  .em-icon-btn__badge,
+  .em-navbar::before {
+    animation: none;
+  }
+
+  .em-nav-indicator {
+    transition-duration: 0.01ms;
+  }
+}


### PR DESCRIPTION
**Pull Request: Add CSS Float-Drift Navbar for Gaming Hub Layouts**
Fixes #56483 

**Summary**
This PR implements the Float-Drift Navbar requested in issue #56483 (assigned to me). It adds a pure CSS/HTML navigation bar for gaming hub layouts: a detached "glass dock" that floats above the page, with icons that idle in a gentle asynchronous float and an active-tab indicator that drifts smoothly between tabs — no JavaScript required.

**What's included**
New submission folder, as required by the issue's submission guidelines: submissions/examples/CSS Float-Drift Navbar for Gaming Hub Layouts/

- demo.html — standalone showcase page: brand mark, 5-tab nav, search/notification/avatar actions
- style.css — all component styles, animations, and responsive rules
- README.md — usage docs, full CSS custom-property reference, and customization examples
