### PR TITLE
fix: rename ease-float keyframes to ease-kf-float for consistent naming (#57712)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -635,7 +635,7 @@
   }
 }
 
-@keyframes ease-float {
+@keyframes ease-kf-float {
 
   0%,
   100% {
@@ -680,7 +680,7 @@
 }
 
 .ease-float {
-  animation: ease-float 3s ease-in-out infinite;
+  animation: ease-kf-float 3s ease-in-out infinite;
 }
 .ease-zoom-in {
   animation: ease-kf-zoom-in var(--ease-speed-medium) var(--ease-ease-bounce) both;


### PR DESCRIPTION
## Summary

Fixes keyframe naming inconsistency and potential collision risks by renaming the bare `@keyframes ease-float` to follow the established `ease-kf-` prefix convention used by all other keyframe definitions.

## Problem

The `@keyframes ease-float` was using a bare name without the `ease-kf-` prefix, breaking the established naming convention throughout the animation library. This creates risk of keyframe name collisions in bundled CSS projects where multiple libraries are combined.

## Solution

Renamed:
- `@keyframes ease-float` → `@keyframes ease-kf-float`
- Updated animation reference in `.ease-float` class accordingly

This ensures:
- Consistent naming with all other keyframe definitions  
- Reduces collision risk in CSS bundling scenarios
- Makes naming convention explicit and predictable

## Impact

- Keyframe now follows the `ease-kf-` prefix convention
- Animation functionality unchanged, only name changed
- Improves code consistency and maintainability
- Prevents potential namespace conflicts in bundled projects

## Testing

Animation functionality remains unchanged. All tests pass.

Closes #57712