### PR TITLE
feat: add bounce-pulse popover for gaming hub layouts

### DIFF
--- a/submissions/examples/56418-bounce-pulse-popover-ds/README.md
+++ b/submissions/examples/56418-bounce-pulse-popover-ds/README.md
@@ -1,0 +1,76 @@
+# Bounce-Pulse Popover
+
+A pure CSS popover that bounces in and then gently pulses to draw
+attention, designed for gaming-hub style layouts — achievement
+unlocks, loot drops, level-up alerts, or other notification-style
+callouts.
+
+## 1. What does this do?
+
+Shows a small floating panel anchored below a trigger button. On
+open, the panel bounces in with a springy overshoot (scaling past
+100% and settling back down), then pulses its outer glow twice to
+draw the eye — appropriate for "something just happened" style
+notifications rather than a static info panel. Everything is driven
+by a hidden checkbox and CSS — no JavaScript.
+
+## 2. How is it used?
+
+Open `demo.html` directly in any browser — no build step or server
+required. Each popover trigger/panel pair needs three parts sharing
+the same unique `id`:
+
+```html
+<div class="bp-popover-wrap">
+  <input type="checkbox" id="bpop-1" class="bp-popover-toggle">
+  <label for="bpop-1" class="bp-popover-trigger">
+    Trigger label
+  </label>
+  <div class="bp-popover" role="dialog" aria-label="Description of the popover">
+    <div class="bp-popover-arrow"></div>
+    <div class="bp-popover-icon">🏆</div>
+    <div class="bp-popover-header">
+      <span class="bp-popover-title">Title</span>
+      <span class="bp-popover-sub">Subtitle</span>
+    </div>
+    <p class="bp-popover-desc">Description text.</p>
+  </div>
+</div>
+```
+
+Clicking the trigger label toggles the checkbox, which drives the
+`:checked ~ .bp-popover` selector that shows and animates the panel.
+Clicking the trigger again closes it.
+
+### Key values to tune
+
+- `top: calc(100% + 14px)` — vertical offset from the trigger
+- `bp-bounce-in` keyframe's scale/translateY values — adjust for a
+  stronger or subtler bounce
+- `bp-pulse` keyframe's `box-shadow` spread and `rgba` alpha — adjust
+  glow intensity and color
+- `animation: bp-bounce-in 0.55s ..., bp-pulse 1.8s ... 2` — the `2`
+  at the end of the pulse animation controls how many times it
+  repeats after the bounce settles
+
+## 3. Features
+
+- **Pure CSS / HTML** — no JavaScript, driven entirely by a hidden
+  checkbox and the `:checked` selector.
+- **Bounce-pulse entrance** — a springy `bp-bounce-in` keyframe
+  (overshoot scale + vertical settle) followed by two cycles of a
+  `bp-pulse` glow animation, layered together via a two-part
+  `animation` shorthand with a delay so the pulse starts only once
+  the bounce has settled.
+- **Fully responsive** — panels are centered under their trigger on
+  wider viewports and left-aligned (with an adjusted arrow position)
+  under `640px`, where popovers stack vertically.
+- **`prefers-reduced-motion` support** — disables both the bounce
+  and pulse animations, falling back to a short, plain opacity fade
+  with no motion or glow.
+- **Accessible trigger** — the trigger is a real `<label>` bound to a
+  checkbox (keyboard/focus-operable via native form control
+  behavior, with a visible focus ring), and the panel carries
+  `role="dialog"` with an `aria-label`.
+
+Fixes #56418.

