### PR TITLE
fix: accordion panels expand/collapse smoothly regardless of content height (closes #57533)

### DIFF
--- a/submissions/examples/accordion-smooth-expand/README.md
+++ b/submissions/examples/accordion-smooth-expand/README.md
@@ -1,0 +1,80 @@
+# Smooth Accordion (fixes #57533)
+
+Fixes: accordion panels with different amounts of content used to jump to
+their full height instead of animating smoothly.
+
+## Root cause
+
+The old approach animated `max-height` toward a large fixed guess (e.g.
+`max-height: 1000px`). Because the transition duration is fixed but the
+*actual* content height varies per panel, short panels finish early while
+tall panels either overshoot the easing curve or visually "snap" once they
+hit their real height — this reads as a jump.
+
+## Fix
+
+Animate the CSS grid track instead of `max-height`:
+
+```css
+.accordion-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease;
+}
+.accordion-content-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+.accordion-content.is-open {
+  grid-template-rows: 1fr;
+}
+```
+
+`grid-template-rows: 0fr → 1fr` is animatable and resolves against the
+row's real intrinsic content size, so every panel — regardless of how much
+content it holds — animates to its own correct height. No JS height
+measurement, no magic pixel values, no per-panel tuning.
+
+## Browser support
+
+Animating `grid-template-rows` works in all evergreen browsers: Chrome 66+,
+Firefox 66+, Safari 14.1+. Covers the Chrome 138 environment from the bug
+report and effectively all current usage.
+
+## No JavaScript
+
+Open/close state uses the checkbox hack instead of a script:
+
+```html
+<input type="checkbox" id="acc-1" class="accordion-toggle" />
+<label for="acc-1" class="accordion-header">Question 1</label>
+<div class="accordion-content">...</div>
+```
+
+```css
+.accordion-toggle:checked ~ .accordion-content {
+  grid-template-rows: 1fr;
+}
+```
+
+The checkbox is visually hidden (not `display: none`, so it stays keyboard-
+and screen-reader-accessible) and the `<label>` acts as the clickable
+header. This matches the framework's zero-dependency, no-build-step
+philosophy, and lines up with the roadmap item "CSS-only accordion & tabs."
+
+## Files
+
+- `demo.html` — three accordion panels (short / long / medium content),
+  no `<script>` tag
+- `style.css` — the fix, plus base styling for the demo
+
+## Notes for integration
+
+- Naming here is illustrative (`accordion-header`, `accordion-content`,
+  etc.) — happy to have it renamed to `ease-*` conventions on integration.
+- Respects `prefers-reduced-motion`.
+- Keyboard accessible: the hidden checkbox is still tab-focusable and
+  toggled with Space/Enter via its `<label>`, with a visible focus ring.
+- No accordion component currently exists in `core/` or `components/`
+  (roadmap lists "CSS-only accordion & tabs" as planned for v1.3), so this
+  can also serve as a first reference implementation, not just a bugfix.

--- a/submissions/examples/accordion-smooth-expand/demo.html
+++ b/submissions/examples/accordion-smooth-expand/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Smooth Accordion — pure CSS fix (Issue #57533)</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<main class="accordion-demo">
+  <h1>Smooth Accordion (Pure CSS)</h1>
+  <p class="accordion-demo-note">
+    Fixes #57533 — panels no longer jump when they contain different
+    amounts of content. No JavaScript required.
+  </p>
+
+  <div class="accordion">
+
+    <div class="accordion-item">
+      <input type="checkbox" id="acc-1" class="accordion-toggle" />
+      <label for="acc-1" class="accordion-header">Question 1: Short content</label>
+      <div class="accordion-content">
+        <div class="accordion-content-inner">
+          <p>Short content.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion-item">
+      <input type="checkbox" id="acc-2" class="accordion-toggle" />
+      <label for="acc-2" class="accordion-header">Question 2: Long content</label>
+      <div class="accordion-content">
+        <div class="accordion-content-inner">
+          <p>
+            This panel contains significantly more content to demonstrate
+            how the expansion animation used to become abrupt when the
+            height changed considerably. With the grid-based fix, this
+            panel now expands and collapses just as smoothly as the short
+            one above, because the browser animates toward the panel's
+            actual intrinsic height instead of a fixed max-height value.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion-item">
+      <input type="checkbox" id="acc-3" class="accordion-toggle" />
+      <label for="acc-3" class="accordion-header">Question 3: Medium content</label>
+      <div class="accordion-content">
+        <div class="accordion-content-inner">
+          <p>A medium amount of content to further verify that panels of
+          different sizes all animate consistently.</p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/accordion-smooth-expand/style.css
+++ b/submissions/examples/accordion-smooth-expand/style.css
@@ -1,0 +1,115 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f1115;
+  color: #e6e6e6;
+  margin: 0;
+  padding: 3rem 1.5rem;
+}
+
+.accordion-demo {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.accordion-demo h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.accordion-demo-note {
+  color: #9aa0a8;
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.accordion-item {
+  border: 1px solid #2a2e37;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #161922;
+}
+
+/* Hide the real checkbox but keep it in the accessibility tree and
+   keyboard-focusable via its label. */
+.accordion-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.accordion-header {
+  width: 100%;
+  text-align: left;
+  padding: 1rem 1.25rem;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.accordion-header::after {
+  content: "+";
+  font-size: 1.25rem;
+  font-weight: 400;
+  transition: transform 0.3s ease;
+}
+
+/* Visible focus ring on the label when the hidden checkbox has keyboard focus */
+.accordion-toggle:focus-visible + .accordion-header {
+  outline: 2px solid #6c63ff;
+  outline-offset: -2px;
+}
+
+.accordion-toggle:checked + .accordion-header::after {
+  transform: rotate(45deg);
+}
+
+/* --- the actual fix ------------------------------------------------- */
+
+.accordion-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease;
+}
+
+.accordion-content-inner {
+  overflow: hidden;
+  min-height: 0; /* required: lets the grid track collapse to 0 cleanly */
+}
+
+.accordion-content-inner p {
+  margin: 0 1.25rem 1rem;
+  line-height: 1.5;
+  color: #c7cad1;
+}
+
+.accordion-toggle:checked ~ .accordion-content {
+  grid-template-rows: 1fr;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .accordion-content {
+    transition: none;
+  }
+  .accordion-header::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What this fixes
Closes #57533 — accordion panels with different amounts of content jumped
to full height instead of animating smoothly.

## Root cause
The old approach animated `max-height` toward a large fixed guess (e.g.
`max-height: 1000px`). Since the transition duration is fixed but real
content height varies per panel, short panels finished early while tall
panels either overshot the easing curve or visually snapped once they hit
their true height — reading as a jump.

## Fix
Animate the CSS grid track instead of `max-height`:

```css
.accordion-content {
  display: grid;
  grid-template-rows: 0fr;
  transition: grid-template-rows 0.3s ease;
}
.accordion-toggle:checked ~ .accordion-content {
  grid-template-rows: 1fr;
}
```

`grid-template-rows: 0fr → 1fr` is animatable and resolves against the
row's real intrinsic size, so every panel animates to its own correct
height — no JS height measurement, no magic pixel values.

## No JavaScript
Open/close state uses the checkbox hack (hidden `<input type="checkbox">`
+ `<label>` header) instead of a script, matching the framework's
zero-dependency philosophy and the roadmap's "CSS-only accordion & tabs"
item.

## Where this lives
Per CONTRIBUTING.md, added as a new submission — did not touch `core/` or
`components/`: