### PR TITLE
feat: add neumorphic sticky blur navigation header

### DIFF
--- a/submissions/examples/ease-advanced-sticky-blur-glass-navigation-header-with-scroll-shrink-effect-188/README.md
+++ b/submissions/examples/ease-advanced-sticky-blur-glass-navigation-header-with-scroll-shrink-effect-188/README.md
@@ -1,0 +1,59 @@
+# Sticky Blur Glass Navigation Header with Scroll Shrink Effect
+
+## What does this do?
+
+This submission provides a responsive navigation header that uses a translucent backdrop,
+neumorphic depth, and an eased compact state after the page begins scrolling.
+
+The demonstration also includes an accessible mobile menu and updates the current navigation item
+as each linked section enters the viewport.
+
+## How is it used?
+
+Copy `demo.html` and `style.css` into the same directory, then open `demo.html` directly in a
+modern browser. The component has no server, package, font, CDN, or framework dependency.
+
+Use the header shell and matching section anchors as follows:
+
+```html
+<header class="site-header" data-scrolled="false">
+  <div class="nav-shell">
+    <a class="brand" href="#home">Northline</a>
+    <nav class="primary-nav" aria-label="Primary navigation">
+      <a href="#routes" aria-current="page">Routes</a>
+      <a href="#stories">Stories</a>
+    </nav>
+  </div>
+</header>
+```
+
+The inline script in `demo.html` changes `data-scrolled` when `window.scrollY` passes 32 pixels.
+The compact appearance is controlled by this selector:
+
+```css
+.site-header[data-scrolled="true"] .nav-shell {
+  min-height: 62px;
+}
+```
+
+Colors, blur strength, shadows, and the expanded or compact heights can be adjusted through the
+custom properties and navigation rules near the beginning of `style.css`.
+
+## Why is it useful?
+
+The component keeps primary navigation available without permanently occupying a large part of the
+viewport. Its state change is communicated through restrained motion, while the glass layer and
+paired light and dark shadows create a distinct neumorphic finish without sacrificing contrast.
+
+It fits EaseMotion CSS's animation-first philosophy because the visual transition follows a clear,
+human-readable state: `data-scrolled="false"` for the spacious header and `data-scrolled="true"`
+for the compact one.
+
+## Accessibility and responsive behavior
+
+- A skip link lets keyboard users bypass the fixed navigation.
+- The mobile menu exposes `aria-expanded`, supports Escape, and closes after navigation.
+- Current-section links use `aria-current="page"`.
+- Every interactive element has a visible focus indicator.
+- `prefers-reduced-motion` removes smooth scrolling and reduces transition durations.
+- The layout collapses at 900, 760, and 480 pixels without changing the document order.

