### PR TITLE
feat: add Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node (#53754)

### DIFF
--- a/submissions/examples/missing-type-module-in-package-json-sah/README.md
+++ b/submissions/examples/missing-type-module-in-package-json-sah/README.md
@@ -1,0 +1,6 @@
+# Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node
+
+Closes #53754
+
+## Description
+This directory contains the solution files for Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node.

--- a/submissions/examples/missing-type-module-in-package-json-sah/demo.html
+++ b/submissions/examples/missing-type-module-in-package-json-sah/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Missing &quot;type&quot;: &quot;module&quot; in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="missing-type-module-in-package-json">
+        <h1>Solution for Issue #53754</h1>
+        <p>Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node</p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/missing-type-module-in-package-json-sah/style.css
+++ b/submissions/examples/missing-type-module-in-package-json-sah/style.css
@@ -1,0 +1,22 @@
+/* 
+ * Solution for Missing "type": "module" in package.json causes MODULE_TYPELESS_PACKAGE_JSON warnings/errors in Node
+ * Issue: #53754
+ */
+.missing-type-module-in-package-json {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    margin: 14px auto;
+    background-color: #f6f6f6;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    transition: all 0.3s ease;
+}
+
+.missing-type-module-in-package-json:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 12px rgba(0,0,0,0.15);
+}


### PR DESCRIPTION
Closes #53754