### PR TITLE
feat: add cyberpunk neon border button with glowing ripple (closes #5…

### DIFF
--- a/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/README.md
+++ b/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/README.md
@@ -1,0 +1,74 @@
+# ⚡ Cyberpunk Neon Border Button — Glowing Ripple Hover Effect
+### High-Contrast Accessibility Edition
+
+Resolves: #57962
+
+## Description
+A neon-outlined button component with a glowing radial ripple that expands
+from the pointer position on hover/focus, in a cyberpunk-inspired palette
+(cyan, magenta, yellow). Built with pure CSS animation/transitions plus a
+tiny JS helper that tracks pointer position for the ripple's origin — no
+external dependencies.
+
+Despite the vibrant aesthetic, this edition is built accessibility-first:
+strong focus indicators, `prefers-reduced-motion` support, and a dedicated
+`forced-colors` (Windows High Contrast Mode) treatment so the component
+stays usable and visible for all users.
+
+## Features
+- Glowing neon border in three color variants (cyan / magenta / yellow).
+- Ripple effect that expands from the pointer's hover position, tracked via
+  CSS custom properties (`--cnb-x`, `--cnb-y`) set in a tiny JS snippet.
+- Keyboard-accessible: `:focus-visible` triggers the same ripple/glow as
+  hover, with the ripple centered for keyboard users.
+- Highly visible focus ring (`outline`) independent of the glow effect, so
+  focus is never lost even with reduced motion or forced colors.
+- Disabled state clearly distinguished (dimmed, no glow/ripple).
+- Fully responsive — buttons stack on narrow viewports.
+
+## Files
+- `demo.html` — standalone demo with four button states.
+- `style.css` — all button styling, ripple animation, and accessibility
+  media queries.
+- `README.md` — this file.
+
+## Usage
+1. Include `style.css` in your page.
+2. Add the button markup:
+   ```html
+   <button class="cnb-btn cnb-btn--cyan">
+     <span class="cnb-btn__label">Launch</span>
+     <span class="cnb-ripple" aria-hidden="true"></span>
+   </button>
+   ```
+3. Copy the small pointer-tracking script from `demo.html` and attach it to
+   your `.cnb-btn` elements so the ripple follows the pointer.
+
+## Customization
+| CSS Custom Property | Purpose                                   |
+|----------------------|--------------------------------------------|
+| `--cnb-color`         | Base neon color (set per variant class)     |
+| `--cnb-x`, `--cnb-y`  | Ripple origin, updated on `pointermove`     |
+| `--cnb-radius`        | Corner radius                               |
+| `--cnb-border-width`  | Border thickness                            |
+
+Add new color variants by defining a class like:
+```css
+.cnb-btn--green { --cnb-color: #39ff14; }
+```
+
+## Accessibility
+- `:focus-visible` reproduces the hover glow/ripple for keyboard users, plus
+  a separate high-contrast `outline` so focus is always visible regardless
+  of the glow.
+- `prefers-reduced-motion: reduce` disables all transitions/transforms.
+- `forced-colors: active` (Windows High Contrast Mode) swaps the neon glow
+  for a solid `CanvasText`/`Highlight`-based treatment so the button remains
+  legible and its states distinguishable.
+- Disabled buttons use `opacity` + border/color changes, not color alone,
+  to signal state.
+
+## Testing
+Opened `demo.html` in a browser and verified hover, keyboard focus (Tab),
+disabled state, `prefers-reduced-motion` emulation, and forced-colors
+emulation via browser dev tools.

--- a/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/demo.html
+++ b/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>⚡ Cyberpunk Neon Border Button (High-Contrast Accessibility Edition)</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="cnb-stage">
+    <h1 class="cnb-title">⚡ Cyberpunk Neon Border Button</h1>
+    <p class="cnb-subtitle">High-Contrast Accessibility Edition — glowing ripple hover effect</p>
+
+    <div class="cnb-showcase">
+
+      <button class="cnb-btn cnb-btn--cyan">
+        <span class="cnb-btn__label">Launch</span>
+        <span class="cnb-ripple" aria-hidden="true"></span>
+      </button>
+
+      <button class="cnb-btn cnb-btn--magenta">
+        <span class="cnb-btn__label">Deploy</span>
+        <span class="cnb-ripple" aria-hidden="true"></span>
+      </button>
+
+      <button class="cnb-btn cnb-btn--yellow">
+        <span class="cnb-btn__label">Execute</span>
+        <span class="cnb-ripple" aria-hidden="true"></span>
+      </button>
+
+      <button class="cnb-btn cnb-btn--cyan" disabled>
+        <span class="cnb-btn__label">Disabled</span>
+        <span class="cnb-ripple" aria-hidden="true"></span>
+      </button>
+
+    </div>
+
+    <div class="cnb-hint">
+      <span>Hover or focus (Tab key) any button to see the glowing ripple.</span>
+    </div>
+  </main>
+
+  <script>
+    // Positions the ripple's transform-origin at the pointer location
+    // so the glow expands from wherever the user hovers/clicks.
+    document.querySelectorAll('.cnb-btn').forEach((btn) => {
+      btn.addEventListener('pointermove', (e) => {
+        const rect = btn.getBoundingClientRect();
+        const x = ((e.clientX - rect.left) / rect.width) * 100;
+        const y = ((e.clientY - rect.top) / rect.height) * 100;
+        btn.style.setProperty('--cnb-x', `${x}%`);
+        btn.style.setProperty('--cnb-y', `${y}%`);
+      });
+
+      // Keyboard focus: center the ripple origin for non-pointer users
+      btn.addEventListener('focus', () => {
+        btn.style.setProperty('--cnb-x', `50%`);
+        btn.style.setProperty('--cnb-y', `50%`);
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/style.css
+++ b/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/style.css
@@ -1,0 +1,207 @@
+/* =========================================================
+   ⚡ Cyberpunk Neon Border Button — Glowing Ripple Hover Effect
+   High-Contrast Accessibility Edition
+========================================================= */
+
+:root {
+  --cnb-bg: #0a0a12;
+  --cnb-surface: #12121e;
+  --cnb-text: #f5f5f7;
+  --cnb-cyan: #00fff2;
+  --cnb-magenta: #ff00e5;
+  --cnb-yellow: #f7ff00;
+  --cnb-radius: 10px;
+  --cnb-border-width: 2px;
+  --cnb-transition-fast: 0.2s ease;
+  --cnb-transition-ripple: 0.6s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cnb-bg);
+  color: var(--cnb-text);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+}
+
+.cnb-stage {
+  width: 100%;
+  max-width: 720px;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.cnb-title {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  margin: 0 0 0.4rem;
+  letter-spacing: 0.5px;
+  text-shadow: 0 0 16px rgba(0, 255, 242, 0.5);
+}
+
+.cnb-subtitle {
+  color: #b6b6c2;
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+.cnb-showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+/* ---------- Base button ---------- */
+.cnb-btn {
+  --cnb-color: var(--cnb-cyan);
+  --cnb-x: 50%;
+  --cnb-y: 50%;
+
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+
+  padding: 0.9rem 2rem;
+  min-width: 140px;
+  border-radius: var(--cnb-radius);
+  border: var(--cnb-border-width) solid var(--cnb-color);
+  background: var(--cnb-surface);
+  color: var(--cnb-text);
+
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+
+  transition: box-shadow var(--cnb-transition-fast),
+              transform var(--cnb-transition-fast),
+              border-color var(--cnb-transition-fast);
+}
+
+.cnb-btn__label {
+  position: relative;
+  z-index: 1;
+}
+
+/* Color variants */
+.cnb-btn--cyan    { --cnb-color: var(--cnb-cyan); }
+.cnb-btn--magenta { --cnb-color: var(--cnb-magenta); }
+.cnb-btn--yellow  { --cnb-color: var(--cnb-yellow); }
+
+/* ---------- Ripple ---------- */
+.cnb-ripple {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle at var(--cnb-x) var(--cnb-y),
+    color-mix(in srgb, var(--cnb-color) 55%, transparent) 0%,
+    transparent 60%
+  );
+  opacity: 0;
+  transform: scale(0.4);
+  transition: opacity var(--cnb-transition-ripple),
+              transform var(--cnb-transition-ripple);
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* ---------- Hover / focus states ---------- */
+.cnb-btn:hover,
+.cnb-btn:focus-visible {
+  box-shadow: 0 0 18px color-mix(in srgb, var(--cnb-color) 70%, transparent),
+              0 0 36px color-mix(in srgb, var(--cnb-color) 40%, transparent);
+  transform: translateY(-2px);
+}
+
+.cnb-btn:hover .cnb-ripple,
+.cnb-btn:focus-visible .cnb-ripple {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.cnb-btn:active {
+  transform: translateY(0);
+}
+
+/* Strong, visible focus ring for keyboard users (accessibility requirement) */
+.cnb-btn:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 3px;
+}
+
+/* Disabled state: clearly distinguishable, no glow/ripple */
+.cnb-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  border-color: #55555f;
+  box-shadow: none;
+  transform: none;
+}
+
+.cnb-btn:disabled .cnb-ripple {
+  display: none;
+}
+
+.cnb-hint {
+  color: #8b8b96;
+  font-size: 0.85rem;
+}
+
+/* ---------- Accessibility: reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .cnb-btn,
+  .cnb-ripple {
+    transition-duration: 0.01ms !important;
+  }
+  .cnb-btn:hover,
+  .cnb-btn:focus-visible {
+    transform: none;
+  }
+}
+
+/* ---------- Accessibility: forced/high-contrast colors mode ---------- */
+@media (forced-colors: active) {
+  .cnb-btn {
+    border: 2px solid CanvasText;
+    background: Canvas;
+    color: CanvasText;
+    forced-color-adjust: none;
+  }
+  .cnb-ripple {
+    background: Highlight;
+    opacity: 0;
+  }
+  .cnb-btn:hover .cnb-ripple,
+  .cnb-btn:focus-visible .cnb-ripple {
+    opacity: 0.3;
+  }
+  .cnb-btn:focus-visible {
+    outline: 3px solid Highlight;
+  }
+  .cnb-btn:disabled {
+    border-color: GrayText;
+    color: GrayText;
+    opacity: 1;
+  }
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .cnb-showcase {
+    flex-direction: column;
+    align-items: center;
+  }
+  .cnb-btn {
+    width: 100%;
+    max-width: 260px;
+  }
+}


### PR DESCRIPTION
**Title:** feat: add ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23 component (High-Contrast Accessibility Edition)

**Description:**

## What this does
Adds a new component submission — a **Cyberpunk Neon Border Button** with a glowing radial ripple hover effect, in three color variants (cyan, magenta, yellow), built as the "High-Contrast Accessibility Edition."

Closes #57962

## Files added
- `submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/demo.html`
- `submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/style.css`
- `submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-23/README.md`

## Implementation notes
- Neon border + glow via `box-shadow` and CSS custom properties (`--cnb-color` per variant).
- Ripple is a radial gradient positioned via `--cnb-x`/`--cnb-y`, updated on `pointermove` so it expands from wherever the user hovers.
- `:focus-visible` reproduces the same ripple/glow for keyboard users (centered origin), plus a separate high-contrast `outline` so focus is never dependent on the glow alone.
- Disabled state is distinguished by opacity + border/color change (not color alone), with ripple disabled entirely.
- Fully responsive — buttons stack on narrow viewports.

## Accessibility (per the "High-Contrast Accessibility Edition" requirement)
- `@media (prefers-reduced-motion: reduce)` disables all transitions/transforms.
- `@media (forced-colors: active)` swaps the neon glow for a `CanvasText`/`Highlight`-based treatment so the button stays legible in Windows High Contrast Mode.
- Keyboard focus is always visible via a dedicated outline, independent of hover-only effects.

## Testing
Opened `demo.html` in a browser and verified:
- Hover ripple follows pointer position correctly across all three color variants.
- Tab/keyboard focus triggers the same glow/ripple with a visible outline.
- Disabled button shows no glow/ripple and is visually distinct.
- `prefers-reduced-motion` and `forced-colors` emulation via dev tools both behave as expected.