### PR TITLE
fix(breadcrumb): optimize stylesheet for print media

### DIFF
--- a/submissions/examples/fix-breadcrumb-print-optimization/README.md
+++ b/submissions/examples/fix-breadcrumb-print-optimization/README.md
@@ -1,0 +1,11 @@
+# Fix ease-breadcrumb Print Optimization
+
+## Description
+Applies a `@media print` query block to the `breadcrumb` component. This removes ink-heavy features such as linear-gradients, background-colors, and box-shadows, replacing them with standard high-contrast black borders for readable physical prints.
+
+## Usage
+Include the component as usual. When the document is printed, the browser automatically applies the media query overrides.
+
+## Performance & Accessibility Compliance
+Prevents ink waste and guarantees maximum contrast on physical paper.
+Fixes: #57140

--- a/submissions/examples/fix-breadcrumb-print-optimization/demo.html
+++ b/submissions/examples/fix-breadcrumb-print-optimization/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Print Optimization Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        max-width: 800px;
+        margin: 0 auto;
+        line-height: 1.5;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+        margin-top: 2rem;
+        padding: 2.5rem;
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        color: #1e3a8a;
+        margin-bottom: 2rem;
+    }
+    @media print {
+        body {
+            background-color: #ffffff;
+            padding: 0;
+        }
+        .instructions, h1 {
+            display: none !important;
+        }
+        .demo-container {
+            border: none !important;
+            box-shadow: none !important;
+            padding: 0 !important;
+        }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>ease-breadcrumb Print Optimization Demo</h1>
+
+    <div class="instructions">
+        <p><strong>Testing instructions:</strong></p>
+        <ol>
+            <li>Observe the screen styling: it contains gradients and soft drop-shadows.</li>
+            <li>Press <code>Ctrl + P</code> (or <code>Cmd + P</code> on macOS) to launch the browser print preview.</li>
+            <li>Verify in the preview that gradients and shadows are entirely stripped, and the component renders as a simple black-bordered container to preserve ink and ensure maximum contrast.</li>
+        </ol>
+    </div>
+
+    <div class="demo-container">
+      <h2>Accessible Component</h2>
+
+      <div class="ease-breadcrumb">
+        <h3>Printable Content</h3>
+        <p>This layout is optimized for print media. When printed, it preserves ink and keeps high contrast.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fix-breadcrumb-print-optimization/style.css
+++ b/submissions/examples/fix-breadcrumb-print-optimization/style.css
@@ -1,0 +1,63 @@
+/* 
+ * Fix for ease-breadcrumb print optimization
+ * This stylesheet implements the @media print query 
+ * to optimize ink usage and readability when printing.
+ * 
+ * Changes include:
+ * 1. Removing background images, gradients, and shadows
+ * 2. Forcing backgrounds to transparent
+ * 3. Forcing text color to dark gray or black
+ * 4. Ensuring page break properties prevent awkward split content
+ */
+
+.ease-breadcrumb {
+    /* Base styles for screens */
+    position: relative;
+    box-sizing: border-box;
+    background: linear-gradient(135deg, var(--ease-color-primary, #2563eb), var(--ease-color-secondary, #4f46e5));
+    color: #ffffff;
+    border-radius: var(--ease-radius-md, 4px);
+    padding: 1.5rem;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    border: 1px solid transparent;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ease-breadcrumb:hover {
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.15), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    transform: translateY(-2px);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY & PRINT FIX
+ * Optimizes rendering on physical paper 
+ */
+@media print {
+    .ease-breadcrumb {
+        /* Strip out colors and gradients to save ink */
+        background: transparent !important;
+        background-color: transparent !important;
+        color: #000000 !important;
+
+        /* Replace shadow with a simple high-contrast thin border */
+        box-shadow: none !important;
+        border: 1px solid #000000 !important;
+
+        /* Reset transitions and scale transforms */
+        transition: none !important;
+        transform: none !important;
+
+        /* Keep the content together during pagination */
+        page-break-inside: avoid !important;
+        break-inside: avoid !important;
+
+        /* Ensure all child text elements inherit print black */
+        text-shadow: none !important;
+    }
+
+    .ease-breadcrumb * {
+        color: #000000 !important;
+        background: transparent !important;
+        text-shadow: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Fixes #57140.

The `breadcrumb` component contains heavy gradients, box-shadows, and background colors that are not optimized for printing. This PR introduces a `@media print` query that strips away these ink-heavy features, replacing them with standard high-contrast borders for physical paper printing.

### Changes Made
* `style.css`: Comprehensive CSS fix adding print media styles.
* `demo.html`: Interactive demo with print preview layout.
* `README.md`: Describes the fix and usage.

### Checklist
* [x] I have followed the contribution guidelines
* [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags
* [x] `style.css` has original, meaningful CSS (50+ lines)
* [x] `README.md` included
* [x] Files placed in `submissions/examples/fix-breadcrumb-print-optimization/`
* [x] No edits to `core/` or `components/`
* [x] Single squashed commit following conventional-commit format
* [x] Over 50 lines of code added to ensure comprehensive fixes