### PR TITLE
feat: add phi accrual failure detector monitor

### DIFF
--- a/submissions/examples/phi-accrual-failure-detector-kp/README.md
+++ b/submissions/examples/phi-accrual-failure-detector-kp/README.md
@@ -1,0 +1,26 @@
+# Phi Accrual Failure Detector Monitor
+
+A responsive, CSS-only operations monitor that demonstrates probabilistic
+failure detection from heartbeat arrival history.
+
+## What it demonstrates
+
+- Adaptive suspicion instead of a fixed binary timeout
+- A rolling heartbeat interval distribution
+- Phi confidence bands for healthy, watch, and suspect states
+- Reversible routing decisions when a delayed node recovers
+- A timeline from missed heartbeat to restored traffic
+
+## Interaction
+
+Use the **Deliver heartbeat** control to simulate a late node returning. The
+native checkbox remains keyboard focusable, so `Tab` and `Space` transition the
+monitor from suspect to healthy without JavaScript.
+
+## Technical notes
+
+- Pure HTML and CSS
+- Responsive desktop and mobile layouts
+- Visible keyboard focus handling
+- Reduced-motion support
+- No external assets or runtime dependencies

--- a/submissions/examples/phi-accrual-failure-detector-kp/demo.html
+++ b/submissions/examples/phi-accrual-failure-detector-kp/demo.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phi Accrual Failure Detector</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <input class="scenario-input" id="recover-node" type="checkbox" />
+
+    <main class="app">
+      <header class="topbar">
+        <a class="brand" href="#" aria-label="Pulseguard home">
+          <span class="brand-icon"><i></i></span>
+          <span
+            ><strong>Pulseguard</strong
+            ><small>failure intelligence</small></span
+          >
+        </a>
+        <div class="environment"><span>PRODUCTION</span><b>payments-eu</b></div>
+        <label class="scenario-control" for="recover-node">
+          <span>
+            <strong class="suspect-only">Deliver heartbeat</strong>
+            <strong class="healthy-only">Node recovered</strong>
+            <small>simulate next sample</small>
+          </span>
+          <i aria-hidden="true"><b></b></i>
+        </label>
+      </header>
+
+      <section class="hero">
+        <div>
+          <p class="eyebrow">CLUSTER OBSERVABILITY / NODE PAY-03</p>
+          <div class="title-row">
+            <h1>Phi accrual failure detector</h1>
+            <span class="status suspect-only">SUSPECT</span>
+            <span class="status healthy-only">HEALTHY</span>
+          </div>
+          <p class="subtitle suspect-only">
+            Heartbeat delay raised suspicion without treating one late packet as
+            a binary failure.
+          </p>
+          <p class="subtitle healthy-only">
+            The latest sample restored confidence and retained the learned
+            arrival distribution.
+          </p>
+        </div>
+        <dl class="hero-meta">
+          <div>
+            <dt>Window</dt>
+            <dd>100 samples</dd>
+          </div>
+          <div>
+            <dt>Threshold</dt>
+            <dd>φ 8.0</dd>
+          </div>
+          <div>
+            <dt>Min std dev</dt>
+            <dd>100ms</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="metrics" aria-label="Failure detector metrics">
+        <article>
+          <span>Current phi</span>
+          <strong class="suspect-only danger">9.42</strong>
+          <strong class="healthy-only good">0.18</strong>
+          <small class="suspect-only">above suspicion threshold</small>
+          <small class="healthy-only">confidence restored</small>
+        </article>
+        <article>
+          <span>Last heartbeat</span>
+          <strong class="suspect-only">4.8s ago</strong>
+          <strong class="healthy-only">12ms ago</strong>
+          <small>observer monotonic clock</small>
+        </article>
+        <article>
+          <span>Mean interval</span>
+          <strong>1.02s</strong>
+          <small>rolling arrival window</small>
+        </article>
+        <article>
+          <span>Availability decision</span>
+          <strong class="suspect-only danger">Degraded</strong>
+          <strong class="healthy-only good">Available</strong>
+          <small>threshold-based interpretation</small>
+        </article>
+      </section>
+
+      <div class="workspace">
+        <section class="chart-panel panel">
+          <header class="panel-head">
+            <div>
+              <p class="eyebrow">SUSPICION SIGNAL</p>
+              <h2>Phi over time</h2>
+            </div>
+            <div class="legend">
+              <span><i class="line-key"></i>φ score</span>
+              <span><i class="threshold-key"></i>threshold 8.0</span>
+            </div>
+          </header>
+
+          <div class="chart">
+            <div class="axis y-axis">
+              <span>12</span><span>8</span><span>4</span><span>0</span>
+            </div>
+            <div class="plot">
+              <div class="threshold"><span>SUSPECT φ ≥ 8</span></div>
+              <div class="grid-line one"></div>
+              <div class="grid-line two"></div>
+              <div class="grid-line three"></div>
+              <svg
+                viewBox="0 0 760 300"
+                preserveAspectRatio="none"
+                aria-hidden="true"
+              >
+                <defs>
+                  <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0" stop-color="#d34a47" stop-opacity=".25" />
+                    <stop offset="1" stop-color="#d34a47" stop-opacity=".02" />
+                  </linearGradient>
+                </defs>
+                <path
+                  class="area suspect-only"
+                  d="M0 285 L70 281 L140 278 L210 271 L280 254 L350 222 L420 180 L490 128 L560 79 L630 49 L700 65 L760 54 L760 300 L0 300 Z"
+                />
+                <path
+                  class="signal suspect-only"
+                  d="M0 285 L70 281 L140 278 L210 271 L280 254 L350 222 L420 180 L490 128 L560 79 L630 49 L700 65 L760 54"
+                />
+                <path
+                  class="signal healthy-only"
+                  d="M0 285 L70 281 L140 278 L210 271 L280 254 L350 222 L420 180 L490 128 L560 79 L630 49 L700 65 L760 286"
+                />
+              </svg>
+              <div class="sample sample-a"><i></i><span>1.01s</span></div>
+              <div class="sample sample-b"><i></i><span>1.08s</span></div>
+              <div class="sample sample-c"><i></i><span>0.97s</span></div>
+              <div class="sample sample-late suspect-only">
+                <i></i><span>4.8s late</span>
+              </div>
+              <div class="sample sample-back healthy-only">
+                <i></i><span>heartbeat 12ms</span>
+              </div>
+            </div>
+            <div class="x-axis">
+              <span>10:14:20</span><span>10:14:25</span><span>10:14:30</span
+              ><span>now</span>
+            </div>
+          </div>
+
+          <div class="node-strip">
+            <article>
+              <i class="node blue">01</i
+              ><span><b>pay-01</b><small>φ 0.09</small></span
+              ><em>HEALTHY</em>
+            </article>
+            <article>
+              <i class="node purple">02</i
+              ><span><b>pay-02</b><small>φ 0.11</small></span
+              ><em>HEALTHY</em>
+            </article>
+            <article class="target">
+              <i class="node orange">03</i>
+              <span>
+                <b>pay-03</b>
+                <small class="suspect-only">φ 9.42</small>
+                <small class="healthy-only">φ 0.18</small>
+              </span>
+              <em class="suspect-only danger">SUSPECT</em>
+              <em class="healthy-only">HEALTHY</em>
+            </article>
+          </div>
+        </section>
+
+        <aside class="details panel">
+          <section class="decision">
+            <header>
+              <div>
+                <p class="eyebrow">DECISION MODEL</p>
+                <h2>Confidence bands</h2>
+              </div>
+              <small>adaptive</small>
+            </header>
+            <div class="gauge">
+              <span class="band healthy-band"
+                ><b>0–3</b><small>healthy</small></span
+              >
+              <span class="band watch-band"
+                ><b>3–8</b><small>watch</small></span
+              >
+              <span class="band suspect-band"
+                ><b>8+</b><small>suspect</small></span
+              >
+              <i class="needle"></i>
+            </div>
+            <p class="decision-note suspect-only">
+              φ 9.42 means the observed pause is unlikely under the learned
+              arrival distribution.
+            </p>
+            <p class="decision-note healthy-only">
+              φ 0.18 is consistent with the learned heartbeat distribution.
+            </p>
+          </section>
+
+          <section class="distribution">
+            <header>
+              <div>
+                <p class="eyebrow">ARRIVAL MODEL</p>
+                <h2>Sample distribution</h2>
+              </div>
+              <small>last 100</small>
+            </header>
+            <dl>
+              <div>
+                <dt>Mean</dt>
+                <dd>1,020ms</dd>
+              </div>
+              <div>
+                <dt>Std deviation</dt>
+                <dd>118ms</dd>
+              </div>
+              <div>
+                <dt>Minimum</dt>
+                <dd>811ms</dd>
+              </div>
+              <div>
+                <dt>Maximum</dt>
+                <dd>1,284ms</dd>
+              </div>
+            </dl>
+            <div class="histogram" aria-label="Heartbeat interval histogram">
+              <i style="--h: 20%"></i><i style="--h: 42%"></i
+              ><i style="--h: 78%"></i> <i style="--h: 100%"></i
+              ><i style="--h: 86%"></i><i style="--h: 52%"></i>
+              <i style="--h: 27%"></i><i style="--h: 12%"></i>
+            </div>
+          </section>
+
+          <section class="timeline">
+            <header>
+              <div>
+                <p class="eyebrow">DETECTOR LOG</p>
+                <h2>Decision timeline</h2>
+              </div>
+              <small>monotonic</small>
+            </header>
+            <ol>
+              <li class="done">
+                <time>00ms</time><i></i
+                ><span
+                  ><b>Heartbeat expected</b
+                  ><small>mean interval elapsed</small></span
+                >
+              </li>
+              <li class="done">
+                <time>2.1s</time><i></i
+                ><span
+                  ><b>Enter watch band</b><small>φ crossed 3.0</small></span
+                >
+              </li>
+              <li>
+                <time>4.8s</time><i></i>
+                <span>
+                  <b class="suspect-only">Mark node suspect</b>
+                  <b class="healthy-only">Heartbeat received</b>
+                  <small class="suspect-only">φ crossed 8.0</small>
+                  <small class="healthy-only">sample added to window</small>
+                </span>
+              </li>
+              <li>
+                <time>now</time><i></i>
+                <span>
+                  <b class="suspect-only">Route traffic away</b>
+                  <b class="healthy-only">Restore traffic</b>
+                  <small class="suspect-only"
+                    >decision remains reversible</small
+                  >
+                  <small class="healthy-only">φ returned below 3.0</small>
+                </span>
+              </li>
+            </ol>
+          </section>
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/phi-accrual-failure-detector-kp/style.css
+++ b/submissions/examples/phi-accrual-failure-detector-kp/style.css
@@ -1,0 +1,1042 @@
+:root {
+  color-scheme: light;
+
+  --ink: #182226;
+  --muted: #68777d;
+  --canvas: #e8edef;
+  --surface: #fff;
+  --soft: #f4f6f7;
+  --line: #d5dde0;
+  --line-dark: #b9c4c8;
+  --nav: #141b1f;
+  --red: #d34a47;
+  --red-soft: #fff0ef;
+  --green: #0c8973;
+  --green-soft: #e8f7f3;
+  --amber: #d88921;
+  --blue: #2c6db4;
+  --purple: #7352b4;
+  --shadow: 0 18px 46px rgba(20, 31, 36, 0.1);
+  --ease: 520ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--canvas);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background:
+    linear-gradient(rgba(24, 34, 38, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(24, 34, 38, 0.035) 1px, transparent 1px),
+    var(--canvas);
+  background-size: 32px 32px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.scenario-input {
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.app {
+  width: min(1480px, calc(100% - 32px));
+  min-height: calc(100vh - 32px);
+  margin: 16px auto;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line-dark);
+  border-radius: 7px;
+  box-shadow: var(--shadow);
+}
+
+.topbar {
+  min-height: 68px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 22px;
+  padding: 0 25px;
+  color: #fff;
+  background: var(--nav);
+}
+
+.brand {
+  width: max-content;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.brand-icon {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  background: #f6f8f8;
+  border-radius: 4px;
+}
+
+.brand-icon i,
+.brand-icon i::before,
+.brand-icon i::after {
+  width: 4px;
+  height: 4px;
+  background: var(--green);
+  border-radius: 50%;
+}
+
+.brand-icon i {
+  position: relative;
+  box-shadow:
+    7px 0 0 var(--green),
+    14px 0 0 var(--green);
+}
+
+.brand-icon i::before,
+.brand-icon i::after {
+  content: "";
+  position: absolute;
+}
+
+.brand-icon i::before {
+  top: -7px;
+  left: 7px;
+}
+
+.brand-icon i::after {
+  top: 7px;
+  left: 7px;
+}
+
+.brand strong,
+.brand small {
+  display: block;
+}
+
+.brand strong {
+  font-size: 15px;
+}
+
+.brand small {
+  margin-top: 2px;
+  color: #9aaab0;
+  font-size: 9px;
+}
+
+.environment {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #afbec3;
+  font-size: 9px;
+}
+
+.environment span {
+  padding: 4px 6px;
+  color: #f3c3c1;
+  background: rgba(211, 74, 71, 0.15);
+  border: 1px solid rgba(211, 74, 71, 0.45);
+  border-radius: 3px;
+}
+
+.scenario-control {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 9px 7px 12px;
+  border: 1px solid #53636a;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.scenario-control strong,
+.scenario-control small {
+  display: block;
+  text-align: right;
+}
+
+.scenario-control strong {
+  font-size: 10px;
+}
+
+.scenario-control small {
+  margin-top: 2px;
+  color: #93a5ac;
+  font-size: 8px;
+}
+
+.scenario-control > i {
+  width: 42px;
+  height: 22px;
+  padding: 3px;
+  background: #4c5a60;
+  border-radius: 14px;
+  transition: var(--ease);
+}
+
+.scenario-control > i b {
+  display: block;
+  width: 16px;
+  height: 16px;
+  background: #fff;
+  border-radius: 50%;
+  transition: var(--ease);
+}
+
+.scenario-input:focus-visible + .app .scenario-control {
+  outline: 3px solid #73b8ff;
+  outline-offset: 3px;
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 36px;
+  padding: 29px 31px 25px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 7px;
+  color: #52636a;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 8px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 34px;
+  line-height: 1.06;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 15px;
+  letter-spacing: 0;
+}
+
+.status {
+  padding: 4px 8px;
+  color: var(--red);
+  background: var(--red-soft);
+  border: 1px solid #e5a8a5;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.subtitle {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.hero-meta {
+  min-width: 360px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 0;
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.hero-meta div {
+  padding: 13px 14px;
+}
+
+.hero-meta div + div {
+  border-left: 1px solid var(--line);
+}
+
+.hero-meta dt {
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.hero-meta dd {
+  margin: 5px 0 0;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--line);
+}
+
+.metrics article {
+  min-height: 115px;
+  padding: 23px 22px 19px;
+  border-bottom: 3px solid var(--red);
+  transition: var(--ease);
+}
+
+.metrics article + article {
+  border-left: 1px solid var(--line);
+}
+
+.metrics span,
+.metrics strong,
+.metrics small {
+  display: block;
+}
+
+.metrics span {
+  color: #52636a;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.metrics strong {
+  margin: 10px 0 4px;
+  font-size: 22px;
+}
+
+.metrics small {
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.danger {
+  color: var(--red);
+}
+
+.good {
+  color: var(--green);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(340px, 0.9fr);
+  gap: 14px;
+  padding: 14px;
+  background: var(--soft);
+}
+
+.panel {
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.panel-head,
+.details header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 15px;
+}
+
+.panel-head {
+  min-height: 66px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-head .eyebrow,
+.details .eyebrow {
+  margin-bottom: 5px;
+}
+
+.legend {
+  display: flex;
+  gap: 15px;
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.legend span {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.legend i {
+  width: 18px;
+  height: 2px;
+  display: inline-block;
+}
+
+.line-key {
+  background: var(--red);
+}
+
+.threshold-key {
+  border-top: 2px dashed var(--amber);
+}
+
+.chart {
+  min-height: 430px;
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  grid-template-rows: 1fr 30px;
+  padding: 25px 20px 5px 10px;
+  background:
+    linear-gradient(90deg, rgba(24, 34, 38, 0.035) 1px, transparent 1px),
+    #fcfdfd;
+  background-size: 45px 100%;
+}
+
+.y-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-bottom: 4px;
+  color: var(--muted);
+  font-family: Consolas, monospace;
+  font-size: 8px;
+}
+
+.plot {
+  position: relative;
+  min-height: 340px;
+  border-bottom: 1px solid var(--line-dark);
+  border-left: 1px solid var(--line-dark);
+}
+
+.plot svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.signal {
+  fill: none;
+  stroke: var(--red);
+  stroke-width: 3;
+  vector-effect: non-scaling-stroke;
+  transition: var(--ease);
+}
+
+.area {
+  fill: url("#area");
+}
+
+.threshold {
+  position: absolute;
+  top: 33%;
+  right: 0;
+  left: 0;
+  z-index: 1;
+  border-top: 2px dashed var(--amber);
+}
+
+.threshold span {
+  position: absolute;
+  top: -20px;
+  right: 8px;
+  padding: 3px 5px;
+  color: #8a5818;
+  background: #fff7e8;
+  font-size: 7px;
+  font-weight: 800;
+}
+
+.grid-line {
+  position: absolute;
+  right: 0;
+  left: 0;
+  border-top: 1px solid var(--line);
+}
+
+.grid-line.one {
+  top: 0;
+}
+
+.grid-line.two {
+  top: 66%;
+}
+
+.grid-line.three {
+  bottom: 0;
+}
+
+.sample {
+  position: absolute;
+  bottom: 8px;
+  z-index: 2;
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.sample i {
+  width: 7px;
+  height: 7px;
+  display: block;
+  margin: 0 auto 4px;
+  background: #fff;
+  border: 2px solid var(--red);
+  border-radius: 50%;
+}
+
+.sample-a {
+  left: 9%;
+}
+
+.sample-b {
+  left: 27%;
+}
+
+.sample-c {
+  left: 46%;
+}
+
+.sample-late,
+.sample-back {
+  right: 1%;
+  bottom: 82%;
+  color: var(--red);
+  font-weight: 800;
+}
+
+.sample-back {
+  bottom: 8px;
+  color: var(--green);
+}
+
+.x-axis {
+  grid-column: 2;
+  display: flex;
+  justify-content: space-between;
+  padding-top: 9px;
+  color: var(--muted);
+  font-family: Consolas, monospace;
+  font-size: 7px;
+}
+
+.node-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--line);
+}
+
+.node-strip article {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 15px;
+}
+
+.node-strip article + article {
+  border-left: 1px solid var(--line);
+}
+
+.node {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  color: #fff;
+  background: var(--blue);
+  border-radius: 3px;
+  font-style: normal;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.node.purple {
+  background: var(--purple);
+}
+
+.node.orange {
+  background: var(--amber);
+}
+
+.node-strip b,
+.node-strip small {
+  display: block;
+}
+
+.node-strip b {
+  font-size: 9px;
+}
+
+.node-strip small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.node-strip em {
+  margin-left: auto;
+  color: var(--green);
+  font-style: normal;
+  font-size: 7px;
+  font-weight: 800;
+}
+
+.node-strip .target {
+  background: var(--red-soft);
+  transition: var(--ease);
+}
+
+.details > section {
+  padding: 17px;
+}
+
+.details > section + section {
+  border-top: 1px solid var(--line);
+}
+
+.details header > small {
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.gauge {
+  display: grid;
+  grid-template-columns: 3fr 5fr 4fr;
+  margin-top: 17px;
+  position: relative;
+}
+
+.band {
+  min-height: 56px;
+  display: grid;
+  place-content: center;
+  text-align: center;
+}
+
+.band b,
+.band small {
+  display: block;
+}
+
+.band b {
+  font-size: 10px;
+}
+
+.band small {
+  margin-top: 3px;
+  font-size: 7px;
+}
+
+.healthy-band {
+  color: #086754;
+  background: var(--green-soft);
+}
+
+.watch-band {
+  color: #865516;
+  background: #fff7e8;
+}
+
+.suspect-band {
+  color: #963a37;
+  background: var(--red-soft);
+}
+
+.needle {
+  position: absolute;
+  right: 14%;
+  bottom: -5px;
+  width: 2px;
+  height: 66px;
+  background: var(--ink);
+  transform-origin: bottom;
+  transition: var(--ease);
+}
+
+.needle::before {
+  content: "";
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: 8px;
+  height: 8px;
+  background: var(--ink);
+  border-radius: 50%;
+}
+
+.decision-note {
+  margin: 14px 0 0;
+  padding: 9px 10px;
+  color: #813633;
+  background: var(--red-soft);
+  border-left: 3px solid var(--red);
+  font-size: 8px;
+  line-height: 1.5;
+}
+
+.distribution dl {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin: 14px 0 0;
+  border: 1px solid var(--line);
+}
+
+.distribution dl div {
+  padding: 9px;
+}
+
+.distribution dl div:nth-child(even) {
+  border-left: 1px solid var(--line);
+}
+
+.distribution dl div:nth-child(n + 3) {
+  border-top: 1px solid var(--line);
+}
+
+.distribution dt {
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.distribution dd {
+  margin: 4px 0 0;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.histogram {
+  height: 75px;
+  display: flex;
+  align-items: flex-end;
+  gap: 5px;
+  padding-top: 12px;
+}
+
+.histogram i {
+  width: 100%;
+  height: var(--h);
+  background: #93aaaf;
+  border-radius: 2px 2px 0 0;
+  transition: var(--ease);
+}
+
+.timeline ol {
+  margin: 17px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 31px 10px 1fr;
+  gap: 8px;
+  min-height: 58px;
+}
+
+.timeline li:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  bottom: 0;
+  left: 43px;
+  width: 1px;
+  background: var(--line-dark);
+}
+
+.timeline time {
+  color: var(--muted);
+  font-family: Consolas, monospace;
+  font-size: 7px;
+}
+
+.timeline li > i {
+  z-index: 1;
+  width: 9px;
+  height: 9px;
+  background: #fff;
+  border: 2px solid var(--red);
+  border-radius: 50%;
+  transition: var(--ease);
+}
+
+.timeline b,
+.timeline small {
+  display: block;
+}
+
+.timeline b {
+  font-size: 9px;
+}
+
+.timeline small {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.healthy-only {
+  display: none;
+}
+
+.scenario-input:checked + .app .suspect-only {
+  display: none;
+}
+
+.scenario-input:checked + .app .healthy-only {
+  display: block;
+}
+
+.scenario-input:checked + .app .scenario-control .healthy-only,
+.scenario-input:checked + .app .title-row .healthy-only,
+.scenario-input:checked + .app .node-strip .healthy-only {
+  display: inline;
+}
+
+.scenario-input:checked + .app .scenario-control > i {
+  background: var(--green);
+}
+
+.scenario-input:checked + .app .scenario-control > i b {
+  transform: translateX(20px);
+}
+
+.scenario-input:checked + .app .status {
+  color: #086754;
+  background: var(--green-soft);
+  border-color: #93d1c4;
+}
+
+.scenario-input:checked + .app .metrics article {
+  border-bottom-color: var(--green);
+}
+
+.scenario-input:checked + .app .signal {
+  stroke: var(--green);
+}
+
+.scenario-input:checked + .app .sample i {
+  border-color: var(--green);
+}
+
+.scenario-input:checked + .app .node-strip .target {
+  background: var(--green-soft);
+}
+
+.scenario-input:checked + .app .needle {
+  right: 88%;
+}
+
+.scenario-input:checked + .app .decision-note {
+  color: #086754;
+  background: var(--green-soft);
+  border-left-color: var(--green);
+}
+
+.scenario-input:checked + .app .histogram i {
+  background: #70bbaa;
+}
+
+.scenario-input:checked + .app .timeline li > i {
+  border-color: var(--green);
+  background: var(--green);
+  box-shadow: inset 0 0 0 2px #fff;
+}
+
+@media (max-width: 1080px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .details {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .details > section + section {
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 760px) {
+  .app {
+    width: 100%;
+    min-height: 100vh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .topbar {
+    grid-template-columns: 1fr auto;
+    padding: 0 14px;
+  }
+
+  .environment {
+    display: none;
+  }
+
+  .brand small,
+  .scenario-control small {
+    display: none;
+  }
+
+  .scenario-control {
+    padding: 6px;
+    border: 0;
+  }
+
+  .scenario-control strong {
+    max-width: 70px;
+    font-size: 8px;
+  }
+
+  .hero {
+    display: block;
+    padding: 24px 17px 20px;
+  }
+
+  .title-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  h1 {
+    font-size: 28px;
+  }
+
+  .hero-meta {
+    min-width: 0;
+    margin-top: 18px;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .metrics article:nth-child(3) {
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+
+  .metrics article:nth-child(4) {
+    border-top: 1px solid var(--line);
+  }
+
+  .workspace {
+    padding: 9px;
+  }
+
+  .legend {
+    display: none;
+  }
+
+  .chart {
+    min-height: 350px;
+    padding-right: 10px;
+  }
+
+  .plot {
+    min-height: 275px;
+  }
+
+  .node-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .node-strip article + article {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .details {
+    display: block;
+  }
+
+  .details > section + section {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 400px) {
+  .brand strong {
+    font-size: 13px;
+  }
+
+  .brand-icon {
+    width: 32px;
+    height: 32px;
+  }
+
+  .hero-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-meta div + div {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics article + article {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .metrics article {
+    min-height: 102px;
+  }
+
+  .panel-head {
+    padding-right: 12px;
+    padding-left: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only phi-accrual failure detector monitor
- visualize heartbeat history, adaptive suspicion, confidence bands, and reversible routing decisions
- include responsive layouts and a keyboard-accessible node recovery transition

## Why
The example explains why distributed systems benefit from probabilistic failure detection instead of a fixed binary timeout. It connects the learned heartbeat distribution to a phi score and an operational availability decision.

## Validation
- `npx prettier --check submissions/examples/phi-accrual-failure-detector-kp/**/*.{html,css,md}`
- Stylelint via stdin for the new stylesheet
- `npm run lint:duplicates`
- `npm test` (61 tests)
- Playwright/Chrome QA at 1440x1000 and 390x844, including keyboard interaction and zero horizontal overflow