### PR TITLE
feat: add Tooltip Overflow Clipping Fix showcase (#57530)

### DIFF
--- a/submissions/examples/57530-tooltip-overflow-hidden-fix/README.md
+++ b/submissions/examples/57530-tooltip-overflow-hidden-fix/README.md
@@ -1,0 +1,116 @@
+# Tooltip Overflow Clipping Fix
+
+## The Problem
+
+In CSS layout design, tooltips are typically positioned using `position: absolute` relative to their parent trigger buttons (which have `position: relative`).
+
+However, if an ancestor container (like a `.card` layout) has `overflow: hidden` (or `overflow: auto` / `overflow: scroll` to clip content, crop images, or manage grid/carousel bounds), **any nested absolute elements will be cropped by that container's boundary** if their containing block resides inside it. As a result, the tooltips are cut off and rendered completely unreadable.
+
+This showcase demonstrates three pure CSS techniques to break tooltips out of `overflow: hidden` containers.
+
+---
+
+## The CSS Solutions
+
+### 1. Solution A: CSS Anchor Positioning (Modern Web Standard)
+
+Modern CSS introduces **Anchor Positioning**, allowing absolute and fixed elements to position themselves relative to a designated anchor on the screen, completely disregarding parent overflow constraints.
+
+#### How it works:
+
+We declare the trigger button as the anchor using the `anchor-name` property. The tooltip is positioned using `position: fixed` to remove it from the parent card's clipping tree, but stays tethered to the button using the `position-anchor` property. The browser recalculates its layout coordinates in real-time, even during page scrolling.
+
+#### HTML / CSS:
+
+```html
+<button class="action-btn anchor-trigger" aria-label="Button Trigger">
+  Trigger Button
+</button>
+<span class="tooltip-bubble tooltip-anchor" role="tooltip">Tooltip text</span>
+```
+
+```css
+.anchor-trigger {
+  anchor-name: --my-anchor;
+}
+
+.tooltip-anchor {
+  position: fixed; /* Escapes overflow hidden clipping */
+  position-anchor: --my-anchor;
+  bottom: calc(anchor(--my-anchor top) + 10px);
+  left: anchor(--my-anchor center);
+  transform: translateX(-50%);
+}
+```
+
+---
+
+### 2. Solution B: Decoupled Container Structure (Legacy-Friendly)
+
+A robust structural layout solution that works across all older browsers without relying on experimental APIs.
+
+#### How it works:
+
+An absolutely positioned element is positioned relative to its nearest **positioned ancestor** (any element with `position: relative`, `absolute`, `fixed`, or `sticky`). If we separate the container that establishes the positioning context and the container that clips overflow, we can bypass the clipping completely:
+
+1. An outer wrapper `card-outer-wrap` is given `position: relative` (to serve as the containing block).
+2. The inner wrapper `card-inner-clip` is given `overflow: hidden`, but is kept `position: static` (not positioned).
+3. The tooltip, nested inside, bubbles up past the static inner wrapper and positions itself relative to the outer wrapper, which does not clip overflow.
+
+#### HTML / CSS:
+
+```html
+<!-- Outer wrapper establishes containing block context -->
+<div class="card-outer-wrap" style="position: relative;">
+  <!-- Inner container handles overflow clipping -->
+  <div class="card-inner-clip" style="position: static; overflow: hidden;">
+    <button class="action-btn" aria-label="Button Trigger">
+      Hover
+      <!-- Tooltip is absolute relative to card-outer-wrap -->
+      <span class="tooltip-bubble tooltip-structural" role="tooltip"
+        >Tooltip text</span
+      >
+    </button>
+  </div>
+</div>
+```
+
+```css
+.tooltip-structural {
+  position: absolute;
+  bottom: 242px; /* Positioned relative to card-outer-wrap */
+  left: 50%;
+  transform: translateX(-50%);
+}
+```
+
+---
+
+### 3. Solution C: Viewport Fixed Position Breakout
+
+Useful for fixed layouts, application modals, or sticky panels that do not shift position on document scroll.
+
+#### How it works:
+
+Setting `position: fixed` removes the element from the card container flow, positioning it relative to the viewport instead. We apply fixed coordinates (such as offset-margins or precise heights) to place it near the trigger, ensuring it is drawn in the top layer.
+
+---
+
+## Custom CSS Properties
+
+You can customize the layout themes and tooltips by modifying these variables:
+
+| Property             | Default Value                            | Description                                             |
+| -------------------- | ---------------------------------------- | ------------------------------------------------------- |
+| `--bg-tooltip`       | `#ffffff`                                | Background color of the tooltip bubble.                 |
+| `--text-tooltip`     | `#0a0b10`                                | Color of the tooltip text.                              |
+| `--tooltip-shadow`   | `0 10px 30px -5px rgba(0, 0, 0, 0.4)...` | Drop shadow styling for the tooltips.                   |
+| `--transition-speed` | `0.3s`                                   | Default duration for hover state transition animations. |
+
+---
+
+## Accessibility Compliance
+
+- **Keyboard Support**: Focus states are integrated using `:focus-within` selectors. Keyboard users can Tab through buttons, which triggers the tooltip transitions and allows reading their content.
+- **Screen Reader Support**: Uses appropriate semantic components (e.g. `button`, `span`) along with matching `role="tooltip"` and `aria-label` properties.
+- **Motion Reduction**: Disables coordinate and scaling transitions when `prefers-reduced-motion: reduce` is detected to prevent motion sickness.

--- a/submissions/examples/57530-tooltip-overflow-hidden-fix/demo.html
+++ b/submissions/examples/57530-tooltip-overflow-hidden-fix/demo.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="EaseMotion CSS Tooltip Overflow Clipping Showcase - Detailed breakdown of how to solve tooltip clipping inside overflow hidden parent containers using pure CSS/HTML."
+    />
+    <title>Tooltip Overflow Clipping Fix Showcase</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="showcase-container">
+      <!-- Showcase Header -->
+      <header class="showcase-header">
+        <h1>Tooltip Overflow Clipping Fix</h1>
+        <p>
+          Demonstrating and resolving the CSS issue where absolute tooltips are
+          cropped by parent containers with <code>overflow: hidden</code> using
+          pure HTML and CSS.
+        </p>
+      </header>
+
+      <!-- 1. The Bug Showcase -->
+      <section class="showcase-section">
+        <h2 class="section-title">
+          1. The Bug (Clipped Tooltips)
+          <span class="badge badge-red">Broken</span>
+        </h2>
+        <p class="section-desc">
+          Because the parent card uses <code>overflow: hidden</code> and
+          <code>position: relative</code>, absolutely positioned tooltips are
+          cropped by the card's boundary and are completely unreadable.
+        </p>
+
+        <div class="card-grid">
+          <!-- Broken Card A -->
+          <article class="demo-card overflow-hidden">
+            <div class="card-body">
+              <h3>Standard User Card</h3>
+              <p>
+                A classic user profile dashboard card. Hovering over the buttons
+                triggers absolute tooltips that get cut off by the card borders.
+              </p>
+            </div>
+            <div class="card-action-bar">
+              <button
+                class="action-btn action-btn-clipped"
+                aria-label="Edit Profile"
+              >
+                Edit
+                <span class="tooltip-bubble tooltip-clipped" role="tooltip"
+                  >Edit Profile Settings</span
+                >
+              </button>
+              <button
+                class="action-btn action-btn-clipped"
+                aria-label="Delete User"
+              >
+                Delete
+                <span class="tooltip-bubble tooltip-clipped" role="tooltip"
+                  >Permanently Delete Account</span
+                >
+              </button>
+            </div>
+          </article>
+
+          <!-- Broken Card B -->
+          <article class="demo-card overflow-hidden">
+            <div class="card-body">
+              <h3>Analytics Overview</h3>
+              <p>
+                An analytics card displaying metrics. Action tooltips at the
+                bottom are truncated, preventing the user from understanding the
+                options.
+              </p>
+            </div>
+            <div class="card-action-bar">
+              <button
+                class="action-btn action-btn-clipped"
+                aria-label="Export Logs"
+              >
+                Export
+                <span class="tooltip-bubble tooltip-clipped" role="tooltip"
+                  >Download CSV Log Sheet</span
+                >
+              </button>
+              <button
+                class="action-btn action-btn-clipped"
+                aria-label="Refresh Data"
+              >
+                Refresh
+                <span class="tooltip-bubble tooltip-clipped" role="tooltip"
+                  >Sync Server Metrics</span
+                >
+              </button>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- 2. Fix A: CSS Anchor Positioning -->
+      <section class="showcase-section">
+        <h2 class="section-title">
+          2. Solution A: CSS Anchor Positioning
+          <span class="badge badge-blue">Modern Standard</span>
+        </h2>
+        <p class="section-desc">
+          By using <code>position: fixed</code> on the tooltip and anchoring it
+          to the trigger via <code>anchor-name</code> and
+          <code>position-anchor</code>, the tooltip completely escapes the
+          parent's clipping context while staying tethered to the trigger.
+        </p>
+
+        <div class="card-grid">
+          <!-- Anchor Card A -->
+          <article class="demo-card overflow-hidden">
+            <div class="card-body">
+              <h3>Modern Anchor Card</h3>
+              <p>
+                Uses CSS Anchor Positioning. The tooltips are rendered in fixed
+                viewport space, rendering above the card even with overflow:
+                hidden active.
+              </p>
+            </div>
+            <div class="card-action-bar">
+              <!-- Trigger button receives anchor-name -->
+              <button
+                class="action-btn anchor-trigger-red"
+                aria-label="Edit Settings"
+              >
+                Edit
+              </button>
+              <!-- Tooltip is placed outside the card element in DOM or fixed positioned relative to anchor -->
+              <span
+                class="tooltip-bubble tooltip-anchor tooltip-anchor-red"
+                role="tooltip"
+                >Edit Settings Panel</span
+              >
+
+              <button
+                class="action-btn anchor-trigger-blue"
+                aria-label="Sync Data"
+              >
+                Sync
+              </button>
+              <span
+                class="tooltip-bubble tooltip-anchor tooltip-anchor-blue"
+                role="tooltip"
+                >Sync Database Cluster</span
+              >
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- 3. Fix B: Decoupled Container Layout -->
+      <section class="showcase-section">
+        <h2 class="section-title">
+          3. Solution B: Decoupled Stacking Contexts
+          <span class="badge badge-emerald">Legacy-Friendly</span>
+        </h2>
+        <p class="section-desc">
+          We separate positioning and clipping. The outer wrapper is positioned
+          (<code>position: relative; overflow: visible</code>), establishing the
+          containing block for absolute children. The inner wrapper is not
+          positioned but has <code>overflow: hidden</code>. The tooltip escapes
+          the clipping boundaries completely.
+        </p>
+
+        <div class="card-grid">
+          <!-- Decoupled Container Layout Card -->
+          <div class="card-outer-wrap">
+            <div class="card-inner-clip">
+              <div class="card-body">
+                <h3>Decoupled Card Structure</h3>
+                <p>
+                  By keeping the inner wrapper unpositioned (static), tooltips
+                  bubble up to the outer container. They render outside the
+                  clipping box without breaking on older browsers.
+                </p>
+              </div>
+              <div class="card-action-bar">
+                <button class="action-btn" aria-label="View Details">
+                  View Details
+                  <span class="tooltip-bubble tooltip-structural" role="tooltip"
+                    >Inspect detailed reports</span
+                  >
+                </button>
+                <button class="action-btn" aria-label="Settings">
+                  Settings
+                  <span
+                    class="tooltip-bubble tooltip-structural tooltip-structural-right"
+                    role="tooltip"
+                    >Configure preferences</span
+                  >
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 4. Fix C: Viewport Fixed Coordinate Positioning -->
+      <section class="showcase-section">
+        <h2 class="section-title">
+          4. Solution C: Viewport Fixed Coordinates
+          <span class="badge badge-emerald">Simple Layouts</span>
+        </h2>
+        <p class="section-desc">
+          For static card headers or non-scrolling layouts, setting
+          <code>position: fixed</code> along with predefined vertical viewport
+          margins will prevent clipping inside small, fixed UI areas.
+        </p>
+
+        <div class="card-grid">
+          <!-- Viewport Fixed Card -->
+          <article class="demo-card overflow-hidden">
+            <div class="card-body">
+              <h3>Viewport Fixed Card</h3>
+              <p>
+                Using viewport-fixed coordinates. Useful for standalone
+                application modals or sticky panels that do not shift context on
+                scroll.
+              </p>
+            </div>
+            <div class="card-action-bar">
+              <button class="action-btn" aria-label="Trigger Fixed Tooltip">
+                Hover Me
+                <span
+                  class="tooltip-bubble tooltip-fixed-viewport"
+                  role="tooltip"
+                  >Viewport Fixed Tooltip Bubble</span
+                >
+              </button>
+            </div>
+          </article>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/57530-tooltip-overflow-hidden-fix/style.css
+++ b/submissions/examples/57530-tooltip-overflow-hidden-fix/style.css
@@ -1,0 +1,507 @@
+@import url("https://fonts.googleapis.com/css2?family=Cabinet+Grotesk:wght@800&family=Satoshi:wght@400;500;700&display=swap");
+
+/* ==========================================================================
+   Design Tokens & CSS Variables
+   ========================================================================== */
+:root {
+  --bg-primary: #0a0b10;
+  --bg-surface: #12131a;
+  --bg-card: #181922;
+  --bg-tooltip: #ffffff;
+  --text-primary: #ffffff;
+  --text-secondary: #8e90a6;
+  --text-tooltip: #0a0b10;
+  --border-color: rgba(255, 255, 255, 0.08);
+
+  /* Color Schemes */
+  --accent-red: #ff3366;
+  --accent-blue: #3b82f6;
+  --accent-emerald: #10b981;
+  --accent-amber: #f59e0b;
+
+  /* Typography */
+  --font-display: "Cabinet Grotesk", sans-serif;
+  --font-body: "Satoshi", sans-serif;
+
+  /* Transitions */
+  --transition-speed: 0.3s;
+  --transition-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --transition-smooth: cubic-bezier(0.25, 0.8, 0.25, 1);
+
+  /* Shadow Design */
+  --tooltip-shadow:
+    0 10px 30px -5px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(255, 255, 255, 0.1);
+  --card-shadow: 0 20px 40px -15px rgba(0, 0, 0, 0.5);
+}
+
+/* ==========================================================================
+   Base styles
+   ========================================================================== */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  min-height: 100vh;
+  line-height: 1.6;
+  padding: 3rem 2rem;
+  background-image:
+    radial-gradient(
+      circle at 10% 10%,
+      rgba(255, 51, 102, 0.04) 0%,
+      transparent 40%
+    ),
+    radial-gradient(
+      circle at 90% 90%,
+      rgba(59, 130, 246, 0.04) 0%,
+      transparent 40%
+    );
+}
+
+.showcase-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+}
+
+/* Header Section */
+.showcase-header {
+  text-align: center;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 2rem;
+}
+
+.showcase-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(
+    135deg,
+    var(--text-primary),
+    var(--text-secondary)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.75rem;
+}
+
+.showcase-header p {
+  color: var(--text-secondary);
+  font-size: clamp(0.95rem, 2vw, 1.15rem);
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+/* Section Grid Layout */
+.showcase-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.section-title span.badge {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.35rem 0.75rem;
+  border-radius: 50px;
+}
+
+.badge-red {
+  background: rgba(255, 51, 102, 0.1);
+  color: var(--accent-red);
+  border: 1px solid rgba(255, 51, 102, 0.2);
+}
+
+.badge-blue {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--accent-blue);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.badge-emerald {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--accent-emerald);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-top: -0.75rem;
+  max-width: 900px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+}
+
+/* ==========================================================================
+   The Card Component (With overflow: hidden)
+   ========================================================================== */
+.demo-card {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2.25rem;
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+  height: 280px;
+  position: relative;
+}
+
+/* This is the culprit class: overflow: hidden clips standard absolute tooltips */
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.card-body h3 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+}
+
+.card-body p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.card-action-bar {
+  display: flex;
+  gap: 1rem;
+  margin-top: auto;
+}
+
+/* Standard Button trigger styling */
+.action-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: all 0.25s ease;
+  position: relative;
+  outline: none;
+}
+
+.action-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.action-btn:focus-visible {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+/* Base tooltip bubble style */
+.tooltip-bubble {
+  background-color: var(--bg-tooltip);
+  color: var(--text-tooltip);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.5rem 0.85rem;
+  border-radius: 8px;
+  white-space: nowrap;
+  box-shadow: var(--tooltip-shadow);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.2s var(--transition-smooth),
+    transform 0.2s var(--transition-bounce),
+    visibility 0.2s ease;
+  z-index: 1000;
+}
+
+.tooltip-bubble::before {
+  content: "";
+  position: absolute;
+  border: 6px solid transparent;
+}
+
+/* Hover/Focus Active states */
+.action-btn:hover .tooltip-bubble,
+.action-btn:focus-within .tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ==========================================================================
+   PROBLEM: Clipped Absolute Tooltip
+   ========================================================================== */
+.action-btn-clipped {
+  position: relative; /* Trigger is positioning ancestor */
+}
+
+.tooltip-clipped {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) translateY(5px);
+}
+
+.tooltip-clipped::before {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--bg-tooltip);
+}
+
+.action-btn-clipped:hover .tooltip-clipped,
+.action-btn-clipped:focus-within .tooltip-clipped {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ==========================================================================
+   FIX 1: CSS Anchor Positioning (Modern Pure CSS)
+   ========================================================================== */
+.anchor-trigger-red {
+  anchor-name: --anchor-red;
+}
+.anchor-trigger-blue {
+  anchor-name: --anchor-blue;
+}
+
+.tooltip-anchor-red {
+  position-anchor: --anchor-red;
+}
+
+.tooltip-anchor-blue {
+  position-anchor: --anchor-blue;
+}
+
+.tooltip-anchor {
+  position: fixed; /* Escape clipping context completely */
+  bottom: calc(anchor(--anchor-red top) + 10px);
+  left: anchor(--anchor-red center);
+  transform: translateX(-50%) translateY(5px);
+}
+
+.tooltip-anchor-blue.tooltip-anchor {
+  bottom: calc(anchor(--anchor-blue top) + 10px);
+  left: anchor(--anchor-blue center);
+}
+
+.tooltip-anchor::before {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--bg-tooltip);
+}
+
+.action-btn:hover + .tooltip-anchor,
+.action-btn:focus-within + .tooltip-anchor {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ==========================================================================
+   FIX 2: Multi-layer Container Architecture (Structural Layout CSS Fix)
+   ========================================================================== */
+.card-outer-wrap {
+  position: relative; /* Containing block is established here (outside clipping) */
+  height: 280px;
+}
+
+.card-inner-clip {
+  height: 100%;
+  padding: 2.25rem;
+  border-radius: 20px;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  /* Applying overflow: hidden here. Since card-inner-clip is static (not positioned),
+     it does NOT act as a containing block for the absolute tooltip.
+     The tooltip resolves to the card-outer-wrap, which has NO overflow hidden,
+     allowing it to spill outside boundaries cleanly! */
+  position: static;
+  overflow: hidden;
+}
+
+.tooltip-structural {
+  position: absolute; /* Relative to card-outer-wrap */
+  bottom: 242px; /* Positioned near button trigger */
+  left: 58px;
+  transform: translateY(5px);
+}
+
+.tooltip-structural-right {
+  left: 172px;
+}
+
+.tooltip-structural::before {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--bg-tooltip);
+}
+
+.action-btn:hover .tooltip-structural,
+.action-btn:focus-within .tooltip-structural {
+  transform: translateY(0);
+}
+
+/* ==========================================================================
+   FIX 3: Viewport Fixed coordinate breakout
+   ========================================================================== */
+.tooltip-fixed-viewport {
+  position: fixed;
+  bottom: calc(100% - 220px); /* Manual offset calculated from viewport */
+  left: 50%;
+  transform: translateX(-50%) translateY(5px);
+}
+
+.tooltip-fixed-viewport::before {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--bg-tooltip);
+}
+
+.action-btn:hover .tooltip-fixed-viewport,
+.action-btn:focus-within .tooltip-fixed-viewport {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ==========================================================================
+   Responsive Media Queries
+   ========================================================================== */
+@media (max-width: 992px) {
+  body {
+    padding: 2rem 1.5rem;
+  }
+
+  .showcase-container {
+    gap: 2.5rem;
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .showcase-header h1 {
+    font-size: 2.25rem;
+  }
+
+  .card-outer-wrap {
+    height: auto;
+  }
+
+  .card-inner-clip {
+    position: relative; /* Revert on mobile to standard container, use absolute positioning offsets */
+    height: 280px;
+  }
+
+  /* Fallback structural tooltip adjustment for mobile */
+  .tooltip-structural {
+    bottom: calc(100% - 190px);
+    left: 50%;
+    transform: translateX(-50%) translateY(5px);
+  }
+
+  .tooltip-structural-right {
+    left: 50%;
+  }
+
+  .action-btn:hover .tooltip-structural,
+  .action-btn:focus-within .tooltip-structural {
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem;
+  }
+
+  .demo-card {
+    padding: 1.5rem;
+    height: 300px;
+  }
+
+  .card-inner-clip {
+    padding: 1.5rem;
+    height: 300px;
+  }
+
+  .card-action-bar {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .action-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+/* ==========================================================================
+   Accessibility & prefers-reduced-motion
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-bubble {
+    transition: none !important;
+    transform: translateX(-50%) !important;
+  }
+
+  .tooltip-structural {
+    transform: none !important;
+  }
+
+  .action-btn:hover .tooltip-structural,
+  .action-btn:focus-within .tooltip-structural {
+    transform: none !important;
+  }
+
+  .tooltip-anchor {
+    transform: translateX(-50%) !important;
+  }
+
+  .action-btn:hover + .tooltip-anchor,
+  .action-btn:focus-within + .tooltip-anchor {
+    transform: translateX(-50%) !important;
+  }
+}


### PR DESCRIPTION
# Description
This PR resolves issue #57530 by introducing a showcase explaining and fixing the issue where tooltips are clipped by parent containers with `overflow: hidden`. It outlines three pure HTML/CSS methods to break tooltips out of the overflow boundaries.

## Features Showcase
1. **CSS Anchor Positioning**: Uses `position: fixed` and `position-anchor` to escape parent clipping.
2. **Decoupled Container Stacking**: Separates positioning (`position: relative`) from the clipping wrapper (`overflow: hidden; position: static`).
3. **Viewport Fixed Placement**: Outlines fixed layout coordinate breakout settings.
4. **Full Accessibility**: Includes focus-state support (`:focus-within`), screen-reader attributes (`role="tooltip"`), and `prefers-reduced-motion: reduce` query hooks.

## Files Added
- `submissions/examples/57530-tooltip-overflow-hidden-fix/demo.html`
- `submissions/examples/57530-tooltip-overflow-hidden-fix/style.css`
- `submissions/examples/57530-tooltip-overflow-hidden-fix/README.md`

## Verification
- Prettier formatting applied to all files.
- Ran all 61 framework tests (`npm run test`) successfully.
- Verified framework builds correctly via `npm run build`.