### PR TITLE
feat: add skeleton loader example

### DIFF
--- a/submissions/examples/skeleton-loader/README.md
+++ b/submissions/examples/skeleton-loader/README.md
@@ -1,0 +1,102 @@
+````markdown
+# Skeleton Loader
+
+A lightweight CSS-only skeleton loading component with a smooth shimmer animation.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Smooth shimmer animation
+- Responsive layout
+- Card and list skeleton examples
+- Customizable CSS variables
+- Reduced-motion support
+- Lightweight and reusable
+
+## Preview
+
+The component demonstrates loading placeholders for:
+
+- Image
+- Title
+- Text content
+- Button
+- Avatar
+- List items
+
+A shimmer highlight continuously moves across the placeholders to indicate that content is loading.
+
+## Customization
+
+The animation can be customized using CSS custom properties.
+
+```css
+:root {
+    --skeleton-base: #e5e7eb;
+    --skeleton-shimmer: #f8fafc;
+    --shimmer-duration: 1.5s;
+    --card-radius: 14px;
+}
+````
+
+### Available Variables
+
+| Variable             | Purpose                 | Default   |
+| -------------------- | ----------------------- | --------- |
+| `--skeleton-base`    | Base skeleton color     | `#e5e7eb` |
+| `--skeleton-shimmer` | Shimmer highlight color | `#f8fafc` |
+| `--shimmer-duration` | Shimmer speed           | `1.5s`    |
+| `--card-radius`      | Card corner radius      | `14px`    |
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Then add the skeleton elements:
+
+```html
+<div class="skeleton skeleton-title"></div>
+<div class="skeleton skeleton-text"></div>
+<div class="skeleton skeleton-button"></div>
+```
+
+## Accessibility
+
+The demo includes:
+
+* Semantic HTML structure
+* `aria-label` to describe loading content
+* `prefers-reduced-motion` support
+* No JavaScript dependency
+
+## Responsive Design
+
+The skeleton card changes from a horizontal layout to a vertical layout on smaller screens.
+
+## Browser Support
+
+The component uses standard CSS features such as:
+
+* CSS custom properties
+* CSS animations
+* CSS gradients
+* Media queries
+* Pseudo-elements
+
+Modern browsers are recommended.
+
+## Contribution
+
+This component is submitted for EaseMotion CSS.
+
+Files are located at:
+
+`submissions/examples/skeleton-loader/`
+
+```
+```

--- a/submissions/examples/skeleton-loader/demo.html
+++ b/submissions/examples/skeleton-loader/demo.html
@@ -1,0 +1,57 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skeleton Loader</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="demo">
+        <h1>Skeleton Loader</h1>
+        <p class="subtitle">
+            CSS-only shimmer loading animation.
+        </p>
+
+        <section class="skeleton-card" aria-label="Loading content">
+            <div class="skeleton skeleton-image"></div>
+
+            <div class="skeleton-content">
+                <div class="skeleton skeleton-title"></div>
+
+                <div class="skeleton skeleton-text"></div>
+                <div class="skeleton skeleton-text"></div>
+                <div class="skeleton skeleton-text short"></div>
+
+                <div class="skeleton skeleton-button"></div>
+            </div>
+        </section>
+
+        <section class="skeleton-list" aria-label="Loading items">
+
+            <article class="skeleton-item">
+                <div class="skeleton skeleton-avatar"></div>
+
+                <div class="item-content">
+                    <div class="skeleton skeleton-name"></div>
+                    <div class="skeleton skeleton-line"></div>
+                </div>
+            </article>
+
+            <article class="skeleton-item">
+                <div class="skeleton skeleton-avatar"></div>
+
+                <div class="item-content">
+                    <div class="skeleton skeleton-name"></div>
+                    <div class="skeleton skeleton-line"></div>
+                </div>
+            </article>
+
+        </section>
+    </main>
+
+</body>
+</html>
+

