### PR TITLE
feat: add tooltip component with fade-in-up animation

### DIFF
--- a/submissions/examples/tooltip-fade-up-ak/README.md
+++ b/submissions/examples/tooltip-fade-up-ak/README.md
@@ -1,0 +1,16 @@
+# Tooltip with Fade-In-Up Animation
+
+Closes #56638
+
+### What does this do?
+A pure CSS tooltip component built with `::before`/`::after` pseudo-elements, using a `data-tooltip` attribute for the label. It fades and slides up into view on hover or focus.
+
+### How is it used?
+```html
+<button class="tooltip-trigger" data-tooltip="This is a helpful tip!">
+  Hover me
+</button>
+```
+
+### Why is it useful?
+No JavaScript or extra markup is needed — the tooltip text lives in a `data-tooltip` attribute and is rendered via `::before`, with `::after` forming the arrow. The fade-in-up entrance gives it a polished, EaseMotion-style feel, and it's keyboard-accessible via `:focus-visible` and respects `prefers-reduced-motion`.

--- a/submissions/examples/tooltip-fade-up-ak/demo.html
+++ b/submissions/examples/tooltip-fade-up-ak/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Fade-In-Up Tooltip Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="page">
+    <button class="tooltip-trigger" data-tooltip="This is a helpful tip!">
+      Hover me
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/tooltip-fade-up-ak/style.css
+++ b/submissions/examples/tooltip-fade-up-ak/style.css
@@ -1,0 +1,64 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a0a0a;
+}
+
+.tooltip-trigger {
+  position: relative;
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: 1px solid #2d2d2d;
+  background: #121212;
+  color: #eaeaea;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.tooltip-trigger::before,
+.tooltip-trigger::after {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  opacity: 0;
+  visibility: hidden;
+  transform: translate(-50%, 6px);
+  transition: opacity 0.25s ease, transform 0.25s ease, visibility 0.25s ease;
+  pointer-events: none;
+}
+
+.tooltip-trigger::before {
+  content: attr(data-tooltip);
+  white-space: nowrap;
+  background: #1a1a1a;
+  border: 1px solid #2d2d2d;
+  color: #eaeaea;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 6px;
+}
+
+.tooltip-trigger::after {
+  content: "";
+  bottom: calc(100% + 4px);
+  border: 6px solid transparent;
+  border-top-color: #1a1a1a;
+}
+
+.tooltip-trigger:hover::before,
+.tooltip-trigger:hover::after,
+.tooltip-trigger:focus-visible::before,
+.tooltip-trigger:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-trigger::before,
+  .tooltip-trigger::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Adds a pure CSS tooltip using a data-tooltip attribute and ::before/::after pseudo-elements, with a fade-in-up entrance on hover/focus. Keyboard-accessible via :focus-visible and respects prefers-reduced-motion.
Closes #56638

## Pull Request Description
Adds a "Tooltip" component built entirely with `::before`/`::after` pseudo-elements and a `data-tooltip` attribute, no extra markup needed. The tooltip fades and slides up into view on hover or keyboard focus.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/tooltip-fade-up-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A pure CSS tooltip with a fade-in-up entrance animation.

**How does a developer use it?**
```html
<button class="tooltip-trigger" data-tooltip="This is a helpful tip!">
  Hover me
</button>
```

**Why does it fit EaseMotion CSS?**
It's a zero-JS, zero-extra-markup component — the label lives in the `data-tooltip` attribute and renders via `::before`, with `::after` forming the arrow. The fade-in-up entrance gives it a polished, animation-first feel in line with EaseMotion's philosophy, and it's keyboard-accessible via `:focus-visible` while respecting `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Used `tooltip-trigger` as the class name rather than `ease-` prefixed naming per the contribution guide — happy to have it renamed on integration.