### PR TITLE
feat: add cyberpunk text glitch effect (#57082)

### DIFF
--- a/submissions/examples/ease-text-glitch/README.md
+++ b/submissions/examples/ease-text-glitch/README.md
@@ -1,0 +1,24 @@
+# Cyberpunk Text Glitch Effect (`.ease-text-glitch`)
+
+## Description
+This submission fulfills Issue #57082. It introduces a high-impact, cyberpunk-style text glitch animation utility. 
+
+This effect is achieved entirely in CSS by using pseudo-elements to duplicate the text into Cyan and Magenta color channels, and then animating their `clip-path` and `transform` properties to create chaotic, erratic slicing effects.
+
+## Features
+- **Zero JavaScript:** Fully powered by CSS `@keyframes` and `clip-path: polygon()`.
+- **Intermittent Glitch:** By default, the animation plays a quick glitch burst every few seconds and remains static the rest of the time, preventing it from being overly distracting.
+- **Hover Intensification:** Hovering over the text triggers a continuous, intense glitch loop.
+- **Accessible:** Respects `prefers-reduced-motion` by completely hiding the glitch layers and disabling the animation for users with vestibular disorders.
+
+## Usage
+Simply add the `.ease-text-glitch` class to any text element. **Crucially**, you must also provide the exact same text content in the `data-text` attribute, as the CSS pseudo-elements rely on this to create the color channels.
+
+```html
+<h1 class="ease-text-glitch" data-text="ERROR 404">ERROR 404</h1>
+```
+
+## Files Included
+- `demo.html`: A presentation of the glitch effect.
+- `style.css`: The component CSS, ready to be integrated into the core framework.
+- `README.md`: This documentation.

--- a/submissions/examples/ease-text-glitch/demo.html
+++ b/submissions/examples/ease-text-glitch/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Glitch Effect Demo</title>
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      background-color: #0f172a; /* Dark background for better contrast */
+      font-family: 'Courier New', Courier, monospace; /* Monospace looks best with glitch */
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 2rem;
+      color: white;
+    }
+    
+    h1 {
+      font-size: 4rem;
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+
+    p {
+      color: #94a3b8;
+      margin-top: 2rem;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Notice the data-text attribute is required and must match the text content -->
+  <h1 class="ease-text-glitch" data-text="CYBERPUNK">CYBERPUNK</h1>
+  
+  <p>Hover over the text (or wait for the random interval) to see the glitch effect.</p>
+
+</body>
+</html>

--- a/submissions/examples/ease-text-glitch/style.css
+++ b/submissions/examples/ease-text-glitch/style.css
@@ -1,0 +1,99 @@
+/* =========================================
+   EaseMotion - Text Glitch Effect
+   ========================================= */
+
+/* 
+ * The Base Class
+ * Must be position: relative so pseudo-elements align correctly.
+ */
+.ease-text-glitch {
+  position: relative;
+  display: inline-block;
+  /* Prevent the glitch layers from bleeding out of the document flow */
+  transform: translateZ(0); 
+}
+
+/* 
+ * The Glitch Layers
+ * We use ::before and ::after to duplicate the text exactly on top of the original.
+ * They pull their text from the data-text HTML attribute.
+ */
+.ease-text-glitch::before,
+.ease-text-glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.8;
+}
+
+/* Layer 1: The Cyan Channel (shifted left slightly) */
+.ease-text-glitch::before {
+  left: 2px;
+  text-shadow: -2px 0 #0ff;
+  /* 
+   * A continuous glitch animation, mostly pausing, 
+   * occasionally bursting.
+   */
+  animation: ease-glitch-anim-1 2.5s infinite linear alternate-reverse;
+}
+
+/* Layer 2: The Magenta Channel (shifted right slightly) */
+.ease-text-glitch::after {
+  left: -2px;
+  text-shadow: -2px 0 #f0f;
+  animation: ease-glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+/* 
+ * The Animation Keyframes
+ * We use clip-path to slice horizontal chunks of the text and 
+ * shift them back and forth erratically.
+ */
+@keyframes ease-glitch-anim-1 {
+  0% { clip-path: polygon(0 20%, 100% 20%, 100% 21%, 0 21%); transform: translate(0); }
+  2% { clip-path: polygon(0 33%, 100% 33%, 100% 33%, 0 33%); transform: translate(-2px, 1px); }
+  4% { clip-path: polygon(0 44%, 100% 44%, 100% 44%, 0 44%); transform: translate(0); }
+  5% { clip-path: polygon(0 50%, 100% 50%, 100% 20%, 0 20%); transform: translate(2px, -1px); }
+  6% { clip-path: polygon(0 70%, 100% 70%, 100% 70%, 0 70%); transform: translate(0); }
+  7% { clip-path: polygon(0 80%, 100% 80%, 100% 80%, 0 80%); transform: translate(-2px, 1px); }
+  8% { clip-path: polygon(0 50%, 100% 50%, 100% 55%, 0 55%); transform: translate(0); }
+  9% { clip-path: polygon(0 70%, 100% 70%, 100% 80%, 0 80%); transform: translate(2px, -1px); }
+  /* Pause the animation for the rest of the duration */
+  10%, 100% { clip-path: polygon(0 0, 0 0, 0 0, 0 0); transform: translate(0); }
+}
+
+@keyframes ease-glitch-anim-2 {
+  0% { clip-path: polygon(0 25%, 100% 25%, 100% 30%, 0 30%); transform: translate(0); }
+  2% { clip-path: polygon(0 3%, 100% 3%, 100% 3%, 0 3%); transform: translate(2px, -1px); }
+  4% { clip-path: polygon(0 5%, 100% 5%, 100% 20%, 0 20%); transform: translate(0); }
+  5% { clip-path: polygon(0 20%, 100% 20%, 100% 20%, 0 20%); transform: translate(-2px, 1px); }
+  6% { clip-path: polygon(0 40%, 100% 40%, 100% 40%, 0 40%); transform: translate(0); }
+  7% { clip-path: polygon(0 52%, 100% 52%, 100% 59%, 0 59%); transform: translate(2px, -1px); }
+  8% { clip-path: polygon(0 60%, 100% 60%, 100% 60%, 0 60%); transform: translate(0); }
+  9% { clip-path: polygon(0 75%, 100% 75%, 100% 75%, 0 75%); transform: translate(-2px, 1px); }
+  /* Pause the animation for the rest of the duration */
+  10%, 100% { clip-path: polygon(0 0, 0 0, 0 0, 0 0); transform: translate(0); }
+}
+
+/* Hover override: Trigger intense glitch on hover */
+.ease-text-glitch:hover::before {
+  animation: ease-glitch-anim-1 0.3s infinite linear alternate-reverse;
+}
+.ease-text-glitch:hover::after {
+  animation: ease-glitch-anim-2 0.3s infinite linear alternate-reverse;
+}
+
+
+/* =========================================
+   Accessibility
+   ========================================= */
+@media (prefers-reduced-motion: reduce) {
+  .ease-text-glitch::before,
+  .ease-text-glitch::after {
+    animation: none !important;
+    display: none !important; /* Hide the layers entirely to prevent any jarring colors */
+  }
+}


### PR DESCRIPTION
Closes #57082

## Description
This PR addresses issue #57082 by introducing a high-impact, cyberpunk-style text glitch animation utility (`.ease-text-glitch`).

Following the GSSoC guidelines, the component code, documentation, and interactive demo have been submitted to the `submissions/examples/ease-text-glitch/` directory.

## Changes Made
- Created `submissions/examples/ease-text-glitch/demo.html` to showcase the glitch effect applied to a large headline.
- Created `submissions/examples/ease-text-glitch/style.css`. This implementation uses `::before` and `::after` pseudo-elements (pulling text from a `data-text` attribute) to create Cyan and Magenta color channels via `text-shadow`. Complex `@keyframes` using `clip-path: polygon()` slice the text horizontally and shift it erratically.
- Created `submissions/examples/ease-text-glitch/README.md` containing usage documentation.

## Animation Details & Accessibility
By default, the animation plays a quick glitch burst every few seconds and remains static the rest of the time, preventing it from being overly distracting. However, hovering over the text triggers a continuous, intense glitch loop.

As with all EaseMotion utilities, it respects `prefers-reduced-motion`. For users with vestibular disorders, the glitch layers are hidden entirely and the animation is disabled, ensuring a safe browsing experience.

## How to Test
1. Check out this branch.
2. Open `submissions/examples/ease-text-glitch/demo.html` in your browser.
3. Wait a few seconds to see the intermittent glitch bursts, or hover over the text to see the intense continuous glitch.