### PR TITLE
feat: add auto dark mode demo via prefers-color-scheme (#57936)

### DIFF
--- a/submissions/examples/dark-mode-auto/README.md
+++ b/submissions/examples/dark-mode-auto/README.md
@@ -1,0 +1,24 @@
+# Auto Dark Mode
+
+Resolves #57936
+
+## What it does
+Adds a `prefers-color-scheme: dark` media query that swaps core color
+tokens (background, surface, text, border, shadow) to a dark palette
+automatically, based on the user's OS/browser setting — no extra class
+or JS required.
+
+## How it composes with existing theming
+This layers on top of the existing `:root` override pattern described
+in the README. Anyone already overriding `--ease-color-*` manually is
+unaffected, since their own `:root` rule wins over the media query.
+
+## Suggested integration
+Maintainer can fold the dark values into `core/variables.css` by adding
+a `@media (prefers-color-scheme: dark)` block around the existing
+`--ease-color-*` custom properties, using the same token names already
+defined there.
+
+## Try it
+Open `demo.html` in a browser and toggle your system theme between
+light and dark.

--- a/submissions/examples/dark-mode-auto/demo.html
+++ b/submissions/examples/dark-mode-auto/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Auto Dark Mode Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Auto Dark Mode</h1>
+  <p>Switch your OS/browser theme to see this update automatically — no class or JS toggle needed.</p>
+
+  <div class="demo-card">
+    <h3>Card Title</h3>
+    <p>This card's colors follow your system's light/dark preference.</p>
+    <button class="demo-btn">Action</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dark-mode-auto/style.css
+++ b/submissions/examples/dark-mode-auto/style.css
@@ -1,0 +1,58 @@
+/*
+  Auto Dark Mode — self-contained demo
+  Mirrors EaseMotion's --ease-color-* token naming.
+  Maintainer will fold the dark values into core/variables.css.
+*/
+
+:root {
+  --demo-color-bg: #ffffff;
+  --demo-color-surface: #f5f5f5;
+  --demo-color-text: #1a1a1a;
+  --demo-color-text-muted: #555555;
+  --demo-color-border: #e0e0e0;
+  --demo-color-shadow: rgba(0, 0, 0, 0.1);
+  --demo-color-primary: #f97316;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --demo-color-bg: #121212;
+    --demo-color-surface: #1e1e1e;
+    --demo-color-text: #f5f5f5;
+    --demo-color-text-muted: #a0a0a0;
+    --demo-color-border: #2e2e2e;
+    --demo-color-shadow: rgba(0, 0, 0, 0.6);
+  }
+}
+
+body {
+  background: var(--demo-color-bg);
+  color: var(--demo-color-text);
+  font-family: system-ui, sans-serif;
+  transition: background 0.3s ease, color 0.3s ease;
+  padding: 2rem;
+}
+
+.demo-card {
+  background: var(--demo-color-surface);
+  border: 1px solid var(--demo-color-border);
+  box-shadow: 0 4px 12px var(--demo-color-shadow);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 320px;
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.demo-card p {
+  color: var(--demo-color-text-muted);
+}
+
+.demo-btn {
+  background: var(--demo-color-primary);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained demo for automatic dark mode support via prefers-color-scheme, so EaseMotion CSS sites can respect the user's OS/browser theme setting without any extra class or JS toggle. 

Closes #57936.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A prefers-color-scheme: dark media query that swaps core color tokens (background, surface, text, border, shadow) to a dark palette automatically, based on the user's system theme.

**How does a developer use it?**

<!-- No new class needed — works automatically based on OS/browser setting -->
<div class="demo-card">
  <h3>Card Title</h3>
  <p>Content</p>
  <button class="demo-btn">Action</button>
</div>

**Why does it fit EaseMotion CSS?**

It keeps with the "link one file and it works" philosophy, no new class to learn, no JS toggle to wire up. It layers on top of the existing :root variable override pattern, so anyone already customizing --ease-color-* isn't affected; their overrides still win.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Token names here (--demo-color-*) are scoped to the demo since I couldn't touch core/variables.css directly per the contribution policy. Suggested integration: wrap the existing --ease-color-* custom properties in core/variables.css with a matching @media (prefers-color-scheme: dark) block using the same variable names, so it plugs in as a drop-in layer. Happy to adjust the dark palette values if you'd prefer different contrast/tone.

---