### PR TITLE
feat: add [BUG] fix: prevent timeline content from overlapping on mobile (#56731)

### DIFF
--- a/submissions/examples/bug-fix-prevent-timeline-content-from-ov-sah/README.md
+++ b/submissions/examples/bug-fix-prevent-timeline-content-from-ov-sah/README.md
@@ -1,0 +1,3 @@
+# [BUG] fix: prevent timeline content from overlapping on mobile
+
+Accessible component solution for #56731.

--- a/submissions/examples/bug-fix-prevent-timeline-content-from-ov-sah/demo.html
+++ b/submissions/examples/bug-fix-prevent-timeline-content-from-ov-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>[BUG] fix: prevent timeline content from overlapping on mobile</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for [BUG] fix: prevent timeline content from overlapping on mobile -->
+  <h2>[BUG] fix: prevent timeline content from overlapping on mobile</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/bug-fix-prevent-timeline-content-from-ov-sah/style.css
+++ b/submissions/examples/bug-fix-prevent-timeline-content-from-ov-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #56731