### PR TITLE
feat: add adaptive load shedding console

### DIFF
--- a/submissions/examples/adaptive-load-shedding-kp/README.md
+++ b/submissions/examples/adaptive-load-shedding-kp/README.md
@@ -1,0 +1,38 @@
+# Adaptive Load Shedding Console
+
+A CSS-only operations console that visualizes how priority-aware admission
+control keeps a service inside its healthy capacity envelope during a traffic
+surge.
+
+## What it demonstrates
+
+- A semantic checkbox switches between unprotected and guarded states.
+- Critical, standard, and deferrable traffic receive separate admission lanes.
+- Capacity, queue, latency, connection, and error indicators transition
+  together.
+- The shed path returns excess work before it occupies service connections.
+- The layout changes from a horizontal topology to a vertical mobile flow.
+- Motion respects the user's reduced-motion preference.
+
+## Run locally
+
+Open `demo.html` in a browser. Enable **Adaptive guard** in the top-right corner
+to compare the overload state with the protected state.
+
+## Implementation
+
+The interaction uses the sibling selector from the hidden
+`#protection-mode` checkbox to coordinate every visual state. No JavaScript,
+framework, image dependency, or build step is required.
+
+The example uses only:
+
+- `demo.html` for semantic structure and accessible state labels
+- `style.css` for responsive layout, data visualization, and motion
+- `README.md` for usage and implementation notes
+
+## Accessibility
+
+The guard control is keyboard focusable and exposes an accessible name.
+Important state changes are represented with text as well as color, and the
+layout remains usable from 320px wide viewports.

