### PR TITLE
feat: add Modal and tooltip components lack focus trap - keyboard focus escapes component, failing WCAG 2.1 criterion 2.1.2 (#58327)

### DIFF
--- a/submissions/examples/modal-and-tooltip-components-lack-foc-sah/README.md
+++ b/submissions/examples/modal-and-tooltip-components-lack-foc-sah/README.md
@@ -1,0 +1,3 @@
+# Modal and tooltip components lack focus trap - keyboard focus escapes component, failing WCAG 2.1 criterion 2.1.2
+
+Accessible component solution for #58327.

--- a/submissions/examples/modal-and-tooltip-components-lack-foc-sah/demo.html
+++ b/submissions/examples/modal-and-tooltip-components-lack-foc-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Modal and tooltip components lack focus trap - keyboard focus escapes component, failing WCAG 2.1 criterion 2.1.2</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for Modal and tooltip components lack focus trap - keyboard focus escapes component, failing WCAG 2.1 criterion 2.1.2 -->
+  <h2>Modal and tooltip components lack focus trap - keyboard focus escapes component, failing WCAG 2.1 criterion 2.1.2</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/modal-and-tooltip-components-lack-foc-sah/style.css
+++ b/submissions/examples/modal-and-tooltip-components-lack-foc-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #58327