### PR TITLE
Fix: footer links overlap using CSS Grid auto-fit and mobile accordion

### DIFF
--- a/submissions/examples/footer-links-grid-accordion-fix/README.md
+++ b/submissions/examples/footer-links-grid-accordion-fix/README.md
@@ -1,0 +1,45 @@
+﻿# Footer Links — Grid + Accordion Overlap Fix
+
+Fixes #57054: footer navigation links overlapping, overflowing the viewport, or losing readability on small screens.
+
+## How this differs from a typical fix
+
+A common fix uses flex-wrap on the footer with a single max-width: 600px breakpoint switching to a vertical stack. That works, but:
+
+- flex-based columns can end up uneven widths depending on content length
+- a long list of footer columns stacked vertically on mobile can push real page content far down the page with a wall of links
+
+This submission instead:
+
+- Uses CSS Grid with repeat(auto-fit, minmax(180px, 1fr)) for the column layout, columns are genuinely equal-width and self-adjust to however many fit the available space, with no manual breakpoint math deciding the column count.
+- Collapses each footer column into a native details accordion on screens 640px wide or less, so link groups are tucked away by default and expandable on demand, a common accessible real-world footer pattern. No JavaScript required.
+- Uses a custom plus/minus indicator instead of relying on the browser default disclosure triangle, which renders inconsistently across browsers.
+
+## Usage
+
+1. Copy style.css into your project.
+2. Structure your footer as in demo.html: footer containing one or more details.footer-column, each with a summary.footer-column__heading and a div.footer-column__links of anchor tags.
+3. Leave the open attribute on each details for desktop, it has no visual effect above 640px since the accordion styling only applies in the mobile media query. Collapsing only takes effect on narrow screens.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--footer-bg` | `#1f2937` | Footer background color |
+| `--footer-text` | `#d1d5db` | Link text color |
+| `--footer-heading` | `#ffffff` | Column heading color |
+| `--footer-hover` | `#60a5fa` | Link hover/focus color |
+| `--footer-col-min` | `180px` | Minimum column width before columns reflow (grid auto-fit) |
+| `--footer-gap` | `28px` | Gap between columns |
+| `--footer-padding` | `40px 32px` | Footer internal padding |
+
+## Accessibility
+
+- details/summary is natively keyboard-operable (Enter/Space to toggle) and announced correctly by screen readers, unlike a JS-driven accordion needing manual ARIA wiring.
+- Links remain focusable and their hover state also applies on focus-visible.
+- Transitions are disabled under prefers-reduced-motion: reduce.
+
+## Responsive Behavior
+
+- Desktop/tablet: columns arranged via CSS Grid auto-fit, reflowing naturally as space allows.
+- Mobile (640px or less): single column, each footer section collapses into an accordion with a custom plus/minus toggle indicator.

