### PR TITLE
feat: add two-phase commit recovery console

### DIFF
--- a/submissions/examples/two-phase-commit-recovery-kp/README.md
+++ b/submissions/examples/two-phase-commit-recovery-kp/README.md
@@ -1,0 +1,25 @@
+# Two-Phase Commit Recovery Console
+
+A CSS-only distributed transaction console showing recovery after a
+coordinator crash leaves all participants in the prepared state.
+
+## Features
+
+- Compare an in-doubt transaction with its recovered committed state.
+- Visualize the durable commit record, decision replay, and acknowledgements.
+- Track held locks, participant votes, phase progress, and recovery time.
+- Demonstrate why prepared participants require the coordinator's decision.
+- Use a keyboard-accessible checkbox without JavaScript.
+- Support narrow screens and reduced-motion preferences.
+
+## Run
+
+Open `demo.html`, then activate **Decision replay** in the header.
+
+## Files
+
+- `demo.html` defines the recovery topology.
+- `style.css` implements all interaction and responsive states.
+- `README.md` documents the example.
+
+No external assets, frameworks, dependencies, or build step are required.

--- a/submissions/examples/two-phase-commit-recovery-kp/demo.html
+++ b/submissions/examples/two-phase-commit-recovery-kp/demo.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A CSS-only two-phase commit recovery console."
+    />
+    <title>Two-Phase Commit Recovery Console</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <input
+      class="recovery-input"
+      id="recovery-mode"
+      type="checkbox"
+      aria-label="Replay durable commit decision"
+    />
+
+    <div class="app">
+      <header class="topbar">
+        <a class="brand" href="#console" aria-label="CommitScope overview">
+          <span class="brand-mark" aria-hidden="true"><i></i><b></b></span>
+          <span
+            ><strong>CommitScope</strong><small>2PC recovery lab</small></span
+          >
+        </a>
+        <div class="system-state">
+          <i></i>
+          <span class="pending-only">Transaction in doubt</span>
+          <span class="resolved-only">Commit decision resolved</span>
+        </div>
+        <label class="recovery-control" for="recovery-mode">
+          <span>
+            <strong>Decision replay</strong>
+            <small class="pending-only">Ready</small>
+            <small class="resolved-only">Complete</small>
+          </span>
+          <i class="switch" aria-hidden="true"><b></b></i>
+        </label>
+      </header>
+
+      <main id="console">
+        <section class="intro">
+          <div>
+            <p class="eyebrow">Order checkout / transaction tx-7f31</p>
+            <div class="title-row">
+              <h1>Two-phase commit recovery</h1>
+              <span class="status pending-only">In doubt</span>
+              <span class="status resolved-only">Committed</span>
+            </div>
+            <p class="intro-copy pending-only">
+              The coordinator crashed after writing COMMIT, leaving every
+              participant prepared and locked.
+            </p>
+            <p class="intro-copy resolved-only">
+              A recovery coordinator replays the durable decision and releases
+              all participant locks.
+            </p>
+          </div>
+
+          <dl class="transaction-meta">
+            <div>
+              <dt>Participants</dt>
+              <dd>3</dd>
+            </div>
+            <div>
+              <dt>Decision LSN</dt>
+              <dd>981,442</dd>
+            </div>
+            <div>
+              <dt>Timeout</dt>
+              <dd>8 seconds</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="metrics" aria-label="Recovery metrics">
+          <article>
+            <span>Transaction state</span>
+            <strong class="pending-only">PREPARED</strong>
+            <strong class="resolved-only">COMMITTED</strong>
+            <small class="bad pending-only">decision unknown</small>
+            <small class="good resolved-only">durable outcome</small>
+          </article>
+          <article>
+            <span>Locks held</span>
+            <strong class="pending-only">3</strong>
+            <strong class="resolved-only">0</strong>
+            <small>across participant stores</small>
+          </article>
+          <article>
+            <span>Acknowledgements</span>
+            <strong class="pending-only">0 / 3</strong>
+            <strong class="resolved-only">3 / 3</strong>
+            <small>commit confirmation</small>
+          </article>
+          <article>
+            <span>Recovery time</span>
+            <strong class="pending-only">--</strong>
+            <strong class="resolved-only">184ms</strong>
+            <small>decision replay to completion</small>
+          </article>
+        </section>
+
+        <div class="workspace">
+          <section class="flow-panel" aria-labelledby="flow-title">
+            <header class="panel-header">
+              <div>
+                <p class="eyebrow">Recovery topology</p>
+                <h2 id="flow-title">Durable decision replay</h2>
+              </div>
+              <span class="trace-state pending-only">Coordinator offline</span>
+              <span class="trace-state resolved-only">All nodes committed</span>
+            </header>
+
+            <div class="flow">
+              <article class="coordinator">
+                <header>
+                  <span class="coord-icon" aria-hidden="true"><i></i></span>
+                  <div>
+                    <small>Coordinator</small>
+                    <strong class="pending-only">checkout-coord-1</strong>
+                    <strong class="resolved-only">recovery-coord-2</strong>
+                  </div>
+                </header>
+                <div class="coord-state">
+                  <span class="pending-only">OFFLINE</span>
+                  <span class="resolved-only">REPLAYING</span>
+                </div>
+                <dl>
+                  <div>
+                    <dt>Transaction</dt>
+                    <dd>tx-7f31</dd>
+                  </div>
+                  <div>
+                    <dt>Decision</dt>
+                    <dd class="pending-only">unavailable</dd>
+                    <dd class="resolved-only">COMMIT</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <div class="decision-log">
+                <div class="log-head">
+                  <span>Durable WAL</span><strong>LSN 981,442</strong>
+                </div>
+                <div class="log-record">
+                  <code>TX tx-7f31</code>
+                  <b>COMMIT</b>
+                  <span>fsync ✓</span>
+                </div>
+                <small class="pending-only"
+                  >record exists; replay not started</small
+                >
+                <small class="resolved-only"
+                  >decision loaded by recovery coordinator</small
+                >
+              </div>
+
+              <div class="fanout" aria-hidden="true">
+                <span></span><i></i><b></b><em></em>
+              </div>
+
+              <div class="participants">
+                <article class="participant inventory">
+                  <div class="participant-head">
+                    <span>I</span>
+                    <div>
+                      <small>inventory-db</small><strong>Reserve stock</strong>
+                    </div>
+                    <i></i>
+                  </div>
+                  <div class="participant-state">
+                    <b class="pending-only">PREPARED</b>
+                    <b class="resolved-only">COMMITTED</b>
+                    <span class="pending-only">row lock held</span>
+                    <span class="resolved-only">lock released</span>
+                  </div>
+                  <footer class="resolved-only">ACK 92ms</footer>
+                </article>
+
+                <article class="participant payment">
+                  <div class="participant-head">
+                    <span>P</span>
+                    <div>
+                      <small>payment-db</small><strong>Capture payment</strong>
+                    </div>
+                    <i></i>
+                  </div>
+                  <div class="participant-state">
+                    <b class="pending-only">PREPARED</b>
+                    <b class="resolved-only">COMMITTED</b>
+                    <span class="pending-only">ledger lock held</span>
+                    <span class="resolved-only">lock released</span>
+                  </div>
+                  <footer class="resolved-only">ACK 136ms</footer>
+                </article>
+
+                <article class="participant order">
+                  <div class="participant-head">
+                    <span>O</span>
+                    <div>
+                      <small>order-db</small><strong>Create order</strong>
+                    </div>
+                    <i></i>
+                  </div>
+                  <div class="participant-state">
+                    <b class="pending-only">PREPARED</b>
+                    <b class="resolved-only">COMMITTED</b>
+                    <span class="pending-only">order lock held</span>
+                    <span class="resolved-only">lock released</span>
+                  </div>
+                  <footer class="resolved-only">ACK 184ms</footer>
+                </article>
+              </div>
+            </div>
+
+            <footer class="flow-footer">
+              <span class="pending-only">
+                <i></i>
+                Participants cannot decide independently after PREPARE
+              </span>
+              <span class="resolved-only">
+                <i></i>
+                Durable coordinator decision is authoritative and idempotent
+              </span>
+              <span>trace 2pc-7f31</span>
+            </footer>
+          </section>
+
+          <aside class="detail-panel">
+            <section class="phase-section" aria-labelledby="phase-title">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">Protocol state</p>
+                  <h2 id="phase-title">Phase progress</h2>
+                </div>
+                <strong class="pending-only">1 / 2</strong>
+                <strong class="resolved-only">2 / 2</strong>
+              </div>
+
+              <div class="phase-track" aria-hidden="true">
+                <span></span><i></i><b></b>
+              </div>
+              <div class="phase-labels">
+                <span><i></i>Prepare</span>
+                <span><i></i>Decision</span>
+                <span><i></i>Complete</span>
+              </div>
+            </section>
+
+            <section class="votes-section" aria-labelledby="votes-title">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">Participant votes</p>
+                  <h2 id="votes-title">Prepare result</h2>
+                </div>
+              </div>
+              <div class="vote-table">
+                <div class="table-head">
+                  <span>Node</span><span>Vote</span><span>Final</span>
+                </div>
+                <div>
+                  <b>Inventory</b><span>YES</span
+                  ><strong class="pending-only">wait</strong
+                  ><strong class="resolved-only">commit</strong>
+                </div>
+                <div>
+                  <b>Payment</b><span>YES</span
+                  ><strong class="pending-only">wait</strong
+                  ><strong class="resolved-only">commit</strong>
+                </div>
+                <div>
+                  <b>Order</b><span>YES</span
+                  ><strong class="pending-only">wait</strong
+                  ><strong class="resolved-only">commit</strong>
+                </div>
+              </div>
+            </section>
+
+            <section class="steps-section" aria-labelledby="steps-title">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">Recovery sequence</p>
+                  <h2 id="steps-title">Decision timeline</h2>
+                </div>
+                <small>milliseconds</small>
+              </div>
+              <ol>
+                <li>
+                  <span>00</span><i></i>
+                  <p>
+                    <strong>Detect timeout</strong
+                    ><small>coordinator heartbeat missing</small>
+                  </p>
+                </li>
+                <li>
+                  <span>41</span><i></i>
+                  <p>
+                    <strong>Read durable log</strong
+                    ><small>COMMIT found at LSN 981,442</small>
+                  </p>
+                </li>
+                <li>
+                  <span>68</span><i></i>
+                  <p>
+                    <strong class="pending-only">Replay pending</strong
+                    ><strong class="resolved-only">Broadcast COMMIT</strong
+                    ><small>idempotent decision message</small>
+                  </p>
+                </li>
+                <li>
+                  <span>184</span><i></i>
+                  <p>
+                    <strong class="pending-only">Locks remain</strong
+                    ><strong class="resolved-only">Recovery complete</strong
+                    ><small class="pending-only"
+                      >participants still prepared</small
+                    ><small class="resolved-only"
+                      >3 acknowledgements received</small
+                    >
+                  </p>
+                </li>
+              </ol>
+            </section>
+          </aside>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/two-phase-commit-recovery-kp/style.css
+++ b/submissions/examples/two-phase-commit-recovery-kp/style.css
@@ -1,0 +1,1182 @@
+:root {
+  color-scheme: light;
+
+  --ink: #172126;
+  --muted: #68757a;
+  --canvas: #e8edef;
+  --surface: #fff;
+  --soft: #f4f6f7;
+  --line: #d7dee1;
+  --line-dark: #b8c3c8;
+  --nav: #151c20;
+  --danger: #c3403e;
+  --danger-soft: #fff0ef;
+  --success: #11836d;
+  --success-dark: #086651;
+  --success-soft: #e9f7f3;
+  --blue: #286bb4;
+  --violet: #7655ad;
+  --amber: #cd7b18;
+  --shadow: 0 18px 48px rgba(22, 34, 40, 0.1);
+  --ease: 520ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--canvas);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(rgba(23, 33, 38, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(23, 33, 38, 0.035) 1px, transparent 1px),
+    var(--canvas);
+  background-size: 28px 28px;
+}
+
+.recovery-input {
+  position: fixed;
+  top: 18px;
+  right: 24px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.app {
+  width: min(1460px, calc(100% - 32px));
+  min-height: calc(100vh - 32px);
+  margin: 16px auto;
+  overflow: hidden;
+  background: var(--soft);
+  border: 1px solid rgba(23, 33, 38, 0.16);
+  border-radius: 7px;
+  box-shadow: var(--shadow);
+}
+
+.topbar {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  gap: 28px;
+  padding: 0 24px;
+  color: #fff;
+  background: var(--nav);
+}
+
+.brand {
+  display: flex;
+  min-width: 220px;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  position: relative;
+  width: 35px;
+  height: 35px;
+  background: #f0f4f5;
+  border-radius: 4px;
+}
+
+.brand-mark i,
+.brand-mark b {
+  position: absolute;
+  display: block;
+  width: 11px;
+  height: 11px;
+  border: 3px solid var(--danger);
+  border-radius: 2px;
+  transition:
+    border-color var(--ease),
+    transform var(--ease);
+}
+
+.brand-mark i {
+  top: 6px;
+  left: 6px;
+}
+
+.brand-mark b {
+  right: 6px;
+  bottom: 6px;
+}
+
+.brand-mark::after {
+  position: absolute;
+  top: 16px;
+  left: 14px;
+  width: 8px;
+  height: 3px;
+  background: var(--danger);
+  content: "";
+  transform: rotate(45deg);
+  transition: background-color var(--ease);
+}
+
+.brand strong,
+.brand small {
+  display: block;
+  letter-spacing: 0;
+}
+
+.brand strong {
+  font-size: 0.94rem;
+}
+
+.brand small {
+  margin-top: 2px;
+  color: #aeb9be;
+  font-size: 0.63rem;
+}
+
+.system-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: auto;
+  color: #c7d0d4;
+  font-size: 0.7rem;
+}
+
+.system-state > i {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+  box-shadow: 0 0 0 5px rgba(195, 64, 62, 0.12);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.recovery-control {
+  display: flex;
+  min-width: 165px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.recovery-control > span {
+  text-align: right;
+}
+
+.recovery-control strong,
+.recovery-control small {
+  display: block;
+}
+
+.recovery-control strong {
+  font-size: 0.72rem;
+}
+
+.recovery-control small {
+  margin-top: 2px;
+  color: #ed8d8b;
+  font-size: 0.6rem;
+}
+
+.switch {
+  display: flex;
+  width: 47px;
+  height: 25px;
+  align-items: center;
+  padding: 3px;
+  background: #4b575c;
+  border: 1px solid #69767b;
+  border-radius: 14px;
+  transition:
+    background-color var(--ease),
+    border-color var(--ease);
+}
+
+.switch b {
+  width: 17px;
+  height: 17px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  transition: transform var(--ease);
+}
+
+.recovery-input:focus-visible ~ .app .recovery-control {
+  outline: 3px solid #88b9ed;
+  outline-offset: 4px;
+}
+
+.resolved-only {
+  display: none;
+}
+
+.intro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 26px;
+  padding: 28px 30px 24px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+h1,
+h2,
+p {
+  letter-spacing: 0;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  line-height: 1.08;
+}
+
+.status,
+.trace-state {
+  padding: 4px 7px;
+  color: #8e2d2b;
+  background: var(--danger-soft);
+  border: 1px solid #eab5b3;
+  border-radius: 3px;
+  font-size: 0.57rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.intro-copy {
+  max-width: 720px;
+  margin: 11px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.transaction-meta {
+  display: grid;
+  min-width: 350px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  margin: 0;
+  overflow: hidden;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.transaction-meta div {
+  padding: 11px 12px;
+  background: var(--soft);
+}
+
+.transaction-meta dt,
+.transaction-meta dd {
+  margin: 0;
+}
+
+.transaction-meta dt {
+  color: var(--muted);
+  font-size: 0.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.transaction-meta dd {
+  margin-top: 4px;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.metrics article {
+  position: relative;
+  min-height: 120px;
+  padding: 17px 20px;
+  background: var(--surface);
+}
+
+.metrics article::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--danger);
+  content: "";
+  transform-origin: left;
+  transition:
+    background-color var(--ease),
+    transform var(--ease);
+}
+
+.metrics article > span {
+  color: var(--muted);
+  font-size: 0.64rem;
+  font-weight: 700;
+}
+
+.metrics strong {
+  display: block;
+  margin-top: 9px;
+  font-size: 1.45rem;
+  line-height: 1;
+}
+
+.metrics small {
+  display: block;
+  margin-top: 7px;
+  color: var(--muted);
+  font-size: 0.57rem;
+}
+
+.bad {
+  color: #a83230 !important;
+}
+
+.good {
+  color: var(--success-dark) !important;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 350px;
+  gap: 14px;
+  padding: 14px;
+}
+
+.flow-panel,
+.detail-panel {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.detail-panel {
+  align-self: start;
+}
+
+.panel-header {
+  display: flex;
+  min-height: 66px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 17px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-header h2,
+.section-heading h2 {
+  margin: 4px 0 0;
+  font-size: 0.92rem;
+}
+
+.flow {
+  display: grid;
+  min-height: 520px;
+  grid-template-columns: 190px minmax(170px, 0.8fr) 54px minmax(280px, 1.35fr);
+  align-items: center;
+  gap: 14px;
+  padding: 24px 20px;
+  background:
+    linear-gradient(90deg, transparent 49%, rgba(23, 33, 38, 0.035) 50%),
+    var(--surface);
+  background-size: 34px 100%;
+}
+
+.coordinator {
+  padding: 15px;
+  background: var(--soft);
+  border: 1px solid var(--danger);
+  border-radius: 5px;
+  box-shadow: 0 0 0 4px var(--danger-soft);
+  transition:
+    border-color var(--ease),
+    box-shadow var(--ease),
+    background-color var(--ease);
+}
+
+.coordinator header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.coord-icon {
+  position: relative;
+  width: 31px;
+  height: 31px;
+  flex: 0 0 auto;
+  background: var(--danger-soft);
+  border-radius: 4px;
+}
+
+.coord-icon i {
+  position: absolute;
+  inset: 8px;
+  border: 3px solid var(--danger);
+  border-radius: 2px;
+  transition: border-color var(--ease);
+}
+
+.coordinator header small,
+.coordinator header strong {
+  display: block;
+}
+
+.coordinator header small {
+  color: var(--muted);
+  font-size: 0.5rem;
+}
+
+.coordinator header strong {
+  margin-top: 3px;
+  font-size: 0.62rem;
+}
+
+.coord-state {
+  display: grid;
+  height: 78px;
+  place-items: center;
+  margin: 15px 0;
+  color: var(--danger);
+  background: var(--danger-soft);
+  border: 1px dashed #e4aaa7;
+  border-radius: 3px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  transition:
+    color var(--ease),
+    background-color var(--ease),
+    border-color var(--ease);
+}
+
+.coordinator dl {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.coordinator dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 7px;
+}
+
+.coordinator dt,
+.coordinator dd {
+  margin: 0;
+  font-size: 0.5rem;
+}
+
+.coordinator dt {
+  color: var(--muted);
+}
+
+.coordinator dd {
+  font-weight: 700;
+}
+
+.decision-log {
+  padding: 14px;
+  background: #fff8ed;
+  border: 1px solid #e5ba7d;
+  border-radius: 4px;
+}
+
+.log-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.55rem;
+}
+
+.log-head span {
+  color: var(--muted);
+}
+
+.log-record {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 7px;
+  margin-top: 13px;
+  padding: 10px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+
+.log-record code {
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 0.52rem;
+}
+
+.log-record b {
+  color: var(--success-dark);
+  font-size: 0.58rem;
+}
+
+.log-record span {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 0.48rem;
+}
+
+.decision-log > small {
+  display: block;
+  margin-top: 9px;
+  color: var(--muted);
+  font-size: 0.49rem;
+}
+
+.fanout {
+  position: relative;
+  height: 330px;
+}
+
+.fanout span {
+  position: absolute;
+  top: 10%;
+  right: 0;
+  bottom: 10%;
+  width: 2px;
+  background: var(--line-dark);
+}
+
+.fanout::before,
+.fanout i,
+.fanout b,
+.fanout em {
+  position: absolute;
+  right: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--line-dark);
+  content: "";
+}
+
+.fanout::before {
+  top: 50%;
+}
+
+.fanout i {
+  top: 10%;
+}
+
+.fanout b {
+  top: 50%;
+}
+
+.fanout em {
+  bottom: 10%;
+}
+
+.participants {
+  display: grid;
+  gap: 12px;
+}
+
+.participant {
+  position: relative;
+  display: grid;
+  min-height: 98px;
+  grid-template-columns: minmax(130px, 1fr) 110px;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  background: #fff9ef;
+  border: 1px solid #e4ba7c;
+  border-left: 3px solid var(--node-color);
+  border-radius: 4px;
+  transition:
+    background-color var(--ease),
+    border-color var(--ease);
+}
+
+.inventory {
+  --node-color: var(--blue);
+}
+
+.payment {
+  --node-color: var(--violet);
+}
+
+.order {
+  --node-color: var(--amber);
+}
+
+.participant-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.participant-head > span {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: #fff;
+  background: var(--node-color);
+  border-radius: 3px;
+  font-size: 0.55rem;
+  font-weight: 800;
+}
+
+.participant-head small,
+.participant-head strong {
+  display: block;
+}
+
+.participant-head small {
+  color: var(--muted);
+  font-size: 0.48rem;
+}
+
+.participant-head strong {
+  margin-top: 3px;
+  font-size: 0.62rem;
+}
+
+.participant-head i {
+  width: 7px;
+  height: 7px;
+  margin-left: auto;
+  background: var(--amber);
+  border-radius: 50%;
+  transition: background-color var(--ease);
+}
+
+.participant-state {
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+}
+
+.participant-state b,
+.participant-state span {
+  display: block;
+}
+
+.participant-state b {
+  color: #965a0b;
+  font-size: 0.6rem;
+}
+
+.participant-state span {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.48rem;
+}
+
+.participant footer {
+  position: absolute;
+  right: 9px;
+  bottom: 6px;
+  color: var(--success-dark);
+  font-size: 0.45rem;
+  font-weight: 700;
+}
+
+.flow-footer {
+  display: flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 17px;
+  color: var(--muted);
+  background: var(--soft);
+  border-top: 1px solid var(--line);
+  font-size: 0.55rem;
+}
+
+.flow-footer > span:first-child,
+.flow-footer > span:nth-child(2) {
+  align-items: center;
+  gap: 7px;
+}
+
+.flow-footer .pending-only {
+  display: flex;
+}
+
+.flow-footer i {
+  width: 7px;
+  height: 7px;
+  background: var(--danger);
+  border-radius: 50%;
+}
+
+.phase-section,
+.votes-section,
+.steps-section {
+  padding: 17px;
+}
+
+.votes-section,
+.steps-section {
+  border-top: 1px solid var(--line);
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.section-heading > strong {
+  font-size: 0.7rem;
+}
+
+.section-heading > small {
+  color: var(--muted);
+  font-size: 0.48rem;
+}
+
+.phase-track {
+  position: relative;
+  height: 8px;
+  margin: 18px 12px 0;
+  background: var(--soft);
+}
+
+.phase-track::before {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  width: 50%;
+  height: 2px;
+  background: var(--danger);
+  content: "";
+  transition:
+    width var(--ease),
+    background-color var(--ease);
+}
+
+.phase-track span,
+.phase-track i,
+.phase-track b {
+  position: absolute;
+  top: 0;
+  width: 8px;
+  height: 8px;
+  background: var(--danger);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--danger);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.phase-track span {
+  left: 0;
+}
+
+.phase-track i {
+  left: calc(50% - 4px);
+}
+
+.phase-track b {
+  right: 0;
+  background: var(--line-dark);
+  box-shadow: 0 0 0 1px var(--line-dark);
+}
+
+.phase-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.46rem;
+}
+
+.phase-labels i {
+  display: none;
+}
+
+.vote-table {
+  margin-top: 15px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+
+.vote-table > div {
+  display: grid;
+  min-height: 35px;
+  grid-template-columns: 1fr 45px 50px;
+  align-items: center;
+  padding: 0 9px;
+  font-size: 0.5rem;
+}
+
+.vote-table > div + div {
+  border-top: 1px solid var(--line);
+}
+
+.vote-table .table-head {
+  min-height: 28px;
+  color: var(--muted);
+  background: var(--soft);
+  font-size: 0.45rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.vote-table strong {
+  color: #965a0b;
+}
+
+.steps-section ol {
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.steps-section li {
+  position: relative;
+  display: grid;
+  min-height: 55px;
+  grid-template-columns: 30px 8px 1fr;
+  gap: 8px;
+}
+
+.steps-section li:not(:last-child)::after {
+  position: absolute;
+  top: 13px;
+  bottom: -1px;
+  left: 41px;
+  width: 1px;
+  background: var(--line);
+  content: "";
+}
+
+.steps-section li > span {
+  color: var(--muted);
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 0.49rem;
+}
+
+.steps-section li > i {
+  position: relative;
+  z-index: 1;
+  width: 8px;
+  height: 8px;
+  background: var(--danger);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--danger);
+  transition:
+    background-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.steps-section p {
+  margin: 0;
+}
+
+.steps-section strong,
+.steps-section small {
+  display: block;
+}
+
+.steps-section strong {
+  font-size: 0.58rem;
+}
+
+.steps-section small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.49rem;
+}
+
+.recovery-input:checked ~ .app .pending-only {
+  display: none;
+}
+
+.recovery-input:checked ~ .app .resolved-only {
+  display: block;
+}
+
+.recovery-input:checked ~ .app .flow-footer .resolved-only {
+  display: flex;
+}
+
+.recovery-input:checked ~ .app .brand-mark i,
+.recovery-input:checked ~ .app .brand-mark b {
+  border-color: var(--success);
+  transform: scale(0.9);
+}
+
+.recovery-input:checked ~ .app .brand-mark::after,
+.recovery-input:checked ~ .app .system-state > i,
+.recovery-input:checked ~ .app .flow-footer i {
+  background: var(--success);
+}
+
+.recovery-input:checked ~ .app .system-state > i {
+  box-shadow: 0 0 0 5px rgba(17, 131, 109, 0.12);
+}
+
+.recovery-input:checked ~ .app .recovery-control small {
+  color: #72d1bd;
+}
+
+.recovery-input:checked ~ .app .switch {
+  background: var(--success);
+  border-color: #3ba58f;
+}
+
+.recovery-input:checked ~ .app .switch b {
+  transform: translateX(20px);
+}
+
+.recovery-input:checked ~ .app .status,
+.recovery-input:checked ~ .app .trace-state {
+  color: var(--success-dark);
+  background: var(--success-soft);
+  border-color: #9cd6c8;
+}
+
+.recovery-input:checked ~ .app .metrics article::after {
+  background: var(--success);
+  transform: scaleX(0.72);
+}
+
+.recovery-input:checked ~ .app .coordinator {
+  background: #f7fbfa;
+  border-color: var(--success);
+  box-shadow: 0 0 0 4px var(--success-soft);
+}
+
+.recovery-input:checked ~ .app .coord-icon {
+  background: var(--success-soft);
+}
+
+.recovery-input:checked ~ .app .coord-icon i {
+  border-color: var(--success);
+}
+
+.recovery-input:checked ~ .app .coord-state {
+  color: var(--success-dark);
+  background: var(--success-soft);
+  border-color: #9cd6c8;
+}
+
+.recovery-input:checked ~ .app .participant {
+  background: #f7fbfa;
+  border-color: #9fd0c5;
+}
+
+.recovery-input:checked ~ .app .participant-head i {
+  background: var(--success);
+}
+
+.recovery-input:checked ~ .app .participant-state b,
+.recovery-input:checked ~ .app .vote-table strong {
+  color: var(--success-dark);
+}
+
+.recovery-input:checked ~ .app .phase-track::before {
+  width: 100%;
+  background: var(--success);
+}
+
+.recovery-input:checked ~ .app .phase-track span,
+.recovery-input:checked ~ .app .phase-track i,
+.recovery-input:checked ~ .app .phase-track b,
+.recovery-input:checked ~ .app .steps-section li > i {
+  background: var(--success);
+  box-shadow: 0 0 0 1px var(--success);
+}
+
+@media (max-width: 1120px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-panel {
+    display: grid;
+    grid-template-columns: 0.8fr 1fr 1fr;
+  }
+
+  .votes-section,
+  .steps-section {
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 900px) {
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .flow {
+    grid-template-columns: 170px minmax(150px, 0.8fr) 42px minmax(260px, 1.2fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    width: 100%;
+    min-height: 100vh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .topbar {
+    min-height: 62px;
+    gap: 10px;
+    padding: 0 14px;
+  }
+
+  .brand {
+    min-width: 0;
+    margin-right: auto;
+  }
+
+  .brand small,
+  .system-state,
+  .recovery-control strong {
+    display: none;
+  }
+
+  .recovery-control {
+    min-width: 0;
+  }
+
+  .intro {
+    display: block;
+    padding: 23px 17px 20px;
+  }
+
+  .title-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .transaction-meta {
+    min-width: 0;
+    margin-top: 18px;
+  }
+
+  .workspace {
+    padding: 9px;
+  }
+
+  .flow {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    min-height: 0;
+    padding: 20px 14px;
+  }
+
+  .coordinator,
+  .decision-log {
+    width: min(100%, 250px);
+    margin: 0 auto;
+  }
+
+  .fanout {
+    width: 2px;
+    height: 25px;
+    margin: 0 auto;
+    background: var(--line-dark);
+  }
+
+  .fanout span,
+  .fanout::before,
+  .fanout i,
+  .fanout b,
+  .fanout em {
+    display: none;
+  }
+
+  .detail-panel {
+    display: block;
+  }
+
+  .votes-section,
+  .steps-section {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .flow-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 460px) {
+  .metrics,
+  .transaction-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .participant {
+    grid-template-columns: 1fr 90px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only two-phase commit recovery console
- model coordinator failover, durable decision replay, participant acknowledgements, and lock release
- include responsive desktop/mobile layouts and keyboard-accessible recovery control

## Why
The example turns an abstract distributed transaction recovery path into an inspectable state transition without JavaScript. It shows how a recovery coordinator can use a durable COMMIT record to safely converge prepared participants.

## Validation
- `npx prettier --check submissions/examples/two-phase-commit-recovery-kp/**/*.{html,css,md}`
- Stylelint via stdin for the new stylesheet
- `npm run lint:duplicates`
- `npm test` (61 tests)
- Playwright/Chrome QA at 1440x1000 and 390x844, including keyboard toggle and zero horizontal overflow