### PR TITLE
feat: add glow-border metric analytics card with animated sparkline

### DIFF
--- a/submissions/examples/analytics-sparkline-card-ag/README.md
+++ b/submissions/examples/analytics-sparkline-card-ag/README.md
@@ -1,0 +1,50 @@
+# Glow-Border Metric Analytics Card
+
+A pure CSS/HTML KPI card for dashboards, with an animated sparkline chart, a hover glow border, and per-bar tooltips. No charting library, no JavaScript.
+
+## How it works
+
+**Sparkline bars.** Each bar is a `<span>` with its target height set inline via `--ease-bar-height`. All bars share one `@keyframes growSparkline` rule that scales from `scaleY(0)` to `scaleY(1)`, so the height itself comes from the inline custom property while the keyframe stays identical for every bar. `nth-child` delays make the bars grow in left-to-right sequence on load rather than all at once.
+
+**Data tooltips.** Each bar has a `data-value` attribute, and its `::after` pseudo-element reads that value with `content: attr(data-value)`, so the tooltip text comes straight from the markup with no duplication. It's hidden by default and fades in on `:hover`.
+
+**Glow border.** The card has a `::before` pseudo-element slightly larger than itself, filled with a `radial-gradient`, sitting behind the card via `z-index: -1` and hidden with `opacity: 0`. On card hover, it fades in and the card itself lifts slightly with `translateY`.
+
+## Files
+
+- `demo.html` – two KPI cards (Active Users, Revenue) each with a trend badge and sparkline
+- `style.css` – all styling, custom properties, sparkline growth, tooltip, and glow border
+- `README.md` – this file
+
+## Custom properties
+
+Set on `:root` in `style.css`:
+
+- `--ease-metric-duration` – 0.6s
+- `--ease-metric-easing` – ease-out
+- `--ease-metric-radius` – 14px
+- `--ease-metric-bg` – card background
+- `--ease-metric-border` – card border color
+- `--ease-metric-text` – value text color
+- `--ease-metric-muted-text` – label text color
+- `--ease-metric-up` / `--ease-metric-down` – trend badge colors
+- `--ease-metric-glow` – hover glow and bar accent color
+- `--ease-metric-bar-color` – default sparkline bar color
+- `--ease-metric-bar-bg` – (reserved for a track background if desired)
+
+Per-bar, `--ease-bar-height` is set inline on each `.ease-sparkline-bar` to control its individual height.
+
+Example override:
+
+```css
+:root {
+  --ease-metric-glow: #22c55e;
+  --ease-metric-bar-color: #22c55e;
+}
+```
+
+## Notes
+
+- To change the number of bars, add/remove `.ease-sparkline-bar` elements and a matching `nth-child` delay rule
+- Fully responsive; the two-card grid collapses to one column under 600px
+- Respects `prefers-reduced-motion` — bars appear instantly at full height, and the hover glow/lift/tooltip transitions are disabled

