### PR TITLE
feat: add cyberpunk neon border button dark mode variant (closes #57956)

### DIFF
--- a/submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/README.md
+++ b/submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/README.md
@@ -1,0 +1,68 @@
+# 🌙 Cyberpunk Neon Border Button — Glowing Ripple Hover Effect
+### Dark Mode Variant
+
+Resolves: #57956
+
+## Description
+A glassmorphic, dark-mode button component with a soft neon-tinted border
+and a glowing radial ripple that expands from the pointer position on
+hover/focus. Three accent variants (violet, teal, pink) sit on a frosted
+translucent surface (`backdrop-filter: blur`) against a deep gradient
+background, for a moody cyberpunk-at-night look. Pure CSS animation with a
+tiny JS helper for pointer tracking — no external dependencies.
+
+## Features
+- Frosted glass surface (`backdrop-filter: blur`) with a soft neon border
+  that only lights up on interaction.
+- Ripple effect expanding from the pointer's hover position via CSS custom
+  properties (`--cnbd-x`, `--cnbd-y`).
+- Three accent colors: violet, teal, pink — easy to extend with more.
+- Keyboard-accessible: `:focus-visible` reproduces the hover glow/ripple
+  (centered origin) plus a colored outline for clear focus visibility.
+- Disabled state clearly dimmed with no glow/ripple.
+- Responsive — buttons stack on narrow viewports.
+
+## Files
+- `demo.html` — standalone demo with four button states.
+- `style.css` — all button styling, ripple animation, and accessibility
+  media queries.
+- `README.md` — this file.
+
+## Usage
+1. Include `style.css` in your page.
+2. Add the button markup:
+   ```html
+   <button class="cnbd-btn cnbd-btn--violet">
+     <span class="cnbd-btn__label">Connect</span>
+     <span class="cnbd-ripple" aria-hidden="true"></span>
+   </button>
+   ```
+3. Copy the pointer-tracking script from `demo.html` and attach it to your
+   `.cnbd-btn` elements so the ripple follows the pointer.
+
+## Customization
+| CSS Custom Property   | Purpose                                  |
+|-------------------------|-------------------------------------------|
+| `--cnbd-color`           | Accent color (set per variant class)       |
+| `--cnbd-x`, `--cnbd-y`   | Ripple origin, updated on `pointermove`    |
+| `--cnbd-radius`          | Corner radius                              |
+| `--cnbd-blur`            | Glass blur strength                        |
+
+Add new accent colors with:
+```css
+.cnbd-btn--amber { --cnbd-color: #fbbf24; }
+```
+
+## Accessibility
+- `:focus-visible` reproduces the hover ripple/glow and adds a colored
+  outline so keyboard focus is always visible.
+- `prefers-reduced-motion: reduce` disables all transitions/transforms.
+- `forced-colors: active` (Windows High Contrast Mode) replaces the glass
+  effect with a solid `CanvasText`/`Highlight`-based treatment so the
+  button remains legible.
+- Disabled buttons use opacity + border/color changes, not color alone.
+
+## Testing
+Opened `demo.html` in a browser and verified hover ripple tracking, keyboard
+focus (Tab), disabled state, `prefers-reduced-motion` emulation, and
+forced-colors emulation via browser dev tools.

--- a/submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/demo.html
+++ b/submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>🌙 Cyberpunk Neon Border Button (Dark Mode Variant)</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="cnbd-stage">
+    <h1 class="cnbd-title">🌙 Cyberpunk Neon Border Button</h1>
+    <p class="cnbd-subtitle">Dark Mode Variant — glassmorphic surface with a glowing ripple hover effect</p>
+
+    <div class="cnbd-showcase">
+
+      <button class="cnbd-btn cnbd-btn--violet">
+        <span class="cnbd-btn__label">Connect</span>
+        <span class="cnbd-ripple" aria-hidden="true"></span>
+      </button>
+
+      <button class="cnbd-btn cnbd-btn--teal">
+        <span class="cnbd-btn__label">Sync</span>
+        <span class="cnbd-ripple" aria-hidden="true"></span>
+      </button>
+
+      <button class="cnbd-btn cnbd-btn--pink">
+        <span class="cnbd-btn__label">Transmit</span>
+        <span class="cnbd-ripple" aria-hidden="true"></span>
+      </button>
+
+      <button class="cnbd-btn cnbd-btn--violet" disabled>
+        <span class="cnbd-btn__label">Disabled</span>
+        <span class="cnbd-ripple" aria-hidden="true"></span>
+      </button>
+
+    </div>
+
+    <div class="cnbd-hint">
+      <span>Hover or focus (Tab key) any button to see the glassmorphic glow.</span>
+    </div>
+  </main>
+
+  <script>
+    // Tracks pointer position so the ripple expands from wherever
+    // the user hovers, and centers it on keyboard focus.
+    document.querySelectorAll('.cnbd-btn').forEach((btn) => {
+      btn.addEventListener('pointermove', (e) => {
+        const rect = btn.getBoundingClientRect();
+        const x = ((e.clientX - rect.left) / rect.width) * 100;
+        const y = ((e.clientY - rect.top) / rect.height) * 100;
+        btn.style.setProperty('--cnbd-x', `${x}%`);
+        btn.style.setProperty('--cnbd-y', `${y}%`);
+      });
+
+      btn.addEventListener('focus', () => {
+        btn.style.setProperty('--cnbd-x', `50%`);
+        btn.style.setProperty('--cnbd-y', `50%`);
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/style.css
+++ b/submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/style.css
@@ -1,0 +1,209 @@
+/* =========================================================
+   🌙 Cyberpunk Neon Border Button — Glowing Ripple Hover Effect
+   Dark Mode Variant (glassmorphic surface)
+========================================================= */
+
+:root {
+  --cnbd-bg-from: #0b0a14;
+  --cnbd-bg-to: #16112b;
+  --cnbd-surface: rgba(255, 255, 255, 0.04);
+  --cnbd-border-soft: rgba(255, 255, 255, 0.08);
+  --cnbd-text: #eae8ff;
+
+  --cnbd-violet: #a78bfa;
+  --cnbd-teal: #2dd4bf;
+  --cnbd-pink: #f472b6;
+
+  --cnbd-radius: 12px;
+  --cnbd-blur: 10px;
+  --cnbd-transition-fast: 0.2s ease;
+  --cnbd-transition-ripple: 0.6s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, var(--cnbd-bg-to), var(--cnbd-bg-from));
+  color: var(--cnbd-text);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+}
+
+.cnbd-stage {
+  width: 100%;
+  max-width: 720px;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.cnbd-title {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  margin: 0 0 0.4rem;
+  letter-spacing: 0.5px;
+  text-shadow: 0 0 18px rgba(167, 139, 250, 0.5);
+}
+
+.cnbd-subtitle {
+  color: #b3aed1;
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+.cnbd-showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+/* ---------- Base button (glassmorphic) ---------- */
+.cnbd-btn {
+  --cnbd-color: var(--cnbd-violet);
+  --cnbd-x: 50%;
+  --cnbd-y: 50%;
+
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+
+  padding: 0.9rem 2rem;
+  min-width: 140px;
+  border-radius: var(--cnbd-radius);
+  border: 1px solid var(--cnbd-border-soft);
+  background: var(--cnbd-surface);
+  backdrop-filter: blur(var(--cnbd-blur));
+  -webkit-backdrop-filter: blur(var(--cnbd-blur));
+  color: var(--cnbd-text);
+
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+
+  box-shadow: inset 0 0 0 1px transparent;
+  transition: box-shadow var(--cnbd-transition-fast),
+              border-color var(--cnbd-transition-fast),
+              transform var(--cnbd-transition-fast);
+}
+
+.cnbd-btn__label {
+  position: relative;
+  z-index: 1;
+}
+
+/* Color variants (border/glow tint only — surface stays glassy) */
+.cnbd-btn--violet { --cnbd-color: var(--cnbd-violet); }
+.cnbd-btn--teal   { --cnbd-color: var(--cnbd-teal); }
+.cnbd-btn--pink   { --cnbd-color: var(--cnbd-pink); }
+
+/* ---------- Ripple ---------- */
+.cnbd-ripple {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle at var(--cnbd-x) var(--cnbd-y),
+    color-mix(in srgb, var(--cnbd-color) 45%, transparent) 0%,
+    transparent 65%
+  );
+  opacity: 0;
+  transform: scale(0.4);
+  transition: opacity var(--cnbd-transition-ripple),
+              transform var(--cnbd-transition-ripple);
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* ---------- Hover / focus states ---------- */
+.cnbd-btn:hover,
+.cnbd-btn:focus-visible {
+  border-color: var(--cnbd-color);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--cnbd-color) 55%, transparent),
+              inset 0 0 12px color-mix(in srgb, var(--cnbd-color) 25%, transparent);
+  transform: translateY(-2px);
+}
+
+.cnbd-btn:hover .cnbd-ripple,
+.cnbd-btn:focus-visible .cnbd-ripple {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.cnbd-btn:active {
+  transform: translateY(0);
+}
+
+.cnbd-btn:focus-visible {
+  outline: 2px solid var(--cnbd-color);
+  outline-offset: 3px;
+}
+
+/* Disabled state */
+.cnbd-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+  border-color: var(--cnbd-border-soft);
+  box-shadow: none;
+  transform: none;
+}
+
+.cnbd-btn:disabled .cnbd-ripple {
+  display: none;
+}
+
+.cnbd-hint {
+  color: #8b86a8;
+  font-size: 0.85rem;
+}
+
+/* ---------- Accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .cnbd-btn,
+  .cnbd-ripple {
+    transition-duration: 0.01ms !important;
+  }
+  .cnbd-btn:hover,
+  .cnbd-btn:focus-visible {
+    transform: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .cnbd-btn {
+    border: 2px solid CanvasText;
+    background: Canvas;
+    backdrop-filter: none;
+    color: CanvasText;
+    forced-color-adjust: none;
+  }
+  .cnbd-ripple {
+    background: Highlight;
+    opacity: 0;
+  }
+  .cnbd-btn:hover .cnbd-ripple,
+  .cnbd-btn:focus-visible .cnbd-ripple {
+    opacity: 0.3;
+  }
+  .cnbd-btn:focus-visible {
+    outline: 3px solid Highlight;
+  }
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .cnbd-showcase {
+    flex-direction: column;
+    align-items: center;
+  }
+  .cnbd-btn {
+    width: 100%;
+    max-width: 260px;
+  }
+}


### PR DESCRIPTION
**Title:** feat: add ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17 component (Dark Mode Variant)

**Description:**

## What this does
Adds a new component submission — a **Cyberpunk Neon Border Button with Glowing Ripple Hover Effect**, Dark Mode Variant. Glassmorphic, translucent surface with a soft neon-tinted border in three accent colors (violet, teal, pink), against a deep gradient dark background.

Closes #57956

## Files added
- `submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/demo.html`
- `submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/style.css`
- `submissions/examples/ease-ui-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-17/README.md`

## Implementation notes
- Frosted-glass surface via `backdrop-filter: blur`, border/glow stays neutral until hover/focus.
- Ripple is a radial gradient positioned via `--cnbd-x`/`--cnbd-y`, updated on `pointermove` so it expands from wherever the user hovers.
- `:focus-visible` reproduces the same ripple/glow for keyboard users (centered origin), plus a colored outline for clear focus visibility.
- Disabled state distinguished by opacity + border/color change, ripple disabled entirely.
- Fully responsive — buttons stack on narrow viewports.

## Accessibility
- `@media (prefers-reduced-motion: reduce)` disables all transitions/transforms.
- `@media (forced-colors: active)` swaps the glass/glow treatment for a `CanvasText`/`Highlight`-based one so the button stays legible in Windows High Contrast Mode.
- Keyboard focus always visible via a dedicated colored outline, independent of hover-only effects.

## Testing
Opened `demo.html` in a browser and verified:
- Hover ripple follows pointer position correctly across all three accent colors.
- Tab/keyboard focus triggers the same glow/ripple with a visible outline.
- Disabled button shows no glow/ripple and is visually distinct.
- `prefers-reduced-motion` and `forced-colors` emulation via dev tools both behave as expected.