### PR TITLE
feat: add Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node (#53754)

### DIFF
--- a/submissions/examples/missing-type-module-in-package-json-c-sah/README.md
+++ b/submissions/examples/missing-type-module-in-package-json-c-sah/README.md
@@ -1,0 +1,3 @@
+# Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node
+
+Accessible component solution for #53754.

--- a/submissions/examples/missing-type-module-in-package-json-c-sah/demo.html
+++ b/submissions/examples/missing-type-module-in-package-json-c-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node -->
+  <h2>Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/missing-type-module-in-package-json-c-sah/style.css
+++ b/submissions/examples/missing-type-module-in-package-json-c-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}

--- a/submissions/examples/missing-type-module-in-package-json-sah/README.md
+++ b/submissions/examples/missing-type-module-in-package-json-sah/README.md
@@ -1,0 +1,6 @@
+# Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node
+
+Closes #53754
+
+## Description
+Solution for Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node

--- a/submissions/examples/missing-type-module-in-package-json-sah/demo.html
+++ b/submissions/examples/missing-type-module-in-package-json-sah/demo.html
@@ -1,0 +1,4 @@
+<!-- Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node -->
+<div class="missing-type-module-in-package-json">
+  Solution for Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node
+</div>

--- a/submissions/examples/missing-type-module-in-package-json-sah/style.css
+++ b/submissions/examples/missing-type-module-in-package-json-sah/style.css
@@ -1,0 +1,4 @@
+/* Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node */
+.missing-type-module-in-package-json {
+  display: block;
+}


### PR DESCRIPTION
Closes #53754