### PR TITLE
feat: add bounce-in entrance animation utilities

### DIFF
--- a/submissions/examples/bounce-in-entrance-ak/README.md
+++ b/submissions/examples/bounce-in-entrance-ak/README.md
@@ -1,0 +1,15 @@
+# Bounce-In Entrance Utilities
+
+## What does this do?
+Adds a family of four bounce-in entrance animations (`top`, `bottom`, `left`, `right`) that use a custom cubic-bezier curve to create snappy, physics-like UI entrances.
+
+## How is it used?
+```html
+<div class="bounce-in-top">Content</div>
+<div class="bounce-in-bottom">Content</div>
+<div class="bounce-in-left">Content</div>
+<div class="bounce-in-right">Content</div>
+```
+
+## Why is it useful?
+Entrance animations are one of the most common motion needs in UI design. This set covers all four directional variants with a consistent bounce feel, fitting EaseMotion's goal of providing expressive, ready-to-use motion utilities without requiring custom keyframe work from the end user.

--- a/submissions/examples/bounce-in-entrance-ak/demo.html
+++ b/submissions/examples/bounce-in-entrance-ak/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Bounce-In Entrance Utilities</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    background: #111;
+    color: #fff;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    padding: 40px;
+  }
+  .box {
+    width: 120px;
+    height: 120px;
+    background: #4f46e5;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+  <div class="box bounce-in-top">bounce-in-top</div>
+  <div class="box bounce-in-bottom">bounce-in-bottom</div>
+  <div class="box bounce-in-left">bounce-in-left</div>
+  <div class="box bounce-in-right">bounce-in-right</div>
+</body>
+</html>

--- a/submissions/examples/bounce-in-entrance-ak/style.css
+++ b/submissions/examples/bounce-in-entrance-ak/style.css
@@ -1,0 +1,62 @@
+/* Bounce-in entrance utilities
+   Custom cubic-bezier keyframes for snappy UI entrances */
+
+@keyframes bounceInTop {
+  0% {
+    transform: translateY(-500px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes bounceInBottom {
+  0% {
+    transform: translateY(500px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes bounceInLeft {
+  0% {
+    transform: translateX(-500px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes bounceInRight {
+  0% {
+    transform: translateX(500px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.bounce-in-top {
+  animation: bounceInTop 1s cubic-bezier(0.28, 0.84, 0.42, 1.1) both;
+}
+
+.bounce-in-bottom {
+  animation: bounceInBottom 1s cubic-bezier(0.28, 0.84, 0.42, 1.1) both;
+}
+
+.bounce-in-left {
+  animation: bounceInLeft 1s cubic-bezier(0.28, 0.84, 0.42, 1.1) both;
+}
+
+.bounce-in-right {
+  animation: bounceInRight 1s cubic-bezier(0.28, 0.84, 0.42, 1.1) both;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a family of four bounce-in entrance animations (top, bottom, left, right) using a custom cubic-bezier curve for snappy, physics-like UI entrances. Addresses issue #56631.
Closes #56631

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/bounce-in-entrance-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
Four directional bounce-in entrance animations (top, bottom, left, right).

**How does a developer use it?**
```html
<div class="bounce-in-top">Content</div>
<div class="bounce-in-bottom">Content</div>
<div class="bounce-in-left">Content</div>
<div class="bounce-in-right">Content</div>
```

**Why does it fit EaseMotion CSS?**
Entrance animations are a core motion need in UI design. This covers all four directional variants with a consistent bounce feel using `cubic-bezier(0.28, 0.84, 0.42, 1.1)`, giving developers physics-like motion without writing custom keyframes.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Edge

## Notes for Maintainer
Timing/bezier values are a starting point — happy to adjust if you want a different bounce feel. Closes #56631.