### PR TITLE
feat: add [BUG] fix: prevent accordion header text from overflowing on narrow screens (#56693)

### DIFF
--- a/submissions/examples/bug-fix-prevent-accordion-header-text-fr-sah/README.md
+++ b/submissions/examples/bug-fix-prevent-accordion-header-text-fr-sah/README.md
@@ -1,0 +1,3 @@
+# [BUG] fix: prevent accordion header text from overflowing on narrow screens
+
+Accessible component solution for #56693.

--- a/submissions/examples/bug-fix-prevent-accordion-header-text-fr-sah/demo.html
+++ b/submissions/examples/bug-fix-prevent-accordion-header-text-fr-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>[BUG] fix: prevent accordion header text from overflowing on narrow screens</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for [BUG] fix: prevent accordion header text from overflowing on narrow screens -->
+  <h2>[BUG] fix: prevent accordion header text from overflowing on narrow screens</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/bug-fix-prevent-accordion-header-text-fr-sah/style.css
+++ b/submissions/examples/bug-fix-prevent-accordion-header-text-fr-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #56693