### PR TITLE
feat: add CSS scale-hover tabs for gaming hub layouts

### DIFF
--- a/submissions/examples/css-scale-hover-tabs-gaming/README.md
+++ b/submissions/examples/css-scale-hover-tabs-gaming/README.md
@@ -1,0 +1,46 @@
+# CSS Scale-Hover Tabs (Gaming Hub)
+
+A pure CSS tabs component styled as a gaming hub category browser, with a sliding indicator bar and a scale-hover effect on each trigger. No JavaScript, no dependencies.
+
+## How it works
+
+This builds on the same radio-hack pattern used in tabs elsewhere in the framework, with one addition: a sliding indicator bar under the tab row. Since all four tabs sit in an equal-width CSS Grid, each one occupies a known 25% slice, so the indicator can move to the correct tab purely with `translateX(0%, 100%, 200%, 300%)` based on which radio is checked — no JavaScript measuring of tab positions needed.
+
+The hover scale on each trigger is deliberately transform-only, so it never affects the grid layout or shifts the indicator's math, even while a tab is being hovered and another is active at the same time.
+
+## Files
+
+- `demo.html` – a 4-tab gaming category browser (Action, RPG, Strategy, Indie)
+- `style.css` – all styling, custom properties, sliding indicator, and hover scale
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-tabs-duration` – 0.3s
+- `--ease-tabs-easing` – cubic-bezier(0.4, 0, 0.2, 1)
+- `--ease-tabs-radius` – 8px
+- `--ease-tabs-bg` – panel background
+- `--ease-tabs-border` – border color
+- `--ease-tabs-text` – inactive tab text color
+- `--ease-tabs-active-text` – active tab / panel text color
+- `--ease-tabs-accent` – indicator bar color
+- `--ease-tabs-accent-glow` – indicator glow color
+- `--ease-tabs-hover-scale` – how much a tab scales on hover (1.08 = 8%)
+
+Example override:
+
+```css
+:root {
+  --ease-tabs-accent: #ef4444;
+  --ease-tabs-accent-glow: rgba(239, 68, 68, 0.35);
+}
+```
+
+## Notes
+
+- If you add or remove tabs, update both the grid column count and the indicator's `translateX` percentages to match (currently built for exactly 4 equal-width tabs)
+- Fully responsive, with breakpoints at 768px and 480px
+- Radio/label pairing keeps tabs keyboard-navigable by default
+- Respects `prefers-reduced-motion` — hover scale, indicator sliding, and the panel entrance animation are all disabled for users who have that set

--- a/submissions/examples/css-scale-hover-tabs-gaming/demo.html
+++ b/submissions/examples/css-scale-hover-tabs-gaming/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scale-Hover Tabs — Gaming Hub</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Game Library</p>
+    <h1 class="ease-heading">Browse by Category</h1>
+    <p class="ease-subtitle">Pure CSS tabs with a sliding indicator and scale-hover, built for a gaming hub.</p>
+
+    <div class="ease-tabs">
+
+      <input type="radio" name="ease-tabs-gaming-group" id="ease-tab-action" class="ease-tabs-input" checked />
+      <input type="radio" name="ease-tabs-gaming-group" id="ease-tab-rpg" class="ease-tabs-input" />
+      <input type="radio" name="ease-tabs-gaming-group" id="ease-tab-strategy" class="ease-tabs-input" />
+      <input type="radio" name="ease-tabs-gaming-group" id="ease-tab-indie" class="ease-tabs-input" />
+
+      <div class="ease-tabs-list" role="tablist">
+        <label for="ease-tab-action" class="ease-tabs-trigger">Action</label>
+        <label for="ease-tab-rpg" class="ease-tabs-trigger">RPG</label>
+        <label for="ease-tab-strategy" class="ease-tabs-trigger">Strategy</label>
+        <label for="ease-tab-indie" class="ease-tabs-trigger">Indie</label>
+        <div class="ease-tabs-indicator" aria-hidden="true"></div>
+      </div>
+
+      <div class="ease-tabs-panels">
+        <div class="ease-tabs-panel ease-tabs-panel-action">
+          <h2>Action</h2>
+          <p>Fast-paced titles built around reflexes and combat. Currently trending: Nova Strike, Ember Rush.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-rpg">
+          <h2>RPG</h2>
+          <p>Deep character progression and story-driven worlds. Currently trending: Fable Depths, Ashfall.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-strategy">
+          <h2>Strategy</h2>
+          <p>Slower-paced planning and resource management. Currently trending: Dominion, Copper Fields.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-indie">
+          <h2>Indie</h2>
+          <p>Smaller studio releases with distinct art styles. Currently trending: Paperbound, Static Bloom.</p>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-scale-hover-tabs-gaming/style.css
+++ b/submissions/examples/css-scale-hover-tabs-gaming/style.css
@@ -1,0 +1,200 @@
+:root {
+  --ease-tabs-duration: 0.3s;
+  --ease-tabs-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-tabs-radius: 8px;
+  --ease-tabs-bg: #16181d;
+  --ease-tabs-border: #2a2d34;
+  --ease-tabs-text: #a8a8a8;
+  --ease-tabs-active-text: #f0f0f0;
+  --ease-tabs-accent: #7c3aed;
+  --ease-tabs-accent-glow: rgba(124, 58, 237, 0.35);
+  --ease-tabs-hover-scale: 1.08;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-tabs-active-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-tabs-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-tabs-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-tabs-list {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--ease-tabs-border);
+  margin-bottom: 1.5rem;
+}
+
+.ease-tabs-trigger {
+  text-align: center;
+  padding: 0.7rem 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ease-tabs-text);
+  cursor: pointer;
+  transition: color var(--ease-tabs-duration) var(--ease-tabs-easing),
+              transform var(--ease-tabs-duration) var(--ease-tabs-easing);
+  position: relative;
+  z-index: 1;
+}
+
+/* hover scale is transform-only, so it never disturbs the grid layout
+   or the sliding indicator's math */
+.ease-tabs-trigger:hover {
+  transform: scale(var(--ease-tabs-hover-scale));
+}
+
+/* sliding indicator bar, one quarter of the row wide, moved with translateX */
+.ease-tabs-indicator {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 25%;
+  height: 2px;
+  background: var(--ease-tabs-accent);
+  box-shadow: 0 0 8px var(--ease-tabs-accent-glow);
+  transition: transform var(--ease-tabs-duration) var(--ease-tabs-easing);
+}
+
+#ease-tab-action:checked ~ .ease-tabs-list .ease-tabs-indicator {
+  transform: translateX(0%);
+}
+#ease-tab-rpg:checked ~ .ease-tabs-list .ease-tabs-indicator {
+  transform: translateX(100%);
+}
+#ease-tab-strategy:checked ~ .ease-tabs-list .ease-tabs-indicator {
+  transform: translateX(200%);
+}
+#ease-tab-indie:checked ~ .ease-tabs-list .ease-tabs-indicator {
+  transform: translateX(300%);
+}
+
+#ease-tab-action:checked ~ .ease-tabs-list label[for="ease-tab-action"],
+#ease-tab-rpg:checked ~ .ease-tabs-list label[for="ease-tab-rpg"],
+#ease-tab-strategy:checked ~ .ease-tabs-list label[for="ease-tab-strategy"],
+#ease-tab-indie:checked ~ .ease-tabs-list label[for="ease-tab-indie"] {
+  color: var(--ease-tabs-active-text);
+}
+
+.ease-tabs-panel {
+  display: none;
+  background: var(--ease-tabs-bg);
+  border: 1px solid var(--ease-tabs-border);
+  border-radius: var(--ease-tabs-radius);
+  padding: 1.25rem;
+}
+
+.ease-tabs-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.ease-tabs-panel p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #a8a8a8;
+  line-height: 1.6;
+}
+
+#ease-tab-action:checked ~ .ease-tabs-panels .ease-tabs-panel-action,
+#ease-tab-rpg:checked ~ .ease-tabs-panels .ease-tabs-panel-rpg,
+#ease-tab-strategy:checked ~ .ease-tabs-panels .ease-tabs-panel-strategy,
+#ease-tab-indie:checked ~ .ease-tabs-panels .ease-tabs-panel-indie {
+  display: block;
+  animation: ease-tabs-panel-in 0.3s var(--ease-tabs-easing);
+}
+
+@keyframes ease-tabs-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-tabs-trigger {
+    font-size: 0.75rem;
+    padding: 0.6rem 0.3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-trigger {
+    transition: none !important;
+  }
+
+  .ease-tabs-trigger:hover {
+    transform: none;
+  }
+
+  .ease-tabs-indicator {
+    transition: none !important;
+  }
+
+  .ease-tabs-panel {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML scale-hover tabs component with a sliding indicator bar, styled as a gaming hub category browser, per issue #56399.

---

## Type of Change
- [x] 🧩 New component
- [x] ✨ New animation / hover effect


---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-scale-hover-tabs-gaming/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A tabs component with a sliding indicator bar that moves under the active tab, plus a scale-hover effect on each trigger, styled as a gaming category browser.

**How does a developer use it?**
```html
<input type="radio" name="ease-tabs-gaming-group" id="ease-tab-action" class="ease-tabs-input" checked />
<label for="ease-tab-action" class="ease-tabs-trigger">Action</label>
<div class="ease-tabs-indicator"></div>
<div class="ease-tabs-panel ease-tabs-panel-action">...</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-tabs-indicator`, `ease-tabs-trigger`), zero dependencies, and it extends the framework's existing radio-hack tabs pattern with a sliding indicator computed purely via CSS Grid + `translateX` percentages, no JavaScript measuring required. The hover scale is kept transform-only and deliberately isolated from the indicator's position math so the two effects never visually conflict.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Indicator position is tied to a 4-column CSS Grid — if the tab count changes, both the grid columns and the indicator's `translateX` percentages need updating together (documented in the README). Respects `prefers-reduced-motion`.