### PR TITLE
feat(scroll): add reading progress bar using CSS animation-timeline 

### DIFF
--- a/components/reading-progress.css
+++ b/components/reading-progress.css
@@ -1,0 +1,56 @@
+/* ============================================================
+   EaseMotion CSS — reading-progress.css
+   Pure CSS Scroll-Driven Reading Progress Bar
+   ============================================================ */
+
+@keyframes ease-kf-reading-progress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@layer easemotion-components {
+  .ease-reading-progress {
+    --ease-reading-progress-height: 5px;
+    --ease-reading-progress-z-index: var(--ease-z-toast, 9999);
+    --ease-reading-progress-bg: linear-gradient(
+      to right,
+      var(--ease-color-primary, #6c63ff),
+      var(--ease-color-secondary, #ff6584)
+    );
+    --ease-reading-progress-shadow: 0 1px 5px rgba(0, 0, 0, 0.2);
+
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: var(--ease-reading-progress-height);
+    z-index: var(--ease-reading-progress-z-index);
+    background: var(--ease-reading-progress-bg);
+    box-shadow: var(--ease-reading-progress-shadow);
+    transform-origin: left;
+    transform: scaleX(0);
+    will-change: transform;
+
+    /* Native Scroll-Driven Animation */
+    animation: ease-kf-reading-progress auto linear;
+    animation-timeline: scroll(root);
+  }
+
+  /* Accommodate elements that scroll internally instead of the root */
+  .ease-reading-progress-container {
+    animation-timeline: scroll(nearest);
+  }
+
+  /* Accessibility */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-reading-progress {
+      animation: none;
+      transform: scaleX(1);
+      opacity: 0.5;
+    }
+  }
+}

--- a/easemotion.css
+++ b/easemotion.css
@@ -61,6 +61,7 @@
 @import "./components/toast.css";
 @import "./components/view-transitions.css";
 @import "./components/forms.css";
+@import "./components/reading-progress.css";
 
 
 /* Accessibility: Respect user's reduced motion preference */


### PR DESCRIPTION

## Description
This PR resolves #57484 by adding a new `ease-reading-progress` utility component that creates a pure CSS reading progress bar using the modern CSS Scroll-Driven Animations API.

## Changes Made
* **Added `components/reading-progress.css`**: Implemented the `.ease-reading-progress` class with customizable CSS variables (`--ease-reading-progress-height`, `--ease-reading-progress-bg`).
* **Scroll-Driven Animation**: Utilized `animation-timeline: scroll(root)` to bind the progress bar's `scaleX` transform directly to the user's scroll position, eliminating the need for JavaScript scroll event listeners.
* **Accessibility**: Added a `@media (prefers-reduced-motion: reduce)` block to automatically disable the animation and maintain a static visible state for users with motion sensitivities.
* **Imported to Core**: Added the `@import` statement to the main `easemotion.css` bundle so it is readily available for all users.

## Related Issue
Closes #57484

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 📝 Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have considered accessibility (prefers-reduced-motion)
- [x] My changes generate no new warnings