### PR TITLE
feat: add CSS underline navigation with center-expand hover effect

### DIFF
--- a/submissions/examples/css-underline-navigation/README.md
+++ b/submissions/examples/css-underline-navigation/README.md
@@ -1,0 +1,42 @@
+# CSS Underline Navigation
+
+A pure CSS navigation menu where each link grows an underline out from its center on hover. No JavaScript, no dependencies.
+
+## How it works
+
+Each `.ease-nav-link` has a `::after` pseudo-element positioned at its bottom edge, starting at `width: 0` and centered horizontally with `left: 50%` plus `transform: translateX(-50%)`. On hover or keyboard focus, the width transitions to 100%, so the underline expands outward from the middle rather than sliding in from one side.
+
+`:focus-visible` triggers the same underline as `:hover`, so keyboard users get the same visual feedback tabbing through the nav.
+
+## Files
+
+- `demo.html` – a 4-link nav menu (Home, Projects, About, Contact)
+- `style.css` – all styling, custom properties, and the underline transition
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-nav-duration` – 0.3s
+- `--ease-nav-easing` – cubic-bezier(0.4, 0, 0.2, 1)
+- `--ease-nav-text` – default link color
+- `--ease-nav-hover-text` – hover/focus link color
+- `--ease-nav-accent` – underline color
+- `--ease-nav-gap` – spacing between nav links
+- `--ease-nav-underline-height` – thickness of the underline
+
+Example override:
+
+```css
+:root {
+  --ease-nav-accent: #22c55e;
+  --ease-nav-underline-height: 3px;
+}
+```
+
+## Notes
+
+- Underline expands from center outward, not from one edge, for a slightly more polished feel than a plain left-to-right slide
+- Fully responsive; gap and font size shrink slightly on mobile
+- Respects `prefers-reduced-motion` — the underline appears/disappears instantly with no width transition

--- a/submissions/examples/css-underline-navigation/demo.html
+++ b/submissions/examples/css-underline-navigation/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Underline Navigation</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Site Navigation</p>
+    <h1 class="ease-heading">Underline Nav</h1>
+    <p class="ease-subtitle">Hover a link to see the underline slide underneath it. Pure CSS.</p>
+
+    <nav class="ease-nav">
+      <a href="#" class="ease-nav-link">Home</a>
+      <a href="#" class="ease-nav-link">Projects</a>
+      <a href="#" class="ease-nav-link">About</a>
+      <a href="#" class="ease-nav-link">Contact</a>
+    </nav>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-underline-navigation/style.css
+++ b/submissions/examples/css-underline-navigation/style.css
@@ -1,0 +1,115 @@
+:root {
+  --ease-nav-duration: 0.3s;
+  --ease-nav-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-nav-text: #a8a8a8;
+  --ease-nav-hover-text: #f0f0f0;
+  --ease-nav-accent: #6c63ff;
+  --ease-nav-gap: 2rem;
+  --ease-nav-underline-height: 2px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: #f0f0f0;
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-nav-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+.ease-nav {
+  display: flex;
+  gap: var(--ease-nav-gap);
+  flex-wrap: wrap;
+}
+
+.ease-nav-link {
+  position: relative;
+  color: var(--ease-nav-text);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding-bottom: 0.35rem;
+  transition: color var(--ease-nav-duration) var(--ease-nav-easing);
+}
+
+/* the underline is a pseudo-element, starting collapsed to zero
+   width and centered, then expanding out to full width on hover */
+.ease-nav-link::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0;
+  height: var(--ease-nav-underline-height);
+  background: var(--ease-nav-accent);
+  transform: translateX(-50%);
+  transition: width var(--ease-nav-duration) var(--ease-nav-easing);
+}
+
+.ease-nav-link:hover {
+  color: var(--ease-nav-hover-text);
+}
+
+.ease-nav-link:hover::after,
+.ease-nav-link:focus-visible::after {
+  width: 100%;
+}
+
+.ease-nav-link:focus-visible {
+  outline: none;
+  color: var(--ease-nav-hover-text);
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.4rem;
+  }
+
+  .ease-nav {
+    gap: 1.25rem;
+  }
+
+  .ease-nav-link {
+    font-size: 0.875rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-nav-link,
+  .ease-nav-link::after {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #57891

Adds a pure CSS/HTML navigation menu where each link's underline expands out from center on hover or keyboard focus.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-underline-navigation/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A nav menu where each link's underline expands out from its center on hover or keyboard focus, rather than sliding in from one edge.

**How does a developer use it?**
```html
<nav class="ease-nav">
  <a href="#" class="ease-nav-link">Home</a>
</nav>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-nav-link`), zero dependencies, and the underline is a single `::after` pseudo-element animating `width` from a centered origin, no extra markup needed per link. `:focus-visible` mirrors the `:hover` state, so keyboard navigation gets the same visual feedback as mouse hover.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---

## Notes for Maintainer
Underline expands from center via `left: 50%` + `translateX(-50%)` combined with a `width` transition, rather than sliding from one side — a small but intentional polish choice. `:focus-visible` included alongside `:hover` for keyboard accessibility. Respects `prefers-reduced-motion`.