### PR TITLE
Add high-contrast accessibility edition of 3D tilt product card

### DIFF
--- a/submissions/examples/ease-layout-3d-perspective-tilt-product-showcase-card-with-light-reflections-31/README.md
+++ b/submissions/examples/ease-layout-3d-perspective-tilt-product-showcase-card-with-light-reflections-31/README.md
@@ -1,0 +1,17 @@
+# 3D Perspective Tilt Product Showcase Card (High-Contrast Accessibility Edition)
+
+A cursor-following 3D tilt product card built with WCAG contrast in mind: pure black background, pure white 3px border, and a high-visibility yellow accent — all comfortably exceeding standard contrast ratios rather than relying on subtle glows or low-contrast grays.
+
+## How it works
+Same mechanism as the framework's base tilt card: a small script tracks cursor position and writes it into CSS custom properties (`--ease-tilt-rx`, `--ease-tilt-ry`, `--ease-tilt-shine-x/y`); CSS handles all rendering via `rotateX`/`rotateY` and a radial-gradient shine. The accessibility edition swaps the low-contrast dark-on-dark palette for pure black/white/yellow, and thickens the border from 1px to 3px so the card boundary stays clearly visible even without the glow.
+
+## Files
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+`--ease-tilt-duration`, `--ease-tilt-easing`, `--ease-tilt-radius`, `--ease-tilt-bg`, `--ease-tilt-border`, `--ease-tilt-text`, `--ease-tilt-muted-text`, `--ease-tilt-accent`, `--ease-tilt-perspective`
+
+## Notes
+- Palette chosen for high contrast (pure black/white/yellow) rather than the original's more subdued purple-on-dark
+- Border thickened to 3px so the card reads clearly without relying on the hover glow
+- Respects `prefers-reduced-motion`

--- a/submissions/examples/ease-layout-3d-perspective-tilt-product-showcase-card-with-light-reflections-31/demo.html
+++ b/submissions/examples/ease-layout-3d-perspective-tilt-product-showcase-card-with-light-reflections-31/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Tilt Product Card — High-Contrast</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Featured Product</p>
+    <h1 class="ease-heading">Aria Wireless Headphones</h1>
+    <p class="ease-subtitle">High-contrast tilt card. Move your cursor across it to tilt.</p>
+
+    <div class="ease-scene">
+      <div class="ease-tilt-card">
+        <div class="ease-tilt-shine"></div>
+        <div class="ease-tilt-content">
+          <span class="ease-tilt-badge">New</span>
+          <div class="ease-tilt-thumb">🎧</div>
+          <h2>Aria Wireless</h2>
+          <p>Noise-cancelling, 30-hour battery, spatial audio.</p>
+          <span class="ease-tilt-price">$189</span>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const card = document.querySelector('.ease-tilt-card');
+    card.addEventListener('mousemove', (e) => {
+      const rect = card.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const rotateY = ((x / rect.width) - 0.5) * 20;
+      const rotateX = ((y / rect.height) - 0.5) * -20;
+      card.style.setProperty('--ease-tilt-rx', `${rotateX}deg`);
+      card.style.setProperty('--ease-tilt-ry', `${rotateY}deg`);
+      card.style.setProperty('--ease-tilt-shine-x', `${(x / rect.width) * 100}%`);
+      card.style.setProperty('--ease-tilt-shine-y', `${(y / rect.height) * 100}%`);
+    });
+    card.addEventListener('mouseleave', () => {
+      card.style.setProperty('--ease-tilt-rx', '0deg');
+      card.style.setProperty('--ease-tilt-ry', '0deg');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-layout-3d-perspective-tilt-product-showcase-card-with-light-reflections-31/style.css
+++ b/submissions/examples/ease-layout-3d-perspective-tilt-product-showcase-card-with-light-reflections-31/style.css
@@ -1,0 +1,78 @@
+:root {
+  --ease-tilt-duration: 0.4s;
+  --ease-tilt-easing: ease-out;
+  --ease-tilt-radius: 14px;
+  /* high-contrast palette: pure black/white base, thick visible border */
+  --ease-tilt-bg: #000000;
+  --ease-tilt-border: #ffffff;
+  --ease-tilt-text: #ffffff;
+  --ease-tilt-muted-text: #d8d8d8;
+  --ease-tilt-accent: #ffd400;
+  --ease-tilt-perspective: 1000px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0; min-height: 100vh;
+  display: flex; align-items: center; justify-content: center; flex-direction: column;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #000;
+  color: var(--ease-tilt-text);
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.ease-container { max-width: 420px; }
+.ease-eyebrow { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.8rem; color: var(--ease-tilt-accent); margin: 0 0 0.5rem; font-weight: 700; }
+.ease-heading { font-size: 1.5rem; margin: 0 0 0.5rem; }
+.ease-subtitle { color: var(--ease-tilt-muted-text); margin: 0 0 2.5rem; font-size: 0.9rem; }
+
+.ease-scene { perspective: var(--ease-tilt-perspective); }
+
+.ease-tilt-card {
+  position: relative;
+  width: 280px;
+  margin: 0 auto;
+  border-radius: var(--ease-tilt-radius);
+  background: var(--ease-tilt-bg);
+  border: 3px solid var(--ease-tilt-border);
+  overflow: hidden;
+  transform-style: preserve-3d;
+  transform: rotateX(var(--ease-tilt-rx, 0deg)) rotateY(var(--ease-tilt-ry, 0deg));
+  transition: transform var(--ease-tilt-duration) var(--ease-tilt-easing);
+}
+
+.ease-tilt-shine {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at var(--ease-tilt-shine-x, 50%) var(--ease-tilt-shine-y, 50%), rgba(255, 212, 0, 0.3), transparent 60%);
+  opacity: 0;
+  transition: opacity var(--ease-tilt-duration) var(--ease-tilt-easing);
+  pointer-events: none;
+}
+
+.ease-tilt-card:hover .ease-tilt-shine { opacity: 1; }
+
+.ease-tilt-content { position: relative; padding: 1.75rem; transform: translateZ(20px); }
+
+.ease-tilt-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: #000;
+  background: var(--ease-tilt-accent);
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  margin-bottom: 0.75rem;
+}
+
+.ease-tilt-thumb { font-size: 2.5rem; margin-bottom: 0.75rem; }
+.ease-tilt-content h2 { margin: 0 0 0.4rem; font-size: 1.15rem; }
+.ease-tilt-content p { margin: 0 0 1rem; font-size: 0.85rem; color: var(--ease-tilt-muted-text); line-height: 1.5; }
+.ease-tilt-price { font-size: 1.25rem; font-weight: 700; color: var(--ease-tilt-accent); }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tilt-card, .ease-tilt-shine { transition: none !important; transform: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #57970

Adds a high-contrast accessibility variant of the 3D perspective tilt product card, using a WCAG-friendly black/white/yellow palette and a thicker card border.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/ease-layout-3d-perspective-tilt-product-showcase-card-with-light-reflections-31/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A cursor-following 3D tilt card with light reflection, styled for high contrast accessibility rather than the original's subtle low-contrast palette.
**Why does it fit?** Reuses the framework's tilt/shine mechanism, with a deliberately high-contrast palette (pure black/white/yellow, 3px border) so the component remains clearly legible for users needing higher contrast.

## Demo
- [x] Demo added
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
High-Contrast Accessibility Edition per spec — pure black/white base, thick 3px border, yellow accent for strong visibility without relying on the hover glow alone. Respects `prefers-reduced-motion`.