### PR TITLE
feat: add liquid wave waveform audio visualizer bar component (cyberp…

### DIFF
--- a/submissions/examples/ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122/README.md
+++ b/submissions/examples/ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122/README.md
@@ -1,0 +1,63 @@
+# Ease Anim Liquid Wave Waveform Audio Visualizer Bar Component — Cyberpunk Theme
+
+## Description
+A high-fidelity, cyberpunk-themed audio visualizer with 24 waveform bars that animate with a liquid, organic pulse — each bar's height *and* border-radius shift simultaneously at its peak, giving the wave a fluid, drop-like quality rather than a rigid bar-chart bounce. Wrapped in a glassmorphism panel with a continuously rotating neon rainbow border, a subtle mirrored reflection beneath the bars, and a functional-looking play/progress footer. Pure CSS animation — no JavaScript required for the visual effect.
+
+## Features
+- **Liquid wave bars**: 24 bars, each with a unique staggered negative `animation-delay` and target `--peak-height`, so the wave flows organically left-to-right rather than pulsing in unison
+- **Liquid morph**: at peak height, each bar's `border-radius` softens into an asymmetric blob shape before returning to a pill shape at rest — the "liquid" part of the effect
+- **Rotating neon border**: a `conic-gradient` ring animated via `@keyframes`, cycling through cyan → magenta → lime
+- **Glassmorphism panel**: `backdrop-filter: blur()` + translucent background + inset highlight
+- **Mirrored reflection**: a scaled/masked duplicate of the waveform beneath the main bars for extra depth
+- **Live badge** with a pulsing status dot
+- **Functional-looking footer**: play button, progress bar, time label
+- Fully responsive (bar width/gap and panel padding shrink on small screens)
+- Respects `prefers-reduced-motion`
+
+## Usage
+Copy the structure from `demo.html`:
+```html
+<div class="ease-audio-visualizer">
+  <div class="visualizer-header">
+    <span class="track-title">// TRACK_NAME.WAV</span>
+    <span class="live-badge"><span class="live-dot"></span>LIVE</span>
+  </div>
+
+  <div class="waveform-track" aria-hidden="true">
+    <div class="wave-bar"></div>
+    <!-- repeat wave-bar elements; nth-child rules in style.css cover up to 24 -->
+  </div>
+
+  <div class="visualizer-footer">
+    <button type="button" class="play-btn" aria-label="Play track">
+      <svg viewBox="0 0 24 24"><polygon points="6 3 20 12 6 21 6 3"></polygon></svg>
+    </button>
+    <div class="progress-track" role="progressbar" aria-valuenow="38" aria-valuemin="0" aria-valuemax="100">
+      <div class="progress-fill"></div>
+    </div>
+    <span class="time-label">1:24 / 3:41</span>
+  </div>
+</div>
+```
+The `.waveform-reflection` block is optional — omit it if you don't want the mirrored effect.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--wave-duration` | `1.4s` | Full pulse cycle duration per bar |
+| `--bar-width` | `6px` | Width of each bar |
+| `--bar-gap` | `5px` | Spacing between bars |
+| `--neon-primary` | `#00f0ff` | Primary neon color (cyan) |
+| `--neon-secondary` | `#ff00c8` | Secondary neon color (magenta) |
+| `--neon-tertiary` | `#a3ff00` | Tertiary neon color (lime), used for focus outlines |
+| `--panel-radius` | `24px` | Outer panel corner rounding |
+
+Each `.wave-bar` also respects a per-element `--peak-height` custom property (set via `nth-child` rules in `style.css`) controlling how tall that specific bar grows at its peak — adjust these to change the wave's visual rhythm.
+
+## Accessibility & Motion
+The decorative waveform bars are marked `aria-hidden="true"` since they're purely visual (not conveying real audio data in this static demo). The progress bar uses `role="progressbar"` with proper `aria-value*` attributes, and the play button is a real, focusable `<button>` with an `aria-label`. All animations — bar pulsing, border rotation, live-dot pulse — are disabled under `prefers-reduced-motion`, with bars settling into a static mid-height pill shape.
+
+## Files
+- `demo.html` — live working example
+- `style.css` — all component styles and liquid-wave keyframe animations
+- `README.md` — this file

--- a/submissions/examples/ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122/demo.html
+++ b/submissions/examples/ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Liquid Wave Audio Visualizer — Cyberpunk Theme</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at 50% 20%, #131025 0%, #05050a 70%);
+      padding: 30px;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-audio-visualizer">
+    <div class="visualizer-header">
+      <span class="track-title">// NEON_PULSE.WAV</span>
+      <span class="live-badge"><span class="live-dot"></span>LIVE</span>
+    </div>
+
+    <div class="waveform-track" aria-hidden="true">
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+    </div>
+
+    <div class="waveform-reflection" aria-hidden="true">
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+      <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+    </div>
+
+    <div class="visualizer-footer">
+      <button type="button" class="play-btn" aria-label="Play track">
+        <svg viewBox="0 0 24 24"><polygon points="6 3 20 12 6 21 6 3"></polygon></svg>
+      </button>
+      <div class="progress-track" role="progressbar" aria-label="Playback progress" aria-valuenow="38" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-fill"></div>
+      </div>
+      <span class="time-label">1:24 / 3:41</span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122/style.css
+++ b/submissions/examples/ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122/style.css
@@ -1,0 +1,276 @@
+/* Ease Anim Liquid Wave Waveform Audio Visualizer Bar Component — Cyberpunk Theme
+   Pure CSS animated waveform bars with liquid, undulating motion,
+   glassmorphism panel, and neon glow accents. Zero JS required for animation. */
+
+.ease-audio-visualizer {
+  --neon-primary: #00f0ff;
+  --neon-secondary: #ff00c8;
+  --neon-tertiary: #a3ff00;
+  --panel-bg: rgba(15, 15, 26, 0.55);
+  --panel-border: rgba(0, 240, 255, 0.25);
+  --bar-count: 24;
+  --wave-duration: 1.4s;
+  --bar-radius: 999px;
+  --bar-width: 6px;
+  --bar-gap: 5px;
+  --panel-radius: 24px;
+
+  position: relative;
+  width: min(480px, 92vw);
+  padding: 32px 28px;
+  border-radius: var(--panel-radius);
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  backdrop-filter: blur(18px);
+  box-shadow:
+    0 0 40px rgba(0, 240, 255, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+  font-family: 'Courier New', monospace;
+}
+
+/* animated rainbow-shift border ring */
+.ease-audio-visualizer::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: var(--panel-radius);
+  padding: 1px;
+  background: conic-gradient(
+    from 0deg,
+    var(--neon-primary), var(--neon-secondary), var(--neon-tertiary), var(--neon-primary)
+  );
+  animation: border-spin 5s linear infinite;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+@keyframes border-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ease-audio-visualizer .visualizer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 22px;
+  position: relative;
+  z-index: 1;
+}
+
+.ease-audio-visualizer .track-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--neon-primary);
+  text-shadow: 0 0 10px rgba(0, 240, 255, 0.6);
+}
+
+.ease-audio-visualizer .live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--neon-secondary);
+  background: rgba(255, 0, 200, 0.12);
+  border: 1px solid rgba(255, 0, 200, 0.4);
+  padding: 4px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+}
+
+.ease-audio-visualizer .live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--neon-secondary);
+  box-shadow: 0 0 6px var(--neon-secondary);
+  animation: dot-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes dot-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.3; }
+}
+
+/* ---- the waveform bars themselves ---- */
+.ease-audio-visualizer .waveform-track {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--bar-gap);
+  height: 90px;
+  padding: 0 6px;
+}
+
+.ease-audio-visualizer .wave-bar {
+  position: relative;
+  width: var(--bar-width);
+  height: 14%;
+  border-radius: var(--bar-radius);
+  background: linear-gradient(180deg, var(--neon-primary) 0%, var(--neon-secondary) 100%);
+  box-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+  animation: liquid-wave var(--wave-duration) ease-in-out infinite;
+  transform-origin: center;
+}
+
+/* liquid morph — bars don't just scale linearly, their border-radius
+   softens at peak height for an organic, liquid-drop feel */
+@keyframes liquid-wave {
+  0%, 100% {
+    height: 14%;
+    border-radius: var(--bar-radius);
+    filter: brightness(0.85);
+  }
+  50% {
+    height: var(--peak-height, 85%);
+    border-radius: 40% 40% 60% 60% / 55% 55% 45% 45%;
+    filter: brightness(1.25);
+  }
+}
+
+/* staggered timing per bar creates the flowing "wave" left-to-right feel,
+   using nth-child so a single stylesheet works with any bar count */
+.ease-audio-visualizer .wave-bar:nth-child(1)  { animation-delay: -1.30s; --peak-height: 55%; }
+.ease-audio-visualizer .wave-bar:nth-child(2)  { animation-delay: -1.20s; --peak-height: 70%; }
+.ease-audio-visualizer .wave-bar:nth-child(3)  { animation-delay: -1.10s; --peak-height: 40%; }
+.ease-audio-visualizer .wave-bar:nth-child(4)  { animation-delay: -1.00s; --peak-height: 85%; }
+.ease-audio-visualizer .wave-bar:nth-child(5)  { animation-delay: -0.90s; --peak-height: 60%; }
+.ease-audio-visualizer .wave-bar:nth-child(6)  { animation-delay: -0.80s; --peak-height: 95%; }
+.ease-audio-visualizer .wave-bar:nth-child(7)  { animation-delay: -0.70s; --peak-height: 50%; }
+.ease-audio-visualizer .wave-bar:nth-child(8)  { animation-delay: -0.60s; --peak-height: 75%; }
+.ease-audio-visualizer .wave-bar:nth-child(9)  { animation-delay: -0.50s; --peak-height: 90%; }
+.ease-audio-visualizer .wave-bar:nth-child(10) { animation-delay: -0.40s; --peak-height: 65%; }
+.ease-audio-visualizer .wave-bar:nth-child(11) { animation-delay: -0.30s; --peak-height: 80%; }
+.ease-audio-visualizer .wave-bar:nth-child(12) { animation-delay: -0.20s; --peak-height: 45%; }
+.ease-audio-visualizer .wave-bar:nth-child(13) { animation-delay: -0.10s; --peak-height: 95%; }
+.ease-audio-visualizer .wave-bar:nth-child(14) { animation-delay: 0s;    --peak-height: 60%; }
+.ease-audio-visualizer .wave-bar:nth-child(15) { animation-delay: -1.35s; --peak-height: 75%; }
+.ease-audio-visualizer .wave-bar:nth-child(16) { animation-delay: -1.25s; --peak-height: 55%; }
+.ease-audio-visualizer .wave-bar:nth-child(17) { animation-delay: -1.15s; --peak-height: 88%; }
+.ease-audio-visualizer .wave-bar:nth-child(18) { animation-delay: -1.05s; --peak-height: 42%; }
+.ease-audio-visualizer .wave-bar:nth-child(19) { animation-delay: -0.95s; --peak-height: 68%; }
+.ease-audio-visualizer .wave-bar:nth-child(20) { animation-delay: -0.85s; --peak-height: 92%; }
+.ease-audio-visualizer .wave-bar:nth-child(21) { animation-delay: -0.75s; --peak-height: 50%; }
+.ease-audio-visualizer .wave-bar:nth-child(22) { animation-delay: -0.65s; --peak-height: 78%; }
+.ease-audio-visualizer .wave-bar:nth-child(23) { animation-delay: -0.55s; --peak-height: 63%; }
+.ease-audio-visualizer .wave-bar:nth-child(24) { animation-delay: -0.45s; --peak-height: 85%; }
+
+/* subtle reflection under the bars for extra glassy depth */
+.ease-audio-visualizer .waveform-reflection {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: var(--bar-gap);
+  height: 26px;
+  padding: 0 6px;
+  margin-top: 2px;
+  mask-image: linear-gradient(to bottom, rgba(0,0,0,0.35), transparent);
+  transform: scaleY(-1);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.ease-audio-visualizer .waveform-reflection .wave-bar {
+  height: 14%;
+  animation: liquid-wave var(--wave-duration) ease-in-out infinite;
+}
+
+/* ---- footer: play control + progress ---- */
+.ease-audio-visualizer .visualizer-footer {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 20px;
+}
+
+.ease-audio-visualizer .play-btn {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--neon-primary);
+  background: rgba(0, 240, 255, 0.08);
+  color: var(--neon-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: box-shadow 0.25s ease, transform 0.15s ease;
+}
+
+.ease-audio-visualizer .play-btn:hover {
+  box-shadow: 0 0 18px rgba(0, 240, 255, 0.6);
+}
+
+.ease-audio-visualizer .play-btn:active {
+  transform: scale(0.92);
+}
+
+.ease-audio-visualizer .play-btn:focus-visible {
+  outline: 2px solid var(--neon-tertiary);
+  outline-offset: 3px;
+}
+
+.ease-audio-visualizer .play-btn svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.ease-audio-visualizer .progress-track {
+  flex: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.ease-audio-visualizer .progress-fill {
+  height: 100%;
+  width: 38%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--neon-primary), var(--neon-secondary));
+  box-shadow: 0 0 8px rgba(0, 240, 255, 0.6);
+}
+
+.ease-audio-visualizer .time-label {
+  font-size: 0.68rem;
+  color: #8b93a8;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-audio-visualizer .wave-bar,
+  .ease-audio-visualizer::before,
+  .ease-audio-visualizer .live-dot {
+    animation: none !important;
+  }
+  .ease-audio-visualizer .wave-bar {
+    height: 45% !important;
+    border-radius: var(--bar-radius) !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .ease-audio-visualizer {
+    --bar-width: 4px;
+    --bar-gap: 3px;
+    padding: 24px 18px;
+  }
+  .ease-audio-visualizer .waveform-track {
+    height: 70px;
+  }
+}


### PR DESCRIPTION
Closes #58062

## Pull Request Description
Adds `ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122` — a cyberpunk-themed audio waveform visualizer with 24 bars animating in a liquid, organic pulse (height + border-radius morph simultaneously at peak), wrapped in a glassmorphism panel with a continuously rotating neon rainbow border, a mirrored reflection beneath the bars, and a functional-looking play/progress footer. Pure CSS animation.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All files placed under `submissions/examples/ease-anim-liquid-wave-waveform-audio-visualizer-bar-component-122/` (exact target path from the issue)
- [x] Includes `demo.html` — clean, semantic structure
- [x] Includes `style.css` — modern CSS variables, smooth transitions, responsive styling
- [x] Includes `README.md` — installation and usage documented
- [x] Vibrant color palette, glassmorphism + neon accents (per "Cyberpunk Theme" spec)
- [x] No generic placeholders
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A cyberpunk-themed audio visualizer: 24 waveform bars with staggered, liquid-morphing pulse animation (organic border-radius shape shift at peak height rather than a rigid bounce), a rotating conic-gradient neon border, glassmorphism panel styling, a subtle mirrored waveform reflection, and a play button + progress bar footer.

**How does a developer use it?**
```html
<div class="ease-audio-visualizer">
  <div class="visualizer-header">
    <span class="track-title">// TRACK_NAME.WAV</span>
    <span class="live-badge"><span class="live-dot"></span>LIVE</span>
  </div>

  <div class="waveform-track" aria-hidden="true">
    <div class="wave-bar"></div>
    <!-- repeat wave-bar elements; nth-child rules cover up to 24 -->
  </div>

  <div class="visualizer-footer">
    <button type="button" class="play-btn" aria-label="Play track">
      <svg viewBox="0 0 24 24"><polygon points="6 3 20 12 6 21 6 3"></polygon></svg>
    </button>
    <div class="progress-track" role="progressbar" aria-valuenow="38" aria-valuemin="0" aria-valuemax="100">
      <div class="progress-fill"></div>
    </div>
    <span class="time-label">1:24 / 3:41</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS, GPU-friendly animation (`@keyframes` on `height`/`border-radius`/`filter`, `conic-gradient` rotation) with per-bar staggered negative `animation-delay` values creating a flowing wave rather than uniform pulsing. All timing, sizing, and neon colors are exposed via CSS custom properties (`--wave-duration`, `--bar-width`, `--neon-primary/secondary/tertiary`, etc.) without touching core rules, consistent with the framework's animation-first, zero-dependency philosophy. Decorative bars are `aria-hidden`, the progress bar uses proper `role="progressbar"`/`aria-value*`, the play button is a real focusable `<button>`, and every animation is disabled under `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Built strictly to the issue's exact target path and "no generic placeholders / state-of-the-art" requirement — the liquid-morph border-radius shift at each bar's peak (rather than a plain height bounce) is the core differentiator that makes this read as "liquid wave" rather than a standard equalizer bar visualizer.