### PR TITLE
fix: fix hover-glow filter fallback for Firefox and Safari without color-mix support (#57713)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1016,9 +1016,14 @@
 .ease-hover-glow:hover {
   filter: drop-shadow(0 0 8px rgba(108, 99, 255, 0.45))
           drop-shadow(0 0 20px rgba(108, 99, 255, 0.30));
-  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--ease-color-primary) 45%, transparent))
-          drop-shadow(0 0 20px color-mix(in srgb, var(--ease-color-primary) 30%, transparent));
   box-shadow: none;
+}
+
+@supports (color: color-mix(in srgb, blue, red)) {
+  .ease-hover-glow:hover {
+    filter: drop-shadow(0 0 8px color-mix(in srgb, var(--ease-color-primary) 45%, transparent))
+            drop-shadow(0 0 20px color-mix(in srgb, var(--ease-color-primary) 30%, transparent));
+  }
 }
 
 /* Lift (shadow depth) on hover */


### PR DESCRIPTION
## Summary

Fixes the glow effect disappearing on Firefox and Safari browsers that don't support CSS Color Module Level 4's `color-mix()` function by properly separating the rgba fallback from the modern color-mix override.

## Problem

The `.ease-hover-glow:hover` selector was declaring the `filter` property twice within the same rule block:

1. First: rgba() fallback (supported everywhere)
2. Second: color-mix() version (modern browsers only)

The second declaration immediately overwrites the first, causing browsers without color-mix() support to lose both filter definitions and the glow effect entirely.

## Solution

Used `@supports` rule to provide proper progressive enhancement:
- Base rule applies rgba() fallback (works in all browsers)
- `@supports` block overrides with color-mix() version only where supported

This ensures:
- Glow works everywhere (via rgba fallback)
- Modern browsers get dynamic primary color glow (via color-mix)
- Proper feature detection instead of duplicate declarations

## Browser Impact

- Firefox: glow effect now works (was broken before)
- Safari: glow effect now works (was broken before)  
- Chrome/Edge/Modern browsers: glow works with dynamic primary color via color-mix

## Testing

Glow effect now displays correctly on all browsers while maintaining enhanced experience in modern ones.

Closes #57713