### PR TITLE
feat: add glitch-flicker carousel for gaming hub layouts

### DIFF
--- a/submissions/examples/56390-glitch-flicker-carousel-ds/README.md
+++ b/submissions/examples/56390-glitch-flicker-carousel-ds/README.md
@@ -1,0 +1,69 @@
+# Glitch-Flicker Carousel
+
+A pure CSS carousel with a glitch/flicker transition effect, designed
+for gaming-hub style layouts — featured titles, tournament banners,
+or patch/update highlights.
+
+## 1. What does this do?
+
+Renders an image-free carousel where each slide transitions in with a
+short RGB-split "glitch" flicker (staggered opacity steps plus offset
+cyan/magenta text ghosts) instead of a plain fade or slide, giving it
+a gaming/cyberpunk aesthetic. Slides can be changed with the dot
+navigation or the hover-revealed prev/next arrows.
+
+## 2. How is it used?
+
+Open `demo.html` directly in any browser — no build step, server, or
+JavaScript required. The carousel is driven entirely by hidden radio
+inputs and the `:checked` CSS selector:
+
+```html
+<div class="glitch-carousel">
+  <input type="radio" name="glitch-slide" id="slide-1" class="glitch-radio" checked>
+  <input type="radio" name="glitch-slide" id="slide-2" class="glitch-radio">
+
+  <div class="glitch-track">
+    <div class="glitch-slide glitch-slide-1">
+      <div class="glitch-slide-inner" data-text="YOUR TITLE">
+        <span class="glitch-slide-title">YOUR TITLE</span>
+        <span class="glitch-slide-sub">Your subtitle</span>
+      </div>
+      <label for="slide-2" class="glitch-arrow glitch-arrow-prev">&#10094;</label>
+      <label for="slide-2" class="glitch-arrow glitch-arrow-next">&#10095;</label>
+    </div>
+  </div>
+
+  <div class="glitch-nav">
+    <label for="slide-1" class="glitch-dot"></label>
+    <label for="slide-2" class="glitch-dot"></label>
+  </div>
+</div>
+```
+
+Each `.glitch-slide-inner` needs a `data-text` attribute matching its
+visible title text — this is what the `::before`/`::after` glitch
+ghost layers read via `content: attr(data-text)`. To add more slides,
+add another `input[type="radio"]` with a unique `id`, a matching
+`.glitch-slide`, and a `.glitch-dot` label, and update each slide's
+prev/next `label[for]` targets to point at its correct neighbors.
+
+## 3. Features
+
+- **Pure CSS / HTML** — no JavaScript, driven entirely by radio
+  `:checked` state.
+- **Glitch-flicker transition** — a stepped-opacity keyframe
+  (`glitch-flicker-in`) combined with two offset, color-tinted text
+  ghosts (`glitch-shift-a` / `glitch-shift-b`) simulating an RGB
+  channel split.
+- **Fully responsive** — uses `aspect-ratio` and `clamp()` for fluid
+  sizing, with an adjusted aspect ratio and smaller controls under
+  `560px`.
+- **`prefers-reduced-motion` support** — disables the glitch
+  keyframes and ghost layers, falling back to a plain, short opacity
+  crossfade.
+- **Accessible controls** — dot and arrow navigation are real
+  `<label>` elements tied to radio inputs, with `aria-label`s
+  describing each action.
+
+Fixes #56390.