--- a/submissions/examples/adaptive-load-shedding-kp/demo.html
+++ b/submissions/examples/adaptive-load-shedding-kp/demo.html
@@ -1,0 +1,472 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A CSS-only adaptive load shedding control room with priority-aware admission states."
+    />
+    <title>Adaptive Load Shedding Console</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <input
+      class="protection-input"
+      type="checkbox"
+      id="protection-mode"
+      aria-label="Enable adaptive load shedding"
+    />
+
+    <div class="console-shell">
+      <header class="topbar">
+        <a class="brand" href="#overview" aria-label="Loadline overview">
+          <span class="brand-mark" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
+          <span>
+            <strong>Loadline</strong>
+            <small>edge admission control</small>
+          </span>
+        </a>
+
+        <div class="cluster-state" aria-label="Cluster status">
+          <span class="state-dot"></span>
+          <span class="unsafe-label">Capacity breach active</span>
+          <span class="safe-label">Capacity envelope stable</span>
+        </div>
+
+        <label class="protection-switch" for="protection-mode">
+          <span class="switch-copy">
+            <span>Adaptive guard</span>
+            <small class="unsafe-label">Disabled</small>
+            <small class="safe-label">Enabled</small>
+          </span>
+          <span class="switch-track" aria-hidden="true">
+            <span class="switch-thumb"></span>
+          </span>
+        </label>
+      </header>
+
+      <main id="overview">
+        <section class="summary-band" aria-labelledby="page-title">
+          <div class="summary-heading">
+            <p class="eyebrow">Production / checkout-edge / us-east-1</p>
+            <div class="title-row">
+              <h1 id="page-title">Adaptive load shedding</h1>
+              <span class="mode-pill unsafe-label">Unprotected</span>
+              <span class="mode-pill safe-label">Guarded</span>
+            </div>
+            <p class="summary-copy unsafe-label">
+              Demand is outrunning healthy capacity. Every request is entering
+              the service pool and amplifying queue pressure.
+            </p>
+            <p class="summary-copy safe-label">
+              Admission control protects critical traffic and sheds excess work
+              before the service pool saturates.
+            </p>
+          </div>
+
+          <dl class="window-meta">
+            <div>
+              <dt>Decision window</dt>
+              <dd>10 seconds</dd>
+            </div>
+            <div>
+              <dt>Signal source</dt>
+              <dd>p99 + queue depth</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="metric-strip" aria-label="Current load metrics">
+          <article class="metric">
+            <div class="metric-topline">
+              <span>Demand</span>
+              <span class="metric-trend demand-trend">+61%</span>
+            </div>
+            <strong>8,420</strong>
+            <small>requests / second</small>
+            <span class="metric-spark demand-spark" aria-hidden="true">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </span>
+          </article>
+
+          <article class="metric">
+            <div class="metric-topline">
+              <span>Admitted</span>
+              <span class="metric-trend unsafe-label">+3,220 over</span>
+              <span class="metric-trend safe-label">98% healthy</span>
+            </div>
+            <strong class="unsafe-label">8,420</strong>
+            <strong class="safe-label">5,090</strong>
+            <small>requests / second</small>
+            <span class="metric-spark admitted-spark" aria-hidden="true">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </span>
+          </article>
+
+          <article class="metric">
+            <div class="metric-topline">
+              <span>p99 latency</span>
+              <span class="metric-trend unsafe-label">Critical</span>
+              <span class="metric-trend safe-label">Within SLO</span>
+            </div>
+            <strong class="unsafe-label">3.8s</strong>
+            <strong class="safe-label">284ms</strong>
+            <small>target under 400ms</small>
+            <span class="latency-track" aria-hidden="true">
+              <span></span>
+              <b></b>
+            </span>
+          </article>
+
+          <article class="metric">
+            <div class="metric-topline">
+              <span>Error rate</span>
+              <span class="metric-trend unsafe-label">+17.9%</span>
+              <span class="metric-trend safe-label">-17.9%</span>
+            </div>
+            <strong class="unsafe-label">18.7%</strong>
+            <strong class="safe-label">0.8%</strong>
+            <small>rolling five minutes</small>
+            <span class="error-scale" aria-hidden="true">
+              <i></i><i></i><i></i><i></i><i></i>
+            </span>
+          </article>
+        </section>
+
+        <div class="workspace">
+          <section class="flow-panel" aria-labelledby="flow-title">
+            <header class="panel-header">
+              <div>
+                <p class="panel-kicker">Live topology</p>
+                <h2 id="flow-title">Request admission flow</h2>
+              </div>
+              <div class="sample-rate">
+                <span></span>
+                1:100 sampled
+              </div>
+            </header>
+
+            <div class="flow-stage">
+              <div class="incoming-column">
+                <div class="stage-label">
+                  <span>Incoming</span>
+                  <strong>8.4k rps</strong>
+                </div>
+
+                <div class="request-stack" aria-hidden="true">
+                  <span class="request-chip critical">P0</span>
+                  <span class="request-chip standard">P1</span>
+                  <span class="request-chip bulk">P2</span>
+                  <span class="request-chip standard">P1</span>
+                  <span class="request-chip critical">P0</span>
+                  <span class="request-chip bulk">P2</span>
+                </div>
+              </div>
+
+              <div class="connector incoming-connector" aria-hidden="true">
+                <span></span>
+                <i></i>
+              </div>
+
+              <div class="controller-column">
+                <div class="controller">
+                  <div class="controller-head">
+                    <span class="controller-icon" aria-hidden="true">
+                      <i></i>
+                      <i></i>
+                      <i></i>
+                    </span>
+                    <div>
+                      <small>Admission controller</small>
+                      <strong class="unsafe-label">Pass through</strong>
+                      <strong class="safe-label">Priority gate</strong>
+                    </div>
+                  </div>
+
+                  <div class="capacity-dial" aria-label="Capacity utilization">
+                    <div class="dial-ring">
+                      <span class="dial-value unsafe-label">162%</span>
+                      <span class="dial-value safe-label">98%</span>
+                    </div>
+                    <small>healthy envelope</small>
+                  </div>
+
+                  <div class="decision-signals">
+                    <span>
+                      <i></i>
+                      Queue depth
+                      <b class="unsafe-label">1,842</b>
+                      <b class="safe-label">126</b>
+                    </span>
+                    <span>
+                      <i></i>
+                      CPU pressure
+                      <b class="unsafe-label">96%</b>
+                      <b class="safe-label">71%</b>
+                    </span>
+                    <span>
+                      <i></i>
+                      SLO burn
+                      <b class="unsafe-label">14.2x</b>
+                      <b class="safe-label">0.7x</b>
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="connector decision-connector" aria-hidden="true">
+                <span></span>
+                <i></i>
+              </div>
+
+              <div class="lane-column">
+                <div class="stage-label">
+                  <span>Priority lanes</span>
+                  <strong class="unsafe-label">No policy</strong>
+                  <strong class="safe-label">Policy active</strong>
+                </div>
+
+                <article class="traffic-lane critical-lane">
+                  <div class="lane-badge">P0</div>
+                  <div class="lane-copy">
+                    <strong>Checkout</strong>
+                    <small>Critical customer path</small>
+                  </div>
+                  <div class="lane-meter" aria-hidden="true">
+                    <span></span>
+                  </div>
+                  <div class="lane-result">
+                    <b>1.2k</b>
+                    <small>admit</small>
+                  </div>
+                </article>
+
+                <article class="traffic-lane standard-lane">
+                  <div class="lane-badge">P1</div>
+                  <div class="lane-copy">
+                    <strong>Catalog API</strong>
+                    <small>Interactive requests</small>
+                  </div>
+                  <div class="lane-meter" aria-hidden="true">
+                    <span></span>
+                  </div>
+                  <div class="lane-result">
+                    <b class="unsafe-label">4.1k</b>
+                    <b class="safe-label">3.3k</b>
+                    <small>admit</small>
+                  </div>
+                </article>
+
+                <article class="traffic-lane bulk-lane">
+                  <div class="lane-badge">P2</div>
+                  <div class="lane-copy">
+                    <strong>Recommendations</strong>
+                    <small>Deferrable background work</small>
+                  </div>
+                  <div class="lane-meter" aria-hidden="true">
+                    <span></span>
+                  </div>
+                  <div class="lane-result">
+                    <b class="unsafe-label">3.1k</b>
+                    <b class="safe-label">590</b>
+                    <small class="unsafe-label">admit</small>
+                    <small class="safe-label">admit</small>
+                  </div>
+                </article>
+
+                <div class="shed-channel">
+                  <div>
+                    <span class="shed-mark" aria-hidden="true"></span>
+                    <span>
+                      <strong>Early shed</strong>
+                      <small>Retry-After: 2s</small>
+                    </span>
+                  </div>
+                  <b class="unsafe-label">0 rps</b>
+                  <b class="safe-label">3,330 rps</b>
+                </div>
+              </div>
+
+              <div class="connector origin-connector" aria-hidden="true">
+                <span></span>
+                <i></i>
+              </div>
+
+              <div class="service-column">
+                <div class="stage-label">
+                  <span>Service pool</span>
+                  <strong>32 instances</strong>
+                </div>
+
+                <div class="service-grid" aria-label="Service instance health">
+                  <span></span><span></span><span></span><span></span>
+                  <span></span><span></span><span></span><span></span>
+                  <span></span><span></span><span></span><span></span>
+                  <span></span><span></span><span></span><span></span>
+                </div>
+
+                <div class="pool-health">
+                  <span class="unsafe-label">11 instances throttling</span>
+                  <span class="safe-label">32 instances healthy</span>
+                  <div class="health-line" aria-hidden="true">
+                    <i></i><i></i><i></i><i></i><i></i><i></i>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <footer class="flow-footer">
+              <span class="unsafe-label">
+                <i class="footer-state"></i>
+                Collapse risk: retries are feeding the overload loop
+              </span>
+              <span class="safe-label">
+                <i class="footer-state"></i>
+                Stable: rejected work exits before consuming a connection
+              </span>
+              <span>Updated 2s ago</span>
+            </footer>
+          </section>
+
+          <aside class="insight-panel" aria-labelledby="envelope-title">
+            <header class="panel-header compact">
+              <div>
+                <p class="panel-kicker">Capacity model</p>
+                <h2 id="envelope-title">Resource envelope</h2>
+              </div>
+              <span class="model-badge">Live</span>
+            </header>
+
+            <div class="envelope-chart">
+              <div class="chart-axis">
+                <span>0</span>
+                <span>25</span>
+                <span>50</span>
+                <span>75</span>
+                <span>100%</span>
+              </div>
+
+              <div class="resource-row cpu-row">
+                <div class="resource-copy">
+                  <span>CPU</span>
+                  <strong class="unsafe-label">96%</strong>
+                  <strong class="safe-label">71%</strong>
+                </div>
+                <div class="resource-track">
+                  <span></span>
+                  <i></i>
+                </div>
+              </div>
+
+              <div class="resource-row queue-row">
+                <div class="resource-copy">
+                  <span>Queue</span>
+                  <strong class="unsafe-label">92%</strong>
+                  <strong class="safe-label">24%</strong>
+                </div>
+                <div class="resource-track">
+                  <span></span>
+                  <i></i>
+                </div>
+              </div>
+
+              <div class="resource-row conn-row">
+                <div class="resource-copy">
+                  <span>Connections</span>
+                  <strong class="unsafe-label">99%</strong>
+                  <strong class="safe-label">68%</strong>
+                </div>
+                <div class="resource-track">
+                  <span></span>
+                  <i></i>
+                </div>
+              </div>
+
+              <div class="resource-row memory-row">
+                <div class="resource-copy">
+                  <span>Memory</span>
+                  <strong class="unsafe-label">84%</strong>
+                  <strong class="safe-label">63%</strong>
+                </div>
+                <div class="resource-track">
+                  <span></span>
+                  <i></i>
+                </div>
+              </div>
+            </div>
+
+            <div class="policy-block">
+              <div class="policy-heading">
+                <span>Active policy</span>
+                <strong class="unsafe-label">None</strong>
+                <strong class="safe-label">SLO-first v4</strong>
+              </div>
+
+              <dl class="policy-list">
+                <div>
+                  <dt>Trigger</dt>
+                  <dd>p99 &gt; 400ms</dd>
+                </div>
+                <div>
+                  <dt>Hard ceiling</dt>
+                  <dd>5,200 rps</dd>
+                </div>
+                <div>
+                  <dt>Recovery</dt>
+                  <dd>3 clean windows</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div class="decision-log">
+              <div class="log-heading">
+                <span>Decision log</span>
+                <small>Last 30s</small>
+              </div>
+
+              <ol>
+                <li>
+                  <span class="log-time">00:28</span>
+                  <i></i>
+                  <span>
+                    <strong class="unsafe-label">Queue crossed ceiling</strong>
+                    <strong class="safe-label">P2 admission reduced</strong>
+                    <small class="unsafe-label">1,842 waiting</small>
+                    <small class="safe-label">590 rps retained</small>
+                  </span>
+                </li>
+                <li>
+                  <span class="log-time">00:19</span>
+                  <i></i>
+                  <span>
+                    <strong class="unsafe-label"
+                      >Latency burn accelerated</strong
+                    >
+                    <strong class="safe-label">P0 reserve protected</strong>
+                    <small class="unsafe-label">14.2x budget rate</small>
+                    <small class="safe-label">1,200 rps guaranteed</small>
+                  </span>
+                </li>
+                <li>
+                  <span class="log-time">00:10</span>
+                  <i></i>
+                  <span>
+                    <strong class="unsafe-label">Pool entered throttle</strong>
+                    <strong class="safe-label">Envelope stabilized</strong>
+                    <small class="unsafe-label">11 instances affected</small>
+                    <small class="safe-label">p99 trending down</small>
+                  </span>
+                </li>
+              </ol>
+            </div>
+          </aside>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/adaptive-load-shedding-kp/style.css
+++ b/submissions/examples/adaptive-load-shedding-kp/style.css
@@ -1,0 +1,1879 @@
+:root {
+  color-scheme: light;
+
+  --ink: #182024;
+  --muted: #68747a;
+  --line: #d8dee1;
+  --line-strong: #b9c3c8;
+  --surface: #ffffff;
+  --surface-soft: #f4f6f7;
+  --canvas: #e9edef;
+  --nav: #14191c;
+  --nav-muted: #aeb8bd;
+  --danger: #c83b36;
+  --danger-dark: #8f2625;
+  --danger-soft: #fff0ee;
+  --warning: #d98218;
+  --warning-soft: #fff5e5;
+  --success: #14866d;
+  --success-dark: #0c6653;
+  --success-soft: #e8f7f2;
+  --info: #2468b4;
+  --info-soft: #eaf3fd;
+  --critical: #1d6bb8;
+  --standard: #7b58b5;
+  --bulk: #c87916;
+  --shadow: 0 18px 45px rgba(30, 42, 48, 0.09);
+  --fast: 180ms ease;
+  --slow: 520ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--canvas);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(rgba(24, 32, 36, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(24, 32, 36, 0.035) 1px, transparent 1px),
+    var(--canvas);
+  background-size: 28px 28px;
+}
+
+button,
+input,
+label {
+  font: inherit;
+}
+
+.protection-input {
+  position: fixed;
+  top: 18px;
+  right: 28px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.console-shell {
+  width: min(1520px, calc(100% - 32px));
+  min-height: calc(100vh - 32px);
+  margin: 16px auto;
+  overflow: hidden;
+  background: var(--surface-soft);
+  border: 1px solid rgba(24, 32, 36, 0.16);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.topbar {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  gap: 28px;
+  padding: 0 24px;
+  color: #fff;
+  background: var(--nav);
+  border-bottom: 1px solid #2e373c;
+}
+
+.brand {
+  display: inline-flex;
+  min-width: 220px;
+  align-items: center;
+  gap: 11px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  grid-template-columns: repeat(3, 1fr);
+  align-items: end;
+  gap: 3px;
+  padding: 7px;
+  background: #f2f5f6;
+  border-radius: 5px;
+}
+
+.brand-mark span {
+  display: block;
+  background: var(--danger);
+  border-radius: 1px;
+  transition:
+    height var(--slow),
+    background-color var(--slow);
+}
+
+.brand-mark span:nth-child(1) {
+  height: 45%;
+}
+
+.brand-mark span:nth-child(2) {
+  height: 85%;
+}
+
+.brand-mark span:nth-child(3) {
+  height: 65%;
+}
+
+.brand strong,
+.brand small {
+  display: block;
+  letter-spacing: 0;
+}
+
+.brand strong {
+  font-size: 0.96rem;
+  line-height: 1.15;
+}
+
+.brand small {
+  margin-top: 3px;
+  color: var(--nav-muted);
+  font-size: 0.68rem;
+}
+
+.cluster-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: auto;
+  color: #e0e6e8;
+  font-size: 0.78rem;
+}
+
+.state-dot {
+  width: 8px;
+  height: 8px;
+  background: #f05c52;
+  border-radius: 50%;
+  box-shadow: 0 0 0 5px rgba(240, 92, 82, 0.12);
+  animation: alert-pulse 1.6s ease-in-out infinite;
+}
+
+.protection-switch {
+  display: flex;
+  min-width: 182px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.switch-copy {
+  text-align: right;
+}
+
+.switch-copy > span,
+.switch-copy small {
+  display: block;
+}
+
+.switch-copy > span {
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.switch-copy small {
+  margin-top: 2px;
+  color: #f28e87;
+  font-size: 0.66rem;
+}
+
+.switch-track {
+  position: relative;
+  display: inline-flex;
+  width: 48px;
+  height: 26px;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 3px;
+  background: #4a555a;
+  border: 1px solid #68747a;
+  border-radius: 14px;
+  transition:
+    background-color var(--fast),
+    border-color var(--fast);
+}
+
+.switch-thumb {
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  transition: transform var(--slow);
+}
+
+.protection-input:focus-visible ~ .console-shell .protection-switch {
+  outline: 3px solid #86b7f1;
+  outline-offset: 4px;
+}
+
+.safe-label {
+  display: none;
+}
+
+.summary-band {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 28px;
+  padding: 30px 32px 26px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+
+.summary-heading {
+  min-width: 0;
+}
+
+.eyebrow,
+.panel-kicker {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+h1,
+h2,
+p {
+  letter-spacing: 0;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.65rem, 3vw, 2.4rem);
+  line-height: 1.08;
+}
+
+.mode-pill {
+  padding: 5px 8px;
+  color: var(--danger-dark);
+  background: var(--danger-soft);
+  border: 1px solid #efb8b4;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.summary-copy {
+  max-width: 760px;
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.window-meta {
+  display: grid;
+  min-width: 300px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  overflow: hidden;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.window-meta div {
+  padding: 12px 14px;
+  background: var(--surface-soft);
+}
+
+.window-meta dt,
+.window-meta dd {
+  margin: 0;
+}
+
+.window-meta dt {
+  color: var(--muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.window-meta dd {
+  margin-top: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.metric-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  background: var(--line);
+  border-bottom: 1px solid var(--line);
+  gap: 1px;
+}
+
+.metric {
+  position: relative;
+  min-width: 0;
+  min-height: 136px;
+  padding: 18px 22px 16px;
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.metric::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--danger);
+  content: "";
+  transform-origin: left;
+  transition:
+    transform var(--slow),
+    background-color var(--slow);
+}
+
+.metric-topline {
+  display: flex;
+  min-height: 18px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.metric-trend {
+  color: var(--danger-dark);
+  font-size: 0.61rem;
+}
+
+.metric > strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.metric > small {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 0.64rem;
+}
+
+.metric-spark {
+  position: absolute;
+  right: 18px;
+  bottom: 17px;
+  display: flex;
+  height: 30px;
+  align-items: end;
+  gap: 3px;
+}
+
+.metric-spark i {
+  display: block;
+  width: 3px;
+  background: #d65e58;
+  border-radius: 1px 1px 0 0;
+  transition:
+    height var(--slow),
+    background-color var(--slow);
+}
+
+.metric-spark i:nth-child(1) {
+  height: 25%;
+}
+
+.metric-spark i:nth-child(2) {
+  height: 38%;
+}
+
+.metric-spark i:nth-child(3) {
+  height: 33%;
+}
+
+.metric-spark i:nth-child(4) {
+  height: 54%;
+}
+
+.metric-spark i:nth-child(5) {
+  height: 62%;
+}
+
+.metric-spark i:nth-child(6) {
+  height: 74%;
+}
+
+.metric-spark i:nth-child(7) {
+  height: 90%;
+}
+
+.metric-spark i:nth-child(8) {
+  height: 100%;
+}
+
+.latency-track {
+  position: absolute;
+  right: 20px;
+  bottom: 21px;
+  width: 92px;
+  height: 6px;
+  background: #e9edef;
+  border-radius: 3px;
+}
+
+.latency-track::after {
+  position: absolute;
+  top: -4px;
+  left: 22%;
+  width: 1px;
+  height: 14px;
+  background: var(--ink);
+  content: "";
+}
+
+.latency-track span {
+  display: block;
+  width: 94%;
+  height: 100%;
+  background: var(--danger);
+  border-radius: inherit;
+  transition:
+    width var(--slow),
+    background-color var(--slow);
+}
+
+.latency-track b {
+  position: absolute;
+  top: -3px;
+  right: 3px;
+  width: 12px;
+  height: 12px;
+  background: var(--danger);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--danger);
+  transition:
+    right var(--slow),
+    background-color var(--slow),
+    box-shadow var(--slow);
+}
+
+.error-scale {
+  position: absolute;
+  right: 20px;
+  bottom: 19px;
+  display: flex;
+  gap: 4px;
+}
+
+.error-scale i {
+  width: 12px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 1px;
+  transition:
+    background-color var(--slow),
+    opacity var(--slow);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 16px;
+  padding: 16px;
+}
+
+.flow-panel,
+.insight-panel {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.panel-header {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 15px 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-header h2 {
+  margin: 4px 0 0;
+  font-size: 0.98rem;
+}
+
+.sample-rate,
+.model-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.sample-rate span {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+  animation: alert-pulse 1.6s ease-in-out infinite;
+}
+
+.model-badge {
+  padding: 4px 7px;
+  color: var(--info);
+  background: var(--info-soft);
+  border: 1px solid #bdd8f3;
+  border-radius: 3px;
+  text-transform: uppercase;
+}
+
+.flow-stage {
+  display: grid;
+  min-height: 480px;
+  grid-template-columns:
+    minmax(86px, 0.7fr) 44px minmax(180px, 1.15fr) 44px
+    minmax(260px, 1.65fr) 44px minmax(130px, 0.9fr);
+  align-items: center;
+  padding: 26px 20px;
+  background:
+    linear-gradient(90deg, transparent 49%, rgba(24, 32, 36, 0.035) 50%),
+    var(--surface);
+  background-size: 36px 100%;
+}
+
+.stage-label {
+  display: flex;
+  min-height: 38px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.stage-label span,
+.stage-label strong {
+  display: block;
+  font-size: 0.61rem;
+}
+
+.stage-label span {
+  color: var(--muted);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.stage-label strong {
+  text-align: right;
+}
+
+.request-stack {
+  position: relative;
+  display: grid;
+  min-height: 250px;
+  place-items: center;
+}
+
+.request-chip {
+  position: absolute;
+  display: grid;
+  width: 45px;
+  height: 26px;
+  place-items: center;
+  color: #fff;
+  border: 2px solid #fff;
+  border-radius: 3px;
+  box-shadow: 0 4px 12px rgba(24, 32, 36, 0.2);
+  font-size: 0.6rem;
+  font-weight: 800;
+  animation: request-wave 2.8s ease-in-out infinite;
+}
+
+.request-chip.critical {
+  background: var(--critical);
+}
+
+.request-chip.standard {
+  background: var(--standard);
+}
+
+.request-chip.bulk {
+  background: var(--bulk);
+}
+
+.request-chip:nth-child(1) {
+  top: 3%;
+  left: 9%;
+  animation-delay: -0.3s;
+}
+
+.request-chip:nth-child(2) {
+  top: 19%;
+  right: 4%;
+  animation-delay: -1.4s;
+}
+
+.request-chip:nth-child(3) {
+  top: 37%;
+  left: 0;
+  animation-delay: -2.2s;
+}
+
+.request-chip:nth-child(4) {
+  top: 55%;
+  right: 2%;
+  animation-delay: -0.8s;
+}
+
+.request-chip:nth-child(5) {
+  top: 73%;
+  left: 10%;
+  animation-delay: -1.8s;
+}
+
+.request-chip:nth-child(6) {
+  top: 88%;
+  right: 8%;
+  animation-delay: -2.6s;
+}
+
+.connector {
+  position: relative;
+  height: 2px;
+  margin: 0 7px;
+  background: var(--line-strong);
+}
+
+.connector span {
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 20px;
+  height: 6px;
+  background: var(--danger);
+  border-radius: 3px;
+  animation: packet-cross 1.4s linear infinite;
+  transition:
+    width var(--slow),
+    background-color var(--slow);
+}
+
+.connector i {
+  position: absolute;
+  top: -4px;
+  right: -1px;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 7px solid var(--line-strong);
+}
+
+.controller {
+  padding: 16px;
+  background: var(--surface-soft);
+  border: 1px solid var(--danger);
+  border-radius: 6px;
+  box-shadow: 0 0 0 4px var(--danger-soft);
+  transition:
+    border-color var(--slow),
+    box-shadow var(--slow),
+    background-color var(--slow);
+}
+
+.controller-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.controller-icon {
+  display: flex;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  align-items: end;
+  justify-content: center;
+  gap: 3px;
+  padding: 7px;
+  background: var(--danger-soft);
+  border-radius: 4px;
+  transition: background-color var(--slow);
+}
+
+.controller-icon i {
+  display: block;
+  width: 4px;
+  background: var(--danger);
+  transition:
+    height var(--slow),
+    background-color var(--slow);
+}
+
+.controller-icon i:nth-child(1) {
+  height: 45%;
+}
+
+.controller-icon i:nth-child(2) {
+  height: 100%;
+}
+
+.controller-icon i:nth-child(3) {
+  height: 72%;
+}
+
+.controller-head small,
+.controller-head strong {
+  display: block;
+}
+
+.controller-head small {
+  color: var(--muted);
+  font-size: 0.59rem;
+}
+
+.controller-head strong {
+  margin-top: 3px;
+  font-size: 0.76rem;
+}
+
+.capacity-dial {
+  display: grid;
+  place-items: center;
+  padding: 18px 0;
+}
+
+.dial-ring {
+  position: relative;
+  display: grid;
+  width: 104px;
+  height: 104px;
+  place-items: center;
+  background: conic-gradient(
+    var(--danger) 0deg 330deg,
+    var(--surface) 330deg 360deg
+  );
+  border-radius: 50%;
+  transition: background var(--slow);
+}
+
+.dial-ring::before {
+  position: absolute;
+  width: 78px;
+  height: 78px;
+  background: var(--surface-soft);
+  border-radius: 50%;
+  content: "";
+}
+
+.dial-ring::after {
+  position: absolute;
+  top: -4px;
+  right: 18px;
+  width: 8px;
+  height: 8px;
+  background: var(--danger);
+  border: 3px solid var(--surface-soft);
+  border-radius: 50%;
+  content: "";
+  transition:
+    top var(--slow),
+    right var(--slow),
+    background-color var(--slow);
+}
+
+.dial-value {
+  position: relative;
+  z-index: 1;
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+
+.capacity-dial > small {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.58rem;
+}
+
+.decision-signals {
+  display: grid;
+  gap: 7px;
+}
+
+.decision-signals > span {
+  display: grid;
+  grid-template-columns: 6px 1fr auto;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.57rem;
+}
+
+.decision-signals i {
+  width: 5px;
+  height: 5px;
+  background: var(--danger);
+  border-radius: 50%;
+  transition: background-color var(--slow);
+}
+
+.decision-signals b {
+  color: var(--ink);
+}
+
+.lane-column {
+  min-width: 0;
+}
+
+.traffic-lane {
+  display: grid;
+  min-height: 68px;
+  grid-template-columns: 34px minmax(90px, 1fr) minmax(52px, 0.8fr) 42px;
+  align-items: center;
+  gap: 9px;
+  padding: 10px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--lane-color);
+  border-radius: 4px;
+  transition:
+    opacity var(--slow),
+    transform var(--slow),
+    background-color var(--slow);
+}
+
+.traffic-lane + .traffic-lane {
+  margin-top: 9px;
+}
+
+.critical-lane {
+  --lane-color: var(--critical);
+}
+
+.standard-lane {
+  --lane-color: var(--standard);
+}
+
+.bulk-lane {
+  --lane-color: var(--bulk);
+}
+
+.lane-badge {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  color: #fff;
+  background: var(--lane-color);
+  border-radius: 3px;
+  font-size: 0.58rem;
+  font-weight: 800;
+}
+
+.lane-copy {
+  min-width: 0;
+}
+
+.lane-copy strong,
+.lane-copy small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lane-copy strong {
+  font-size: 0.7rem;
+}
+
+.lane-copy small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.54rem;
+}
+
+.lane-meter {
+  height: 5px;
+  overflow: hidden;
+  background: #e7ebed;
+  border-radius: 3px;
+}
+
+.lane-meter span {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: var(--lane-color);
+  border-radius: inherit;
+  transition: width var(--slow);
+}
+
+.lane-result {
+  text-align: right;
+}
+
+.lane-result b,
+.lane-result small {
+  display: block;
+}
+
+.lane-result b {
+  font-size: 0.67rem;
+}
+
+.lane-result small {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 0.53rem;
+}
+
+.shed-channel {
+  display: flex;
+  min-height: 54px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 9px;
+  padding: 9px 11px;
+  color: #7c5522;
+  background: var(--warning-soft);
+  border: 1px dashed #e8b36e;
+  border-radius: 4px;
+  opacity: 0.45;
+  transition:
+    opacity var(--slow),
+    transform var(--slow);
+}
+
+.shed-channel > div {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.shed-channel strong,
+.shed-channel small {
+  display: block;
+}
+
+.shed-channel strong,
+.shed-channel > b {
+  font-size: 0.64rem;
+}
+
+.shed-channel small {
+  margin-top: 2px;
+  font-size: 0.52rem;
+}
+
+.shed-mark {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--warning);
+  border-radius: 50%;
+}
+
+.shed-mark::after {
+  position: absolute;
+  top: 9px;
+  left: 3px;
+  width: 12px;
+  height: 2px;
+  background: var(--warning);
+  content: "";
+  transform: rotate(-45deg);
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 7px;
+  padding: 14px;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.service-grid span {
+  display: block;
+  aspect-ratio: 1;
+  background: var(--danger);
+  border: 2px solid #fff;
+  border-radius: 3px;
+  box-shadow: 0 0 0 1px #e2aaa7;
+  animation: instance-flicker 1.8s ease-in-out infinite alternate;
+  transition:
+    background-color var(--slow),
+    box-shadow var(--slow),
+    opacity var(--slow);
+}
+
+.service-grid span:nth-child(3n) {
+  animation-delay: -0.8s;
+}
+
+.service-grid span:nth-child(4n) {
+  opacity: 0.4;
+  animation-delay: -1.3s;
+}
+
+.service-grid span:nth-child(5n) {
+  background: var(--warning);
+  box-shadow: 0 0 0 1px #e6b46f;
+}
+
+.pool-health {
+  margin-top: 12px;
+}
+
+.pool-health > span {
+  display: block;
+  color: var(--danger-dark);
+  font-size: 0.58rem;
+  font-weight: 700;
+}
+
+.health-line {
+  display: flex;
+  height: 26px;
+  align-items: end;
+  gap: 3px;
+  margin-top: 7px;
+}
+
+.health-line i {
+  display: block;
+  width: 100%;
+  background: var(--danger);
+  transition:
+    height var(--slow),
+    background-color var(--slow);
+}
+
+.health-line i:nth-child(1) {
+  height: 84%;
+}
+
+.health-line i:nth-child(2) {
+  height: 96%;
+}
+
+.health-line i:nth-child(3) {
+  height: 72%;
+}
+
+.health-line i:nth-child(4) {
+  height: 100%;
+}
+
+.health-line i:nth-child(5) {
+  height: 88%;
+}
+
+.health-line i:nth-child(6) {
+  height: 94%;
+}
+
+.flow-footer {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 18px;
+  color: var(--muted);
+  background: var(--surface-soft);
+  border-top: 1px solid var(--line);
+  font-size: 0.6rem;
+}
+
+.flow-footer > span:first-child,
+.flow-footer > span:nth-child(2) {
+  align-items: center;
+  gap: 7px;
+}
+
+.flow-footer .unsafe-label {
+  display: flex;
+}
+
+.footer-state {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+}
+
+.insight-panel {
+  align-self: start;
+}
+
+.panel-header.compact {
+  min-height: 68px;
+}
+
+.envelope-chart {
+  padding: 20px 18px 18px;
+}
+
+.chart-axis {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  margin: 0 0 13px 87px;
+  color: #8c979c;
+  font-size: 0.52rem;
+}
+
+.chart-axis span {
+  text-align: right;
+}
+
+.chart-axis span:first-child {
+  text-align: left;
+}
+
+.resource-row {
+  display: grid;
+  grid-template-columns: 76px 1fr;
+  align-items: center;
+  gap: 11px;
+}
+
+.resource-row + .resource-row {
+  margin-top: 17px;
+}
+
+.resource-copy {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 5px;
+}
+
+.resource-copy span {
+  color: var(--muted);
+  font-size: 0.6rem;
+}
+
+.resource-copy strong {
+  font-size: 0.62rem;
+}
+
+.resource-track {
+  position: relative;
+  height: 17px;
+  overflow: hidden;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 24.5%,
+      rgba(24, 32, 36, 0.1) 25%,
+      transparent 25.5%,
+      transparent 49.5%,
+      rgba(24, 32, 36, 0.1) 50%,
+      transparent 50.5%,
+      transparent 74.5%,
+      rgba(24, 32, 36, 0.1) 75%,
+      transparent 75.5%
+    ),
+    var(--surface-soft);
+  border-radius: 2px;
+}
+
+.resource-track::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 80%;
+  width: 2px;
+  background: var(--danger-dark);
+  content: "";
+  opacity: 0.5;
+}
+
+.resource-track span {
+  display: block;
+  width: var(--unsafe-value);
+  height: 100%;
+  background: var(--danger);
+  border-radius: inherit;
+  transition:
+    width var(--slow),
+    background-color var(--slow);
+}
+
+.resource-track i {
+  position: absolute;
+  top: 4px;
+  left: calc(var(--unsafe-value) - 8px);
+  width: 8px;
+  height: 8px;
+  background: #fff;
+  border-radius: 1px;
+  transition: left var(--slow);
+}
+
+.cpu-row {
+  --unsafe-value: 96%;
+  --safe-value: 71%;
+}
+
+.queue-row {
+  --unsafe-value: 92%;
+  --safe-value: 24%;
+}
+
+.conn-row {
+  --unsafe-value: 99%;
+  --safe-value: 68%;
+}
+
+.memory-row {
+  --unsafe-value: 84%;
+  --safe-value: 63%;
+}
+
+.policy-block {
+  margin: 2px 18px 18px;
+  padding: 14px;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.policy-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.65rem;
+}
+
+.policy-heading > span {
+  color: var(--muted);
+}
+
+.policy-heading strong {
+  color: var(--danger-dark);
+}
+
+.policy-list {
+  display: grid;
+  gap: 8px;
+  margin: 11px 0 0;
+}
+
+.policy-list div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.policy-list dt,
+.policy-list dd {
+  margin: 0;
+  font-size: 0.58rem;
+}
+
+.policy-list dt {
+  color: var(--muted);
+}
+
+.policy-list dd {
+  font-weight: 700;
+}
+
+.decision-log {
+  padding: 15px 18px 20px;
+  border-top: 1px solid var(--line);
+}
+
+.log-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.log-heading small {
+  color: var(--muted);
+  font-size: 0.55rem;
+  font-weight: 500;
+}
+
+.decision-log ol {
+  margin: 15px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.decision-log li {
+  position: relative;
+  display: grid;
+  min-height: 57px;
+  grid-template-columns: 36px 8px 1fr;
+  gap: 8px;
+}
+
+.decision-log li:not(:last-child)::after {
+  position: absolute;
+  top: 15px;
+  bottom: -2px;
+  left: 48px;
+  width: 1px;
+  background: var(--line);
+  content: "";
+}
+
+.log-time {
+  color: var(--muted);
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.54rem;
+}
+
+.decision-log li > i {
+  position: relative;
+  z-index: 1;
+  width: 8px;
+  height: 8px;
+  background: var(--danger);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--danger);
+  transition:
+    background-color var(--slow),
+    box-shadow var(--slow);
+}
+
+.decision-log li strong,
+.decision-log li small {
+  display: block;
+}
+
+.decision-log li strong {
+  font-size: 0.62rem;
+}
+
+.decision-log li small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.54rem;
+}
+
+.protection-input:checked ~ .console-shell .unsafe-label {
+  display: none;
+}
+
+.protection-input:checked ~ .console-shell .safe-label {
+  display: block;
+}
+
+.protection-input:checked ~ .console-shell .cluster-state .safe-label,
+.protection-input:checked ~ .console-shell .flow-footer .safe-label {
+  display: flex;
+}
+
+.protection-input:checked ~ .console-shell .brand-mark span,
+.protection-input:checked ~ .console-shell .controller-icon i,
+.protection-input:checked ~ .console-shell .decision-signals i,
+.protection-input:checked ~ .console-shell .health-line i {
+  background: var(--success);
+}
+
+.protection-input:checked ~ .console-shell .state-dot,
+.protection-input:checked ~ .console-shell .sample-rate span,
+.protection-input:checked ~ .console-shell .footer-state {
+  background: var(--success);
+  box-shadow: 0 0 0 5px rgba(20, 134, 109, 0.12);
+  animation: none;
+}
+
+.protection-input:checked ~ .console-shell .switch-copy small {
+  color: #72d3bd;
+}
+
+.protection-input:checked ~ .console-shell .switch-track {
+  background: var(--success);
+  border-color: #38a88f;
+}
+
+.protection-input:checked ~ .console-shell .switch-thumb {
+  transform: translateX(20px);
+}
+
+.protection-input:checked ~ .console-shell .mode-pill {
+  color: var(--success-dark);
+  background: var(--success-soft);
+  border-color: #9ed7c9;
+}
+
+.protection-input:checked ~ .console-shell .metric::after {
+  background: var(--success);
+  transform: scaleX(0.72);
+}
+
+.protection-input:checked ~ .console-shell .metric-trend,
+.protection-input:checked ~ .console-shell .pool-health > span,
+.protection-input:checked ~ .console-shell .policy-heading strong {
+  color: var(--success-dark);
+}
+
+.protection-input:checked ~ .console-shell .metric-spark i {
+  height: 48%;
+  background: var(--success);
+}
+
+.protection-input:checked ~ .console-shell .admitted-spark i:nth-child(2n) {
+  height: 58%;
+}
+
+.protection-input:checked ~ .console-shell .latency-track span {
+  width: 18%;
+  background: var(--success);
+}
+
+.protection-input:checked ~ .console-shell .latency-track b {
+  right: 74px;
+  background: var(--success);
+  box-shadow: 0 0 0 1px var(--success);
+}
+
+.protection-input:checked ~ .console-shell .error-scale i {
+  background: var(--success);
+  opacity: 0.18;
+}
+
+.protection-input:checked ~ .console-shell .error-scale i:first-child {
+  opacity: 1;
+}
+
+.protection-input:checked ~ .console-shell .connector span {
+  width: 12px;
+  background: var(--success);
+}
+
+.protection-input:checked ~ .console-shell .decision-connector span {
+  animation-duration: 2s;
+}
+
+.protection-input:checked ~ .console-shell .controller {
+  background: #f6fbf9;
+  border-color: var(--success);
+  box-shadow: 0 0 0 4px var(--success-soft);
+}
+
+.protection-input:checked ~ .console-shell .controller-icon {
+  background: var(--success-soft);
+}
+
+.protection-input:checked ~ .console-shell .dial-ring {
+  background: conic-gradient(
+    var(--success) 0deg 286deg,
+    var(--surface) 286deg 360deg
+  );
+}
+
+.protection-input:checked ~ .console-shell .dial-ring::after {
+  top: 7px;
+  right: 8px;
+  background: var(--success);
+}
+
+.protection-input:checked ~ .console-shell .standard-lane .lane-meter span {
+  width: 80%;
+}
+
+.protection-input:checked ~ .console-shell .bulk-lane {
+  background: var(--warning-soft);
+  transform: translateY(2px);
+}
+
+.protection-input:checked ~ .console-shell .bulk-lane .lane-meter span {
+  width: 19%;
+}
+
+.protection-input:checked ~ .console-shell .shed-channel {
+  opacity: 1;
+  transform: translateY(2px);
+}
+
+.protection-input:checked ~ .console-shell .service-grid span {
+  background: var(--success);
+  box-shadow: 0 0 0 1px #80c8b7;
+  opacity: 1;
+  animation: none;
+}
+
+.protection-input:checked ~ .console-shell .health-line i:nth-child(1) {
+  height: 56%;
+}
+
+.protection-input:checked ~ .console-shell .health-line i:nth-child(2) {
+  height: 62%;
+}
+
+.protection-input:checked ~ .console-shell .health-line i:nth-child(3) {
+  height: 58%;
+}
+
+.protection-input:checked ~ .console-shell .health-line i:nth-child(4) {
+  height: 66%;
+}
+
+.protection-input:checked ~ .console-shell .health-line i:nth-child(5) {
+  height: 61%;
+}
+
+.protection-input:checked ~ .console-shell .health-line i:nth-child(6) {
+  height: 64%;
+}
+
+.protection-input:checked ~ .console-shell .resource-track span {
+  width: var(--safe-value);
+  background: var(--success);
+}
+
+.protection-input:checked ~ .console-shell .resource-track i {
+  left: calc(var(--safe-value) - 8px);
+}
+
+.protection-input:checked ~ .console-shell .decision-log li > i {
+  background: var(--success);
+  box-shadow: 0 0 0 1px var(--success);
+}
+
+@keyframes alert-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(0.75);
+  }
+}
+
+@keyframes request-wave {
+  0%,
+  100% {
+    transform: translateX(-3px);
+  }
+
+  50% {
+    transform: translateX(5px);
+  }
+}
+
+@keyframes packet-cross {
+  from {
+    transform: translateX(-8px);
+  }
+
+  to {
+    transform: translateX(26px);
+  }
+}
+
+@keyframes instance-flicker {
+  from {
+    filter: saturate(0.7);
+    transform: scale(0.94);
+  }
+
+  to {
+    filter: saturate(1.2);
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 1220px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .insight-panel {
+    display: grid;
+    grid-template-columns: 1.25fr 0.9fr 1.1fr;
+    align-items: stretch;
+  }
+
+  .insight-panel > .panel-header {
+    grid-column: 1 / -1;
+  }
+
+  .policy-block {
+    align-self: stretch;
+    margin: 18px 0;
+    border-top: 0;
+    border-bottom: 0;
+    border-radius: 0;
+  }
+
+  .decision-log {
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 980px) {
+  .metric-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .flow-stage {
+    grid-template-columns:
+      minmax(80px, 0.7fr) 36px minmax(165px, 1fr)
+      36px minmax(230px, 1.4fr);
+  }
+
+  .origin-connector,
+  .service-column {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .console-shell {
+    width: 100%;
+    min-height: 100vh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .topbar {
+    min-height: 62px;
+    gap: 12px;
+    padding: 0 15px;
+  }
+
+  .brand {
+    min-width: 0;
+    margin-right: auto;
+  }
+
+  .brand small,
+  .cluster-state {
+    display: none;
+  }
+
+  .protection-switch {
+    min-width: 0;
+  }
+
+  .switch-copy > span {
+    display: none;
+  }
+
+  .summary-band {
+    display: block;
+    padding: 24px 18px 20px;
+  }
+
+  .title-row {
+    flex-wrap: wrap;
+  }
+
+  .window-meta {
+    min-width: 0;
+    margin-top: 20px;
+  }
+
+  .workspace {
+    padding: 10px;
+  }
+
+  .flow-stage {
+    grid-template-columns: 1fr;
+    gap: 13px;
+    padding: 18px;
+  }
+
+  .incoming-column,
+  .controller-column,
+  .lane-column,
+  .service-column {
+    width: 100%;
+  }
+
+  .request-stack {
+    display: flex;
+    min-height: 44px;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+  }
+
+  .request-chip {
+    position: static;
+    width: 38px;
+    height: 24px;
+    animation: request-wave 2.8s ease-in-out infinite;
+  }
+
+  .connector {
+    width: 2px;
+    height: 24px;
+    margin: 0 auto;
+  }
+
+  .connector span {
+    top: 0;
+    left: -2px;
+    width: 6px;
+    height: 12px;
+    animation: packet-drop 1.4s linear infinite;
+  }
+
+  .connector i {
+    top: auto;
+    right: -4px;
+    bottom: -1px;
+    border-top: 7px solid var(--line-strong);
+    border-right: 5px solid transparent;
+    border-bottom: 0;
+    border-left: 5px solid transparent;
+  }
+
+  .origin-connector,
+  .service-column {
+    display: block;
+  }
+
+  .service-grid {
+    grid-template-columns: repeat(8, 1fr);
+  }
+
+  .insight-panel {
+    display: block;
+  }
+
+  .policy-block {
+    margin: 2px 18px 18px;
+    border: 1px solid var(--line);
+    border-radius: 4px;
+  }
+
+  .decision-log {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .metric-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .metric {
+    min-height: 120px;
+  }
+
+  .window-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-header {
+    min-height: 62px;
+    padding: 13px 14px;
+  }
+
+  .flow-stage {
+    padding: 14px;
+  }
+
+  .traffic-lane {
+    grid-template-columns: 32px minmax(80px, 1fr) 42px;
+  }
+
+  .lane-meter {
+    display: none;
+  }
+
+  .service-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .flow-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .chart-axis {
+    margin-left: 78px;
+  }
+
+  .resource-row {
+    grid-template-columns: 67px 1fr;
+  }
+}
+
+@keyframes packet-drop {
+  from {
+    transform: translateY(-5px);
+  }
+
+  to {
+    transform: translateY(18px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

- add a CSS-only adaptive load shedding operations console
- compare unprotected overload with priority-aware admission control
- visualize critical, standard, and deferrable traffic across capacity, queue, latency, connection, and error signals
- provide responsive horizontal and mobile flow layouts with reduced-motion support

## Why

Overload protection is difficult to understand from isolated metrics. This example makes the admission decision and its system-wide effect visible in one interactive state transition, while keeping the implementation dependency-free.

## Validation

- Prettier check passed for all three submission files
- Stylelint passed for the scoped stylesheet via stdin
- duplicate class and keyframe check passed
- Vitest passed: 61 tests
- Playwright assertions passed in installed Chrome at 1440px and 390px
- keyboard toggle retains focus and both viewports have zero horizontal overflow
- staged diff check passed

## Scope

Adds only:

- `submissions/examples/adaptive-load-shedding-kp/demo.html`
- `submissions/examples/adaptive-load-shedding-kp/style.css`
- `submissions/examples/adaptive-load-shedding-kp/README.md`