### PR TITLE
feat: add staggered entrance tabs

### DIFF
--- a/submissions/examples/staggered-entrance-tabs/README.md
+++ b/submissions/examples/staggered-entrance-tabs/README.md
@@ -1,0 +1,23 @@
+# CSS Staggered Entrance Tabs
+
+A pure CSS animated Tabs component featuring a smooth
+staggered entrance transition for interactive interface layouts.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Responsive design
+- Keyboard-focusable controls
+- Staggered content entrance animation
+- Custom CSS animation properties
+- Reduced-motion support
+- No external dependencies
+
+## Files
+
+```text
+staggered-entrance-tabs/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/staggered-entrance-tabs/demo.html
+++ b/submissions/examples/staggered-entrance-tabs/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Staggered Entrance Tabs</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="demo">
+    <section class="tabs" aria-label="Interactive interface tabs">
+
+      <!-- Tab controls -->
+      <input class="tabs__input" type="radio" name="tabs"
+             id="tab-overview" checked>
+
+      <input class="tabs__input" type="radio" name="tabs"
+             id="tab-features">
+
+      <input class="tabs__input" type="radio" name="tabs"
+             id="tab-details">
+
+      <div class="tabs__nav" role="tablist">
+        <label class="tabs__label" for="tab-overview" role="tab">
+          Overview
+        </label>
+
+        <label class="tabs__label" for="tab-features" role="tab">
+          Features
+        </label>
+
+        <label class="tabs__label" for="tab-details" role="tab">
+          Details
+        </label>
+      </div>
+
+      <!-- Tab content -->
+      <div class="tabs__panels">
+
+        <article class="tabs__panel panel--overview">
+          <span class="eyebrow">01 / Overview</span>
+
+          <h1>Interfaces that feel alive.</h1>
+
+          <p>
+            A pure CSS tab component with a smooth staggered
+            entrance animation for interactive interfaces.
+          </p>
+
+          <div class="cards">
+            <div class="card">Pure CSS</div>
+            <div class="card">Responsive</div>
+            <div class="card">Accessible</div>
+          </div>
+        </article>
+
+        <article class="tabs__panel panel--features">
+          <span class="eyebrow">02 / Features</span>
+
+          <h2>Motion without JavaScript.</h2>
+
+          <p>
+            Content elements enter one after another to create
+            a clean staggered reveal.
+          </p>
+
+          <ul>
+            <li>Pure CSS animation</li>
+            <li>Custom animation properties</li>
+            <li>Responsive design</li>
+          </ul>
+        </article>
+
+        <article class="tabs__panel panel--details">
+          <span class="eyebrow">03 / Details</span>
+
+          <h2>Simple and reusable.</h2>
+
+          <p>
+            Copy the markup and stylesheet into your project.
+            No JavaScript or external dependencies are required.
+          </p>
+
+          <div class="highlight">
+            CSS only
+          </div>
+        </article>
+
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/staggered-entrance-tabs/style.css
+++ b/submissions/examples/staggered-entrance-tabs/style.css
@@ -1,0 +1,438 @@
+:root {
+    --tab-duration: 650ms;
+    --tab-easing: cubic-bezier(.22, 1, .36, 1);
+    --tab-stagger: 100ms;
+    --tab-lift: 20px;
+  
+    --background: #0b1020;
+    --surface: #151c32;
+    --surface-light: #202a48;
+    --text: #f7f9ff;
+    --muted: #aeb8d0;
+    --accent: #8175ff;
+    --accent-light: #62d8ff;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+  
+    font-family:
+      Inter,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    color: var(--text);
+  
+    background:
+      radial-gradient(
+        circle at 20% 10%,
+        rgba(129, 117, 255, 0.2),
+        transparent 35%
+      ),
+      radial-gradient(
+        circle at 85% 90%,
+        rgba(98, 216, 255, 0.12),
+        transparent 30%
+      ),
+      var(--background);
+  }
+  
+  /* Main container */
+  
+  .demo {
+    width: min(920px, calc(100% - 32px));
+    min-height: 100vh;
+    margin: auto;
+  
+    display: grid;
+    place-items: center;
+  
+    padding: 40px 0;
+  }
+  
+  /* Tabs */
+  
+  .tabs {
+    width: 100%;
+    padding: 10px;
+  
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 24px;
+  
+    background: rgba(21, 28, 50, 0.9);
+  
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.35);
+  }
+  
+  /* Hide radio buttons */
+  
+  .tabs__input {
+    position: absolute;
+  
+    width: 1px;
+    height: 1px;
+  
+    opacity: 0;
+  }
+  
+  /* Navigation */
+  
+  .tabs__nav {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  
+    gap: 6px;
+    padding: 6px;
+  
+    border-radius: 16px;
+  
+    background: rgba(255, 255, 255, 0.05);
+  }
+  
+  .tabs__label {
+    cursor: pointer;
+  
+    padding: 14px 12px;
+  
+    border-radius: 12px;
+  
+    text-align: center;
+  
+    color: var(--muted);
+  
+    font-weight: 700;
+  
+    transition:
+      color 220ms ease,
+      background 220ms ease,
+      transform 220ms ease;
+  }
+  
+  .tabs__label:hover {
+    color: var(--text);
+    transform: translateY(-2px);
+  }
+  
+  /* Keyboard focus */
+  
+  .tabs__input:focus-visible
+  ~ .tabs__nav .tabs__label {
+    outline: 2px solid transparent;
+  }
+  
+  .tabs__input:focus-visible
+  + .tabs__input
+  + .tabs__input
+  ~ .tabs__nav
+  .tabs__label:first-child {
+    outline: 2px solid var(--accent-light);
+    outline-offset: 3px;
+  }
+  
+  /* Active tabs */
+  
+  #tab-overview:checked
+  ~ .tabs__nav
+  .tabs__label:nth-child(1),
+  
+  #tab-features:checked
+  ~ .tabs__nav
+  .tabs__label:nth-child(2),
+  
+  #tab-details:checked
+  ~ .tabs__nav
+  .tabs__label:nth-child(3) {
+    color: white;
+  
+    background:
+      linear-gradient(
+        135deg,
+        var(--accent),
+        #6256d8
+      );
+  }
+  
+  /* Panels */
+  
+  .tabs__panels {
+    margin-top: 10px;
+  }
+  
+  .tabs__panel {
+    display: none;
+  
+    min-height: 360px;
+  
+    padding: clamp(28px, 6vw, 64px);
+  
+    border-radius: 18px;
+  
+    background:
+      linear-gradient(
+        145deg,
+        var(--surface-light),
+        var(--surface)
+      );
+  
+    overflow: hidden;
+  }
+  
+  /* Show selected panel */
+  
+  #tab-overview:checked
+  ~ .tabs__panels
+  .panel--overview,
+  
+  #tab-features:checked
+  ~ .tabs__panels
+  .panel--features,
+  
+  #tab-details:checked
+  ~ .tabs__panels
+  .panel--details {
+    display: block;
+  
+    animation:
+      panel-enter
+      var(--tab-duration)
+      var(--tab-easing)
+      both;
+  }
+  
+  /* Text */
+  
+  .eyebrow {
+    display: block;
+  
+    margin-bottom: 14px;
+  
+    color: var(--accent-light);
+  
+    font-size: 0.78rem;
+    font-weight: 800;
+  
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  
+  h1,
+  h2 {
+    max-width: 700px;
+  
+    margin: 0 0 16px;
+  
+    font-size: clamp(2rem, 6vw, 4rem);
+  
+    line-height: 1.05;
+  }
+  
+  p {
+    max-width: 650px;
+  
+    margin: 0;
+  
+    color: var(--muted);
+  
+    font-size: 1.05rem;
+  
+    line-height: 1.7;
+  }
+  
+  /* Cards */
+  
+  .cards {
+    display: grid;
+  
+    grid-template-columns:
+      repeat(3, 1fr);
+  
+    gap: 12px;
+  
+    margin-top: 32px;
+  }
+  
+  .card {
+    padding: 20px;
+  
+    border: 1px solid
+      rgba(255, 255, 255, 0.08);
+  
+    border-radius: 14px;
+  
+    background:
+      rgba(255, 255, 255, 0.04);
+  
+    opacity: 0;
+  
+    animation:
+      item-enter
+      var(--tab-duration)
+      var(--tab-easing)
+      both;
+  }
+  
+  .card:nth-child(1) {
+    animation-delay:
+      var(--tab-stagger);
+  }
+  
+  .card:nth-child(2) {
+    animation-delay:
+      calc(var(--tab-stagger) * 2);
+  }
+  
+  .card:nth-child(3) {
+    animation-delay:
+      calc(var(--tab-stagger) * 3);
+  }
+  
+  /* Feature list */
+  
+  .panel--features ul {
+    margin-top: 28px;
+  
+    padding-left: 22px;
+  
+    color: var(--muted);
+  
+    line-height: 2;
+  }
+  
+  .panel--features li {
+    opacity: 0;
+  
+    animation:
+      item-enter
+      var(--tab-duration)
+      var(--tab-easing)
+      both;
+  }
+  
+  .panel--features li:nth-child(1) {
+    animation-delay:
+      var(--tab-stagger);
+  }
+  
+  .panel--features li:nth-child(2) {
+    animation-delay:
+      calc(var(--tab-stagger) * 2);
+  }
+  
+  .panel--features li:nth-child(3) {
+    animation-delay:
+      calc(var(--tab-stagger) * 3);
+  }
+  
+  /* Highlight */
+  
+  .highlight {
+    width: fit-content;
+  
+    margin-top: 30px;
+    padding: 18px 28px;
+  
+    border-radius: 14px;
+  
+    color: var(--accent-light);
+  
+    background:
+      rgba(98, 216, 255, 0.08);
+  
+    font-size: 1.5rem;
+    font-weight: 800;
+  
+    opacity: 0;
+  
+    animation:
+      item-enter
+      var(--tab-duration)
+      var(--tab-easing)
+      both;
+  
+    animation-delay:
+      var(--tab-stagger);
+  }
+  
+  /* Animations */
+  
+  @keyframes panel-enter {
+    from {
+      opacity: 0;
+  
+      transform:
+        translateY(var(--tab-lift));
+    }
+  
+    to {
+      opacity: 1;
+  
+      transform:
+        translateY(0);
+    }
+  }
+  
+  @keyframes item-enter {
+    from {
+      opacity: 0;
+  
+      transform:
+        translateY(var(--tab-lift))
+        scale(0.98);
+    }
+  
+    to {
+      opacity: 1;
+  
+      transform:
+        translateY(0)
+        scale(1);
+    }
+  }
+  
+  /* Responsive */
+  
+  @media (max-width: 620px) {
+  
+    .demo {
+      width:
+        calc(100% - 20px);
+  
+      padding: 20px 0;
+    }
+  
+    .tabs__nav {
+      grid-template-columns: 1fr;
+    }
+  
+    .tabs__panel {
+      min-height: 400px;
+  
+      padding: 30px 22px;
+    }
+  
+    .cards {
+      grid-template-columns: 1fr;
+    }
+  }
+  
+  /* Reduced motion */
+  
+  @media (prefers-reduced-motion: reduce) {
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 1ms !important;
+      animation-delay: 0ms !important;
+      transition: none !important;
+    }
+  }


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS **Staggered Entrance Tabs** component for interactive interface layouts.

The component provides a smooth staggered entrance animation when switching tabs while keeping the implementation lightweight and JavaScript-free.

## Type of Change

* [x] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other

## Feature Description

**What does this add?**

A responsive CSS-only tabs component with staggered entrance animations for tab content.

**How does a developer use it?**

```html
<link rel="stylesheet" href="style.css">
```

Use the tab markup from `demo.html` and customize the animation through CSS custom properties.

**Why does it fit EaseMotion CSS?**

The component follows the animation-first philosophy of EaseMotion CSS by providing a reusable interaction using only HTML and CSS. Animation timing, easing, stagger delay, and movement distance can be customized through CSS variables.

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari

## Notes for Maintainer

The component uses native radio inputs for CSS-only tab state and includes reduced-motion support through `prefers-reduced-motion`.

Closes #50313
