### PR TITLE
Add ease-football-scoreboard component

### DIFF
--- a/submissions/examples/ease-football-scoreboard-ij/README.md
+++ b/submissions/examples/ease-football-scoreboard-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Football Scoreboard
+
+A live match scoreboard UI showing two teams, a goal-scoring pop animation, a pulsing LIVE indicator and a swaying possession meter.
+
+## Run
+Open `demo.html` in any browser.
+
+## Interaction
+- Press **GOAL +1** to increment the home score and replay the goal pop.

--- a/submissions/examples/ease-football-scoreboard-ij/demo.html
+++ b/submissions/examples/ease-football-scoreboard-ij/demo.html
@@ -1,0 +1,49 @@
+<!-- EaseMotion component: football-scoreboard -->
+<!doctype html>
+<html lang="en" data-sport="football">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ease Football Scoreboard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="stadium-board">
+  <header class="board-meta">
+    <span class="league-tag">PREMIER LEAGUE</span>
+    <span class="match-clock">76:42</span>
+  </header>
+  <section id="scorePanel" class="score-panel" aria-label="live match score">
+    <div class="team-block">
+      <div class="team-crest home-crest">FC</div>
+      <h1 class="team-name">Northwind United</h1>
+    </div>
+    <div class="score-digits">
+      <span id="homeScore" class="digit digit-home">2</span>
+      <span class="digit-sep">&ndash;</span>
+      <span id="awayScore" class="digit digit-away">1</span>
+    </div>
+    <div class="team-block">
+      <div class="team-crest away-crest">SC</div>
+      <h1 class="team-name">Riverside City</h1>
+    </div>
+  </section>
+  <footer class="match-status">
+    <span class="status-dot live-dot"></span>
+    <span class="status-label">2nd Half &middot; Live</span>
+    <div class="possession-meter"><i class="possession-fill">72%</i></div>
+    <button id="goalBtn" class="goal-btn" type="button">GOAL +1</button>
+  </footer>
+</main>
+<script>
+const panel=document.getElementById('scorePanel');
+const home=document.getElementById('homeScore');
+document.getElementById('goalBtn').addEventListener('click',()=>{
+  home.textContent=String(Number(home.textContent)+1);
+  panel.classList.remove('goal');
+  void panel.offsetWidth;
+  panel.classList.add('goal');
+});
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-football-scoreboard-ij/style.css
+++ b/submissions/examples/ease-football-scoreboard-ij/style.css
@@ -1,0 +1,52 @@
+:root{
+  --pitch:hsl(150,42%,14%);
+  --line:hsl(52,100%,62%);
+  --flash:hsl(8,84%,56%);
+  --team-home:hsl(216,72%,52%);
+  --team-away:hsl(39,90%,56%);
+  --board-glow:radial-gradient(circle at 20% 0%,hsl(150,38%,22%),hsl(150,45%,10%));
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,"Segoe UI",Roboto,sans-serif;background:#0b1220;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
+.stadium-board{width:min(560px,92vw);background:var(--board-glow);border:2px solid var(--line);border-radius:18px;overflow:hidden;box-shadow:0 18px 50px hsl(216,70%,6% / 0.55)}
+.board-meta{display:flex;justify-content:space-between;align-items:center;padding:10px 18px;background:hsl(150,45%,8% / 0.6);border-bottom:1px dashed var(--line)}
+.league-tag{font-size:.72rem;letter-spacing:2px;color:var(--line);font-weight:700}
+.match-clock{font-variant-numeric:tabular-nums;color:hsl(52,90%,80%);font-size:.85rem}
+.score-panel{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:26px 20px}
+.team-block{display:flex;flex-direction:column;align-items:center;gap:10px;width:120px}
+.team-crest{width:54px;height:54px;border-radius:50%;display:grid;place-items:center;font-weight:900;font-size:1.1rem;color:#fff;border:3px solid hsl(0,0%,100% / 0.35)}
+.home-crest{background:linear-gradient(135deg,var(--team-home),hsl(216,72%,34%))}
+.away-crest{background:linear-gradient(135deg,var(--team-away),hsl(39,90%,38%))}
+.team-name{font-size:.85rem;text-align:center;color:#eef3ff;font-weight:600}
+.score-digits{display:flex;align-items:center;gap:14px;font-family:"Courier New",ui-monospace,monospace}
+.digit{font-size:4.5rem;font-weight:900;color:var(--line);text-shadow:0 0 22px hsl(52,100%,62% / 0.45)}
+.digit-sep{font-size:3rem;color:hsl(52,60%,45%)}
+.score-panel.goal .digit-home{animation:score-pop-football-scoreboard 0.9s cubic-bezier(0.2,1.4,0.3,1) both}
+.score-panel.goal .digit-away{animation:score-bump-football-scoreboard 0.9s 0.15s cubic-bezier(0.2,1.4,0.3,1) both}
+.match-status{display:flex;align-items:center;gap:10px;padding:12px 18px;background:hsl(150,40%,7% / 0.75);border-top:1px solid hsl(52,60%,45% / 0.5)}
+.status-dot{width:11px;height:11px;border-radius:50%;background:var(--flash)}
+.live-dot{animation:pulse-live-football-scoreboard 1.1s ease-in-out infinite}
+.status-label{color:#dbe7ff;font-size:.82rem;font-weight:600;letter-spacing:0.4px}
+.possession-meter{flex:1;height:8px;margin-left:6px;background:hsl(150,30%,16%);border-radius:99px;overflow:hidden}
+.possession-fill{display:block;height:100%;width:72%;background:linear-gradient(90deg,var(--team-home),hsl(216,72%,60%));border-radius:99px;animation:slosh-possession-football-scoreboard 4s ease-in-out infinite}
+.goal-btn{border:0;background:var(--flash);color:#fff;font-weight:800;font-size:.75rem;padding:7px 12px;border-radius:8px;cursor:pointer}
+.goal-btn:active{transform:scale(0.94)}
+@keyframes score-pop-football-scoreboard{
+  0%{transform:scale(1) rotate(0deg)}
+  30%{transform:scale(1.35) rotate(-4deg);color:#fff}
+  60%{transform:scale(0.92) rotate(2deg)}
+  100%{transform:scale(1) rotate(0deg)}
+}
+@keyframes score-bump-football-scoreboard{
+  0%{transform:translateY(0)}
+  40%{transform:translateY(-14px)}
+  100%{transform:translateY(0)}
+}
+@keyframes pulse-live-football-scoreboard{
+  0%,100%{box-shadow:0 0 0 0 hsl(8,84%,56% / 0.7)}
+  50%{box-shadow:0 0 0 7px hsl(8,84%,56% / 0)}
+}
+@keyframes slosh-possession-football-scoreboard{
+  0%,100%{width:72%}
+  50%{width:58%}
+}


### PR DESCRIPTION
## Component: ease-football-scoreboard - live match scoreboard with animated goal pop on scoring

**Closes #58879**

### What this adds
A live football scoreboard. The home team score digit pops and flares when the GOAL +1 button is pressed while the away digit bumps in reaction. The LIVE indicator dot pulses and the possession meter sways to show in-game motion.

### Acceptance Criteria covered
- Score digits animate with a custom pop keyframe when a goal is registered
- The live indicator and possession meter are styled and animated as part of the scoreboard chrome
- Pressing GOAL +1 updates the score and replays the goal animation

### Files
- `submissions/examples/ease-football-scoreboard-ij/demo.html`
- `submissions/examples/ease-football-scoreboard-ij/style.css`
- `submissions/examples/ease-football-scoreboard-ij/README.md`

### How to review
Open demo.html directly in a browser. Press GOAL +1 and watch the home score digit pop and flash; the away digit bumps; the LIVE dot pulses continuously.