### PR TITLE
feat: add scale-hover feature grid for creative portfolio layouts

### DIFF
--- a/submissions/examples/56339-scale-hover-feature-grid-ds/README.md
+++ b/submissions/examples/56339-scale-hover-feature-grid-ds/README.md
@@ -1,0 +1,62 @@
+# Scale-Hover Feature Grid
+
+A responsive grid of feature cards that scale up smoothly on hover
+or focus, designed for creative portfolio layouts — skills,
+services, or project highlight sections.
+
+## 1. What does this do?
+
+Renders a responsive grid of cards. On hover (or keyboard focus),
+the hovered card scales up slightly and lifts with a soft shadow and
+accent border, while its icon scales and tilts a touch further for
+emphasis — all other cards stay put, so the hovered item reads
+clearly as the focus.
+
+## 2. How is it used?
+
+Open `demo.html` directly in any browser — no build step or server
+required. Structure:
+
+```html
+<div class="sh-grid">
+  <a class="sh-card" href="#">
+    <div class="sh-card-icon">🎨</div>
+    <h3 class="sh-card-title">Card Title</h3>
+    <p class="sh-card-desc">Card description text.</p>
+  </a>
+  <!-- repeat .sh-card for each grid item -->
+</div>
+```
+
+`.sh-grid` is a plain CSS grid that reflows from 3 columns down to 2
+and then 1 as the viewport narrows. Each `.sh-card` can be any block
+or link element — the demo uses `<a>` since feature cards are
+commonly clickable, but the styles apply equally to a `<div>`.
+
+### Key values to tune
+
+- `.sh-grid { grid-template-columns: repeat(3, 1fr); }` — change the
+  base column count
+- `.sh-card:hover, .sh-card:focus-visible { transform: scale(1.06); }`
+  — the hover scale amount (reduced to `1.03` under `560px` to avoid
+  an oversized card on small/touch screens)
+- `.sh-card-icon` hover transform (`scale(1.12) rotate(-4deg)`) —
+  the icon's extra emphasis motion
+
+## 3. Features
+
+- **Pure CSS / HTML** — no JavaScript, hover/focus state only.
+- **Scale-hover interaction** — smooth `transform: scale()` on the
+  card plus a slightly larger, rotated scale on its icon, using an
+  eased cubic-bezier curve for a natural, non-linear feel.
+- **Fully responsive** — 3 columns on desktop, 2 columns under
+  `900px`, 1 column under `560px`, with a reduced hover scale on
+  narrow/touch viewports.
+- **`prefers-reduced-motion` support** — removes all `transform`
+  scaling on hover/focus, keeping only the border/shadow color
+  change, so the card still indicates interactivity without motion.
+- **Keyboard accessible** — `:focus-visible` receives the identical
+  scale/shadow treatment as `:hover` plus a visible outline, so
+  keyboard users get the same affordance as mouse users.
+
+Fixes #56339.

