### PR TITLE
feat: add [BUG]:Missing -webkit-backdrop-filter prefix breaks blur effect in Safari (command palette + footer) (#55205)

### DIFF
--- a/submissions/examples/bug-missing-webkit-backdrop-filter-pr-sah/README.md
+++ b/submissions/examples/bug-missing-webkit-backdrop-filter-pr-sah/README.md
@@ -1,0 +1,3 @@
+# [BUG]:Missing -webkit-backdrop-filter prefix breaks blur effect in Safari (command palette + footer)
+
+Accessible component solution for #55205.

--- a/submissions/examples/bug-missing-webkit-backdrop-filter-pr-sah/demo.html
+++ b/submissions/examples/bug-missing-webkit-backdrop-filter-pr-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>[BUG]:Missing -webkit-backdrop-filter prefix breaks blur effect in Safari (command palette + footer)</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for [BUG]:Missing -webkit-backdrop-filter prefix breaks blur effect in Safari (command palette + footer) -->
+  <h2>[BUG]:Missing -webkit-backdrop-filter prefix breaks blur effect in Safari (command palette + footer)</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/bug-missing-webkit-backdrop-filter-pr-sah/style.css
+++ b/submissions/examples/bug-missing-webkit-backdrop-filter-pr-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #55205