### PR TITLE
Add ease-tag-cloud-widget component

### DIFF
--- a/submissions/examples/ease-tag-cloud-widget-ij/README.md
+++ b/submissions/examples/ease-tag-cloud-widget-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Tag Cloud Widget
+
+A filterable topic tag cloud with four size tiers, weight-colored pills and a gentle floating animation.
+
+## Run
+Open `demo.html` in any browser.
+
+## Interaction
+- Type in the filter box to hide tags that do not match.

--- a/submissions/examples/ease-tag-cloud-widget-ij/demo.html
+++ b/submissions/examples/ease-tag-cloud-widget-ij/demo.html
@@ -1,0 +1,47 @@
+<!-- EaseMotion component: tag-cloud-widget -->
+<!DOCTYPE html>
+<html lang="en" data-widget="topics">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>Ease Tag Cloud Widget</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<aside class="cloud-panel">
+  <header class="cloud-header">
+    <h2>Trending Topics</h2>
+    <input id="cloudFilter" class="cloud-filter" type="search" placeholder="Filter tags..." aria-label="filter tags">
+  </header>
+  <div id="cloudCanvas" class="cloud-canvas" aria-label="tag cloud">
+    <span class="tag size-xl">Javascript</span>
+    <span class="tag size-lg">Design</span>
+    <span class="tag size-md">Accessibility</span>
+    <span class="tag size-sm">CSS</span>
+    <span class="tag size-xl">Motion</span>
+    <span class="tag size-md">TypeScript</span>
+    <span class="tag size-sm">SVG</span>
+    <span class="tag size-lg">Prototyping</span>
+    <span class="tag size-md">UX</span>
+    <span class="tag size-sm">Icons</span>
+    <span class="tag size-lg">Micro-interactions</span>
+    <span class="tag size-md">Colors</span>
+    <span class="tag size-sm">Fonts</span>
+    <span class="tag size-xl">Animation</span>
+  </div>
+  <footer class="cloud-foot">
+    <span>Top 14 topics this week</span>
+  </footer>
+</aside>
+<script>
+const filter=document.getElementById('cloudFilter');
+const canvas=document.getElementById('cloudCanvas');
+filter.addEventListener('input',()=>{
+  const q=filter.value.trim().toLowerCase();
+  for(const tag of canvas.children){
+    tag.style.display=tag.textContent.toLowerCase().includes(q)?'':'none';
+  }
+});
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-tag-cloud-widget-ij/style.css
+++ b/submissions/examples/ease-tag-cloud-widget-ij/style.css
@@ -1,0 +1,27 @@
+:root{
+  --cloud-bg:hsl(260,18%,9%);
+  --cloud-text:hsl(260,30%,88%);
+  --tag-a:hsl(262,82%,66%);
+  --tag-b:hsl(190,90%,58%);
+  --tag-c:hsl(38,95%,58%);
+  --cloud-mute:hsl(260,14%,52%);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:"Inter",ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 70% 20%,hsl(262,40%,18%),hsl(260,22%,7%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:28px}
+.cloud-panel{width:min(680px,94vw);background:hsl(260,20%,12% / 0.85);border:1px solid hsl(262,40%,30% / 0.5);border-radius:22px;backdrop-filter:blur(8px);box-shadow:0 24px 60px hsl(260,30%,3% / 0.6)}
+.cloud-header{display:flex;justify-content:space-between;align-items:center;gap:14px;padding:18px 22px;border-bottom:1px solid hsl(262,30%,24% / 0.6)}
+.cloud-header h2{font-size:1.15rem;font-weight:700;color:var(--cloud-text)}
+.cloud-filter{background:hsl(260,22%,16%);border:1px solid hsl(262,30%,26%);color:var(--cloud-text);padding:8px 14px;border-radius:99px;width:170px;font-size:.85rem;outline:none}
+.cloud-filter:focus{border-color:var(--tag-a);box-shadow:0 0 0 3px hsl(262,82%,66% / 0.22)}
+.cloud-canvas{display:flex;flex-wrap:wrap;align-items:center;gap:10px 12px;padding:26px 22px;min-height:230px}
+.tag{border-radius:99px;font-weight:600;line-height:1;cursor:default;transition:transform 0.2s ease,background 0.2s ease}
+.tag:hover{transform:translateY(-4px) scale(1.06)}
+.size-xl{font-size:1.5rem;padding:12px 20px;background:hsl(262,82%,66% / 0.16);color:var(--tag-a);animation:rise-tag-cloud-widget 4.2s ease-in-out infinite}
+.size-lg{font-size:1.18rem;padding:9px 16px;background:hsl(190,90%,58% / 0.13);color:var(--tag-b);animation:rise-tag-cloud-widget 4.6s 0.3s ease-in-out infinite}
+.size-md{font-size:.95rem;padding:8px 13px;background:hsl(38,95%,58% / 0.12);color:var(--tag-c);animation:rise-tag-cloud-widget 4.9s 0.7s ease-in-out infinite}
+.size-sm{font-size:.75rem;padding:6px 10px;background:hsl(260,20%,22% / 0.9);color:var(--cloud-mute);animation:rise-tag-cloud-widget 5.3s 1s ease-in-out infinite}
+.cloud-foot{padding:10px 22px;border-top:1px solid hsl(262,30%,24% / 0.6);color:var(--cloud-mute);font-size:.78rem;letter-spacing:0.4px}
+@keyframes rise-tag-cloud-widget{
+  0%,100%{transform:translateY(0) scale(1)}
+  50%{transform:translateY(-6px) scale(1.03)}
+}


### PR DESCRIPTION
## Component: ease-tag-cloud-widget - filterable topic tag cloud with floating size-weighted tags

**Closes #58882**

### What this adds
A filterable topic tag cloud. Tags are rendered at four size tiers based on weight and float gently on staggered cycles. Typing in the filter box hides tags that do not match the query in real time.

### Acceptance Criteria covered
- Tags render at four distinct size tiers with weight-based colors
- Tags float with a staggered rise animation
- Typing in the filter narrows the visible tags instantly

### Files
- `submissions/examples/ease-tag-cloud-widget-ij/demo.html`
- `submissions/examples/ease-tag-cloud-widget-ij/style.css`
- `submissions/examples/ease-tag-cloud-widget-ij/README.md`

### How to review
Open demo.html directly in a browser. Type css in the filter and watch non-matching tags hide; the remaining tags float continuously.