### PR TITLE
fix: allow importing individual component CSS files via exports (#53768)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "./engine/compiler": "./easemotion/engine/compiler.js",
     "./engine/optimizer": "./easemotion/engine/optimizer.js",
     "./engine/runtime": "./easemotion/engine/runtime.js",
-    "./core": "./core/animations.css"
+    "./core": "./core/animations.css",
+    "./components/*.css": "./components/*.css"
   },
   "files": [
     "easemotion.css",


### PR DESCRIPTION
## 📌 Related Issue

Closes #53768


## ✨ Fix: Component CSS exports support

This PR updates the package exports map to allow importing individual component CSS files directly.


## 🐛 Problem

Previously, importing component styles like:

```js
import 'easemotion-css/components/buttons.css';