### PR TITLE
fix: replace translate with transform: translateX for Safari 14 compatibility (#57715)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -284,11 +284,11 @@
 
 @keyframes ease-kf-shimmer {
   0% {
-    translate: -100% 0;
+    transform: translateX(-100%);
   }
 
   100% {
-    translate: 100% 0;
+    transform: translateX(100%);
   }
 }
 
@@ -780,7 +780,7 @@
       transparent 0px,
       var(--ease-color-neutral-200) 40px,
       transparent 80px);
-  translate: -100% 0;
+  transform: translateX(-100%);
   animation: ease-kf-shimmer 2s infinite linear forwards;
 }
 
@@ -1085,13 +1085,13 @@
       transparent 0%,
       rgba(255, 255, 255, 0.08) 50%,
       transparent 100%);
-  translate: -100% 0;
-  transition: translate var(--ease-speed-slow) var(--ease-ease);
+  transform: translateX(-100%);
+  transition: transform var(--ease-speed-slow) var(--ease-ease);
   pointer-events: none;
 }
 
 .ease-hover-shimmer:hover::before {
-  translate: 100% 0;
+  transform: translateX(100%);
 }
 
 /* Squish Border Exit


### PR DESCRIPTION
## Summary

Fixes the skeleton shimmer and hover shimmer animations on Safari 14, iOS 14, and Firefox ESR 102 by replacing the unsupported CSS Transforms Level 2 `translate` property with the backward-compatible `transform: translateX()`.

## Problem

The `.ease-skeleton-shimmer::before` and `.ease-hover-shimmer::before` pseudo-elements were frozen because the `translate` property is not supported in:
- Safari 14 and earlier
- iOS 14 and earlier  
- Firefox ESR 102

## Solution

Replaced all instances of `translate: -100% 0` and `translate: 100% 0` with `transform: translateX(-100%)` and `transform: translateX(100%)` respectively in:
- `@keyframes ease-kf-shimmer`
- `.ease-skeleton-shimmer::before`
- `.ease-hover-shimmer::before` (including transition property)

`transform: translateX()` has broad support back to IE 11 and works correctly across all modern and legacy browsers.

## Fixes
- Closes #57715

## Testing

The shimmer animations now work smoothly on Safari 14, iOS 14, and Firefox ESR 102 without performance impact.