### PR TITLE
feat: add animated stepper/step indicator component

### DIFF
--- a/submissions/examples/animated-stepper-ak/README.md
+++ b/submissions/examples/animated-stepper-ak/README.md
@@ -1,0 +1,35 @@
+# Animated Stepper / Step Indicator
+
+## What does this do?
+A CSS-only animated stepper/step indicator for multi-step forms, onboarding wizards, and checkout flows, with horizontal and vertical layout variants.
+
+## How is it used?
+```html
+<div class="ease-stepper">
+  <div class="ease-stepper__step ease-stepper__step--completed">
+    <div class="ease-stepper__circle"></div>
+    <span class="ease-stepper__label">Cart</span>
+  </div>
+  <div class="ease-stepper__connector ease-stepper__connector--filled"></div>
+  <div class="ease-stepper__step ease-stepper__step--active">
+    <div class="ease-stepper__circle" aria-current="step">2</div>
+    <span class="ease-stepper__label">Shipping</span>
+  </div>
+  <div class="ease-stepper__connector"></div>
+  <div class="ease-stepper__step ease-stepper__step--upcoming">
+    <div class="ease-stepper__circle">3</div>
+    <span class="ease-stepper__label">Payment</span>
+  </div>
+</div>
+```
+Add `.ease-stepper--vertical` to the wrapper for a vertical layout.
+
+## Why is it useful?
+Step indicators are a commonly needed pattern not currently in EaseMotion CSS. This provides completed/active/upcoming states, a scale-in checkmark for completed steps, a left-to-right connector fill animation, a pulsing ring on the active step, full accessibility (`aria-current="step"`, `aria-label` on each circle), and `prefers-reduced-motion` support — matching the component request in issue #55260.
+
+## CSS Custom Properties
+- `--ease-step-color-completed` (default: `#6366f1`)
+- `--ease-step-color-active` (default: `#6366f1`)
+- `--ease-step-color-upcoming` (default: `#d1d5db`)
+- `--ease-step-size` — circle diameter (default: `2rem`)
+- `--ease-step-connector-duration` (default: `0.4s`)

