### PR TITLE
feat: add rotate-fade popover for gaming hub layouts

### DIFF
--- a/submissions/examples/56417-rotate-fade-popover-ds/README.md
+++ b/submissions/examples/56417-rotate-fade-popover-ds/README.md
@@ -1,0 +1,75 @@
+# Rotate-Fade Popover
+
+A pure CSS popover that rotates and fades in on open, designed for
+gaming-hub style layouts — player cards, quick match stats, or
+hover-info panels.
+
+## 1. What does this do?
+
+Shows a small floating panel anchored below a trigger button. On
+open, the panel animates in with a combined rotate + fade + scale
+entrance (a slight tilt straightening out as it appears and
+overshoots slightly before settling), instead of a plain fade. On
+close it fades back out smoothly. Everything is driven by a hidden
+checkbox and CSS — no JavaScript.
+
+## 2. How is it used?
+
+Open `demo.html` directly in any browser — no build step or server
+required. Each popover trigger/panel pair needs three parts sharing
+the same unique `id`:
+
+```html
+<div class="rf-popover-wrap">
+  <input type="checkbox" id="pop-1" class="rf-popover-toggle">
+  <label for="pop-1" class="rf-popover-trigger">
+    Trigger label
+  </label>
+  <div class="rf-popover" role="dialog" aria-label="Description of the popover">
+    <div class="rf-popover-arrow"></div>
+    <div class="rf-popover-header">
+      <span class="rf-popover-title">Title</span>
+      <span class="rf-popover-rank">Subtitle / meta line</span>
+    </div>
+    <div class="rf-popover-body">
+      <div class="rf-stat"><span>Label</span><strong>Value</strong></div>
+    </div>
+  </div>
+</div>
+```
+
+Clicking the trigger label toggles the checkbox, which drives the
+`:checked ~ .rf-popover` selector that shows and animates the panel.
+Clicking the trigger again (or any other trigger) closes it.
+
+### CSS custom properties / key values to tune
+
+The animation and positioning are controlled by plain property values
+rather than custom properties, so they're easy to override per
+instance by targeting `.rf-popover` with a more specific selector:
+
+- `top: calc(100% + 14px)` — vertical offset from the trigger
+- `transform-origin: top center` — pivot point for the rotate effect
+- The `rf-rotate-fade-in` keyframe's rotation/scale values — adjust
+  for a stronger or subtler entrance
+
+## 3. Features
+
+- **Pure CSS / HTML** — no JavaScript, driven entirely by a hidden
+  checkbox and the `:checked` selector.
+- **Rotate-fade entrance** — combines `rotate()`, `scale()`,
+  `translateY()`, and `opacity` in one keyframe
+  (`rf-rotate-fade-in`) using a slight overshoot easing
+  (`cubic-bezier(0.34, 1.56, 0.64, 1)`) for a lively, game-UI feel.
+- **Fully responsive** — panels are centered under their trigger on
+  wider viewports and left-aligned (with an adjusted arrow position)
+  under `640px`, where popovers stack vertically.
+- **`prefers-reduced-motion` support** — disables the rotate/scale
+  animation and overshoot, falling back to a short, plain opacity
+  fade with no motion.
+- **Accessible trigger** — the trigger is a real `<label>` bound to a
+  checkbox (keyboard/focus-operable via native form control
+  behavior, with a visible focus ring), and the panel carries
+  `role="dialog"` with an `aria-label`.
+
+Fixes #56417.

