### PR TITLE
ci: enforce strict npm ci without fallback to npm install

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci || npm install
+        run: npm ci
 
       - name: Build minified CSS (ensure dist is current)
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci || npm install
+        run: npm ci
 
       - name: Validate Minified CSS Bundle
         run: npm run validate:bundle

--- a/.github/workflows/css-size-benchmark.yml
+++ b/.github/workflows/css-size-benchmark.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm ci || npm install
+        run: npm ci
 
       - name: Create Measurement Script
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci || npm install
+        run: npm ci
 
       - name: Run Stylelint
         run: npm run lint


### PR DESCRIPTION
## Pull Request Description

Updates the CI workflows to use strict `npm ci` without falling back to `npm install`. This ensures deterministic dependency resolution, enforces the committed `package-lock.json`, and causes the pipeline to fail fast when lockfile inconsistencies occur.

---

## Type of Change 

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (CI Configuration Update)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [ ] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It enforces strict dependency installation in the CI pipeline for more reliable and deterministic builds.

**How does a developer use it?**

```html
<!-- Not applicable as this is a CI pipeline configuration update -->

##Issue #57790 