--- a/submissions/examples/analytics-sparkline-card-ag/demo.html
+++ b/submissions/examples/analytics-sparkline-card-ag/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glow-Border Metric Analytics Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Dashboard</p>
+    <h1 class="ease-heading">Metrics Overview</h1>
+    <p class="ease-subtitle">A glow-border KPI card with an animated CSS sparkline. No charting library.</p>
+
+    <div class="ease-metric-grid">
+
+      <div class="ease-metric-card">
+        <div class="ease-metric-top">
+          <span class="ease-metric-icon">👥</span>
+          <span class="ease-metric-trend ease-metric-trend-up">+14.8%</span>
+        </div>
+        <p class="ease-metric-label">Active Users</p>
+        <p class="ease-metric-value">24,910</p>
+
+        <div class="ease-sparkline">
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 35%;" data-value="18"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 52%;" data-value="24"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 40%;" data-value="21"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 68%;" data-value="31"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 58%;" data-value="27"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 82%;" data-value="38"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 95%;" data-value="42"></span>
+        </div>
+      </div>
+
+      <div class="ease-metric-card">
+        <div class="ease-metric-top">
+          <span class="ease-metric-icon">💳</span>
+          <span class="ease-metric-trend ease-metric-trend-down">-3.2%</span>
+        </div>
+        <p class="ease-metric-label">Revenue</p>
+        <p class="ease-metric-value">$8,204</p>
+
+        <div class="ease-sparkline">
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 70%;" data-value="9.1k"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 62%;" data-value="8.7k"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 66%;" data-value="8.9k"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 50%;" data-value="7.6k"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 45%;" data-value="7.2k"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 48%;" data-value="7.4k"></span>
+          <span class="ease-sparkline-bar" style="--ease-bar-height: 42%;" data-value="8.2k"></span>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/analytics-sparkline-card-ag/style.css
+++ b/submissions/examples/analytics-sparkline-card-ag/style.css
@@ -1,0 +1,236 @@
+:root {
+  --ease-metric-duration: 0.6s;
+  --ease-metric-easing: ease-out;
+  --ease-metric-radius: 14px;
+  --ease-metric-bg: #16181d;
+  --ease-metric-border: #2a2d34;
+  --ease-metric-text: #f0f0f0;
+  --ease-metric-muted-text: #a8a8a8;
+  --ease-metric-up: #4ade80;
+  --ease-metric-down: #f87171;
+  --ease-metric-glow: #6c63ff;
+  --ease-metric-bar-color: #6c63ff;
+  --ease-metric-bar-bg: #22252c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-metric-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-metric-glow);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: #a0a0a0;
+  margin: 0 0 2rem;
+  font-size: 0.95rem;
+}
+
+.ease-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+
+/* the glow-border: a pseudo-element slightly larger than the card,
+   filled with a radial gradient, hidden by default and faded in on
+   hover, sitting behind the card via z-index */
+.ease-metric-card {
+  position: relative;
+  background: var(--ease-metric-bg);
+  border: 1px solid var(--ease-metric-border);
+  border-radius: var(--ease-metric-radius);
+  padding: 1.25rem;
+  transition: transform var(--ease-metric-duration) var(--ease-metric-easing);
+}
+
+.ease-metric-card::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: calc(var(--ease-metric-radius) + 2px);
+  background: radial-gradient(circle at 50% 0%, var(--ease-metric-glow), transparent 70%);
+  opacity: 0;
+  z-index: -1;
+  transition: opacity var(--ease-metric-duration) var(--ease-metric-easing);
+}
+
+.ease-metric-card:hover {
+  transform: translateY(-4px);
+}
+
+.ease-metric-card:hover::before {
+  opacity: 0.55;
+}
+
+.ease-metric-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.ease-metric-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.95rem;
+}
+
+.ease-metric-trend {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
+
+.ease-metric-trend-up {
+  color: var(--ease-metric-up);
+  background: rgba(74, 222, 128, 0.12);
+}
+
+.ease-metric-trend-down {
+  color: var(--ease-metric-down);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.ease-metric-label {
+  margin: 0 0 0.15rem;
+  font-size: 0.8rem;
+  color: var(--ease-metric-muted-text);
+}
+
+.ease-metric-value {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+/* sparkline: flex row of bars, each grown from 0 to its target
+   height via the growSparkline keyframe, using an inline custom
+   property so the same keyframe works for every bar */
+.ease-sparkline {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 48px;
+}
+
+.ease-sparkline-bar {
+  position: relative;
+  flex: 1;
+  height: var(--ease-bar-height);
+  background: var(--ease-metric-bar-color);
+  border-radius: 3px 3px 0 0;
+  transform-origin: bottom;
+  animation: growSparkline var(--ease-metric-duration) var(--ease-metric-easing) both;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.ease-sparkline-bar:nth-child(1) { animation-delay: 0.05s; }
+.ease-sparkline-bar:nth-child(2) { animation-delay: 0.1s; }
+.ease-sparkline-bar:nth-child(3) { animation-delay: 0.15s; }
+.ease-sparkline-bar:nth-child(4) { animation-delay: 0.2s; }
+.ease-sparkline-bar:nth-child(5) { animation-delay: 0.25s; }
+.ease-sparkline-bar:nth-child(6) { animation-delay: 0.3s; }
+.ease-sparkline-bar:nth-child(7) { animation-delay: 0.35s; }
+
+@keyframes growSparkline {
+  from {
+    transform: scaleY(0);
+    opacity: 0;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+.ease-sparkline-bar:hover {
+  background: var(--ease-metric-glow);
+  transform: scaleY(1.06);
+}
+
+/* pure CSS tooltip: hidden by default, shown via the bar's :hover,
+   value pulled from the data-value attribute with the attr() function */
+.ease-sparkline-bar::after {
+  content: attr(data-value);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.85);
+  background: #22252c;
+  color: var(--ease-metric-text);
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.ease-sparkline-bar:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+@media (max-width: 600px) {
+  .ease-metric-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+
+  .ease-heading {
+    font-size: 1.4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-metric-card,
+  .ease-metric-card::before,
+  .ease-sparkline-bar,
+  .ease-sparkline-bar::after {
+    transition: none !important;
+    animation: none !important;
+  }
+
+  .ease-sparkline-bar {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #57745

Adds a pure CSS/HTML metric analytics card with a hover glow border and an animated CSS sparkline chart, per the issue spec.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/analytics-sparkline-card-ag/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A KPI metric card with an icon badge, trend percentage indicator, animated CSS-only sparkline bars, per-bar data tooltips, and a radial glow border on hover — no charting library.

**How does a developer use it?**
```html
<div class="ease-metric-card">
  <div class="ease-metric-top">
    <span class="ease-metric-icon">👥</span>
    <span class="ease-metric-trend ease-metric-trend-up">+14.8%</span>
  </div>
  <p class="ease-metric-value">24,910</p>
  <div class="ease-sparkline">
    <span class="ease-sparkline-bar" style="--ease-bar-height: 60%;" data-value="24"></span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Class names read like plain English (`ease-sparkline-bar`, `ease-metric-trend`), zero dependencies, and it demonstrates several reusable CSS-only patterns in one component: a shared `@keyframes growSparkline` driven per-bar by an inline custom property, `attr()`-powered tooltips with no duplicated markup, and a glow border built from a `::before` radial gradient pseudo-element.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Sparkline bar heights are set inline via `--ease-bar-height` per bar so one shared `growSparkline` keyframe handles every bar regardless of value. Tooltips pull their text directly from each bar's `data-value` attribute via `attr()`, avoiding duplicated content. Respects `prefers-reduced-motion` by disabling all animation/transition.