--- a/submissions/examples/footer-links-grid-accordion-fix/demo.html
+++ b/submissions/examples/footer-links-grid-accordion-fix/demo.html
@@ -1,0 +1,58 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Footer Links — Grid + Accordion Overlap Fix</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="fdemo">
+    <h1 class="fdemo__title">Footer Links — Overlap Fix</h1>
+    <p class="fdemo__subtitle">
+      Uses CSS Grid repeat(auto-fit, minmax()) for self-adjusting equal columns,
+      collapsing into an accordion (native details, no JS) on small screens.
+    </p>
+  </main>
+
+  <footer class="footer">
+    <details class="footer-column" open>
+      <summary class="footer-column__heading">Resources</summary>
+      <div class="footer-column__links">
+        <a href="#">Documentation</a>
+        <a href="#">Developer Guides and Tutorials</a>
+        <a href="#">API Reference</a>
+      </div>
+    </details>
+
+    <details class="footer-column" open>
+      <summary class="footer-column__heading">Community</summary>
+      <div class="footer-column__links">
+        <a href="#">Discussion Forum</a>
+        <a href="#">Open Source Contributions</a>
+        <a href="#">Support Center</a>
+      </div>
+    </details>
+
+    <details class="footer-column" open>
+      <summary class="footer-column__heading">Company</summary>
+      <div class="footer-column__links">
+        <a href="#">About Us</a>
+        <a href="#">Careers</a>
+        <a href="#">Contact</a>
+      </div>
+    </details>
+
+    <details class="footer-column" open>
+      <summary class="footer-column__heading">Legal</summary>
+      <div class="footer-column__links">
+        <a href="#">Privacy Policy</a>
+        <a href="#">Terms of Service</a>
+        <a href="#">Cookie Settings</a>
+      </div>
+    </details>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/footer-links-grid-accordion-fix/style.css
+++ b/submissions/examples/footer-links-grid-accordion-fix/style.css
@@ -1,0 +1,116 @@
+﻿/* =========================================
+   Footer Links — Grid + Accordion Overlap Fix
+   Fixes #57054
+   CSS Grid auto-fit columns; collapses into a
+   native <details> accordion on small screens
+   ========================================= */
+
+:root {
+  --footer-bg: #1f2937;
+  --footer-text: #d1d5db;
+  --footer-heading: #ffffff;
+  --footer-hover: #60a5fa;
+  --footer-col-min: 180px;
+  --footer-gap: 28px;
+  --footer-padding: 40px 32px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+}
+
+.fdemo {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1.5rem;
+  text-align: center;
+}
+
+.fdemo__title { margin-bottom: 0.25rem; color: #111; }
+.fdemo__subtitle { color: #555; line-height: 1.6; }
+
+.footer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--footer-col-min), 1fr));
+  gap: var(--footer-gap);
+  background: var(--footer-bg);
+  padding: var(--footer-padding);
+}
+
+.footer-column {
+  min-width: 0;
+}
+
+.footer-column__heading {
+  margin: 0 0 12px;
+  font-size: 18px;
+  color: var(--footer-heading);
+  cursor: pointer;
+  list-style: none;
+}
+
+.footer-column__heading::-webkit-details-marker {
+  display: none;
+}
+
+.footer-column__links {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.footer-column__links a {
+  color: var(--footer-text);
+  text-decoration: none;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  transition: color 0.3s ease;
+}
+
+.footer-column__links a:hover,
+.footer-column__links a:focus-visible {
+  color: var(--footer-hover);
+}
+
+@media (max-width: 640px) {
+  .footer {
+    grid-template-columns: 1fr;
+    gap: 4px;
+    padding: 24px 20px;
+  }
+
+  .footer-column {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 12px 0;
+  }
+
+  .footer-column__heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .footer-column__heading::after {
+    content: "+";
+    font-size: 1.1rem;
+    color: var(--footer-text);
+  }
+
+  .footer-column[open] .footer-column__heading::after {
+    content: "\2212";
+  }
+
+  .footer-column__links {
+    padding-top: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .footer-column__links a {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Fixes #57054

## The Bug
Footer sections with multiple navigation columns overlapped, overflowed the viewport, or caused horizontal scrolling on small screens.

## The Fix
- CSS Grid `repeat(auto-fit, minmax(180px, 1fr))` for genuinely equal, self-adjusting columns (no manual breakpoint math)
- Each footer column collapses into a native `<details>` accordion on screens ≤640px — no JS required
- Custom `+`/`−` toggle indicator for consistent cross-browser rendering
- `overflow-wrap` / `word-break` on link text; `min-width: 0` on grid items to prevent overflow

## Files
- `submissions/examples/footer-links-grid-accordion-fix/demo.html`
- `submissions/examples/footer-links-grid-accordion-fix/style.css`
- `submissions/examples/footer-links-grid-accordion-fix/README.md`

## Checklist
- [x] Reproduces and resolves the exact scenario from the issue
- [x] Pure CSS/HTML, no external JS frameworks
- [x] Fully responsive
- [x] Files placed under `submissions/examples/`