### PR TITLE
fix: footer text invisible in light mode - #56700

### DIFF
--- a/components/footer.css
+++ b/components/footer.css
@@ -51,6 +51,14 @@
     color: var(--ease-footer-text-light);
   }
   
+  .ease-footer-logo {
+    color: var(--ease-footer-heading-light);
+  }
+  
+  .ease-footer-description {
+    color: var(--ease-footer-text-light);
+  }
+  
   .ease-footer-col-title {
     color: var(--ease-footer-heading-light);
   }
@@ -80,6 +88,23 @@
     color: var(--ease-footer-text-light);
   }
   
+  .ease-footer-bottom-links a {
+    color: var(--ease-footer-text-light);
+  }
+  
+  .ease-footer-newsletter {
+    background: rgba(0, 0, 0, 0.03);
+    border-color: var(--ease-footer-border-light);
+  }
+  
+  .ease-footer-newsletter-title {
+    color: var(--ease-footer-heading-light);
+  }
+  
+  .ease-footer-newsletter-text {
+    color: var(--ease-footer-text-light);
+  }
+  
   .ease-footer-newsletter-input {
     background: rgba(255, 255, 255, 0.9);
     border-color: var(--ease-footer-border-light);
@@ -93,6 +118,81 @@
   .ease-footer-newsletter-btn {
     background: var(--ease-footer-accent-gradient);
   }
+}
+
+/* Light mode via data-theme attribute */
+[data-theme="light"] .ease-footer {
+  background: var(--ease-footer-bg-light);
+  border-top-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-logo {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-description {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-col-title {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-links a {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-links a:hover {
+  color: var(--ease-footer-accent);
+}
+
+[data-theme="light"] .ease-footer-social a {
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--ease-footer-heading-light);
+  border: 1px solid var(--ease-footer-border-light);
+}
+
+[data-theme="light"] .ease-footer-social a:hover {
+  background: var(--ease-footer-accent-gradient);
+  color: #fff;
+  border-color: transparent;
+}
+
+[data-theme="light"] .ease-footer-bottom {
+  border-top-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-bottom-links a {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: var(--ease-footer-border-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-title {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-text {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-input {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-input::placeholder {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-btn {
+  background: var(--ease-footer-accent-gradient);
 }
 
 /* ── Animated Background Orbs ───────────────────────────────── */

--- a/submissions/examples/56700-footer-text-light-mode/README.md
+++ b/submissions/examples/56700-footer-text-light-mode/README.md
@@ -1,0 +1,49 @@
+# Footer Text Invisible in Light Mode - Fix #56700
+
+**Issue:** Footer text ("Built with ❤️ using EaseMotion CSS...") disappears when toggling to Light Mode because:
+1. Footer only used `@media (prefers-color-scheme: light)` — no `[data-theme]` attribute support
+2. `.ease-footer-description` color was not overridden in light mode
+3. `.ease-footer-logo` color was not overridden in light mode
+
+## The Fix
+
+### Problem
+- Footer CSS at line 47 only had `@media (prefers-color-scheme: light)` — doesn't work with JS theme toggle using `data-theme` attribute
+- `.ease-footer-logo` color stayed as dark mode `--ease-footer-heading` (#f1f5f9) in light mode
+- `.ease-footer-description` color stayed as dark mode `--ease-footer-text` (#9ca3af) in light mode
+
+### Solution
+Added `[data-theme="light"]` selectors alongside existing media queries, plus missing light mode overrides:
+
+```css
+/* Added missing light mode overrides in media query */
+@media (prefers-color-scheme: light) {
+  .ease-footer-logo {
+    color: var(--ease-footer-heading-light);
+  }
+  .ease-footer-description {
+    color: var(--ease-footer-text-light);
+  }
+}
+
+/* Added data-theme attribute support */
+[data-theme="light"] .ease-footer-logo {
+  color: var(--ease-footer-heading-light);
+}
+[data-theme="light"] .ease-footer-description {
+  color: var(--ease-footer-text-light);
+}
+```
+
+## Changes Made
+
+| File | Change |
+|------|--------|
+| `components/footer.css` | Added `[data-theme="light"]` selectors + missing light mode color overrides |
+
+## How to Test
+
+1. Open the demo in a browser
+2. Click "Toggle Theme" to switch between dark and light modes
+3. Footer text should remain visible in both modes
+4. Test with OS light mode preference via `prefers-color-scheme` media query

--- a/submissions/examples/56700-footer-text-light-mode/demo.html
+++ b/submissions/examples/56700-footer-text-light-mode/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Footer Light Mode Fix - #56700</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header style="padding:2rem; background:#0f172a; color:#fff; text-align:center;">
+    <h1>Footer Light Mode Fix</h1>
+    <p>Toggle between dark and light mode to see the fix</p>
+    <button id="themeToggle" style="margin-top:1rem; padding:0.5rem 1.5rem; border:none; border-radius:8px; background:linear-gradient(135deg,#6366f1,#8b5cf6); color:#fff; cursor:pointer; font-size:1rem;">Toggle Theme</button>
+  </header>
+
+  <main style="padding:2rem; max-width:800px; margin:0 auto;">
+    <h2>The Bug</h2>
+    <p>Footer text disappeared in light mode because:</p>
+    <ul>
+      <li>Footer only used <code>@media (prefers-color-scheme: light)</code> — no <code>[data-theme]</code> support</li>
+      <li><code>.ease-footer-description</code> color was not overridden in light mode</li>
+      <li><code>.ease-footer-logo</code> color was not overridden in light mode</li>
+    </ul>
+
+    <h2>The Fix</h2>
+    <ul>
+      <li>Added <code>[data-theme="light"]</code> selectors alongside media queries</li>
+      <li>Added missing <code>.ease-footer-description</code> light mode color</li>
+      <li>Added missing <code>.ease-footer-logo</code> light mode color</li>
+      <li>Added missing <code>.ease-footer-newsletter</code> light mode styles</li>
+    </ul>
+  </main>
+
+  <footer class="ease-footer" role="contentinfo">
+    <div class="ease-footer-main">
+      <div class="ease-footer-brand">
+        <div class="ease-footer-logo">
+          <span class="ease-footer-logo-icon">✦</span>
+          <span class="ease-footer-logo-text">EaseMotion CSS</span>
+        </div>
+        <p class="ease-footer-description">Modern CSS framework for smooth, accessible animations.</p>
+        <div class="ease-footer-social">
+          <a href="#" aria-label="GitHub">GH</a>
+          <a href="#" aria-label="Twitter">TW</a>
+        </div>
+      </div>
+      <div class="ease-footer-col">
+        <h3 class="ease-footer-col-title">Product</h3>
+        <ul class="ease-footer-links">
+          <li><a href="#">Features</a></li>
+          <li><a href="#">Documentation</a></li>
+          <li><a href="#">Components</a></li>
+        </ul>
+      </div>
+      <div class="ease-footer-col">
+        <h3 class="ease-footer-col-title">Community</h3>
+        <ul class="ease-footer-links">
+          <li><a href="#">GitHub</a></li>
+          <li><a href="#">Discord</a></li>
+          <li><a href="#">Twitter</a></li>
+        </ul>
+      </div>
+      <div class="ease-footer-newsletter">
+        <h3 class="ease-footer-newsletter-title">Stay Updated</h3>
+        <p class="ease-footer-newsletter-text">Get the latest updates and news.</p>
+        <form class="ease-footer-newsletter-form" aria-label="Newsletter signup">
+          <input type="email" class="ease-footer-newsletter-input" placeholder="Enter your email" aria-label="Email address">
+          <button type="submit" class="ease-footer-newsletter-btn">Subscribe</button>
+        </form>
+      </div>
+    </div>
+    <div class="ease-footer-bottom">
+      <p class="ease-footer-copyright">© 2026 EaseMotion CSS. All rights reserved.</p>
+      <div class="ease-footer-bottom-links">
+        <a href="#">Privacy</a>
+        <a href="#">Terms</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    const toggle = document.getElementById('themeToggle');
+    toggle.addEventListener('click', () => {
+      const html = document.documentElement;
+      const current = html.getAttribute('data-theme');
+      html.setAttribute('data-theme', current === 'light' ? 'dark' : 'light');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/56700-footer-text-light-mode/style.css
+++ b/submissions/examples/56700-footer-text-light-mode/style.css
@@ -1,0 +1,358 @@
+/* Footer Fix - Issue #56700 - Footer text invisible in light mode */
+/* Fix: Add data-theme="light" selectors alongside prefers-color-scheme media query */
+
+/* === Reset === */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+/* === Dark Mode (Default) === */
+.ease-footer {
+  --ease-footer-bg: #0f172a;
+  --ease-footer-text: #9ca3af;
+  --ease-footer-heading: #f1f5f9;
+  --ease-footer-accent: #6366f1;
+  --ease-footer-border: #1e293b;
+  --ease-footer-accent-gradient: linear-gradient(135deg, #6366f1, #8b5cf6);
+
+  background: var(--ease-footer-bg);
+  color: var(--ease-footer-text);
+  border-top: 1px solid var(--ease-footer-border);
+}
+
+/* === Light Mode Variables === */
+@media (prefers-color-scheme: light) {
+  .ease-footer {
+    --ease-footer-bg-light: #f8fafc;
+    --ease-footer-text-light: #64748b;
+    --ease-footer-heading-light: #0f172a;
+    --ease-footer-border-light: #e2e8f0;
+  }
+}
+
+/* === Footer Structure === */
+.ease-footer-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 2fr;
+  gap: 2rem;
+}
+
+.ease-footer-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ease-footer-heading);
+}
+
+.ease-footer-logo-icon {
+  font-size: 1.5rem;
+}
+
+.ease-footer-description {
+  color: var(--ease-footer-text);
+  margin: 0.75rem 0;
+  font-size: 0.9rem;
+}
+
+.ease-footer-social {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.ease-footer-social a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--ease-footer-text);
+  text-decoration: none;
+  font-size: 0.8rem;
+  transition: all 0.3s ease;
+}
+
+.ease-footer-social a:hover {
+  background: var(--ease-footer-accent-gradient);
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.ease-footer-col-title {
+  color: var(--ease-footer-heading);
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 1rem;
+}
+
+.ease-footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-footer-links li {
+  margin-bottom: 0.5rem;
+}
+
+.ease-footer-links a {
+  color: var(--ease-footer-text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.ease-footer-links a:hover {
+  color: var(--ease-footer-accent);
+}
+
+/* Newsletter */
+.ease-footer-newsletter {
+  background: rgba(255, 255, 255, 0.03);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--ease-footer-border);
+}
+
+.ease-footer-newsletter-title {
+  color: var(--ease-footer-heading);
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.ease-footer-newsletter-text {
+  color: var(--ease-footer-text);
+  font-size: 0.85rem;
+  margin: 0 0 1rem;
+}
+
+.ease-footer-newsletter-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ease-footer-newsletter-input {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--ease-footer-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--ease-footer-heading);
+  font-size: 0.85rem;
+}
+
+.ease-footer-newsletter-input::placeholder {
+  color: var(--ease-footer-text);
+}
+
+.ease-footer-newsletter-btn {
+  padding: 0.6rem 1.25rem;
+  background: var(--ease-footer-accent-gradient);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.ease-footer-newsletter-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.4);
+}
+
+/* Bottom bar */
+.ease-footer-bottom {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 2rem;
+  border-top: 1px solid var(--ease-footer-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.ease-footer-copyright {
+  margin: 0;
+}
+
+.ease-footer-bottom-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.ease-footer-bottom-links a {
+  color: var(--ease-footer-text);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.ease-footer-bottom-links a:hover {
+  color: var(--ease-footer-accent);
+}
+
+/* ==============================
+   LIGHT MODE - Media Query
+   ============================== */
+@media (prefers-color-scheme: light) {
+  .ease-footer {
+    background: var(--ease-footer-bg-light);
+    border-top-color: var(--ease-footer-border-light);
+    color: var(--ease-footer-text-light);
+  }
+  
+  .ease-footer-logo {
+    color: var(--ease-footer-heading-light);
+  }
+  
+  .ease-footer-description {
+    color: var(--ease-footer-text-light);
+  }
+  
+  .ease-footer-col-title {
+    color: var(--ease-footer-heading-light);
+  }
+  
+  .ease-footer-links a {
+    color: var(--ease-footer-text-light);
+  }
+  
+  .ease-footer-links a:hover {
+    color: var(--ease-footer-accent);
+  }
+  
+  .ease-footer-social a {
+    background: rgba(0, 0, 0, 0.05);
+    color: var(--ease-footer-heading-light);
+    border: 1px solid var(--ease-footer-border-light);
+  }
+  
+  .ease-footer-social a:hover {
+    background: var(--ease-footer-accent-gradient);
+    color: #fff;
+    border-color: transparent;
+  }
+  
+  .ease-footer-bottom {
+    border-top-color: var(--ease-footer-border-light);
+    color: var(--ease-footer-text-light);
+  }
+  
+  .ease-footer-bottom-links a {
+    color: var(--ease-footer-text-light);
+  }
+  
+  .ease-footer-newsletter {
+    background: rgba(0, 0, 0, 0.03);
+    border-color: var(--ease-footer-border-light);
+  }
+  
+  .ease-footer-newsletter-title {
+    color: var(--ease-footer-heading-light);
+  }
+  
+  .ease-footer-newsletter-text {
+    color: var(--ease-footer-text-light);
+  }
+  
+  .ease-footer-newsletter-input {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: var(--ease-footer-border-light);
+    color: var(--ease-footer-heading-light);
+  }
+  
+  .ease-footer-newsletter-input::placeholder {
+    color: var(--ease-footer-text-light);
+  }
+}
+
+/* ==============================
+   LIGHT MODE - Data Attribute
+   ============================== */
+[data-theme="light"] .ease-footer {
+  background: var(--ease-footer-bg-light);
+  border-top-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-logo {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-description {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-col-title {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-links a {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-links a:hover {
+  color: var(--ease-footer-accent);
+}
+
+[data-theme="light"] .ease-footer-social a {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--ease-footer-heading-light);
+  border: 1px solid var(--ease-footer-border-light);
+}
+
+[data-theme="light"] .ease-footer-social a:hover {
+  background: var(--ease-footer-accent-gradient);
+  color: #fff;
+  border-color: transparent;
+}
+
+[data-theme="light"] .ease-footer-bottom {
+  border-top-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-bottom-links a {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: var(--ease-footer-border-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-title {
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-text {
+  color: var(--ease-footer-text-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-input {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: var(--ease-footer-border-light);
+  color: var(--ease-footer-heading-light);
+}
+
+[data-theme="light"] .ease-footer-newsletter-input::placeholder {
+  color: var(--ease-footer-text-light);
+}


### PR DESCRIPTION
Fixes #56700

## Problem
Footer text ("Built with ❤️ using EaseMotion CSS...") disappeared in light mode because:
1. Footer only used `@media (prefers-color-scheme: light)` — no `[data-theme]` attribute support
2. `.ease-footer-description` color was not overridden in light mode
3. `.ease-footer-logo` color was not overridden in light mode

## Solution
- Added `[data-theme="light"]` selectors alongside existing media queries
- Added missing light mode color overrides for `.ease-footer-logo` and `.ease-footer-description`
- Added missing newsletter section light mode styles

## Changes
- `components/footer.css`: Added data-theme attribute selectors + missing light mode overrides

## Testing
- Toggle theme to light mode — footer text should remain visible
- Works with both OS preference and JS theme toggle