### PR TITLE
feat: add [BUG] ease-slide-in-left and ease-slide-in-right cause horizontal overflow on mobile viewports (#55252)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ npm-debug.log*
 *.orig
 tatus
 
+
+process_batch_9.mjs
+issues.json

--- a/submissions/examples/bug-ease-slide-in-left-and-ease-slide-in-sah/README.md
+++ b/submissions/examples/bug-ease-slide-in-left-and-ease-slide-in-sah/README.md
@@ -1,0 +1,3 @@
+# [BUG] ease-slide-in-left and ease-slide-in-right cause horizontal overflow on mobile viewports
+
+Accessible component solution for #55252.

--- a/submissions/examples/bug-ease-slide-in-left-and-ease-slide-in-sah/demo.html
+++ b/submissions/examples/bug-ease-slide-in-left-and-ease-slide-in-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>[BUG] ease-slide-in-left and ease-slide-in-right cause horizontal overflow on mobile viewports</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for [BUG] ease-slide-in-left and ease-slide-in-right cause horizontal overflow on mobile viewports -->
+  <h2>[BUG] ease-slide-in-left and ease-slide-in-right cause horizontal overflow on mobile viewports</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/bug-ease-slide-in-left-and-ease-slide-in-sah/style.css
+++ b/submissions/examples/bug-ease-slide-in-left-and-ease-slide-in-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #55252