### PR TITLE
feat: add CSS staggered entrance tabs for product catalog layouts

### DIFF
--- a/submissions/examples/css-staggered-entrance-tabs/README.md
+++ b/submissions/examples/css-staggered-entrance-tabs/README.md
@@ -1,0 +1,44 @@
+# CSS Staggered Entrance Tabs
+
+A pure CSS tabs component styled as a product catalog, where each panel's content — tag, title, description, price — animates in one piece at a time rather than all at once. No JavaScript, no dependencies.
+
+## How it works
+
+Tab switching uses the standard radio-hack pattern. The staggering happens inside each panel: every direct child gets the class `.ease-tabs-item` and the same `@keyframes` fade-up animation, but `nth-child` selectors assign each one a progressively later `animation-delay`, calculated from a single `--ease-stagger-step` custom property multiplied per position. This means the tag appears first, then the title, then the description, then the price, each roughly 80ms after the last.
+
+Since the delay is computed from one shared custom property rather than hardcoded per element, changing the pacing for the whole component is a one-line change.
+
+## Files
+
+- `demo.html` – a 3-tab product catalog (Headphones, Keyboard, Backpack)
+- `style.css` – all styling, custom properties, tab switching, and the stagger animation
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-stagger-duration` – 0.4s, how long each item's own fade-up takes
+- `--ease-stagger-easing` – ease-out
+- `--ease-stagger-step` – 0.08s, the delay added per item position
+- `--ease-stagger-radius` – 10px
+- `--ease-stagger-bg` – panel background
+- `--ease-stagger-border` – border color
+- `--ease-stagger-text` – title text color
+- `--ease-stagger-muted-text` – description and inactive tab color
+- `--ease-stagger-accent` – active tab underline, tag, and price accent
+
+Example override:
+
+```css
+:root {
+  --ease-stagger-step: 0.15s;
+  --ease-stagger-accent: #22c55e;
+}
+```
+
+## Notes
+
+- If you add or remove items inside a panel, add a matching `nth-child(n)` rule with the next delay multiple, or later items will all inherit the last defined delay
+- Fully responsive, with breakpoints at 768px and 480px
+- Respects `prefers-reduced-motion` — all items appear instantly at full opacity with no stagger for users who have that set

--- a/submissions/examples/css-staggered-entrance-tabs/demo.html
+++ b/submissions/examples/css-staggered-entrance-tabs/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Staggered Entrance Tabs — Product Catalog</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Shop</p>
+    <h1 class="ease-heading">Product Catalog</h1>
+    <p class="ease-subtitle">Each tab's content animates in piece by piece, not all at once.</p>
+
+    <div class="ease-tabs">
+
+      <input type="radio" name="ease-stagger-tabs-group" id="ease-stagger-tab-1" class="ease-tabs-input" checked />
+      <input type="radio" name="ease-stagger-tabs-group" id="ease-stagger-tab-2" class="ease-tabs-input" />
+      <input type="radio" name="ease-stagger-tabs-group" id="ease-stagger-tab-3" class="ease-tabs-input" />
+
+      <div class="ease-tabs-list" role="tablist">
+        <label for="ease-stagger-tab-1" class="ease-tabs-trigger">Headphones</label>
+        <label for="ease-stagger-tab-2" class="ease-tabs-trigger">Keyboard</label>
+        <label for="ease-stagger-tab-3" class="ease-tabs-trigger">Backpack</label>
+      </div>
+
+      <div class="ease-tabs-panels">
+
+        <div class="ease-tabs-panel ease-tabs-panel-1">
+          <span class="ease-tabs-item ease-tabs-tag">New Arrival</span>
+          <h2 class="ease-tabs-item">Aria Wireless Headphones</h2>
+          <p class="ease-tabs-item">Over-ear, noise-cancelling, 30-hour battery life.</p>
+          <span class="ease-tabs-item ease-tabs-price">$189</span>
+        </div>
+
+        <div class="ease-tabs-panel ease-tabs-panel-2">
+          <span class="ease-tabs-item ease-tabs-tag">Bestseller</span>
+          <h2 class="ease-tabs-item">Drift Mechanical Keyboard</h2>
+          <p class="ease-tabs-item">Hot-swappable switches, per-key RGB, aluminum frame.</p>
+          <span class="ease-tabs-item ease-tabs-price">$129</span>
+        </div>
+
+        <div class="ease-tabs-panel ease-tabs-panel-3">
+          <span class="ease-tabs-item ease-tabs-tag">Limited Stock</span>
+          <h2 class="ease-tabs-item">Voyage Travel Backpack</h2>
+          <p class="ease-tabs-item">Water-resistant, 22L, dedicated laptop compartment.</p>
+          <span class="ease-tabs-item ease-tabs-price">$74</span>
+        </div>
+
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-staggered-entrance-tabs/style.css
+++ b/submissions/examples/css-staggered-entrance-tabs/style.css
@@ -1,0 +1,185 @@
+:root {
+  --ease-stagger-duration: 0.4s;
+  --ease-stagger-easing: ease-out;
+  --ease-stagger-step: 0.08s;
+  --ease-stagger-radius: 10px;
+  --ease-stagger-bg: #16181d;
+  --ease-stagger-border: #2a2d34;
+  --ease-stagger-text: #f0f0f0;
+  --ease-stagger-muted-text: #a8a8a8;
+  --ease-stagger-accent: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-stagger-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-stagger-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-tabs-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-tabs-list {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--ease-stagger-border);
+  margin-bottom: 1.5rem;
+}
+
+.ease-tabs-trigger {
+  padding: 0.6rem 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ease-stagger-muted-text);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+#ease-stagger-tab-1:checked ~ .ease-tabs-list label[for="ease-stagger-tab-1"],
+#ease-stagger-tab-2:checked ~ .ease-tabs-list label[for="ease-stagger-tab-2"],
+#ease-stagger-tab-3:checked ~ .ease-tabs-list label[for="ease-stagger-tab-3"] {
+  color: var(--ease-stagger-text);
+  border-bottom-color: var(--ease-stagger-accent);
+}
+
+.ease-tabs-panel {
+  display: none;
+  background: var(--ease-stagger-bg);
+  border: 1px solid var(--ease-stagger-border);
+  border-radius: var(--ease-stagger-radius);
+  padding: 1.5rem;
+}
+
+#ease-stagger-tab-1:checked ~ .ease-tabs-panels .ease-tabs-panel-1,
+#ease-stagger-tab-2:checked ~ .ease-tabs-panels .ease-tabs-panel-2,
+#ease-stagger-tab-3:checked ~ .ease-tabs-panels .ease-tabs-panel-3 {
+  display: block;
+}
+
+/* every direct child of the active panel gets the same entrance keyframe,
+   but nth-child gives each one a slightly later delay, so the tag, title,
+   description, and price animate in one after another instead of at once */
+.ease-tabs-item {
+  display: block;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: ease-stagger-item-in var(--ease-stagger-duration) var(--ease-stagger-easing) both;
+}
+
+.ease-tabs-panel > .ease-tabs-item:nth-child(1) { animation-delay: calc(var(--ease-stagger-step) * 1); }
+.ease-tabs-panel > .ease-tabs-item:nth-child(2) { animation-delay: calc(var(--ease-stagger-step) * 2); }
+.ease-tabs-panel > .ease-tabs-item:nth-child(3) { animation-delay: calc(var(--ease-stagger-step) * 3); }
+.ease-tabs-panel > .ease-tabs-item:nth-child(4) { animation-delay: calc(var(--ease-stagger-step) * 4); }
+
+@keyframes ease-stagger-item-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ease-tabs-tag {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ease-stagger-accent);
+  margin-bottom: 0.5rem;
+}
+
+.ease-tabs-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.2rem;
+}
+
+.ease-tabs-panel p {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  color: var(--ease-stagger-muted-text);
+  line-height: 1.5;
+}
+
+.ease-tabs-price {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-tabs-trigger {
+    padding: 0.5rem 0.7rem;
+    font-size: 0.8rem;
+  }
+
+  .ease-tabs-panel {
+    padding: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-item {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #50302

Adds a pure CSS/HTML tabs component styled as a product catalog, where each panel's content elements animate in one at a time via a shared staggered delay.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-staggered-entrance-tabs/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Product catalog tabs where each panel's tag, title, description, and price fade up in sequence rather than appearing all at once, using a shared `--ease-stagger-step` custom property to compute each item's delay.

**How does a developer use it?**
```html
<div class="ease-tabs-panel ease-tabs-panel-1">
  <span class="ease-tabs-item ease-tabs-tag">New Arrival</span>
  <h2 class="ease-tabs-item">Product Title</h2>
  <p class="ease-tabs-item">Description.</p>
  <span class="ease-tabs-item ease-tabs-price">$189</span>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-tabs-item`, `ease-tabs-panel`), zero dependencies, and it demonstrates a reusable stagger technique where per-item delay is computed from one shared custom property (`calc(var(--ease-stagger-step) * n)`) via `nth-child`, rather than hardcoding a separate delay value per element.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Stagger delay is computed via `calc()` from a single `--ease-stagger-step` property rather than hardcoded per item, so pacing is a one-line change. Documented in the README that adding/removing panel items requires a matching `nth-child` rule. Respects `prefers-reduced-motion`.