### PR TITLE
add scroll review

### DIFF
--- a/submissions/examples/scroll-utility/README.md
+++ b/submissions/examples/scroll-utility/README.md
@@ -1,0 +1,28 @@
+# ease-reveal
+
+Scroll-triggered reveal animations — elements fade, slide, or zoom into view as the user scrolls, using pure CSS scroll-driven animations (`animation-timeline: view()`). No JavaScript or IntersectionObserver required.
+
+## What
+Adds `.ease-reveal` base class plus direction variants: `ease-reveal-up`, `ease-reveal-left`, `ease-reveal-right`, `ease-reveal-zoom`.
+
+## How
+- Uses the CSS `animation-timeline: view()` scroll-driven animations spec to tie keyframe progress to scroll position instead of time.
+- `animation-range: entry 0% cover 30%` controls when the animation starts/finishes relative to the element entering the viewport.
+- A `@supports not (animation-timeline: view())` fallback keeps content visible in browsers that don't yet support scroll-driven animations, so nothing is ever permanently hidden.
+- Respects `prefers-reduced-motion`.
+
+## Why
+Scroll reveal is one of the most requested modern web effects (used heavily in portfolios/landing pages) and EaseMotion CSS currently has no scroll-linked animation utility — only time-based ones. This adds a genuinely different animation trigger model to the library.
+
+## Files
+- `demo.html` — scrollable page showing all 4 reveal directions
+- `style.css` — the `ease-reveal` classes and keyframes
+- `README.md` — this file
+
+## Usage
+\```html
+<div class="ease-reveal ease-reveal-up">Content</div>
+\```
+
+## Browser support note
+Scroll-driven animations are supported in modern Chromium browsers. Safari/Firefox users get the `@supports` fallback (static visible content) until support lands.

--- a/submissions/examples/scroll-utility/demo.html
+++ b/submissions/examples/scroll-utility/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-reveal — EaseMotion CSS Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body{font-family:system-ui,sans-serif;background:#f7f7f9;margin:0;}
+  .spacer{height:70vh;display:flex;align-items:center;justify-content:center;color:#999;font-size:1.1rem;}
+  .box{max-width:400px;margin:2rem auto;padding:1.5rem;background:#fff;border-radius:14px;box-shadow:0 2px 10px rgba(0,0,0,.06);}
+  h1{text-align:center;padding:2rem 0 0;}
+</style>
+</head>
+<body>
+
+<h1>ease-reveal — Scroll Reveal Demo</h1>
+<div class="spacer">Scroll down to see elements reveal ↓</div>
+
+<div class="box ease-reveal ease-reveal-up">Fades and slides up into view</div>
+<div class="box ease-reveal ease-reveal-left">Slides in from the left</div>
+<div class="box ease-reveal ease-reveal-right">Slides in from the right</div>
+<div class="box ease-reveal ease-reveal-zoom">Zooms in on scroll</div>
+
+<div class="spacer">End of demo</div>
+
+</body>
+</html>

--- a/submissions/examples/scroll-utility/style.css
+++ b/submissions/examples/scroll-utility/style.css
@@ -1,0 +1,52 @@
+/* ==========================================================================
+   EaseMotion CSS — ease-reveal
+   Scroll-triggered reveal animations (pure CSS, no JS/IntersectionObserver)
+   ========================================================================== */
+
+.ease-reveal {
+  animation-timeline: view();
+  animation-range: entry 0% cover 30%;
+  animation-fill-mode: both;
+}
+
+/* Fallback for browsers without scroll-driven animation support:
+   content stays visible instead of hidden */
+@supports not (animation-timeline: view()) {
+  .ease-reveal { opacity: 1 !important; transform: none !important; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-reveal { animation: none !important; opacity: 1; transform: none; }
+}
+
+.ease-reveal-up {
+  animation-name: ease-reveal-up;
+}
+@keyframes ease-reveal-up {
+  from { opacity: 0; transform: translateY(40px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ease-reveal-left {
+  animation-name: ease-reveal-left;
+}
+@keyframes ease-reveal-left {
+  from { opacity: 0; transform: translateX(-60px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.ease-reveal-right {
+  animation-name: ease-reveal-right;
+}
+@keyframes ease-reveal-right {
+  from { opacity: 0; transform: translateX(60px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.ease-reveal-zoom {
+  animation-name: ease-reveal-zoom;
+}
+@keyframes ease-reveal-zoom {
+  from { opacity: 0; transform: scale(0.85); }
+  to   { opacity: 1; transform: scale(1); }
+}


### PR DESCRIPTION
## Summary

Adds `ease-reveal`, a new pure-CSS scroll-reveal utility with four direction variants (up, left, right, zoom), implemented using the native `animation-timeline: view()` scroll-driven animations spec — no JavaScript or IntersectionObserver polyfill needed.

## Changes

- `submissions/examples/ease-reveal-<suffix>/demo.html`
- `submissions/examples/ease-reveal-<suffix>/style.css`
- `submissions/examples/ease-reveal-<suffix>/README.md`

## Why

EaseMotion CSS currently only has time-based animation triggers (on load, on hover). Scroll reveal is a top request for landing pages/portfolios and introduces a new, distinct animation-trigger model to the framework.

## Testing

- Verified in Chrome/Edge (native `animation-timeline` support) — reveals trigger correctly as each box enters the viewport.
- Verified fallback in Firefox/Safari via `@supports not` — content remains visible, no broken/stuck-hidden elements.
- Verified `prefers-reduced-motion: reduce` disables all animation and content stays visible.

## Checklist

- [x] This feature does not duplicate an existing EaseMotion CSS class
- [x] I understand my naming will be standardized by the maintainer
- [x] I submitted code inside `submissions/` only — not in `core/` or `components/`
- [x] Commits are squashed into a single logical commit