### PR TITLE
feat: add CSS ripple-wave drawer for gaming hub layouts

### DIFF
--- a/submissions/examples/gaming-drawer-ripple-ak/README.md
+++ b/submissions/examples/gaming-drawer-ripple-ak/README.md
@@ -1,0 +1,32 @@
+# CSS Ripple-Wave Drawer for Gaming Hub Layouts
+
+Closes #56451
+
+### What does this do?
+A slide-in navigation drawer for gaming hub layouts with a wave-shaped clip-path edge that animates in on open, plus a ripple effect on the toggle button when pressed.
+
+### How is it used?
+```html
+<button class="drawer-toggle" id="drawerToggle">
+  <span class="drawer-toggle-ripple"></span>
+  ☰ Menu
+</button>
+
+<aside class="gaming-drawer" id="gamingDrawer">
+  <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
+  <ul class="gaming-drawer-links">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Games</a></li>
+  </ul>
+</aside>
+
+<div class="gaming-drawer-overlay" id="gamingOverlay"></div>
+```
+A small script toggles the `open` class on `.gaming-drawer` and `.gaming-drawer-overlay`; all motion is pure CSS transitions/keyframes.
+
+### Why is it useful?
+It gives gaming hub navigation a distinctive "wave" identity via an animated `clip-path`, instead of a plain rectangular slide-in drawer, and the button ripple reinforces interactivity — both done with pure CSS transitions and keyframes, no animation JS. It's responsive down to mobile widths, closes via overlay click, and respects `prefers-reduced-motion`.
+
+### Notes
+- The minimal JS only toggles CSS classes; no JS animation logic.
+- Accent color (`#a855f7`) is a demo placeholder; can be swapped for CSS custom properties during integration.

--- a/submissions/examples/gaming-drawer-ripple-ak/demo.html
+++ b/submissions/examples/gaming-drawer-ripple-ak/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gaming Hub Ripple-Wave Drawer Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gaming-page">
+    <button class="drawer-toggle" id="drawerToggle">
+      <span class="drawer-toggle-ripple"></span>
+      ☰ Menu
+    </button>
+
+    <aside class="gaming-drawer" id="gamingDrawer">
+      <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
+      <ul class="gaming-drawer-links">
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Games</a></li>
+        <li><a href="#">Tournaments</a></li>
+        <li><a href="#">Leaderboard</a></li>
+        <li><a href="#">Community</a></li>
+      </ul>
+    </aside>
+
+    <div class="gaming-drawer-overlay" id="gamingOverlay"></div>
+  </div>
+
+  <script>
+    const toggle = document.getElementById('drawerToggle');
+    const drawer = document.getElementById('gamingDrawer');
+    const overlay = document.getElementById('gamingOverlay');
+
+    function closeDrawer() {
+      drawer.classList.remove('open');
+      overlay.classList.remove('open');
+    }
+
+    toggle.addEventListener('click', () => {
+      drawer.classList.toggle('open');
+      overlay.classList.toggle('open');
+    });
+
+    overlay.addEventListener('click', closeDrawer);
+  </script>
+</body>
+</html>

--- a/submissions/examples/gaming-drawer-ripple-ak/style.css
+++ b/submissions/examples/gaming-drawer-ripple-ak/style.css
@@ -1,0 +1,136 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0a0a0f;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.gaming-page {
+  padding: 24px;
+}
+
+.drawer-toggle {
+  position: relative;
+  overflow: hidden;
+  padding: 10px 20px;
+  border: 1px solid #24242e;
+  border-radius: 8px;
+  background: #121218;
+  color: #eaeaea;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.drawer-toggle-ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(168, 85, 247, 0.45);
+  transform: scale(0);
+  pointer-events: none;
+  width: 20px;
+  height: 20px;
+  top: 50%;
+  left: 50%;
+  margin: -10px 0 0 -10px;
+  animation: none;
+}
+
+.drawer-toggle:active .drawer-toggle-ripple {
+  animation: ripple-expand 0.6s ease-out;
+}
+
+@keyframes ripple-expand {
+  to {
+    transform: scale(14);
+    opacity: 0;
+  }
+}
+
+.gaming-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 280px;
+  background: linear-gradient(180deg, #121218, #0e0e13);
+  border-right: 1px solid #24242e;
+  transform: translateX(-100%);
+  clip-path: polygon(0 0, 100% 0, 92% 50%, 100% 100%, 0 100%);
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1), clip-path 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+  z-index: 20;
+  padding: 24px 20px;
+}
+
+.gaming-drawer.open {
+  transform: translateX(0);
+  clip-path: polygon(0 0, 100% 0, 100% 50%, 100% 100%, 0 100%);
+}
+
+.gaming-drawer-header {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: #eaeaea;
+  margin-bottom: 24px;
+}
+
+.gaming-drawer-header span {
+  color: #a855f7;
+}
+
+.gaming-drawer-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.gaming-drawer-links a {
+  color: #9a9aa8;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.25s ease;
+}
+
+.gaming-drawer-links a:hover,
+.gaming-drawer-links a:focus-visible {
+  color: #a855f7;
+}
+
+.gaming-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+  z-index: 10;
+}
+
+.gaming-drawer-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (max-width: 480px) {
+  .gaming-drawer {
+    width: 82vw;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gaming-drawer,
+  .gaming-drawer-overlay {
+    transition: none;
+  }
+  .drawer-toggle:active .drawer-toggle-ripple {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Adds a slide-in navigation drawer with an animated wave-shaped clip-path edge and a ripple effect on the toggle button, using pure CSS transitions/keyframes (JS only toggles classes). Responsive down to mobile and respects prefers-reduced-motion.
Closes #56451

## Pull Request Description
Adds a "CSS Ripple-Wave Drawer for Gaming Hub Layouts" — a slide-in navigation drawer with an animated wave-shaped `clip-path` edge, opened via a toggle button that shows a ripple effect on press.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/gaming-drawer-ripple-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A slide-in navigation drawer with a wave-shaped clip-path animation and a ripple toggle button.

**How does a developer use it?**
```html
<button class="drawer-toggle" id="drawerToggle">
  <span class="drawer-toggle-ripple"></span>
  ☰ Menu
</button>

<aside class="gaming-drawer" id="gamingDrawer">
  <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
  <ul class="gaming-drawer-links">
    <li><a href="#">Home</a></li>
    <li><a href="#">Games</a></li>
  </ul>
</aside>

<div class="gaming-drawer-overlay" id="gamingOverlay"></div>
```
A small script toggles the `open` class on `.gaming-drawer`/`.gaming-drawer-overlay`; all motion is handled by CSS transitions and keyframes.

**Why does it fit EaseMotion CSS?**
It gives gaming hub navigation a distinctive identity via an animated `clip-path` wave edge instead of a plain rectangular slide-in, and the button ripple reinforces interactivity — both achieved with pure CSS transitions/keyframes, no animation logic in JS, fitting EaseMotion's animation-first philosophy. It's responsive down to mobile widths and respects `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
JS is limited to toggling CSS classes on click (open/close, overlay dismiss) — no animation logic lives in JS. Accent color (`#a855f7`) is a demo placeholder; happy to swap to CSS custom properties during integration.