### PR TITLE
add copy clipboard feedback button

### DIFF
--- a/submissions/examples/copy-clipboard-feedback/README.md
+++ b/submissions/examples/copy-clipboard-feedback/README.md
@@ -1,0 +1,28 @@
+# ease-copy-btn
+
+A copy-to-clipboard button that morphs its icon from a copy glyph into an animated checkmark on successful copy, with a bounce feedback animation.
+
+## What
+Adds `.ease-copy-btn` — a small icon button with two stacked icon states (`icon-copy`, `icon-check`) that cross-fade/scale-morph via a `.copied` class toggle.
+
+## How
+- Both icons are absolutely stacked; CSS `opacity` + `transform` transitions handle the morph between them.
+- A tiny inline `<script>` calls `navigator.clipboard.writeText()` and toggles the `.copied` class — this is the only JS, purely for the browser clipboard API which CSS cannot access; all visual animation is CSS-driven (`@keyframes ease-copy-bounce`).
+- Reverts to the copy icon automatically after ~1.8s via `setTimeout`.
+- Respects `prefers-reduced-motion`.
+
+## Why
+Copy buttons are ubiquitous in documentation sites, code blocks, and share links. EaseMotion CSS has button/interaction utilities but no dedicated clipboard-feedback pattern — this demonstrates a practical micro-interaction combining CSS animation with a minimal necessary JS hook.
+
+## Files
+- `demo.html` — a code snippet row with a working copy button
+- `style.css` — the `ease-copy-btn` classes and keyframes
+- `README.md` — this file
+
+## Usage
+\```html
+<button class="ease-copy-btn" data-copy="text to copy" onclick="easeCopy(this)">
+  <span class="icon-copy">⧉</span>
+  <span class="icon-check">✓</span>
+</button>
+\```

--- a/submissions/examples/copy-clipboard-feedback/demo.html
+++ b/submissions/examples/copy-clipboard-feedback/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-copy-btn — EaseMotion CSS Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body{font-family:system-ui,sans-serif;background:#f7f7f9;padding:3rem;}
+  .code-row{display:flex;align-items:center;gap:1rem;background:#1e1e2e;color:#eee;padding:1rem 1.25rem;border-radius:10px;max-width:480px;font-family:monospace;}
+  .code-row code{flex:1;overflow-x:auto;}
+</style>
+</head>
+<body>
+
+<h1>ease-copy-btn — Copy to Clipboard Demo</h1>
+
+<div class="code-row">
+  <code>npm install easemotion-css</code>
+  <button class="ease-copy-btn" data-copy="npm install easemotion-css" onclick="easeCopy(this)">
+    <span class="icon-copy">⧉</span>
+    <span class="icon-check">✓</span>
+  </button>
+</div>
+
+<script>
+function easeCopy(btn){
+  const text = btn.getAttribute('data-copy');
+  navigator.clipboard.writeText(text).then(() => {
+    btn.classList.add('copied');
+    setTimeout(() => btn.classList.remove('copied'), 1800);
+  });
+}
+</script>
+
+</body>
+</html>

--- a/submissions/examples/copy-clipboard-feedback/style.css
+++ b/submissions/examples/copy-clipboard-feedback/style.css
@@ -1,0 +1,64 @@
+/* ==========================================================================
+   EaseMotion CSS — ease-copy-btn
+   Copy-to-clipboard button with icon morph + bounce feedback (CSS animation,
+   JS only used to call navigator.clipboard — no animation logic in JS)
+   ========================================================================== */
+
+.ease-copy-btn {
+  position: relative;
+  width: 38px;
+  height: 38px;
+  border: none;
+  border-radius: 8px;
+  background: #33334d;
+  color: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  transition: background 0.2s ease;
+}
+
+.ease-copy-btn:hover {
+  background: #45456a;
+}
+
+.ease-copy-btn .icon-copy,
+.ease-copy-btn .icon-check {
+  position: absolute;
+  font-size: 1.1rem;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.ease-copy-btn .icon-check {
+  opacity: 0;
+  transform: scale(0.4) rotate(-45deg);
+  color: #4ade80;
+}
+
+.ease-copy-btn .icon-copy {
+  opacity: 1;
+  transform: scale(1) rotate(0deg);
+}
+
+/* State toggled by JS after successful clipboard write */
+.ease-copy-btn.copied .icon-copy {
+  opacity: 0;
+  transform: scale(0.4) rotate(45deg);
+}
+
+.ease-copy-btn.copied .icon-check {
+  opacity: 1;
+  animation: ease-copy-bounce 0.5s ease;
+}
+
+@keyframes ease-copy-bounce {
+  0%   { transform: scale(0.4) rotate(-45deg); }
+  60%  { transform: scale(1.3) rotate(0deg); }
+  100% { transform: scale(1) rotate(0deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-copy-btn .icon-check { animation: none !important; }
+}


### PR DESCRIPTION
## Summary

Adds `ease-copy-btn`, a copy-to-clipboard button component that morphs its icon into an animated checkmark with a bounce effect on successful copy.

## Changes

- `submissions/examples/ease-copy-btn-<suffix>/demo.html`
- `submissions/examples/ease-copy-btn-<suffix>/style.css`
- `submissions/examples/ease-copy-btn-<suffix>/README.md`

## Why

Copy-to-clipboard buttons are extremely common (docs sites, code blocks, referral links) and EaseMotion CSS has no existing clipboard-feedback pattern. This shows how the library can combine a minimal necessary JS hook (calling `navigator.clipboard`, which CSS cannot do) with fully CSS-driven visual feedback.

## Testing

- Verified click copies text to clipboard and the icon morphs to a checkmark with bounce.
- Verified button auto-reverts to copy icon after ~1.8s.
- Verified `prefers-reduced-motion` disables the bounce animation while the icon swap still occurs (accessibility-safe).

## Checklist

- [x] This feature does not duplicate an existing EaseMotion CSS class
- [x] I understand my naming will be standardized by the maintainer
- [x] I submitted code inside `submissions/` only — not in `core/` or `components/`
- [x] Commits are squashed into a single logical commit