### PR TITLE
feat(divider): add focus-visible keyboard navigation support

### DIFF
--- a/submissions/examples/feat-divider-focus-visible/README.md
+++ b/submissions/examples/feat-divider-focus-visible/README.md
@@ -1,0 +1,32 @@
+# Divider Focus-Visible Keyboard Navigation Enhancement
+
+## Description
+This submission enhances the `divider` component with a robust implementation of
+the `:focus-visible` CSS pseudo-class, ensuring that keyboard users always receive
+a clear, visible focus indicator when navigating the page using Tab or arrow keys.
+
+Mouse and pointer users are not affected because `:focus-visible` is only triggered
+when the browser determines the focus is keyboard-initiated.
+
+## Accessibility Standards
+- WCAG 2.1 Success Criterion 2.4.7: Focus Visible (Level AA)
+- WCAG 2.1 Success Criterion 2.4.11: Focus Appearance (Level AAA)
+
+## Changes
+- `style.css`: 90+ lines. Includes base component styles, a `:focus-visible`
+  block with a 3px outline and shadow, a high-contrast override using
+  `prefers-contrast: more`, disabled state styles, and a `:focus-within`
+  container variant.
+- `demo.html`: Full HTML5 boilerplate with keyboard focus testing instructions
+  and multiple interactive component variants.
+- `README.md`: Documents the accessibility rationale, WCAG criteria, and
+  testing steps.
+
+## How to Test
+1. Open `demo.html` in any modern browser.
+2. Press Tab to navigate to each component. A clear blue ring should appear.
+3. Click the component with a mouse. No focus ring should appear.
+4. In browser DevTools, emulate `prefers-contrast: more` to verify the
+   high-contrast override shows a solid canvastext outline.
+
+Fixes #57450

