### PR TITLE
feat: add quorum read repair explorer

### DIFF
--- a/submissions/examples/quorum-read-repair-kp/README.md
+++ b/submissions/examples/quorum-read-repair-kp/README.md
@@ -1,0 +1,25 @@
+# Quorum Read Repair Explorer
+
+A CSS-only distributed-systems visualization showing how a read quorum selects
+the latest replica value and repairs an outdated node.
+
+## Features
+
+- Compare an inconsistent three-replica set with its converged state.
+- Visualize `N = 3`, `R = 2`, `W = 2`, and the `R + W > N` guarantee.
+- Follow quorum votes, vector clocks, winner selection, and background repair.
+- Track visible versions, confidence, latency, and convergence together.
+- Use a keyboard-accessible checkbox without JavaScript.
+- Adapt the topology for narrow screens and reduced-motion preferences.
+
+## Run
+
+Open `demo.html` and activate **Quorum read** in the header.
+
+## Files
+
+- `demo.html` defines the semantic replica topology.
+- `style.css` implements interaction, motion, metrics, and responsive states.
+- `README.md` documents the example.
+
+No external assets, frameworks, dependencies, or build step are required.

--- a/submissions/examples/quorum-read-repair-kp/demo.html
+++ b/submissions/examples/quorum-read-repair-kp/demo.html
@@ -1,0 +1,374 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A CSS-only quorum read and replica repair visualization."
+    />
+    <title>Quorum Read Repair Explorer</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <input
+      class="repair-input"
+      id="repair-mode"
+      type="checkbox"
+      aria-label="Run quorum read repair"
+    />
+
+    <div class="app">
+      <header class="topbar">
+        <a class="brand" href="#overview" aria-label="QuorumScope overview">
+          <span class="brand-mark" aria-hidden="true">
+            <i></i><i></i><i></i>
+          </span>
+          <span>
+            <strong>QuorumScope</strong>
+            <small>replica consistency lab</small>
+          </span>
+        </a>
+
+        <div class="cluster-status">
+          <span></span>
+          <span class="idle-only">Replica drift detected</span>
+          <span class="active-only">Replica set converged</span>
+        </div>
+
+        <label class="repair-control" for="repair-mode">
+          <span>
+            <strong>Quorum read</strong>
+            <small class="idle-only">Ready</small>
+            <small class="active-only">Complete</small>
+          </span>
+          <i class="switch" aria-hidden="true"><b></b></i>
+        </label>
+      </header>
+
+      <main id="overview">
+        <section class="intro">
+          <div>
+            <p class="eyebrow">
+              Catalog store / key product:42 / region ap-south
+            </p>
+            <div class="title-row">
+              <h1>Quorum read repair</h1>
+              <span class="state-pill idle-only">Inconsistent</span>
+              <span class="state-pill active-only">Converged</span>
+            </div>
+            <p class="intro-copy idle-only">
+              One replica serves an older version while two nodes agree on the
+              latest value.
+            </p>
+            <p class="intro-copy active-only">
+              The coordinator selects the quorum winner and repairs the stale
+              replica in the background.
+            </p>
+          </div>
+
+          <dl class="formula">
+            <div>
+              <dt>Replication</dt>
+              <dd>N = 3</dd>
+            </div>
+            <div>
+              <dt>Read quorum</dt>
+              <dd>R = 2</dd>
+            </div>
+            <div>
+              <dt>Write quorum</dt>
+              <dd>W = 2</dd>
+            </div>
+            <div class="formula-result">
+              <dt>Guarantee</dt>
+              <dd>R + W &gt; N</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="metrics" aria-label="Consistency metrics">
+          <article>
+            <span>Visible versions</span>
+            <strong class="idle-only">2</strong>
+            <strong class="active-only">1</strong>
+            <small class="bad idle-only">v42 and v39</small>
+            <small class="good active-only">all nodes at v42</small>
+          </article>
+          <article>
+            <span>Quorum latency</span>
+            <strong class="idle-only">--</strong>
+            <strong class="active-only">74ms</strong>
+            <small>two matching responses</small>
+          </article>
+          <article>
+            <span>Read confidence</span>
+            <strong class="idle-only">33%</strong>
+            <strong class="active-only">100%</strong>
+            <small class="bad idle-only">single-node read</small>
+            <small class="good active-only">quorum verified</small>
+          </article>
+          <article>
+            <span>Repairs issued</span>
+            <strong class="idle-only">0</strong>
+            <strong class="active-only">1</strong>
+            <small>asynchronous mutation</small>
+          </article>
+        </section>
+
+        <div class="workspace">
+          <section class="topology-panel" aria-labelledby="topology-title">
+            <header class="panel-header">
+              <div>
+                <p class="eyebrow">Live request trace</p>
+                <h2 id="topology-title">Replica resolution</h2>
+              </div>
+              <span class="trace-state idle-only">Awaiting read</span>
+              <span class="trace-state active-only">Repair applied</span>
+            </header>
+
+            <div class="topology">
+              <div class="client">
+                <span class="client-icon" aria-hidden="true"></span>
+                <div>
+                  <small>Client request</small>
+                  <strong>GET product:42</strong>
+                </div>
+              </div>
+
+              <div class="client-link flow-link" aria-hidden="true">
+                <span></span><i></i>
+              </div>
+
+              <article class="coordinator">
+                <header>
+                  <span class="coord-mark" aria-hidden="true"
+                    ><i></i><i></i
+                  ></span>
+                  <div>
+                    <small>Coordinator</small>
+                    <strong>Read reconciler</strong>
+                  </div>
+                </header>
+
+                <div class="vote-ring">
+                  <span class="idle-only">0/2</span>
+                  <span class="active-only">2/2</span>
+                </div>
+                <small class="ring-label">responses required</small>
+
+                <dl>
+                  <div>
+                    <dt>Winner</dt>
+                    <dd class="idle-only">pending</dd>
+                    <dd class="active-only">v42</dd>
+                  </div>
+                  <div>
+                    <dt>Vector clock</dt>
+                    <dd class="idle-only">unresolved</dd>
+                    <dd class="active-only">[8, 12, 4]</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <div class="fanout" aria-hidden="true">
+                <span></span><i></i><b></b><em></em>
+              </div>
+
+              <div class="replicas">
+                <article class="replica replica-a">
+                  <div class="replica-head">
+                    <span>A</span>
+                    <div>
+                      <small>mumbai-a</small>
+                      <strong>Replica A</strong>
+                    </div>
+                    <i></i>
+                  </div>
+                  <div class="version">
+                    <span>Version</span>
+                    <strong>v42</strong>
+                  </div>
+                  <div class="value">
+                    <span>price</span>
+                    <b>₹1,299</b>
+                  </div>
+                  <footer>
+                    <span class="response-dot"></span>
+                    <span class="idle-only">not queried</span>
+                    <span class="active-only">52ms response</span>
+                  </footer>
+                </article>
+
+                <article class="replica replica-b">
+                  <div class="replica-head">
+                    <span>B</span>
+                    <div>
+                      <small>mumbai-b</small>
+                      <strong>Replica B</strong>
+                    </div>
+                    <i></i>
+                  </div>
+                  <div class="version">
+                    <span>Version</span>
+                    <strong>v42</strong>
+                  </div>
+                  <div class="value">
+                    <span>price</span>
+                    <b>₹1,299</b>
+                  </div>
+                  <footer>
+                    <span class="response-dot"></span>
+                    <span class="idle-only">not queried</span>
+                    <span class="active-only">74ms response</span>
+                  </footer>
+                </article>
+
+                <article class="replica replica-c">
+                  <div class="replica-head">
+                    <span>C</span>
+                    <div>
+                      <small>mumbai-c</small>
+                      <strong>Replica C</strong>
+                    </div>
+                    <i></i>
+                  </div>
+                  <div class="version">
+                    <span>Version</span>
+                    <strong class="idle-only">v39</strong>
+                    <strong class="active-only">v42</strong>
+                  </div>
+                  <div class="value">
+                    <span>price</span>
+                    <b class="idle-only">₹1,349</b>
+                    <b class="active-only">₹1,299</b>
+                  </div>
+                  <footer>
+                    <span class="response-dot"></span>
+                    <span class="idle-only">stale by 3 writes</span>
+                    <span class="active-only">repaired at 91ms</span>
+                  </footer>
+                  <span class="repair-badge active-only">repaired</span>
+                </article>
+              </div>
+            </div>
+
+            <footer class="topology-footer">
+              <span class="idle-only">
+                <i></i>
+                A direct read can return stale data
+              </span>
+              <span class="active-only">
+                <i></i>
+                Latest quorum value returned before background repair
+              </span>
+              <span>trace qrm-1042</span>
+            </footer>
+          </section>
+
+          <aside class="detail-panel">
+            <section class="decision-section" aria-labelledby="decision-title">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">Version comparison</p>
+                  <h2 id="decision-title">Quorum decision</h2>
+                </div>
+                <span class="decision-badge idle-only">Pending</span>
+                <span class="decision-badge active-only">Committed</span>
+              </div>
+
+              <div class="version-table">
+                <div class="table-head">
+                  <span>Node</span><span>Clock</span><span>Vote</span>
+                </div>
+                <div>
+                  <b>A</b><code>[8,12,4]</code>
+                  <span class="idle-only">--</span>
+                  <span class="active-only vote">v42</span>
+                </div>
+                <div>
+                  <b>B</b><code>[8,12,4]</code>
+                  <span class="idle-only">--</span>
+                  <span class="active-only vote">v42</span>
+                </div>
+                <div>
+                  <b>C</b>
+                  <code class="idle-only">[8,9,4]</code>
+                  <code class="active-only">[8,12,4]</code>
+                  <span class="idle-only stale">v39</span>
+                  <span class="active-only repaired">fixed</span>
+                </div>
+              </div>
+            </section>
+
+            <section class="progress-section" aria-labelledby="progress-title">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">Consistency state</p>
+                  <h2 id="progress-title">Convergence</h2>
+                </div>
+                <strong class="idle-only">67%</strong>
+                <strong class="active-only">100%</strong>
+              </div>
+
+              <div class="progress-track" aria-hidden="true">
+                <span></span><i></i>
+              </div>
+
+              <div class="node-key">
+                <span><i></i>A current</span>
+                <span><i></i>B current</span>
+                <span class="node-c-key">
+                  <i></i>
+                  <b class="idle-only">C stale</b>
+                  <b class="active-only">C current</b>
+                </span>
+              </div>
+            </section>
+
+            <section class="timeline-section" aria-labelledby="timeline-title">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">Operation log</p>
+                  <h2 id="timeline-title">Read timeline</h2>
+                </div>
+                <small>milliseconds</small>
+              </div>
+
+              <ol>
+                <li>
+                  <span>00</span><i></i>
+                  <p>
+                    <strong>Fan out read</strong><small>A, B, C queried</small>
+                  </p>
+                </li>
+                <li>
+                  <span>52</span><i></i>
+                  <p><strong>First vote</strong><small>A returns v42</small></p>
+                </li>
+                <li>
+                  <span>74</span><i></i>
+                  <p>
+                    <strong class="idle-only">Quorum not run</strong>
+                    <strong class="active-only">Quorum reached</strong>
+                    <small class="idle-only">waiting for execution</small>
+                    <small class="active-only">A and B agree on v42</small>
+                  </p>
+                </li>
+                <li>
+                  <span>91</span><i></i>
+                  <p>
+                    <strong class="idle-only">Repair pending</strong>
+                    <strong class="active-only">Repair applied</strong>
+                    <small class="idle-only">C remains at v39</small>
+                    <small class="active-only">C updated to v42</small>
+                  </p>
+                </li>
+              </ol>
+            </section>
+          </aside>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/quorum-read-repair-kp/style.css
+++ b/submissions/examples/quorum-read-repair-kp/style.css
@@ -1,0 +1,1352 @@
+:root {
+  color-scheme: light;
+
+  --ink: #172126;
+  --muted: #66747a;
+  --canvas: #e8edef;
+  --surface: #fff;
+  --soft: #f4f6f7;
+  --line: #d7dee1;
+  --line-dark: #b7c2c7;
+  --nav: #151c20;
+  --danger: #c3433f;
+  --danger-soft: #fff0ee;
+  --success: #12836d;
+  --success-dark: #096652;
+  --success-soft: #e9f7f3;
+  --blue: #276bb5;
+  --violet: #7354ad;
+  --amber: #cd7a17;
+  --shadow: 0 18px 48px rgba(22, 34, 40, 0.1);
+  --ease: 520ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--canvas);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(rgba(23, 33, 38, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(23, 33, 38, 0.035) 1px, transparent 1px),
+    var(--canvas);
+  background-size: 28px 28px;
+}
+
+.repair-input {
+  position: fixed;
+  top: 18px;
+  right: 24px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.app {
+  width: min(1460px, calc(100% - 32px));
+  min-height: calc(100vh - 32px);
+  margin: 16px auto;
+  overflow: hidden;
+  background: var(--soft);
+  border: 1px solid rgba(23, 33, 38, 0.16);
+  border-radius: 7px;
+  box-shadow: var(--shadow);
+}
+
+.topbar {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  gap: 28px;
+  padding: 0 24px;
+  color: #fff;
+  background: var(--nav);
+}
+
+.brand {
+  display: flex;
+  min-width: 230px;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: flex;
+  width: 35px;
+  height: 35px;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  background: #f0f4f5;
+  border-radius: 4px;
+}
+
+.brand-mark i {
+  width: 6px;
+  height: 6px;
+  background: var(--danger);
+  border-radius: 50%;
+  box-shadow: 0 9px 0 var(--danger);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease),
+    transform var(--ease);
+}
+
+.brand-mark i:nth-child(2) {
+  transform: translateY(-4px);
+}
+
+.brand strong,
+.brand small {
+  display: block;
+  letter-spacing: 0;
+}
+
+.brand strong {
+  font-size: 0.94rem;
+}
+
+.brand small {
+  margin-top: 2px;
+  color: #aeb9be;
+  font-size: 0.63rem;
+}
+
+.cluster-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: auto;
+  color: #c6cfd3;
+  font-size: 0.7rem;
+}
+
+.cluster-status > span:first-child {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+  box-shadow: 0 0 0 5px rgba(195, 67, 63, 0.12);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.repair-control {
+  display: flex;
+  min-width: 160px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.repair-control > span {
+  text-align: right;
+}
+
+.repair-control strong,
+.repair-control small {
+  display: block;
+}
+
+.repair-control strong {
+  font-size: 0.72rem;
+}
+
+.repair-control small {
+  margin-top: 2px;
+  color: #ed8f8b;
+  font-size: 0.6rem;
+}
+
+.switch {
+  display: flex;
+  width: 47px;
+  height: 25px;
+  align-items: center;
+  padding: 3px;
+  background: #4b575c;
+  border: 1px solid #69767b;
+  border-radius: 14px;
+  transition:
+    background-color var(--ease),
+    border-color var(--ease);
+}
+
+.switch b {
+  width: 17px;
+  height: 17px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  transition: transform var(--ease);
+}
+
+.repair-input:focus-visible ~ .app .repair-control {
+  outline: 3px solid #88b9ed;
+  outline-offset: 4px;
+}
+
+.active-only {
+  display: none;
+}
+
+.intro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 26px;
+  padding: 28px 30px 24px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+h1,
+h2,
+p {
+  letter-spacing: 0;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  line-height: 1.08;
+}
+
+.state-pill,
+.trace-state,
+.decision-badge {
+  padding: 4px 7px;
+  color: #8e2e2b;
+  background: var(--danger-soft);
+  border: 1px solid #eab7b4;
+  border-radius: 3px;
+  font-size: 0.57rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.intro-copy {
+  max-width: 700px;
+  margin: 11px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.formula {
+  display: grid;
+  min-width: 420px;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin: 0;
+  overflow: hidden;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.formula div {
+  padding: 11px 12px;
+  background: var(--soft);
+}
+
+.formula dt,
+.formula dd {
+  margin: 0;
+}
+
+.formula dt {
+  color: var(--muted);
+  font-size: 0.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.formula dd {
+  margin-top: 4px;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.formula .formula-result {
+  color: #fff;
+  background: var(--danger);
+  transition: background-color var(--ease);
+}
+
+.formula-result dt {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.metrics article {
+  position: relative;
+  min-height: 120px;
+  padding: 17px 20px;
+  background: var(--surface);
+}
+
+.metrics article::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--danger);
+  content: "";
+  transform-origin: left;
+  transition:
+    background-color var(--ease),
+    transform var(--ease);
+}
+
+.metrics article > span {
+  color: var(--muted);
+  font-size: 0.64rem;
+  font-weight: 700;
+}
+
+.metrics strong {
+  display: block;
+  margin-top: 9px;
+  font-size: 1.65rem;
+  line-height: 1;
+}
+
+.metrics small {
+  display: block;
+  margin-top: 7px;
+  color: var(--muted);
+  font-size: 0.57rem;
+}
+
+.metrics .bad,
+.bad {
+  color: #a7322f;
+}
+
+.metrics .good,
+.good {
+  color: var(--success-dark);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 350px;
+  gap: 14px;
+  padding: 14px;
+}
+
+.topology-panel,
+.detail-panel {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.detail-panel {
+  align-self: start;
+}
+
+.panel-header {
+  display: flex;
+  min-height: 66px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 17px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-header h2,
+.section-heading h2 {
+  margin: 4px 0 0;
+  font-size: 0.92rem;
+}
+
+.topology {
+  display: grid;
+  min-height: 530px;
+  grid-template-columns: 138px 45px 190px 55px minmax(300px, 1fr);
+  align-items: center;
+  padding: 24px 20px;
+  background:
+    linear-gradient(90deg, transparent 49%, rgba(23, 33, 38, 0.035) 50%),
+    var(--surface);
+  background-size: 34px 100%;
+}
+
+.client {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 11px;
+  background: var(--soft);
+  border: 1px solid var(--line-dark);
+  border-radius: 4px;
+}
+
+.client-icon {
+  position: relative;
+  width: 27px;
+  height: 22px;
+  flex: 0 0 auto;
+  border: 2px solid var(--ink);
+  border-radius: 2px;
+}
+
+.client-icon::after {
+  position: absolute;
+  right: 5px;
+  bottom: -6px;
+  left: 5px;
+  height: 2px;
+  background: var(--ink);
+  content: "";
+  box-shadow: 0 3px 0 var(--ink);
+}
+
+.client small,
+.client strong {
+  display: block;
+}
+
+.client small {
+  color: var(--muted);
+  font-size: 0.51rem;
+}
+
+.client strong {
+  margin-top: 3px;
+  font-size: 0.59rem;
+  overflow-wrap: anywhere;
+}
+
+.flow-link {
+  position: relative;
+  height: 2px;
+  background: var(--line-dark);
+}
+
+.flow-link::after {
+  position: absolute;
+  top: -4px;
+  right: -1px;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 7px solid var(--line-dark);
+  content: "";
+}
+
+.flow-link span {
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 14px;
+  height: 6px;
+  background: var(--danger);
+  border-radius: 3px;
+  animation: packet 1.4s linear infinite;
+  transition: background-color var(--ease);
+}
+
+.coordinator {
+  padding: 15px;
+  background: var(--soft);
+  border: 1px solid var(--danger);
+  border-radius: 5px;
+  box-shadow: 0 0 0 4px var(--danger-soft);
+  transition:
+    border-color var(--ease),
+    box-shadow var(--ease),
+    background-color var(--ease);
+}
+
+.coordinator header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.coord-mark {
+  position: relative;
+  width: 31px;
+  height: 31px;
+  flex: 0 0 auto;
+  background: var(--danger-soft);
+  border-radius: 4px;
+}
+
+.coord-mark i {
+  position: absolute;
+  top: 8px;
+  width: 8px;
+  height: 8px;
+  background: var(--danger);
+  border-radius: 50%;
+  transition: background-color var(--ease);
+}
+
+.coord-mark i:first-child {
+  left: 6px;
+}
+
+.coord-mark i:last-child {
+  right: 6px;
+  box-shadow: -7px 9px 0 var(--danger);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.coordinator header small,
+.coordinator header strong {
+  display: block;
+}
+
+.coordinator header small {
+  color: var(--muted);
+  font-size: 0.51rem;
+}
+
+.coordinator header strong {
+  margin-top: 3px;
+  font-size: 0.67rem;
+}
+
+.vote-ring {
+  display: grid;
+  width: 92px;
+  height: 92px;
+  place-items: center;
+  margin: 17px auto 0;
+  background: conic-gradient(var(--danger) 0 45deg, #e4e9eb 45deg 360deg);
+  border-radius: 50%;
+  transition: background var(--ease);
+}
+
+.vote-ring::before {
+  position: absolute;
+  width: 68px;
+  height: 68px;
+  background: var(--soft);
+  border-radius: 50%;
+  content: "";
+}
+
+.vote-ring span {
+  position: relative;
+  z-index: 1;
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.ring-label {
+  display: block;
+  margin-top: 7px;
+  color: var(--muted);
+  font-size: 0.5rem;
+  text-align: center;
+}
+
+.coordinator dl {
+  display: grid;
+  gap: 6px;
+  margin: 15px 0 0;
+}
+
+.coordinator dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.coordinator dt,
+.coordinator dd {
+  margin: 0;
+  font-size: 0.51rem;
+}
+
+.coordinator dt {
+  color: var(--muted);
+}
+
+.coordinator dd {
+  font-weight: 700;
+}
+
+.fanout {
+  position: relative;
+  height: 330px;
+}
+
+.fanout span {
+  position: absolute;
+  top: 10%;
+  right: 0;
+  bottom: 10%;
+  width: 2px;
+  background: var(--line-dark);
+}
+
+.fanout::before,
+.fanout i,
+.fanout b,
+.fanout em {
+  position: absolute;
+  right: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--line-dark);
+  content: "";
+}
+
+.fanout::before {
+  top: 50%;
+}
+
+.fanout i {
+  top: 10%;
+}
+
+.fanout b {
+  top: 50%;
+}
+
+.fanout em {
+  bottom: 10%;
+}
+
+.replicas {
+  display: grid;
+  gap: 12px;
+}
+
+.replica {
+  position: relative;
+  display: grid;
+  min-height: 100px;
+  grid-template-columns: minmax(120px, 1.2fr) 70px 90px;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--node-color);
+  border-radius: 4px;
+  transition:
+    background-color var(--ease),
+    border-color var(--ease),
+    opacity var(--ease);
+}
+
+.replica-a {
+  --node-color: var(--blue);
+}
+
+.replica-b {
+  --node-color: var(--violet);
+}
+
+.replica-c {
+  --node-color: var(--amber);
+
+  background: #fff9ef;
+  border-color: #e6bf86;
+}
+
+.replica-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.replica-head > span {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: #fff;
+  background: var(--node-color);
+  border-radius: 3px;
+  font-size: 0.58rem;
+  font-weight: 800;
+}
+
+.replica-head small,
+.replica-head strong {
+  display: block;
+}
+
+.replica-head small {
+  color: var(--muted);
+  font-size: 0.49rem;
+}
+
+.replica-head strong {
+  margin-top: 2px;
+  font-size: 0.63rem;
+}
+
+.replica-head i {
+  width: 7px;
+  height: 7px;
+  margin-left: auto;
+  background: var(--node-color);
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--node-color) 15%, transparent);
+}
+
+.version,
+.value {
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+}
+
+.version span,
+.version strong,
+.value span,
+.value b {
+  display: block;
+}
+
+.version span,
+.value span {
+  color: var(--muted);
+  font-size: 0.47rem;
+}
+
+.version strong,
+.value b {
+  margin-top: 4px;
+  font-size: 0.7rem;
+}
+
+.replica footer {
+  position: absolute;
+  right: 12px;
+  bottom: 7px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 0.46rem;
+}
+
+.response-dot {
+  width: 5px;
+  height: 5px;
+  background: var(--line-dark);
+  border-radius: 50%;
+  transition: background-color var(--ease);
+}
+
+.repair-badge {
+  position: absolute;
+  top: 7px;
+  right: 9px;
+  padding: 3px 5px;
+  color: var(--success-dark);
+  background: var(--success-soft);
+  border: 1px solid #9ed5c8;
+  border-radius: 2px;
+  font-size: 0.45rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.topology-footer {
+  display: flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 17px;
+  color: var(--muted);
+  background: var(--soft);
+  border-top: 1px solid var(--line);
+  font-size: 0.55rem;
+}
+
+.topology-footer > span:first-child,
+.topology-footer > span:nth-child(2) {
+  align-items: center;
+  gap: 7px;
+}
+
+.topology-footer .idle-only {
+  display: flex;
+}
+
+.topology-footer i {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+}
+
+.decision-section,
+.progress-section,
+.timeline-section {
+  padding: 17px;
+}
+
+.progress-section,
+.timeline-section {
+  border-top: 1px solid var(--line);
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.section-heading > strong {
+  font-size: 0.72rem;
+}
+
+.section-heading > small {
+  color: var(--muted);
+  font-size: 0.49rem;
+}
+
+.version-table {
+  margin-top: 15px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+
+.version-table > div {
+  display: grid;
+  grid-template-columns: 40px 1fr 48px;
+  align-items: center;
+  min-height: 35px;
+  padding: 0 9px;
+  font-size: 0.52rem;
+}
+
+.version-table > div + div {
+  border-top: 1px solid var(--line);
+}
+
+.version-table .table-head {
+  min-height: 29px;
+  color: var(--muted);
+  background: var(--soft);
+  font-size: 0.47rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.version-table code {
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 0.51rem;
+}
+
+.vote,
+.repaired {
+  color: var(--success-dark);
+  font-weight: 800;
+}
+
+.stale {
+  color: #9c5b0a;
+  font-weight: 800;
+}
+
+.progress-track {
+  position: relative;
+  height: 9px;
+  margin-top: 16px;
+  background: var(--soft);
+  border-radius: 5px;
+}
+
+.progress-track span {
+  display: block;
+  width: 67%;
+  height: 100%;
+  background: var(--danger);
+  border-radius: inherit;
+  transition:
+    width var(--ease),
+    background-color var(--ease);
+}
+
+.progress-track i {
+  position: absolute;
+  top: 1px;
+  left: calc(67% - 7px);
+  width: 7px;
+  height: 7px;
+  background: #fff;
+  border: 1px solid var(--danger);
+  border-radius: 50%;
+  transition:
+    left var(--ease),
+    border-color var(--ease);
+}
+
+.node-key {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin-top: 13px;
+}
+
+.node-key > span {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 0.48rem;
+}
+
+.node-key i {
+  width: 6px;
+  height: 6px;
+  background: var(--success);
+  border-radius: 50%;
+}
+
+.node-key b {
+  font-weight: 500;
+}
+
+.node-c-key i {
+  background: var(--amber);
+  transition: background-color var(--ease);
+}
+
+.timeline-section ol {
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-section li {
+  position: relative;
+  display: grid;
+  min-height: 55px;
+  grid-template-columns: 30px 8px 1fr;
+  gap: 8px;
+}
+
+.timeline-section li:not(:last-child)::after {
+  position: absolute;
+  top: 13px;
+  bottom: -1px;
+  left: 41px;
+  width: 1px;
+  background: var(--line);
+  content: "";
+}
+
+.timeline-section li > span {
+  color: var(--muted);
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 0.5rem;
+}
+
+.timeline-section li > i {
+  position: relative;
+  z-index: 1;
+  width: 8px;
+  height: 8px;
+  background: var(--danger);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--danger);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.timeline-section p {
+  margin: 0;
+}
+
+.timeline-section strong,
+.timeline-section small {
+  display: block;
+}
+
+.timeline-section strong {
+  font-size: 0.59rem;
+}
+
+.timeline-section small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.5rem;
+}
+
+.repair-input:checked ~ .app .idle-only {
+  display: none;
+}
+
+.repair-input:checked ~ .app .active-only {
+  display: block;
+}
+
+.repair-input:checked ~ .app .topology-footer .active-only {
+  display: flex;
+}
+
+.repair-input:checked ~ .app .brand-mark i {
+  background: var(--success);
+  box-shadow: 0 9px 0 var(--success);
+  transform: translateY(0);
+}
+
+.repair-input:checked ~ .app .cluster-status > span:first-child {
+  background: var(--success);
+  box-shadow: 0 0 0 5px rgba(18, 131, 109, 0.12);
+}
+
+.repair-input:checked ~ .app .repair-control small {
+  color: #72d2bd;
+}
+
+.repair-input:checked ~ .app .switch {
+  background: var(--success);
+  border-color: #3aa58f;
+}
+
+.repair-input:checked ~ .app .switch b {
+  transform: translateX(20px);
+}
+
+.repair-input:checked ~ .app .state-pill,
+.repair-input:checked ~ .app .trace-state,
+.repair-input:checked ~ .app .decision-badge {
+  color: var(--success-dark);
+  background: var(--success-soft);
+  border-color: #9cd6c8;
+}
+
+.repair-input:checked ~ .app .formula .formula-result,
+.repair-input:checked ~ .app .metrics article::after {
+  background: var(--success);
+}
+
+.repair-input:checked ~ .app .metrics article::after {
+  transform: scaleX(0.72);
+}
+
+.repair-input:checked ~ .app .flow-link span,
+.repair-input:checked ~ .app .topology-footer i {
+  background: var(--success);
+}
+
+.repair-input:checked ~ .app .coordinator {
+  background: #f7fbfa;
+  border-color: var(--success);
+  box-shadow: 0 0 0 4px var(--success-soft);
+}
+
+.repair-input:checked ~ .app .coord-mark {
+  background: var(--success-soft);
+}
+
+.repair-input:checked ~ .app .coord-mark i {
+  background: var(--success);
+}
+
+.repair-input:checked ~ .app .coord-mark i:last-child {
+  box-shadow: -7px 9px 0 var(--success);
+}
+
+.repair-input:checked ~ .app .vote-ring {
+  background: conic-gradient(var(--success) 0 360deg);
+}
+
+.repair-input:checked ~ .app .replica {
+  background: #f8fbfa;
+  border-color: #a8d4ca;
+}
+
+.repair-input:checked ~ .app .replica-c {
+  --node-color: var(--success);
+}
+
+.repair-input:checked ~ .app .response-dot {
+  background: var(--success);
+}
+
+.repair-input:checked ~ .app .progress-track span {
+  width: 100%;
+  background: var(--success);
+}
+
+.repair-input:checked ~ .app .progress-track i {
+  left: calc(100% - 7px);
+  border-color: var(--success);
+}
+
+.repair-input:checked ~ .app .node-c-key i {
+  background: var(--success);
+}
+
+.repair-input:checked ~ .app .timeline-section li > i {
+  background: var(--success);
+  box-shadow: 0 0 0 1px var(--success);
+}
+
+@keyframes packet {
+  from {
+    transform: translateX(-5px);
+  }
+
+  to {
+    transform: translateX(30px);
+  }
+}
+
+@media (max-width: 1120px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-panel {
+    display: grid;
+    grid-template-columns: 1fr 0.8fr 1fr;
+  }
+
+  .progress-section,
+  .timeline-section {
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 900px) {
+  .formula {
+    min-width: 360px;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .topology {
+    grid-template-columns: 120px 36px 170px 42px minmax(280px, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    width: 100%;
+    min-height: 100vh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .topbar {
+    min-height: 62px;
+    gap: 10px;
+    padding: 0 14px;
+  }
+
+  .brand {
+    min-width: 0;
+    margin-right: auto;
+  }
+
+  .brand small,
+  .cluster-status,
+  .repair-control strong {
+    display: none;
+  }
+
+  .repair-control {
+    min-width: 0;
+  }
+
+  .intro {
+    display: block;
+    padding: 23px 17px 20px;
+  }
+
+  .title-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .formula {
+    min-width: 0;
+    margin-top: 18px;
+  }
+
+  .workspace {
+    padding: 9px;
+  }
+
+  .topology {
+    grid-template-columns: 1fr;
+    gap: 15px;
+    min-height: 0;
+    padding: 18px 14px;
+  }
+
+  .client,
+  .coordinator {
+    width: min(100%, 230px);
+    margin: 0 auto;
+  }
+
+  .client-link {
+    width: 2px;
+    height: 25px;
+    margin: 0 auto;
+  }
+
+  .client-link::after {
+    top: auto;
+    right: -4px;
+    bottom: -1px;
+    border-top: 7px solid var(--line-dark);
+    border-right: 5px solid transparent;
+    border-bottom: 0;
+    border-left: 5px solid transparent;
+  }
+
+  .client-link span {
+    width: 6px;
+    height: 12px;
+    animation: packet-down 1.4s linear infinite;
+  }
+
+  .fanout {
+    width: 2px;
+    height: 25px;
+    margin: 0 auto;
+    background: var(--line-dark);
+  }
+
+  .fanout span,
+  .fanout::before,
+  .fanout i,
+  .fanout b,
+  .fanout em {
+    display: none;
+  }
+
+  .replica {
+    grid-template-columns: minmax(120px, 1fr) 65px 80px;
+  }
+
+  .detail-panel {
+    display: block;
+  }
+
+  .progress-section,
+  .timeline-section {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .topology-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 460px) {
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .formula {
+    grid-template-columns: 1fr;
+  }
+
+  .replica {
+    grid-template-columns: 1fr 62px;
+    padding-bottom: 30px;
+  }
+
+  .value {
+    display: none;
+  }
+
+  .node-key {
+    grid-template-columns: 1fr;
+  }
+}
+
+@keyframes packet-down {
+  from {
+    transform: translateY(-4px);
+  }
+
+  to {
+    transform: translateY(18px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

- add a CSS-only quorum read repair explorer
- compare a stale three-replica set with its converged state
- visualize quorum votes, vector clocks, winner selection, and asynchronous repair
- include responsive topology and reduced-motion support

## Why

Replica drift is difficult to reason about from raw logs. This example shows how `R + W > N` allows a coordinator to return the latest quorum value and repair a stale replica without blocking the client response.

## Validation

- Prettier check passed for all submission files
- Stylelint passed for the scoped stylesheet via stdin
- duplicate class and keyframe check passed
- Vitest passed: 61 tests
- Playwright assertions passed in installed Chrome at 1440px and 390px
- keyboard control retains focus and both viewports have zero horizontal overflow
- staged diff check passed

## Scope

Adds only:

- `submissions/examples/quorum-read-repair-kp/demo.html`
- `submissions/examples/quorum-read-repair-kp/style.css`
- `submissions/examples/quorum-read-repair-kp/README.md`