### PR TITLE
fix: remove unconditional will-change from reveal animations to prevent GPU exhaustion (#57711)

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1220,7 +1220,6 @@
 /* Base: hidden state */
 .ease-reveal {
   opacity: 0;
-  will-change: transform, opacity;
   transition:
     opacity 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1)),
     transform 0.7s var(--ease-ease, cubic-bezier(0.4, 0, 0.2, 1));
@@ -1229,7 +1228,6 @@
 .ease-reveal.ease-reveal-active {
   opacity: 1;
   transform: translate(0, 0) scale(1);
-  will-change: auto;
 }
 
 /* Direction variants */


### PR DESCRIPTION
## Summary

Fixes GPU compositor memory exhaustion by removing the unconditional `will-change: transform, opacity` property from the reveal animation base class.

## Problem

The `.ease-reveal` class was permanently setting `will-change: transform, opacity`, which tells the browser to maintain dedicated GPU compositor layers for EVERY reveal element on the page, regardless of visibility or animation state.

On content-heavy pages with many reveal animations (common in long-scrolling sites), this causes:
- Significant GPU memory waste
- Performance degradation from excessive compositor overhead
- Potential browser slowdown or crashes on memory-constrained devices

## Solution

Removed the unconditional `will-change` property from `.ease-reveal`. Modern browsers automatically optimize transform and opacity transitions without this hint, and the browser's automatic optimization is more efficient than a permanent hint.

Also removed the redundant `will-change: auto` reset from the active state since there's no unconditional hint to reset.

## Impact

- Reduces memory footprint on pages with multiple reveal animations
- Eliminates wasted GPU resources
- Maintains smooth transition performance through automatic browser optimization
- More efficient use of system resources

## Testing

Animation performance remains smooth and unchanged visually. All tests pass.

Closes #57711