### PR TITLE
Add ease-weather-forecast-panel component

### DIFF
--- a/submissions/examples/ease-weather-forecast-panel-ij/README.md
+++ b/submissions/examples/ease-weather-forecast-panel-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Weather Forecast Panel
+
+A six-hour weather forecast panel with current conditions and CSS-drawn sun, cloud and rain icons.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- Icons are pure CSS; no image assets are used.

--- a/submissions/examples/ease-weather-forecast-panel-ij/demo.html
+++ b/submissions/examples/ease-weather-forecast-panel-ij/demo.html
@@ -1,0 +1,58 @@
+<!-- EaseMotion component: weather-forecast-panel -->
+<!doctype html>
+<html lang="en" data-city="sf">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Ease Weather Forecast Panel</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<section class="weather-card">
+  <div class="weather-hero">
+    <p class="weather-place">San Francisco, CA</p>
+    <div class="temp-reading">
+      <span class="temp-value">18</span>
+      <span class="temp-unit">deg C</span>
+    </div>
+    <p class="weather-desc">Partly cloudy - feels like 17</p>
+    <div class="weather-stats">
+      <span class="stat">Humidity 64%</span>
+      <span class="stat">Wind 12 km/h</span>
+    </div>
+  </div>
+  <div class="hour-strip">
+    <div class="hour-cell">
+      <span class="hour-label">Now</span>
+      <i class="weather-ico ico-cloud"></i>
+      <span class="hour-temp">18</span>
+    </div>
+    <div class="hour-cell">
+      <span class="hour-label">2 PM</span>
+      <i class="weather-ico ico-sun"></i>
+      <span class="hour-temp">21</span>
+    </div>
+    <div class="hour-cell">
+      <span class="hour-label">3 PM</span>
+      <i class="weather-ico ico-sun"></i>
+      <span class="hour-temp">22</span>
+    </div>
+    <div class="hour-cell">
+      <span class="hour-label">4 PM</span>
+      <i class="weather-ico ico-cloud"></i>
+      <span class="hour-temp">20</span>
+    </div>
+    <div class="hour-cell">
+      <span class="hour-label">5 PM</span>
+      <i class="weather-ico ico-rain"></i>
+      <span class="hour-temp">16</span>
+    </div>
+    <div class="hour-cell">
+      <span class="hour-label">6 PM</span>
+      <i class="weather-ico ico-rain"></i>
+      <span class="hour-temp">15</span>
+    </div>
+  </div>
+</section>
+</body>
+</html>

