### PR TITLE
feat: add floating labels example

### DIFF
--- a/submissions/examples/floating-labels/README.md
+++ b/submissions/examples/floating-labels/README.md
@@ -1,0 +1,31 @@
+# Floating Labels
+
+## Issue
+
+#57926
+
+## Description
+
+A reusable floating-label form component where the label smoothly moves above the input when the field is focused or contains text.
+
+## Features
+
+- Smooth floating label animation
+- Works with text, email, and password inputs
+- Pure HTML and CSS
+- No JavaScript required
+- Responsive design
+- Supports reduced-motion preferences
+
+## Files
+
+- `demo.html` - Demonstration page
+- `style.css` - Floating-label styles and animations
+
+## Usage
+
+```html
+<div class="form-group">
+  <input type="text" id="name" placeholder=" " required>
+  <label for="name">Your Name</label>
+</div>

--- a/submissions/examples/floating-labels/demo.html
+++ b/submissions/examples/floating-labels/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Floating Labels</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <h1>Floating Labels</h1>
+
+    <div class="form-group">
+      <input type="text" id="name" placeholder=" " required>
+      <label for="name">Your Name</label>
+    </div>
+
+    <div class="form-group">
+      <input type="email" id="email" placeholder=" " required>
+      <label for="email">Email Address</label>
+    </div>
+
+    <div class="form-group">
+      <input type="password" id="password" placeholder=" " required>
+      <label for="password">Password</label>
+    </div>
+
+    <button type="button">Submit</button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/floating-labels/style.css
+++ b/submissions/examples/floating-labels/style.css
@@ -1,0 +1,87 @@
+* {
+    box-sizing: border-box;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-family: Arial, sans-serif;
+    background: #f4f4f4;
+  }
+  
+  .container {
+    width: 350px;
+    padding: 30px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  }
+  
+  h1 {
+    text-align: center;
+    margin-bottom: 30px;
+  }
+  
+  .form-group {
+    position: relative;
+    margin-bottom: 25px;
+  }
+  
+  .form-group input {
+    width: 100%;
+    padding: 14px 12px;
+    border: 2px solid #ccc;
+    border-radius: 6px;
+    outline: none;
+    font-size: 16px;
+    background: transparent;
+    transition: border-color 0.3s ease;
+  }
+  
+  .form-group label {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    padding: 0 5px;
+    color: #777;
+    background: white;
+    pointer-events: none;
+    transition: 0.3s ease;
+  }
+  
+  .form-group input:focus {
+    border-color: #333;
+  }
+  
+  .form-group input:focus + label,
+  .form-group input:not(:placeholder-shown) + label {
+    top: 0;
+    font-size: 12px;
+    color: #333;
+  }
+  
+  button {
+    width: 100%;
+    padding: 13px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: transform 0.2s ease;
+  }
+  
+  button:hover {
+    transform: translateY(-2px);
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    .form-group input,
+    .form-group label,
+    button {
+      transition: none;
+    }
+  }


### PR DESCRIPTION
## Related Issue

Closes #57926

## What does this PR do?

- Adds a reusable Floating Labels example
- Adds smooth label transition on focus
- Keeps labels floated when inputs contain text
- Uses only HTML and CSS
- Adds reduced-motion support
- Includes demo.html, style.css, and README.md

## Files Added

submissions/examples/floating-labels/
├── demo.html
├── style.css
└── README.md

## Testing

- Tested focus state
- Tested filled input state
- Tested responsive layout
- Tested reduced-motion preference