### PR TITLE
Add neumorphic toggle switch with vibrant gradient variant

### DIFF
--- a/submissions/examples/ease-anim-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-14/README.md
+++ b/submissions/examples/ease-anim-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-14/README.md
@@ -1,0 +1,23 @@
+# Neumorphic Interactive Toggle Switch (Vibrant Gradient)
+
+A pure CSS toggle switch with a neumorphic inset track and a springy, "haptic-feeling" thumb snap. No JavaScript.
+
+## How it works
+
+The track uses inset box-shadows (dark + light, same tone as the background) to look pressed into the surface. The thumb is a real checkbox/label pairing — checking it slides the thumb across via `translateX` and switches the track to a vibrant gradient. The bounce comes from `cubic-bezier(0.34, 1.56, 0.64, 1)`, which overshoots slightly past the resting position before settling, giving a tactile "snap" feel.
+
+## Files
+- `demo.html` – two toggle rows (notifications, email digest)
+- `style.css` – all styling, custom properties, and the snap transition
+- `README.md` – this file
+
+## Custom properties
+- `--ease-toggle-duration`, `--ease-toggle-easing` – snap timing/curve
+- `--ease-toggle-bg`, `--ease-toggle-shadow-light/dark` – neumorphic surface tones
+- `--ease-toggle-track-width/height`, `--ease-toggle-thumb-size` – dimensions
+- `--ease-toggle-gradient-start/end` – active-state gradient colors
+
+## Notes
+- Fully responsive
+- `:focus-visible` outline for keyboard users
+- Respects `prefers-reduced-motion` — snap is instant, no transition

--- a/submissions/examples/ease-anim-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-14/demo.html
+++ b/submissions/examples/ease-anim-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-14/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neumorphic Toggle — Vibrant Gradient</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Preferences</p>
+    <h1 class="ease-heading">Notification Settings</h1>
+    <p class="ease-subtitle">A neumorphic toggle with a springy haptic-feeling snap. Pure CSS.</p>
+
+    <div class="ease-toggle-row">
+      <span class="ease-toggle-label">Push notifications</span>
+      <label class="ease-toggle">
+        <input type="checkbox" class="ease-toggle-input" checked />
+        <span class="ease-toggle-track">
+          <span class="ease-toggle-thumb"></span>
+        </span>
+      </label>
+    </div>
+
+    <div class="ease-toggle-row">
+      <span class="ease-toggle-label">Email digest</span>
+      <label class="ease-toggle">
+        <input type="checkbox" class="ease-toggle-input" />
+        <span class="ease-toggle-track">
+          <span class="ease-toggle-thumb"></span>
+        </span>
+      </label>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/ease-anim-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-14/style.css
+++ b/submissions/examples/ease-anim-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-14/style.css
@@ -1,0 +1,109 @@
+:root {
+  --ease-toggle-duration: 0.35s;
+  --ease-toggle-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-toggle-bg: #1a1c22;
+  --ease-toggle-shadow-light: #24272f;
+  --ease-toggle-shadow-dark: #0d0e11;
+  --ease-toggle-track-width: 56px;
+  --ease-toggle-track-height: 30px;
+  --ease-toggle-thumb-size: 24px;
+  --ease-toggle-gradient-start: #ff6ec7;
+  --ease-toggle-gradient-end: #6c63ff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-toggle-bg);
+  color: #f0f0f0;
+  padding: 3rem 1.5rem;
+}
+
+.ease-container { max-width: 420px; margin: 0 auto; }
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-toggle-gradient-end);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading { font-size: 1.6rem; margin: 0 0 0.5rem; }
+.ease-subtitle { color: #a0a0a0; margin: 0 0 2rem; font-size: 0.9rem; }
+
+.ease-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  border-bottom: 1px solid #24272f;
+}
+
+.ease-toggle-label { font-size: 0.9rem; }
+
+.ease-toggle { display: inline-block; cursor: pointer; }
+
+.ease-toggle-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* neumorphic track: inset shadow gives the pressed-in groove look */
+.ease-toggle-track {
+  position: relative;
+  display: block;
+  width: var(--ease-toggle-track-width);
+  height: var(--ease-toggle-track-height);
+  border-radius: 999px;
+  background: var(--ease-toggle-bg);
+  box-shadow: inset 3px 3px 6px var(--ease-toggle-shadow-dark),
+              inset -3px -3px 6px var(--ease-toggle-shadow-light);
+  transition: background var(--ease-toggle-duration) var(--ease-toggle-easing);
+}
+
+.ease-toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: var(--ease-toggle-thumb-size);
+  height: var(--ease-toggle-thumb-size);
+  border-radius: 50%;
+  background: #3a3d47;
+  box-shadow: 2px 2px 4px var(--ease-toggle-shadow-dark),
+              -2px -2px 4px var(--ease-toggle-shadow-light);
+  transition: transform var(--ease-toggle-duration) var(--ease-toggle-easing),
+              background var(--ease-toggle-duration) var(--ease-toggle-easing);
+}
+
+/* the "haptic elasticity" comes from the bouncy cubic-bezier
+   overshooting slightly on the thumb's translateX */
+.ease-toggle-input:checked ~ .ease-toggle-track {
+  background: linear-gradient(135deg, var(--ease-toggle-gradient-start), var(--ease-toggle-gradient-end));
+}
+
+.ease-toggle-input:checked ~ .ease-toggle-track .ease-toggle-thumb {
+  transform: translateX(calc(var(--ease-toggle-track-width) - var(--ease-toggle-thumb-size) - 6px));
+  background: #fff;
+}
+
+.ease-toggle-input:focus-visible ~ .ease-toggle-track {
+  outline: 2px solid var(--ease-toggle-gradient-end);
+  outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  body { padding: 2rem 1rem; }
+  .ease-heading { font-size: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toggle-track,
+  .ease-toggle-thumb {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #57953

Adds a neumorphic toggle switch (vibrant gradient variant) with a springy haptic-feeling snap, per the issue spec.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes inside `submissions/examples/ease-anim-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-14/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---
## Feature Description
**What does this add?** A neumorphic toggle switch with inset-shadow track and a bouncy thumb snap on state change.

**How does a developer use it?**
```html
<label class="ease-toggle">
  <input type="checkbox" class="ease-toggle-input" />
  <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
</label>
```

**Why does it fit EaseMotion CSS?** Plain-English class names, zero dependencies, combines neumorphic inset shadows with a bouncy cubic-bezier snap for tactile feedback, fully themeable via custom properties.

---
## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---
## Notes for Maintainer
Bounce achieved via cubic-bezier overshoot rather than a keyframe, keeping the transition lightweight. Respects `prefers-reduced-motion`.