--- a/submissions/examples/feat-divider-focus-visible/demo.html
+++ b/submissions/examples/feat-divider-focus-visible/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Divider Focus-Visible Keyboard Navigation - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            background: #f9fafb;
+            padding: 3rem;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 2rem;
+            min-height: 100vh;
+            max-width: 700px;
+            margin: 0 auto;
+        }
+        h1 {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: #111827;
+            margin: 0;
+        }
+        .notice {
+            background: #eff6ff;
+            border-left: 4px solid #3b82f6;
+            color: #1e40af;
+            padding: 1rem 1.25rem;
+            border-radius: 6px;
+            width: 100%;
+            box-sizing: border-box;
+            font-size: 0.9rem;
+            line-height: 1.6;
+        }
+        .notice code {
+            background: #dbeafe;
+            padding: 0.1rem 0.3rem;
+            border-radius: 3px;
+            font-size: 0.85rem;
+        }
+        .demo-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            align-items: center;
+        }
+        .section-label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: #6b7280;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.25rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Divider: Focus-Visible Enhancement</h1>
+
+    <div class="notice">
+        <strong>How to test keyboard focus:</strong>
+        Press <code>Tab</code> to move focus to the components below. You will see
+        a clear 3px blue outline ring appear. Click with your mouse instead and you
+        will notice no ring appears, because <code>:focus-visible</code> is only
+        triggered for keyboard navigation.
+    </div>
+
+    <div>
+        <p class="section-label">Default State</p>
+        <div class="demo-row">
+            <div class="ease-divider" tabindex="0" role="button" aria-label="Default divider">
+                <span class="ease-divider-label">Divider</span>
+            </div>
+            <div class="ease-divider" tabindex="0" role="button" aria-label="With badge divider">
+                <span class="ease-divider-label">With Badge</span>
+                <span class="ease-divider-badge" aria-label="3 notifications">3</span>
+            </div>
+        </div>
+    </div>
+
+    <div>
+        <p class="section-label">Disabled State</p>
+        <div class="demo-row">
+            <div class="ease-divider" tabindex="-1" role="button"
+                 aria-disabled="true" aria-label="Disabled divider">
+                <span class="ease-divider-label">Disabled</span>
+            </div>
+        </div>
+    </div>
+
+    <div>
+        <p class="section-label">Container Variant (focus-within)</p>
+        <div class="ease-divider-container" role="group" aria-label="divider container">
+            <div class="ease-divider" tabindex="0" role="button" style="width:100%; border-radius: inherit;">
+                <span class="ease-divider-label">Inner Divider Element</span>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/feat-divider-focus-visible/style.css
+++ b/submissions/examples/feat-divider-focus-visible/style.css
@@ -1,0 +1,127 @@
+/*
+ * Feature: divider Focus-Visible Keyboard Navigation Enhancement
+ * Implements robust :focus-visible styles so keyboard users always
+ * see a clear indicator when navigating with Tab or arrow keys.
+ * Mouse and pointer users are not affected because :focus-visible
+ * only triggers for keyboard-initiated focus, not pointer focus.
+ *
+ * WCAG 2.1 Success Criterion 2.4.7: Focus Visible (Level AA)
+ * WCAG 2.1 Success Criterion 2.4.11: Focus Appearance (Level AAA)
+ */
+
+/* ===== Base Component Styles ===== */
+.ease-divider {
+    position: relative;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: var(--ease-surface, #ffffff);
+    color: var(--ease-on-surface, #1f2937);
+    border: 1px solid var(--ease-border, #d1d5db);
+    border-radius: var(--ease-radius-md, 6px);
+    padding: 0.75rem 1.25rem;
+    font-size: 0.9375rem;
+    font-family: inherit;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background-color 0.15s ease,
+                border-color 0.15s ease,
+                color 0.15s ease;
+    /* Remove default browser outline - we provide our own */
+    outline: none;
+}
+
+.ease-divider:hover {
+    background-color: var(--ease-surface-hover, #f9fafb);
+    border-color: var(--ease-primary, #3b82f6);
+    color: var(--ease-primary, #3b82f6);
+}
+
+.ease-divider:active {
+    background-color: var(--ease-surface-active, #eff6ff);
+    border-color: var(--ease-primary-dark, #2563eb);
+}
+
+/* ===== Focus-Visible Indicator ===== */
+/*
+ * The :focus-visible pseudo-class applies only when the browser
+ * determines the focus should be visually indicated (e.g., keyboard nav).
+ * This prevents the focus ring from appearing on mouse clicks.
+ */
+.ease-divider:focus-visible {
+    outline: 3px solid var(--ease-primary, #3b82f6);
+    outline-offset: 3px;
+    border-color: var(--ease-primary, #3b82f6);
+    box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.15);
+}
+
+/* ===== High-Contrast Focus Override ===== */
+/*
+ * When both prefers-contrast: more and keyboard focus are active,
+ * boost the focus ring to a solid 4px canvastext border so it remains
+ * visible regardless of color theme.
+ */
+@media (prefers-contrast: more) {
+    .ease-divider:focus-visible {
+        outline: 4px solid canvastext;
+        outline-offset: 4px;
+        box-shadow: none;
+    }
+}
+
+/* ===== Disabled State ===== */
+.ease-divider[disabled],
+.ease-divider[aria-disabled="true"] {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+/* ===== Component Inner Elements ===== */
+.ease-divider-label {
+    font-weight: 500;
+    line-height: 1.4;
+}
+
+.ease-divider-icon {
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+    fill: currentColor;
+}
+
+.ease-divider-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.3rem;
+    background-color: var(--ease-primary, #3b82f6);
+    color: #ffffff;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+/* ===== Focus-Within for Container Variants ===== */
+/*
+ * For compound components where focus lands on an inner element,
+ * use :focus-within on the container to show an outer ring.
+ */
+.ease-divider-container {
+    position: relative;
+    border-radius: var(--ease-radius-md, 6px);
+    outline: none;
+}
+
+.ease-divider-container:focus-within {
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+@media (prefers-contrast: more) {
+    .ease-divider-container:focus-within {
+        box-shadow: 0 0 0 4px canvastext;
+    }
+}


### PR DESCRIPTION
### Description
Fixes #57450.

Adds a robust `:focus-visible` implementation to the `divider` component.
This ensures keyboard users always see a clear, visible focus ring when
navigating the page with Tab or arrow keys, while mouse users are not
affected since `:focus-visible` only triggers for keyboard-initiated focus.

### Changes Made
- `style.css`: 90+ lines. Includes base styles, a `:focus-visible` block
  with a 3px blue outline and soft shadow ring, a `prefers-contrast: more`
  override with a solid `canvastext` outline, disabled state handling, and
  a `:focus-within` container variant.
- `demo.html`: Full HTML5 boilerplate with Tab-navigation testing instructions
  and multiple interactive component states.
- `README.md`: Documents WCAG 2.1 SC 2.4.7 and 2.4.11 compliance and
  testing steps.

### Checklist
- [x] I have followed the contribution guidelines
- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags
- [x] `style.css` has original, meaningful CSS (90+ lines)
- [x] `README.md` included
- [x] Files placed in `submissions/examples/feat-divider-focus-visible/`
- [x] No edits to `core/` or `components/`
- [x] Single commit following conventional-commit format
- [x] Only files inside `submissions/` directory are modified
