### PR TITLE
add animated multi stepper

### DIFF
--- a/submissions/examples/animated-multi-stepper/README.md
+++ b/submissions/examples/animated-multi-stepper/README.md
@@ -1,0 +1,30 @@
+# ease-stepper
+
+An animated multi-step progress indicator (e.g. checkout/onboarding flow) where the connecting line fills in to match completed steps, and the active step pulses.
+
+## What
+Adds `.ease-stepper` (container) and `.ease-step` (individual step, with optional `.done` / `.active` modifiers).
+
+## How
+- The container takes `--completed` and `--total` custom properties to compute progress.
+- A `::before` pseudo-element draws the full-width static connecting line; a `::after` pseudo-element draws the animated blue fill on top, animating its `width` from 0 to the computed completed-percentage via `@keyframes ease-stepper-fill`.
+- The active step gets a soft pulsing box-shadow (`ease-step-pulse`) to draw attention to the current step.
+- Completed steps get a solid filled circle with a checkmark; all computation is done via CSS `calc()` — no JS.
+- Respects `prefers-reduced-motion` by skipping straight to final state.
+
+## Why
+Step/progress indicators are core to checkout flows, onboarding, and multi-page forms — a very common real-world need with no equivalent yet in EaseMotion CSS's component set.
+
+## Files
+- `demo.html` — a 4-step example with 2 completed, 1 active
+- `style.css` — the `ease-stepper` / `ease-step` classes and keyframes
+- `README.md` — this file
+
+## Usage
+\```html
+<div class="ease-stepper" style="--completed:2;--total:4;">
+  <div class="ease-step done"><span class="ease-step-circle">✓</span><span class="ease-step-label">Account</span></div>
+  <div class="ease-step active"><span class="ease-step-circle">3</span><span class="ease-step-label">Payment</span></div>
+  <div class="ease-step"><span class="ease-step-circle">4</span><span class="ease-step-label">Confirm</span></div>
+</div>
+\```

--- a/submissions/examples/animated-multi-stepper/demo.html
+++ b/submissions/examples/animated-multi-stepper/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-stepper — EaseMotion CSS Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body{font-family:system-ui,sans-serif;background:#f7f7f9;padding:3rem;}
+  h1{margin-bottom:2.5rem;}
+</style>
+</head>
+<body>
+
+<h1>ease-stepper — Multi-Step Progress Demo</h1>
+
+<div class="ease-stepper" style="--completed:2;--total:4;">
+  <div class="ease-step done"><span class="ease-step-circle">✓</span><span class="ease-step-label">Account</span></div>
+  <div class="ease-step done"><span class="ease-step-circle">✓</span><span class="ease-step-label">Details</span></div>
+  <div class="ease-step active"><span class="ease-step-circle">3</span><span class="ease-step-label">Payment</span></div>
+  <div class="ease-step"><span class="ease-step-circle">4</span><span class="ease-step-label">Confirm</span></div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/animated-multi-stepper/style.css
+++ b/submissions/examples/animated-multi-stepper/style.css
@@ -1,0 +1,106 @@
+/* ==========================================================================
+   EaseMotion CSS — ease-stepper
+   Multi-step progress indicator with animated connecting-line fill
+   ========================================================================== */
+
+.ease-stepper {
+  --progress: calc((var(--completed, 0) / (var(--total, 1) - 1)) * 100%);
+  display: flex;
+  align-items: flex-start;
+  position: relative;
+  max-width: 500px;
+}
+
+.ease-step {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  text-align: center;
+}
+
+.ease-step-circle {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #e2e2e2;
+  color: #888;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  z-index: 2;
+  transition: background 0.4s ease, color 0.4s ease, transform 0.3s ease;
+}
+
+.ease-step-label {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #888;
+}
+
+/* Connecting line, drawn once behind all steps */
+.ease-stepper::before {
+  content: "";
+  position: absolute;
+  top: 18px;
+  left: calc(100% / (var(--total, 1) * 2));
+  right: calc(100% / (var(--total, 1) * 2));
+  height: 3px;
+  background: #e2e2e2;
+  z-index: 1;
+}
+
+/* Animated fill overlay */
+.ease-stepper::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  left: calc(100% / (var(--total, 1) * 2));
+  height: 3px;
+  background: #4f7cff;
+  z-index: 1;
+  width: 0%;
+  animation: ease-stepper-fill 0.8s ease-out forwards;
+  animation-delay: 0.2s;
+  --end-width: calc((100% - (100% / var(--total, 1))) * (var(--completed, 0) / (var(--total, 1) - 1)));
+}
+
+@keyframes ease-stepper-fill {
+  to { width: var(--end-width); }
+}
+
+.ease-step.done .ease-step-circle {
+  background: #4f7cff;
+  color: #fff;
+}
+
+.ease-step.active .ease-step-circle {
+  background: #fff;
+  color: #4f7cff;
+  border: 3px solid #4f7cff;
+  transform: scale(1.1);
+  animation: ease-step-pulse 1.6s ease-in-out infinite;
+}
+
+.ease-step.done .ease-step-label,
+.ease-step.active .ease-step-label {
+  color: #222;
+  font-weight: 600;
+}
+
+@keyframes ease-step-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(79,124,255,0.3); }
+  50%      { box-shadow: 0 0 0 6px rgba(79,124,255,0.1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stepper::after,
+  .ease-step.active .ease-step-circle {
+    animation: none !important;
+  }
+  .ease-stepper::after {
+    width: var(--end-width);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `ease-stepper`, an animated multi-step progress indicator where the connecting line between steps fills in via CSS animation to reflect completed steps, and the active step has a pulsing highlight.

## Changes

- `submissions/examples/ease-stepper-<suffix>/demo.html`
- `submissions/examples/ease-stepper-<suffix>/style.css`
- `submissions/examples/ease-stepper-<suffix>/README.md`

## Why

Step indicators are essential for checkout flows, onboarding wizards, and multi-page forms. EaseMotion CSS has no equivalent component, and this one is driven entirely by CSS custom properties/`calc()` with zero JavaScript.

## Testing

- Verified fill line animates correctly for different `--completed`/`--total` combinations (2/4, 1/3, 3/5).
- Verified active-step pulse animation loops smoothly.
- Verified `prefers-reduced-motion` jumps directly to final fill state without animating.

## Checklist

- [x] This feature does not duplicate an existing EaseMotion CSS class
- [x] I understand my naming will be standardized by the maintainer
- [x] I submitted code inside `submissions/` only — not in `core/` or `components/`
- [x] Commits are squashed into a single logical commit