### PR TITLE
feat: add CSS zoom-in card grid for gaming hub layouts

### DIFF
--- a/submissions/examples/gaming-card-grid-zoom-ak/README.md
+++ b/submissions/examples/gaming-card-grid-zoom-ak/README.md
@@ -1,0 +1,26 @@
+# CSS Zoom-In Card Grid for Gaming Hub Layouts
+
+Closes #56458
+
+### What does this do?
+A responsive card grid for gaming hub layouts where each card's thumbnail zooms in smoothly on hover/focus, accompanied by a subtle glow border and content lift.
+
+### How is it used?
+```html
+<div class="gaming-grid">
+  <div class="gaming-card">
+    <div class="gaming-card-thumb" style="background: linear-gradient(135deg, #a855f7, #4c1d95);"></div>
+    <div class="gaming-card-body">
+      <h3>Neon Strike</h3>
+      <p>FPS &middot; 4.8 ★</p>
+    </div>
+  </div>
+</div>
+```
+
+### Why is it useful?
+It's a common game/tournament browsing pattern that uses only pure CSS `transform: scale()` and `box-shadow` transitions — no JavaScript — to give strong, GPU-accelerated hover feedback. The grid is fully responsive across desktop, tablet, and mobile, includes `:focus-within` for keyboard accessibility, and falls back to a static state under `prefers-reduced-motion`.
+
+### Notes
+- Accent color (`#a855f7`) and thumbnail gradients are demo placeholders; can be swapped for CSS custom properties during integration.
+- Fully pure CSS/HTML, no external JS frameworks.

--- a/submissions/examples/gaming-card-grid-zoom-ak/demo.html
+++ b/submissions/examples/gaming-card-grid-zoom-ak/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gaming Hub Zoom-In Card Grid Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gaming-grid">
+    <div class="gaming-card">
+      <div class="gaming-card-thumb" style="background: linear-gradient(135deg, #a855f7, #4c1d95);"></div>
+      <div class="gaming-card-body">
+        <h3>Neon Strike</h3>
+        <p>FPS &middot; 4.8 ★</p>
+      </div>
+    </div>
+
+    <div class="gaming-card">
+      <div class="gaming-card-thumb" style="background: linear-gradient(135deg, #06b6d4, #0e7490);"></div>
+      <div class="gaming-card-body">
+        <h3>Rogue Circuit</h3>
+        <p>Strategy &middot; 4.6 ★</p>
+      </div>
+    </div>
+
+    <div class="gaming-card">
+      <div class="gaming-card-thumb" style="background: linear-gradient(135deg, #f43f5e, #7f1d1d);"></div>
+      <div class="gaming-card-body">
+        <h3>Ashfall Arena</h3>
+        <p>Battle Royale &middot; 4.9 ★</p>
+      </div>
+    </div>
+
+    <div class="gaming-card">
+      <div class="gaming-card-thumb" style="background: linear-gradient(135deg, #22c55e, #14532d);"></div>
+      <div class="gaming-card-body">
+        <h3>Pixel Kingdoms</h3>
+        <p>RPG &middot; 4.7 ★</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gaming-card-grid-zoom-ak/style.css
+++ b/submissions/examples/gaming-card-grid-zoom-ak/style.css
@@ -1,0 +1,102 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0a0a0f;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.gaming-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  padding: 40px;
+}
+
+.gaming-card {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #121218;
+  border: 1px solid #24242e;
+  cursor: pointer;
+}
+
+.gaming-card-thumb {
+  height: 140px;
+  width: 100%;
+  transform: scale(1);
+  transition: transform 0.4s ease;
+}
+
+.gaming-card:hover .gaming-card-thumb,
+.gaming-card:focus-within .gaming-card-thumb {
+  transform: scale(1.12);
+}
+
+.gaming-card-body {
+  padding: 14px 16px;
+  transition: transform 0.35s ease;
+}
+
+.gaming-card:hover .gaming-card-body,
+.gaming-card:focus-within .gaming-card-body {
+  transform: translateY(-2px);
+}
+
+.gaming-card-body h3 {
+  margin: 0 0 4px;
+  font-size: 15px;
+  color: #eaeaea;
+}
+
+.gaming-card-body p {
+  margin: 0;
+  font-size: 12px;
+  color: #8a8a9a;
+}
+
+.gaming-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  box-shadow: 0 0 0 0 rgba(168, 85, 247, 0);
+  transition: box-shadow 0.4s ease;
+  pointer-events: none;
+}
+
+.gaming-card:hover::after,
+.gaming-card:focus-within::after {
+  box-shadow: 0 0 0 2px rgba(168, 85, 247, 0.6), 0 12px 24px rgba(168, 85, 247, 0.15);
+}
+
+@media (max-width: 1024px) {
+  .gaming-grid {
+    grid-template-columns: repeat(2, 1fr);
+    padding: 24px;
+  }
+}
+
+@media (max-width: 520px) {
+  .gaming-grid {
+    grid-template-columns: 1fr;
+    padding: 16px;
+    gap: 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gaming-card-thumb,
+  .gaming-card-body,
+  .gaming-card::after {
+    transition: none;
+  }
+
+  .gaming-card:hover .gaming-card-thumb,
+  .gaming-card:focus-within .gaming-card-thumb {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Adds a responsive card grid where thumbnails zoom in smoothly on hover/focus with a glow border and content lift, using pure CSS transform/box-shadow transitions, no JS. Fully responsive across desktop/tablet/mobile, keyboard-accessible via focus-within, and respects prefers-reduced-motion.
Closes #56458

## Pull Request Description
Adds a "CSS Zoom-In Card Grid for Gaming Hub Layouts" — a responsive card grid where each card's thumbnail zooms in smoothly on hover/focus, accompanied by a subtle glow border and content lift, for showcasing games/tournaments on gaming hub pages.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/gaming-card-grid-zoom-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A responsive card grid with a zoom-in thumbnail hover/focus effect.

**How does a developer use it?**
```html
<div class="gaming-grid">
  <div class="gaming-card">
    <div class="gaming-card-thumb" style="background: linear-gradient(135deg, #a855f7, #4c1d95);"></div>
    <div class="gaming-card-body">
      <h3>Neon Strike</h3>
      <p>FPS &middot; 4.8 ★</p>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It uses only pure CSS `transform: scale()` and `box-shadow` transitions — no JavaScript — to give strong, GPU-accelerated hover feedback for a common game/tournament browsing pattern, in line with EaseMotion's animation-first philosophy. It's fully responsive across desktop, tablet, and mobile, keyboard-accessible via `:focus-within`, and falls back to a static state under `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Used plain class names (`gaming-grid`, `gaming-card`, etc.) rather than `ease-` prefixed naming per the contribution guide. Accent color and thumbnail gradients are demo placeholders — happy to swap to CSS custom properties during integration.