### PR TITLE
feat: add CSS blur-entrance drawer for gaming hub layouts

### DIFF
--- a/submissions/examples/gaming-drawer-blur-ak/README.md
+++ b/submissions/examples/gaming-drawer-blur-ak/README.md
@@ -1,0 +1,29 @@
+# CSS Blur-Entrance Drawer for Gaming Hub Layouts
+
+Closes #56446
+
+### What does this do?
+A navigation drawer for gaming hub layouts that enters with a blur-to-sharp animation — starting blurred, scaled down, and transparent, then transitioning to a crisp frosted-glass panel with `backdrop-filter` as it opens.
+
+### How is it used?
+```html
+<button class="drawer-toggle" id="drawerToggle">☰ Menu</button>
+
+<aside class="gaming-drawer" id="gamingDrawer">
+  <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
+  <ul class="gaming-drawer-links">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Games</a></li>
+  </ul>
+</aside>
+
+<div class="gaming-drawer-overlay" id="gamingOverlay"></div>
+```
+A small script toggles the `open` class on `.gaming-drawer` and `.gaming-drawer-overlay`; all motion is handled by CSS transitions.
+
+### Why is it useful?
+It's a distinctive, modern entrance treatment (blur + scale + fade) built purely with CSS `filter`, `backdrop-filter`, `transform`, and `opacity` transitions — no animation logic in JS — fitting EaseMotion's animation-first philosophy. It's responsive down to mobile widths, dismissible via overlay click, and respects `prefers-reduced-motion`.
+
+### Notes
+- The minimal JS only toggles CSS classes; no JS animation logic.
+- Accent color (`#a855f7`) is a demo placeholder; can be swapped for CSS custom properties during integration.

--- a/submissions/examples/gaming-drawer-blur-ak/demo.html
+++ b/submissions/examples/gaming-drawer-blur-ak/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gaming Hub Blur-Entrance Drawer Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gaming-page">
+    <button class="drawer-toggle" id="drawerToggle">☰ Menu</button>
+
+    <aside class="gaming-drawer" id="gamingDrawer">
+      <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
+      <ul class="gaming-drawer-links">
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Games</a></li>
+        <li><a href="#">Tournaments</a></li>
+        <li><a href="#">Leaderboard</a></li>
+        <li><a href="#">Community</a></li>
+      </ul>
+    </aside>
+
+    <div class="gaming-drawer-overlay" id="gamingOverlay"></div>
+  </div>
+
+  <script>
+    const toggle = document.getElementById('drawerToggle');
+    const drawer = document.getElementById('gamingDrawer');
+    const overlay = document.getElementById('gamingOverlay');
+
+    function closeDrawer() {
+      drawer.classList.remove('open');
+      overlay.classList.remove('open');
+    }
+
+    toggle.addEventListener('click', () => {
+      drawer.classList.toggle('open');
+      overlay.classList.toggle('open');
+    });
+
+    overlay.addEventListener('click', closeDrawer);
+  </script>
+</body>
+</html>

--- a/submissions/examples/gaming-drawer-blur-ak/style.css
+++ b/submissions/examples/gaming-drawer-blur-ak/style.css
@@ -1,0 +1,122 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0a0a0f;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.gaming-page {
+  padding: 24px;
+}
+
+.drawer-toggle {
+  padding: 10px 20px;
+  border: 1px solid #24242e;
+  border-radius: 8px;
+  background: #121218;
+  color: #eaeaea;
+  font-size: 14px;
+  cursor: pointer;
+  transition: border-color 0.25s ease;
+}
+
+.drawer-toggle:hover {
+  border-color: #a855f7;
+}
+
+.gaming-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 280px;
+  background: rgba(18, 18, 24, 0.7);
+  backdrop-filter: blur(0px);
+  -webkit-backdrop-filter: blur(0px);
+  border-right: 1px solid #24242e;
+  opacity: 0;
+  transform: scale(0.94);
+  filter: blur(8px);
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.45s ease, transform 0.45s ease, filter 0.45s ease,
+    backdrop-filter 0.45s ease, visibility 0.45s ease;
+  z-index: 20;
+  padding: 24px 20px;
+}
+
+.gaming-drawer.open {
+  opacity: 1;
+  transform: scale(1);
+  filter: blur(0px);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.gaming-drawer-header {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: #eaeaea;
+  margin-bottom: 24px;
+}
+
+.gaming-drawer-header span {
+  color: #a855f7;
+}
+
+.gaming-drawer-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.gaming-drawer-links a {
+  color: #9a9aa8;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.25s ease;
+}
+
+.gaming-drawer-links a:hover,
+.gaming-drawer-links a:focus-visible {
+  color: #a855f7;
+}
+
+.gaming-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+  z-index: 10;
+}
+
+.gaming-drawer-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (max-width: 480px) {
+  .gaming-drawer {
+    width: 82vw;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gaming-drawer,
+  .gaming-drawer-overlay {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Adds a navigation drawer that enters with a blur-to-sharp animation, transitioning from blurred/scaled-down/transparent to a crisp frosted-glass panel using CSS filter, backdrop-filter, transform, and opacity transitions (JS only toggles classes). Responsive down to mobile and respects prefers-reduced-motion.
Closes #56446

## Pull Request Description
Adds a "CSS Blur-Entrance Drawer for Gaming Hub Layouts" — a navigation drawer that enters with a blur-to-sharp animation, starting blurred, scaled down, and transparent, then resolving into a crisp frosted-glass panel as it opens.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/gaming-drawer-blur-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A navigation drawer with a blur-to-sharp frosted-glass entrance animation.

**How does a developer use it?**
```html
<button class="drawer-toggle" id="drawerToggle">☰ Menu</button>

<aside class="gaming-drawer" id="gamingDrawer">
  <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
  <ul class="gaming-drawer-links">
    <li><a href="#">Home</a></li>
    <li><a href="#">Games</a></li>
  </ul>
</aside>

<div class="gaming-drawer-overlay" id="gamingOverlay"></div>
```
A small script toggles the `open` class on `.gaming-drawer`/`.gaming-drawer-overlay`; all motion is handled by CSS transitions.

**Why does it fit EaseMotion CSS?**
It's a distinctive, modern entrance treatment combining `filter`, `backdrop-filter`, `transform`, and `opacity` transitions — no animation logic in JS — fitting EaseMotion's animation-first, human-readable philosophy. It's responsive down to mobile widths, dismissible via overlay click, and respects `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
JS is limited to toggling CSS classes on click (open/close, overlay dismiss) — no animation logic lives in JS. Accent color (`#a855f7`) is a demo placeholder; happy to swap to CSS custom properties during integration. Also worth noting `backdrop-filter` support varies slightly across older browsers, though it degrades gracefully to a semi-transparent panel.