### PR TITLE
feat: add shimmer-sweep card grid for gaming hub layouts

### DIFF
--- a/submissions/examples/shimmer-sweep-card-grid-ak/README.md
+++ b/submissions/examples/shimmer-sweep-card-grid-ak/README.md
@@ -1,0 +1,23 @@
+# Shimmer-Sweep Card Grid for Gaming Hub Layouts
+
+## What does this do?
+A responsive CSS card grid where each card plays a diagonal shimmer-sweep effect on hover/focus and lifts with a shadow, designed for gaming hub / library-style layouts.
+
+## How is it used?
+```html
+<div class="shimmer-grid">
+  <div class="shimmer-card">
+    <img src="cover.jpg" alt="Game cover">
+    <div class="card-title">Game Name</div>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Shimmer effects add a premium, polished feel to card-based UIs like game libraries and storefronts. This submission provides a diagonal light-sweep on hover using a pseudo-element gradient, a subtle lift + shadow transition, keyframe entrance animation, full responsiveness across desktop/tablet/mobile, keyboard focus support (`:focus-within`), and `prefers-reduced-motion` handling — fitting EaseMotion's accessible, animation-first philosophy.
+
+## CSS Custom Properties
+- `--card-radius`: corner radius of each card (default `14px`)
+- `--card-bg`: card background color (default `#1b1b2f`)
+- `--shimmer-color`: color/opacity of the sweep highlight (default `rgba(255, 255, 255, 0.35)`)
+- `--transition-speed`: duration for shimmer sweep and hover transitions (default `0.4s`)

--- a/submissions/examples/shimmer-sweep-card-grid-ak/demo.html
+++ b/submissions/examples/shimmer-sweep-card-grid-ak/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Shimmer-Sweep Card Grid — Gaming Hub</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    background: #0d0d17;
+    color: #fff;
+    margin: 0;
+  }
+  h1 {
+    padding: 24px 24px 0;
+    font-size: 22px;
+  }
+  .art-1 { background: linear-gradient(135deg, #6366f1, #22d3ee); }
+  .art-2 { background: linear-gradient(135deg, #ec4899, #f59e0b); }
+  .art-3 { background: linear-gradient(135deg, #10b981, #3b82f6); }
+  .art-4 { background: linear-gradient(135deg, #f43f5e, #8b5cf6); }
+</style>
+</head>
+<body>
+  <h1>Gaming Hub</h1>
+  <div class="shimmer-grid">
+    <div class="shimmer-card" tabindex="0">
+      <div class="placeholder-art art-1">Cover Art</div>
+      <div class="card-title">Nebula Drift</div>
+    </div>
+    <div class="shimmer-card" tabindex="0">
+      <div class="placeholder-art art-2">Cover Art</div>
+      <div class="card-title">Iron Vanguard</div>
+    </div>
+    <div class="shimmer-card" tabindex="0">
+      <div class="placeholder-art art-3">Cover Art</div>
+      <div class="card-title">Shadow Realms</div>
+    </div>
+    <div class="shimmer-card" tabindex="0">
+      <div class="placeholder-art art-4">Cover Art</div>
+      <div class="card-title">Skybound Legends</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/shimmer-sweep-card-grid-ak/style.css
+++ b/submissions/examples/shimmer-sweep-card-grid-ak/style.css
@@ -1,0 +1,127 @@
+/* CSS Shimmer-Sweep Card Grid for Gaming Hub Layouts
+   Pure CSS, responsive, with prefers-reduced-motion support */
+
+:root {
+  --card-radius: 14px;
+  --card-bg: #1b1b2f;
+  --shimmer-color: rgba(255, 255, 255, 0.35);
+  --transition-speed: 0.4s;
+}
+
+.shimmer-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  padding: 24px;
+}
+
+@media (max-width: 1024px) {
+  .shimmer-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .shimmer-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.shimmer-card {
+  position: relative;
+  border-radius: var(--card-radius);
+  overflow: hidden;
+  background: var(--card-bg);
+  aspect-ratio: 3 / 4;
+  cursor: pointer;
+  animation: cardFadeIn 0.5s ease both;
+}
+
+@keyframes cardFadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.shimmer-card .placeholder-art {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-family: sans-serif;
+  font-size: 13px;
+}
+
+.shimmer-card .card-title {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 14px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.85), transparent);
+  color: #fff;
+  font-family: sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+/* Diagonal shimmer-sweep overlay */
+.shimmer-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 60%;
+  height: 100%;
+  background: linear-gradient(
+    115deg,
+    transparent 0%,
+    var(--shimmer-color) 50%,
+    transparent 100%
+  );
+  transform: skewX(-20deg);
+  pointer-events: none;
+}
+
+.shimmer-card:hover::before,
+.shimmer-card:focus-within::before {
+  animation: shimmerSweep var(--transition-speed) ease forwards;
+}
+
+@keyframes shimmerSweep {
+  0% {
+    left: -150%;
+  }
+  100% {
+    left: 150%;
+  }
+}
+
+.shimmer-card:hover,
+.shimmer-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+  transition: transform var(--transition-speed) ease,
+              box-shadow var(--transition-speed) ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shimmer-card,
+  .shimmer-card::before {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .shimmer-card:hover,
+  .shimmer-card:focus-within {
+    transform: none;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a responsive CSS card grid with a diagonal shimmer-sweep hover effect for gaming hub layouts. Closes #56455.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/shimmer-sweep-card-grid-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A responsive card grid where each card plays a diagonal shimmer-sweep on hover/focus and lifts with a shadow.

**How does a developer use it?**
```html
<div class="shimmer-grid">
  <div class="shimmer-card">
    <img src="cover.jpg" alt="Game cover">
    <div class="card-title">Game Name</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Shimmer effects add a premium, polished feel to card-based UIs like game libraries and storefronts. This includes a diagonal light-sweep via a pseudo-element gradient, a subtle lift + shadow transition, keyframe entrance animation, full responsiveness (desktop/tablet/mobile), keyboard focus support via `:focus-within`, and `prefers-reduced-motion` handling — matching EaseMotion's accessible, animation-first philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Edge

## Notes for Maintainer
Used placeholder gradient blocks instead of `<img>` in the demo to keep it fully self-contained with no external assets. CSS custom properties (`--card-radius`, `--card-bg`, `--shimmer-color`, `--transition-speed`) are exposed for theming. Closes #56455.