--- a/submissions/examples/ease-weather-forecast-panel-ij/style.css
+++ b/submissions/examples/ease-weather-forecast-panel-ij/style.css
@@ -1,0 +1,47 @@
+:root{
+  --wx-bg:hsl(213,35%,95%);
+  --wx-ink:hsl(218,35%,22%);
+  --wx-line:hsl(214,25%,86%);
+  --wx-sun:hsl(48,100%,58%);
+  --wx-rain:hsl(200,80%,52%);
+}
+*{margin:0;box-sizing:border-box;padding:0}
+body{font-family:"Inter",ui-sans-serif,system-ui,sans-serif;background:linear-gradient(180deg,var(--wx-bg),hsl(213,40%,90%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
+.weather-card{width:min(430px,94vw);background:hsl(0,0%,100%);border:1px solid var(--wx-line);border-radius:24px;overflow:hidden;box-shadow:0 20px 45px hsl(214,30%,60% / 0.3)}
+.weather-hero{background:linear-gradient(150deg,hsl(204,70%,92%),hsl(204,65%,84%));padding:22px 20px 18px;text-align:center}
+.weather-place{font-size:.8rem;font-weight:700;color:hsl(218,30%,40%);letter-spacing:0.5px}
+.temp-reading{display:flex;align-items:flex-start;justify-content:center;gap:4px;margin:6px 0 2px}
+.temp-value{font-size:3.4rem;font-weight:800;line-height:1;font-variant-numeric:tabular-nums;color:var(--wx-ink);animation:temp-breathe-weather-forecast-panel 3s ease-in-out infinite}
+.temp-unit{font-size:1.1rem;font-weight:700;color:hsl(218,30%,45%);margin-top:8px}
+.weather-desc{font-size:.85rem;color:hsl(218,28%,38%);margin-bottom:12px}
+.weather-stats{display:flex;gap:18px;justify-content:center}
+.stat{font-size:.74rem;font-weight:600;color:hsl(218,28%,42%);background:hsl(0,0%,100% / 0.55);padding:5px 11px;border-radius:99px}
+.hour-strip{display:flex;justify-content:space-between;padding:16px 14px}
+.hour-cell{display:flex;flex-direction:column;align-items:center;gap:7px;flex:1;border-right:1px dashed var(--wx-line)}
+.hour-cell:last-child{border-right:0}
+.hour-label{font-size:.68rem;font-weight:700;color:hsl(218,25%,50%)}
+.hour-temp{font-size:.82rem;font-weight:800;color:var(--wx-ink);font-variant-numeric:tabular-nums}
+.weather-ico{display:block;position:relative}
+.ico-sun{width:38px;height:38px;border-radius:50%;background:var(--wx-sun);box-shadow:0 0 0 4px hsl(48,100%,58% / 0.25);animation:sun-turn-weather-forecast-panel 6s linear infinite}
+.ico-sun::before{content:"";position:absolute;inset:-9px;border-radius:50%;border:2px dashed hsl(48,90%,64%)}
+.ico-cloud,.ico-rain{width:46px;height:24px;background:hsl(210,15%,92%);border-radius:24px;box-shadow:0 6px 12px hsl(210,20%,55% / 0.3);animation:cloud-drift-weather-forecast-panel 5s ease-in-out infinite}
+.ico-cloud::before,.ico-rain::before{content:"";position:absolute;top:-14px;left:8px;width:24px;height:24px;background:hsl(210,15%,92%);border-radius:50%}
+.ico-cloud::after{content:"";position:absolute;top:-8px;left:22px;width:18px;height:18px;background:hsl(210,15%,92%);border-radius:50%}
+.ico-rain::after{content:"";position:absolute;top:24px;left:10px;width:3px;height:10px;background:var(--wx-rain);border-radius:2px;box-shadow:12px 2px 0 hsl(200,80%,55%),-8px 6px 0 hsl(200,80%,48%);animation:drop-fall-weather-forecast-panel 1.2s linear infinite}
+@keyframes temp-breathe-weather-forecast-panel{
+  0%,100%{opacity:1;transform:scale(1) translateY(0)}
+  50%{opacity:0.85;transform:scale(1.04) translateY(-2px)}
+}
+@keyframes sun-turn-weather-forecast-panel{
+  0%,100%{transform:rotate(0deg)}
+  50%{transform:rotate(180deg)}
+}
+@keyframes cloud-drift-weather-forecast-panel{
+  0%,100%{transform:translateX(0)}
+  50%{transform:translateX(5px)}
+}
+@keyframes drop-fall-weather-forecast-panel{
+  0%{opacity:0;transform:translateY(-3px)}
+  30%{opacity:1}
+  100%{opacity:0;transform:translateY(8px)}
+}


### PR DESCRIPTION
## Component: ease-weather-forecast-panel - hourly weather forecast panel with CSS-drawn condition icons

**Closes #58887**

### What this adds
A six-hour weather forecast panel. Current conditions show temperature, humidity and wind while the hourly strip renders CSS-drawn sun, cloud and rain icons that drift and rain.

### Acceptance Criteria covered
- The current conditions header shows place, temperature and stats
- Hourly cells render CSS-drawn condition icons with no image assets
- Icons animate with a slow drift and a falling-rain keyframe

### Files
- `submissions/examples/ease-weather-forecast-panel-ij/demo.html`
- `submissions/examples/ease-weather-forecast-panel-ij/style.css`
- `submissions/examples/ease-weather-forecast-panel-ij/README.md`

### How to review
Open demo.html directly in a browser. Confirm the hourly strip shows sun, cloud and rain icons and that the rain icons animate falling drops.