### PR TITLE
Add glassmorphic variant of cyberpunk neon ripple button

### DIFF
--- a/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-19/README.md
+++ b/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-19/README.md
@@ -1,0 +1,15 @@
+# Cyberpunk Neon Border Button (Glassmorphic Style)
+
+A neon ripple button set inside a frosted glass panel, combining cyberpunk glow with glassmorphism. No JavaScript.
+
+## How it works
+The panel uses `backdrop-filter: blur()` with a translucent fill, sitting on a purple-to-black gradient background. The buttons themselves use the same `currentColor`-driven ripple and box-shadow glow mechanism as the framework's other cyberpunk buttons.
+
+## Files
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+`--ease-neon-duration`, `--ease-neon-easing`, `--ease-neon-cyan`, `--ease-neon-pink`, `--ease-neon-radius`, `--ease-glass-panel-bg`, `--ease-glass-panel-border`
+
+## Notes
+Includes `-webkit-backdrop-filter` for Safari. Respects `prefers-reduced-motion`.

--- a/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-19/demo.html
+++ b/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-19/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cyberpunk Neon Ripple Button — Glassmorphic</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ease-glass-panel">
+    <p class="ease-eyebrow">Uplink</p>
+    <h1 class="ease-heading">Network Actions</h1>
+    <p class="ease-subtitle">Neon buttons over a frosted glass panel.</p>
+    <div class="ease-btn-row">
+      <button class="ease-neon-btn ease-neon-btn-cyan">Sync</button>
+      <button class="ease-neon-btn ease-neon-btn-pink">Purge</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-19/style.css
+++ b/submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-19/style.css
@@ -1,0 +1,77 @@
+:root {
+  --ease-neon-duration: 0.6s;
+  --ease-neon-easing: ease-out;
+  --ease-neon-cyan: #00e5ff;
+  --ease-neon-pink: #ff4ecb;
+  --ease-neon-radius: 8px;
+  --ease-glass-panel-bg: rgba(255, 255, 255, 0.06);
+  --ease-glass-panel-border: rgba(255, 255, 255, 0.15);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0; min-height: 100vh;
+  display: flex; align-items: center; justify-content: center;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: linear-gradient(150deg, #1a0f3d, #0a0a12);
+  color: #e8e8f0;
+  padding: 2rem 1rem;
+}
+
+.ease-glass-panel {
+  width: 100%; max-width: 420px;
+  background: var(--ease-glass-panel-bg);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border: 1px solid var(--ease-glass-panel-border);
+  border-radius: 16px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.ease-eyebrow { text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.7rem; color: var(--ease-neon-cyan); margin: 0 0 0.5rem; }
+.ease-heading { font-size: 1.4rem; margin: 0 0 0.4rem; }
+.ease-subtitle { color: #a8a8c0; margin: 0 0 1.75rem; font-size: 0.85rem; }
+
+.ease-btn-row { display: flex; gap: 1.1rem; justify-content: center; flex-wrap: wrap; }
+
+.ease-neon-btn {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--ease-neon-cyan);
+  color: var(--ease-neon-cyan);
+  padding: 0.7rem 1.5rem;
+  border-radius: var(--ease-neon-radius);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  box-shadow: 0 0 6px var(--ease-neon-cyan);
+  transition: box-shadow 0.25s ease;
+}
+
+.ease-neon-btn-pink { border-color: var(--ease-neon-pink); color: var(--ease-neon-pink); box-shadow: 0 0 6px var(--ease-neon-pink); }
+
+.ease-neon-btn::before {
+  content: ""; position: absolute; top: 50%; left: 50%;
+  width: 8px; height: 8px; border-radius: 50%;
+  background: currentColor; opacity: 0;
+  transform: translate(-50%, -50%) scale(0);
+}
+
+.ease-neon-btn:hover { box-shadow: 0 0 16px var(--ease-neon-cyan), 0 0 28px var(--ease-neon-cyan); }
+.ease-neon-btn-pink:hover { box-shadow: 0 0 16px var(--ease-neon-pink), 0 0 28px var(--ease-neon-pink); }
+.ease-neon-btn:hover::before { animation: ease-neon-ripple var(--ease-neon-duration) var(--ease-neon-easing); }
+
+@keyframes ease-neon-ripple {
+  0% { opacity: 0.45; transform: translate(-50%, -50%) scale(0); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(35); }
+}
+
+.ease-neon-btn:focus-visible { outline: 2px solid currentColor; outline-offset: 3px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-neon-btn, .ease-neon-btn::before { transition: none !important; animation: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #57958

Adds a glassmorphic variant of the cyberpunk neon ripple button, set inside a frosted glass panel.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/ease-layout-cyberpunk-neon-border-button-with-glowing-ripple-hover-effect-19/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** Neon ripple buttons displayed inside a blurred, translucent glass panel over a gradient background.
**Why does it fit?** Combines the framework's existing ripple/glow button mechanism with glassmorphism, reusing `currentColor` for the ripple.

## Demo
- [x] Demo added
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes `-webkit-backdrop-filter` prefix for Safari support. Respects `prefers-reduced-motion`.