### PR TITLE
feat: add float drift stepper for creative portfolio layouts

### DIFF
--- a/submissions/examples/float-drift-stepper-creative-portfolio-sd/README.md
+++ b/submissions/examples/float-drift-stepper-creative-portfolio-sd/README.md
@@ -1,0 +1,29 @@
+# Float-Drift Stepper
+
+CSS-only stepper with a gentle float-drift motion on the active step.
+
+## Usage
+
+```html
+<ol class="float-drift-stepper">
+  <li class="step active">Ideate</li>
+  <li class="step">Create</li>
+  <li class="step">Launch</li>
+</ol>
+```
+
+Add `.active` to the current step.
+
+## CSS Custom Properties
+
+| Property                   | Default   | Description           |
+| -------------------------- | --------- | --------------------- |
+| `--stepper-duration`       | `0.4s`    | Animation duration    |
+| `--stepper-easing`         | `ease`    | Animation easing      |
+| `--stepper-accent-color`   | `#0891b2` | Active step color     |
+| `--stepper-drift-distance` | `6px`     | Upward float distance |
+| `--stepper-size`           | `2.75rem` | Step indicator size   |
+
+## Why?
+
+Lightweight, pure CSS, responsive, honors reduced motion, and easy to theme via custom properties.

--- a/submissions/examples/float-drift-stepper-creative-portfolio-sd/demo.html
+++ b/submissions/examples/float-drift-stepper-creative-portfolio-sd/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Float-Drift Stepper</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      body {
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: 0;
+        background: #fafafa;
+        font-family: system-ui, sans-serif;
+      }
+      .float-drift-stepper {
+        max-width: 28rem;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <ol class="float-drift-stepper">
+      <li class="step active">Ideate</li>
+      <li class="step">Create</li>
+      <li class="step">Launch</li>
+    </ol>
+  </body>
+</html>

--- a/submissions/examples/float-drift-stepper-creative-portfolio-sd/style.css
+++ b/submissions/examples/float-drift-stepper-creative-portfolio-sd/style.css
@@ -1,0 +1,100 @@
+.float-drift-stepper {
+  --stepper-duration: 0.4s;
+  --stepper-easing: ease;
+  --stepper-accent-color: #0891b2;
+  --stepper-drift-distance: 6px;
+  --stepper-size: 2.75rem;
+
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  counter-reset: step;
+}
+
+.float-drift-stepper .step {
+  flex: 1;
+  position: relative;
+  text-align: center;
+  counter-increment: step;
+  font:
+    700 0.85rem/1.4 system-ui,
+    sans-serif;
+  color: #6b7280;
+}
+
+.float-drift-stepper .step::before {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--stepper-size);
+  height: var(--stepper-size);
+  margin: 0 auto 0.5rem;
+  border-radius: 50%;
+  background: #e5e7eb;
+  color: #6b7280;
+  font-size: 0.9em;
+  content: counter(step);
+  transition: all var(--stepper-duration) var(--stepper-easing);
+}
+
+.float-drift-stepper .step.active::before {
+  background: var(--stepper-accent-color);
+  color: #fff;
+  transform: translateY(calc(var(--stepper-drift-distance) * -1));
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.float-drift-stepper .step:not(:last-child)::after {
+  position: absolute;
+  top: calc(var(--stepper-size) / 2);
+  left: calc(50% + var(--stepper-size) / 2 + 2px);
+  width: calc(100% - var(--stepper-size) - 4px);
+  height: 2px;
+  background: #e5e7eb;
+  content: "";
+  z-index: -1;
+}
+
+@media (max-width: 480px) {
+  .float-drift-stepper {
+    flex-direction: column;
+    gap: 1.5rem;
+    width: fit-content;
+    position: relative;
+  }
+
+  .float-drift-stepper::before {
+    position: absolute;
+    top: calc(var(--stepper-size) / 2);
+    bottom: calc(var(--stepper-size) / 2);
+    left: calc(var(--stepper-size) / 2);
+    width: 2px;
+    background: #e5e7eb;
+    content: "";
+    z-index: -1;
+  }
+
+  .float-drift-stepper .step {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    text-align: left;
+    width: 100%;
+  }
+
+  .float-drift-stepper .step::before {
+    margin: 0;
+    flex-shrink: 0;
+  }
+
+  .float-drift-stepper .step:not(:last-child)::after {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .float-drift-stepper .step::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS stepper featuring a subtle float-drift animation styled for creative portfolio interfaces. The component is responsive, lightweight, customizable through CSS custom properties, and includes prefers-reduced-motion support.

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS stepper with a float-drift effect that subtly lifts and highlights the active step.

**How does a developer use it?**

```html
<div class="float-drift-stepper">
  <!-- steps -->
</div>
```

**Why does it fit EaseMotion CSS?**

It provides a lightweight, reusable animation pattern that enhances visual feedback while remaining customizable, performant, and JavaScript-free.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

* Pure CSS implementation.
* Includes float-drift animation.
* Includes prefers-reduced-motion support.
* Responsive by default.
* Customizable through CSS variables.

Closes #56363
