### PR TITLE
fix: prevent modal content clipping on small screens

### DIFF
--- a/submissions/docs/modal-clipping-fix-ak/README.md
+++ b/submissions/docs/modal-clipping-fix-ak/README.md
@@ -1,0 +1,22 @@
+# Modal Content Clipping Fix — Small Screens
+
+## What does this do?
+Fixes `.modal` content getting clipped on small screens/short viewports by adding internal scrolling, as reported in issue #55348.
+
+## How is it used?
+```html
+<div class="modal">
+  <div class="modal-content">
+    <h2>Terms &amp; Conditions</h2>
+    <p>Long content here...</p>
+    <button>Accept</button>
+  </div>
+</div>
+```
+
+## Why is it useful?
+Modals with large content previously overflowed the viewport with no way to scroll, hiding the lower content and action buttons entirely (issue #55348). This fix caps `.modal-content` at `max-height: 90vh` with `overflow-y: auto`, so content that exceeds the available height becomes scrollable instead of clipped — matching the issue's expected behavior. `demo.html` includes a before/after comparison so the maintainer can visually verify the fix before integrating it into `core/`.
+
+## Notes
+- This submission only demonstrates the fix (per contribution freeze rules, `core/` is not modified directly).
+- Tested by reducing browser height and on mobile viewport widths.

--- a/submissions/docs/modal-clipping-fix-ak/demo.html
+++ b/submissions/docs/modal-clipping-fix-ak/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Modal Clipping Fix — Small Screens</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    background: #111;
+    color: #fff;
+    margin: 0;
+  }
+  .section {
+    padding: 20px;
+  }
+  h1 {
+    font-size: 18px;
+  }
+  h2.label {
+    font-size: 14px;
+    color: #999;
+  }
+  p.note {
+    color: #999;
+    font-size: 13px;
+  }
+  /* Broken version for comparison — mimics the reported bug */
+  .modal-broken {
+    position: relative;
+    background: #1b1b2f;
+    color: #fff;
+    border-radius: 12px;
+    width: 100%;
+    max-width: 480px;
+    height: 200px;
+    overflow: hidden;
+    padding: 24px;
+    box-sizing: border-box;
+    font-family: sans-serif;
+    margin: 0 auto;
+  }
+</style>
+</head>
+<body>
+  <div class="section">
+    <h1>Modal Clipping Fix Demo</h1>
+    <p class="note">Reduce browser height or view on mobile. The "before" modal clips content with no way to scroll; the "after" modal scrolls internally.</p>
+
+    <h2 class="label">❌ Before (content clipped, no scroll)</h2>
+    <div class="modal-broken">
+      <h2>Terms &amp; Conditions</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Repeat this content multiple times to exceed viewport height.</p>
+      <p>Additional long content to reproduce the overflow issue.</p>
+      <button>Accept</button>
+    </div>
+
+    <h2 class="label">✅ After (fix applied — scrolls internally)</h2>
+    <div class="modal" style="position: static; background: none; padding: 0;">
+      <div class="modal-content">
+        <h2>Terms &amp; Conditions</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Repeat this content multiple times to exceed viewport height.</p>
+        <p>Additional long content to reproduce the overflow issue.</p>
+        <p>More content to confirm scrolling works when the modal exceeds 90vh.</p>
+        <p>Even more content here to push past the visible area reliably.</p>
+        <button>Accept</button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/docs/modal-clipping-fix-ak/style.css
+++ b/submissions/docs/modal-clipping-fix-ak/style.css
@@ -1,0 +1,66 @@
+/* Fix: prevent modal content clipping on small screens
+   Demonstrates internal scrolling for the .modal component */
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.modal-content {
+  background: #1b1b2f;
+  color: #fff;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 480px;
+
+  /* Core fix: cap height to the viewport and let the
+     content area scroll internally instead of clipping */
+  max-height: 90vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  padding: 24px;
+  box-sizing: border-box;
+  font-family: sans-serif;
+}
+
+.modal-content h2 {
+  margin-top: 0;
+}
+
+.modal-content p {
+  line-height: 1.6;
+  color: #ccc;
+}
+
+.modal-content button {
+  margin-top: 16px;
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+
+  /* Keep the action button reachable by scrolling with content,
+     rather than pinning it (which can hide it behind short viewports) */
+  display: inline-block;
+}
+
+@media (max-width: 480px) {
+  .modal {
+    padding: 12px;
+  }
+
+  .modal-content {
+    max-height: 95vh;
+    padding: 18px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Fixes `.modal` content getting clipped on small screens/short viewports by adding internal scrolling. Closes #55348.

## Type of Change
- [x] 🐛 Bug fix in an existing submission

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/modal-clipping-fix-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A fix for modal content getting clipped on small screens with no way to scroll to hidden content.

**How does a developer use it?**
```html
<div class="modal">
  <div class="modal-content">
    <h2>Terms &amp; Conditions</h2>
    <p>Long content here...</p>
    <button>Accept</button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Reported in issue #55348: modals with large content overflow the viewport with no way to scroll, hiding lower content and action buttons on smaller screens. This caps `.modal-content` at `max-height: 90vh` with `overflow-y: auto`, so content that exceeds the available height becomes scrollable instead of clipped, matching the issue's expected behavior.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Edge

## Notes for Maintainer
`demo.html` includes a before/after comparison (clipped vs. scrollable) so the fix is easy to verify visually before integrating into `core/`. Tested by reducing browser height and on mobile viewport widths. Closes #55348.