### PR TITLE
feat: add smooth accordion chevron rotation

### DIFF
--- a/submissions/examples/chevron-rotate-ak/README.md
+++ b/submissions/examples/chevron-rotate-ak/README.md
@@ -1,0 +1,17 @@
+# Smooth Accordion Chevron Rotation
+
+Closes #57014
+
+### What does this do?
+Rotates a dropdown indicator chevron 180 degrees smoothly on a single axis when the accordion header is hovered or interacted with.
+
+### How is it used?
+```html
+<div class="accordion-header">
+  Click Accordion
+  <span class="chevron">▼</span>
+</div>
+```
+
+### Why is it useful?
+It's a minimal, hardware-accelerated transform-based micro-interaction that gives strong visual feedback on a common UI pattern (accordions/dropdowns) without heavy layout changes or JavaScript, fitting EaseMotion's human-readable, animation-first philosophy.

--- a/submissions/examples/chevron-rotate-ak/demo.html
+++ b/submissions/examples/chevron-rotate-ak/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Smooth Accordion Chevron Rotation Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="page">
+    <div class="accordion-header" style="display: flex; justify-content: space-between; width: 200px; padding: 10px; border: 1px solid #2d2d2d; border-radius: 8px; background: #121212; color: #eaeaea; cursor: pointer;">
+      Click Accordion
+      <span class="chevron" style="transition: transform 0.3s ease;">▼</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/chevron-rotate-ak/style.css
+++ b/submissions/examples/chevron-rotate-ak/style.css
@@ -1,0 +1,17 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a0a0a;
+}
+
+.accordion-header:hover .chevron {
+  transform: rotate(-180deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Adds a hover/interaction-based 180-degree rotation for accordion dropdown chevrons using a hardware-accelerated transform, avoiding heavy layout changes or JS. Respects prefers-reduced-motion.
Closes #57014

## Pull Request Description
Adds a smooth chevron rotation micro-interaction for accordion headers. On hover/interaction, the dropdown indicator chevron rotates 180 degrees on a single axis using a hardware-accelerated `transform`, giving clear visual feedback with no layout shift or JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/chevron-rotate-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A 180-degree chevron rotation micro-interaction for accordion dropdown headers.

**How does a developer use it?**
```html
<div class="accordion-header">
  Click Accordion
  <span class="chevron">▼</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It demonstrates how a minimal transform-based change can deliver strong visual feedback for a common UI pattern, using only GPU-accelerated `transform` instead of forcing custom layouts or JS execution — in line with EaseMotion's human-readable, animation-first philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Used a plain `.chevron` class rather than `ease-` prefixed naming per the contribution guide — happy to have it renamed/standardized on integration.