--- a/submissions/examples/animated-stepper-ak/demo.html
+++ b/submissions/examples/animated-stepper-ak/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Animated Stepper / Step Indicator</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    background: #f5f5f7;
+    padding: 40px;
+  }
+  h1 {
+    font-size: 20px;
+    margin-bottom: 32px;
+  }
+  h2.label {
+    font-size: 14px;
+    color: #666;
+    margin-top: 48px;
+  }
+</style>
+</head>
+<body>
+  <h1>Animated Stepper Demo</h1>
+
+  <h2 class="label">Horizontal — in progress</h2>
+  <div class="ease-stepper" role="list" aria-label="Checkout steps">
+    <div class="ease-stepper__step ease-stepper__step--completed">
+      <div class="ease-stepper__circle" aria-label="Cart, completed"></div>
+      <span class="ease-stepper__label">Cart</span>
+    </div>
+    <div class="ease-stepper__connector ease-stepper__connector--filled"></div>
+    <div class="ease-stepper__step ease-stepper__step--active">
+      <div class="ease-stepper__circle" aria-current="step" aria-label="Shipping, current step">2</div>
+      <span class="ease-stepper__label">Shipping</span>
+    </div>
+    <div class="ease-stepper__connector"></div>
+    <div class="ease-stepper__step ease-stepper__step--upcoming">
+      <div class="ease-stepper__circle" aria-label="Payment, upcoming">3</div>
+      <span class="ease-stepper__label">Payment</span>
+    </div>
+    <div class="ease-stepper__connector"></div>
+    <div class="ease-stepper__step ease-stepper__step--upcoming">
+      <div class="ease-stepper__circle" aria-label="Confirm, upcoming">4</div>
+      <span class="ease-stepper__label">Confirm</span>
+    </div>
+  </div>
+
+  <h2 class="label">Vertical — onboarding flow</h2>
+  <div class="ease-stepper ease-stepper--vertical" role="list" aria-label="Onboarding steps">
+    <div class="ease-stepper__step ease-stepper__step--completed">
+      <div class="ease-stepper__circle" aria-label="Create account, completed"></div>
+      <span class="ease-stepper__label">Create account</span>
+    </div>
+    <div class="ease-stepper__connector ease-stepper__connector--filled"></div>
+    <div class="ease-stepper__step ease-stepper__step--active">
+      <div class="ease-stepper__circle" aria-current="step" aria-label="Verify email, current step">2</div>
+      <span class="ease-stepper__label">Verify email</span>
+    </div>
+    <div class="ease-stepper__connector"></div>
+    <div class="ease-stepper__step ease-stepper__step--upcoming">
+      <div class="ease-stepper__circle" aria-label="Set up profile, upcoming">3</div>
+      <span class="ease-stepper__label">Set up profile</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-stepper-ak/style.css
+++ b/submissions/examples/animated-stepper-ak/style.css
@@ -1,0 +1,162 @@
+/* Animated Stepper / Step Indicator
+   For multi-step forms, onboarding wizards, and checkout flows */
+
+:root {
+  --ease-step-color-completed: #6366f1;
+  --ease-step-color-active: #6366f1;
+  --ease-step-color-upcoming: #d1d5db;
+  --ease-step-size: 2rem;
+  --ease-step-connector-duration: 0.4s;
+}
+
+.ease-stepper {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  font-family: sans-serif;
+}
+
+.ease-stepper--vertical {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.ease-stepper__step {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  position: relative;
+}
+
+.ease-stepper--vertical .ease-stepper__step {
+  flex-direction: column;
+  align-items: flex-start;
+  flex: none;
+}
+
+.ease-stepper__circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--ease-step-size);
+  height: var(--ease-step-size);
+  border-radius: 50%;
+  background: var(--ease-step-color-upcoming);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  flex-shrink: 0;
+  position: relative;
+  transition: background 0.3s ease;
+}
+
+.ease-stepper__step--completed .ease-stepper__circle,
+.ease-stepper__step--active .ease-stepper__circle {
+  background: var(--ease-step-color-completed);
+}
+
+/* Checkmark for completed steps */
+.ease-stepper__step--completed .ease-stepper__circle::after {
+  content: "✓";
+  animation: stepCheckIn 0.3s ease forwards;
+}
+
+@keyframes stepCheckIn {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* Active step pulse ring */
+.ease-stepper__step--active .ease-stepper__circle::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 2px solid var(--ease-step-color-active);
+  animation: stepPulse 1.6s ease-out infinite;
+}
+
+@keyframes stepPulse {
+  0% {
+    transform: scale(0.9);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1.4);
+    opacity: 0;
+  }
+}
+
+.ease-stepper__label {
+  margin-left: 10px;
+  font-size: 0.85rem;
+  color: #444;
+  white-space: nowrap;
+}
+
+.ease-stepper--vertical .ease-stepper__label {
+  margin-left: 12px;
+  margin-top: 0;
+}
+
+/* Connector line between steps */
+.ease-stepper__connector {
+  flex: 1;
+  height: 3px;
+  background: var(--ease-step-color-upcoming);
+  margin: 0 8px;
+  position: relative;
+  overflow: hidden;
+}
+
+.ease-stepper--vertical .ease-stepper__connector {
+  width: 3px;
+  height: 32px;
+  margin: 4px 0 4px calc(var(--ease-step-size) / 2 - 1.5px);
+}
+
+.ease-stepper__connector::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0%;
+  background: var(--ease-step-color-completed);
+  transition: width var(--ease-step-connector-duration) ease;
+}
+
+.ease-stepper--vertical .ease-stepper__connector::after {
+  width: 100%;
+  height: 0%;
+  transition: height var(--ease-step-connector-duration) ease;
+}
+
+.ease-stepper__connector--filled::after {
+  width: 100%;
+}
+
+.ease-stepper--vertical .ease-stepper__connector--filled::after {
+  height: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stepper__circle::before,
+  .ease-stepper__circle::after,
+  .ease-stepper__connector::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .ease-stepper__label {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS-only animated stepper/step indicator component for multi-step forms, onboarding wizards, and checkout flows, with horizontal and vertical variants. Closes #55260.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/animated-stepper-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
An animated stepper/step indicator with completed, active, and upcoming states, plus horizontal and vertical layout variants.

**How does a developer use it?**
```html
<div class="ease-stepper">
  <div class="ease-stepper__step ease-stepper__step--completed">
    <div class="ease-stepper__circle"></div>
    <span class="ease-stepper__label">Cart</span>
  </div>
  <div class="ease-stepper__connector ease-stepper__connector--filled"></div>
  <div class="ease-stepper__step ease-stepper__step--active">
    <div class="ease-stepper__circle" aria-current="step">2</div>
    <span class="ease-stepper__label">Shipping</span>
  </div>
</div>
```
Add `.ease-stepper--vertical` to the wrapper for a vertical layout.

**Why does it fit EaseMotion CSS?**
Step indicators are a commonly needed UI pattern not currently in EaseMotion CSS, per the component request in #55260. This includes a scale-in checkmark for completed steps, a left-to-right connector fill animation, a pulsing ring on the active step, full accessibility (`aria-current="step"`, `aria-label` on each circle), and `prefers-reduced-motion` support.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Edge

## Notes for Maintainer
Followed the class naming and CSS custom properties proposed in the issue (`--ease-step-color-completed`, `--ease-step-color-active`, `--ease-step-color-upcoming`, `--ease-step-size`, `--ease-step-connector-duration`). Submitted under `submissions/examples/` per the freeze rules rather than directly at `components/stepper.css` as the issue mentions — ready for you to integrate there. Closes #55260.