### PR TITLE
feat: add morph-glow progress bar component for portfolios

### DIFF
--- a/submissions/examples/ease-morph-glow-progress-bar/README.md
+++ b/submissions/examples/ease-morph-glow-progress-bar/README.md
@@ -1,0 +1,48 @@
+# Ease Morph-Glow Progress Bar
+
+## Description
+A skill/progress bar for portfolio sites where the fill continuously morphs its leading edge into an organic, liquid-like shape while glowing and emitting a shimmer sweep. Pure CSS, zero JavaScript.
+
+## Features
+- Fill animates in from 0 to target width via `transform: scaleX()`
+- Continuous subtle `border-radius` morph gives the fill edge an organic, non-rigid feel
+- Pulsing glow (`box-shadow`) around the fill
+- Shimmer highlight sweeping across the fill on a loop
+- Fully responsive (percentage-based width, no fixed pixel sizing)
+- Fully customizable per-bar via CSS custom properties (colors, glow, timing)
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-morph-progress">
+  <div class="progress-row is-visible">
+    <div class="progress-label-row">
+      <span class="progress-label">CSS / Animation</span>
+      <span class="progress-percent">92%</span>
+    </div>
+    <div class="progress-track">
+      <div class="progress-fill" style="--fill-scale: 0.92;"></div>
+    </div>
+  </div>
+</div>
+```
+Set `--fill-scale` to a decimal (0–1) matching the displayed percentage. Add the `.is-visible` class to `.progress-row` to trigger the fill-in animation — pair with a scroll-reveal `IntersectionObserver` script if you want it to trigger on scroll rather than immediately, or leave it present by default as shown here.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--fill-duration` | `1.2s` | Fill-in transition duration |
+| `--morph-duration` | `3s` | Border-radius morph cycle speed |
+| `--fill-color` / `--fill-color-2` | `#38bdf8` / `#a78bfa` | Fill gradient endpoints |
+| `--glow-color` | `rgba(56, 189, 248, 0.5)` | Glow shadow color |
+| `--bar-height` | `14px` | Track thickness |
+
+Override per bar for different skill colors, as shown in the JavaScript/Motion Design examples in `demo.html`.
+
+## Accessibility
+Uses `transform: scaleX()` rather than animating `width` directly, avoiding layout thrashing. Respects `prefers-reduced-motion` by disabling the morph, glow pulse, and shimmer animations entirely, leaving a clean static rounded bar.
+
+## Files
+- `demo.html` — live working example with 3 differently-colored skill bars
+- `style.css` — component styles and all animations
+- `README.md` — this file