--- a/submissions/examples/56417-rotate-fade-popover-ds/demo.html
+++ b/submissions/examples/56417-rotate-fade-popover-ds/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Fade Popover — Gaming Hub Layout Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<h1>Rotate-Fade Popover</h1>
+<p class="intro">
+  A pure CSS popover that rotates and fades in on open, built for
+  gaming-hub style layouts (player cards, match stats, quick info).
+  Click a trigger button to open its popover, then click the trigger
+  again or press <kbd>Esc</kbd>-equivalent by clicking elsewhere to
+  close it. Enable "prefers reduced motion" in your OS settings to
+  see the reduced-motion fallback.
+</p>
+
+<div class="popover-demo-row">
+
+  <div class="rf-popover-wrap">
+    <input type="checkbox" id="pop-1" class="rf-popover-toggle">
+    <label for="pop-1" class="rf-popover-trigger">
+      🧙 Shadowblade
+    </label>
+    <div class="rf-popover" role="dialog" aria-label="Shadowblade player card">
+      <div class="rf-popover-arrow"></div>
+      <div class="rf-popover-header">
+        <span class="rf-popover-title">Shadowblade</span>
+        <span class="rf-popover-rank">Rank: Diamond II</span>
+      </div>
+      <div class="rf-popover-body">
+        <div class="rf-stat"><span>Win Rate</span><strong>62%</strong></div>
+        <div class="rf-stat"><span>Matches</span><strong>340</strong></div>
+        <div class="rf-stat"><span>Main Role</span><strong>Assassin</strong></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="rf-popover-wrap">
+    <input type="checkbox" id="pop-2" class="rf-popover-toggle">
+    <label for="pop-2" class="rf-popover-trigger">
+      🛡️ Ironwall
+    </label>
+    <div class="rf-popover" role="dialog" aria-label="Ironwall player card">
+      <div class="rf-popover-arrow"></div>
+      <div class="rf-popover-header">
+        <span class="rf-popover-title">Ironwall</span>
+        <span class="rf-popover-rank">Rank: Platinum I</span>
+      </div>
+      <div class="rf-popover-body">
+        <div class="rf-stat"><span>Win Rate</span><strong>54%</strong></div>
+        <div class="rf-stat"><span>Matches</span><strong>212</strong></div>
+        <div class="rf-stat"><span>Main Role</span><strong>Tank</strong></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="rf-popover-wrap">
+    <input type="checkbox" id="pop-3" class="rf-popover-toggle">
+    <label for="pop-3" class="rf-popover-trigger">
+      🏹 Windrunner
+    </label>
+    <div class="rf-popover" role="dialog" aria-label="Windrunner player card">
+      <div class="rf-popover-arrow"></div>
+      <div class="rf-popover-header">
+        <span class="rf-popover-title">Windrunner</span>
+        <span class="rf-popover-rank">Rank: Diamond IV</span>
+      </div>
+      <div class="rf-popover-body">
+        <div class="rf-stat"><span>Win Rate</span><strong>58%</strong></div>
+        <div class="rf-stat"><span>Matches</span><strong>401</strong></div>
+        <div class="rf-stat"><span>Main Role</span><strong>Marksman</strong></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/56417-rotate-fade-popover-ds/style.css
+++ b/submissions/examples/56417-rotate-fade-popover-ds/style.css
@@ -1,0 +1,228 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #101018;
+  color: #e8e8f0;
+  padding: 32px 20px;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+.intro {
+  color: #9a9ab0;
+  max-width: 640px;
+  margin-bottom: 40px;
+  line-height: 1.5;
+}
+
+.popover-demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 40px;
+  padding-top: 40px;
+}
+
+.rf-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.rf-popover-toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rf-popover-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  background: #1c1c28;
+  border: 1px solid #33334a;
+  color: #e8e8f0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.rf-popover-trigger:hover {
+  background: #23233a;
+  border-color: #4d6bff;
+}
+
+.rf-popover-toggle:focus-visible + .rf-popover-trigger {
+  outline: 2px solid #4d6bff;
+  outline-offset: 2px;
+}
+
+.rf-popover {
+  position: absolute;
+  top: calc(100% + 14px);
+  left: 50%;
+  transform-origin: top center;
+  transform: translateX(-50%) translateY(-6px) rotate(-6deg) scale(0.92);
+  width: 220px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  background: #1a1a26;
+  border: 1px solid #33334a;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 10;
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    visibility 0s linear 0.25s;
+}
+
+.rf-popover-arrow {
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: #1a1a26;
+  border-left: 1px solid #33334a;
+  border-top: 1px solid #33334a;
+}
+
+.rf-popover-toggle:checked ~ .rf-popover {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0) rotate(0deg) scale(1);
+  transition:
+    opacity 0.3s ease,
+    transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+    visibility 0s linear 0s;
+  animation: rf-rotate-fade-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes rf-rotate-fade-in {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-6px) rotate(-8deg) scale(0.9);
+  }
+  60% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(2px) rotate(1deg) scale(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) rotate(0deg) scale(1);
+  }
+}
+
+.rf-popover-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #2c2c3e;
+}
+
+.rf-popover-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #f4f4ff;
+}
+
+.rf-popover-rank {
+  font-size: 0.75rem;
+  color: #8fa8ff;
+}
+
+.rf-popover-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rf-stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.8rem;
+}
+
+.rf-stat span {
+  color: #9a9ab0;
+}
+
+.rf-stat strong {
+  color: #e8e8f0;
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .popover-demo-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 60px;
+  }
+
+  .rf-popover {
+    width: 200px;
+    left: 0;
+    transform-origin: top left;
+    transform: translateX(0) translateY(-6px) rotate(-6deg) scale(0.92);
+  }
+
+  .rf-popover-toggle:checked ~ .rf-popover {
+    transform: translateX(0) translateY(0) rotate(0deg) scale(1);
+  }
+
+  .rf-popover-arrow {
+    left: 24px;
+    transform: translateX(0) rotate(45deg);
+  }
+
+  @keyframes rf-rotate-fade-in {
+    0% {
+      opacity: 0;
+      transform: translateX(0) translateY(-6px) rotate(-8deg) scale(0.9);
+    }
+    60% {
+      opacity: 1;
+      transform: translateX(0) translateY(2px) rotate(1deg) scale(1.02);
+    }
+    100% {
+      opacity: 1;
+      transform: translateX(0) translateY(0) rotate(0deg) scale(1);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rf-popover {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+
+  .rf-popover-toggle:checked ~ .rf-popover {
+    animation: none;
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+
+  @media (max-width: 640px) {
+    .rf-popover {
+      transform: translateX(0) translateY(0) scale(1);
+    }
+
+    .rf-popover-toggle:checked ~ .rf-popover {
+      transform: translateX(0) translateY(0) scale(1);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #56417

## Pull Request Description
Adds a pure CSS/HTML popover with a rotate + fade + scale entrance animation for gaming-hub style layouts (player cards, match stats, quick info panels). Open/close state is driven entirely by a hidden checkbox and the :checked selector, no JavaScript. Includes responsive positioning that switches from centered to left-aligned stacking under 640px, and a prefers-reduced-motion fallback that disables the rotate/scale in favor of a plain opacity fade.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/56417-rotate-fade-popover-ds/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS popover component with a rotate-fade-scale entrance animation, for gaming-hub style player cards and quick-info panels.

**How does a developer use it?**
```html
<div class="rf-popover-wrap">
  <input type="checkbox" id="pop-1" class="rf-popover-toggle">
  <label for="pop-1" class="rf-popover-trigger">
    Trigger label
  </label>
  <div class="rf-popover" role="dialog" aria-label="Description of the popover">
    <div class="rf-popover-arrow"></div>
    <div class="rf-popover-header">
      <span class="rf-popover-title">Title</span>
      <span class="rf-popover-rank">Subtitle / meta line</span>
    </div>
    <div class="rf-popover-body">
      <div class="rf-stat"><span>Label</span><strong>Value</strong></div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a pure CSS, zero-JS interactive component consistent with EaseMotion's animation-first, human-readable philosophy. The entrance uses a readable single keyframe (`rf-rotate-fade-in`) rather than opaque generated CSS, and like the rest of the framework it respects `prefers-reduced-motion`, falling back to a plain fade with no motion.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Popover positioning uses `position: absolute` relative to `.rf-popover-wrap`, centered under the trigger on wide viewports and left-aligned under 640px. Open/close is a single shared toggle pattern per popover (independent checkboxes), so multiple popovers can be open at once by design — happy to change to a single shared radio-group if you'd prefer only one open at a time.