### PR TITLE
feat: add gossip anti-entropy convergence lab

### DIFF
--- a/submissions/examples/gossip-anti-entropy-kp/README.md
+++ b/submissions/examples/gossip-anti-entropy-kp/README.md
@@ -1,0 +1,26 @@
+# Gossip Anti-Entropy Convergence Lab
+
+A responsive, CSS-only operations console that explains how replicas detect and
+repair divergent data through periodic anti-entropy exchanges.
+
+## What it demonstrates
+
+- Random peer selection for a bounded gossip repair session
+- Merkle digest comparison across eight token ranges
+- Incremental row transfer for only the divergent ranges
+- Replica generation and root-digest convergence
+- A four-stage exchange timeline from peer selection to verification
+
+## Interaction
+
+Use the **Run repair** switch in the header. The native checkbox remains
+keyboard focusable, so `Tab` and `Space` can move the console from the drifted
+state to the converged state without JavaScript.
+
+## Technical notes
+
+- Pure HTML and CSS
+- Responsive topology for desktop, tablet, and mobile layouts
+- Visible keyboard focus treatment
+- Reduced-motion support
+- No external assets or runtime dependencies

--- a/submissions/examples/gossip-anti-entropy-kp/demo.html
+++ b/submissions/examples/gossip-anti-entropy-kp/demo.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gossip Anti-Entropy Lab</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <input class="mode-input" id="sync-mode" type="checkbox" />
+
+    <main class="console">
+      <header class="topbar">
+        <a class="brand" href="#" aria-label="Meshkeeper home">
+          <span class="brand-mark" aria-hidden="true">
+            <i></i><i></i><i></i>
+          </span>
+          <span>
+            <strong>Meshkeeper</strong>
+            <small>anti-entropy control plane</small>
+          </span>
+        </a>
+
+        <div class="cluster-health">
+          <span class="health-dot"></span>
+          <span class="pending-only">Replica drift detected</span>
+          <span class="synced-only">Cluster converged</span>
+        </div>
+
+        <label class="sync-control" for="sync-mode">
+          <span>
+            <strong class="pending-only">Run repair</strong>
+            <strong class="synced-only">Repair complete</strong>
+            <small>keyboard accessible</small>
+          </span>
+          <span class="switch" aria-hidden="true"><i></i></span>
+        </label>
+      </header>
+
+      <section class="intro">
+        <div>
+          <p class="eyebrow">CATALOG CLUSTER / RING EU-WEST-2</p>
+          <div class="title-row">
+            <h1>Gossip anti-entropy</h1>
+            <span class="state-badge pending-only">DIVERGED</span>
+            <span class="state-badge synced-only">CONVERGED</span>
+          </div>
+          <p class="summary pending-only">
+            Replica C missed two writes. Compare Merkle digests and repair only
+            the divergent token ranges.
+          </p>
+          <p class="summary synced-only">
+            Peer exchange repaired both divergent ranges without a full database
+            scan.
+          </p>
+        </div>
+
+        <dl class="cluster-meta">
+          <div>
+            <dt>Replication</dt>
+            <dd>3 nodes</dd>
+          </div>
+          <div>
+            <dt>Gossip interval</dt>
+            <dd>5 seconds</dd>
+          </div>
+          <div>
+            <dt>Dataset</dt>
+            <dd>48.2 GB</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="metrics" aria-label="Cluster metrics">
+        <article>
+          <span>Convergence</span>
+          <strong class="pending-only">67%</strong>
+          <strong class="synced-only">100%</strong>
+          <small class="pending-only">2 ranges divergent</small>
+          <small class="synced-only">all replicas aligned</small>
+          <i></i>
+        </article>
+        <article>
+          <span>Digest agreement</span>
+          <strong class="pending-only">6 / 8</strong>
+          <strong class="synced-only">8 / 8</strong>
+          <small>Merkle leaf ranges</small>
+          <i></i>
+        </article>
+        <article>
+          <span>Repair payload</span>
+          <strong class="pending-only">Pending</strong>
+          <strong class="synced-only">24 KB</strong>
+          <small>incremental transfer</small>
+          <i></i>
+        </article>
+        <article>
+          <span>Repair duration</span>
+          <strong class="pending-only">--</strong>
+          <strong class="synced-only">312ms</strong>
+          <small>digest to acknowledgement</small>
+          <i></i>
+        </article>
+      </section>
+
+      <div class="workspace">
+        <section class="topology panel">
+          <header class="panel-head">
+            <div>
+              <p class="eyebrow">REPLICA TOPOLOGY</p>
+              <h2>Peer convergence map</h2>
+            </div>
+            <span class="topology-status pending-only">2 MISMATCHES</span>
+            <span class="topology-status synced-only">DIGESTS MATCH</span>
+          </header>
+
+          <div class="mesh">
+            <svg
+              class="links"
+              viewBox="0 0 800 390"
+              preserveAspectRatio="none"
+              aria-hidden="true"
+            >
+              <path class="link link-ab" d="M190 100 L610 100" />
+              <path class="link link-bc" d="M610 100 L400 305" />
+              <path class="link link-ca" d="M400 305 L190 100" />
+              <path class="repair-path" d="M610 100 L400 305" />
+            </svg>
+
+            <article class="node node-a">
+              <div class="node-title">
+                <span class="node-icon">A</span>
+                <span
+                  ><small>eu-west-2a</small><strong>catalog-01</strong></span
+                >
+              </div>
+              <span class="node-state">HEALTHY</span>
+              <dl>
+                <div>
+                  <dt>Generation</dt>
+                  <dd>8,412</dd>
+                </div>
+                <div>
+                  <dt>Root digest</dt>
+                  <dd>7F2A</dd>
+                </div>
+              </dl>
+              <footer>coordinator peer</footer>
+            </article>
+
+            <article class="node node-b">
+              <div class="node-title">
+                <span class="node-icon violet">B</span>
+                <span
+                  ><small>eu-west-2b</small><strong>catalog-02</strong></span
+                >
+              </div>
+              <span class="node-state">HEALTHY</span>
+              <dl>
+                <div>
+                  <dt>Generation</dt>
+                  <dd>8,412</dd>
+                </div>
+                <div>
+                  <dt>Root digest</dt>
+                  <dd>7F2A</dd>
+                </div>
+              </dl>
+              <footer>repair source</footer>
+            </article>
+
+            <article class="node node-c">
+              <div class="node-title">
+                <span class="node-icon amber">C</span>
+                <span
+                  ><small>eu-west-2c</small><strong>catalog-03</strong></span
+                >
+              </div>
+              <span class="node-state pending-only danger">DRIFTED</span>
+              <span class="node-state synced-only">HEALTHY</span>
+              <dl>
+                <div>
+                  <dt>Generation</dt>
+                  <dd class="pending-only">8,410</dd>
+                  <dd class="synced-only">8,412</dd>
+                </div>
+                <div>
+                  <dt>Root digest</dt>
+                  <dd class="pending-only">9C11</dd>
+                  <dd class="synced-only">7F2A</dd>
+                </div>
+              </dl>
+              <footer class="pending-only">repair target</footer>
+              <footer class="synced-only">acknowledged 312ms</footer>
+            </article>
+
+            <div class="exchange pending-only">
+              <strong>Digest mismatch</strong><small>B ↔ C</small>
+            </div>
+            <div class="exchange synced-only">
+              <strong>24 KB transferred</strong><small>B → C</small>
+            </div>
+          </div>
+
+          <footer class="topology-foot">
+            <span
+              ><i></i> Periodic peer selection prevents repair hotspots</span
+            >
+            <code>session ae-8412</code>
+          </footer>
+        </section>
+
+        <aside class="diagnostics panel">
+          <section class="phase">
+            <header>
+              <div>
+                <p class="eyebrow">SESSION STATE</p>
+                <h2>Repair phases</h2>
+              </div>
+              <strong class="pending-only">1 / 4</strong>
+              <strong class="synced-only">4 / 4</strong>
+            </header>
+            <div class="phase-track"><i></i><i></i><i></i><i></i></div>
+            <div class="phase-labels">
+              <span>Gossip</span><span>Compare</span><span>Stream</span
+              ><span>Verify</span>
+            </div>
+          </section>
+
+          <section class="ranges">
+            <header>
+              <div>
+                <p class="eyebrow">MERKLE COMPARISON</p>
+                <h2>Token ranges</h2>
+              </div>
+              <small>8 leaves</small>
+            </header>
+            <div class="range-grid" aria-label="Merkle token ranges">
+              <span>00-1F</span><span>20-3F</span><span>40-5F</span>
+              <span class="mismatch">60-7F</span><span>80-9F</span>
+              <span>A0-BF</span><span class="mismatch">C0-DF</span>
+              <span>E0-FF</span>
+            </div>
+            <p class="pending-only range-note">
+              <b>60-7F</b> and <b>C0-DF</b> require row-level exchange.
+            </p>
+            <p class="synced-only range-note success">
+              All leaf digests now match root <b>7F2A</b>.
+            </p>
+          </section>
+
+          <section class="timeline">
+            <header>
+              <div>
+                <p class="eyebrow">EXCHANGE LOG</p>
+                <h2>Session timeline</h2>
+              </div>
+              <small>milliseconds</small>
+            </header>
+            <ol>
+              <li class="done">
+                <time>00</time><i></i>
+                <span
+                  ><strong>Select peer B ↔ C</strong
+                  ><small>randomized peer round</small></span
+                >
+              </li>
+              <li>
+                <time>38</time><i></i>
+                <span>
+                  <strong class="pending-only">Compare digests</strong>
+                  <strong class="synced-only">Digest mismatch found</strong>
+                  <small>2 of 8 leaves differ</small>
+                </span>
+              </li>
+              <li>
+                <time>147</time><i></i>
+                <span>
+                  <strong class="pending-only">Stream rows</strong>
+                  <strong class="synced-only">Stream 24 KB delta</strong>
+                  <small class="pending-only">waiting for repair</small>
+                  <small class="synced-only">12 keys, 2 tombstones</small>
+                </span>
+              </li>
+              <li>
+                <time>312</time><i></i>
+                <span>
+                  <strong class="pending-only">Verify root</strong>
+                  <strong class="synced-only">Convergence confirmed</strong>
+                  <small class="pending-only">not started</small>
+                  <small class="synced-only">all replicas report 7F2A</small>
+                </span>
+              </li>
+            </ol>
+          </section>
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/gossip-anti-entropy-kp/style.css
+++ b/submissions/examples/gossip-anti-entropy-kp/style.css
@@ -1,0 +1,1051 @@
+:root {
+  color-scheme: light;
+
+  --ink: #162126;
+  --muted: #68777d;
+  --canvas: #e9eef0;
+  --surface: #ffffff;
+  --soft: #f4f7f8;
+  --line: #d4dde0;
+  --line-dark: #b6c3c8;
+  --nav: #141c20;
+  --teal: #0b8871;
+  --teal-dark: #066653;
+  --teal-soft: #e8f7f3;
+  --red: #c74642;
+  --red-soft: #fff0ef;
+  --amber: #d2811d;
+  --violet: #7452b5;
+  --blue: #276cb7;
+  --shadow: 0 18px 48px rgba(22, 34, 40, 0.1);
+  --ease: 520ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--canvas);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(rgba(22, 33, 38, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(22, 33, 38, 0.035) 1px, transparent 1px),
+    var(--canvas);
+  background-size: 32px 32px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.mode-input {
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.console {
+  width: min(1480px, calc(100% - 32px));
+  min-height: calc(100vh - 32px);
+  margin: 16px auto;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line-dark);
+  border-radius: 7px;
+  box-shadow: var(--shadow);
+}
+
+.topbar {
+  min-height: 68px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 24px;
+  padding: 0 26px;
+  color: #fff;
+  background: var(--nav);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  width: max-content;
+}
+
+.brand-mark {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: block;
+  background: #f5f8f8;
+  border-radius: 4px;
+}
+
+.brand-mark i {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--teal);
+  border-radius: 2px;
+}
+
+.brand-mark i:nth-child(1) {
+  top: 7px;
+  left: 7px;
+}
+
+.brand-mark i:nth-child(2) {
+  right: 7px;
+  bottom: 7px;
+}
+
+.brand-mark i:nth-child(3) {
+  top: 14px;
+  left: 14px;
+  border: 0;
+  border-radius: 0;
+  background: var(--teal);
+  transform: rotate(45deg);
+}
+
+.brand strong,
+.brand small {
+  display: block;
+}
+
+.brand strong {
+  font-size: 15px;
+}
+
+.brand small {
+  margin-top: 2px;
+  color: #9fb0b7;
+  font-size: 10px;
+}
+
+.cluster-health {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ced9dc;
+  font-size: 11px;
+}
+
+.health-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--red);
+  border-radius: 50%;
+  box-shadow: 0 0 0 5px rgba(199, 70, 66, 0.13);
+  transition: var(--ease);
+}
+
+.sync-control {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 184px;
+  padding: 7px 9px 7px 12px;
+  border: 1px solid #526269;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: var(--ease);
+}
+
+.sync-control:hover {
+  border-color: #8da0a8;
+}
+
+.sync-control strong,
+.sync-control small {
+  display: block;
+  text-align: right;
+}
+
+.sync-control strong {
+  font-size: 11px;
+}
+
+.sync-control small {
+  margin-top: 1px;
+  color: #93a5ad;
+  font-size: 8px;
+}
+
+.switch {
+  width: 42px;
+  height: 22px;
+  padding: 3px;
+  background: #4c5a60;
+  border-radius: 14px;
+  transition: var(--ease);
+}
+
+.switch i {
+  display: block;
+  width: 16px;
+  height: 16px;
+  background: #fff;
+  border-radius: 50%;
+  transition: var(--ease);
+}
+
+.mode-input:focus-visible + .console .sync-control {
+  outline: 3px solid #75b9ff;
+  outline-offset: 3px;
+}
+
+.intro {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+  padding: 30px 32px 26px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #52656d;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 8px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 34px;
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 15px;
+  letter-spacing: 0;
+}
+
+.state-badge,
+.topology-status {
+  padding: 4px 8px;
+  color: var(--red);
+  background: var(--red-soft);
+  border: 1px solid #e6aaa7;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.summary {
+  max-width: 690px;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.cluster-meta {
+  min-width: 360px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 0;
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.cluster-meta div {
+  padding: 13px 15px;
+}
+
+.cluster-meta div + div {
+  border-left: 1px solid var(--line);
+}
+
+.cluster-meta dt,
+.node dt {
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.cluster-meta dd,
+.node dd {
+  margin: 5px 0 0;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--line);
+}
+
+.metrics article {
+  position: relative;
+  min-height: 116px;
+  padding: 24px 22px 20px;
+  overflow: hidden;
+}
+
+.metrics article + article {
+  border-left: 1px solid var(--line);
+}
+
+.metrics span,
+.metrics small,
+.metrics strong {
+  display: block;
+}
+
+.metrics span {
+  color: #52656d;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.metrics strong {
+  margin: 10px 0 4px;
+  font-size: 23px;
+}
+
+.metrics small {
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.metrics i {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: var(--red);
+  transform-origin: left;
+  transition: var(--ease);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 2.1fr) minmax(330px, 0.9fr);
+  gap: 14px;
+  padding: 14px;
+  background: var(--soft);
+}
+
+.panel {
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.panel-head,
+.phase header,
+.ranges header,
+.timeline header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.panel-head {
+  min-height: 66px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-head .eyebrow,
+.phase .eyebrow,
+.ranges .eyebrow,
+.timeline .eyebrow {
+  margin-bottom: 5px;
+}
+
+.mesh {
+  position: relative;
+  min-height: 530px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(22, 33, 38, 0.04) 1px, transparent 1px),
+    linear-gradient(rgba(22, 33, 38, 0.04) 1px, transparent 1px), #fbfcfc;
+  background-size: 42px 42px;
+}
+
+.links {
+  position: absolute;
+  inset: 9% 7%;
+  width: 86%;
+  height: 78%;
+  overflow: visible;
+}
+
+.link {
+  fill: none;
+  stroke: #b9c8cd;
+  stroke-width: 2;
+  stroke-dasharray: 7 6;
+}
+
+.repair-path {
+  fill: none;
+  stroke: var(--red);
+  stroke-width: 3;
+  stroke-dasharray: 5 8;
+  transition: var(--ease);
+}
+
+.node {
+  position: absolute;
+  width: 235px;
+  padding: 15px;
+  background: #fff;
+  border: 1px solid var(--line-dark);
+  border-radius: 5px;
+  box-shadow: 0 8px 24px rgba(22, 33, 38, 0.08);
+  transition: var(--ease);
+}
+
+.node-a {
+  top: 50px;
+  left: 42px;
+}
+
+.node-b {
+  top: 50px;
+  right: 42px;
+}
+
+.node-c {
+  bottom: 45px;
+  left: 50%;
+  border-color: #d68e8a;
+  transform: translateX(-50%);
+}
+
+.node-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.node-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  color: #fff;
+  background: var(--blue);
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.node-icon.violet {
+  background: var(--violet);
+}
+
+.node-icon.amber {
+  background: var(--amber);
+}
+
+.node-title small,
+.node-title strong {
+  display: block;
+}
+
+.node-title small {
+  margin-bottom: 3px;
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.node-title strong {
+  font-size: 11px;
+}
+
+.node-state {
+  position: absolute;
+  top: 17px;
+  right: 14px;
+  color: var(--teal-dark);
+  font-size: 8px;
+  font-weight: 800;
+}
+
+.node-state::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 5px;
+  background: var(--teal);
+  border-radius: 50%;
+}
+
+.node-state.danger {
+  color: var(--red);
+}
+
+.node-state.danger::before {
+  background: var(--red);
+}
+
+.node dl {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin: 0;
+  padding: 11px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.node dl div + div {
+  padding-left: 13px;
+  border-left: 1px solid var(--line);
+}
+
+.node footer {
+  padding-top: 10px;
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.exchange {
+  position: absolute;
+  top: 235px;
+  left: 50%;
+  z-index: 2;
+  min-width: 145px;
+  padding: 10px 12px;
+  text-align: center;
+  background: var(--red-soft);
+  border: 1px solid #e3aaa7;
+  border-radius: 4px;
+  transform: translateX(-50%);
+  transition: var(--ease);
+}
+
+.exchange strong,
+.exchange small {
+  display: block;
+}
+
+.exchange strong {
+  color: var(--red);
+  font-size: 9px;
+}
+
+.exchange small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.topology-foot {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 0 18px;
+  color: var(--muted);
+  background: var(--soft);
+  border-top: 1px solid var(--line);
+  font-size: 9px;
+}
+
+.topology-foot span {
+  display: flex;
+  align-items: center;
+}
+
+.topology-foot i {
+  width: 7px;
+  height: 7px;
+  margin-right: 7px;
+  background: var(--teal);
+  border-radius: 50%;
+}
+
+.topology-foot code {
+  font-size: 9px;
+}
+
+.diagnostics > section {
+  padding: 17px;
+}
+
+.diagnostics > section + section {
+  border-top: 1px solid var(--line);
+}
+
+.phase header > strong {
+  font-size: 11px;
+}
+
+.phase-track {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  margin: 24px 8px 8px;
+}
+
+.phase-track::before,
+.phase-track::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  right: 0;
+  left: 0;
+  height: 2px;
+  background: var(--line-dark);
+}
+
+.phase-track::after {
+  width: 8%;
+  background: var(--red);
+  transition: var(--ease);
+}
+
+.phase-track i {
+  position: relative;
+  z-index: 1;
+  width: 10px;
+  height: 10px;
+  background: #fff;
+  border: 2px solid var(--line-dark);
+  border-radius: 50%;
+  transition: var(--ease);
+}
+
+.phase-track i:first-child {
+  border-color: var(--red);
+}
+
+.phase-labels {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.range-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+  margin-top: 16px;
+}
+
+.range-grid span {
+  padding: 10px 4px;
+  color: #52656d;
+  text-align: center;
+  background: var(--teal-soft);
+  border: 1px solid #a9dbcf;
+  border-radius: 3px;
+  font-family: Consolas, monospace;
+  font-size: 8px;
+}
+
+.range-grid .mismatch {
+  color: var(--red);
+  background: var(--red-soft);
+  border-color: #e4aaa7;
+  font-weight: 800;
+  transition: var(--ease);
+}
+
+.range-note {
+  margin: 13px 0 0;
+  padding: 9px 10px;
+  color: #7c3a37;
+  background: var(--red-soft);
+  border-left: 3px solid var(--red);
+  font-size: 8px;
+  line-height: 1.5;
+}
+
+.timeline ol {
+  margin: 18px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 25px 10px 1fr;
+  gap: 9px;
+  min-height: 61px;
+}
+
+.timeline li:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  top: 11px;
+  bottom: -1px;
+  left: 38px;
+  width: 1px;
+  background: var(--line-dark);
+}
+
+.timeline time {
+  color: var(--muted);
+  font-family: Consolas, monospace;
+  font-size: 7px;
+}
+
+.timeline li > i {
+  z-index: 1;
+  width: 9px;
+  height: 9px;
+  background: #fff;
+  border: 2px solid var(--line-dark);
+  border-radius: 50%;
+  transition: var(--ease);
+}
+
+.timeline li.done > i {
+  border-color: var(--red);
+  box-shadow: inset 0 0 0 2px #fff;
+  background: var(--red);
+}
+
+.timeline strong,
+.timeline small {
+  display: block;
+}
+
+.timeline strong {
+  font-size: 9px;
+}
+
+.timeline small {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.synced-only {
+  display: none;
+}
+
+.mode-input:checked + .console .pending-only {
+  display: none;
+}
+
+.mode-input:checked + .console .synced-only {
+  display: block;
+}
+
+.mode-input:checked + .console .cluster-health .synced-only,
+.mode-input:checked + .console .sync-control .synced-only,
+.mode-input:checked + .console .title-row .synced-only {
+  display: inline;
+}
+
+.mode-input:checked + .console .health-dot {
+  background: var(--teal);
+  box-shadow: 0 0 0 5px rgba(11, 136, 113, 0.14);
+}
+
+.mode-input:checked + .console .sync-control {
+  border-color: #348f7e;
+}
+
+.mode-input:checked + .console .switch {
+  background: var(--teal);
+}
+
+.mode-input:checked + .console .switch i {
+  transform: translateX(20px);
+}
+
+.mode-input:checked + .console .state-badge,
+.mode-input:checked + .console .topology-status {
+  color: var(--teal-dark);
+  background: var(--teal-soft);
+  border-color: #93d3c5;
+}
+
+.mode-input:checked + .console .metrics i {
+  background: var(--teal);
+}
+
+.mode-input:checked + .console .repair-path {
+  stroke: var(--teal);
+  stroke-dasharray: 0;
+}
+
+.mode-input:checked + .console .node-c {
+  border-color: #75c4b3;
+  box-shadow: 0 8px 28px rgba(11, 136, 113, 0.16);
+}
+
+.mode-input:checked + .console .exchange {
+  background: var(--teal-soft);
+  border-color: #8bd0c1;
+}
+
+.mode-input:checked + .console .exchange strong {
+  color: var(--teal-dark);
+}
+
+.mode-input:checked + .console .phase-track::after {
+  width: 100%;
+  background: var(--teal);
+}
+
+.mode-input:checked + .console .phase-track i,
+.mode-input:checked + .console .timeline li > i {
+  border-color: var(--teal);
+  box-shadow: inset 0 0 0 2px #fff;
+  background: var(--teal);
+}
+
+.mode-input:checked + .console .range-grid .mismatch {
+  color: #52656d;
+  background: var(--teal-soft);
+  border-color: #a9dbcf;
+  font-weight: 400;
+}
+
+.mode-input:checked + .console .range-note.success {
+  color: var(--teal-dark);
+  background: var(--teal-soft);
+  border-left-color: var(--teal);
+}
+
+@media (max-width: 1080px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .diagnostics {
+    display: grid;
+    grid-template-columns: 0.8fr 1.1fr 1.1fr;
+  }
+
+  .diagnostics > section + section {
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 760px) {
+  .console {
+    width: 100%;
+    min-height: 100vh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .topbar {
+    grid-template-columns: 1fr auto;
+    gap: 12px;
+    padding: 0 14px;
+  }
+
+  .cluster-health {
+    display: none;
+  }
+
+  .brand small,
+  .sync-control small {
+    display: none;
+  }
+
+  .sync-control {
+    min-width: 0;
+    padding: 7px;
+    border: 0;
+  }
+
+  .sync-control strong {
+    max-width: 70px;
+    font-size: 8px;
+  }
+
+  .intro {
+    display: block;
+    padding: 24px 17px 20px;
+  }
+
+  .title-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  h1 {
+    font-size: 28px;
+  }
+
+  .cluster-meta {
+    min-width: 0;
+    margin-top: 18px;
+  }
+
+  .cluster-meta div {
+    padding: 11px 9px;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .metrics article:nth-child(3) {
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+
+  .metrics article:nth-child(4) {
+    border-top: 1px solid var(--line);
+  }
+
+  .workspace {
+    padding: 9px;
+  }
+
+  .mesh {
+    min-height: 760px;
+  }
+
+  .links {
+    display: none;
+  }
+
+  .node {
+    right: 16px;
+    left: 16px;
+    width: auto;
+  }
+
+  .node-a {
+    top: 30px;
+  }
+
+  .node-b {
+    top: 230px;
+  }
+
+  .node-c {
+    top: 510px;
+    bottom: auto;
+    transform: none;
+  }
+
+  .exchange {
+    top: 430px;
+  }
+
+  .diagnostics {
+    display: block;
+  }
+
+  .diagnostics > section + section {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 400px) {
+  .brand strong {
+    font-size: 13px;
+  }
+
+  .brand-mark {
+    width: 32px;
+    height: 32px;
+  }
+
+  .cluster-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .cluster-meta div + div {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics article + article {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .metrics article {
+    min-height: 102px;
+  }
+
+  .panel-head {
+    align-items: flex-start;
+  }
+
+  .topology-status {
+    max-width: 96px;
+    text-align: center;
+  }
+
+  .topology-foot {
+    align-items: flex-start;
+    flex-direction: column;
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only gossip anti-entropy convergence lab
- visualize peer selection, Merkle range comparison, incremental repair, and digest verification
- include responsive topology layouts and a keyboard-accessible repair transition

## Why
The example makes a distributed replica repair cycle inspectable without JavaScript. It demonstrates how anti-entropy exchanges isolate divergent token ranges and transfer only the required rows instead of scanning or copying the full dataset.

## Validation
- `npx prettier --check submissions/examples/gossip-anti-entropy-kp/**/*.{html,css,md}`
- Stylelint via stdin for the new stylesheet
- `npm run lint:duplicates`
- `npm test` (61 tests)
- Playwright/Chrome QA at 1440x1000 and 390x844, including keyboard interaction and zero horizontal overflow