### PR TITLE
feat: add prefers-reduced-motion accessibility override

### DIFF
--- a/submissions/docs/reduced-motion-override-ak/README.md
+++ b/submissions/docs/reduced-motion-override-ak/README.md
@@ -1,0 +1,19 @@
+# Reduced Motion Override
+
+## What does this do?
+Adds a global `prefers-reduced-motion` media query override that scales down or disables motion for any element using an `ease-*` utility class, for users who have requested reduced motion at the OS/browser level.
+
+## How is it used?
+```html
+<div class="ease-demo-card">
+  Animated content — motion automatically reduces when the user
+  has enabled "reduce motion" in their system settings.
+</div>
+```
+No extra markup or class needed — the override targets `[class*="ease-"]` globally, so it applies automatically to any existing or future EaseMotion animation/transition utility.
+
+## Why is it useful?
+Motion-heavy interfaces can cause discomfort (dizziness, nausea, distraction) for users with vestibular disorders or motion sensitivity. Respecting `prefers-reduced-motion` is a baseline accessibility requirement (WCAG 2.3.3). This override collapses animation/transition durations to near-zero and removes transform-based hover motion, while leaving opacity-based feedback intact, so the framework degrades gracefully for users who need it — fitting EaseMotion's animation-first philosophy without excluding accessibility-conscious users.
+
+## Testing
+Open DevTools → Rendering tab → emulate `prefers-reduced-motion: reduce`, then reload `demo.html` to see the override applied.

--- a/submissions/docs/reduced-motion-override-ak/demo.html
+++ b/submissions/docs/reduced-motion-override-ak/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Reduced Motion Override — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    background: #111;
+    color: #fff;
+    padding: 32px;
+    max-width: 520px;
+    margin: 0 auto;
+  }
+  h1 {
+    font-size: 20px;
+  }
+  p {
+    color: #aaa;
+    font-size: 14px;
+    line-height: 1.6;
+  }
+  code {
+    background: #222;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+  .ease-demo-card {
+    margin-top: 24px;
+    padding: 20px;
+    border-radius: 12px;
+    background: #1b1b2f;
+  }
+</style>
+</head>
+<body>
+  <h1>Reduced Motion Override Demo</h1>
+  <p>
+    This card animates in and scales on hover by default. To test the
+    accessibility override, open DevTools → Rendering tab →
+    <strong>Emulate CSS media feature <code>prefers-reduced-motion</code></strong>,
+    set it to <code>reduce</code>, then reload this page. Motion should
+    become near-instant and hover scaling should stop.
+  </p>
+
+  <div class="ease-demo-card">
+    This card uses <code>ease-*</code>-style animation and transition
+    classes, which are automatically scaled down when the user has
+    requested reduced motion.
+  </div>
+</body>
+</html>

--- a/submissions/docs/reduced-motion-override-ak/style.css
+++ b/submissions/docs/reduced-motion-override-ak/style.css
@@ -1,0 +1,44 @@
+/* Accessibility: prefers-reduced-motion override
+   Scales down or disables motion for users who have requested
+   reduced motion at the OS/browser level. */
+
+/* Baseline demo animation used to show the override in action */
+@keyframes demoSlideIn {
+  0% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-demo-card {
+  animation: demoSlideIn 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.ease-demo-card:hover {
+  transform: scale(1.04);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+/* Reduced-motion override:
+   Applies globally to any element using an ease-* animation/transition
+   utility class, scaling durations down to near-instant and removing
+   transform-based motion, while preserving opacity changes for
+   state feedback. */
+@media (prefers-reduced-motion: reduce) {
+  [class*="ease-"] {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  [class*="ease-"]:hover,
+  [class*="ease-"]:focus-within {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a global `prefers-reduced-motion` accessibility override that scales down or disables motion for elements using `ease-*` utility classes. 
Closes #55655.

## Type of Change
- [x] 📝 Documentation improvement

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/reduced-motion-override-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A global `prefers-reduced-motion` override that automatically scales down/disables motion for any element using an `ease-*` utility class.

**How does a developer use it?**
```html
<div class="ease-demo-card">
  Animated content — motion automatically reduces when the user
  has enabled "reduce motion" in their system settings.
</div>
```
No extra markup needed — the override targets `[class*="ease-"]` globally.

**Why does it fit EaseMotion CSS?**
Respecting `prefers-reduced-motion` is a baseline accessibility requirement (WCAG 2.3.3) for motion-heavy interfaces. This override collapses animation/transition durations to near-zero and removes transform-based hover motion while preserving opacity-based feedback, letting the framework degrade gracefully for motion-sensitive users without abandoning its animation-first identity.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Edge

## Notes for Maintainer
This was one of three ideas proposed in #55655 by @codewithtanishq (not yet confirmed against your roadmap) — flagging in case you want to coordinate credit/scope with them. Tested by emulating `prefers-reduced-motion: reduce` in DevTools Rendering tab.