### PR TITLE
add animated flip-card-component

### DIFF
--- a/submissions/examples/flip-card-component/README.md
+++ b/submissions/examples/flip-card-component/README.md
@@ -1,0 +1,29 @@
+# ease-flip-card
+
+A 3D flip card that rotates on the Y-axis to reveal back-side content, triggered by hover or keyboard focus/click — pure CSS, no JavaScript.
+
+## What
+Adds `.ease-flip-card` (hover-triggered by default) and `.ease-flip-card-click` modifier (focus/click-triggered, for touch/keyboard accessibility), with `.ease-flip-card-front` / `.ease-flip-card-back` faces inside `.ease-flip-card-inner`.
+
+## How
+- Uses `perspective` on the outer container and `transform-style: preserve-3d` + `backface-visibility: hidden` on the inner faces to create a true 3D flip illusion.
+- The inner wrapper rotates `rotateY(180deg)` on `:hover` (default) or `:focus-within` (click/keyboard variant using `tabindex="0"`), so both mouse and keyboard users can trigger it without JS.
+- Respects `prefers-reduced-motion` by removing the transition (flip becomes instant).
+
+## Why
+Flip cards are a widely used pattern for pricing tables, team/profile cards, and flashcard-style content. EaseMotion CSS has hover-based cards already but no 3D-perspective flip interaction — this adds a genuinely different animation technique (3D transforms) to the library.
+
+## Files
+- `demo.html` — hover-triggered and click/focus-triggered examples
+- `style.css` — the `ease-flip-card` classes
+- `README.md` — this file
+
+## Usage
+\```html
+<div class="ease-flip-card" tabindex="0">
+  <div class="ease-flip-card-inner">
+    <div class="ease-flip-card-front"><h3>Front</h3></div>
+    <div class="ease-flip-card-back"><p>Back content</p></div>
+  </div>
+</div>
+\```

--- a/submissions/examples/flip-card-component/demo.html
+++ b/submissions/examples/flip-card-component/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-flip-card — EaseMotion CSS Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body{font-family:system-ui,sans-serif;background:#f7f7f9;padding:3rem;display:flex;gap:2rem;flex-wrap:wrap;}
+</style>
+</head>
+<body>
+
+<div class="ease-flip-card" tabindex="0">
+  <div class="ease-flip-card-inner">
+    <div class="ease-flip-card-front">
+      <h3>Hover Me</h3>
+    </div>
+    <div class="ease-flip-card-back">
+      <p>Here's the content on the back of the card!</p>
+    </div>
+  </div>
+</div>
+
+<div class="ease-flip-card ease-flip-card-click" tabindex="0">
+  <div class="ease-flip-card-inner">
+    <div class="ease-flip-card-front">
+      <h3>Click Me</h3>
+    </div>
+    <div class="ease-flip-card-back">
+      <p>Click-triggered flip (toggle via CSS :focus / tabindex)</p>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/flip-card-component/style.css
+++ b/submissions/examples/flip-card-component/style.css
@@ -1,0 +1,61 @@
+/* ==========================================================================
+   EaseMotion CSS — ease-flip-card
+   3D flip card revealing back-side content on hover or focus/click
+   ========================================================================== */
+
+.ease-flip-card {
+  width: 240px;
+  height: 160px;
+  perspective: 1000px;
+  cursor: pointer;
+}
+
+.ease-flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s cubic-bezier(0.4, 0.2, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+.ease-flip-card:hover .ease-flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+/* Click/keyboard variant: flips on focus instead of hover */
+.ease-flip-card-click:hover .ease-flip-card-inner {
+  transform: none;
+}
+.ease-flip-card-click:focus .ease-flip-card-inner,
+.ease-flip-card-click:focus-within .ease-flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.ease-flip-card-front,
+.ease-flip-card-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  text-align: center;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+}
+
+.ease-flip-card-front {
+  background: linear-gradient(135deg, #4f7cff, #6b8bff);
+  color: #fff;
+}
+
+.ease-flip-card-back {
+  background: #fff;
+  color: #222;
+  transform: rotateY(180deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-flip-card-inner { transition: none !important; }
+}


### PR DESCRIPTION
## Summary

Adds `ease-flip-card`, a pure-CSS 3D flip card component that reveals back-side content on hover (default) or keyboard focus/click (`.ease-flip-card-click` variant), using `perspective` + `rotateY` transforms.

## Changes

- `submissions/examples/ease-flip-card-<suffix>/demo.html`
- `submissions/examples/ease-flip-card-<suffix>/style.css`
- `submissions/examples/ease-flip-card-<suffix>/README.md`

## Why

Flip cards are a common pattern for pricing tables, profile cards, and flashcards. EaseMotion CSS has hover-effect cards already but nothing using true 3D perspective transforms — this adds a distinct animation technique to the framework's toolkit, and includes a keyboard/focus-accessible variant for non-hover devices.

## Testing

- Verified hover flip works smoothly in Chrome, Firefox, Safari.
- Verified `.ease-flip-card-click` variant flips correctly via keyboard Tab + focus (accessible for non-mouse users).
- Verified `prefers-reduced-motion` removes the transition so the flip is instant rather than animated.

## Checklist

- [x] This feature does not duplicate an existing EaseMotion CSS class
- [x] I understand my naming will be standardized by the maintainer
- [x] I submitted code inside `submissions/` only — not in `core/` or `components/`
- [x] Commits are squashed into a single logical commit