### PR TITLE
feat: add consumer rebalance inspector example

### DIFF
--- a/submissions/examples/consumer-rebalance-inspector-kp/README.md
+++ b/submissions/examples/consumer-rebalance-inspector-kp/README.md
@@ -1,0 +1,29 @@
+# Consumer Rebalance Inspector KP
+
+## What does this do?
+
+Consumer Rebalance Inspector KP adds an operational component for inspecting how a streaming consumer group redistributes partitions when a member joins. It includes a coordinator phase rail, partition ownership lanes, lag meters, event context, and live-to-stable state simulation.
+
+## How is it used?
+
+Use a semantic checkbox to switch the component from the active rebalance to its settled assignment. Build the sequence from phase nodes and the ownership plan from consumer lanes.
+
+```html
+<input type="checkbox" id="settle-rebalance" />
+<label for="settle-rebalance">Complete rebalance</label>
+
+<article class="consumer-lane">
+  <span class="consumer-id">consumer-01</span>
+  <span class="partition-track">
+    <span class="partition partition--stable">P0</span>
+    <span class="partition partition--moving">P1</span>
+  </span>
+  <span class="lag-meter"
+    ><i><b></b></i
+  ></span>
+</article>
+```
+
+## Why is it useful?
+
+The component turns an abstract coordinator protocol into an inspectable flow. Motion communicates phase progress and ownership movement, while semantic controls, keyboard focus, responsive phase orientation, compact operational states, and reduced-motion support make the example practical.

