### PR TITLE
feat: add CSS rotate-click carousel for neumorphic soft layouts

### DIFF
--- a/submissions/examples/css-rotate-click-carousel-neumorphic/README.md
+++ b/submissions/examples/css-rotate-click-carousel-neumorphic/README.md
@@ -1,0 +1,46 @@
+# CSS Rotate-Click Carousel
+
+A pure CSS carousel with a soft neumorphic aesthetic, where each slide rotates into place when its dot is clicked. No JavaScript, no dependencies.
+
+## How it works
+
+Same radio-hack navigation as other carousels in this framework, but the visual style is neumorphic rather than the dark flat-card look used elsewhere: instead of a border, the surface has a light shadow on the top-left and a dark shadow on the bottom-right (both the same base color as the background), which makes it look like it's gently raised out of the page.
+
+Each slide starts rotated with `rotate(25deg)` and slightly scaled down, then animates to `rotate(0deg)` at full scale when its radio is checked — a spin-in rather than a slide or fade. The dots reuse the same neumorphic language: unselected dots are raised (outer shadow), the active dot is pressed in (inset shadow) and tinted with the accent color.
+
+## Files
+
+- `demo.html` – a 3-slide "daily reminders" wellness carousel
+- `style.css` – all styling, custom properties, and the rotate-in transition
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-rotate-duration` – 0.5s
+- `--ease-rotate-easing` – cubic-bezier(0.34, 1.56, 0.64, 1)
+- `--ease-rotate-radius` – 20px
+- `--ease-rotate-angle` – 25deg, how far a slide is rotated before becoming active
+- `--ease-rotate-bg` / `--ease-rotate-surface` – base background/card color
+- `--ease-rotate-text` – title text color
+- `--ease-rotate-muted-text` – description text color
+- `--ease-rotate-accent` – active dot color
+- `--ease-rotate-shadow-light` / `--ease-rotate-shadow-dark` – the two neumorphic shadow tones
+
+Example override:
+
+```css
+:root {
+  --ease-rotate-bg: #f0ede5;
+  --ease-rotate-surface: #f0ede5;
+  --ease-rotate-shadow-light: #ffffff;
+  --ease-rotate-shadow-dark: #d4d0c4;
+}
+```
+
+## Notes
+
+- Neumorphic shadows work best when `--ease-rotate-shadow-light` and `--ease-rotate-shadow-dark` are close in tone to the background — too much contrast breaks the "soft" look
+- Fully responsive; the viewport grows slightly taller on mobile to fit wrapped text
+- Respects `prefers-reduced-motion` — slides and dots lose their transition, appearing/disappearing instantly

--- a/submissions/examples/css-rotate-click-carousel-neumorphic/demo.html
+++ b/submissions/examples/css-rotate-click-carousel-neumorphic/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Rotate-Click Carousel — Neumorphic</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Wellness Tips</p>
+    <h1 class="ease-heading">Daily Reminders</h1>
+    <p class="ease-subtitle">Click a dot to rotate to the next reminder. Soft neumorphic style, pure CSS.</p>
+
+    <div class="ease-carousel">
+
+      <input type="radio" name="ease-rotate-carousel-group" id="ease-rotate-slide-1" class="ease-carousel-input" checked />
+      <input type="radio" name="ease-rotate-carousel-group" id="ease-rotate-slide-2" class="ease-carousel-input" />
+      <input type="radio" name="ease-rotate-carousel-group" id="ease-rotate-slide-3" class="ease-carousel-input" />
+
+      <div class="ease-carousel-viewport">
+        <div class="ease-carousel-slide ease-carousel-slide-1">
+          <span class="ease-carousel-icon">💧</span>
+          <h2>Stay Hydrated</h2>
+          <p>Aim for 8 glasses of water spread through the day.</p>
+        </div>
+        <div class="ease-carousel-slide ease-carousel-slide-2">
+          <span class="ease-carousel-icon">🧘</span>
+          <h2>Take a Breath</h2>
+          <p>A short 3-minute breathing break resets focus.</p>
+        </div>
+        <div class="ease-carousel-slide ease-carousel-slide-3">
+          <span class="ease-carousel-icon">🚶</span>
+          <h2>Move a Little</h2>
+          <p>Stand and stretch for a minute every hour.</p>
+        </div>
+      </div>
+
+      <div class="ease-carousel-dots" role="tablist">
+        <label for="ease-rotate-slide-1" class="ease-carousel-dot" aria-label="Slide 1"></label>
+        <label for="ease-rotate-slide-2" class="ease-carousel-dot" aria-label="Slide 2"></label>
+        <label for="ease-rotate-slide-3" class="ease-carousel-dot" aria-label="Slide 3"></label>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-rotate-click-carousel-neumorphic/style.css
+++ b/submissions/examples/css-rotate-click-carousel-neumorphic/style.css
@@ -1,0 +1,162 @@
+:root {
+  --ease-rotate-duration: 0.5s;
+  --ease-rotate-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-rotate-radius: 20px;
+  --ease-rotate-angle: 25deg;
+  --ease-rotate-bg: #e8e6f0;
+  --ease-rotate-surface: #e8e6f0;
+  --ease-rotate-text: #3a3a4a;
+  --ease-rotate-muted-text: #71717f;
+  --ease-rotate-accent: #7c6ee0;
+  --ease-rotate-shadow-light: #ffffff;
+  --ease-rotate-shadow-dark: #c3c1d1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-rotate-bg);
+  color: var(--ease-rotate-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-rotate-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: var(--ease-rotate-muted-text);
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-carousel-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* neumorphic surface: no border, instead a light shadow on one side
+   and a dark shadow on the other, so the card looks like it's raised
+   out of the same-color background */
+.ease-carousel-viewport {
+  position: relative;
+  height: 190px;
+  border-radius: var(--ease-rotate-radius);
+  background: var(--ease-rotate-surface);
+  box-shadow: 8px 8px 16px var(--ease-rotate-shadow-dark),
+              -8px -8px 16px var(--ease-rotate-shadow-light);
+  overflow: hidden;
+}
+
+.ease-carousel-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1.5rem;
+  opacity: 0;
+  transform: rotate(var(--ease-rotate-angle)) scale(0.9);
+  transition: opacity var(--ease-rotate-duration) var(--ease-rotate-easing),
+              transform var(--ease-rotate-duration) var(--ease-rotate-easing);
+  pointer-events: none;
+}
+
+#ease-rotate-slide-1:checked ~ .ease-carousel-viewport .ease-carousel-slide-1,
+#ease-rotate-slide-2:checked ~ .ease-carousel-viewport .ease-carousel-slide-2,
+#ease-rotate-slide-3:checked ~ .ease-carousel-viewport .ease-carousel-slide-3 {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  pointer-events: auto;
+}
+
+.ease-carousel-icon {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.ease-carousel-slide h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+}
+
+.ease-carousel-slide p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ease-rotate-muted-text);
+  line-height: 1.5;
+}
+
+.ease-carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 1.25rem;
+}
+
+/* neumorphic dots: pressed-in look using inset shadows instead of a
+   flat filled circle */
+.ease-carousel-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--ease-rotate-surface);
+  box-shadow: 3px 3px 6px var(--ease-rotate-shadow-dark),
+              -3px -3px 6px var(--ease-rotate-shadow-light);
+  cursor: pointer;
+  transition: box-shadow 0.2s ease;
+}
+
+#ease-rotate-slide-1:checked ~ .ease-carousel-dots label:nth-child(1),
+#ease-rotate-slide-2:checked ~ .ease-carousel-dots label:nth-child(2),
+#ease-rotate-slide-3:checked ~ .ease-carousel-dots label:nth-child(3) {
+  box-shadow: inset 2px 2px 4px var(--ease-rotate-shadow-dark),
+              inset -2px -2px 4px var(--ease-rotate-shadow-light);
+  background: var(--ease-rotate-accent);
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.4rem;
+  }
+
+  .ease-carousel-viewport {
+    height: 210px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-carousel-slide {
+    transition: none !important;
+  }
+
+  .ease-carousel-dot {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #50474

Adds a pure CSS/HTML carousel with a soft neumorphic aesthetic, where each slide rotates into place when its dot is clicked.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-rotate-click-carousel/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A carousel styled with neumorphic soft-shadow surfaces instead of borders, where clicking a dot rotates the incoming slide into place rather than fading or sliding it in.

**How does a developer use it?**
```html
<input type="radio" name="ease-rotate-carousel-group" id="ease-rotate-slide-1" class="ease-carousel-input" checked />
<div class="ease-carousel-slide ease-carousel-slide-1">...</div>
<label for="ease-rotate-slide-1" class="ease-carousel-dot"></label>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-carousel-dot`, `ease-carousel-slide`), zero dependencies, and it's the framework's first neumorphic-styled example — using paired light/dark box-shadows instead of borders for both the card surface and the dot navigation, with the active dot switching to an inset shadow to look "pressed in."

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Neumorphic shadows use `--ease-rotate-shadow-light`/`--ease-rotate-shadow-dark`, both close in tone to the background — documented in the README that too much contrast between them breaks the soft look. Respects `prefers-reduced-motion`.