### PR TITLE
Add ease-camera-shutter-ui component

### DIFF
--- a/submissions/examples/ease-camera-shutter-ui-ij/README.md
+++ b/submissions/examples/ease-camera-shutter-ui-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Camera Shutter UI
+
+A camera viewfinder shell with a focus reticle, a REC indicator, mode buttons and an animated shutter release.
+
+## Run
+Open `demo.html` in any browser.
+
+## Interaction
+- Click the round shutter button to replay the capture animation.

--- a/submissions/examples/ease-camera-shutter-ui-ij/demo.html
+++ b/submissions/examples/ease-camera-shutter-ui-ij/demo.html
@@ -1,0 +1,51 @@
+<!-- EaseMotion component: camera-shutter-ui -->
+<!DOCTYPE html>
+<html lang="en" data-device="camera">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3">
+<title>Ease Camera Shutter UI</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="camera-shell">
+  <div class="viewfinder">
+    <div class="sky-glow"></div>
+    <div class="ridge sky-ridge"></div>
+    <div class="ridge mid-ridge"></div>
+    <div class="ridge near-ridge"></div>
+    <div id="reticle" class="focus-reticle" aria-hidden="true">
+      <span class="reticle-corner tl"></span>
+      <span class="reticle-corner tr"></span>
+      <span class="reticle-corner bl"></span>
+      <span class="reticle-corner br"></span>
+    </div>
+    <div class="rec-chip"><i class="rec-dot"></i>REC</div>
+  </div>
+  <div class="shutter-deck">
+    <button class="mode-btn" type="button" aria-label="switch camera">switch</button>
+    <button id="shutter" class="shutter-btn" type="button" aria-label="capture photo">
+      <span class="shutter-inner"></span>
+    </button>
+    <button class="mode-btn" type="button" aria-label="toggle flash">flash</button>
+  </div>
+  <div class="settings-row">
+    <span class="setting-chip">1x</span>
+    <span class="setting-chip">4:3</span>
+    <span class="setting-chip">f1.8</span>
+    <span class="setting-chip">ISO 100</span>
+  </div>
+</div>
+<script>
+const shutter=document.getElementById('shutter');
+const reticle=document.getElementById('reticle');
+shutter.addEventListener('click',()=>{
+  shutter.classList.remove('firing');
+  reticle.classList.remove('tracking');
+  void shutter.offsetWidth;
+  shutter.classList.add('firing');
+  reticle.classList.add('tracking');
+});
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-camera-shutter-ui-ij/style.css
+++ b/submissions/examples/ease-camera-shutter-ui-ij/style.css
@@ -1,0 +1,51 @@
+:root{
+  --camera-body:hsl(0,0%,12%);
+  --camera-trim:hsl(0,0%,28%);
+  --camera-accent:hsl(14,100%,58%);
+  --camera-sky:hsl(202,88%,62%);
+}
+*{padding:0;box-sizing:border-box;margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:linear-gradient(160deg,hsl(0,0%,6%),hsl(0,0%,15%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.camera-shell{width:min(420px,94vw);background:var(--camera-body);border:1px solid hsl(0,0%,20%);border-radius:26px;padding:16px;box-shadow:0 26px 60px hsl(0,0%,3% / 0.7)}
+.viewfinder{position:relative;aspect-ratio:4/3;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,var(--camera-sky),hsl(202,80%,48%))}
+.sky-glow{position:absolute;inset:0;background:radial-gradient(circle at 28% 18%,hsl(48,100%,82%),transparent 55%)}
+.ridge{position:absolute;left:-12%;right:-12%;height:60px;border-radius:50%}
+.sky-ridge{top:34%;background:linear-gradient(180deg,hsl(24,24%,46%),hsl(24,18%,34%))}
+.mid-ridge{top:52%;height:70px;background:linear-gradient(180deg,hsl(24,20%,36%),hsl(24,16%,26%))}
+.near-ridge{top:72%;height:76px;background:linear-gradient(180deg,hsl(24,14%,26%),hsl(0,0%,12%))}
+.focus-reticle{position:absolute;inset:0;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;pointer-events:none}
+.reticle-corner{width:26px;height:26px;border-color:hsl(0,0%,100% / 0.9);border-style:solid;border-width:0}
+.tl{border-top-width:3px;border-left-width:3px;border-top-left-radius:6px}
+.tr{border-top-width:3px;border-right-width:3px;border-top-right-radius:6px}
+.bl{border-bottom-width:3px;border-left-width:3px;border-bottom-left-radius:6px}
+.br{border-bottom-width:3px;border-right-width:3px;border-bottom-right-radius:6px}
+.focus-reticle.tracking{animation:focus-lock-camera-shutter-ui 0.8s ease both}
+.rec-chip{position:absolute;top:10px;left:10px;display:flex;align-items:center;gap:6px;background:hsl(0,0%,5% / 0.55);color:#fff;font-size:.7rem;letter-spacing:1.4px;font-weight:700;padding:5px 9px;border-radius:6px}
+.rec-dot{width:8px;height:8px;border-radius:50%;background:var(--camera-accent);animation:rec-blink-camera-shutter-ui 1s step-end infinite}
+.shutter-deck{display:flex;align-items:center;justify-content:space-between;padding:16px 8px 6px}
+.mode-btn{width:44px;height:44px;border-radius:50%;border:1px solid var(--camera-trim);background:hsl(0,0%,16%);color:#fff;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:1px;cursor:pointer}
+.mode-btn:active{transform:scale(0.92)}
+.shutter-btn{width:76px;height:76px;border-radius:50%;border:4px solid hsl(0,0%,42%);background:hsl(0,0%,22%);cursor:pointer;display:grid;place-items:center}
+.shutter-inner{width:58px;height:58px;border-radius:50%;background:radial-gradient(circle at 35% 30%,hsl(0,0%,88%),hsl(0,0%,62%))}
+.shutter-btn.firing{animation:shutter-press-camera-shutter-ui 0.4s ease both}
+.shutter-btn.firing .shutter-inner{animation:spin-shutter-camera-shutter-ui 0.6s linear both}
+.settings-row{display:flex;gap:8px;justify-content:center;padding:10px 0 2px}
+.setting-chip{font-size:.72rem;color:hsl(0,0%,88%);background:hsl(0,0%,16%);border:1px solid hsl(0,0%,26%);border-radius:99px;padding:5px 10px;letter-spacing:0.3px}
+@keyframes focus-lock-camera-shutter-ui{
+  0%{transform:scale(0.96)}
+  50%{transform:scale(1.06)}
+  100%{transform:scale(1);opacity:1}
+}
+@keyframes rec-blink-camera-shutter-ui{
+  0%,55%{opacity:1}
+  56%,100%{opacity:0.15}
+}
+@keyframes shutter-press-camera-shutter-ui{
+  0%{transform:translateY(0) scale(1)}
+  40%{transform:translateY(4px) scale(0.88)}
+  100%{transform:translateY(0) scale(1)}
+}
+@keyframes spin-shutter-camera-shutter-ui{
+  0%{transform:rotate(0deg) scale(0.75)}
+  100%{transform:rotate(360deg) scale(1)}
+}


### PR DESCRIPTION
## Component: ease-camera-shutter-ui - camera viewfinder with pulsing shutter press and focus lock

**Closes #58884**

### What this adds
A camera viewfinder interface. The shutter button compresses and its inner ring spins while the focus reticle locks with a scale pulse. The REC dot blinks in the corner of the frame.

### Acceptance Criteria covered
- The shutter button presses inward with a spinning inner ring
- The focus reticle locks with a tracking animation on capture
- Clicking the shutter button replays the full capture sequence

### Files
- `submissions/examples/ease-camera-shutter-ui-ij/demo.html`
- `submissions/examples/ease-camera-shutter-ui-ij/style.css`
- `submissions/examples/ease-camera-shutter-ui-ij/README.md`

### How to review
Open demo.html directly in a browser. Click the round shutter button; the focus reticle tracks and the inner ring spins. The REC chip blinks continuously.