--- a/submissions/examples/consumer-rebalance-inspector-kp/demo.html
+++ b/submissions/examples/consumer-rebalance-inspector-kp/demo.html
@@ -1,0 +1,226 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Consumer Rebalance Inspector KP</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="inspector" aria-labelledby="inspector-title">
+        <input type="checkbox" id="settle-rebalance" />
+
+        <header class="inspector-header">
+          <span class="stream-mark" aria-hidden="true">
+            <i></i><i></i><i></i>
+          </span>
+          <span class="header-copy">
+            <small>STREAM OPERATIONS</small>
+            <strong id="inspector-title">Consumer rebalance inspector</strong>
+            <span>Production / eu-central-1</span>
+          </span>
+          <span class="trace-badge"><i></i> Live group trace</span>
+        </header>
+
+        <section class="group-summary" aria-label="Consumer group summary">
+          <span class="group-name">
+            <small>Consumer group</small>
+            <strong>checkout-events-v4</strong>
+            <code>topic: order.lifecycle</code>
+          </span>
+          <span class="summary-stat">
+            <small>Partitions</small>
+            <strong>6</strong>
+            <em>replication 3</em>
+          </span>
+          <span class="summary-stat">
+            <small>Members</small>
+            <strong>3</strong>
+            <em class="members-live">1 joining</em>
+            <em class="members-settled">stable</em>
+          </span>
+          <span class="summary-state">
+            <i aria-hidden="true"></i>
+            <span>
+              <small>Group state</small>
+              <strong class="state-live">Rebalancing</strong>
+              <strong class="state-settled">Stable</strong>
+            </span>
+          </span>
+        </section>
+
+        <div class="section-heading">
+          <span>
+            <small>COORDINATOR PHASE</small>
+            <strong>Rebalance sequence</strong>
+          </span>
+          <label for="settle-rebalance">
+            <span class="action-live">Complete rebalance</span>
+            <span class="action-settled">Replay live phase</span>
+            <i aria-hidden="true"></i>
+          </label>
+        </div>
+
+        <ol class="phase-rail" aria-label="Rebalance progress">
+          <li class="phase phase--done">
+            <i>1</i>
+            <span>
+              <small>Phase 1</small>
+              <strong>Revoke</strong>
+              <em>482 ms</em>
+            </span>
+          </li>
+          <li class="phase-link phase-link--done" aria-hidden="true">
+            <i></i>
+          </li>
+          <li class="phase phase--active">
+            <i>2</i>
+            <span>
+              <small>Phase 2</small>
+              <strong>Assign</strong>
+              <em class="phase-live-copy">in progress</em>
+              <em class="phase-settled-copy">731 ms</em>
+            </span>
+          </li>
+          <li class="phase-link phase-link--active" aria-hidden="true">
+            <i></i>
+          </li>
+          <li class="phase phase--pending">
+            <i>3</i>
+            <span>
+              <small>Phase 3</small>
+              <strong>Sync</strong>
+              <em class="phase-live-copy">waiting</em>
+              <em class="phase-settled-copy">206 ms</em>
+            </span>
+          </li>
+          <li class="phase-link" aria-hidden="true"><i></i></li>
+          <li class="phase phase--pending">
+            <i>4</i>
+            <span>
+              <small>Phase 4</small>
+              <strong>Resume</strong>
+              <em class="phase-live-copy">waiting</em>
+              <em class="phase-settled-copy">ready</em>
+            </span>
+          </li>
+        </ol>
+
+        <section class="assignment-panel" aria-labelledby="assignment-title">
+          <header>
+            <span>
+              <small>PARTITION OWNERSHIP</small>
+              <strong id="assignment-title">Assignment plan</strong>
+            </span>
+            <span class="movement-count">
+              <b class="movement-live">4 moving</b>
+              <b class="movement-settled">0 moving</b>
+            </span>
+          </header>
+
+          <div class="consumer-lanes">
+            <article class="consumer-lane consumer-lane--one">
+              <span class="consumer-id">
+                <i>C1</i>
+                <span>
+                  <strong>consumer-01</strong>
+                  <small>pod checkout-7f98</small>
+                </span>
+                <em class="consumer-live-state">revoking</em>
+                <em class="consumer-settled-state">2 assigned</em>
+              </span>
+              <span class="partition-track">
+                <span class="partition partition--stable">P0 <i></i></span>
+                <span class="partition partition--moving">P1 <i></i></span>
+                <span class="partition partition--leaving">P2 <i></i></span>
+              </span>
+              <span class="lag-meter">
+                <small>Lag</small>
+                <i><b></b></i>
+                <strong class="lag-live">1,284</strong>
+                <strong class="lag-settled">94</strong>
+              </span>
+            </article>
+
+            <article class="consumer-lane consumer-lane--two">
+              <span class="consumer-id">
+                <i>C2</i>
+                <span>
+                  <strong>consumer-02</strong>
+                  <small>pod checkout-a221</small>
+                </span>
+                <em class="consumer-live-state">assigning</em>
+                <em class="consumer-settled-state">2 assigned</em>
+              </span>
+              <span class="partition-track">
+                <span class="partition partition--stable">P3 <i></i></span>
+                <span class="partition partition--moving">P2 <i></i></span>
+                <span class="partition partition--leaving">P4 <i></i></span>
+              </span>
+              <span class="lag-meter">
+                <small>Lag</small>
+                <i><b></b></i>
+                <strong class="lag-live">896</strong>
+                <strong class="lag-settled">61</strong>
+              </span>
+            </article>
+
+            <article class="consumer-lane consumer-lane--three">
+              <span class="consumer-id">
+                <i>C3</i>
+                <span>
+                  <strong>consumer-03</strong>
+                  <small>pod checkout-c04d</small>
+                </span>
+                <em class="consumer-live-state">joining</em>
+                <em class="consumer-settled-state">2 assigned</em>
+              </span>
+              <span class="partition-track">
+                <span class="partition partition--incoming">P4 <i></i></span>
+                <span class="partition partition--incoming">P5 <i></i></span>
+              </span>
+              <span class="lag-meter">
+                <small>Lag</small>
+                <i><b></b></i>
+                <strong class="lag-live">new</strong>
+                <strong class="lag-settled">28</strong>
+              </span>
+            </article>
+          </div>
+        </section>
+
+        <section class="event-strip" aria-label="Coordinator event">
+          <span class="event-icon" aria-hidden="true">E</span>
+          <span>
+            <small class="event-live">MEMBER JOINED</small>
+            <small class="event-settled">ASSIGNMENT COMMITTED</small>
+            <strong class="event-live"
+              >consumer-03 triggered cooperative reassignment</strong
+            >
+            <strong class="event-settled"
+              >All six partitions resumed without duplicate ownership</strong
+            >
+          </span>
+          <code class="event-live">generation 184 -> 185</code>
+          <code class="event-settled">generation 185 active</code>
+        </section>
+
+        <footer class="inspector-footer">
+          <span class="footer-status">
+            <i aria-hidden="true"></i>
+            <span>
+              <small class="footer-live">Consumption paused</small>
+              <small class="footer-settled">Consumption healthy</small>
+              <strong class="footer-live">Waiting for assignment sync</strong>
+              <strong class="footer-settled"
+                >All consumers are processing</strong
+              >
+            </span>
+          </span>
+          <button type="button">Open coordinator log</button>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/consumer-rebalance-inspector-kp/style.css
+++ b/submissions/examples/consumer-rebalance-inspector-kp/style.css
@@ -1,0 +1,1249 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #090d10;
+  color: #edf2f2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.page-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 52px 20px;
+  background:
+    linear-gradient(rgba(89, 109, 116, 0.07) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(89, 109, 116, 0.07) 1px, transparent 1px),
+    #090d10;
+  background-size: 30px 30px;
+}
+
+.inspector {
+  position: relative;
+  width: min(100%, 1040px);
+  overflow: hidden;
+  border: 1px solid #2b383c;
+  border-radius: 8px;
+  background: #141a1d;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.44);
+}
+
+#settle-rebalance {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.inspector-header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 22px 26px;
+  border-bottom: 1px solid #2a3538;
+  background: #171e21;
+}
+
+.stream-mark {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-content: center;
+  gap: 4px;
+  border: 1px solid #31535a;
+  border-radius: 6px;
+  background: #163139;
+}
+
+.stream-mark i {
+  position: relative;
+  display: block;
+  width: 22px;
+  height: 3px;
+  border-radius: 3px;
+  background: #70d8e9;
+}
+
+.stream-mark i::after {
+  position: absolute;
+  top: -2px;
+  right: -1px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #8be6d1;
+  content: "";
+}
+
+.stream-mark i:nth-child(2) {
+  width: 17px;
+}
+
+.stream-mark i:nth-child(3) {
+  width: 12px;
+}
+
+.header-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.header-copy small,
+.section-heading small,
+.assignment-panel header small {
+  color: #70dbe8;
+  font-size: 0.61rem;
+  font-weight: 800;
+}
+
+.header-copy strong {
+  overflow: hidden;
+  color: #f1f5f4;
+  font-size: 1.13rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-copy > span {
+  color: #819094;
+  font-size: 0.68rem;
+}
+
+.trace-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 9px;
+  border: 1px solid #3b4c50;
+  border-radius: 5px;
+  color: #b4c0c1;
+  font-size: 0.64rem;
+  font-weight: 700;
+}
+
+.trace-badge i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #f0b96e;
+  box-shadow: 0 0 0 0 rgba(240, 185, 110, 0.35);
+  animation: trace-pulse 1.8s ease-out infinite;
+}
+
+.group-summary {
+  display: grid;
+  grid-template-columns:
+    minmax(240px, 1.45fr) repeat(2, minmax(100px, 0.55fr))
+    minmax(145px, 0.75fr);
+  gap: 1px;
+  margin: 0 26px;
+  border-right: 1px solid #2b3639;
+  border-bottom: 1px solid #2b3639;
+  border-left: 1px solid #2b3639;
+  background: #2b3639;
+}
+
+.group-name,
+.summary-stat,
+.summary-state {
+  min-width: 0;
+  min-height: 91px;
+  padding: 16px;
+  background: #111719;
+}
+
+.group-name,
+.summary-stat {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+}
+
+.group-name small,
+.summary-stat small,
+.summary-state small {
+  color: #748386;
+  font-size: 0.59rem;
+}
+
+.group-name strong {
+  overflow: hidden;
+  color: #e7eceb;
+  font-size: 0.76rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.group-name code {
+  color: #789094;
+  font-family: SFMono-Regular, Consolas, monospace;
+  font-size: 0.56rem;
+}
+
+.summary-stat strong {
+  color: #edf2f1;
+  font-size: 1.05rem;
+}
+
+.summary-stat em {
+  grid-area: 3 / 1;
+  color: #7e9092;
+  font-size: 0.55rem;
+  font-style: normal;
+}
+
+.members-live {
+  color: #f1bd72 !important;
+}
+
+.summary-state {
+  display: grid;
+  grid-template-columns: 31px minmax(0, 1fr);
+  align-content: center;
+  align-items: center;
+  gap: 10px;
+}
+
+.summary-state > i {
+  position: relative;
+  width: 31px;
+  height: 31px;
+  border-radius: 50%;
+  background: conic-gradient(#efb86d 0 72%, #3d3429 72% 100%);
+  animation: state-spin 2.4s linear infinite;
+}
+
+.summary-state > i::before {
+  position: absolute;
+  inset: 6px;
+  border-radius: inherit;
+  background: #191c1c;
+  content: "";
+}
+
+.summary-state > span {
+  display: grid;
+  gap: 4px;
+}
+
+.summary-state strong {
+  grid-area: 2 / 1;
+  color: #efbd75;
+  font-size: 0.77rem;
+}
+
+.members-settled,
+.state-settled,
+.action-settled,
+.phase-settled-copy,
+.consumer-settled-state,
+.lag-settled,
+.movement-settled,
+.event-settled,
+.footer-settled {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 22px 26px 12px;
+}
+
+.section-heading > span,
+.assignment-panel header > span:first-child {
+  display: grid;
+  gap: 4px;
+}
+
+.section-heading strong,
+.assignment-panel header strong {
+  color: #dfe6e5;
+  font-size: 0.82rem;
+}
+
+.section-heading label {
+  position: relative;
+  display: grid;
+  min-width: 142px;
+  min-height: 34px;
+  place-items: center;
+  padding: 0 34px 0 11px;
+  border: 1px solid #66533e;
+  border-radius: 5px;
+  background: #2b2319;
+  color: #efc483;
+  cursor: pointer;
+  font-size: 0.62rem;
+  font-weight: 750;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.section-heading label:hover {
+  border-color: #8b704f;
+  transform: translateY(-1px);
+}
+
+.section-heading label > span {
+  grid-area: 1 / 1;
+}
+
+.section-heading label > i {
+  position: absolute;
+  right: 9px;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: #684f30;
+}
+
+.section-heading label > i::before {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  width: 8px;
+  height: 8px;
+  border: 1px solid #ffd391;
+  border-left-color: transparent;
+  border-radius: 50%;
+  content: "";
+}
+
+#settle-rebalance:focus-visible ~ .section-heading label {
+  outline: 3px solid rgba(112, 219, 232, 0.28);
+  outline-offset: 3px;
+}
+
+.phase-rail {
+  display: grid;
+  grid-template-columns:
+    minmax(110px, 1fr) minmax(36px, 0.32fr)
+    minmax(110px, 1fr) minmax(36px, 0.32fr) minmax(110px, 1fr)
+    minmax(36px, 0.32fr) minmax(110px, 1fr);
+  align-items: center;
+  gap: 8px;
+  margin: 0 26px;
+  padding: 15px;
+  border: 1px solid #2c383b;
+  border-radius: 7px;
+  background: #101618;
+  list-style: none;
+}
+
+.phase {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  align-items: center;
+  min-width: 0;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid #344044;
+  border-radius: 6px;
+  background: #192124;
+  transition:
+    border-color 200ms ease,
+    background-color 200ms ease,
+    opacity 200ms ease;
+}
+
+.phase > i {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border-radius: 5px;
+  background: #2b373b;
+  color: #aebbbc;
+  font-size: 0.59rem;
+  font-style: normal;
+  font-weight: 850;
+}
+
+.phase > span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.phase small {
+  color: #6d7c80;
+  font-size: 0.51rem;
+}
+
+.phase strong {
+  color: #dce4e3;
+  font-size: 0.66rem;
+}
+
+.phase em {
+  grid-area: 3 / 1;
+  color: #819093;
+  font-size: 0.52rem;
+  font-style: normal;
+}
+
+.phase--done {
+  border-color: #34594f;
+  background: #172722;
+}
+
+.phase--done > i {
+  background: #285448;
+  color: #8ae7ce;
+}
+
+.phase--active {
+  border-color: #68543d;
+  background: #282119;
+}
+
+.phase--active > i {
+  background: #62492d;
+  color: #ffd08c;
+}
+
+.phase--active em {
+  color: #efbd75;
+}
+
+.phase--pending {
+  opacity: 0.62;
+}
+
+.phase-link {
+  position: relative;
+  height: 1px;
+  background: #384448;
+}
+
+.phase-link::after {
+  position: absolute;
+  top: -3px;
+  right: 0;
+  width: 6px;
+  height: 6px;
+  border-top: 1px solid #68777a;
+  border-right: 1px solid #68777a;
+  content: "";
+  transform: rotate(45deg);
+}
+
+.phase-link > i {
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #efb96e;
+  box-shadow: 0 0 8px rgba(239, 185, 110, 0.62);
+  animation: phase-travel 1.7s ease-in-out infinite;
+}
+
+.phase-link--done {
+  background: #3b665b;
+}
+
+.phase-link--done::after {
+  border-color: #78ddc2;
+}
+
+.assignment-panel {
+  margin: 14px 26px;
+  overflow: hidden;
+  border: 1px solid #2c383b;
+  border-radius: 7px;
+  background: #101618;
+}
+
+.assignment-panel > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 13px 15px;
+  border-bottom: 1px solid #293538;
+}
+
+.movement-count {
+  display: grid;
+  min-width: 60px;
+  min-height: 25px;
+  place-items: center;
+  border-radius: 4px;
+  background: #3a2c1e;
+  color: #efc17d;
+  font-size: 0.56rem;
+}
+
+.movement-count b {
+  grid-area: 1 / 1;
+}
+
+.consumer-lanes {
+  display: grid;
+}
+
+.consumer-lane {
+  display: grid;
+  grid-template-columns:
+    minmax(190px, 1.05fr) minmax(240px, 1.5fr)
+    minmax(150px, 0.75fr);
+  align-items: center;
+  gap: 16px;
+  padding: 13px 15px;
+  border-bottom: 1px solid #273235;
+  transition:
+    background-color 200ms ease,
+    opacity 200ms ease;
+}
+
+.consumer-lane:last-child {
+  border-bottom: 0;
+}
+
+.consumer-lane--three {
+  background: #171a19;
+}
+
+.consumer-id {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  min-width: 0;
+  gap: 9px;
+}
+
+.consumer-id > i {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 5px;
+  background: #25363b;
+  color: #82dfea;
+  font-size: 0.58rem;
+  font-style: normal;
+  font-weight: 850;
+}
+
+.consumer-id > span {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.consumer-id strong {
+  overflow: hidden;
+  color: #dce4e3;
+  font-size: 0.64rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.consumer-id small {
+  overflow: hidden;
+  color: #718084;
+  font-family: SFMono-Regular, Consolas, monospace;
+  font-size: 0.51rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.consumer-id em {
+  grid-area: 1 / 3;
+  padding: 3px 6px;
+  border-radius: 4px;
+  background: #3a2d20;
+  color: #efc17e;
+  font-size: 0.49rem;
+  font-style: normal;
+}
+
+.partition-track {
+  display: flex;
+  min-width: 0;
+  gap: 7px;
+}
+
+.partition {
+  position: relative;
+  display: grid;
+  width: 50px;
+  height: 31px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid #3b4a4e;
+  border-radius: 5px;
+  background: #202a2d;
+  color: #b6c2c3;
+  font-size: 0.57rem;
+  font-weight: 800;
+  transition:
+    border-color 220ms ease,
+    background-color 220ms ease,
+    color 220ms ease,
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+
+.partition i {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 7px;
+  height: 7px;
+  border: 1px solid #101618;
+  border-radius: 50%;
+  background: #72d9e7;
+}
+
+.partition--moving,
+.partition--incoming {
+  border-color: #6a553d;
+  background: #2b241b;
+  color: #f0c17d;
+}
+
+.partition--moving i,
+.partition--incoming i {
+  background: #efb96f;
+  animation: partition-pulse 1.6s ease-out infinite;
+}
+
+.partition--leaving {
+  border-style: dashed;
+  opacity: 0.55;
+}
+
+.lag-meter {
+  display: grid;
+  grid-template-columns: auto minmax(40px, 1fr) 45px;
+  align-items: center;
+  min-width: 0;
+  gap: 8px;
+}
+
+.lag-meter small {
+  color: #718084;
+  font-size: 0.53rem;
+}
+
+.lag-meter > i {
+  height: 4px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: #2d383b;
+}
+
+.lag-meter > i b {
+  display: block;
+  width: 76%;
+  height: 100%;
+  border-radius: inherit;
+  background: #efb96f;
+  transition:
+    width 240ms ease,
+    background-color 240ms ease;
+}
+
+.consumer-lane--two .lag-meter > i b {
+  width: 59%;
+}
+
+.consumer-lane--three .lag-meter > i b {
+  width: 18%;
+}
+
+.lag-meter strong {
+  grid-area: 1 / 3;
+  color: #e8bb78;
+  font-family: SFMono-Regular, Consolas, monospace;
+  font-size: 0.56rem;
+  text-align: right;
+}
+
+.event-strip {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  margin: 0 26px 20px;
+  padding: 12px 14px;
+  border: 1px solid #4f4436;
+  border-radius: 6px;
+  background: #211d18;
+}
+
+.event-icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border-radius: 5px;
+  background: #5c472e;
+  color: #ffd18e;
+  font-size: 0.59rem;
+  font-weight: 850;
+}
+
+.event-strip > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.event-strip small,
+.event-strip strong {
+  grid-area: 1 / 1;
+}
+
+.event-strip strong {
+  grid-area: 2 / 1;
+  overflow: hidden;
+  color: #e6ded3;
+  font-size: 0.63rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-strip small {
+  color: #efb96f;
+  font-size: 0.51rem;
+  font-weight: 800;
+}
+
+.event-strip code {
+  color: #ad9b83;
+  font-family: SFMono-Regular, Consolas, monospace;
+  font-size: 0.54rem;
+}
+
+.inspector-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px 26px;
+  border-top: 1px solid #2a3538;
+  background: #111719;
+}
+
+.footer-status {
+  display: grid;
+  grid-template-columns: 29px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.footer-status > i {
+  position: relative;
+  width: 29px;
+  height: 29px;
+  border-radius: 50%;
+  background: #594225;
+  transition: background-color 220ms ease;
+}
+
+.footer-status > i::before,
+.footer-status > i::after {
+  position: absolute;
+  top: 8px;
+  left: 13px;
+  width: 2px;
+  height: 8px;
+  border-radius: 2px;
+  background: #f6c77f;
+  content: "";
+}
+
+.footer-status > i::after {
+  top: 19px;
+  height: 2px;
+}
+
+.footer-status > span {
+  display: grid;
+  gap: 3px;
+}
+
+.footer-status small,
+.footer-status strong {
+  grid-area: 1 / 1;
+}
+
+.footer-status strong {
+  grid-area: 2 / 1;
+  color: #e5ebe9;
+  font-size: 0.68rem;
+}
+
+.footer-status small {
+  color: #7c8b8e;
+  font-size: 0.56rem;
+}
+
+.inspector-footer button {
+  min-height: 36px;
+  padding: 0 13px;
+  border: 1px solid #3b4a4e;
+  border-radius: 5px;
+  background: #202a2d;
+  color: #d5dddd;
+  cursor: pointer;
+  font-size: 0.62rem;
+  font-weight: 750;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.inspector-footer button:hover {
+  border-color: #54767b;
+  background: #263437;
+  transform: translateY(-1px);
+}
+
+.inspector-footer button:focus-visible {
+  outline: 3px solid rgba(112, 219, 232, 0.28);
+  outline-offset: 3px;
+}
+
+#settle-rebalance:checked ~ .group-summary .members-live,
+#settle-rebalance:checked ~ .group-summary .state-live,
+#settle-rebalance:checked ~ .section-heading .action-live,
+#settle-rebalance:checked ~ .phase-rail .phase-live-copy,
+#settle-rebalance:checked ~ .assignment-panel .consumer-live-state,
+#settle-rebalance:checked ~ .assignment-panel .lag-live,
+#settle-rebalance:checked ~ .assignment-panel .movement-live,
+#settle-rebalance:checked ~ .event-strip .event-live,
+#settle-rebalance:checked ~ .inspector-footer .footer-live {
+  opacity: 0;
+  visibility: hidden;
+}
+
+#settle-rebalance:checked ~ .group-summary .members-settled,
+#settle-rebalance:checked ~ .group-summary .state-settled,
+#settle-rebalance:checked ~ .section-heading .action-settled,
+#settle-rebalance:checked ~ .phase-rail .phase-settled-copy,
+#settle-rebalance:checked ~ .assignment-panel .consumer-settled-state,
+#settle-rebalance:checked ~ .assignment-panel .lag-settled,
+#settle-rebalance:checked ~ .assignment-panel .movement-settled,
+#settle-rebalance:checked ~ .event-strip .event-settled,
+#settle-rebalance:checked ~ .inspector-footer .footer-settled {
+  opacity: 1;
+  visibility: visible;
+}
+
+#settle-rebalance:checked ~ .group-summary .summary-state > i {
+  background: #2a5a4e;
+  animation: none;
+}
+
+#settle-rebalance:checked ~ .group-summary .summary-state > i::before {
+  top: 8px;
+  right: auto;
+  bottom: auto;
+  left: 8px;
+  width: 11px;
+  height: 6px;
+  border-bottom: 2px solid #8ae8ce;
+  border-left: 2px solid #8ae8ce;
+  border-radius: 0;
+  background: transparent;
+  transform: rotate(-45deg);
+}
+
+#settle-rebalance:checked ~ .group-summary .state-settled {
+  color: #7ee2c5;
+}
+
+#settle-rebalance:checked ~ .section-heading label {
+  border-color: #3c645b;
+  background: #18322d;
+  color: #83e0c7;
+}
+
+#settle-rebalance:checked ~ .section-heading label > i {
+  background: #28564b;
+}
+
+#settle-rebalance:checked ~ .section-heading label > i::before {
+  top: 5px;
+  left: 5px;
+  width: 8px;
+  height: 4px;
+  border: 0;
+  border-bottom: 2px solid #8ce8cf;
+  border-left: 2px solid #8ce8cf;
+  border-radius: 0;
+  transform: rotate(-45deg);
+}
+
+#settle-rebalance:checked ~ .phase-rail .phase {
+  border-color: #345a51;
+  background: #172822;
+  opacity: 1;
+}
+
+#settle-rebalance:checked ~ .phase-rail .phase > i {
+  background: #28564a;
+  color: #8ae8ce;
+}
+
+#settle-rebalance:checked ~ .phase-rail .phase-link {
+  background: #3b665b;
+}
+
+#settle-rebalance:checked ~ .phase-rail .phase-link::after {
+  border-color: #78ddc2;
+}
+
+#settle-rebalance:checked ~ .phase-rail .phase-link > i {
+  background: #78ddc2;
+  box-shadow: 0 0 8px rgba(120, 221, 194, 0.62);
+}
+
+#settle-rebalance:checked ~ .assignment-panel .movement-count {
+  background: #1e3e36;
+  color: #83e0c7;
+}
+
+#settle-rebalance:checked ~ .assignment-panel .consumer-lane--three {
+  background: transparent;
+}
+
+#settle-rebalance:checked ~ .assignment-panel .consumer-id em {
+  background: #244a40;
+  color: #8ae6cd;
+}
+
+#settle-rebalance:checked ~ .assignment-panel .partition {
+  border-color: #3a6258;
+  border-style: solid;
+  background: #192d27;
+  color: #8ce4cd;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+#settle-rebalance:checked ~ .assignment-panel .partition i {
+  background: #78ddc2;
+  animation: none;
+}
+
+#settle-rebalance:checked ~ .assignment-panel .partition--leaving {
+  display: none;
+}
+
+#settle-rebalance:checked
+  ~ .assignment-panel
+  .consumer-lane--one
+  .partition--moving {
+  transform: translateX(57px);
+}
+
+#settle-rebalance:checked ~ .assignment-panel .lag-meter > i b {
+  width: 12%;
+  background: #78ddc2;
+}
+
+#settle-rebalance:checked
+  ~ .assignment-panel
+  .consumer-lane--two
+  .lag-meter
+  > i
+  b {
+  width: 8%;
+}
+
+#settle-rebalance:checked
+  ~ .assignment-panel
+  .consumer-lane--three
+  .lag-meter
+  > i
+  b {
+  width: 5%;
+}
+
+#settle-rebalance:checked ~ .assignment-panel .lag-settled {
+  color: #80dfc6;
+}
+
+#settle-rebalance:checked ~ .event-strip {
+  border-color: #365c53;
+  background: #172823;
+}
+
+#settle-rebalance:checked ~ .event-strip .event-icon {
+  background: #28564a;
+  color: #8ce8cf;
+}
+
+#settle-rebalance:checked ~ .event-strip small {
+  color: #77ddc3;
+}
+
+#settle-rebalance:checked ~ .inspector-footer .footer-status > i {
+  background: #28564a;
+}
+
+#settle-rebalance:checked ~ .inspector-footer .footer-status > i::before {
+  top: 8px;
+  left: 8px;
+  width: 10px;
+  height: 5px;
+  border-bottom: 2px solid #8ce8cf;
+  border-left: 2px solid #8ce8cf;
+  background: transparent;
+  transform: rotate(-45deg);
+}
+
+#settle-rebalance:checked ~ .inspector-footer .footer-status > i::after {
+  display: none;
+}
+
+@keyframes phase-travel {
+  0% {
+    opacity: 0;
+    transform: translateX(0);
+  }
+
+  18% {
+    opacity: 1;
+  }
+
+  82% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateX(calc(100% + 30px));
+  }
+}
+
+@keyframes trace-pulse {
+  70% {
+    box-shadow: 0 0 0 7px rgba(240, 185, 110, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(240, 185, 110, 0);
+  }
+}
+
+@keyframes partition-pulse {
+  70% {
+    box-shadow: 0 0 0 6px rgba(239, 185, 111, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 185, 111, 0);
+  }
+}
+
+@keyframes state-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 860px) {
+  .group-summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .group-name {
+    grid-column: 1 / -1;
+  }
+
+  .phase-rail {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .phase-link {
+    width: 1px;
+    height: 24px;
+    margin-left: 30px;
+  }
+
+  .phase-link::after {
+    top: auto;
+    right: -3px;
+    bottom: 0;
+    transform: rotate(135deg);
+  }
+
+  .phase-link > i {
+    top: 0;
+    left: -2px;
+    animation-name: phase-travel-mobile;
+  }
+
+  .consumer-lane {
+    grid-template-columns: minmax(190px, 1fr) minmax(220px, 1fr);
+  }
+
+  .lag-meter {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 600px) {
+  .page-shell {
+    align-items: start;
+    padding: 10px;
+  }
+
+  .inspector-header {
+    grid-template-columns: auto minmax(0, 1fr);
+    padding: 18px 16px;
+  }
+
+  .trace-badge {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .header-copy strong {
+    white-space: normal;
+  }
+
+  .group-summary,
+  .phase-rail,
+  .assignment-panel,
+  .event-strip {
+    margin-right: 16px;
+    margin-left: 16px;
+  }
+
+  .group-summary {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .group-name,
+  .summary-state {
+    grid-column: 1 / -1;
+  }
+
+  .group-name,
+  .summary-stat,
+  .summary-state {
+    min-height: 76px;
+    padding: 13px;
+  }
+
+  .section-heading {
+    display: grid;
+    padding: 20px 16px 12px;
+  }
+
+  .section-heading label {
+    width: 100%;
+  }
+
+  .consumer-lane {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .partition-track {
+    overflow-x: auto;
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+
+  #settle-rebalance:checked
+    ~ .assignment-panel
+    .consumer-lane--one
+    .partition--moving {
+    transform: none;
+  }
+
+  .event-strip {
+    grid-template-columns: 32px minmax(0, 1fr);
+  }
+
+  .event-strip code {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .event-strip strong {
+    white-space: normal;
+  }
+
+  .inspector-footer {
+    display: grid;
+    padding: 16px;
+  }
+
+  .inspector-footer button {
+    width: 100%;
+  }
+}
+
+@keyframes phase-travel-mobile {
+  0% {
+    opacity: 0;
+    transform: translateY(0);
+  }
+
+  18% {
+    opacity: 1;
+  }
+
+  82% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(23px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained consumer rebalance inspector for understanding how a streaming group redistributes partitions when a member joins. A semantic control changes the coordinator phases, partition ownership, lag meters, event context, and health state from active rebalance to stable assignment without JavaScript.

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A responsive stream-operations component with an animated coordinator phase rail, consumer ownership lanes, moving partition states, lag meters, and live-to-stable simulation.

**How does a developer use it?**

```html
<input type="checkbox" id="settle-rebalance" />
<label for="settle-rebalance">Complete rebalance</label>

<article class="consumer-lane">
  <span class="consumer-id">consumer-01</span>
  <span class="partition-track">
    <span class="partition partition--stable">P0</span>
    <span class="partition partition--moving">P1</span>
  </span>
  <span class="lag-meter"><i><b></b></i></span>
</article>
```

**Why does it fit EaseMotion CSS?**

Motion communicates coordinator progress and ownership movement rather than decorating the interface. The CSS-only implementation remains human-readable while semantic controls, keyboard focus, responsive phase orientation, compact operational states, and reduced-motion support keep it practical.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome (Playwright with installed Chrome at desktop and mobile viewports)
- [ ] Firefox
- [ ] Edge
- [ ] Safari (optional but appreciated)

---

## Notes for Maintainer

Validated with Prettier, Stylelint through stdin (the repository ignore file excludes submissions), `git diff --check`, and Playwright interaction checks. Verified keyboard state switching, phase completion, partition ownership movement, lag reduction, corrected responsive event layout, and zero horizontal overflow at 1280px and 500px widths. The branch was rebased onto the latest upstream `main` before push.
