### PR TITLE
fix: prevent feature badge text from overflowing inside cards

### DIFF
--- a/submissions/examples/feature-badge-responsive/README.md
+++ b/submissions/examples/feature-badge-responsive/README.md
@@ -1,0 +1,32 @@
+# Feature Badge Responsive
+
+## Description
+
+This submission fixes an issue where long feature badge text overflows outside the card on smaller screens. The badge now wraps correctly while maintaining proper spacing and responsiveness.
+
+## Features
+
+- Prevents badge text overflow
+- Responsive badge sizing
+- Supports long badge labels
+- Pure CSS solution
+- Mobile-friendly layout
+
+## Usage
+
+```html
+<div class="feature-card">
+  <span class="feature-badge">Most Popular</span>
+
+  <h2>Pro Plan</h2>
+
+  <p>Card description...</p>
+</div>
+```
+
+## Benefits
+
+- Eliminates badge overflow
+- Improves readability
+- Maintains responsive card layout
+- Lightweight and easy to integrate

--- a/submissions/examples/feature-badge-responsive/demo.html
+++ b/submissions/examples/feature-badge-responsive/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Feature Badge Responsive</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="card-container">
+
+  <div class="feature-card">
+    <span class="feature-badge">
+      Best Choice for Enterprise Applications with Advanced Responsive Features
+    </span>
+
+    <h2>Enterprise Plan</h2>
+
+    <p>
+      Perfect for businesses that need scalable, responsive, and reliable UI components.
+    </p>
+
+    <button>Learn More</button>
+  </div>
+
+  <div class="feature-card">
+    <span class="feature-badge">
+      Most Popular
+    </span>
+
+    <h2>Pro Plan</h2>
+
+    <p>
+      Includes premium features for developers and growing teams.
+    </p>
+
+    <button>Learn More</button>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/feature-badge-responsive/style.css
+++ b/submissions/examples/feature-badge-responsive/style.css
@@ -1,0 +1,83 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    font-family:Arial, Helvetica, sans-serif;
+    background:#f5f5f5;
+    padding:40px 20px;
+}
+
+.card-container{
+    display:flex;
+    justify-content:center;
+    flex-wrap:wrap;
+    gap:24px;
+}
+
+.feature-card{
+    width:340px;
+    background:#fff;
+    padding:24px;
+    border-radius:12px;
+    box-shadow:0 4px 10px rgba(0,0,0,.1);
+}
+
+.feature-badge{
+    display:inline-block;
+    background:#2563eb;
+    color:#fff;
+    padding:8px 14px;
+    border-radius:20px;
+    font-size:14px;
+    margin-bottom:18px;
+
+    overflow-wrap:break-word;
+    word-break:break-word;
+    white-space:normal;
+    max-width:100%;
+}
+
+.feature-card h2{
+    margin-bottom:12px;
+    color:#222;
+}
+
+.feature-card p{
+    color:#555;
+    line-height:1.6;
+    margin-bottom:20px;
+}
+
+.feature-card button{
+    padding:10px 18px;
+    border:none;
+    border-radius:6px;
+    background:#2563eb;
+    color:#fff;
+    cursor:pointer;
+    transition:.3s;
+}
+
+.feature-card button:hover{
+    background:#1d4ed8;
+}
+
+@media(max-width:600px){
+
+    body{
+        padding:20px;
+    }
+
+    .feature-card{
+        width:100%;
+    }
+
+    .feature-badge{
+        font-size:13px;
+        padding:8px 12px;
+    }
+
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes an issue where long feature badge text overflows outside card containers on smaller screens. The update introduces responsive text wrapping and adaptive badge sizing to ensure badges remain readable and properly contained across desktop, tablet, and mobile devices.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/feature-badge-responsive/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes feature badge text overflow by allowing long badge labels to wrap correctly while maintaining a responsive card layout.

**How does a developer use it?**

```html
<div class="feature-card">
  <span class="feature-badge">
    Most Popular
  </span>

  <h2>Pro Plan</h2>

  <p>Card description...</p>
</div>
```

**Why does it fit EaseMotion CSS?**

This enhancement provides a lightweight, reusable, and responsive solution using pure CSS. It improves usability while staying consistent with EaseMotion CSS's developer-friendly, utility-first design philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The fix uses `overflow-wrap`, `word-break`, responsive sizing, and flexible badge styling to prevent long labels from overflowing card boundaries. All changes are isolated within the example submission and do not modify `core/` or `components/`.
```