### PR TITLE
feat: add border glow-up tint utility

### DIFF
--- a/submissions/examples/border-glow-ak/README.md
+++ b/submissions/examples/border-glow-ak/README.md
@@ -1,0 +1,16 @@
+# Dark Mode Border Glow-Up Tint
+
+Closes #57021
+
+### What does this do?
+Adds a smooth border-color and glow transition to a container on hover, shifting from a dull default border to a glowing indigo accent.
+
+### How is it used?
+```html
+<div class="ease-dark-card ease-border-glow">
+  ...
+</div>
+```
+
+### Why is it useful?
+It's a single, composable utility class that adds modern visual hierarchy to layout boxes on hover without triggering layout reflow (only `border-color` and `box-shadow` are animated). It also respects `prefers-reduced-motion` for accessibility.

--- a/submissions/examples/border-glow-ak/demo.html
+++ b/submissions/examples/border-glow-ak/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dark Mode Border Glow-Up Tint Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="page">
+    <div class="ease-dark-card ease-border-glow" style="width: 260px; padding: 20px; background: #121212; border: 1px solid #2d2d2d; border-radius: 10px; color: #eaeaea;">
+      <h3 style="margin: 0 0 8px;">Hover me</h3>
+      <p style="margin: 0; font-size: 14px; color: #aaaaaa;">
+        Border tints smoothly from a dull default line to a glowing indigo accent.
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/border-glow-ak/style.css
+++ b/submissions/examples/border-glow-ak/style.css
@@ -1,0 +1,22 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a0a0a;
+}
+
+.ease-border-glow {
+  transition: border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.ease-border-glow:hover {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.25), 0 0 16px rgba(99, 102, 241, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-border-glow {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Adds a hover utility that transitions a card's border from a dull default line to a glowing indigo accent, using only border-color and box-shadow to avoid layout reflow. Respects prefers-reduced-motion.
Closes #57021

## Pull Request Description
Adds `ease-border-glow`, a lightweight utility class for dark-mode card containers. On hover, the border transitions from a dull default line to a glowing indigo accent, giving layout boxes a modern, composable hover treatment without touching layout-affecting properties.

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/border-glow-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A hover utility (`ease-border-glow`) that tints a container's border from a dull default line to a glowing indigo accent.

**How does a developer use it?**
```html
<div class="ease-dark-card ease-border-glow">
  ...
</div>
```

**Why does it fit EaseMotion CSS?**
It's a single, drop-in utility selector that heightens visual hierarchy on hover, animating only `border-color` and `box-shadow` so it never triggers layout reflow — in line with EaseMotion's lightweight, composable, animation-first philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Timing is set to `0.35s ease` — happy to adjust to match the framework's standard easing curve if there's a convention I should follow.