--- a/submissions/examples/56418-bounce-pulse-popover-ds/demo.html
+++ b/submissions/examples/56418-bounce-pulse-popover-ds/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Bounce-Pulse Popover — Gaming Hub Layout Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<h1>Bounce-Pulse Popover</h1>
+<p class="intro">
+  A pure CSS popover that bounces in and then gently pulses to draw
+  attention, built for gaming-hub style layouts (loot drops,
+  achievement unlocks, alerts). Click a trigger to open its popover;
+  click again to close it. Enable "prefers reduced motion" in your OS
+  settings to see the reduced-motion fallback.
+</p>
+
+<div class="popover-demo-row">
+
+  <div class="bp-popover-wrap">
+    <input type="checkbox" id="bpop-1" class="bp-popover-toggle">
+    <label for="bpop-1" class="bp-popover-trigger">
+      🏆 Achievement
+    </label>
+    <div class="bp-popover" role="dialog" aria-label="Achievement unlocked notification">
+      <div class="bp-popover-arrow"></div>
+      <div class="bp-popover-icon">🏆</div>
+      <div class="bp-popover-header">
+        <span class="bp-popover-title">Achievement Unlocked</span>
+        <span class="bp-popover-sub">First Blood</span>
+      </div>
+      <p class="bp-popover-desc">Land the first elimination of a match.</p>
+    </div>
+  </div>
+
+  <div class="bp-popover-wrap">
+    <input type="checkbox" id="bpop-2" class="bp-popover-toggle">
+    <label for="bpop-2" class="bp-popover-trigger">
+      🎁 Loot Drop
+    </label>
+    <div class="bp-popover" role="dialog" aria-label="Loot drop notification">
+      <div class="bp-popover-arrow"></div>
+      <div class="bp-popover-icon">🎁</div>
+      <div class="bp-popover-header">
+        <span class="bp-popover-title">Loot Drop</span>
+        <span class="bp-popover-sub">Legendary Rarity</span>
+      </div>
+      <p class="bp-popover-desc">Shadowfang Blade added to your inventory.</p>
+    </div>
+  </div>
+
+  <div class="bp-popover-wrap">
+    <input type="checkbox" id="bpop-3" class="bp-popover-toggle">
+    <label for="bpop-3" class="bp-popover-trigger">
+      ⚡ Level Up
+    </label>
+    <div class="bp-popover" role="dialog" aria-label="Level up notification">
+      <div class="bp-popover-arrow"></div>
+      <div class="bp-popover-icon">⚡</div>
+      <div class="bp-popover-header">
+        <span class="bp-popover-title">Level Up!</span>
+        <span class="bp-popover-sub">Now Level 42</span>
+      </div>
+      <p class="bp-popover-desc">New ability slot unlocked.</p>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/56418-bounce-pulse-popover-ds/style.css
+++ b/submissions/examples/56418-bounce-pulse-popover-ds/style.css
@@ -1,0 +1,239 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #101018;
+  color: #e8e8f0;
+  padding: 32px 20px;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+.intro {
+  color: #9a9ab0;
+  max-width: 640px;
+  margin-bottom: 40px;
+  line-height: 1.5;
+}
+
+.popover-demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 40px;
+  padding-top: 40px;
+}
+
+.bp-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.bp-popover-toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.bp-popover-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  background: #1c1c28;
+  border: 1px solid #33334a;
+  color: #e8e8f0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.bp-popover-trigger:hover {
+  background: #23233a;
+  border-color: #ffb347;
+}
+
+.bp-popover-toggle:focus-visible + .bp-popover-trigger {
+  outline: 2px solid #ffb347;
+  outline-offset: 2px;
+}
+
+.bp-popover {
+  position: absolute;
+  top: calc(100% + 14px);
+  left: 50%;
+  transform: translateX(-50%) translateY(-16px) scale(0.7);
+  width: 240px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  background: #1a1a26;
+  border: 1px solid #3a3320;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 10;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    visibility 0s linear 0.2s;
+}
+
+.bp-popover-arrow {
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: #1a1a26;
+  border-left: 1px solid #3a3320;
+  border-top: 1px solid #3a3320;
+}
+
+.bp-popover-toggle:checked ~ .bp-popover {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0) scale(1);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    visibility 0s linear 0s;
+  animation:
+    bp-bounce-in 0.55s cubic-bezier(0.34, 1.56, 0.64, 1),
+    bp-pulse 1.8s ease-in-out 0.55s 2;
+}
+
+@keyframes bp-bounce-in {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-16px) scale(0.7);
+  }
+  40% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(4px) scale(1.06);
+  }
+  65% {
+    transform: translateX(-50%) translateY(-3px) scale(0.98);
+  }
+  85% {
+    transform: translateX(-50%) translateY(1px) scale(1.01);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@keyframes bp-pulse {
+  0%,
+  100% {
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45), 0 0 0 0 rgba(255, 179, 71, 0.35);
+  }
+  50% {
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45), 0 0 0 8px rgba(255, 179, 71, 0);
+  }
+}
+
+.bp-popover-icon {
+  font-size: 1.6rem;
+  margin-bottom: 6px;
+}
+
+.bp-popover-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 6px;
+}
+
+.bp-popover-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #ffd9a0;
+}
+
+.bp-popover-sub {
+  font-size: 0.75rem;
+  color: #ffb347;
+}
+
+.bp-popover-desc {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #b8b8c8;
+  line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+  .popover-demo-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 60px;
+  }
+
+  .bp-popover {
+    width: 220px;
+    left: 0;
+    transform: translateX(0) translateY(-16px) scale(0.7);
+  }
+
+  .bp-popover-toggle:checked ~ .bp-popover {
+    transform: translateX(0) translateY(0) scale(1);
+  }
+
+  .bp-popover-arrow {
+    left: 24px;
+    transform: translateX(0) rotate(45deg);
+  }
+
+  @keyframes bp-bounce-in {
+    0% {
+      opacity: 0;
+      transform: translateX(0) translateY(-16px) scale(0.7);
+    }
+    40% {
+      opacity: 1;
+      transform: translateX(0) translateY(4px) scale(1.06);
+    }
+    65% {
+      transform: translateX(0) translateY(-3px) scale(0.98);
+    }
+    85% {
+      transform: translateX(0) translateY(1px) scale(1.01);
+    }
+    100% {
+      opacity: 1;
+      transform: translateX(0) translateY(0) scale(1);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bp-popover {
+    transition: opacity 0.15s linear, visibility 0s linear 0.15s;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+
+  .bp-popover-toggle:checked ~ .bp-popover {
+    animation: none;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+    transition: opacity 0.15s linear, visibility 0s linear 0s;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+
+  @media (max-width: 640px) {
+    .bp-popover {
+      transform: translateX(0) translateY(0) scale(1);
+    }
+
+    .bp-popover-toggle:checked ~ .bp-popover {
+      transform: translateX(0) translateY(0) scale(1);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #56418

## Pull Request Description
Adds a pure CSS/HTML popover with a springy bounce-in entrance followed by a double pulse glow, for gaming-hub style notification UI (achievement unlocks, loot drops, level-up alerts). Open/close state is driven entirely by a hidden checkbox and the :checked selector, no JavaScript. Includes responsive positioning that switches from centered to left-aligned stacking under 640px, and a prefers-reduced-motion fallback that disables both the bounce and pulse animations in favor of a plain opacity fade.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/56418-bounce-pulse-popover-ds/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS popover with a bounce-in entrance and pulsing glow, for gaming-hub notification-style UI like achievement or loot-drop alerts.

**How does a developer use it?**
```html
<div class="bp-popover-wrap">
  <input type="checkbox" id="bpop-1" class="bp-popover-toggle">
  <label for="bpop-1" class="bp-popover-trigger">
    Trigger label
  </label>
  <div class="bp-popover" role="dialog" aria-label="Description of the popover">
    <div class="bp-popover-arrow"></div>
    <div class="bp-popover-icon">🏆</div>
    <div class="bp-popover-header">
      <span class="bp-popover-title">Title</span>
      <span class="bp-popover-sub">Subtitle</span>
    </div>
    <p class="bp-popover-desc">Description text.</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a pure CSS, zero-JS interactive component in line with EaseMotion's animation-first, human-readable philosophy. The entrance is built from two readable, purpose-named keyframes (`bp-bounce-in`, `bp-pulse`) rather than opaque generated CSS, and like the rest of the framework it respects `prefers-reduced-motion`, falling back to a plain fade with no motion or glow.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This follows the same checkbox-driven popover structure as my earlier Rotate-Fade Popover PR (#56417) — the entrance animation and content are the only real differences. Happy to consolidate shared positioning/responsive CSS between the two if you'd prefer that over duplicating it per submission.