### PR TITLE
feat: add forced-colors media query not handled - Windows High Contrast Mode renders components with broken colors and invisible borders (#58330)

### DIFF
--- a/submissions/examples/forced-colors-media-query-not-handled-sah/README.md
+++ b/submissions/examples/forced-colors-media-query-not-handled-sah/README.md
@@ -1,0 +1,3 @@
+# forced-colors media query not handled - Windows High Contrast Mode renders components with broken colors and invisible borders
+
+Accessible component solution for #58330.

--- a/submissions/examples/forced-colors-media-query-not-handled-sah/demo.html
+++ b/submissions/examples/forced-colors-media-query-not-handled-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>forced-colors media query not handled - Windows High Contrast Mode renders components with broken colors and invisible borders</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for forced-colors media query not handled - Windows High Contrast Mode renders components with broken colors and invisible borders -->
+  <h2>forced-colors media query not handled - Windows High Contrast Mode renders components with broken colors and invisible borders</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/forced-colors-media-query-not-handled-sah/style.css
+++ b/submissions/examples/forced-colors-media-query-not-handled-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #58330