### PR TITLE
50260 product catalog fade out tabs

### DIFF
--- a/submissions/examples/product-catalog-fade-out-tabs/README.md
+++ b/submissions/examples/product-catalog-fade-out-tabs/README.md
@@ -1,0 +1,24 @@
+# CSS Fade-Out Tabs (Product Catalog)
+
+A sleek, pure CSS tabbed component engineered specifically for e-commerce and product catalog layouts. It utilizes a refined fade and slight blur transition to elegantly reveal product grids without jarring structural shifts.
+
+## 🚀 Features
+
+- **Zero JavaScript:** Built entirely using HTML state management via hidden radio inputs, ensuring lightning-fast load times critical for e-commerce conversions.
+- **E-Commerce Aesthetics:** Features a highly minimalist, monochromatic design that lets product photography stand out. Includes a responsive CSS Grid layout for `.product-card` items and clean "Add to Cart" ghost buttons.
+- **Fade Transition:** Employs a custom `@keyframes` sequence (`em-fade-transition`) that combines opacity fading with a subtle CSS blur filter for a premium, high-end reveal effect.
+- **Accessible & Responsive:** Adapts to mobile devices by stacking tab headers and switching the product grid to a single column. Fully keyboard navigable via `tabindex="0"` and completely respects `@media (prefers-reduced-motion: reduce)`.
+
+## 🛠️ Usage
+
+Copy the HTML from `demo.html` and link the styles from `style.css`. The structure accommodates standard product catalog elements like images, titles, prices, and CTA buttons.
+
+### CSS Custom Properties
+Adjust the primary branding and animation timing via the `:root` pseudo-class:
+
+```css
+:root {
+    --em-cat-accent: #000000;         /* Main brand color */
+    --em-fade-duration: 0.5s;         /* Speed of the fade transition */
+    --em-fade-easing: cubic-bezier(0.4, 0, 0.2, 1); /* Animation easing */
+}

--- a/submissions/examples/product-catalog-fade-out-tabs/demo.html
+++ b/submissions/examples/product-catalog-fade-out-tabs/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-Out Tabs - EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="catalog-wrapper">
+        <header class="catalog-header">
+            <h1>New Arrivals</h1>
+            <p>Browse our latest collections with seamless fade transitions.</p>
+        </header>
+
+        <div class="em-tabs-container">
+            <input type="radio" id="em-tab-1" name="em-tabs" class="em-tab-input" checked>
+            <input type="radio" id="em-tab-2" name="em-tabs" class="em-tab-input">
+            <input type="radio" id="em-tab-3" name="em-tabs" class="em-tab-input">
+
+            <div class="em-tabs-header">
+                <label for="em-tab-1" class="em-tab-label" tabindex="0">Apparel</label>
+                <label for="em-tab-2" class="em-tab-label" tabindex="0">Accessories</label>
+                <label for="em-tab-3" class="em-tab-label" tabindex="0">Footwear</label>
+            </div>
+
+            <div class="em-tabs-content">
+                <div class="em-tab-panel" id="em-panel-1">
+                    <div class="product-grid">
+                        <div class="product-card">
+                            <div class="product-image placeholder-img"></div>
+                            <h3 class="product-title">Minimalist Cotton Tee</h3>
+                            <div class="product-price">$28.00</div>
+                            <button class="add-to-cart">Add to Cart</button>
+                        </div>
+                        <div class="product-card">
+                            <div class="product-image placeholder-img"></div>
+                            <h3 class="product-title">Heavyweight Hoodie</h3>
+                            <div class="product-price">$65.00</div>
+                            <button class="add-to-cart">Add to Cart</button>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-2">
+                    <div class="product-grid">
+                        <div class="product-card">
+                            <div class="product-image placeholder-img"></div>
+                            <h3 class="product-title">Matte Black Watch</h3>
+                            <div class="product-price">$120.00</div>
+                            <button class="add-to-cart">Add to Cart</button>
+                        </div>
+                        <div class="product-card">
+                            <div class="product-image placeholder-img"></div>
+                            <h3 class="product-title">Leather Cardholder</h3>
+                            <div class="product-price">$45.00</div>
+                            <button class="add-to-cart">Add to Cart</button>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="em-tab-panel" id="em-panel-3">
+                    <div class="product-grid">
+                        <div class="product-card">
+                            <div class="product-image placeholder-img"></div>
+                            <h3 class="product-title">Everyday Canvas Sneaker</h3>
+                            <div class="product-price">$75.00</div>
+                            <button class="add-to-cart">Add to Cart</button>
+                        </div>
+                        <div class="product-card">
+                            <div class="product-image placeholder-img"></div>
+                            <h3 class="product-title">Trail Running Shoes</h3>
+                            <div class="product-price">$130.00</div>
+                            <button class="add-to-cart">Add to Cart</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/submissions/examples/product-catalog-fade-out-tabs/style.css
+++ b/submissions/examples/product-catalog-fade-out-tabs/style.css
@@ -1,0 +1,221 @@
+:root {
+    --em-cat-bg: #fdfdfd;
+    --em-cat-surface: #ffffff;
+    --em-cat-text: #1a1a1a;
+    --em-cat-muted: #757575;
+    --em-cat-border: #eaeaea;
+    --em-cat-accent: #000000;
+    
+    --em-fade-duration: 0.5s;
+    --em-fade-easing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+body {
+    margin: 0;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    background-color: var(--em-cat-bg);
+    color: var(--em-cat-text);
+    display: flex;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+}
+
+.catalog-wrapper {
+    max-width: 900px;
+    width: 100%;
+}
+
+.catalog-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.catalog-header h1 {
+    font-size: 2.25rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem 0;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.catalog-header p {
+    color: var(--em-cat-muted);
+    font-size: 1rem;
+    margin: 0;
+}
+
+.em-tabs-container {
+    width: 100%;
+}
+
+.em-tab-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.em-tabs-header {
+    display: flex;
+    justify-content: center;
+    gap: 2.5rem;
+    margin-bottom: 2.5rem;
+    border-bottom: 1px solid var(--em-cat-border);
+}
+
+.em-tab-label {
+    padding: 1rem 0;
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--em-cat-muted);
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    position: relative;
+    transition: color 0.3s ease;
+}
+
+.em-tab-label::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background-color: var(--em-cat-accent);
+    transform: scaleX(0);
+    transition: transform 0.3s ease;
+}
+
+.em-tab-label:hover {
+    color: var(--em-cat-text);
+}
+
+.em-tabs-content {
+    position: relative;
+    min-height: 400px;
+}
+
+.em-tab-panel {
+    display: none;
+    animation: em-fade-transition var(--em-fade-duration) var(--em-fade-easing) forwards;
+}
+
+.product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+}
+
+.product-card {
+    background: var(--em-cat-surface);
+    padding: 1rem;
+    transition: transform 0.3s ease;
+}
+
+.product-card:hover {
+    transform: translateY(-4px);
+}
+
+.placeholder-img {
+    width: 100%;
+    aspect-ratio: 4/5;
+    background-color: #f5f5f5;
+    border-radius: 4px;
+    margin-bottom: 1.25rem;
+}
+
+.product-title {
+    font-size: 1.125rem;
+    font-weight: 400;
+    margin: 0 0 0.5rem 0;
+}
+
+.product-price {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--em-cat-muted);
+    margin-bottom: 1.25rem;
+}
+
+.add-to-cart {
+    width: 100%;
+    background: transparent;
+    color: var(--em-cat-text);
+    border: 1px solid var(--em-cat-text);
+    padding: 0.875rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.add-to-cart:hover {
+    background: var(--em-cat-accent);
+    color: #ffffff;
+}
+
+#em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"],
+#em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"],
+#em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"] {
+    color: var(--em-cat-text);
+}
+
+#em-tab-1:checked ~ .em-tabs-header [for="em-tab-1"]::after,
+#em-tab-2:checked ~ .em-tabs-header [for="em-tab-2"]::after,
+#em-tab-3:checked ~ .em-tabs-header [for="em-tab-3"]::after {
+    transform: scaleX(1);
+}
+
+#em-tab-1:checked ~ .em-tabs-content #em-panel-1,
+#em-tab-2:checked ~ .em-tabs-content #em-panel-2,
+#em-tab-3:checked ~ .em-tabs-content #em-panel-3 {
+    display: block;
+}
+
+.em-tab-label:focus-visible {
+    outline: 2px solid var(--em-cat-accent);
+    outline-offset: 4px;
+}
+
+@keyframes em-fade-transition {
+    0% {
+        opacity: 0;
+        filter: blur(4px);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0);
+    }
+}
+
+@media (max-width: 600px) {
+    .em-tabs-header {
+        flex-direction: column;
+        gap: 0;
+        border-bottom: none;
+    }
+    .em-tab-label {
+        text-align: center;
+        border-bottom: 1px solid var(--em-cat-border);
+    }
+    .em-tab-label::after {
+        bottom: 0;
+    }
+    .product-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .em-tab-panel {
+        animation: none;
+    }
+    .product-card {
+        transition: none;
+    }
+    .product-card:hover {
+        transform: none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR resolves issue #50260 by introducing a pure CSS Fade-Out Tabs component, styled precisely to match minimalist, high-converting Product Catalog and e-commerce interfaces for the EaseMotion CSS library.

**Key Implementations:**
* **HTML (`demo.html`)**: Implemented the hidden radio-button state architecture. The inner panels are populated with a responsive CSS Grid containing mock `.product-card` UI elements (placeholders for images, titles, pricing, and CTAs) to demonstrate real-world catalog usage.
* **CSS (`style.css`)**: 
  * Designed the `em-fade-transition` keyframe animation. To elevate the standard fade effect, I combined opacity scaling from `0` to `1` with a subtle `blur(4px)` to `blur(0)` filter, creating a premium visual entrance.
  * Applied a clean, monochromatic e-commerce aesthetic utilizing standard sans-serif typography, stark borders, and sleek, animated underline indicators for the active tab states.
  * *(Note: In accordance with requested repository rules, all HTML and CSS code comments have been fully stripped from the source files).*
* **Customization**: Centralized parameters for `--em-fade-duration`, `--em-fade-easing`, and core brand colors inside the `:root` variables for rapid theme integration.
* **Responsiveness**: Re-flows fluidly on devices under `600px`; the inline tab headers transform into a stacked column layout, and the product grid drops to a single column to ensure mobile readability.
* **Accessibility**: Added `tabindex="0"` to the labels with custom `:focus-visible` styling for robust keyboard accessibility. Integrated `prefers-reduced-motion` support to fall back to an instantaneous display without animations.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📄 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (specifically under `submissions/examples/product-catalog-fade-out-tabs/`)
- [x] Includes `demo.html` with a clean HTML5 showcase.
- [x] Includes `style.css` with pure CSS/HTML (No external JS frameworks).
- [x] Includes `README.md` with proper documentation.
- [x] Code is fully responsive across all viewports.
- [x] Code is accessible and includes `prefers-reduced-motion` support.

Closes #50260