### PR TITLE
fix: prevent feature badge text from overflowing inside cards

### DIFF
--- a/submissions/examples/badge-overflow-fix-koko/README.md
+++ b/submissions/examples/badge-overflow-fix-koko/README.md
@@ -1,0 +1,20 @@
+# Badge Overflow Fix (badge-overflow-koko)
+
+## What does this do?
+Fixes an issue where long feature badge text overflows outside its container/card, especially on smaller screens.
+
+## How is it used?
+Wrap your badge text inside `.feature-badge` within a `.feature-card`:
+
+\`\`\`html
+<div class="feature-card">
+  <span class="feature-badge">
+    Best Choice for Enterprise Applications with Advanced Responsive Features
+  </span>
+  <h3>Enterprise Plan</h3>
+  <p>Designed for growing businesses.</p>
+</div>
+\`\`\`
+
+## Why is it useful?
+Ensures badge text wraps properly and stays within its card boundary across all screen sizes, preventing layout breakage — fixes issue #57527.

--- a/submissions/examples/badge-overflow-fix-koko/demo.html
+++ b/submissions/examples/badge-overflow-fix-koko/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Badge Overflow Fix Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="feature-card">
+  <span class="feature-badge">
+    Best Choice for Enterprise Applications with Advanced Responsive Features
+  </span>
+  <h3>Enterprise Plan</h3>
+  <p>Designed for growing businesses.</p>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/badge-overflow-fix-koko/style.css
+++ b/submissions/examples/badge-overflow-fix-koko/style.css
@@ -1,0 +1,45 @@
+body {
+  font-family: sans-serif;
+  padding: 40px;
+  background: #f0f0f0;
+}
+
+.feature-card {
+  max-width: 320px;
+  padding: 16px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.feature-badge {
+  display: inline-block;
+  max-width: 100%;
+  padding: 4px 10px;
+  background: #4f46e5;
+  color: #fff;
+  font-size: 12px;
+  border-radius: 6px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+}
+
+.feature-card h3 {
+  margin: 8px 0 4px;
+}
+
+.feature-card p {
+  margin: 0;
+  color: #555;
+}
+
+@media (max-width: 480px) {
+  .feature-card {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #57527

Fixed the badge overflow issue by adding overflow-wrap, word-break, and proper box-sizing so long badge text wraps within the card boundary instead of overflowing, especially on smaller screens.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` (submissions/examples/badge-overflow-fix-koko/)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fix that prevents long badge text from overflowing outside its card container.

**How does a developer use it?**

```html
<div class="feature-card">
  <span class="feature-badge">
    Best Choice for Enterprise Applications with Advanced Responsive Features
  </span>
  <h3>Enterprise Plan</h3>
  <p>Designed for growing businesses.</p>
</div>
```

**Why does it fit EaseMotion CSS?**

Ensures consistent, responsive layout behavior across screen sizes, which aligns with EaseMotion CSS's reliability and usability goals.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome

---

## Notes for Maintainer

Tested locally with Live Server across different card widths — badge wraps correctly and stays within the card boundary.