### PR TITLE
feat: add `exports` map in package.json blocks importing individual component CSS files (#53768)

### DIFF
--- a/submissions/examples/exports-map-in-package-json-blocks-im-sah/README.md
+++ b/submissions/examples/exports-map-in-package-json-blocks-im-sah/README.md
@@ -1,0 +1,3 @@
+# `exports` map in package.json blocks importing individual component CSS files
+
+Accessible component solution for #53768.

--- a/submissions/examples/exports-map-in-package-json-blocks-im-sah/demo.html
+++ b/submissions/examples/exports-map-in-package-json-blocks-im-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>`exports` map in package.json blocks importing individual component CSS files</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for `exports` map in package.json blocks importing individual component CSS files -->
+  <h2>`exports` map in package.json blocks importing individual component CSS files</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/exports-map-in-package-json-blocks-im-sah/style.css
+++ b/submissions/examples/exports-map-in-package-json-blocks-im-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #53768