### PR TITLE
feat(icon): add forced-colors mode accessibility support

### DIFF
--- a/submissions/examples/feat-icon-forced-colors-ag/README.md
+++ b/submissions/examples/feat-icon-forced-colors-ag/README.md
@@ -1,0 +1,33 @@
+# Icon Forced Colors Mode Support
+
+## Description
+This submission enhances the `icon` component with full support for the
+`forced-colors: active` CSS media query, ensuring the component remains fully
+accessible and visible when users enable Windows High Contrast Mode or
+other forced-color themes.
+
+Without this query, components that rely on background colors or box-shadows
+for boundaries often become invisible because the OS strips these properties
+away. This fix maps component states to standard CSS system colors like
+`CanvasText`, `Highlight`, and `GrayText`.
+
+## Accessibility Standards
+- WCAG 2.1 Success Criterion 1.4.1: Use of Color (Level A)
+- WCAG 2.1 Success Criterion 1.4.11: Non-text Contrast (Level AA)
+
+## Changes
+- `style.css`: 90+ lines. Base styles define the default layout and colors.
+  The `@media (forced-colors: active)` block overrides colors using CSS
+  system colors, ensuring borders and text adapt correctly.
+- `demo.html`: Full HTML5 boilerplate with testing instructions and examples
+  of both active and disabled component states.
+- `README.md`: Documents the accessibility rationale and testing steps.
+
+## How to Test
+1. Open `demo.html` in Chrome or Edge.
+2. Open DevTools, press `Ctrl+Shift+P` (Windows) or `Cmd+Shift+P` (Mac).
+3. Type "Emulate CSS forced-colors" and select "forced-colors: active".
+4. Observe that the component borders, text, and hover states now use the
+   strict high-contrast system colors.
+
+Fixes #57855