--- a/submissions/examples/ease-advanced-sticky-blur-glass-navigation-header-with-scroll-shrink-effect-188/demo.html
+++ b/submissions/examples/ease-advanced-sticky-blur-glass-navigation-header-with-scroll-shrink-effect-188/demo.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Northline travel journal with a responsive, scroll-aware glass navigation header."
+    />
+    <title>Northline | Sticky Glass Navigation</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+
+    <header class="site-header" data-scrolled="false">
+      <div class="nav-shell">
+        <a class="brand" href="#home" aria-label="Northline home">
+          <span class="brand-mark" aria-hidden="true">N</span>
+          <span>Northline</span>
+        </a>
+
+        <button
+          class="menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="primary-navigation"
+        >
+          <span class="menu-label">Menu</span>
+        </button>
+
+        <nav
+          id="primary-navigation"
+          class="primary-nav"
+          aria-label="Primary navigation"
+        >
+          <a href="#routes" aria-current="page">Routes</a>
+          <a href="#stories">Stories</a>
+          <a href="#studio">Studio</a>
+          <a class="nav-action" href="#journal">Open journal</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main-content">
+      <section id="home" class="hero" aria-labelledby="hero-title">
+        <div class="hero-copy">
+          <p class="eyebrow">Field journal 04 / Faroe Islands</p>
+          <h1 id="hero-title">Follow the weather north.</h1>
+          <p class="hero-summary">
+            A seven-day route through quiet harbors, green cliffs, and the roads
+            that connect them.
+          </p>
+          <div class="hero-actions">
+            <a class="primary-action" href="#routes">View the route</a>
+            <a class="text-action" href="#stories">Read field notes</a>
+          </div>
+        </div>
+
+        <div
+          class="route-board"
+          aria-label="Trip summary from Vagar to Vidareidi"
+        >
+          <div class="route-board-topline">
+            <span>62.1 degrees north</span>
+            <span>7 days</span>
+          </div>
+          <div class="route-line" aria-hidden="true">
+            <span class="route-stop route-stop-start"></span>
+            <span class="route-stop route-stop-mid"></span>
+            <span class="route-stop route-stop-end"></span>
+          </div>
+          <div class="route-cities">
+            <span>Vagar</span>
+            <span>Torshavn</span>
+            <span>Vidareidi</span>
+          </div>
+          <div class="route-stat">
+            <strong>148 km</strong>
+            <span>coast, tunnel, and mountain road</span>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="routes"
+        class="content-section route-section"
+        aria-labelledby="routes-title"
+      >
+        <div class="section-heading">
+          <p class="section-index">01</p>
+          <h2 id="routes-title">Three roads worth taking slowly.</h2>
+        </div>
+        <div class="route-list">
+          <article class="route-item">
+            <p class="route-day">Day 01</p>
+            <div>
+              <h3>Vagar to Torshavn</h3>
+              <p>
+                Lake-edge walks, the first undersea tunnel, and an evening by
+                the harbor.
+              </p>
+            </div>
+            <p class="route-distance">49 km</p>
+          </article>
+          <article class="route-item">
+            <p class="route-day">Day 04</p>
+            <div>
+              <h3>Eysturoy crossing</h3>
+              <p>
+                Sharp ridgelines, small wool workshops, and the road above
+                Funningur.
+              </p>
+            </div>
+            <p class="route-distance">57 km</p>
+          </article>
+          <article class="route-item">
+            <p class="route-day">Day 07</p>
+            <div>
+              <h3>North to Vidareidi</h3>
+              <p>
+                Single-lane tunnels opening onto the highest sea cliffs in the
+                islands.
+              </p>
+            </div>
+            <p class="route-distance">42 km</p>
+          </article>
+        </div>
+      </section>
+
+      <section
+        id="stories"
+        class="content-section story-section"
+        aria-labelledby="stories-title"
+      >
+        <div class="story-note">
+          <p class="section-index">02 / Field note</p>
+          <blockquote id="stories-title">
+            "The forecast changes by the hour. The road rewards anyone willing
+            to change with it."
+          </blockquote>
+          <p class="story-meta">Kalsoy, 18:40 / wind from the west</p>
+        </div>
+        <div class="weather-strip" aria-label="Recorded weather observations">
+          <div><strong>08:00</strong><span>Low cloud / 8 C</span></div>
+          <div><strong>13:20</strong><span>Clear breaks / 11 C</span></div>
+          <div><strong>18:40</strong><span>West wind / 9 C</span></div>
+        </div>
+      </section>
+
+      <section
+        id="studio"
+        class="content-section studio-section"
+        aria-labelledby="studio-title"
+      >
+        <div class="section-heading">
+          <p class="section-index">03</p>
+          <h2 id="studio-title">Built from notes gathered outside.</h2>
+        </div>
+        <p class="studio-copy">
+          Northline publishes practical routes for independent travelers. Every
+          guide is walked, driven, redrawn, and checked in changing conditions
+          before it reaches the journal.
+        </p>
+      </section>
+
+      <section
+        id="journal"
+        class="journal-section"
+        aria-labelledby="journal-title"
+      >
+        <p class="eyebrow">Northline Journal / Issue 04</p>
+        <h2 id="journal-title">Keep the route close.</h2>
+        <a class="primary-action" href="#home">Return to the start</a>
+      </section>
+    </main>
+
+    <script>
+      const header = document.querySelector(".site-header");
+      const menuToggle = document.querySelector(".menu-toggle");
+      const navigation = document.querySelector(".primary-nav");
+      const navLinks = [...navigation.querySelectorAll('a[href^="#"]')];
+      const observedSections = navLinks
+        .map((link) => document.querySelector(link.getAttribute("href")))
+        .filter(Boolean);
+
+      const closeMenu = () => {
+        menuToggle.setAttribute("aria-expanded", "false");
+        navigation.dataset.open = "false";
+        menuToggle.querySelector(".menu-label").textContent = "Menu";
+      };
+
+      const updateHeader = () => {
+        header.dataset.scrolled = String(window.scrollY > 32);
+      };
+
+      menuToggle.addEventListener("click", () => {
+        const isOpen = menuToggle.getAttribute("aria-expanded") === "true";
+        menuToggle.setAttribute("aria-expanded", String(!isOpen));
+        navigation.dataset.open = String(!isOpen);
+        menuToggle.querySelector(".menu-label").textContent = isOpen
+          ? "Menu"
+          : "Close";
+      });
+
+      navLinks.forEach((link) => link.addEventListener("click", closeMenu));
+
+      document.addEventListener("keydown", (event) => {
+        const menuIsOpen = menuToggle.getAttribute("aria-expanded") === "true";
+        if (event.key === "Escape" && menuIsOpen) {
+          closeMenu();
+          menuToggle.focus();
+        }
+      });
+
+      window.addEventListener("resize", () => {
+        if (window.innerWidth > 760) closeMenu();
+      });
+
+      const sectionObserver = new IntersectionObserver(
+        (entries) => {
+          const visibleSection = entries
+            .filter((entry) => entry.isIntersecting)
+            .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+
+          if (!visibleSection) return;
+
+          navLinks.forEach((link) => {
+            const isCurrent =
+              link.getAttribute("href") === `#${visibleSection.target.id}`;
+            if (isCurrent) link.setAttribute("aria-current", "page");
+            else link.removeAttribute("aria-current");
+          });
+        },
+        { rootMargin: "-35% 0px -55%", threshold: [0, 0.25, 0.6] }
+      );
+
+      observedSections.forEach((section) => sectionObserver.observe(section));
+      window.addEventListener("scroll", updateHeader, { passive: true });
+      updateHeader();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/ease-advanced-sticky-blur-glass-navigation-header-with-scroll-shrink-effect-188/style.css
+++ b/submissions/examples/ease-advanced-sticky-blur-glass-navigation-header-with-scroll-shrink-effect-188/style.css
@@ -1,0 +1,782 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, "Segoe UI", Arial, sans-serif;
+  color: #17242a;
+  background: #e8eef1;
+  font-synthesis: none;
+
+  --ink: #17242a;
+  --muted: #52646c;
+  --paper: #eef3f5;
+  --paper-deep: #dce5e9;
+  --blue: #1663d6;
+  --red: #d64c3f;
+  --green: #28765a;
+  --line: rgba(37, 58, 68, 0.16);
+  --glass: rgba(238, 243, 245, 0.78);
+  --shadow-dark: rgba(72, 91, 100, 0.28);
+  --shadow-light: rgba(255, 255, 255, 0.9);
+}
+
+* {
+  box-sizing: border-box;
+  letter-spacing: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 110px;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  overflow-x: hidden;
+  background: var(--paper);
+}
+
+a {
+  color: inherit;
+}
+
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 200;
+  padding: 10px 14px;
+  color: #fff;
+  background: var(--ink);
+  border-radius: 4px;
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  position: fixed;
+  top: 18px;
+  right: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0 24px;
+  pointer-events: none;
+}
+
+.nav-shell {
+  width: min(1160px, 100%);
+  min-height: 82px;
+  margin: 0 auto;
+  padding: 0 14px 0 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  background: var(--glass);
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 8px;
+  box-shadow:
+    15px 15px 34px var(--shadow-dark),
+    -12px -12px 28px var(--shadow-light),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(22px) saturate(130%);
+  -webkit-backdrop-filter: blur(22px) saturate(130%);
+  pointer-events: auto;
+  transition:
+    min-height 280ms ease,
+    width 280ms ease,
+    box-shadow 280ms ease,
+    background-color 280ms ease;
+}
+
+.site-header[data-scrolled="true"] .nav-shell {
+  width: min(980px, 100%);
+  min-height: 62px;
+  background: rgba(238, 243, 245, 0.9);
+  box-shadow:
+    9px 9px 22px rgba(72, 91, 100, 0.22),
+    -8px -8px 20px rgba(255, 255, 255, 0.86),
+    inset 0 1px 0 #fff;
+}
+
+.brand {
+  min-width: max-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+  font-size: 1rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  background: var(--ink);
+  border-radius: 6px;
+  box-shadow:
+    4px 4px 9px rgba(63, 78, 85, 0.32),
+    -3px -3px 8px rgba(255, 255, 255, 0.7);
+  transition: transform 220ms ease;
+}
+
+.brand:hover .brand-mark,
+.brand:focus-visible .brand-mark {
+  transform: translateY(-2px);
+}
+
+.primary-nav {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.primary-nav a {
+  position: relative;
+  min-height: 42px;
+  padding: 0 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    background-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.primary-nav a:not(.nav-action)::after {
+  content: "";
+  position: absolute;
+  right: 14px;
+  bottom: 6px;
+  left: 14px;
+  height: 2px;
+  background: var(--red);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 180ms ease;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus-visible,
+.primary-nav a[aria-current="page"] {
+  color: var(--ink);
+}
+
+.primary-nav a:hover::after,
+.primary-nav a:focus-visible::after,
+.primary-nav a[aria-current="page"]::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.primary-nav .nav-action {
+  margin-left: 4px;
+  color: #fff;
+  background: var(--blue);
+  box-shadow:
+    5px 5px 12px rgba(64, 82, 92, 0.28),
+    -4px -4px 10px rgba(255, 255, 255, 0.75);
+}
+
+.primary-nav .nav-action:hover,
+.primary-nav .nav-action:focus-visible {
+  color: #fff;
+  background: #0e54bc;
+  box-shadow:
+    2px 2px 6px rgba(64, 82, 92, 0.32),
+    -2px -2px 6px rgba(255, 255, 255, 0.72);
+}
+
+.menu-toggle {
+  min-width: 68px;
+  min-height: 42px;
+  padding: 0 12px;
+  display: none;
+  color: var(--ink);
+  background: var(--paper-deep);
+  border: 0;
+  border-radius: 6px;
+  box-shadow:
+    4px 4px 9px rgba(68, 87, 96, 0.25),
+    -4px -4px 9px rgba(255, 255, 255, 0.8);
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.menu-toggle:active {
+  box-shadow:
+    inset 3px 3px 7px rgba(68, 87, 96, 0.25),
+    inset -3px -3px 7px rgba(255, 255, 255, 0.78);
+}
+
+.hero {
+  min-height: 760px;
+  padding: 180px max(24px, calc((100% - 1160px) / 2)) 90px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(340px, 0.9fr);
+  align-items: center;
+  gap: 80px;
+  background-color: #e8eef1;
+  background-image:
+    linear-gradient(rgba(32, 54, 64, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(32, 54, 64, 0.06) 1px, transparent 1px);
+  background-size: 42px 42px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow,
+.section-index {
+  margin: 0 0 22px;
+  color: var(--red);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 720px;
+  margin: 0;
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 5rem;
+  font-weight: 500;
+  line-height: 0.98;
+}
+
+.hero-summary {
+  max-width: 590px;
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  margin-top: 34px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 18px;
+}
+
+.primary-action,
+.text-action {
+  min-height: 48px;
+  padding: 0 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.primary-action {
+  color: #fff;
+  background: var(--ink);
+  box-shadow:
+    7px 7px 15px rgba(70, 88, 96, 0.3),
+    -6px -6px 14px rgba(255, 255, 255, 0.76);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.primary-action:hover,
+.primary-action:focus-visible {
+  transform: translateY(-3px);
+  box-shadow:
+    10px 10px 20px rgba(70, 88, 96, 0.32),
+    -8px -8px 18px rgba(255, 255, 255, 0.78);
+}
+
+.text-action {
+  color: var(--blue);
+  border: 1px solid rgba(22, 99, 214, 0.32);
+  transition:
+    color 180ms ease,
+    background-color 180ms ease;
+}
+
+.text-action:hover,
+.text-action:focus-visible {
+  color: #fff;
+  background: var(--blue);
+}
+
+.route-board {
+  min-height: 390px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: rgba(232, 238, 241, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+  box-shadow:
+    22px 22px 46px rgba(80, 98, 107, 0.28),
+    -20px -20px 42px rgba(255, 255, 255, 0.88),
+    inset 0 1px 0 #fff;
+}
+
+.route-board-topline,
+.route-cities {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.route-line {
+  position: relative;
+  height: 56px;
+  margin: 54px 6px 20px;
+  border-top: 2px solid var(--ink);
+  transform: skewY(-5deg);
+}
+
+.route-line::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  right: 18%;
+  width: 22%;
+  height: 22px;
+  border-top: 2px solid var(--blue);
+  border-radius: 50%;
+}
+
+.route-stop {
+  position: absolute;
+  top: -7px;
+  width: 12px;
+  height: 12px;
+  background: var(--paper);
+  border: 3px solid var(--ink);
+  border-radius: 50%;
+}
+
+.route-stop-start {
+  left: 0;
+}
+
+.route-stop-mid {
+  left: 47%;
+  border-color: var(--red);
+}
+
+.route-stop-end {
+  right: 0;
+  border-color: var(--green);
+}
+
+.route-stat {
+  margin-top: 34px;
+  padding-top: 24px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+  border-top: 1px solid var(--line);
+}
+
+.route-stat strong {
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 2.15rem;
+  font-weight: 500;
+}
+
+.route-stat span {
+  max-width: 160px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  text-align: right;
+}
+
+.content-section {
+  padding: 110px max(24px, calc((100% - 1160px) / 2));
+  scroll-margin-top: 90px;
+}
+
+.section-heading {
+  display: grid;
+  grid-template-columns: 100px minmax(0, 720px);
+  gap: 24px;
+  align-items: start;
+}
+
+.section-heading h2,
+.journal-section h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 3.2rem;
+  font-weight: 500;
+  line-height: 1.08;
+}
+
+.route-list {
+  margin: 72px 0 0 124px;
+  border-top: 1px solid var(--line);
+}
+
+.route-item {
+  min-height: 150px;
+  padding: 28px 0;
+  display: grid;
+  grid-template-columns: 100px minmax(0, 1fr) 100px;
+  gap: 24px;
+  align-items: start;
+  border-bottom: 1px solid var(--line);
+  transition:
+    padding-left 220ms ease,
+    background-color 220ms ease;
+}
+
+.route-item:hover {
+  padding-left: 18px;
+  background: rgba(255, 255, 255, 0.32);
+}
+
+.route-day,
+.route-distance,
+.story-meta {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.route-item h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.18rem;
+}
+
+.route-item div p {
+  max-width: 600px;
+  margin: 10px 0 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.route-distance {
+  color: var(--blue);
+  text-align: right;
+}
+
+.story-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.46fr);
+  gap: 90px;
+  color: #fff;
+  background: var(--ink);
+}
+
+.story-section .section-index {
+  color: #76b99e;
+}
+
+.story-note blockquote {
+  max-width: 770px;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 3.2rem;
+  line-height: 1.18;
+}
+
+.story-meta {
+  margin-top: 32px;
+  color: #9cb0b8;
+}
+
+.weather-strip {
+  align-self: end;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.weather-strip div {
+  padding: 18px 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.weather-strip strong {
+  color: #fff;
+  font-size: 0.8rem;
+}
+
+.weather-strip span {
+  color: #9cb0b8;
+  font-size: 0.8rem;
+  text-align: right;
+}
+
+.studio-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.6fr);
+  gap: 80px;
+  align-items: end;
+  background: #e5ece7;
+  border-bottom: 1px solid rgba(40, 118, 90, 0.18);
+}
+
+.studio-section .section-index {
+  color: var(--green);
+}
+
+.studio-copy {
+  margin: 0;
+  color: #466159;
+  font-size: 1.08rem;
+  line-height: 1.8;
+}
+
+.journal-section {
+  min-height: 500px;
+  padding: 110px max(24px, calc((100% - 1160px) / 2));
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  background: #efe9e5;
+}
+
+.journal-section h2 {
+  margin-bottom: 36px;
+  font-size: 4rem;
+}
+
+:focus-visible {
+  outline: 3px solid #f2a900;
+  outline-offset: 4px;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    min-height: auto;
+    grid-template-columns: 1fr;
+    gap: 64px;
+  }
+
+  .hero h1 {
+    font-size: 4rem;
+  }
+
+  .route-board {
+    min-height: 340px;
+  }
+
+  .story-section,
+  .studio-section {
+    grid-template-columns: 1fr;
+    gap: 56px;
+  }
+
+  .weather-strip {
+    width: min(520px, 100%);
+  }
+}
+
+@media (max-width: 760px) {
+  html {
+    scroll-padding-top: 90px;
+  }
+
+  .site-header {
+    top: 10px;
+    padding: 0 12px;
+  }
+
+  .nav-shell,
+  .site-header[data-scrolled="true"] .nav-shell {
+    position: relative;
+    min-height: 62px;
+    padding: 0 10px 0 14px;
+  }
+
+  .menu-toggle {
+    display: inline-block;
+  }
+
+  .primary-nav {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    left: 0;
+    padding: 10px;
+    display: grid;
+    gap: 4px;
+    visibility: hidden;
+    background: rgba(238, 243, 245, 0.96);
+    border: 1px solid rgba(255, 255, 255, 0.82);
+    border-radius: 8px;
+    box-shadow:
+      12px 12px 26px rgba(72, 91, 100, 0.26),
+      -8px -8px 20px rgba(255, 255, 255, 0.84);
+    opacity: 0;
+    transform: translateY(-8px);
+    pointer-events: none;
+    transition:
+      opacity 180ms ease,
+      transform 180ms ease,
+      visibility 180ms ease;
+  }
+
+  .primary-nav[data-open="true"] {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .primary-nav a {
+    justify-content: flex-start;
+  }
+
+  .primary-nav .nav-action {
+    margin: 4px 0 0;
+    justify-content: center;
+  }
+
+  .hero {
+    padding-top: 142px;
+    padding-bottom: 72px;
+  }
+
+  .hero h1 {
+    font-size: 3.25rem;
+  }
+
+  .content-section,
+  .journal-section {
+    padding-top: 80px;
+    padding-bottom: 80px;
+  }
+
+  .section-heading {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .section-heading h2,
+  .story-note blockquote {
+    font-size: 2.45rem;
+  }
+
+  .route-list {
+    margin: 48px 0 0;
+  }
+
+  .route-item {
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+
+  .route-distance {
+    grid-column: 2;
+    text-align: left;
+  }
+
+  .journal-section h2 {
+    font-size: 3rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .brand > span:last-child {
+    display: none;
+  }
+
+  .hero {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .hero h1 {
+    font-size: 2.65rem;
+  }
+
+  .hero-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .primary-action,
+  .text-action {
+    width: 100%;
+  }
+
+  .route-board {
+    min-height: 320px;
+    padding: 20px;
+  }
+
+  .route-cities {
+    font-size: 0.66rem;
+  }
+
+  .route-stat {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .route-stat span {
+    text-align: left;
+  }
+
+  .route-item {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .route-distance {
+    grid-column: 1;
+  }
+
+  .section-heading h2,
+  .story-note blockquote {
+    font-size: 2.1rem;
+  }
+
+  .journal-section h2 {
+    font-size: 2.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds the assigned Neumorphic Finish variation of the sticky blur glass navigation header. The header shrinks from 82px to 62px after scrolling, tracks the current linked section, and provides a keyboard-accessible responsive menu.

Closes #58128

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-advanced-sticky-blur-glass-navigation-header-with-scroll-shrink-effect-188/`
- [x] Includes `demo.html` - self-contained and opens without a server
- [x] Includes `style.css` - original standalone CSS
- [x] Includes `README.md` - behavior, usage, and EaseMotion fit
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A responsive glass navigation header with paired neumorphic shadows, an eased scroll-shrink state, active-section feedback, and a mobile navigation panel.

**How does a developer use it?**

```html
<header class="site-header" data-scrolled="false">
  <div class="nav-shell">
    <a class="brand" href="#home">Northline</a>
    <nav class="primary-nav" aria-label="Primary navigation">
      <a href="#routes">Routes</a>
    </nav>
  </div>
</header>
```

**Why does it fit EaseMotion CSS?**

The visual transition follows a readable `data-scrolled` state and uses restrained motion to preserve navigation context. The demo also respects reduced-motion preferences.

---

## Demo

- [x] `demo.html` works directly in the browser with no CDN or framework

---

## Browser Testing

- [x] Chrome / Chromium at 1440x900 and 390x844
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Validation

- Prettier check passed for all three files
- Stylelint passed for the standalone stylesheet
- Desktop and mobile browser checks passed with no horizontal overflow
- Scroll shrink, current-section state, mobile menu, and Escape handling verified
- Browser console errors: 0

## Notes for Maintainer

The small vanilla JavaScript controller is inline in `demo.html` so the submission remains within the exact three-file structure required by the issue and repository validator.
