### PR TITLE
feat: add CSS skeleton loader with shimmer animation

### DIFF
--- a/submissions/examples/css-skeleton-loader-shimmer/README.md
+++ b/submissions/examples/css-skeleton-loader-shimmer/README.md
@@ -1,0 +1,41 @@
+# CSS Skeleton Loader — Shimmer
+
+A pure CSS skeleton loading placeholder with a shimmer sweep, used to show while real content is still loading. No JavaScript, no dependencies.
+
+## How it works
+
+Each skeleton block uses a linear gradient that's wider than the element itself (`background-size: 200% 100%`), with a slightly lighter band in the middle. Animating `background-position` from one side to the other makes that lighter band sweep across the block, reading as a shimmer of light rather than a flat pulsing color.
+
+## Files
+
+- `demo.html` – two example skeleton layouts: an article card and a profile row
+- `style.css` – all styling, custom properties, and the shimmer keyframe
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-skeleton-duration` – 1.6s
+- `--ease-skeleton-easing` – ease-in-out
+- `--ease-skeleton-radius` – 8px
+- `--ease-skeleton-base` – the base skeleton color
+- `--ease-skeleton-shine` – the lighter sweep color
+- `--ease-skeleton-card-bg` – surrounding card background
+- `--ease-skeleton-border` – card border color
+- `--ease-skeleton-gap` – spacing between skeleton cards
+
+Example override:
+
+```css
+:root {
+  --ease-skeleton-base: #e5e5e5;
+  --ease-skeleton-shine: #f5f5f5;
+}
+```
+
+## Notes
+
+- Swap any `.ease-skeleton` block for real content once it loads — the class is meant to be temporary
+- Fully responsive; thumbnail height shrinks slightly on mobile
+- Respects `prefers-reduced-motion` — the shimmer animation is disabled and the skeleton shows as a flat, static color

--- a/submissions/examples/css-skeleton-loader-shimmer/demo.html
+++ b/submissions/examples/css-skeleton-loader-shimmer/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Skeleton Loader — Shimmer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Loading State</p>
+    <h1 class="ease-heading">Article Preview</h1>
+    <p class="ease-subtitle">A shimmering skeleton placeholder shown while content loads.</p>
+
+    <div class="ease-skeleton-card">
+      <div class="ease-skeleton ease-skeleton-thumb"></div>
+      <div class="ease-skeleton ease-skeleton-line ease-skeleton-line-title"></div>
+      <div class="ease-skeleton ease-skeleton-line"></div>
+      <div class="ease-skeleton ease-skeleton-line ease-skeleton-line-short"></div>
+    </div>
+
+    <div class="ease-skeleton-card">
+      <div class="ease-skeleton ease-skeleton-avatar-row">
+        <div class="ease-skeleton ease-skeleton-avatar"></div>
+        <div class="ease-skeleton-avatar-lines">
+          <div class="ease-skeleton ease-skeleton-line ease-skeleton-line-name"></div>
+          <div class="ease-skeleton ease-skeleton-line ease-skeleton-line-short"></div>
+        </div>
+      </div>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-skeleton-loader-shimmer/style.css
+++ b/submissions/examples/css-skeleton-loader-shimmer/style.css
@@ -1,0 +1,147 @@
+:root {
+  --ease-skeleton-duration: 1.6s;
+  --ease-skeleton-easing: ease-in-out;
+  --ease-skeleton-radius: 8px;
+  --ease-skeleton-base: #1c1f26;
+  --ease-skeleton-shine: #2a2e38;
+  --ease-skeleton-card-bg: #16181d;
+  --ease-skeleton-border: #2a2d34;
+  --ease-skeleton-gap: 1.25rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: #f0f0f0;
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 460px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #6c63ff;
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-skeleton-card {
+  background: var(--ease-skeleton-card-bg);
+  border: 1px solid var(--ease-skeleton-border);
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-bottom: var(--ease-skeleton-gap);
+}
+
+/* the shimmer: a gradient wider than the element itself, animated
+   across via background-position, so it reads as a sweep of light
+   passing over a flat-colored block */
+.ease-skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--ease-skeleton-base) 25%,
+    var(--ease-skeleton-shine) 50%,
+    var(--ease-skeleton-base) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--ease-skeleton-radius);
+  animation: ease-skeleton-shimmer var(--ease-skeleton-duration) var(--ease-skeleton-easing) infinite;
+}
+
+@keyframes ease-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.ease-skeleton-thumb {
+  height: 140px;
+  margin-bottom: 1rem;
+}
+
+.ease-skeleton-line {
+  height: 12px;
+  margin-bottom: 0.6rem;
+}
+
+.ease-skeleton-line:last-child {
+  margin-bottom: 0;
+}
+
+.ease-skeleton-line-title {
+  height: 16px;
+  width: 70%;
+}
+
+.ease-skeleton-line-short {
+  width: 45%;
+}
+
+.ease-skeleton-avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: none;
+  animation: none;
+}
+
+.ease-skeleton-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ease-skeleton-avatar-lines {
+  flex: 1;
+}
+
+.ease-skeleton-line-name {
+  height: 13px;
+  width: 55%;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.4rem;
+  }
+
+  .ease-skeleton-thumb {
+    height: 110px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-skeleton {
+    animation: none !important;
+    background: var(--ease-skeleton-base);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #57892

Adds a pure CSS/HTML skeleton loading placeholder with a shimmer sweep animation.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-skeleton-loader-shimmer/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A skeleton loading placeholder with a continuous shimmer sweep, shown for two layouts: an article card thumbnail + text lines, and a profile avatar + name row.

**How does a developer use it?**
```html
<div class="ease-skeleton ease-skeleton-line"></div>
<div class="ease-skeleton ease-skeleton-avatar"></div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-skeleton-line`, `ease-skeleton-thumb`), zero dependencies, and the shimmer is achieved purely by animating `background-position` on an oversized gradient — no extra pseudo-elements or masks needed. Fully theme-able via custom properties for the base and shine colors.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Shimmer uses `background-position` animation on a 200%-wide gradient rather than a separate sweeping overlay element, keeping the markup minimal. Respects `prefers-reduced-motion` by freezing to a flat static color.