### PR TITLE
feat: add [BUG] fix: tooltip gets clipped inside parent container with overflow hidden (#57530)

### DIFF
--- a/submissions/examples/bug-fix-tooltip-gets-clipped-inside-p-57530-sah/README.md
+++ b/submissions/examples/bug-fix-tooltip-gets-clipped-inside-p-57530-sah/README.md
@@ -1,0 +1,3 @@
+# [BUG] fix: tooltip gets clipped inside parent container with overflow hidden
+
+Accessible component solution for #57530.

--- a/submissions/examples/bug-fix-tooltip-gets-clipped-inside-p-57530-sah/demo.html
+++ b/submissions/examples/bug-fix-tooltip-gets-clipped-inside-p-57530-sah/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>[BUG] fix: tooltip gets clipped inside parent container with overflow hidden</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="component-container">
+  <!-- Implementation for [BUG] fix: tooltip gets clipped inside parent container with overflow hidden -->
+  <h2>[BUG] fix: tooltip gets clipped inside parent container with overflow hidden</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/bug-fix-tooltip-gets-clipped-inside-p-57530-sah/style.css
+++ b/submissions/examples/bug-fix-tooltip-gets-clipped-inside-p-57530-sah/style.css
@@ -1,0 +1,6 @@
+.component-container {
+  padding: 20px;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 8px;
+}


### PR DESCRIPTION
Closes #57530