### PR TITLE
50253 responsive dashboard slide right tabs

### DIFF
--- a/submissions/examples/responsive-dashboard-slide-right-tabs/README.md
+++ b/submissions/examples/responsive-dashboard-slide-right-tabs/README.md
@@ -1,0 +1,24 @@
+# CSS Slide-Right Tabs (Responsive Dashboard)
+
+A robust, purely CSS-driven tabbed interface engineered specifically for responsive dashboards and admin panels. It features a clever flex-layout that transforms from a top horizontal tab bar on mobile directly into a left-hand sidebar navigation on desktop viewports.
+
+## 🚀 Features
+
+- **Zero JavaScript:** Built entirely using HTML state management via hidden radio inputs, ensuring perfect reliability for admin interfaces.
+- **Dynamic Flexbox Layout:** On mobile, tabs sit horizontally above the content. At `640px` and wider, the flex direction pivots, creating a seamless sidebar navigation UI while preserving the slide-right animation context.
+- **Slide-Right Transition:** Employs a crisp `em-slide-right` `@keyframes` sequence that smoothly translates content into view, giving the panels a native desktop app feel.
+- **Accessible & Clean:** Styled with modern dashboard aesthetics (Slate grays, crisp borders, soft drop-shadows). Fully keyboard navigable via `tabindex="0"` and perfectly honors `@media (prefers-reduced-motion: reduce)`.
+
+## 🛠️ Usage
+
+Copy the HTML from `demo.html` and link the styles from `style.css`. The internal content includes mock components like status bars and metric grids typical for dashboard data presentation.
+
+### CSS Custom Properties
+Adjust the primary branding and animation timing via the `:root` pseudo-class:
+
+```css
+:root {
+    --em-brand: #0ea5e9;           /* Main dashboard action color */
+    --em-slide-offset: -25px;      /* Starting offset for the slide animation */
+    --em-transition-speed: 0.35s;  /* Speed of the slide-right reveal */
+}

--- a/submissions/examples/responsive-dashboard-slide-right-tabs/demo.html
+++ b/submissions/examples/responsive-dashboard-slide-right-tabs/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Right Tabs - EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="dashboard-wrapper">
+        <header class="dashboard-header">
+            <h1>System Dashboard</h1>
+            <p>Responsive slide-right tabs engineered for complex data layouts and admin panels.</p>
+        </header>
+
+        <div class="em-tabs-container">
+            <input type="radio" id="em-tab-1" name="em-tabs" class="em-tab-input" checked>
+            <input type="radio" id="em-tab-2" name="em-tabs" class="em-tab-input">
+            <input type="radio" id="em-tab-3" name="em-tabs" class="em-tab-input">
+
+            <div class="em-tabs-header">
+                <label for="em-tab-1" class="em-tab-label" tabindex="0">Overview</label>
+                <label for="em-tab-2" class="em-tab-label" tabindex="0">Performance</label>
+                <label for="em-tab-3" class="em-tab-label" tabindex="0">Security</label>
+            </div>
+
+            <div class="em-tabs-content">
+                <div class="em-tab-panel" id="em-panel-1">
+                    <div class="dash-card">
+                        <h2>System Health</h2>
+                        <p>All primary nodes are operating within normal parameters. Storage capacity is currently at 68%.</p>
+                        <div class="status-bar">
+                            <div class="status-fill" style="width: 68%;"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-2">
+                    <div class="dash-card">
+                        <h2>Network Latency</h2>
+                        <p>Average response time across all regions is 42ms. No packet loss detected in the last 24 hours.</p>
+                        <div class="metrics-grid">
+                            <div class="metric">US-East: 38ms</div>
+                            <div class="metric">EU-West: 45ms</div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-3">
+                    <div class="dash-card">
+                        <h2>Active Threats</h2>
+                        <p>Firewall has successfully blocked 1,204 unauthorized access attempts today. Signatures are up to date.</p>
+                        <button class="action-btn">View Security Logs</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/submissions/examples/responsive-dashboard-slide-right-tabs/style.css
+++ b/submissions/examples/responsive-dashboard-slide-right-tabs/style.css
@@ -1,0 +1,216 @@
+:root {
+    --em-bg-app: #f1f5f9;
+    --em-bg-surface: #ffffff;
+    --em-text-primary: #0f172a;
+    --em-text-secondary: #64748b;
+    --em-brand: #0ea5e9;
+    --em-brand-hover: #0284c7;
+    --em-border: #e2e8f0;
+    --em-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    
+    --em-slide-offset: -25px;
+    --em-transition-speed: 0.35s;
+    --em-easing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+body {
+    margin: 0;
+    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+    background-color: var(--em-bg-app);
+    color: var(--em-text-primary);
+    display: flex;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+}
+
+.dashboard-wrapper {
+    max-width: 900px;
+    width: 100%;
+}
+
+.dashboard-header {
+    margin-bottom: 2rem;
+}
+
+.dashboard-header h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem 0;
+    color: var(--em-text-primary);
+}
+
+.dashboard-header p {
+    color: var(--em-text-secondary);
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.em-tabs-container {
+    width: 100%;
+    background: var(--em-bg-surface);
+    border-radius: 0.75rem;
+    box-shadow: var(--em-shadow);
+    border: 1px solid var(--em-border);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.em-tab-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.em-tabs-header {
+    display: flex;
+    background-color: #f8fafc;
+    border-bottom: 1px solid var(--em-border);
+}
+
+.em-tab-label {
+    flex: 1;
+    padding: 1rem;
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--em-text-secondary);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.em-tab-label:hover {
+    color: var(--em-text-primary);
+    background-color: #f1f5f9;
+}
+
+.em-tabs-content {
+    padding: 2rem;
+    min-height: 250px;
+    background: var(--em-bg-surface);
+    flex: 1;
+}
+
+.em-tab-panel {
+    display: none;
+    animation: em-slide-right var(--em-transition-speed) var(--em-easing) forwards;
+}
+
+.dash-card h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 1rem 0;
+}
+
+.dash-card p {
+    color: var(--em-text-secondary);
+    line-height: 1.6;
+    margin: 0 0 1.5rem 0;
+}
+
+.status-bar {
+    width: 100%;
+    height: 8px;
+    background-color: var(--em-border);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.status-fill {
+    height: 100%;
+    background-color: var(--em-brand);
+    border-radius: 4px;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.metric {
+    background-color: #f8fafc;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--em-border);
+    font-weight: 500;
+    font-size: 0.875rem;
+}
+
+.action-btn {
+    background-color: var(--em-brand);
+    color: #ffffff;
+    border: none;
+    padding: 0.6rem 1.2rem;
+    border-radius: 0.375rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background-color 0.2s;
+}
+
+.action-btn:hover {
+    background-color: var(--em-brand-hover);
+}
+
+#em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"],
+#em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"],
+#em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"] {
+    color: var(--em-brand);
+    border-bottom-color: var(--em-brand);
+    background-color: var(--em-bg-surface);
+}
+
+#em-tab-1:checked ~ .em-tabs-content #em-panel-1,
+#em-tab-2:checked ~ .em-tabs-content #em-panel-2,
+#em-tab-3:checked ~ .em-tabs-content #em-panel-3 {
+    display: block;
+}
+
+.em-tab-label:focus-visible {
+    outline: 2px solid var(--em-brand);
+    outline-offset: -2px;
+}
+
+@keyframes em-slide-right {
+    0% {
+        opacity: 0;
+        transform: translateX(var(--em-slide-offset));
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@media (min-width: 640px) {
+    .em-tabs-container {
+        flex-direction: row;
+    }
+    .em-tabs-header {
+        flex-direction: column;
+        width: 220px;
+        border-bottom: none;
+        border-right: 1px solid var(--em-border);
+    }
+    .em-tab-label {
+        text-align: left;
+        padding: 1.25rem 1.5rem;
+        border-bottom: none;
+        border-right: 2px solid transparent;
+    }
+    #em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"],
+    #em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"],
+    #em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"] {
+        border-bottom-color: transparent;
+        border-right-color: var(--em-brand);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .em-tab-panel {
+        animation: none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #50253 by introducing a CSS Slide-Right Tabs component, engineered explicitly to handle complex, responsive Dashboard and Admin Panel layouts for the EaseMotion CSS library.

**Key Implementations:**
* **HTML (`demo.html`)**: Implemented the hidden radio-button state architecture. The inner panels are populated with mock dashboard UI elements (`.status-bar`, `.metrics-grid`) to demonstrate real-world usage.
* **CSS (`style.css`)**: 
  * Designed the `em-slide-right` keyframe animation to translate content from `-25px` on the X-axis with a sharp `cubic-bezier(0.4, 0, 0.2, 1)` easing, perfectly mimicking native app transitions.
  * Applied a clean, high-utility aesthetic using system fonts, slate-gray text colors, and subtle box-shadows on a pristine white surface.
  * *(Note: In accordance with repository formatting rules, all HTML and CSS code comments have been fully stripped from the source files).*
* **Customization**: Centralized parameters for `--em-slide-offset`, `--em-transition-speed`, and dashboard brand colors inside the `:root` variables for rapid integration.
* **Responsiveness**: Utilized a "Mobile First" approach. By default, tabs are horizontal. At `min-width: 640px`, the `.em-tabs-container` flips to `flex-direction: row` and the header becomes a 220px wide sidebar navigation column, shifting the active border indicator from bottom to right.
* **Accessibility**: Added `tabindex="0"` to the labels with custom `:focus-visible` styling for robust keyboard accessibility. Integrated `prefers-reduced-motion` support to fall back to an instantaneous display without animations.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📄 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (specifically under `submissions/examples/responsive-dashboard-slide-right-tabs/`)
- [x] Includes `demo.html` with a clean HTML5 showcase.
- [x] Includes `style.css` with pure CSS/HTML (No external JS frameworks).
- [x] Includes `README.md` with proper documentation.
- [x] Code is fully responsive across all viewports.
- [x] Code is accessible and includes `prefers-reduced-motion` support.

Closes #50253