### PR TITLE
feat: add CSS horizontal roll tabs for responsive dashboard layouts

### DIFF
--- a/submissions/examples/css-horizontal-roll-tabs/README.md
+++ b/submissions/examples/css-horizontal-roll-tabs/README.md
@@ -1,0 +1,46 @@
+# CSS Horizontal Roll Tabs
+
+A pure CSS tabs component styled as a dashboard analytics panel, where each panel rolls in from the side rather than fading or sliding flat. No JavaScript, no dependencies.
+
+## How it works
+
+Same radio-hack tab switching as elsewhere in the framework. The roll effect combines two transforms on each panel at once: `translateX()` to move it in from the right, and `rotateX()` to tilt it around the horizontal axis, with `transform-origin: left center` so it rotates around its left edge rather than its center. Moving and rotating together at the same time is what makes it read as a "roll" rather than a plain slide or a plain rotate.
+
+`perspective` is set on the parent `.ease-tabs-scene`, the same requirement as any CSS 3D transform, so the `rotateX` actually has visible depth instead of just squashing flat.
+
+## Files
+
+- `demo.html` – a 3-tab dashboard analytics panel (Today, This Week, This Month)
+- `style.css` – all styling, custom properties, and the roll transition
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-roll-duration` – 0.5s
+- `--ease-roll-easing` – cubic-bezier(0.65, 0, 0.35, 1)
+- `--ease-roll-radius` – 12px
+- `--ease-roll-perspective` – 1000px (lower = more dramatic roll)
+- `--ease-roll-distance` – 60px, how far sideways the panel starts
+- `--ease-roll-angle` – 45deg, how far rotated the panel starts
+- `--ease-roll-bg` – panel background
+- `--ease-roll-border` – border color
+- `--ease-roll-text` – panel title color
+- `--ease-roll-muted-text` – panel description color
+- `--ease-roll-accent` – active tab border color
+
+Example override:
+
+```css
+:root {
+  --ease-roll-distance: 100px;
+  --ease-roll-angle: 60deg;
+}
+```
+
+## Notes
+
+- `perspective` must stay on the parent scene, not the panel, for the 3D roll to render correctly
+- Fully responsive, with breakpoints at 768px and 480px
+- Respects `prefers-reduced-motion` — all transform/transition is disabled, panels appear instantly with no roll

--- a/submissions/examples/css-horizontal-roll-tabs/demo.html
+++ b/submissions/examples/css-horizontal-roll-tabs/demo.html
@@ -1,0 +1,47 @@
+sty<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Horizontal Roll Tabs — Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Analytics</p>
+    <h1 class="ease-heading">Traffic Overview</h1>
+    <p class="ease-subtitle">Panels roll in horizontally on tab switch, pure CSS.</p>
+
+    <div class="ease-tabs">
+
+      <input type="radio" name="ease-roll-tabs-group" id="ease-roll-tab-1" class="ease-tabs-input" checked />
+      <input type="radio" name="ease-roll-tabs-group" id="ease-roll-tab-2" class="ease-tabs-input" />
+      <input type="radio" name="ease-roll-tabs-group" id="ease-roll-tab-3" class="ease-tabs-input" />
+
+      <div class="ease-tabs-list" role="tablist">
+        <label for="ease-roll-tab-1" class="ease-tabs-trigger">Today</label>
+        <label for="ease-roll-tab-2" class="ease-tabs-trigger">This Week</label>
+        <label for="ease-roll-tab-3" class="ease-tabs-trigger">This Month</label>
+      </div>
+
+      <div class="ease-tabs-scene">
+        <div class="ease-tabs-panel ease-tabs-panel-1">
+          <h2>1,204 visits</h2>
+          <p>Up 8% compared to yesterday, driven mostly by direct traffic.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-2">
+          <h2>8,940 visits</h2>
+          <p>Steady week over week, with a spike last Tuesday from a referral link.</p>
+        </div>
+        <div class="ease-tabs-panel ease-tabs-panel-3">
+          <h2>34,110 visits</h2>
+          <p>Best month so far this quarter, largely from organic search growth.</p>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-horizontal-roll-tabs/style.css
+++ b/submissions/examples/css-horizontal-roll-tabs/style.css
@@ -1,0 +1,172 @@
+:root {
+  --ease-roll-duration: 0.5s;
+  --ease-roll-easing: cubic-bezier(0.65, 0, 0.35, 1);
+  --ease-roll-radius: 12px;
+  --ease-roll-perspective: 1000px;
+  --ease-roll-distance: 60px;
+  --ease-roll-angle: 45deg;
+  --ease-roll-bg: #16181d;
+  --ease-roll-border: #2a2d34;
+  --ease-roll-text: #f0f0f0;
+  --ease-roll-muted-text: #a8a8a8;
+  --ease-roll-accent: #7c3aed;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-roll-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-roll-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-tabs-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-tabs-list {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.75rem;
+}
+
+.ease-tabs-trigger {
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--ease-roll-border);
+  background: var(--ease-roll-bg);
+  color: var(--ease-roll-muted-text);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+#ease-roll-tab-1:checked ~ .ease-tabs-list label[for="ease-roll-tab-1"],
+#ease-roll-tab-2:checked ~ .ease-tabs-list label[for="ease-roll-tab-2"],
+#ease-roll-tab-3:checked ~ .ease-tabs-list label[for="ease-roll-tab-3"] {
+  color: var(--ease-roll-text);
+  border-color: var(--ease-roll-accent);
+}
+
+/* perspective on the scene establishes the 3D viewing context for
+   the roll effect on its child panels */
+.ease-tabs-scene {
+  position: relative;
+  height: 140px;
+  perspective: var(--ease-roll-perspective);
+}
+
+.ease-tabs-panel {
+  position: absolute;
+  inset: 0;
+  padding: 1.5rem;
+  background: var(--ease-roll-bg);
+  border: 1px solid var(--ease-roll-border);
+  border-radius: var(--ease-roll-radius);
+  opacity: 0;
+  transform-style: preserve-3d;
+  /* the "roll": moved sideways AND rotated around the X axis at the
+     same time, so it looks like it's turning like a cylinder rolling
+     in from the right rather than just rotating in place */
+  transform: translateX(var(--ease-roll-distance)) rotateX(var(--ease-roll-angle));
+  transform-origin: left center;
+  transition: opacity var(--ease-roll-duration) var(--ease-roll-easing),
+              transform var(--ease-roll-duration) var(--ease-roll-easing);
+  pointer-events: none;
+}
+
+#ease-roll-tab-1:checked ~ .ease-tabs-scene .ease-tabs-panel-1,
+#ease-roll-tab-2:checked ~ .ease-tabs-scene .ease-tabs-panel-2,
+#ease-roll-tab-3:checked ~ .ease-tabs-scene .ease-tabs-panel-3 {
+  opacity: 1;
+  transform: translateX(0) rotateX(0deg);
+  pointer-events: auto;
+}
+
+.ease-tabs-panel h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.35rem;
+}
+
+.ease-tabs-panel p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ease-roll-muted-text);
+  line-height: 1.6;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .ease-heading {
+    font-size: 1.5rem;
+  }
+
+  .ease-tabs-scene {
+    height: 150px;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.3rem;
+  }
+
+  .ease-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .ease-tabs-trigger {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.78rem;
+  }
+
+  .ease-tabs-scene {
+    height: 170px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-panel {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #50295

Adds a pure CSS/HTML tabs component styled as a dashboard analytics panel, where each panel rolls in from the side using a combined translateX + rotateX transform.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-horizontal-roll-tabs/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Dashboard tabs where each panel rolls in from the side on switch, combining `translateX` and `rotateX` on the same element with `transform-origin: left center`, rather than a flat slide or fade.

**How does a developer use it?**
```html
<input type="radio" name="ease-roll-tabs-group" id="ease-roll-tab-1" class="ease-tabs-input" checked />
<label for="ease-roll-tab-1" class="ease-tabs-trigger">Today</label>
<div class="ease-tabs-scene">
  <div class="ease-tabs-panel ease-tabs-panel-1">...</div>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-tabs-scene`, `ease-tabs-panel`), zero dependencies, and it's a distinct 3D technique from the framework's existing tilt-tabs submission — moving and rotating a panel simultaneously around a custom `transform-origin` to create a rolling motion, rather than rotating in place. Exposed via custom properties (`--ease-roll-distance`, `--ease-roll-angle`) so the intensity of the roll is fully tunable.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
`perspective` is set on the parent `.ease-tabs-scene`, required for the `rotateX` to render with visible depth. `transform-origin: left center` on each panel is what makes the combined translate + rotate read as a "roll" rather than a plain rotate-in-place. Respects `prefers-reduced-motion`.
