### PR TITLE
feat: add reduced-motion fallback concept demo (ref #58383)

### DIFF
--- a/submissions/examples/postcss-reduced-motion-fallback/README.md
+++ b/submissions/examples/postcss-reduced-motion-fallback/README.md
@@ -1,0 +1,58 @@
+# ♿ Auto-Generated `prefers-reduced-motion` Fallback (Concept Demo)
+
+Resolves: #58383
+
+## Problem
+Manually wrapping every EaseMotion animation in its own
+`@media (prefers-reduced-motion: reduce)` block is tedious and easy to
+forget, which risks the library being inaccessible by default (WCAG 2.3).
+
+## What this submission is
+Per discussion, this is a **concept/demo submission**, not the full
+Node.js/PostCSS AST plugin described in the issue's technical section. It
+shows exactly what the plugin's *output* would look like and lets you see
+the resulting behavior live in a browser, without needing a build pipeline
+to evaluate the idea.
+
+## How it works
+- `style.css` contains a few small example animation utilities (`.em-bounce`,
+  `.em-spin`, `.em-pulse`) written the normal way — no per-component
+  reduced-motion handling.
+- Below them, a single global fallback block is included (this is the part
+  the proposed plugin would auto-generate and append once at build time,
+  rather than a human writing it per-component):
+  ```css
+  @media (prefers-reduced-motion: reduce) {
+    [class*="em-"] {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
+  ```
+- Because it targets `[class*="em-"]`, it automatically covers *any*
+  current or future EaseMotion utility class without needing to be updated
+  per component — matching the plugin's intended behavior of scanning all
+  `em-*` classes.
+
+## Files
+- `demo.html` — live demo with three animated boxes plus an explanation of
+  what the real plugin would generate.
+- `style.css` — example component animations + the fallback block itself.
+- `README.md` — this file.
+
+## How to Verify
+1. Open `demo.html` in a browser — the three boxes should be animating
+   (bounce / spin / pulse).
+2. Enable "Reduce motion" in your OS accessibility settings (or emulate
+   `prefers-reduced-motion: reduce` via browser DevTools → Rendering tab),
+   then reload the page.
+3. All three animations should stop almost instantly, confirming the
+   fallback rule takes effect without any per-component changes.
+
+## Suggested Next Step (real plugin)
+For the full technical implementation described in the issue
+(`scripts/postcss-reduced-motion.js`, AST parsing, `npm run build`
+integration), that's a separate, larger build-tooling task better suited
+to a contributor working directly in the project's Node/PostCSS build
+pipeline — happy to take a pass at that separately if useful.

--- a/submissions/examples/postcss-reduced-motion-fallback/demo.html
+++ b/submissions/examples/postcss-reduced-motion-fallback/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>♿ Auto Reduced-Motion Fallback — Concept Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="rmf-stage">
+    <h1 class="rmf-title">♿ Auto-Generated Reduced-Motion Fallback</h1>
+    <p class="rmf-subtitle">
+      Concept demo for the proposed PostCSS plugin: any <code>em-*</code>
+      animated component automatically gets a safe fallback for users with
+      <code>prefers-reduced-motion: reduce</code> — without the component
+      author writing a single media query by hand.
+    </p>
+
+    <div class="rmf-showcase">
+      <div class="em-bounce rmf-box">Bounces</div>
+      <div class="em-spin rmf-box">Spins</div>
+      <div class="em-pulse rmf-box">Pulses</div>
+    </div>
+
+    <div class="rmf-hint">
+      <span>
+        Try enabling "Reduce motion" in your OS settings (or emulate
+        <code>prefers-reduced-motion: reduce</code> in DevTools) and reload —
+        the boxes above should stop animating instantly.
+      </span>
+    </div>
+
+    <section class="rmf-code">
+      <h2>What the plugin would generate</h2>
+      <p>Given component authors write only the animated rule:</p>
+      <pre><code>.em-bounce { animation: em-bounce 1s ease infinite; }</code></pre>
+      <p>The plugin scans the built CSS for any <code>animation</code> or
+        <code>transition</code> declaration on an <code>em-*</code> class and
+        auto-appends this global safety net once per build:</p>
+      <pre><code>@media (prefers-reduced-motion: reduce) {
+  [class*="em-"] {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}</code></pre>
+      <p>That block is included directly in <code>style.css</code> below, so
+        this page demonstrates the actual resulting behavior, not just the
+        idea.</p>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/postcss-reduced-motion-fallback/style.css
+++ b/submissions/examples/postcss-reduced-motion-fallback/style.css
@@ -1,0 +1,146 @@
+/* =========================================================
+   ♿ Auto-Generated Reduced-Motion Fallback — Concept Demo
+   Demonstrates what the proposed PostCSS plugin would output:
+   component authors write ONLY the "normal" rules above the
+   fallback marker. Everything below the marker is what the
+   plugin would auto-generate and append at build time.
+========================================================= */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.rmf-stage {
+  max-width: 680px;
+  width: 100%;
+  text-align: center;
+}
+
+.rmf-title {
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  margin: 0 0 0.75rem;
+}
+
+.rmf-subtitle {
+  color: #9da7b3;
+  font-size: 0.95rem;
+  margin: 0 0 2rem;
+  line-height: 1.5;
+}
+
+.rmf-subtitle code,
+.rmf-code code {
+  background: #161b22;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.rmf-showcase {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+}
+
+.rmf-box {
+  width: 110px;
+  height: 110px;
+  border-radius: 12px;
+  background: #1f2937;
+  border: 1px solid #30363d;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: #c9d1d9;
+}
+
+.rmf-hint {
+  color: #7d8590;
+  font-size: 0.85rem;
+  margin-bottom: 2.5rem;
+  line-height: 1.5;
+}
+
+.rmf-code {
+  text-align: left;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+}
+
+.rmf-code h2 {
+  font-size: 1.1rem;
+  margin-top: 0;
+}
+
+.rmf-code p {
+  color: #9da7b3;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.rmf-code pre {
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+}
+
+/* =========================================================
+   ---- "Component author" rules (written by hand) ----
+   These are examples of the kind of small, everyday
+   animation utilities EaseMotion ships. Note: none of these
+   individually handle reduced-motion — that's the point.
+========================================================= */
+
+@keyframes em-bounce-kf {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-14px); }
+}
+
+@keyframes em-spin-kf {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes em-pulse-kf {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.08); }
+}
+
+.em-bounce { animation: em-bounce-kf 1s ease-in-out infinite; }
+.em-spin   { animation: em-spin-kf 1.6s linear infinite; }
+.em-pulse  { animation: em-pulse-kf 1.4s ease-in-out infinite; }
+
+/* =========================================================
+   ---- PLUGIN-GENERATED FALLBACK (auto-appended) ----
+   This block is exactly what the proposed PostCSS plugin
+   would inject automatically at build time, once, covering
+   every "em-*" class that declares animation/transition —
+   no per-component media query needed from contributors.
+========================================================= */
+@media (prefers-reduced-motion: reduce) {
+  [class*="em-"] {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
**Title:** feat: add reduced-motion fallback concept demo (ref #58383)

**Description:**

## What this does
Adds a concept/demo submission illustrating the auto-generated `prefers-reduced-motion` fallback approach proposed in #58383 — showing what the described PostCSS plugin's *output* would look like and behave as, live in a browser.

Ref #58383
*(Note: not using "Closes" since #58392 already addresses the full Node.js/PostCSS plugin implementation — this is a complementary, lighter-weight demo of the concept, not a competing full solution.)*

## Files added
- `submissions/examples/postcss-reduced-motion-fallback/demo.html`
- `submissions/examples/postcss-reduced-motion-fallback/style.css`
- `submissions/examples/postcss-reduced-motion-fallback/README.md`

## What's included
- Three small example animation utilities (`.em-bounce`, `.em-spin`, `.em-pulse`) written the normal way, with no per-component reduced-motion handling.
- A single global fallback block targeting `[class*="em-"]`, demonstrating exactly what the proposed plugin would auto-generate and append once at build time:
  ```css
  @media (prefers-reduced-motion: reduce) {
    [class*="em-"] {
      animation-duration: 0.01ms !important;
      animation-iteration-count: 1 !important;
      transition-duration: 0.01ms !important;
    }
  }
  ```
- Because the selector targets any `em-*` class, this covers current and future utilities automatically — matching the plugin's intended scanning behavior, just applied statically here instead of via a build-time AST pass.

## Scope note
This does **not** implement the full `scripts/postcss-reduced-motion.js` Node/PostCSS AST plugin or `npm run build` integration described in the issue's technical section — that's a larger build-tooling task. This PR is meant to validate/demonstrate the concept and resulting behavior in isolation.

## Testing
Opened `demo.html` in a browser:
- Confirmed all three boxes animate normally by default.
- Enabled "Reduce motion" (OS setting) / emulated `prefers-reduced-motion: reduce` in DevTools, reloaded, and confirmed all animations stop almost instantly — no per-component changes needed.