### PR TITLE
fix: prevent FAQ accordion content from overflowing on mobile screens

### DIFF
--- a/submissions/examples/faq-accordion-overflow/README.md
+++ b/submissions/examples/faq-accordion-overflow/README.md
@@ -1,0 +1,29 @@
+# FAQ Accordion Overflow Fix
+
+## Description
+
+This submission fixes an issue where FAQ accordion questions and answers overflow or create horizontal scrolling on smaller screens. The layout has been improved to wrap long text correctly while maintaining readability.
+
+## Features
+
+- Prevents accordion content overflow
+- Supports long questions and answers
+- Responsive mobile-friendly layout
+- Pure CSS implementation
+- Lightweight and reusable
+
+## Usage
+
+```html
+<details class="faq-item">
+  <summary>Frequently asked question</summary>
+  <p>Your answer goes here.</p>
+</details>
+```
+
+## Benefits
+
+- Eliminates horizontal scrolling
+- Improves readability on mobile devices
+- Handles long content gracefully
+- Easy to integrate into existing projects

--- a/submissions/examples/faq-accordion-overflow/demo.html
+++ b/submissions/examples/faq-accordion-overflow/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FAQ Accordion Overflow Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="faq-container">
+
+  <details class="faq-item">
+    <summary>
+      How can I customize EaseMotion CSS components for enterprise applications with very long section titles?
+    </summary>
+    <p>
+      EaseMotion CSS provides responsive utility classes that automatically adapt layouts across different screen sizes while keeping the code lightweight and maintainable.
+    </p>
+  </details>
+
+  <details class="faq-item">
+    <summary>
+      Does the framework support responsive layouts for mobile, tablet, and desktop devices without additional JavaScript?
+    </summary>
+    <p>
+      Yes. Most responsive behavior is achieved using modern CSS techniques such as Flexbox, Grid, and media queries.
+    </p>
+  </details>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/faq-accordion-overflow/style.css
+++ b/submissions/examples/faq-accordion-overflow/style.css
@@ -1,0 +1,55 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+  padding: 30px;
+}
+
+.faq-container {
+  max-width: 700px;
+  margin: auto;
+}
+
+.faq-item {
+  background: #fff;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  padding: 16px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
+
+.faq-item summary {
+  font-weight: bold;
+  cursor: pointer;
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.faq-item p {
+  margin-top: 12px;
+  color: #444;
+  line-height: 1.6;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 16px;
+  }
+
+  .faq-item {
+    padding: 14px;
+  }
+
+  .faq-item summary,
+  .faq-item p {
+    font-size: 15px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where FAQ accordion content overflows or creates horizontal scrolling on smaller screens. The layout has been improved using responsive CSS to ensure long questions and answers wrap correctly while maintaining readability and consistent spacing across all devices.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/faq-accordion-overflow/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes FAQ accordion content overflow by making long questions and answers wrap correctly on mobile and small-screen devices.

**How does a developer use it?**

```html
<div class="faq-container">
  <details class="faq-item">
    <summary>Frequently asked question</summary>
    <p>Your answer goes here.</p>
  </details>
</div>
```

**Why does it fit EaseMotion CSS?**

This enhancement provides a lightweight, responsive solution using pure CSS. It improves usability while remaining consistent with EaseMotion CSS's human-readable, utility-first design philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The solution uses responsive spacing together with `overflow-wrap` and `word-break` to prevent long FAQ content from overflowing on smaller screens. All changes are isolated within the submission example and do not modify `core/` or `components/`.
```