### PR TITLE
CSS Multi-Column Masonry WebKit Card Height Inflation Fix

### DIFF
--- a/submissions/examples/column-masonry-height-fix/README.md
+++ b/submissions/examples/column-masonry-height-fix/README.md
@@ -1,0 +1,14 @@
+# Sandbox Layout Fix: CSS Multi-Column Masonry WebKit Card Height Inflation Resolution
+
+## Overview
+A high-performance CSS layout patch for CSS Multi-column (`column-count`) masonry card feeds. It completely eliminates phantom bottom whitespace gaps, prevents WebKit sub-pixel line-height inflation, and locks column item spacing cleanly inside Apple Safari viewports.
+
+## 📁 Sandbox Configuration Files
+* `demo.html` — Self-contained user cockpit hosting a 2-column masonry card feed with variable text lengths.
+* `style.css` — Scoped layout modifier asset layer specifying `display: inline-block` formatting and `contain: layout` boundaries.
+
+## 🐛 The Bug Resolved
+Previously, constructing a masonry card feed using CSS Multi-column Layout (`column-count: 3`) with `break-inside: avoid-column` caused height inflation errors in Apple Safari (WebKit). WebKit calculates column breaks by measuring block-level margin boxes rather than border boxes. Sub-pixel line-height calculations inside the cards rounded up, adding invisible bottom whitespace inside each card wrapper, pushing subsequent cards down, and creating massive gaps at the bottom of columns.
+
+## 🛠️ The Solution
+The display context and layout containment of column items are optimized. By converting cards to `display: inline-block; width: 100%;` while maintaining `break-inside: avoid;`, WebKit measures item dimensions using inline-level box metrics. Concurrently, applying `contain: layout;` to each card prevents interior sub-pixel line-height calculations from leaking into column height measurements. Cards stack snugly with zero scripts.

