### PR TITLE
feat: add CSS 3D perspective tilt tabs for creative portfolio layouts

### DIFF
--- a/submissions/examples/css-3d-perspective-tilt-tabs/README.md
+++ b/submissions/examples/css-3d-perspective-tilt-tabs/README.md
@@ -1,0 +1,48 @@
+# CSS 3D Perspective Tilt Tabs
+
+A pure CSS tabs component styled as a portfolio case-study browser, where each panel rotates in on a 3D plane rather than a flat fade or slide. No JavaScript, no dependencies.
+
+## How it works
+
+Tab switching uses the same radio-hack pattern as other tabs in this framework. What's different is the transition: `perspective` is set on the parent `.ease-tabs-scene` container, which establishes how far away the viewer's "eye" is from the 3D plane — a smaller value gives a more dramatic, fish-eye-like tilt, a larger value gives a subtler one.
+
+Each `.ease-tabs-panel` itself starts rotated with `rotateY(14deg)` and slightly scaled down, then animates to `rotateY(0deg)` at full scale when its radio is checked, so it looks like it's rotating into place on a hinge rather than simply appearing. `transform-style: preserve-3d` is set so the panel's own 3D transform is respected within its parent's perspective context.
+
+As a bonus, hovering the active panel adds a very subtle independent `rotateX` tilt, layered on top of the resting `rotateY(0deg)` state, for a bit of life without being distracting.
+
+## Files
+
+- `demo.html` – a 3-tab portfolio case study browser (Nova, Orbit, Fable)
+- `style.css` – all styling, custom properties, and the 3D tilt transition
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-tilt-duration` – 0.45s
+- `--ease-tilt-easing` – cubic-bezier(0.34, 1.56, 0.64, 1) (slight overshoot for a tactile feel)
+- `--ease-tilt-radius` – 12px
+- `--ease-tilt-perspective` – 900px (lower = more dramatic tilt, higher = subtler)
+- `--ease-tilt-angle` – 14deg (how far the panel is rotated before becoming active)
+- `--ease-tilt-bg` – panel background
+- `--ease-tilt-border` – border color
+- `--ease-tilt-text` – active tab / panel title color
+- `--ease-tilt-muted-text` – inactive tab / body text color
+- `--ease-tilt-accent` – active tab border color
+
+Example override:
+
+```css
+:root {
+  --ease-tilt-perspective: 600px;
+  --ease-tilt-angle: 22deg;
+}
+```
+
+## Notes
+
+- `perspective` must live on the parent container, not the panel itself, or the 3D effect won't apply correctly — this is a common gotcha with CSS 3D transforms
+- Fully responsive, with breakpoints at 768px and 480px, and taller scene height on mobile since panel text wraps more
+- Radio/label pairing keeps tabs keyboard-navigable by default
+- Respects `prefers-reduced-motion` — all transform and transition is disabled, panels simply fade via opacity with no rotation

--- a/submissions/examples/css-3d-perspective-tilt-tabs/demo.html
+++ b/submissions/examples/css-3d-perspective-tilt-tabs/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS 3D Perspective Tilt Tabs — Creative Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Case Studies</p>
+    <h1 class="ease-heading">Selected Projects</h1>
+    <p class="ease-subtitle">Pure CSS tabs with a 3D perspective tilt on panel switch. No JavaScript.</p>
+
+    <div class="ease-tabs">
+
+      <input type="radio" name="ease-tilt-tabs-group" id="ease-tilt-tab-1" class="ease-tabs-input" checked />
+      <input type="radio" name="ease-tilt-tabs-group" id="ease-tilt-tab-2" class="ease-tabs-input" />
+      <input type="radio" name="ease-tilt-tabs-group" id="ease-tilt-tab-3" class="ease-tabs-input" />
+
+      <div class="ease-tabs-list" role="tablist">
+        <label for="ease-tilt-tab-1" class="ease-tabs-trigger">Nova</label>
+        <label for="ease-tilt-tab-2" class="ease-tabs-trigger">Orbit</label>
+        <label for="ease-tilt-tab-3" class="ease-tabs-trigger">Fable</label>
+      </div>
+
+      <div class="ease-tabs-scene">
+        <div class="ease-tabs-panel ease-tabs-panel-1">
+          <h2>Nova Landing Page</h2>
+          <p>A conversion-focused marketing site built for a SaaS launch, with a 3D-tilted hero card.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-2">
+          <h2>Orbit Dashboard</h2>
+          <p>Analytics dashboard redesign focused on clarity and fast scanning.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-3">
+          <h2>Fable Mobile App</h2>
+          <p>Reading app UI with a warm, editorial feel and custom typography.</p>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-3d-perspective-tilt-tabs/style.css
+++ b/submissions/examples/css-3d-perspective-tilt-tabs/style.css
@@ -1,0 +1,178 @@
+:root {
+  --ease-tilt-duration: 0.45s;
+  --ease-tilt-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-tilt-radius: 12px;
+  --ease-tilt-perspective: 900px;
+  --ease-tilt-angle: 14deg;
+  --ease-tilt-bg: #16181d;
+  --ease-tilt-border: #2a2d34;
+  --ease-tilt-text: #f0f0f0;
+  --ease-tilt-muted-text: #a8a8a8;
+  --ease-tilt-accent: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-tilt-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-tilt-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-tabs-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-tabs-list {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.75rem;
+}
+
+.ease-tabs-trigger {
+  padding: 0.6rem 1.1rem;
+  border-radius: 8px;
+  border: 1px solid var(--ease-tilt-border);
+  background: var(--ease-tilt-bg);
+  color: var(--ease-tilt-muted-text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+#ease-tilt-tab-1:checked ~ .ease-tabs-list label[for="ease-tilt-tab-1"],
+#ease-tilt-tab-2:checked ~ .ease-tabs-list label[for="ease-tilt-tab-2"],
+#ease-tilt-tab-3:checked ~ .ease-tabs-list label[for="ease-tilt-tab-3"] {
+  color: var(--ease-tilt-text);
+  border-color: var(--ease-tilt-accent);
+}
+
+/* perspective lives on the parent "scene" — it sets how far away
+   the viewer's eye is from the 3D plane, which controls how dramatic
+   the tilt on the panel itself looks */
+.ease-tabs-scene {
+  position: relative;
+  height: 160px;
+  perspective: var(--ease-tilt-perspective);
+}
+
+.ease-tabs-panel {
+  position: absolute;
+  inset: 0;
+  padding: 1.5rem;
+  background: var(--ease-tilt-bg);
+  border: 1px solid var(--ease-tilt-border);
+  border-radius: var(--ease-tilt-radius);
+  opacity: 0;
+  transform-style: preserve-3d;
+  transform: rotateY(var(--ease-tilt-angle)) scale(0.94);
+  transition: opacity var(--ease-tilt-duration) var(--ease-tilt-easing),
+              transform var(--ease-tilt-duration) var(--ease-tilt-easing);
+  pointer-events: none;
+}
+
+#ease-tilt-tab-1:checked ~ .ease-tabs-scene .ease-tabs-panel-1,
+#ease-tilt-tab-2:checked ~ .ease-tabs-scene .ease-tabs-panel-2,
+#ease-tilt-tab-3:checked ~ .ease-tabs-scene .ease-tabs-panel-3 {
+  opacity: 1;
+  transform: rotateY(0deg) scale(1);
+  pointer-events: auto;
+}
+
+/* a subtle live tilt on hover, independent of the panel-switch tilt,
+   using the same perspective scene */
+.ease-tabs-panel:hover {
+  transform: rotateY(0deg) rotateX(2deg) scale(1.015);
+}
+
+.ease-tabs-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.ease-tabs-panel p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ease-tilt-muted-text);
+  line-height: 1.6;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+
+  .ease-tabs-scene {
+    height: 180px;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-tabs-trigger {
+    padding: 0.5rem 0.85rem;
+    font-size: 0.8rem;
+  }
+
+  .ease-tabs-scene {
+    height: 200px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-panel {
+    transition: none !important;
+    transform: none !important;
+  }
+
+  .ease-tabs-panel:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #50358

Adds a pure CSS/HTML tabs component with a 3D perspective tilt transition on panel switch, styled as a portfolio case-study browser.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-3d-perspective-tilt-tabs/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Tabs where each panel rotates in on a 3D plane using `perspective` and `rotateY`, rather than a flat fade or slide, plus a subtle independent hover tilt on the active panel.

**How does a developer use it?**
```html
<input type="radio" name="ease-tilt-tabs-group" id="ease-tilt-tab-1" class="ease-tabs-input" checked />
<label for="ease-tilt-tab-1" class="ease-tabs-trigger">Nova</label>
<div class="ease-tabs-scene">
  <div class="ease-tabs-panel ease-tabs-panel-1">...</div>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-tabs-scene`, `ease-tabs-panel`), zero dependencies, and it introduces genuine 3D CSS transforms to the framework's examples — `perspective` on the parent scene combined with `rotateY`/`transform-style: preserve-3d` on each panel, exposed via custom properties (`--ease-tilt-perspective`, `--ease-tilt-angle`) so the dramatic-ness of the tilt is fully tunable.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
`perspective` is set on the parent `.ease-tabs-scene`, not the panel itself — this is required for the 3D rotation to render correctly (a common gotcha with CSS 3D transforms). Hover adds a small independent `rotateX` on top of the resting state for extra polish. Respects `prefers-reduced-motion` by disabling all transform/transition and falling back to a plain opacity fade.