--- a/submissions/examples/ease-morph-glow-progress-bar/demo.html
+++ b/submissions/examples/ease-morph-glow-progress-bar/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Morph-Glow Progress Bar — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0a0912;
+      padding: 40px;
+      box-sizing: border-box;
+    }
+    .demo-card {
+      background: #131220;
+      border: 1px solid #23223a;
+      border-radius: 18px;
+      padding: 32px;
+      width: 100%;
+      max-width: 440px;
+      box-sizing: border-box;
+    }
+    .demo-card h2 {
+      color: #f5f7fa;
+      font-family: system-ui, sans-serif;
+      font-size: 1.1rem;
+      margin: 0 0 24px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-card">
+    <h2>Skills</h2>
+    <div class="ease-morph-progress">
+      <div class="progress-row is-visible">
+        <div class="progress-label-row">
+          <span class="progress-label">CSS / Animation</span>
+          <span class="progress-percent">92%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" style="--fill-scale: 0.92;"></div>
+        </div>
+      </div>
+
+      <div class="progress-row is-visible">
+        <div class="progress-label-row">
+          <span class="progress-label">JavaScript</span>
+          <span class="progress-percent">78%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" style="--fill-scale: 0.78; --fill-color: #a78bfa; --fill-color-2: #f472b6; --glow-color: rgba(167,139,250,0.5);"></div>
+        </div>
+      </div>
+
+      <div class="progress-row is-visible">
+        <div class="progress-label-row">
+          <span class="progress-label">Motion Design</span>
+          <span class="progress-percent">85%</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" style="--fill-scale: 0.85; --fill-color: #22c55e; --fill-color-2: #38bdf8; --glow-color: rgba(34,197,94,0.5);"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-morph-glow-progress-bar/style.css
+++ b/submissions/examples/ease-morph-glow-progress-bar/style.css
@@ -1,0 +1,113 @@
+/* Ease Morph-Glow Progress Bar — creative portfolio style, pure CSS, zero JS */
+
+.ease-morph-progress {
+  --bar-height: 14px;
+  --track-bg: #1e1e2e;
+  --fill-color: #38bdf8;
+  --fill-color-2: #a78bfa;
+  --glow-color: rgba(56, 189, 248, 0.5);
+  --fill-duration: 1.2s;
+  --morph-duration: 3s;
+  --easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --radius: 999px;
+
+  width: 100%;
+  max-width: 400px;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-morph-progress .progress-row {
+  margin-bottom: 22px;
+}
+
+.ease-morph-progress .progress-row:last-child {
+  margin-bottom: 0;
+}
+
+.ease-morph-progress .progress-label-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-size: 0.82rem;
+}
+
+.ease-morph-progress .progress-label {
+  font-weight: 700;
+  color: #f5f7fa;
+}
+
+.ease-morph-progress .progress-percent {
+  font-weight: 700;
+  color: var(--fill-color);
+  font-variant-numeric: tabular-nums;
+}
+
+.ease-morph-progress .progress-track {
+  position: relative;
+  height: var(--bar-height);
+  background: var(--track-bg);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.ease-morph-progress .progress-fill {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  background: linear-gradient(90deg, var(--fill-color), var(--fill-color-2));
+  border-radius: var(--radius);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--fill-duration) var(--easing);
+
+  /* morphing edge — subtle border-radius shift makes the fill's leading
+     edge feel organic/liquid rather than a hard rectangle */
+  animation: fill-morph var(--morph-duration) ease-in-out infinite;
+}
+
+.ease-morph-progress .progress-row.is-visible .progress-fill {
+  transform: scaleX(var(--fill-scale, 1));
+}
+
+@keyframes fill-morph {
+  0%, 100% { border-radius: 999px 40% 999px 999px / 999px 60% 999px 999px; }
+  50%      { border-radius: 999px 60% 999px 999px / 999px 40% 999px 999px; }
+}
+
+/* continuous glow pulse once filled */
+.ease-morph-progress .progress-row.is-visible .progress-fill {
+  animation: fill-morph var(--morph-duration) ease-in-out infinite,
+             fill-glow-pulse 2s ease-in-out infinite;
+}
+
+@keyframes fill-glow-pulse {
+  0%, 100% { box-shadow: 0 0 10px var(--glow-color); }
+  50%      { box-shadow: 0 0 20px var(--glow-color), 0 0 6px var(--glow-color); }
+}
+
+/* shimmer sweep traveling across the fill */
+.ease-morph-progress .progress-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 30%, rgba(255,255,255,0.4) 50%, transparent 70%);
+  transform: translateX(-100%);
+}
+
+.ease-morph-progress .progress-row.is-visible .progress-fill::after {
+  animation: shimmer-sweep 2.4s ease-in-out infinite;
+}
+
+@keyframes shimmer-sweep {
+  0%   { transform: translateX(-100%); }
+  50%  { transform: translateX(100%); }
+  100% { transform: translateX(100%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-morph-progress .progress-fill,
+  .ease-morph-progress .progress-fill::after {
+    animation: none !important;
+    border-radius: var(--radius) !important;
+  }
+}


### PR DESCRIPTION
Closes #56377

## Pull Request Description
Adds a skill/progress bar for portfolio sites where the fill continuously morphs its leading edge into an organic, liquid-like shape while glowing and emitting a shimmer sweep across it. Pure CSS, zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All files placed under `submissions/examples/ease-morph-glow-progress-bar-savni/`
- [x] Includes `demo.html` — clean HTML5 showcase page
- [x] Includes `style.css` — pure CSS, smooth/performant transitions and keyframes
- [x] Includes `README.md` — usage, custom properties, and features documented
- [x] Pure CSS/HTML, no JS frameworks
- [x] Fully responsive (percentage-based, no fixed sizing)
- [x] Respects `prefers-reduced-motion`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A progress/skill bar (`ease-morph-progress`) where the fill animates in via `transform: scaleX()`, continuously morphs its leading edge shape via animated `border-radius`, glows with a pulsing `box-shadow`, and shows a shimmer sweeping across it — giving a distinctive "liquid glow" feel over a standard flat bar.

**How does a developer use it?**
```html
<div class="ease-morph-progress">
  <div class="progress-row is-visible">
    <div class="progress-label-row">
      <span class="progress-label">CSS / Animation</span>
      <span class="progress-percent">92%</span>
    </div>
    <div class="progress-track">
      <div class="progress-fill" style="--fill-scale: 0.92;"></div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
All motion — fill transition, edge morph, glow pulse, shimmer sweep — is pure CSS `@keyframes`/`transition`, with `transform: scaleX()` used for the fill (avoiding layout thrashing from animating `width`). Every visual parameter (colors, glow, timing, bar height) is exposed via CSS custom properties, overridable per-instance, without touching core rules — matching the framework's animation-first, zero-dependency philosophy. Respects `prefers-reduced-motion` by disabling all decorative animation and falling back to a clean static bar.

---

## Demo
- [x] Demo added (`demo.html` — 3 differently-colored skill bars in a portfolio card layout)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The `.is-visible` class on `.progress-row` triggers the fill animation — present by default in the demo for simplicity, but pairs cleanly with a scroll-reveal `IntersectionObserver` script (same pattern as other submitted progress-bar components) if scroll-triggered reveal is preferred over immediate fill-on-load.