### PR TITLE
feat: add CSS zoom-in popover for gaming hub layouts

### DIFF
--- a/submissions/examples/css-zoom-in-popover/README.md
+++ b/submissions/examples/css-zoom-in-popover/README.md
@@ -1,0 +1,43 @@
+# CSS Zoom-In Popover
+
+A pure CSS popover styled as a player stats breakdown, click-triggered with a zoom-in entrance. No JavaScript, no dependencies.
+
+## How it works
+
+Unlike a hover-tooltip, this popover stays open once clicked, since it's driven by a checkbox rather than `:hover`. The trigger label toggles the checkbox, and the popover itself scales in from `scale(0.85)` to `scale(1)` with `transform-origin: top left`, anchored at the corner nearest the trigger.
+
+A second label inside the popover, also tied to the same checkbox, acts as a close button.
+
+## Files
+
+- `demo.html` – a "view breakdown" trigger revealing a season stats popover
+- `style.css` – all styling, custom properties, and the zoom-in transition
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-popover-duration` – 0.25s
+- `--ease-popover-easing` – cubic-bezier(0.34, 1.56, 0.64, 1) (slight overshoot for a springy zoom)
+- `--ease-popover-radius` – 10px
+- `--ease-popover-bg` – popover background
+- `--ease-popover-border` – border color
+- `--ease-popover-text` – heading text color
+- `--ease-popover-muted-text` – stat label color
+- `--ease-popover-accent` – close button color
+
+Example override:
+
+```css
+:root {
+  --ease-popover-accent: #22c55e;
+  --ease-popover-duration: 0.2s;
+}
+```
+
+## Notes
+
+- Click-triggered rather than hover-triggered, so it works on touch devices too
+- Fully responsive; popover width shrinks slightly at the 480px breakpoint
+- Respects `prefers-reduced-motion` — the popover appears/disappears instantly with no zoom

--- a/submissions/examples/css-zoom-in-popover/demo.html
+++ b/submissions/examples/css-zoom-in-popover/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Zoom-In Popover — Gaming Hub</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Player Stats</p>
+    <h1 class="ease-heading">Season Rankings</h1>
+    <p class="ease-subtitle">A pure CSS click-triggered popover with a zoom-in entrance.</p>
+
+    <div class="ease-popover-wrapper">
+      <input type="checkbox" id="ease-popover-toggle" class="ease-popover-input" />
+      <label for="ease-popover-toggle" class="ease-popover-trigger">Rank #12 &middot; View Breakdown</label>
+
+      <div class="ease-popover">
+        <h2>Season Breakdown</h2>
+        <ul class="ease-popover-list">
+          <li><span>Wins</span><span>142</span></li>
+          <li><span>Losses</span><span>98</span></li>
+          <li><span>Win Rate</span><span>59%</span></li>
+          <li><span>Best Streak</span><span>11</span></li>
+        </ul>
+        <label for="ease-popover-toggle" class="ease-popover-close">Close</label>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-zoom-in-popover/style.css
+++ b/submissions/examples/css-zoom-in-popover/style.css
@@ -1,0 +1,151 @@
+:root {
+  --ease-popover-duration: 0.25s;
+  --ease-popover-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-popover-radius: 10px;
+  --ease-popover-bg: #16181d;
+  --ease-popover-border: #2a2d34;
+  --ease-popover-text: #f0f0f0;
+  --ease-popover-muted-text: #a8a8a8;
+  --ease-popover-accent: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-popover-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-popover-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+.ease-popover-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-popover-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-popover-trigger {
+  display: inline-block;
+  padding: 0.65rem 1.2rem;
+  border-radius: 8px;
+  border: 1px solid var(--ease-popover-border);
+  background: var(--ease-popover-bg);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.ease-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  width: 240px;
+  background: var(--ease-popover-bg);
+  border: 1px solid var(--ease-popover-border);
+  border-radius: var(--ease-popover-radius);
+  padding: 1.1rem;
+  transform-origin: top left;
+  opacity: 0;
+  transform: scale(0.85);
+  pointer-events: none;
+  transition: opacity var(--ease-popover-duration) var(--ease-popover-easing),
+              transform var(--ease-popover-duration) var(--ease-popover-easing);
+}
+
+.ease-popover-input:checked ~ .ease-popover {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.ease-popover h2 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+}
+
+.ease-popover-list {
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+}
+
+.ease-popover-list li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--ease-popover-border);
+}
+
+.ease-popover-list li:last-child {
+  border-bottom: none;
+}
+
+.ease-popover-list li span:first-child {
+  color: var(--ease-popover-muted-text);
+}
+
+.ease-popover-list li span:last-child {
+  font-weight: 600;
+}
+
+.ease-popover-close {
+  display: inline-block;
+  font-size: 0.8rem;
+  color: var(--ease-popover-accent);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.4rem;
+  }
+
+  .ease-popover {
+    width: 200px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-popover {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS/HTML zoom-in popover component styled as a player stats breakdown, per issue #56413.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-zoom-in-popover/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A click-triggered popover with a springy zoom-in entrance, showing a stats breakdown anchored to its trigger.

**How does a developer use it?**
```html
<div class="ease-popover-wrapper">
  <input type="checkbox" id="ease-popover-toggle" class="ease-popover-input" />
  <label for="ease-popover-toggle" class="ease-popover-trigger">View Breakdown</label>
  <div class="ease-popover">...</div>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-popover-trigger`, `ease-popover-list`), zero dependencies, and it's click-triggered rather than hover-only (unlike a tooltip), which makes it usable on touch devices. Uses `transform-origin` to anchor the zoom at the corner nearest the trigger for a natural-feeling entrance.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Click-triggered via checkbox rather than `:hover`, so it works on touch devices and stays open until dismissed. Uses a slight overshoot easing curve for a springy zoom feel. Respects `prefers-reduced-motion`.