### PR TITLE
fix: prevent alert message overflow on small screens

### DIFF
--- a/submissions/docs/alert-overflow-fix-ak/README.md
+++ b/submissions/docs/alert-overflow-fix-ak/README.md
@@ -1,0 +1,18 @@
+# Alert Overflow Fix — Small Screens
+
+## What does this do?
+Fixes `.alert` component text overflowing its container on small screens by applying responsive word wrapping, as reported in issue #55661.
+
+## How is it used?
+```html
+<div class="alert alert--error">
+  Your long alert message wraps correctly instead of overflowing.
+</div>
+```
+
+## Why is it useful?
+Long alert messages previously extended beyond the container on small viewports, breaking layout and readability (issue #55661). This fix applies `overflow-wrap: break-word` and `word-break: break-word` so messages wrap within the container at any screen size, matching the issue's suggested fix. `demo.html` includes a before/after comparison so the maintainer can visually verify the fix before integrating it into `core/`.
+
+## Notes
+- This submission only demonstrates the fix (per contribution freeze rules, `core/` is not modified directly).
+- Tested down to 320px viewport width.

--- a/submissions/docs/alert-overflow-fix-ak/demo.html
+++ b/submissions/docs/alert-overflow-fix-ak/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Alert Overflow Fix — Small Screens</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    background: #111;
+    color: #fff;
+    padding: 24px;
+    max-width: 480px;
+    margin: 0 auto;
+  }
+  h1 {
+    font-size: 18px;
+  }
+  h2 {
+    font-size: 14px;
+    color: #999;
+    margin-top: 32px;
+  }
+  /* Broken version for comparison — mimics the reported bug */
+  .alert-broken {
+    padding: 14px 18px;
+    border-radius: 8px;
+    background: #2a2a3d;
+    color: #fff;
+    font-family: sans-serif;
+    font-size: 15px;
+    white-space: nowrap;
+    overflow: visible;
+  }
+</style>
+</head>
+<body>
+  <h1>Alert Overflow Fix Demo</h1>
+  <p>Resize the browser to a small width (or view on mobile) to see the difference.</p>
+
+  <h2>❌ Before (overflows on small screens)</h2>
+  <div class="alert-broken">
+    This is a very long alert message intended to demonstrate how lengthy content can overflow the alert container on smaller screens
+  </div>
+
+  <h2>✅ After (fix applied)</h2>
+  <div class="alert alert--error">
+    This is a very long alert message intended to demonstrate how lengthy content can overflow the alert container on smaller screens
+  </div>
+
+  <div class="alert alert--warning" style="margin-top:12px;">
+    Another example with a warning variant and a similarly long message to confirm wrapping works consistently.
+  </div>
+</body>
+</html>

--- a/submissions/docs/alert-overflow-fix-ak/style.css
+++ b/submissions/docs/alert-overflow-fix-ak/style.css
@@ -1,0 +1,44 @@
+/* Fix: prevent alert message overflow on small screens
+   Demonstrates responsive text wrapping for the .alert component */
+
+.alert {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  padding: 14px 18px;
+  border-radius: 8px;
+  background: #2a2a3d;
+  color: #fff;
+  font-family: sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+
+  /* Core fix: allow long unbroken strings/messages to wrap
+     instead of overflowing the container on small screens */
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.alert--error {
+  background: #4a1f28;
+  border-left: 4px solid #ef4444;
+}
+
+.alert--warning {
+  background: #4a3a1f;
+  border-left: 4px solid #f59e0b;
+}
+
+.alert--success {
+  background: #1f4a2e;
+  border-left: 4px solid #22c55e;
+}
+
+@media (max-width: 480px) {
+  .alert {
+    padding: 12px 14px;
+    font-size: 14px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Fixes `.alert` component text overflowing its container on small screens by applying responsive word wrapping. 
Closes #55661.

## Type of Change
- [x] 🐛 Bug fix in an existing submission

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/alert-overflow-fix-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A fix for long alert messages overflowing their container on small screens.

**How does a developer use it?**
```html
<div class="alert alert--error">
  Your long alert message wraps correctly instead of overflowing.
</div>
```

**Why does it fit EaseMotion CSS?**
Reported in issue #55661: long alert messages extend past the container instead of wrapping on smaller viewports, breaking layout and readability. This applies `overflow-wrap: break-word` and `word-break: break-word` so messages wrap within the container at any screen size, matching the issue's suggested fix.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Edge

## Notes for Maintainer
`demo.html` includes a before/after comparison (broken vs. fixed) so the fix is easy to verify visually before integrating into `core/`. Tested down to 320px viewport width. Closes #55661.