### PR TITLE
feat: add tail latency hedging lab

### DIFF
--- a/submissions/examples/tail-latency-hedging-kp/README.md
+++ b/submissions/examples/tail-latency-hedging-kp/README.md
@@ -1,0 +1,30 @@
+# Tail Latency Hedging Lab
+
+A CSS-only systems visualization that demonstrates how a delayed replica
+request can reduce read tail latency without exceeding a bounded amplification
+budget.
+
+## Features
+
+- Toggle between a single-request baseline and a hedged read.
+- Compare primary and replica timelines with winner and cancellation states.
+- Watch p99 latency, SLO success, request amplification, and released work
+  update together.
+- Inspect a responsive percentile curve and hedge-budget safety rail.
+- Use the keyboard-accessible control without any JavaScript.
+- Respect reduced-motion preferences on every animated element.
+
+## Run
+
+Open `demo.html` in a browser, then enable **Request hedging** in the header to
+compare both execution paths.
+
+## Files
+
+- `demo.html` contains the semantic experiment structure.
+- `style.css` provides all interaction, data visualization, and responsive
+  behavior.
+- `README.md` documents the example.
+
+The implementation has no dependencies, external assets, frameworks, or build
+step.

--- a/submissions/examples/tail-latency-hedging-kp/demo.html
+++ b/submissions/examples/tail-latency-hedging-kp/demo.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A CSS-only lab for visualizing tail-latency request hedging."
+    />
+    <title>Tail Latency Hedging Lab</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <input
+      class="hedge-input"
+      id="hedge-mode"
+      type="checkbox"
+      aria-label="Enable request hedging"
+    />
+
+    <div class="app">
+      <header class="topbar">
+        <a class="brand" href="#lab" aria-label="HedgeLab overview">
+          <span class="brand-mark" aria-hidden="true">
+            <i></i>
+            <i></i>
+          </span>
+          <span>
+            <strong>HedgeLab</strong>
+            <small>tail-latency control</small>
+          </span>
+        </a>
+
+        <div class="environment">
+          <span></span>
+          product-read / us-central
+        </div>
+
+        <label class="mode-control" for="hedge-mode">
+          <span>
+            <strong>Request hedging</strong>
+            <small class="baseline-only">Off</small>
+            <small class="hedged-only">On</small>
+          </span>
+          <i class="switch" aria-hidden="true"><b></b></i>
+        </label>
+      </header>
+
+      <main id="lab">
+        <section class="intro">
+          <div>
+            <p class="eyebrow">Read path experiment / rolling 10 minutes</p>
+            <div class="title-line">
+              <h1>Tail latency hedging</h1>
+              <span class="status baseline-only">Single request</span>
+              <span class="status hedged-only">Hedge active</span>
+            </div>
+            <p class="intro-copy baseline-only">
+              A slow primary owns the entire latency budget while the healthy
+              replica remains idle.
+            </p>
+            <p class="intro-copy hedged-only">
+              A delayed replica request wins the race and the slower primary is
+              cancelled before it consumes more work.
+            </p>
+          </div>
+
+          <dl class="experiment-meta">
+            <div>
+              <dt>Trigger percentile</dt>
+              <dd>p95</dd>
+            </div>
+            <div>
+              <dt>Hedge delay</dt>
+              <dd>180ms</dd>
+            </div>
+            <div>
+              <dt>Max amplification</dt>
+              <dd>10%</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="metrics" aria-label="Experiment metrics">
+          <article>
+            <span>p99 latency</span>
+            <strong class="baseline-only">1.82s</strong>
+            <strong class="hedged-only">268ms</strong>
+            <small class="bad baseline-only">4.5x over SLO</small>
+            <small class="good hedged-only">33% under SLO</small>
+          </article>
+          <article>
+            <span>Success under 400ms</span>
+            <strong class="baseline-only">91.4%</strong>
+            <strong class="hedged-only">99.3%</strong>
+            <small class="bad baseline-only">8.6% tail misses</small>
+            <small class="good hedged-only">SLO restored</small>
+          </article>
+          <article>
+            <span>Request amplification</span>
+            <strong class="baseline-only">0%</strong>
+            <strong class="hedged-only">7.6%</strong>
+            <small class="neutral">Budget ceiling 10%</small>
+          </article>
+          <article>
+            <span>Work cancelled</span>
+            <strong class="baseline-only">0 rps</strong>
+            <strong class="hedged-only">412 rps</strong>
+            <small class="neutral">After first valid response</small>
+          </article>
+        </section>
+
+        <div class="workspace">
+          <section class="race-panel" aria-labelledby="race-title">
+            <header class="panel-header">
+              <div>
+                <p class="eyebrow">Live trace #8f32</p>
+                <h2 id="race-title">Replica response race</h2>
+              </div>
+              <span class="trace-state baseline-only">Tail waiting</span>
+              <span class="trace-state hedged-only">Winner selected</span>
+            </header>
+
+            <div class="race-canvas">
+              <div class="client-node">
+                <span class="node-icon" aria-hidden="true"></span>
+                <div>
+                  <small>Client</small>
+                  <strong>GET /products/42</strong>
+                </div>
+              </div>
+
+              <div class="splitter" aria-hidden="true">
+                <span></span>
+                <i></i>
+                <b></b>
+              </div>
+
+              <div class="race-lanes">
+                <article class="lane primary-lane">
+                  <div class="lane-top">
+                    <div>
+                      <span class="role-badge">Primary</span>
+                      <strong>replica-a</strong>
+                    </div>
+                    <span class="lane-time baseline-only">1,820ms</span>
+                    <span class="lane-time hedged-only"
+                      >cancelled at 234ms</span
+                    >
+                  </div>
+
+                  <div class="timeline">
+                    <span class="slo-marker"><i>SLO 400ms</i></span>
+                    <span class="request-progress"></span>
+                    <span class="request-dot"></span>
+                    <span class="cancel-mark hedged-only">cancel</span>
+                  </div>
+
+                  <div class="lane-foot">
+                    <span>sent at 00ms</span>
+                    <span class="baseline-only bad">slow disk read</span>
+                    <span class="hedged-only neutral">work released</span>
+                  </div>
+                </article>
+
+                <article class="lane replica-lane">
+                  <div class="lane-top">
+                    <div>
+                      <span class="role-badge">Hedge</span>
+                      <strong>replica-b</strong>
+                    </div>
+                    <span class="lane-time baseline-only">not started</span>
+                    <span class="lane-time hedged-only">54ms response</span>
+                  </div>
+
+                  <div class="timeline">
+                    <span class="hedge-gate">180ms</span>
+                    <span class="request-progress"></span>
+                    <span class="request-dot"></span>
+                    <span class="winner-mark hedged-only">winner</span>
+                  </div>
+
+                  <div class="lane-foot">
+                    <span class="baseline-only">idle replica</span>
+                    <span class="hedged-only">sent after delay</span>
+                    <span class="hedged-only good">valid response</span>
+                  </div>
+                </article>
+              </div>
+
+              <div class="result-connector" aria-hidden="true">
+                <span></span>
+                <i></i>
+              </div>
+
+              <div class="result-node">
+                <span class="result-code">200</span>
+                <div>
+                  <small>Client response</small>
+                  <strong class="baseline-only">1,820ms</strong>
+                  <strong class="hedged-only">234ms</strong>
+                </div>
+              </div>
+            </div>
+
+            <footer class="race-footer">
+              <span class="baseline-only">
+                <i></i>
+                One slow replica controls completion time
+              </span>
+              <span class="hedged-only">
+                <i></i>
+                First valid response commits; remaining work is cancelled
+              </span>
+              <span>sampled 3s ago</span>
+            </footer>
+          </section>
+
+          <aside class="analysis-panel">
+            <section class="curve-block" aria-labelledby="curve-title">
+              <header class="panel-header compact">
+                <div>
+                  <p class="eyebrow">Latency distribution</p>
+                  <h2 id="curve-title">Percentile curve</h2>
+                </div>
+                <span class="curve-unit">milliseconds</span>
+              </header>
+
+              <div class="curve-chart">
+                <div class="y-axis">
+                  <span>2,000</span>
+                  <span>1,500</span>
+                  <span>1,000</span>
+                  <span>500</span>
+                  <span>0</span>
+                </div>
+                <div class="bars">
+                  <div style="--base: 12%; --hedged: 12%">
+                    <span></span><small>p50</small>
+                  </div>
+                  <div style="--base: 21%; --hedged: 20%">
+                    <span></span><small>p75</small>
+                  </div>
+                  <div style="--base: 35%; --hedged: 30%">
+                    <span></span><small>p90</small>
+                  </div>
+                  <div style="--base: 62%; --hedged: 41%">
+                    <span></span><small>p95</small>
+                  </div>
+                  <div style="--base: 91%; --hedged: 48%">
+                    <span></span><small>p99</small>
+                  </div>
+                </div>
+                <span class="chart-slo">400ms SLO</span>
+              </div>
+            </section>
+
+            <section class="budget-block" aria-labelledby="budget-title">
+              <div class="section-title">
+                <div>
+                  <p class="eyebrow">Safety rail</p>
+                  <h2 id="budget-title">Hedge budget</h2>
+                </div>
+                <strong class="baseline-only">0 / 10%</strong>
+                <strong class="hedged-only">7.6 / 10%</strong>
+              </div>
+
+              <div class="budget-track" aria-hidden="true">
+                <span></span>
+                <i></i>
+              </div>
+
+              <dl>
+                <div>
+                  <dt>Eligible reads</dt>
+                  <dd>5,420 rps</dd>
+                </div>
+                <div>
+                  <dt>Hedges launched</dt>
+                  <dd class="baseline-only">0 rps</dd>
+                  <dd class="hedged-only">412 rps</dd>
+                </div>
+                <div>
+                  <dt>Replica wins</dt>
+                  <dd class="baseline-only">0%</dd>
+                  <dd class="hedged-only">86.1%</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section class="policy-block" aria-labelledby="policy-title">
+              <div class="section-title">
+                <div>
+                  <p class="eyebrow">Current rules</p>
+                  <h2 id="policy-title">Launch policy</h2>
+                </div>
+                <span class="policy-state baseline-only">Bypassed</span>
+                <span class="policy-state hedged-only">Enforced</span>
+              </div>
+
+              <ol>
+                <li>
+                  <span>01</span>
+                  <p>
+                    <strong>Wait for p95</strong>
+                    <small>Primary gets a 180ms head start</small>
+                  </p>
+                </li>
+                <li>
+                  <span>02</span>
+                  <p>
+                    <strong>Race one replica</strong>
+                    <small>Only idempotent reads are eligible</small>
+                  </p>
+                </li>
+                <li>
+                  <span>03</span>
+                  <p>
+                    <strong>Cancel the loser</strong>
+                    <small>First valid response commits</small>
+                  </p>
+                </li>
+              </ol>
+            </section>
+          </aside>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/tail-latency-hedging-kp/style.css
+++ b/submissions/examples/tail-latency-hedging-kp/style.css
@@ -1,0 +1,1292 @@
+:root {
+  color-scheme: light;
+
+  --ink: #172126;
+  --muted: #68757b;
+  --canvas: #e8edef;
+  --surface: #fff;
+  --soft: #f4f6f7;
+  --line: #d7dee1;
+  --line-dark: #b8c3c8;
+  --nav: #161d20;
+  --danger: #c63f42;
+  --danger-soft: #fff0f0;
+  --success: #10826d;
+  --success-soft: #e9f7f3;
+  --primary: #2768b2;
+  --replica: #7654b0;
+  --amber: #cc7a19;
+  --shadow: 0 18px 50px rgba(22, 34, 40, 0.1);
+  --ease: 520ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--canvas);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(rgba(23, 33, 38, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(23, 33, 38, 0.035) 1px, transparent 1px),
+    var(--canvas);
+  background-size: 30px 30px;
+}
+
+.hedge-input {
+  position: fixed;
+  top: 20px;
+  right: 24px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.app {
+  width: min(1440px, calc(100% - 32px));
+  min-height: calc(100vh - 32px);
+  margin: 16px auto;
+  overflow: hidden;
+  background: var(--soft);
+  border: 1px solid rgba(23, 33, 38, 0.16);
+  border-radius: 7px;
+  box-shadow: var(--shadow);
+}
+
+.topbar {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  gap: 28px;
+  padding: 0 24px;
+  color: #fff;
+  background: var(--nav);
+}
+
+.brand {
+  display: flex;
+  min-width: 220px;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  position: relative;
+  display: block;
+  width: 34px;
+  height: 34px;
+  background: #f0f4f5;
+  border-radius: 4px;
+}
+
+.brand-mark i {
+  position: absolute;
+  top: 10px;
+  width: 14px;
+  height: 3px;
+  background: var(--danger);
+  border-radius: 2px;
+  transition:
+    background-color var(--ease),
+    transform var(--ease);
+}
+
+.brand-mark i:first-child {
+  left: 5px;
+  transform: rotate(28deg);
+}
+
+.brand-mark i:last-child {
+  right: 5px;
+  transform: translateY(9px) rotate(-28deg);
+}
+
+.brand strong,
+.brand small {
+  display: block;
+  letter-spacing: 0;
+}
+
+.brand strong {
+  font-size: 0.95rem;
+}
+
+.brand small {
+  margin-top: 2px;
+  color: #aab6bb;
+  font-size: 0.64rem;
+}
+
+.environment {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: auto;
+  color: #c3ccd0;
+  font-size: 0.7rem;
+}
+
+.environment span {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+  box-shadow: 0 0 0 5px rgba(198, 63, 66, 0.12);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.mode-control {
+  display: flex;
+  min-width: 170px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 11px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.mode-control > span {
+  text-align: right;
+}
+
+.mode-control strong,
+.mode-control small {
+  display: block;
+}
+
+.mode-control strong {
+  font-size: 0.72rem;
+}
+
+.mode-control small {
+  margin-top: 2px;
+  color: #ed8a8d;
+  font-size: 0.62rem;
+}
+
+.switch {
+  display: flex;
+  width: 47px;
+  height: 25px;
+  align-items: center;
+  padding: 3px;
+  background: #4b575c;
+  border: 1px solid #68767b;
+  border-radius: 14px;
+  transition:
+    background-color var(--ease),
+    border-color var(--ease);
+}
+
+.switch b {
+  width: 17px;
+  height: 17px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  transition: transform var(--ease);
+}
+
+.hedge-input:focus-visible ~ .app .mode-control {
+  outline: 3px solid #87b8ee;
+  outline-offset: 4px;
+}
+
+.hedged-only {
+  display: none;
+}
+
+.intro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 28px;
+  padding: 28px 30px 24px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.61rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.title-line {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+h1,
+h2,
+p {
+  letter-spacing: 0;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  line-height: 1.08;
+}
+
+.status,
+.trace-state,
+.policy-state {
+  padding: 4px 7px;
+  color: #8b292c;
+  background: var(--danger-soft);
+  border: 1px solid #ebb6b8;
+  border-radius: 3px;
+  font-size: 0.58rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.intro-copy {
+  max-width: 720px;
+  margin: 11px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.experiment-meta {
+  display: grid;
+  min-width: 350px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  margin: 0;
+  overflow: hidden;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.experiment-meta div {
+  padding: 11px 12px;
+  background: var(--soft);
+}
+
+.experiment-meta dt,
+.experiment-meta dd {
+  margin: 0;
+}
+
+.experiment-meta dt {
+  color: var(--muted);
+  font-size: 0.53rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.experiment-meta dd {
+  margin-top: 4px;
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.metrics article {
+  position: relative;
+  min-height: 122px;
+  padding: 17px 20px;
+  background: var(--surface);
+}
+
+.metrics article::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--danger);
+  content: "";
+  transform-origin: left;
+  transition:
+    background-color var(--ease),
+    transform var(--ease);
+}
+
+.metrics article > span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.metrics strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.65rem;
+  line-height: 1;
+}
+
+.metrics small {
+  display: block;
+  margin-top: 7px;
+  font-size: 0.58rem;
+}
+
+.bad {
+  color: #a83235;
+}
+
+.good {
+  color: var(--success);
+}
+
+.neutral {
+  color: var(--muted);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 350px;
+  gap: 14px;
+  padding: 14px;
+}
+
+.race-panel,
+.analysis-panel {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.analysis-panel {
+  align-self: start;
+}
+
+.panel-header {
+  display: flex;
+  min-height: 66px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 17px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-header h2,
+.section-title h2 {
+  margin: 4px 0 0;
+  font-size: 0.92rem;
+}
+
+.trace-state {
+  flex: 0 0 auto;
+}
+
+.race-canvas {
+  display: grid;
+  min-height: 510px;
+  grid-template-columns: 145px 54px minmax(360px, 1fr) 54px 120px;
+  align-items: center;
+  padding: 26px 20px;
+  background:
+    linear-gradient(90deg, transparent 49%, rgba(23, 33, 38, 0.035) 50%),
+    var(--surface);
+  background-size: 34px 100%;
+}
+
+.client-node,
+.result-node {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px;
+  background: var(--soft);
+  border: 1px solid var(--line-dark);
+  border-radius: 4px;
+}
+
+.node-icon {
+  position: relative;
+  display: block;
+  width: 30px;
+  height: 24px;
+  flex: 0 0 auto;
+  border: 2px solid var(--ink);
+  border-radius: 2px;
+}
+
+.node-icon::after {
+  position: absolute;
+  right: 6px;
+  bottom: -6px;
+  left: 6px;
+  height: 2px;
+  background: var(--ink);
+  content: "";
+  box-shadow: 0 3px 0 var(--ink);
+}
+
+.client-node small,
+.client-node strong,
+.result-node small,
+.result-node strong {
+  display: block;
+}
+
+.client-node small,
+.result-node small {
+  color: var(--muted);
+  font-size: 0.53rem;
+}
+
+.client-node strong,
+.result-node strong {
+  margin-top: 3px;
+  font-size: 0.61rem;
+  overflow-wrap: anywhere;
+}
+
+.splitter {
+  position: relative;
+  height: 132px;
+}
+
+.splitter::before {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 50%;
+  height: 2px;
+  background: var(--line-dark);
+  content: "";
+}
+
+.splitter span {
+  position: absolute;
+  top: 25%;
+  right: 0;
+  bottom: 25%;
+  width: 2px;
+  background: var(--line-dark);
+}
+
+.splitter i,
+.splitter b {
+  position: absolute;
+  right: 0;
+  width: 50%;
+  height: 2px;
+  background: var(--line-dark);
+}
+
+.splitter i {
+  top: 25%;
+}
+
+.splitter b {
+  bottom: 25%;
+}
+
+.race-lanes {
+  display: grid;
+  gap: 26px;
+}
+
+.lane {
+  padding: 15px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--lane-color);
+  border-radius: 4px;
+  transition:
+    background-color var(--ease),
+    opacity var(--ease);
+}
+
+.primary-lane {
+  --lane-color: var(--primary);
+}
+
+.replica-lane {
+  --lane-color: var(--replica);
+
+  opacity: 0.5;
+}
+
+.lane-top,
+.lane-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.lane-top > div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.role-badge {
+  padding: 3px 5px;
+  color: #fff;
+  background: var(--lane-color);
+  border-radius: 2px;
+  font-size: 0.5rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.lane-top strong {
+  font-size: 0.68rem;
+}
+
+.lane-time {
+  color: var(--muted);
+  font-size: 0.58rem;
+  font-weight: 700;
+}
+
+.timeline {
+  position: relative;
+  height: 30px;
+  margin: 15px 0 10px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      transparent 0,
+      transparent calc(10% - 1px),
+      rgba(23, 33, 38, 0.08) calc(10% - 1px),
+      rgba(23, 33, 38, 0.08) 10%
+    ),
+    var(--soft);
+  border-radius: 2px;
+}
+
+.slo-marker {
+  position: absolute;
+  z-index: 2;
+  top: -7px;
+  bottom: -7px;
+  left: 22%;
+  width: 1px;
+  background: var(--danger);
+}
+
+.slo-marker i {
+  position: absolute;
+  top: -13px;
+  left: 4px;
+  color: var(--danger);
+  font-size: 0.46rem;
+  font-style: normal;
+  white-space: nowrap;
+}
+
+.request-progress {
+  position: absolute;
+  top: 11px;
+  left: 0;
+  width: 91%;
+  height: 8px;
+  background: var(--danger);
+  border-radius: 0 4px 4px 0;
+  transition:
+    width var(--ease),
+    background-color var(--ease);
+}
+
+.request-dot {
+  position: absolute;
+  z-index: 1;
+  top: 8px;
+  left: calc(91% - 6px);
+  width: 14px;
+  height: 14px;
+  background: var(--danger);
+  border: 3px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--danger);
+  transition:
+    left var(--ease),
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.replica-lane .request-progress {
+  width: 0;
+  background: var(--replica);
+}
+
+.replica-lane .request-dot {
+  left: 0;
+  background: var(--line-dark);
+  box-shadow: 0 0 0 1px var(--line-dark);
+}
+
+.hedge-gate {
+  position: absolute;
+  z-index: 2;
+  top: -8px;
+  left: 10%;
+  color: var(--replica);
+  font-size: 0.46rem;
+  font-weight: 700;
+}
+
+.cancel-mark,
+.winner-mark {
+  position: absolute;
+  z-index: 3;
+  top: 5px;
+  left: 14%;
+  padding: 3px 5px;
+  color: #fff;
+  background: var(--danger);
+  border-radius: 2px;
+  font-size: 0.45rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.winner-mark {
+  left: 22%;
+  background: var(--success);
+}
+
+.lane-foot {
+  color: var(--muted);
+  font-size: 0.51rem;
+}
+
+.result-connector {
+  position: relative;
+  height: 2px;
+  background: var(--line-dark);
+}
+
+.result-connector::after {
+  position: absolute;
+  top: -4px;
+  right: -1px;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 7px solid var(--line-dark);
+  content: "";
+}
+
+.result-connector span {
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 16px;
+  height: 6px;
+  background: var(--danger);
+  border-radius: 3px;
+  animation: response-move 1.4s linear infinite;
+  transition: background-color var(--ease);
+}
+
+.result-code {
+  display: grid;
+  width: 34px;
+  height: 28px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: #fff;
+  background: var(--danger);
+  border-radius: 3px;
+  font-size: 0.58rem;
+  font-weight: 800;
+  transition: background-color var(--ease);
+}
+
+.race-footer {
+  display: flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 17px;
+  color: var(--muted);
+  background: var(--soft);
+  border-top: 1px solid var(--line);
+  font-size: 0.56rem;
+}
+
+.race-footer > span:first-child,
+.race-footer > span:nth-child(2) {
+  align-items: center;
+  gap: 7px;
+}
+
+.race-footer .baseline-only {
+  display: flex;
+}
+
+.race-footer i {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+}
+
+.compact {
+  min-height: 64px;
+}
+
+.curve-unit {
+  color: var(--muted);
+  font-size: 0.52rem;
+}
+
+.curve-chart {
+  position: relative;
+  display: grid;
+  height: 220px;
+  grid-template-columns: 35px 1fr;
+  gap: 8px;
+  margin: 18px;
+}
+
+.y-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-bottom: 22px;
+  color: var(--muted);
+  font-size: 0.46rem;
+}
+
+.bars {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  align-items: end;
+  gap: 10px;
+  padding: 0 8px 22px;
+  background: repeating-linear-gradient(
+    0deg,
+    var(--line) 0,
+    var(--line) 1px,
+    transparent 1px,
+    transparent 25%
+  );
+}
+
+.bars div {
+  display: grid;
+  height: 100%;
+  align-items: end;
+  justify-items: center;
+}
+
+.bars span {
+  display: block;
+  width: min(28px, 75%);
+  height: var(--base);
+  background: var(--danger);
+  border-radius: 2px 2px 0 0;
+  transition:
+    height var(--ease),
+    background-color var(--ease);
+}
+
+.bars small {
+  position: absolute;
+  bottom: 2px;
+  color: var(--muted);
+  font-size: 0.47rem;
+}
+
+.chart-slo {
+  position: absolute;
+  right: 0;
+  bottom: 24%;
+  left: 43px;
+  padding-top: 3px;
+  color: var(--danger);
+  border-top: 1px dashed var(--danger);
+  font-size: 0.46rem;
+  text-align: right;
+}
+
+.budget-block,
+.policy-block {
+  padding: 17px;
+  border-top: 1px solid var(--line);
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.section-title > strong {
+  font-size: 0.68rem;
+}
+
+.budget-track {
+  position: relative;
+  height: 9px;
+  margin-top: 15px;
+  background: var(--soft);
+  border-radius: 5px;
+}
+
+.budget-track::after {
+  position: absolute;
+  top: -4px;
+  right: 10%;
+  width: 1px;
+  height: 17px;
+  background: var(--danger);
+  content: "";
+}
+
+.budget-track span {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: var(--success);
+  border-radius: inherit;
+  transition: width var(--ease);
+}
+
+.budget-track i {
+  position: absolute;
+  top: 1px;
+  left: 0;
+  width: 7px;
+  height: 7px;
+  background: #fff;
+  border: 1px solid var(--success);
+  border-radius: 50%;
+  transition: left var(--ease);
+}
+
+.budget-block dl {
+  display: grid;
+  gap: 8px;
+  margin: 14px 0 0;
+}
+
+.budget-block dl div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.budget-block dt,
+.budget-block dd {
+  margin: 0;
+  font-size: 0.55rem;
+}
+
+.budget-block dt {
+  color: var(--muted);
+}
+
+.budget-block dd {
+  font-weight: 700;
+}
+
+.policy-block ol {
+  margin: 15px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.policy-block li {
+  display: grid;
+  grid-template-columns: 25px 1fr;
+  gap: 9px;
+  padding: 9px 0;
+}
+
+.policy-block li + li {
+  border-top: 1px solid var(--line);
+}
+
+.policy-block li > span {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  color: var(--muted);
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  font-size: 0.48rem;
+  font-weight: 800;
+}
+
+.policy-block p {
+  margin: 0;
+}
+
+.policy-block strong,
+.policy-block small {
+  display: block;
+}
+
+.policy-block strong {
+  font-size: 0.6rem;
+}
+
+.policy-block small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.52rem;
+}
+
+.hedge-input:checked ~ .app .baseline-only {
+  display: none;
+}
+
+.hedge-input:checked ~ .app .hedged-only {
+  display: block;
+}
+
+.hedge-input:checked ~ .app .race-footer .hedged-only {
+  display: flex;
+}
+
+.hedge-input:checked ~ .app .environment span {
+  background: var(--success);
+  box-shadow: 0 0 0 5px rgba(16, 130, 109, 0.12);
+}
+
+.hedge-input:checked ~ .app .brand-mark i {
+  background: var(--success);
+}
+
+.hedge-input:checked ~ .app .brand-mark i:first-child {
+  transform: translateY(4px) rotate(18deg);
+}
+
+.hedge-input:checked ~ .app .brand-mark i:last-child {
+  transform: translateY(4px) rotate(-18deg);
+}
+
+.hedge-input:checked ~ .app .mode-control small {
+  color: #72d1bd;
+}
+
+.hedge-input:checked ~ .app .switch {
+  background: var(--success);
+  border-color: #3aa58f;
+}
+
+.hedge-input:checked ~ .app .switch b {
+  transform: translateX(20px);
+}
+
+.hedge-input:checked ~ .app .status,
+.hedge-input:checked ~ .app .trace-state,
+.hedge-input:checked ~ .app .policy-state {
+  color: #086653;
+  background: var(--success-soft);
+  border-color: #9bd6c8;
+}
+
+.hedge-input:checked ~ .app .metrics article::after {
+  background: var(--success);
+  transform: scaleX(0.72);
+}
+
+.hedge-input:checked ~ .app .primary-lane {
+  background: #f7f9fa;
+  opacity: 0.68;
+}
+
+.hedge-input:checked ~ .app .primary-lane .request-progress {
+  width: 14%;
+  background: var(--line-dark);
+}
+
+.hedge-input:checked ~ .app .primary-lane .request-dot {
+  left: calc(14% - 6px);
+  background: var(--line-dark);
+  box-shadow: 0 0 0 1px var(--line-dark);
+}
+
+.hedge-input:checked ~ .app .replica-lane {
+  background: #fbf9ff;
+  opacity: 1;
+}
+
+.hedge-input:checked ~ .app .replica-lane .request-progress {
+  width: 22%;
+  background: var(--success);
+}
+
+.hedge-input:checked ~ .app .replica-lane .request-dot {
+  left: calc(22% - 6px);
+  background: var(--success);
+  box-shadow: 0 0 0 1px var(--success);
+}
+
+.hedge-input:checked ~ .app .result-connector span,
+.hedge-input:checked ~ .app .result-code,
+.hedge-input:checked ~ .app .race-footer i {
+  background: var(--success);
+}
+
+.hedge-input:checked ~ .app .bars span {
+  height: var(--hedged);
+  background: var(--success);
+}
+
+.hedge-input:checked ~ .app .chart-slo {
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.hedge-input:checked ~ .app .budget-track span {
+  width: 76%;
+}
+
+.hedge-input:checked ~ .app .budget-track i {
+  left: calc(76% - 7px);
+}
+
+@keyframes response-move {
+  from {
+    transform: translateX(-5px);
+  }
+
+  to {
+    transform: translateX(38px);
+  }
+}
+
+@media (max-width: 1080px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .analysis-panel {
+    display: grid;
+    grid-template-columns: 1.2fr 0.8fr 0.9fr;
+  }
+
+  .curve-block {
+    grid-row: span 2;
+  }
+
+  .budget-block,
+  .policy-block {
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 820px) {
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .race-canvas {
+    grid-template-columns: 120px 42px minmax(310px, 1fr);
+  }
+
+  .result-connector,
+  .result-node {
+    display: none;
+  }
+
+  .analysis-panel {
+    display: block;
+  }
+
+  .budget-block,
+  .policy-block {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 660px) {
+  .app {
+    width: 100%;
+    min-height: 100vh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .topbar {
+    min-height: 62px;
+    gap: 10px;
+    padding: 0 14px;
+  }
+
+  .brand {
+    min-width: 0;
+    margin-right: auto;
+  }
+
+  .brand small,
+  .environment,
+  .mode-control strong {
+    display: none;
+  }
+
+  .mode-control {
+    min-width: 0;
+  }
+
+  .intro {
+    display: block;
+    padding: 23px 17px 20px;
+  }
+
+  .title-line {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .experiment-meta {
+    min-width: 0;
+    margin-top: 18px;
+  }
+
+  .workspace {
+    padding: 9px;
+  }
+
+  .race-canvas {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    min-height: 0;
+    padding: 18px 14px;
+  }
+
+  .client-node,
+  .result-node {
+    width: min(100%, 220px);
+    margin: 0 auto;
+  }
+
+  .splitter {
+    width: 2px;
+    height: 26px;
+    margin: 0 auto;
+    background: var(--line-dark);
+  }
+
+  .splitter::before,
+  .splitter span,
+  .splitter i,
+  .splitter b {
+    display: none;
+  }
+
+  .result-connector {
+    display: block;
+    width: 2px;
+    height: 26px;
+    margin: 0 auto;
+  }
+
+  .result-connector::after {
+    top: auto;
+    right: -4px;
+    bottom: -1px;
+    border-top: 7px solid var(--line-dark);
+    border-right: 5px solid transparent;
+    border-bottom: 0;
+    border-left: 5px solid transparent;
+  }
+
+  .result-connector span {
+    width: 6px;
+    height: 12px;
+    animation: response-drop 1.4s linear infinite;
+  }
+
+  .result-node {
+    display: flex;
+  }
+
+  .race-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 440px) {
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .experiment-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .lane-top,
+  .lane-foot {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .lane-top > div {
+    width: 100%;
+  }
+
+  .timeline {
+    margin-top: 22px;
+  }
+}
+
+@keyframes response-drop {
+  from {
+    transform: translateY(-4px);
+  }
+
+  to {
+    transform: translateY(18px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

- add a CSS-only tail-latency request hedging lab
- compare a single slow primary with a delayed primary/replica response race
- visualize winner selection, loser cancellation, percentile changes, and the amplification safety budget
- include responsive flow states and reduced-motion support

## Why

Tail latency is often hidden by healthy averages. This example shows how a bounded hedge delay can improve p99 response time while preserving an explicit request-amplification ceiling.

## Validation

- Prettier check passed for all submission files
- Stylelint passed for the scoped stylesheet via stdin
- duplicate class and keyframe check passed
- Vitest passed: 61 tests
- Playwright assertions passed in installed Chrome at 1440px and 390px
- keyboard control retains focus and both viewports have zero horizontal overflow
- staged diff check passed

## Scope

Adds only:

- `submissions/examples/tail-latency-hedging-kp/demo.html`
- `submissions/examples/tail-latency-hedging-kp/style.css`
- `submissions/examples/tail-latency-hedging-kp/README.md`