--- a/submissions/examples/56390-glitch-flicker-carousel-ds/demo.html
+++ b/submissions/examples/56390-glitch-flicker-carousel-ds/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Glitch-Flicker Carousel — Gaming Hub Layout Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<h1>Glitch-Flicker Carousel</h1>
+<p class="intro">
+  A pure CSS carousel with a glitch/flicker transition effect, built for
+  gaming-hub style layouts (featured titles, tournament banners, patch
+  highlights). Use the arrows or dots to navigate. Enable
+  "prefers reduced motion" in your OS settings to see the reduced-motion
+  fallback.
+</p>
+
+<div class="glitch-carousel">
+
+  <input type="radio" name="glitch-slide" id="slide-1" class="glitch-radio" checked>
+  <input type="radio" name="glitch-slide" id="slide-2" class="glitch-radio">
+  <input type="radio" name="glitch-slide" id="slide-3" class="glitch-radio">
+
+  <div class="glitch-track">
+
+    <div class="glitch-slide glitch-slide-1">
+      <div class="glitch-slide-inner" data-text="NEON STRIKE">
+        <span class="glitch-slide-title">NEON STRIKE</span>
+        <span class="glitch-slide-sub">Season 4 · Ranked Now Live</span>
+      </div>
+      <label for="slide-3" class="glitch-arrow glitch-arrow-prev" aria-label="Previous slide">&#10094;</label>
+      <label for="slide-2" class="glitch-arrow glitch-arrow-next" aria-label="Next slide">&#10095;</label>
+    </div>
+
+    <div class="glitch-slide glitch-slide-2">
+      <div class="glitch-slide-inner" data-text="VOID RUNNERS">
+        <span class="glitch-slide-title">VOID RUNNERS</span>
+        <span class="glitch-slide-sub">New Map: Fractured Orbit</span>
+      </div>
+      <label for="slide-1" class="glitch-arrow glitch-arrow-prev" aria-label="Previous slide">&#10094;</label>
+      <label for="slide-3" class="glitch-arrow glitch-arrow-next" aria-label="Next slide">&#10095;</label>
+    </div>
+
+    <div class="glitch-slide glitch-slide-3">
+      <div class="glitch-slide-inner" data-text="ARENA 9">
+        <span class="glitch-slide-title">ARENA 9</span>
+        <span class="glitch-slide-sub">Patch 2.3 · Balance Update</span>
+      </div>
+      <label for="slide-2" class="glitch-arrow glitch-arrow-prev" aria-label="Previous slide">&#10094;</label>
+      <label for="slide-1" class="glitch-arrow glitch-arrow-next" aria-label="Next slide">&#10095;</label>
+    </div>
+
+  </div>
+
+  <div class="glitch-nav">
+    <label for="slide-1" class="glitch-dot" aria-label="Show slide 1"></label>
+    <label for="slide-2" class="glitch-dot" aria-label="Show slide 2"></label>
+    <label for="slide-3" class="glitch-dot" aria-label="Show slide 3"></label>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/56390-glitch-flicker-carousel-ds/style.css
+++ b/submissions/examples/56390-glitch-flicker-carousel-ds/style.css
@@ -1,0 +1,262 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0a0a0f;
+  color: #e8e8f0;
+  padding: 32px 20px;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+  letter-spacing: 0.05em;
+}
+
+.intro {
+  color: #9a9ab0;
+  max-width: 640px;
+  margin-bottom: 32px;
+  line-height: 1.5;
+}
+
+.glitch-carousel {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  aspect-ratio: 16 / 7;
+  margin: 0 auto;
+  overflow: hidden;
+  border-radius: 10px;
+  border: 1px solid #2a2a3a;
+  background: #0d0d14;
+}
+
+.glitch-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.glitch-track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.glitch-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.15s steps(4, end),
+    visibility 0s linear 0.5s;
+  background: radial-gradient(circle at 30% 20%, #1a1a2e, #0a0a0f 70%);
+}
+
+.glitch-slide-1 {
+  background: radial-gradient(circle at 30% 20%, #241a2e, #0a0a0f 70%);
+}
+
+.glitch-slide-2 {
+  background: radial-gradient(circle at 70% 30%, #1a2e28, #0a0a0f 70%);
+}
+
+.glitch-slide-3 {
+  background: radial-gradient(circle at 50% 80%, #2e1a1a, #0a0a0f 70%);
+}
+
+#slide-1:checked ~ .glitch-track .glitch-slide-1,
+#slide-2:checked ~ .glitch-track .glitch-slide-2,
+#slide-3:checked ~ .glitch-track .glitch-slide-3 {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 0.15s steps(4, end),
+    visibility 0s linear 0s;
+  animation: glitch-flicker-in 0.5s steps(6, end);
+}
+
+.glitch-slide-inner {
+  position: relative;
+  text-align: center;
+  padding: 0 24px;
+}
+
+.glitch-slide-title {
+  display: block;
+  font-size: clamp(1.6rem, 5vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: #f4f4ff;
+  text-shadow:
+    0 0 12px rgba(120, 220, 255, 0.35),
+    0 0 32px rgba(255, 80, 200, 0.2);
+}
+
+.glitch-slide-sub {
+  display: block;
+  margin-top: 10px;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #9adfff;
+}
+
+#slide-1:checked ~ .glitch-track .glitch-slide-1 .glitch-slide-inner::before,
+#slide-1:checked ~ .glitch-track .glitch-slide-1 .glitch-slide-inner::after,
+#slide-2:checked ~ .glitch-track .glitch-slide-2 .glitch-slide-inner::before,
+#slide-2:checked ~ .glitch-track .glitch-slide-2 .glitch-slide-inner::after,
+#slide-3:checked ~ .glitch-track .glitch-slide-3 .glitch-slide-inner::before,
+#slide-3:checked ~ .glitch-track .glitch-slide-3 .glitch-slide-inner::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  font-size: clamp(1.6rem, 5vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  pointer-events: none;
+}
+
+.glitch-slide-inner::before {
+  color: #ff4d9d;
+  mix-blend-mode: screen;
+  animation: glitch-shift-a 0.5s steps(6, end) 1;
+}
+
+.glitch-slide-inner::after {
+  color: #4de3ff;
+  mix-blend-mode: screen;
+  animation: glitch-shift-b 0.5s steps(6, end) 1;
+}
+
+@keyframes glitch-flicker-in {
+  0% { opacity: 0; }
+  10% { opacity: 1; }
+  15% { opacity: 0.2; }
+  25% { opacity: 1; }
+  30% { opacity: 0.4; }
+  45% { opacity: 1; }
+  100% { opacity: 1; }
+}
+
+@keyframes glitch-shift-a {
+  0% { transform: translate(0, 0); opacity: 0; }
+  15% { transform: translate(-4px, 1px); opacity: 0.7; }
+  30% { transform: translate(3px, -1px); opacity: 0.5; }
+  45% { transform: translate(-2px, 0); opacity: 0.7; }
+  100% { transform: translate(0, 0); opacity: 0; }
+}
+
+@keyframes glitch-shift-b {
+  0% { transform: translate(0, 0); opacity: 0; }
+  15% { transform: translate(4px, -1px); opacity: 0.7; }
+  30% { transform: translate(-3px, 1px); opacity: 0.5; }
+  45% { transform: translate(2px, 0); opacity: 0.7; }
+  100% { transform: translate(0, 0); opacity: 0; }
+}
+
+.glitch-nav {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 10px;
+  z-index: 2;
+}
+
+.glitch-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.glitch-dot:hover {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+#slide-1:checked ~ .glitch-nav label[for="slide-1"],
+#slide-2:checked ~ .glitch-nav label[for="slide-2"],
+#slide-3:checked ~ .glitch-nav label[for="slide-3"] {
+  background: #4de3ff;
+  transform: scale(1.2);
+}
+
+.glitch-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(10, 10, 15, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #e8e8f0;
+  cursor: pointer;
+  font-size: 0.9rem;
+  opacity: 0;
+  transition: opacity 0.2s ease, background 0.2s ease;
+  z-index: 2;
+}
+
+.glitch-carousel:hover .glitch-arrow {
+  opacity: 1;
+}
+
+.glitch-arrow:hover {
+  background: rgba(77, 227, 255, 0.25);
+}
+
+.glitch-arrow-prev {
+  left: 12px;
+}
+
+.glitch-arrow-next {
+  right: 12px;
+}
+
+@media (max-width: 560px) {
+  .glitch-carousel {
+    aspect-ratio: 4 / 5;
+  }
+
+  .glitch-arrow {
+    width: 28px;
+    height: 28px;
+    font-size: 0.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitch-slide {
+    transition: opacity 0.2s linear, visibility 0s linear 0.2s;
+  }
+
+  #slide-1:checked ~ .glitch-track .glitch-slide-1,
+  #slide-2:checked ~ .glitch-track .glitch-slide-2,
+  #slide-3:checked ~ .glitch-track .glitch-slide-3 {
+    animation: none;
+    transition: opacity 0.2s linear, visibility 0s linear 0s;
+  }
+
+  .glitch-slide-inner::before,
+  .glitch-slide-inner::after {
+    animation: none;
+    opacity: 0;
+  }
+
+  .glitch-dot,
+  .glitch-arrow {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Fixes #56390

## Pull Request Description
Adds a pure CSS/HTML carousel with an RGB-split glitch flicker transition effect for gaming-hub style layouts (featured titles, tournament banners, patch highlights). Slide switching is driven entirely by radio :checked state, no JavaScript. Includes dot and hover-revealed arrow navigation, responsive sizing via aspect-ratio and clamp(), and a prefers-reduced-motion fallback that disables the glitch animation in favor of a plain crossfade.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/56390-glitch-flicker-carousel-ds/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS carousel with a glitch/flicker slide transition for gaming-hub style layouts.

**How does a developer use it?**
```html
<div class="glitch-carousel">
  <input type="radio" name="glitch-slide" id="slide-1" class="glitch-radio" checked>
  <input type="radio" name="glitch-slide" id="slide-2" class="glitch-radio">

  <div class="glitch-track">
    <div class="glitch-slide glitch-slide-1">
      <div class="glitch-slide-inner" data-text="YOUR TITLE">
        <span class="glitch-slide-title">YOUR TITLE</span>
        <span class="glitch-slide-sub">Your subtitle</span>
      </div>
      <label for="slide-2" class="glitch-arrow glitch-arrow-prev">&#10094;</label>
      <label for="slide-2" class="glitch-arrow glitch-arrow-next">&#10095;</label>
    </div>
  </div>

  <div class="glitch-nav">
    <label for="slide-1" class="glitch-dot"></label>
    <label for="slide-2" class="glitch-dot"></label>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a pure CSS, zero-JS motion component — consistent with EaseMotion's animation-first, human-readable philosophy. The glitch effect is built from readable keyframes (`glitch-flicker-in`, `glitch-shift-a`, `glitch-shift-b`) rather than opaque generated CSS, and it respects `prefers-reduced-motion` like the rest of the framework's accessibility-conscious components.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Slide switching and prev/next navigation are implemented with radio `:checked` selectors (no JS), so each slide's arrows target explicit neighbor IDs — adding more slides means wiring each new slide's prev/next `label[for]` by hand. Happy to adjust the glitch timing/intensity if it's too subtle or too strong for the framework's animation style.