### PR TITLE
Add minimalist clean neumorphic toggle switch

### DIFF
--- a/submissions/examples/ease-ui-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-13/README.md
+++ b/submissions/examples/ease-ui-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-13/README.md
@@ -1,0 +1,15 @@
+# Neumorphic Interactive Toggle Switch (Minimalist Clean Edition)
+
+A flat, single-tone toggle switch with a soft elastic thumb snap. No JavaScript.
+
+## How it works
+A standard checkbox/label toggle. The track swaps from a light gray to a solid dark accent on check; the thumb slides via `translateX` with a bouncy `cubic-bezier` for a subtle snap, without any gradients or shadows beyond a light drop-shadow on the thumb — deliberately restrained for the minimalist style.
+
+## Files
+- `demo.html`, `style.css`, `README.md`
+
+## Custom properties
+`--ease-min-duration`, `--ease-min-easing`, `--ease-min-bg`, `--ease-min-text`, `--ease-min-muted`, `--ease-min-border`, `--ease-min-accent`, `--ease-min-track-width/height`, `--ease-min-thumb-size`
+
+## Notes
+Respects `prefers-reduced-motion`. `:focus-visible` outline included.

--- a/submissions/examples/ease-ui-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-13/demo.html
+++ b/submissions/examples/ease-ui-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-13/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toggle Switch — Minimalist Clean</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Settings</p>
+    <h1 class="ease-heading">Preferences</h1>
+    <p class="ease-subtitle">A minimal, single-tone toggle with a soft elastic snap.</p>
+
+    <div class="ease-toggle-row">
+      <span class="ease-toggle-label">Auto-save</span>
+      <label class="ease-toggle">
+        <input type="checkbox" class="ease-toggle-input" checked />
+        <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+      </label>
+    </div>
+    <div class="ease-toggle-row">
+      <span class="ease-toggle-label">Sound effects</span>
+      <label class="ease-toggle">
+        <input type="checkbox" class="ease-toggle-input" />
+        <span class="ease-toggle-track"><span class="ease-toggle-thumb"></span></span>
+      </label>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-ui-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-13/style.css
+++ b/submissions/examples/ease-ui-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-13/style.css
@@ -1,0 +1,73 @@
+:root {
+  --ease-min-duration: 0.3s;
+  --ease-min-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-min-bg: #fafafa;
+  --ease-min-text: #1f1f1f;
+  --ease-min-muted: #757575;
+  --ease-min-border: #e2e2e2;
+  --ease-min-accent: #1f1f1f;
+  --ease-min-track-width: 46px;
+  --ease-min-track-height: 26px;
+  --ease-min-thumb-size: 20px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-min-bg);
+  color: var(--ease-min-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container { max-width: 400px; margin: 0 auto; }
+.ease-eyebrow { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.7rem; color: var(--ease-min-muted); margin: 0 0 0.5rem; }
+.ease-heading { font-size: 1.5rem; margin: 0 0 0.4rem; font-weight: 600; }
+.ease-subtitle { color: var(--ease-min-muted); margin: 0 0 2rem; font-size: 0.85rem; }
+
+.ease-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9rem 0;
+  border-bottom: 1px solid var(--ease-min-border);
+}
+
+.ease-toggle-label { font-size: 0.875rem; }
+.ease-toggle { display: inline-block; cursor: pointer; }
+.ease-toggle-input { position: absolute; opacity: 0; pointer-events: none; }
+
+/* minimalist: flat single-tone track, no gradient, just a clean
+   color swap and a smooth thumb slide */
+.ease-toggle-track {
+  position: relative;
+  display: block;
+  width: var(--ease-min-track-width);
+  height: var(--ease-min-track-height);
+  border-radius: 999px;
+  background: var(--ease-min-border);
+  transition: background var(--ease-min-duration) var(--ease-min-easing);
+}
+
+.ease-toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: var(--ease-min-thumb-size);
+  height: var(--ease-min-thumb-size);
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  transition: transform var(--ease-min-duration) var(--ease-min-easing);
+}
+
+.ease-toggle-input:checked ~ .ease-toggle-track { background: var(--ease-min-accent); }
+.ease-toggle-input:checked ~ .ease-toggle-track .ease-toggle-thumb {
+  transform: translateX(calc(var(--ease-min-track-width) - var(--ease-min-thumb-size) - 6px));
+}
+.ease-toggle-input:focus-visible ~ .ease-toggle-track { outline: 2px solid var(--ease-min-accent); outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toggle-track, .ease-toggle-thumb { transition: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #57952

Adds a minimalist, single-tone toggle switch variant with a soft elastic snap.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/ease-ui-neumorphic-interactive-toggle-switch-with-smooth-haptic-elasticity-13/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A flat, restrained toggle switch with a bouncy thumb slide — the minimalist counterpart to the framework's other toggle variants.
**Why does it fit?** Same checkbox-driven pattern as other toggles, but deliberately stripped of gradients/glows for a clean, single-tone aesthetic.

## Demo
- [x] Demo added
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Deliberately minimal styling per the "Minimalist Clean" variation spec. Respects `prefers-reduced-motion`.