--- a/submissions/examples/skeleton-loader/style.css
+++ b/submissions/examples/skeleton-loader/style.css
@@ -1,0 +1,195 @@
+
+:root {
+    --skeleton-base: #e5e7eb;
+    --skeleton-shimmer: #f8fafc;
+    --background: #f3f4f6;
+    --card-background: #ffffff;
+
+    --shimmer-duration: 1.5s;
+    --card-radius: 14px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    min-height: 100vh;
+    font-family: Arial, sans-serif;
+    background: var(--background);
+    color: #1f2937;
+}
+
+.demo {
+    width: min(850px, 92%);
+    margin: 60px auto;
+}
+
+h1 {
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.subtitle {
+    text-align: center;
+    color: #6b7280;
+    margin-bottom: 40px;
+}
+
+/* Common skeleton */
+
+.skeleton {
+    position: relative;
+    overflow: hidden;
+    background: var(--skeleton-base);
+}
+
+.skeleton::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        var(--skeleton-shimmer) 50%,
+        transparent 100%
+    );
+
+    transform: translateX(-100%);
+    animation: shimmer var(--shimmer-duration) infinite;
+}
+
+/* Main card */
+
+.skeleton-card {
+    display: flex;
+    gap: 25px;
+    padding: 25px;
+    background: var(--card-background);
+    border-radius: var(--card-radius);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+}
+
+.skeleton-image {
+    width: 260px;
+    height: 190px;
+    flex-shrink: 0;
+    border-radius: 10px;
+}
+
+.skeleton-content {
+    flex: 1;
+    padding-top: 5px;
+}
+
+.skeleton-title {
+    width: 65%;
+    height: 28px;
+    border-radius: 6px;
+    margin-bottom: 25px;
+}
+
+.skeleton-text {
+    width: 100%;
+    height: 14px;
+    border-radius: 5px;
+    margin-bottom: 12px;
+}
+
+.skeleton-text.short {
+    width: 70%;
+}
+
+.skeleton-button {
+    width: 120px;
+    height: 38px;
+    border-radius: 7px;
+    margin-top: 15px;
+}
+
+/* Skeleton list */
+
+.skeleton-list {
+    display: grid;
+    gap: 15px;
+    margin-top: 25px;
+}
+
+.skeleton-item {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 20px;
+
+    background: var(--card-background);
+    border-radius: var(--card-radius);
+}
+
+.skeleton-avatar {
+    width: 55px;
+    height: 55px;
+    flex-shrink: 0;
+    border-radius: 50%;
+}
+
+.item-content {
+    flex: 1;
+}
+
+.skeleton-name {
+    width: 35%;
+    height: 16px;
+    border-radius: 5px;
+    margin-bottom: 12px;
+}
+
+.skeleton-line {
+    width: 75%;
+    height: 12px;
+    border-radius: 5px;
+}
+
+/* Shimmer animation */
+
+@keyframes shimmer {
+    100% {
+        transform: translateX(100%);
+    }
+}
+
+/* Responsive */
+
+@media (max-width: 650px) {
+    .skeleton-card {
+        flex-direction: column;
+    }
+
+    .skeleton-image {
+        width: 100%;
+        height: 180px;
+    }
+
+    .skeleton-title {
+        width: 80%;
+    }
+
+    .skeleton-name {
+        width: 50%;
+    }
+
+    .skeleton-line {
+        width: 90%;
+    }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+    .skeleton::after {
+        animation: none;
+    }
+}
+


### PR DESCRIPTION
```markdown
## Description

Added a CSS-only Skeleton Loader with a smooth shimmer animation.

### Changes

- Added `demo.html`
- Added `style.css`
- Added `README.md`
- Added shimmer loading animation
- Added card skeleton
- Added list-item skeleton
- Added responsive layout
- Added CSS custom properties for customization
- Added `prefers-reduced-motion` support
- No JavaScript required

### Issue

Closes #57892

### Checklist

- [x] Added files only inside `submissions/`
- [x] Included `demo.html`
- [x] Included `style.css`
- [x] Included `README.md`
- [x] Pure CSS implementation
- [x] Responsive design
- [x] Accessibility considered
- [x] Reduced-motion support included
- [x] Tested locally
```