--- a/submissions/examples/feat-icon-forced-colors-ag/demo.html
+++ b/submissions/examples/feat-icon-forced-colors-ag/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Icon Forced Colors Mode Support - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            background: #f8fafc;
+            padding: 3rem;
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+        .notice {
+            background: #eff6ff;
+            border-left: 4px solid #3b82f6;
+            color: #1e40af;
+            padding: 1.25rem;
+            border-radius: 6px;
+            line-height: 1.6;
+            font-size: 0.95rem;
+        }
+        .notice code {
+            background: #dbeafe;
+            padding: 0.1rem 0.3rem;
+            border-radius: 3px;
+        }
+        /* Simple test button to toggle emulation in supported browsers */
+        button#toggle-forced {
+            padding: 0.5rem 1rem;
+            background: #1f2937;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            align-self: flex-start;
+        }
+    </style>
+</head>
+<body>
+    <h1>Icon: Forced Colors Support</h1>
+
+    <div class="notice">
+        <strong>How to test:</strong> Open browser DevTools, press <code>Ctrl+Shift+P</code> (or Cmd+Shift+P), type "Emulate CSS forced-colors", and select "forced-colors: active". 
+        Alternatively, enable Windows High Contrast Mode.
+    </div>
+
+    <div class="ease-icon" tabindex="0" role="group" aria-label="icon example">
+        <div class="ease-icon-header">
+            <span class="ease-icon-icon"></span>
+            Interactive Icon
+        </div>
+        <div class="ease-icon-body">
+            This component fully supports forced-colors mode. Shadows are replaced by high-contrast system borders, and all colors adapt to CanvasText and Highlight variables to ensure 100% readability.
+        </div>
+    </div>
+
+    <div class="ease-icon" disabled tabindex="-1" aria-disabled="true">
+        <div class="ease-icon-header">Disabled State</div>
+        <div class="ease-icon-body">
+            In forced-colors mode, disabled elements use the <code>GrayText</code> system color instead of relying on opacity.
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/feat-icon-forced-colors-ag/style.css
+++ b/submissions/examples/feat-icon-forced-colors-ag/style.css
@@ -1,0 +1,114 @@
+/*
+ * Feature: icon Forced Colors Mode Support
+ * Implements @media (forced-colors: active) to ensure the component
+ * remains accessible when Windows High Contrast Mode or similar
+ * forced-color themes are active.
+ *
+ * WCAG 2.1 Success Criterion 1.4.1: Use of Color (Level A)
+ * WCAG 2.1 Success Criterion 1.4.11: Non-text Contrast (Level AA)
+ */
+
+/* ===== Base Component Styles ===== */
+.ease-icon {
+    position: relative;
+    box-sizing: border-box;
+    background-color: var(--ease-surface, #ffffff);
+    color: var(--ease-text, #111827);
+    border: 2px solid var(--ease-border, #d1d5db);
+    border-radius: var(--ease-radius-md, 6px);
+    padding: 1.25rem 1.5rem;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    transition: all 0.2s ease-in-out;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.ease-icon:hover {
+    background-color: var(--ease-surface-hover, #f3f4f6);
+    border-color: var(--ease-primary, #3b82f6);
+}
+
+.ease-icon:focus-visible {
+    outline: 3px solid var(--ease-primary, #3b82f6);
+    outline-offset: 2px;
+}
+
+.ease-icon[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background-color: #f9fafb;
+}
+
+.ease-icon-header {
+    font-weight: 700;
+    font-size: 1.125rem;
+    margin-bottom: 0.5rem;
+    color: var(--ease-heading, #1f2937);
+}
+
+.ease-icon-body {
+    color: var(--ease-muted, #4b5563);
+}
+
+.ease-icon-icon {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    background-color: var(--ease-primary, #3b82f6);
+    mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>');
+    -webkit-mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>');
+}
+
+/* ===== Forced Colors Mode Overrides ===== */
+/*
+ * When the OS forces colors, background-color and box-shadow are often stripped.
+ * We must rely on standard system colors (Canvas, CanvasText, Highlight, etc)
+ * and visible borders to communicate state and boundaries.
+ */
+@media (forced-colors: active) {
+    .ease-icon {
+        /* Re-establish borders since shadows are removed */
+        border: 2px solid CanvasText;
+        /* Clear any background overrides to respect the OS theme */
+        background-color: Canvas !important;
+        color: CanvasText !important;
+    }
+
+    .ease-icon:hover {
+        /* Use Highlight border to indicate interactive hover state */
+        border-color: Highlight;
+    }
+
+    .ease-icon:focus-visible {
+        /* Ensure focus ring uses system Highlight color */
+        outline: 3px solid Highlight;
+        outline-offset: 3px;
+    }
+
+    .ease-icon[disabled] {
+        /* Opacity is often ignored; use GrayText for disabled elements */
+        border-color: GrayText;
+        color: GrayText !important;
+    }
+
+    .ease-icon-header,
+    .ease-icon-body {
+        color: inherit !important;
+    }
+
+    .ease-icon-icon {
+        /* SVGs colored via background-color will disappear. Use CanvasText */
+        background-color: CanvasText;
+    }
+
+    /* For interactive elements, switch icon to Highlight on hover */
+    .ease-icon:hover .ease-icon-icon {
+        background-color: Highlight;
+    }
+
+    /* Disabled icons should be GrayText */
+    .ease-icon[disabled] .ease-icon-icon {
+        background-color: GrayText;
+    }
+}


### PR DESCRIPTION
### Description
Fixes #57855.

Adds robust `@media (forced-colors: active)` support to the `icon` component.
This ensures the component remains fully accessible and its boundaries are clearly
visible when a user activates Windows High Contrast Mode or another forced-color
theme.

### Changes Made
- `style.css`: 90+ lines. Defines base styles and a dedicated `forced-colors` block
  that correctly maps component states (default, hover, focus, disabled) to standard
  CSS system colors (`CanvasText`, `Highlight`, `GrayText`).
- `demo.html`: Full HTML5 boilerplate with DevTools testing instructions and
  interactive examples.
- `README.md`: Documents WCAG compliance and testing procedures.

### Checklist
- [x] I have followed the contribution guidelines
- [x] `demo.html` has `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` tags
- [x] `style.css` has original, meaningful CSS (90+ lines)
- [x] `README.md` included
- [x] Files placed in NEW folder `submissions/examples/feat-icon-forced-colors-ag/`
- [x] No edits to `core/` or `components/` or any existing files
- [x] Single commit following conventional-commit format
- [x] Only files inside `submissions/` directory are added
