### PR TITLE
Fix: blog card title overflow using fluid clamp() typography and container queries

### DIFF
--- a/submissions/examples/blog-card-fluid-title-fix/README.md
+++ b/submissions/examples/blog-card-fluid-title-fix/README.md
@@ -1,0 +1,47 @@
+﻿# Blog Card — Fluid Title Overflow Fix
+
+Fixes #57061: blog card titles overflowing outside the card, overlapping adjacent content, or causing horizontal scroll on narrow screens.
+
+## How this differs from a typical fix
+
+A common fix applies overflow-wrap: break-word plus a single font-size reduction at one max-width breakpoint. That works for the viewport width the developer tested, but:
+
+- font size still jumps abruptly at the breakpoint instead of scaling smoothly
+- it only reacts to the browser viewport, not the actual width of the card's container, so the same card looks wrong in a narrow sidebar on a wide screen
+- very long titles that wrap correctly can still stretch a card several lines taller than its neighbors in a grid, with no option to keep cards visually uniform
+
+This submission addresses all three:
+
+- Fluid typography via clamp(1.05rem, 1rem + 1vw, 1.5rem), the title scales continuously with viewport width, no breakpoint jump.
+- Container Queries (container-type: inline-size), the title also resizes based on the width of its own container, so it renders correctly in a narrow sidebar even on a wide screen, which a viewport-only media query cannot do.
+- hyphens: auto alongside overflow-wrap/word-break, so very long unbroken words hyphenate instead of just breaking mid-word.
+- Optional 2-line clamp (.blog-card__title--clamped) using -webkit-line-clamp for card grids that need uniform card heights, titles beyond 2 lines truncate with an ellipsis instead of stretching the card.
+
+## Usage
+
+1. Copy `style.css` into your project.
+2. Wrap your card grid in an element with class="blog-container" (this sets up the container query context) and structure each card per demo.html: .blog-card containing .blog-card__title, .blog-card__excerpt, and .blog-card__btn.
+3. Add .blog-card__title--clamped to any title you want limited to 2 lines with an ellipsis, instead of wrapping fully.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--bc-title-min` | `1.05rem` | Minimum title font size (smallest containers/viewports) |
+| `--bc-title-max` | `1.5rem` | Maximum title font size (largest containers/viewports) |
+| `--bc-text-color` | `#222` | Title text color |
+| `--bc-muted` | `#555` | Excerpt/secondary text color |
+| `--bc-accent` | `#2563eb` | Button background color |
+| `--bc-radius` | `10px` | Card corner radius |
+| `--bc-shadow` | `0 4px 10px rgba(0,0,0,0.1)` | Card drop shadow |
+
+## Browser Support
+
+- clamp() and overflow-wrap/hyphens: supported in all modern browsers.
+- Container Queries (container-type, @container): supported in all current evergreen browsers (Chrome/Edge 105+, Firefox 110+, Safari 16+). Without support, the title still scales via clamp() and the viewport-based @media (max-width: 600px) fallback.
+- -webkit-line-clamp: widely supported across modern browsers for the optional truncated variant.
+
+## Accessibility
+
+- Text remains selectable and readable at all sizes; hyphens: auto only affects visual line breaks.
+- Truncated (--clamped) titles should be paired with a full title in the link's accessible name or a title attribute if truncation could hide important context.

