### PR TITLE
feat(submission): add entry/exit animation utilities using @starting-style

### DIFF
--- a/submissions/examples/starting-style/README.md
+++ b/submissions/examples/starting-style/README.md
@@ -1,0 +1,16 @@
+# Entry and Exit Utilities using CSS `@starting-style`
+
+This submission provides CSS classes to handle smooth entry and exit animations for elements that transition between `display: none` and `display: block`, such as dialogs, popovers, and dropdowns.
+
+## Features
+
+- **No JavaScript Timers**: Historically, animating an element out before hiding it required complex JavaScript `setTimeout` logic. With the new CSS `allow-discrete` transition and `@starting-style`, it's done entirely natively.
+- **Native HTML `<dialog>` Support**: The classes perfectly integrate with the native `<dialog>` element and the Popover API.
+- **Backdrop Animations**: Includes smooth blur and fade-in animations for the dialog `::backdrop`.
+- **Accessibility**: Utilizes the `prefers-reduced-motion` media query to immediately display/hide the elements for users who prefer reduced motion.
+
+## Usage
+
+1. Include `style.css` in your project.
+2. Apply the `.em-popover` class to any `<dialog>` or `popover` element.
+3. The element will now smoothly scale and fade in when opened, and smoothly scale and fade out when closed, without any additional scripts.

--- a/submissions/examples/starting-style/demo.html
+++ b/submissions/examples/starting-style/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS @starting-style Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: #f8fafc;
+      color: #334155;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 20px;
+    }
+
+    button.trigger-btn {
+      background-color: #6c63ff;
+      color: white;
+      border: none;
+      padding: 12px 24px;
+      font-size: 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      box-shadow: 0 4px 6px rgba(108, 99, 255, 0.2);
+      transition: background-color 0.2s;
+    }
+
+    button.trigger-btn:hover {
+      background-color: #5750d1;
+    }
+
+    button.close-btn {
+      background-color: #e2e8f0;
+      color: #475569;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      margin-top: 16px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Entry & Exit Animations</h1>
+  <p>Smoothly animating elements in and out of the DOM without JavaScript timers.</p>
+
+  <!-- Button triggering the native HTML Dialog -->
+  <button class="trigger-btn" onclick="document.getElementById('my-dialog').showModal()">
+    Open Dialog
+  </button>
+
+  <!-- The Dialog element -->
+  <dialog id="my-dialog" class="em-popover em-dialog-content">
+    <h2>Native Dialog</h2>
+    <p>This dialog animates from <code>display: none</code> to <code>display: block</code> using the CSS <code>@starting-style</code> rule. It also smoothly animates out before disappearing.</p>
+    <button class="close-btn" onclick="document.getElementById('my-dialog').close()">Close</button>
+  </dialog>
+
+</body>
+</html>

--- a/submissions/examples/starting-style/style.css
+++ b/submissions/examples/starting-style/style.css
@@ -1,0 +1,79 @@
+/* ============================================================
+   starting-style/style.css
+   Entry/Exit Utilities using CSS @starting-style
+   ============================================================ */
+
+/* 
+  The base class for our popover/dialog element.
+  We set up the transition for opacity and transform.
+  Crucially, we also transition `display` and `overlay` 
+  to allow exit animations before the element is removed from the screen.
+*/
+.em-popover {
+  /* Final state when visible */
+  opacity: 1;
+  transform: scale(1) translateY(0);
+  
+  /* Transition properties, including the new display/overlay properties */
+  transition: opacity 0.4s ease-out,
+              transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+              display 0.4s allow-discrete,
+              overlay 0.4s allow-discrete;
+}
+
+/* 
+  The entry state: Before the element is fully rendered, 
+  what should it look like? 
+  When the element changes from display: none to display: block,
+  it will start at these values and transition to the base class values.
+*/
+@starting-style {
+  .em-popover[open],
+  .em-popover:popover-open {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+}
+
+/* 
+  The exit state: When the element is no longer open or active.
+  It transitions back to these values before display becomes none.
+*/
+.em-popover:not([open]):not(:popover-open) {
+  opacity: 0;
+  transform: scale(0.9) translateY(10px);
+}
+
+/* Base styling for the demo components */
+.em-dialog-content {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  max-width: 400px;
+  color: #334155;
+  margin: auto;
+}
+
+.em-dialog-content::backdrop {
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
+  transition: background-color 0.4s, backdrop-filter 0.4s;
+}
+
+/* Backdrop animations using @starting-style */
+@starting-style {
+  .em-dialog-content::backdrop {
+    background: rgba(0, 0, 0, 0);
+    backdrop-filter: blur(0px);
+  }
+}
+
+/* Accessibility: respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .em-popover,
+  .em-dialog-content::backdrop {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Description
This PR resolves #57487 by submitting entry/exit animation utilities using the modern CSS `@starting-style` feature. It has been built and formatted strictly according to the repository's submission guidelines.

## Changes Made
* **Created Submission Folder**: Added a new isolated example under `submissions/examples/starting-style/`.
* **Added `style.css`**: Created the `.em-popover` utility class. It utilizes the new CSS `allow-discrete` transition property alongside the `@starting-style` rule to natively fade and scale elements smoothly in and out of the DOM (e.g., when transitioning from `display: none` to `display: block`). It also includes smooth blur transitions for the `::backdrop` pseudo-element.
* **Accessibility**: Added a media query for `prefers-reduced-motion: reduce` to automatically disable the scale and fade transitions, immediately displaying the content for users with motion sensitivities.
* **Added `demo.html`**: Created an interactive boilerplate HTML file using the native HTML `<dialog>` element to demonstrate the CSS in action.
* **Added `README.md`**: Provided documentation on how to apply the classes to popovers and dialogs.

## Related Issue
Closes #57487

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 📝 Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have placed my files exclusively within the `submissions/` directory
- [x] My `demo.html` includes valid DOCTYPE, html, head, and body tags
- [x] I have written original CSS inside `style.css`
- [x] I have performed a self-review of my own code