### PR TITLE
feat: add No Subresource Integrity (SRI) hash documented for CDN usage - compromised CDN can serve malicious CSS (#58329)

### DIFF
--- a/submissions/examples/no-subresource-integrity-sri-hash-doc-sah/README.md
+++ b/submissions/examples/no-subresource-integrity-sri-hash-doc-sah/README.md
@@ -1,0 +1,3 @@
+# No Subresource Integrity (SRI) hash documented for CDN usage - compromised CDN can serve malicious CSS
+
+Accessible component solution for #58329.

--- a/submissions/examples/no-subresource-integrity-sri-hash-doc-sah/demo.html
+++ b/submissions/examples/no-subresource-integrity-sri-hash-doc-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>No Subresource Integrity (SRI) hash documented for CDN usage - compromised CDN can serve malicious CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for No Subresource Integrity (SRI) hash documented for CDN usage - compromised CDN can serve malicious CSS -->
+  <h2>No Subresource Integrity (SRI) hash documented for CDN usage - compromised CDN can serve malicious CSS</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/no-subresource-integrity-sri-hash-doc-sah/style.css
+++ b/submissions/examples/no-subresource-integrity-sri-hash-doc-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #58329