--- a/submissions/examples/56339-scale-hover-feature-grid-ds/demo.html
+++ b/submissions/examples/56339-scale-hover-feature-grid-ds/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Scale-Hover Feature Grid — Creative Portfolio Layout Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<h1>Scale-Hover Feature Grid</h1>
+<p class="intro">
+  A responsive grid of feature cards that scale up smoothly on hover,
+  built for creative portfolio layouts (skills, services, project
+  highlights). Hover or focus a card to see the effect. Enable
+  "prefers reduced motion" in your OS settings to see the
+  reduced-motion fallback.
+</p>
+
+<div class="sh-grid">
+
+  <a class="sh-card" href="#" tabindex="0">
+    <div class="sh-card-icon">🎨</div>
+    <h3 class="sh-card-title">Visual Design</h3>
+    <p class="sh-card-desc">Brand identity, illustration, and interface design that feels intentional.</p>
+  </a>
+
+  <a class="sh-card" href="#" tabindex="0">
+    <div class="sh-card-icon">🧩</div>
+    <h3 class="sh-card-title">UI Systems</h3>
+    <p class="sh-card-desc">Reusable component libraries and design tokens built for scale.</p>
+  </a>
+
+  <a class="sh-card" href="#" tabindex="0">
+    <div class="sh-card-icon">🎬</div>
+    <h3 class="sh-card-title">Motion Design</h3>
+    <p class="sh-card-desc">Micro-interactions and transitions that guide attention naturally.</p>
+  </a>
+
+  <a class="sh-card" href="#" tabindex="0">
+    <div class="sh-card-icon">🖋️</div>
+    <h3 class="sh-card-title">Typography</h3>
+    <p class="sh-card-desc">Type systems that stay readable and expressive at every size.</p>
+  </a>
+
+  <a class="sh-card" href="#" tabindex="0">
+    <div class="sh-card-icon">📐</div>
+    <h3 class="sh-card-title">Layout &amp; Grid</h3>
+    <p class="sh-card-desc">Structured, responsive layouts that adapt without breaking rhythm.</p>
+  </a>
+
+  <a class="sh-card" href="#" tabindex="0">
+    <div class="sh-card-icon">🚀</div>
+    <h3 class="sh-card-title">Prototyping</h3>
+    <p class="sh-card-desc">Fast, interactive prototypes for testing ideas before they ship.</p>
+  </a>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/56339-scale-hover-feature-grid-ds/style.css
+++ b/submissions/examples/56339-scale-hover-feature-grid-ds/style.css
@@ -1,0 +1,118 @@
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #101018;
+  color: #e8e8f0;
+  padding: 32px 20px;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+.intro {
+  color: #9a9ab0;
+  max-width: 640px;
+  margin-bottom: 32px;
+  line-height: 1.5;
+}
+
+.sh-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  padding: 12px;
+}
+
+.sh-card {
+  display: block;
+  position: relative;
+  padding: 28px 22px;
+  border-radius: 14px;
+  background: linear-gradient(160deg, #1a1a26, #14141d);
+  border: 1px solid #2c2c3e;
+  text-decoration: none;
+  color: inherit;
+  transform: scale(1);
+  transition:
+    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
+  will-change: transform;
+}
+
+.sh-card:hover,
+.sh-card:focus-visible {
+  transform: scale(1.06);
+  border-color: #5b8cff;
+  box-shadow: 0 20px 40px rgba(91, 140, 255, 0.18);
+  z-index: 1;
+}
+
+.sh-card:focus-visible {
+  outline: 2px solid #5b8cff;
+  outline-offset: 3px;
+}
+
+.sh-card-icon {
+  font-size: 1.8rem;
+  margin-bottom: 14px;
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.sh-card:hover .sh-card-icon,
+.sh-card:focus-visible .sh-card-icon {
+  transform: scale(1.12) rotate(-4deg);
+}
+
+.sh-card-title {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #f4f4ff;
+}
+
+.sh-card-desc {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #9a9ab0;
+}
+
+@media (max-width: 900px) {
+  .sh-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 560px) {
+  .sh-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sh-card:hover,
+  .sh-card:focus-visible {
+    transform: scale(1.03);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sh-card {
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .sh-card:hover,
+  .sh-card:focus-visible {
+    transform: none;
+  }
+
+  .sh-card-icon {
+    transition: none;
+  }
+
+  .sh-card:hover .sh-card-icon,
+  .sh-card:focus-visible .sh-card-icon {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Fixes #56339

## Pull Request Description
Adds a pure CSS/HTML responsive feature grid where cards scale up smoothly on hover or keyboard focus, for creative portfolio layouts (skills, services, project highlights). Grid reflows from 3 to 2 to 1 columns as viewport narrows, with a reduced hover scale on small screens. Includes a prefers-reduced-motion fallback that removes the scale transform, keeping only a border/shadow color change.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/56339-scale-hover-feature-grid-ds/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A responsive feature card grid where each card scales up smoothly on hover or focus, for creative portfolio layouts.

**How does a developer use it?**
```html
<div class="sh-grid">
  <a class="sh-card" href="#">
    <div class="sh-card-icon">🎨</div>
    <h3 class="sh-card-title">Card Title</h3>
    <p class="sh-card-desc">Card description text.</p>
  </a>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a pure CSS, zero-JS interaction pattern consistent with EaseMotion's animation-first, human-readable philosophy. The scale/lift is a single readable transition rather than opaque generated CSS, and it respects `prefers-reduced-motion` by falling back to a color-only affordance with no motion.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Grid uses `:focus-visible` alongside `:hover` so keyboard users get identical treatment, not just mouse users.