### PR TITLE
feat: add CSS fade-in navbar for gaming hub layouts

### DIFF
--- a/submissions/examples/gaming-navbar-fade-ak/README.md
+++ b/submissions/examples/gaming-navbar-fade-ak/README.md
@@ -1,0 +1,26 @@
+# CSS Fade-In Navbar for Gaming Hub Layouts
+
+Closes #56471
+
+### What does this do?
+A responsive navbar for gaming hub layouts where the brand, nav links, and CTA button fade and slide in with a staggered entrance animation on page load.
+
+### How is it used?
+```html
+<nav class="gaming-navbar">
+  <div class="gaming-navbar-brand">NEXUS<span>PLAY</span></div>
+  <ul class="gaming-navbar-links">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Games</a></li>
+    <li><a href="#">Tournaments</a></li>
+  </ul>
+  <button class="gaming-navbar-cta">Play Now</button>
+</nav>
+```
+
+### Why is it useful?
+It gives gaming hub landing pages a polished, energetic first impression using only pure CSS keyframe animations and staggered `animation-delay` — no JavaScript. It's fully responsive across desktop, tablet, and mobile, and falls back to a static, fully visible state for `prefers-reduced-motion` users.
+
+### Notes
+- Timing/delays and colors (currently a purple `#a855f7` accent) can be swapped for CSS custom properties during framework integration.
+- Fully pure CSS/HTML, no external JS frameworks.

--- a/submissions/examples/gaming-navbar-fade-ak/demo.html
+++ b/submissions/examples/gaming-navbar-fade-ak/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gaming Hub Fade-In Navbar Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav class="gaming-navbar">
+    <div class="gaming-navbar-brand">NEXUS<span>PLAY</span></div>
+    <ul class="gaming-navbar-links">
+      <li><a href="#">Home</a></li>
+      <li><a href="#">Games</a></li>
+      <li><a href="#">Tournaments</a></li>
+      <li><a href="#">Leaderboard</a></li>
+      <li><a href="#">Community</a></li>
+    </ul>
+    <button class="gaming-navbar-cta">Play Now</button>
+  </nav>
+
+  <div class="page-body">
+    <p>Scroll or reload the page to replay the fade-in entrance animation.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gaming-navbar-fade-ak/style.css
+++ b/submissions/examples/gaming-navbar-fade-ak/style.css
@@ -1,0 +1,139 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0a0a0f;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.gaming-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 32px;
+  background: linear-gradient(180deg, #121218, #0e0e13);
+  border-bottom: 1px solid #24242e;
+  opacity: 0;
+  transform: translateY(-16px);
+  animation: navbar-fade-in 0.6s ease forwards;
+}
+
+.gaming-navbar-brand {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: #eaeaea;
+  white-space: nowrap;
+}
+
+.gaming-navbar-brand span {
+  color: #a855f7;
+}
+
+.gaming-navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.gaming-navbar-links li {
+  opacity: 0;
+  transform: translateY(-10px);
+  animation: navbar-fade-in 0.5s ease forwards;
+}
+
+.gaming-navbar-links li:nth-child(1) { animation-delay: 0.15s; }
+.gaming-navbar-links li:nth-child(2) { animation-delay: 0.22s; }
+.gaming-navbar-links li:nth-child(3) { animation-delay: 0.29s; }
+.gaming-navbar-links li:nth-child(4) { animation-delay: 0.36s; }
+.gaming-navbar-links li:nth-child(5) { animation-delay: 0.43s; }
+
+.gaming-navbar-links a {
+  color: #9a9aa8;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.25s ease;
+}
+
+.gaming-navbar-links a:hover,
+.gaming-navbar-links a:focus-visible {
+  color: #a855f7;
+}
+
+.gaming-navbar-cta {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #a855f7;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(-10px);
+  animation: navbar-fade-in 0.5s ease forwards;
+  animation-delay: 0.5s;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.gaming-navbar-cta:hover {
+  background: #9333ea;
+  transform: translateY(-1px);
+}
+
+.page-body {
+  padding: 60px 32px;
+  color: #666;
+  font-size: 14px;
+}
+
+@keyframes navbar-fade-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .gaming-navbar {
+    flex-wrap: wrap;
+    padding: 14px 20px;
+  }
+
+  .gaming-navbar-links {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+    gap: 18px;
+  }
+}
+
+@media (max-width: 480px) {
+  .gaming-navbar-links {
+    gap: 12px;
+    font-size: 13px;
+  }
+
+  .gaming-navbar-cta {
+    padding: 8px 16px;
+    font-size: 13px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gaming-navbar,
+  .gaming-navbar-links li,
+  .gaming-navbar-cta {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Adds a responsive navbar with a staggered fade-in entrance animation for brand, nav links, and CTA button using pure CSS keyframes and animation-delay, no JS. Fully responsive across desktop/tablet/mobile and respects prefers-reduced-motion.
Closes #56471

## Pull Request Description
Adds a "CSS Fade-In Navbar for Gaming Hub Layouts" — a responsive navbar where the brand, nav links, and CTA button fade and slide in with a staggered entrance animation on page load, giving gaming/esports landing pages a polished first impression.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/gaming-navbar-fade-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A responsive navbar with a staggered CSS fade-in entrance animation, styled for gaming hub layouts.

**How does a developer use it?**
```html
<nav class="gaming-navbar">
  <div class="gaming-navbar-brand">NEXUS<span>PLAY</span></div>
  <ul class="gaming-navbar-links">
    <li><a href="#">Home</a></li>
    <li><a href="#">Games</a></li>
    <li><a href="#">Tournaments</a></li>
  </ul>
  <button class="gaming-navbar-cta">Play Now</button>
</nav>
```

**Why does it fit EaseMotion CSS?**
It's built entirely with pure CSS keyframes and staggered `animation-delay` — no JavaScript — giving strong visual entrance feedback in line with EaseMotion's animation-first philosophy. It's fully responsive across desktop, tablet, and mobile viewports, and falls back to a static, fully visible state for `prefers-reduced-motion` users.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Used plain class names (`gaming-navbar`, `gaming-navbar-links`, etc.) rather than `ease-` prefixed naming per the contribution guide. The accent color (`#a855f7`) and stagger timing are hardcoded for the demo — happy to swap to CSS custom properties during integration.