### PR TITLE
feat: add CSS zoom-in drawer for gaming hub layouts

### DIFF
--- a/submissions/examples/gaming-drawer-zoom-ak/README.md
+++ b/submissions/examples/gaming-drawer-zoom-ak/README.md
@@ -1,0 +1,29 @@
+# CSS Zoom-In Drawer for Gaming Hub Layouts
+
+Closes #56443
+
+### What does this do?
+A navigation drawer for gaming hub layouts that zooms in from a scaled-down, transparent state to full size with a springy overshoot, while its nav links pop in with a staggered scale/fade.
+
+### How is it used?
+```html
+<button class="drawer-toggle" id="drawerToggle">☰ Menu</button>
+
+<aside class="gaming-drawer" id="gamingDrawer">
+  <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
+  <ul class="gaming-drawer-links">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Games</a></li>
+  </ul>
+</aside>
+
+<div class="gaming-drawer-overlay" id="gamingOverlay"></div>
+```
+A small script toggles the `open` class on `.gaming-drawer` and `.gaming-drawer-overlay`; all motion is handled by CSS transitions.
+
+### Why is it useful?
+It gives gaming hub navigation a punchy, game-like feel using a spring-style `cubic-bezier` scale/opacity transition plus staggered link entrances — pure CSS, no animation logic in JS — in line with EaseMotion's animation-first philosophy. It's responsive down to mobile widths, dismissible via overlay click, and respects `prefers-reduced-motion`.
+
+### Notes
+- The minimal JS only toggles CSS classes; no JS animation logic.
+- Accent color (`#a855f7`) is a demo placeholder; can be swapped for CSS custom properties during integration.

--- a/submissions/examples/gaming-drawer-zoom-ak/demo.html
+++ b/submissions/examples/gaming-drawer-zoom-ak/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gaming Hub Zoom-In Drawer Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="gaming-page">
+    <button class="drawer-toggle" id="drawerToggle">☰ Menu</button>
+
+    <aside class="gaming-drawer" id="gamingDrawer">
+      <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
+      <ul class="gaming-drawer-links">
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Games</a></li>
+        <li><a href="#">Tournaments</a></li>
+        <li><a href="#">Leaderboard</a></li>
+        <li><a href="#">Community</a></li>
+      </ul>
+    </aside>
+
+    <div class="gaming-drawer-overlay" id="gamingOverlay"></div>
+  </div>
+
+  <script>
+    const toggle = document.getElementById('drawerToggle');
+    const drawer = document.getElementById('gamingDrawer');
+    const overlay = document.getElementById('gamingOverlay');
+
+    function closeDrawer() {
+      drawer.classList.remove('open');
+      overlay.classList.remove('open');
+    }
+
+    toggle.addEventListener('click', () => {
+      drawer.classList.toggle('open');
+      overlay.classList.toggle('open');
+    });
+
+    overlay.addEventListener('click', closeDrawer);
+  </script>
+</body>
+</html>

--- a/submissions/examples/gaming-drawer-zoom-ak/style.css
+++ b/submissions/examples/gaming-drawer-zoom-ak/style.css
@@ -1,0 +1,135 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0a0a0f;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.gaming-page {
+  padding: 24px;
+}
+
+.drawer-toggle {
+  padding: 10px 20px;
+  border: 1px solid #24242e;
+  border-radius: 8px;
+  background: #121218;
+  color: #eaeaea;
+  font-size: 14px;
+  cursor: pointer;
+  transition: border-color 0.25s ease;
+}
+
+.drawer-toggle:hover {
+  border-color: #a855f7;
+}
+
+.gaming-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 280px;
+  background: linear-gradient(180deg, #121218, #0e0e13);
+  border-right: 1px solid #24242e;
+  opacity: 0;
+  transform: scale(0.75);
+  transform-origin: left center;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+    transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), visibility 0.4s ease;
+  z-index: 20;
+  padding: 24px 20px;
+}
+
+.gaming-drawer.open {
+  opacity: 1;
+  transform: scale(1);
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.gaming-drawer-header {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: #eaeaea;
+  margin-bottom: 24px;
+}
+
+.gaming-drawer-header span {
+  color: #a855f7;
+}
+
+.gaming-drawer-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.gaming-drawer-links li {
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.gaming-drawer.open .gaming-drawer-links li {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.gaming-drawer.open .gaming-drawer-links li:nth-child(1) { transition-delay: 0.08s; }
+.gaming-drawer.open .gaming-drawer-links li:nth-child(2) { transition-delay: 0.13s; }
+.gaming-drawer.open .gaming-drawer-links li:nth-child(3) { transition-delay: 0.18s; }
+.gaming-drawer.open .gaming-drawer-links li:nth-child(4) { transition-delay: 0.23s; }
+.gaming-drawer.open .gaming-drawer-links li:nth-child(5) { transition-delay: 0.28s; }
+
+.gaming-drawer-links a {
+  color: #9a9aa8;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.25s ease;
+}
+
+.gaming-drawer-links a:hover,
+.gaming-drawer-links a:focus-visible {
+  color: #a855f7;
+}
+
+.gaming-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+  z-index: 10;
+}
+
+.gaming-drawer-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (max-width: 480px) {
+  .gaming-drawer {
+    width: 82vw;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gaming-drawer,
+  .gaming-drawer-overlay,
+  .gaming-drawer-links li {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Adds a navigation drawer that zooms in from a scaled-down transparent state with a springy overshoot, plus staggered scale/fade entrances for nav links, using pure CSS transitions (JS only toggles classes). Responsive down to mobile and respects prefers-reduced-motion.
Closes #56443

## Pull Request Description
Adds a "CSS Zoom-In Drawer for Gaming Hub Layouts" — a navigation drawer that zooms in from a scaled-down, transparent state to full size with a springy overshoot, while its nav links pop in with a staggered scale/fade for a punchy, game-like feel.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/gaming-drawer-zoom-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A navigation drawer with a springy zoom-in entrance and staggered nav link pop-ins.

**How does a developer use it?**
```html
<button class="drawer-toggle" id="drawerToggle">☰ Menu</button>

<aside class="gaming-drawer" id="gamingDrawer">
  <div class="gaming-drawer-header">NEXUS<span>PLAY</span></div>
  <ul class="gaming-drawer-links">
    <li><a href="#">Home</a></li>
    <li><a href="#">Games</a></li>
  </ul>
</aside>

<div class="gaming-drawer-overlay" id="gamingOverlay"></div>
```
A small script toggles the `open` class on `.gaming-drawer`/`.gaming-drawer-overlay`; all motion is handled by CSS transitions.

**Why does it fit EaseMotion CSS?**
It gives gaming hub navigation a punchy, game-like feel using a spring-style `cubic-bezier` scale/opacity transition plus staggered link entrances — pure CSS, no animation logic in JS — fitting EaseMotion's animation-first philosophy. It's responsive down to mobile widths, dismissible via overlay click, and respects `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
JS is limited to toggling CSS classes on click (open/close, overlay dismiss) — no animation logic lives in JS. Accent color (`#a855f7`) and the overshoot curve are demo placeholders; happy to tune during integration.