--- a/submissions/examples/blog-card-fluid-title-fix/demo.html
+++ b/submissions/examples/blog-card-fluid-title-fix/demo.html
@@ -1,0 +1,59 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Blog Card — Fluid Title Overflow Fix</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="bdemo">
+    <h1 class="bdemo__title">Blog Card — Fluid Title Fix</h1>
+    <p class="bdemo__subtitle">
+      Titles scale fluidly with container width via clamp() and @container queries,
+      not just viewport breakpoints. Resize the window or the sidebar to see the difference.
+    </p>
+
+    <div class="bdemo__layout">
+      <div class="blog-container">
+        <article class="blog-card">
+          <h2 class="blog-card__title">
+            Building Highly Responsive and Accessible User Interfaces Using EaseMotion CSS Utility Classes
+          </h2>
+          <p class="blog-card__excerpt">Learn how to build modern responsive layouts using lightweight CSS utilities.</p>
+          <button class="blog-card__btn">Read more</button>
+        </article>
+
+        <article class="blog-card">
+          <h2 class="blog-card__title">Short Title Example</h2>
+          <p class="blog-card__excerpt">Cards with short titles still align and space correctly.</p>
+          <button class="blog-card__btn">Read more</button>
+        </article>
+
+        <article class="blog-card">
+          <h2 class="blog-card__title blog-card__title--clamped">
+            An Extremely Long Blog Title That Demonstrates Optional Two-Line Clamping With Ellipsis Truncation For Card Grids
+          </h2>
+          <p class="blog-card__excerpt">This card opts into the 2-line clamp + ellipsis variant.</p>
+          <button class="blog-card__btn">Read more</button>
+        </article>
+      </div>
+
+      <aside class="bdemo__sidebar">
+        <p class="bdemo__sidebar-label">Narrow container (sidebar)</p>
+        <div class="blog-container blog-container--narrow">
+          <article class="blog-card">
+            <h2 class="blog-card__title">
+              Building Highly Responsive and Accessible User Interfaces
+            </h2>
+            <p class="blog-card__excerpt">Same card, inside a narrow container, title scales down via container query, not viewport.</p>
+            <button class="blog-card__btn">Read more</button>
+          </article>
+        </div>
+      </aside>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/blog-card-fluid-title-fix/style.css
+++ b/submissions/examples/blog-card-fluid-title-fix/style.css
@@ -1,0 +1,130 @@
+﻿/* =========================================
+   Blog Card — Fluid Title Overflow Fix
+   Fixes #57061
+   Fluid clamp() typography + container-query
+   aware sizing + optional line-clamp truncation
+   ========================================= */
+
+:root {
+  --bc-title-min: 1.05rem;
+  --bc-title-max: 1.5rem;
+  --bc-text-color: #222;
+  --bc-muted: #555;
+  --bc-accent: #2563eb;
+  --bc-radius: 10px;
+  --bc-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+  padding: 30px;
+}
+
+.bdemo__title { margin-bottom: 0.25rem; color: #111; }
+.bdemo__subtitle { color: var(--bc-muted); margin-bottom: 2rem; line-height: 1.6; }
+.bdemo__sidebar-label { font-size: 0.85rem; color: var(--bc-muted); margin-bottom: 0.5rem; }
+
+.bdemo__layout {
+  display: grid;
+  grid-template-columns: 2.2fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .bdemo__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.blog-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  container-type: inline-size;
+  container-name: blog-grid;
+}
+
+.blog-container--narrow {
+  max-width: 260px;
+}
+
+.blog-card {
+  flex: 1 1 320px;
+  max-width: 360px;
+  background: #fff;
+  border-radius: var(--bc-radius);
+  padding: 20px;
+  box-shadow: var(--bc-shadow);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.blog-card__title {
+  font-size: clamp(var(--bc-title-min), 1rem + 1vw, var(--bc-title-max));
+  line-height: 1.4;
+  margin-bottom: 14px;
+  color: var(--bc-text-color);
+
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+}
+
+@container blog-grid (max-width: 340px) {
+  .blog-card__title {
+    font-size: clamp(0.95rem, 4.5cqi, 1.2rem);
+  }
+}
+
+.blog-card__title--clamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.blog-card__excerpt {
+  color: var(--bc-muted);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+.blog-card__btn {
+  margin-top: auto;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 6px;
+  background: var(--bc-accent);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.blog-card__btn:hover {
+  background: #1d4ed8;
+}
+
+@media (max-width: 600px) {
+  body { padding: 16px; }
+
+  .blog-container {
+    flex-direction: column;
+  }
+
+  .blog-card {
+    max-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog-card__btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Fixes #57061

## The Bug
Blog cards with long titles overflowed outside the card or overlapped adjacent elements on mobile/narrow viewports.

## The Fix
- Fluid typography via `clamp()` — title font size scales continuously with viewport width instead of jumping at a single breakpoint
- Container Queries (`container-type: inline-size`) so the title also resizes based on its own container's width, correct even inside a narrow sidebar on a wide screen
- `overflow-wrap` + `word-break` + `hyphens: auto` so long unbroken words wrap/hyphenate cleanly
- `min-width: 0` on the card to stop flex items from forcing overflow
- Optional `.blog-card__title--clamped` modifier for 2-line ellipsis truncation, for grids that need uniform card heights

## Files
- `submissions/examples/blog-card-fluid-title-fix/demo.html`
- `submissions/examples/blog-card-fluid-title-fix/style.css`
- `submissions/examples/blog-card-fluid-title-fix/README.md`

## Checklist
- [x] Reproduces and resolves the exact scenario from the issue
- [x] Pure CSS/HTML, no external JS frameworks
- [x] Fully responsive, including container-based (not just viewport-based) resizing
- [x] Files placed under `submissions/examples/`