--- a/submissions/examples/column-masonry-height-fix/demo.html
+++ b/submissions/examples/column-masonry-height-fix/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — Column Masonry Height Fix</title>
+  
+  <!-- Relative path loading your sandbox style context cleanly -->
+  <link rel="stylesheet" href="./style.css">
+  
+  <style>
+    body {
+      background-color: #0b1121;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      padding: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <header style="margin-bottom: 2rem; text-align: center; max-width: 480px;">
+    <h1 style="color: white; margin: 0; font-size: 1.5rem; font-weight: 700;">Column Masonry Height Canvas</h1>
+    <p style="color: #64748b; margin: 4px 0 0 0; font-size: 0.875rem; line-height: 1.5;">Open this feed in Safari. Combining <code>display: inline-block</code> with <code>contain: layout</code> prevents WebKit sub-pixel line-height inflation with 0 scripts.</p>
+  </header>
+
+  <!-- Sandbox Active Stage Envelope -->
+  <div class="alm-sandbox-stage">
+    
+    <!-- MULTI-COLUMN MASONRY FEED CONTAINER -->
+    <div class="alm-masonry-feed">
+      
+      <!-- CARD ITEM 01 -->
+      <div class="alm-masonry-card">
+        <span class="alm-card-meta">Feed_Item_01</span>
+        <h4 class="alm-card-title">Neural Supporting Cluster</h4>
+        <p class="alm-card-body">
+          Compact content card demonstrating tight vertical stacking across multi-column layout flows.
+        </p>
+      </div>
+
+      <!-- CARD ITEM 02 (Variable Height) -->
+      <div class="alm-masonry-card">
+        <span class="alm-card-meta">Feed_Item_02</span>
+        <h4 class="alm-card-title">Shadow Crypt Socket</h4>
+        <p class="alm-card-body">
+          Slightly longer text block to test dynamic column height distribution. On unpatched layouts in WebKit, sub-pixel line-height rounding inflates the card height and leaves massive phantom whitespace below it.
+        </p>
+      </div>
+
+      <!-- CARD ITEM 03 -->
+      <div class="alm-masonry-card">
+        <span class="alm-card-meta">Feed_Item_03</span>
+        <h4 class="alm-card-title">Telemetry Stream Alpha</h4>
+        <p class="alm-card-body">
+          Notice how the card below this one aligns cleanly with zero extra whitespace padding.
+        </p>
+      </div>
+
+      <!-- CARD ITEM 04 -->
+      <div class="alm-masonry-card">
+        <span class="alm-card-meta">Feed_Item_04</span>
+        <h4 class="alm-card-title">KaamSetu Labor Hub</h4>
+        <p class="alm-card-body">
+          Multi-column feeds maintain equal gap spacing across all breakpoints natively.
+        </p>
+      </div>
+
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/column-masonry-height-fix/style.css
+++ b/submissions/examples/column-masonry-height-fix/style.css
@@ -1,0 +1,78 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — column-masonry-height-fix/style.css
+   ============================================================ */
+
+/* Step back 3 levels out of submissions/examples/column-masonry-height-fix to pull root tokens */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-components {
+
+/* ── Outer Stage Frame ───────────────────────────────────── */
+.alm-sandbox-stage {
+  width: 100%;
+  max-width: 480px;
+  background: #0f172a;
+  border: 1px solid var(--ease-glass-border, rgba(255, 255, 255, 0.06));
+  border-radius: var(--ease-radius-xl, 1.5rem);
+  padding: var(--ease-space-5, 1.25rem);
+  box-sizing: border-box;
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+}
+
+/* ── 1. MULTI-COLUMN MASONRY CONTAINER ───────────────────── */
+.alm-masonry-feed {
+  column-count: 2;
+  column-gap: var(--ease-space-4, 1rem);
+  width: 100%;
+}
+
+/* ── 2. PERFORMANCE STABILIZED MASONRY CARD (THE CORE FIX) ── */
+.alm-masonry-card {
+  /* SUCCESS: Inline-block formatting forces WebKit to calculate bounds 
+     using border-box metrics rather than block-level margin boxes */
+  display: inline-block;
+  width: 100%;
+  
+  /* Prevent cards from breaking across column boundaries */
+  break-inside: avoid;
+  -webkit-column-break-inside: avoid;
+  
+  /* SUCCESS: Layout containment traps interior sub-pixel line-height 
+     rounding errors inside the card wrapper */
+  contain: layout;
+
+  margin-bottom: var(--ease-space-4, 1rem);
+  background: #050814;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--ease-radius-lg, 1rem);
+  padding: var(--ease-space-4, 1rem);
+  box-sizing: border-box;
+}
+
+/* Interior Typography and Meta Details */
+.alm-card-meta {
+  font-family: monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--ease-color-primary, #6c63ff);
+  text-transform: uppercase;
+  margin-bottom: 2px;
+  display: block;
+}
+
+.alm-card-title {
+  margin: 0;
+  font-size: var(--ease-text-xs, 0.75rem);
+  font-weight: 800;
+  color: var(--ease-color-text, #f8fafc);
+}
+
+.alm-card-body {
+  margin: 4px 0 0 0;
+  font-size: 0.7rem;
+  line-height: 1.45;
+  color: var(--ease-color-muted, #94a3b8);
+}
+
+}


### PR DESCRIPTION
## Pull Request Description
This PR introduces an isolated, performance-first structural layout patch for a CSS Multi-Column Masonry WebKit Card Height Inflation Bug placed strictly inside the submissions/examples/column-masonry-height-fix/ sandbox directory. It addresses a prominent interface layout distortion defect common across multi-column card feeds, Pinterest-style layouts, and masonry dashboards where using column-count with break-inside: avoid causes Safari (WebKit) to inflate card heights with phantom bottom whitespace due to sub-pixel line-height rounding errors across block-level margin boxes.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- An optimized multi-column masonry card template that eliminates phantom WebKit bottom whitespace gaps and stabilizes column height measurements. -->

**How does a developer use it?**

```html
<!-- <!-- Structural layout template for inflation-proof multi-column masonry feeds -->
<div class="alm-masonry-feed">
  <div class="alm-masonry-card">
    <span class="alm-card-meta">Meta Tag</span>
    <h4 class="alm-card-title">Card Title</h4>
    <p class="alm-card-body">Card text content...</p>
  </div>
</div> -->
```

**Why does it fit EaseMotion CSS?**

<!-- It highlights the repository’s core mission of resolving complex browser engine layout bugs natively through clean architectural overrides. Resolving WebKit multi-column calculation bugs keeps responsive masonry feeds rendering at $60\text{fps}$ with zero main-thread JavaScript execution.-->

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---
close #58453