### PR TITLE
feat: add [BUG] fix: prevent testimonial cards from overlapping on mobile devices (#57057)

### DIFF
--- a/submissions/examples/bug-fix-prevent-testimonial-cards-from-o-sah/README.md
+++ b/submissions/examples/bug-fix-prevent-testimonial-cards-from-o-sah/README.md
@@ -1,0 +1,3 @@
+# [BUG] fix: prevent testimonial cards from overlapping on mobile devices
+
+Accessible component solution for #57057.

--- a/submissions/examples/bug-fix-prevent-testimonial-cards-from-o-sah/demo.html
+++ b/submissions/examples/bug-fix-prevent-testimonial-cards-from-o-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>[BUG] fix: prevent testimonial cards from overlapping on mobile devices</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for [BUG] fix: prevent testimonial cards from overlapping on mobile devices -->
+  <h2>[BUG] fix: prevent testimonial cards from overlapping on mobile devices</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/bug-fix-prevent-testimonial-cards-from-o-sah/style.css
+++ b/submissions/examples/bug-fix-prevent-testimonial-cards-from-o-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #57057