### PR TITLE
feat: add scale-hover card grid for gaming hub layouts

### DIFF
--- a/submissions/examples/scale-hover-card-grid-ak/README.md
+++ b/submissions/examples/scale-hover-card-grid-ak/README.md
@@ -1,0 +1,23 @@
+# Scale-Hover Card Grid for Gaming Hub Layouts
+
+## What does this do?
+A responsive CSS card grid where each card scales and glows on hover/focus, revealing a title overlay — designed for gaming hub / library-style layouts.
+
+## How is it used?
+```html
+<div class="game-grid">
+  <div class="game-card">
+    <img src="cover.jpg" alt="Game cover">
+    <div class="game-title">Game Name</div>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Card grids with hover-reveal detail are a common pattern in game library and store UIs. This submission provides smooth scale/glow transitions, keyframe entrance animation, full responsiveness across desktop/tablet/mobile, keyboard focus support (`:focus-within`), and `prefers-reduced-motion` handling — fitting EaseMotion's philosophy of expressive, accessible motion utilities.
+
+## CSS Custom Properties
+- `--card-radius`: corner radius of each card (default `14px`)
+- `--card-bg`: card background color (default `#1b1b2f`)
+- `--card-glow`: hover glow shadow color (default `rgba(99, 102, 241, 0.5)`)
+- `--transition-speed`: duration for hover/transform transitions (default `0.35s`)

--- a/submissions/examples/scale-hover-card-grid-ak/demo.html
+++ b/submissions/examples/scale-hover-card-grid-ak/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Scale-Hover Card Grid — Gaming Hub</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    background: #0d0d17;
+    color: #fff;
+    margin: 0;
+  }
+  h1 {
+    padding: 24px 24px 0;
+    font-size: 22px;
+  }
+  .placeholder-art {
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(135deg, #6366f1, #22d3ee);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    color: rgba(255,255,255,0.6);
+  }
+</style>
+</head>
+<body>
+  <h1>Gaming Hub</h1>
+  <div class="game-grid">
+    <div class="game-card" tabindex="0">
+      <div class="placeholder-art">Cover Art</div>
+      <div class="game-title">Nebula Drift</div>
+    </div>
+    <div class="game-card" tabindex="0">
+      <div class="placeholder-art">Cover Art</div>
+      <div class="game-title">Iron Vanguard</div>
+    </div>
+    <div class="game-card" tabindex="0">
+      <div class="placeholder-art">Cover Art</div>
+      <div class="game-title">Shadow Realms</div>
+    </div>
+    <div class="game-card" tabindex="0">
+      <div class="placeholder-art">Cover Art</div>
+      <div class="game-title">Skybound Legends</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/scale-hover-card-grid-ak/style.css
+++ b/submissions/examples/scale-hover-card-grid-ak/style.css
@@ -1,0 +1,116 @@
+/* CSS Scale-Hover Card Grid for Gaming Hub Layouts
+   Pure CSS, responsive, with prefers-reduced-motion support */
+
+:root {
+  --card-radius: 14px;
+  --card-bg: #1b1b2f;
+  --card-glow: rgba(99, 102, 241, 0.5);
+  --transition-speed: 0.35s;
+}
+
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  padding: 24px;
+}
+
+@media (max-width: 1024px) {
+  .game-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .game-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.game-card {
+  position: relative;
+  border-radius: var(--card-radius);
+  overflow: hidden;
+  background: var(--card-bg);
+  aspect-ratio: 3 / 4;
+  cursor: pointer;
+  transition: transform var(--transition-speed) ease,
+              box-shadow var(--transition-speed) ease;
+}
+
+.game-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform var(--transition-speed) ease;
+}
+
+.game-card .game-title {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 14px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.85), transparent);
+  color: #fff;
+  font-family: sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity var(--transition-speed) ease,
+              transform var(--transition-speed) ease;
+}
+
+.game-card:hover,
+.game-card:focus-within {
+  transform: scale(1.06);
+  box-shadow: 0 12px 30px var(--card-glow);
+}
+
+.game-card:hover img,
+.game-card:focus-within img {
+  transform: scale(1.1);
+}
+
+.game-card:hover .game-title,
+.game-card:focus-within .game-title {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes cardFadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.game-card {
+  animation: cardFadeIn 0.5s ease both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .game-card,
+  .game-card img,
+  .game-card .game-title {
+    transition: none;
+    animation: none;
+  }
+
+  .game-card:hover,
+  .game-card:focus-within {
+    transform: none;
+    box-shadow: none;
+  }
+
+  .game-card:hover img,
+  .game-card:focus-within img {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a responsive CSS scale-hover card grid for gaming hub layouts. Cards scale and glow on hover/focus, revealing a title overlay. 
Closes #56459.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/scale-hover-card-grid-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A responsive card grid where cards scale up and glow on hover/focus, revealing a title overlay — built for gaming hub / library-style layouts.

**How does a developer use it?**
```html
<div class="game-grid">
  <div class="game-card">
    <img src="cover.jpg" alt="Game cover">
    <div class="game-title">Game Name</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Hover-reveal card grids are a common pattern in game library/store UIs. This includes smooth scale/glow transitions, keyframe entrance animation, full responsiveness (desktop/tablet/mobile), keyboard focus support via `:focus-within`, and `prefers-reduced-motion` handling — matching EaseMotion's accessible, animation-first philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Edge

## Notes for Maintainer
Used placeholder gradient blocks instead of `<img>` in the demo to keep it fully self-contained with no external assets. CSS custom properties (`--card-radius`, `--card-bg`, `--card-glow`, `--transition-speed`) are exposed for easy theming. Closes #56459.