### PR TITLE
Add ease-pomodoro-session-timer component

### DIFF
--- a/submissions/examples/ease-pomodoro-session-timer-ij/README.md
+++ b/submissions/examples/ease-pomodoro-session-timer-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Pomodoro Session Timer
+
+A pomodoro session timer with a conic-gradient progress ring, pulsing time digits and session dots.
+
+## Run
+Open `demo.html` in any browser.
+
+## Interaction
+- Click **Start** to toggle the running state of the ring and digits.

--- a/submissions/examples/ease-pomodoro-session-timer-ij/demo.html
+++ b/submissions/examples/ease-pomodoro-session-timer-ij/demo.html
@@ -1,0 +1,44 @@
+<!-- EaseMotion component: pomodoro-session-timer -->
+<!DOCTYPE html>
+<html lang="en" data-method="timer">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=contain">
+<title>Ease Pomodoro Session Timer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="focus-app">
+  <nav class="mode-tabs" role="tablist">
+    <button class="tab active-tab" type="button">Focus</button>
+    <button class="tab" type="button">Short Break</button>
+    <button class="tab" type="button">Long Break</button>
+  </nav>
+  <div class="ring-dial" aria-label="session countdown">
+    <div class="ring-track"></div>
+    <div class="ring-progress"></div>
+    <div class="ring-center">
+      <span class="time-digits">25:00</span>
+      <span class="phase-label">Deep work</span>
+    </div>
+  </div>
+  <div class="session-dots" aria-label="completed sessions">
+    <i class="session-dot done"></i>
+    <i class="session-dot done"></i>
+    <i class="session-dot current"></i>
+    <i class="session-dot"></i>
+  </div>
+  <div class="timer-controls">
+    <button id="startBtn" class="timer-btn primary-btn" type="button">Start</button>
+    <button class="timer-btn ghost-btn" type="button">Reset</button>
+  </div>
+</div>
+<script>
+const app=document.querySelector('.focus-app');
+document.getElementById('startBtn').addEventListener('click',(e)=>{
+  app.classList.toggle('running');
+  e.currentTarget.textContent=app.classList.contains('running')?'Pause':'Start';
+});
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-pomodoro-session-timer-ij/style.css
+++ b/submissions/examples/ease-pomodoro-session-timer-ij/style.css
@@ -1,0 +1,43 @@
+:root{
+  --focus-bg:hsl(358,72%,94%);
+  --focus-ink:hsl(358,55%,26%);
+  --focus-accent:hsl(0,78%,52%);
+  --focus-soft:hsl(0,60%,92%);
+  --focus-track:hsl(0,45%,86%);
+}
+*{padding:0;margin:0;box-sizing:border-box}
+body{font-family:"Inter",ui-sans-serif,system-ui,sans-serif;background:var(--focus-bg);color:var(--focus-ink);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
+.focus-app{width:min(360px,94vw);background:hsl(0,0%,100%);border:1px solid var(--focus-track);border-radius:28px;padding:22px;text-align:center;box-shadow:0 20px 45px hsl(358,30%,70% / 0.35)}
+.mode-tabs{display:flex;gap:6px;justify-content:center;margin-bottom:20px;background:var(--focus-soft);border-radius:99px;padding:5px}
+.tab{border:0;background:transparent;padding:8px 12px;border-radius:99px;font-size:.8rem;font-weight:600;color:hsl(358,30%,45%);cursor:pointer}
+.active-tab{background:hsl(0,0%,100%);color:var(--focus-accent);box-shadow:0 3px 10px hsl(358,40%,80% / 0.5)}
+.ring-dial{position:relative;width:200px;height:200px;margin:0 auto 16px}
+.ring-track,.ring-progress{position:absolute;inset:0;border-radius:50%}
+.ring-track{background:conic-gradient(var(--focus-track) 0 360deg)}
+.ring-progress{background:conic-gradient(var(--focus-accent) 0 68%,transparent 68% 100%);animation:spin-ring-pomodoro-session-timer 20s linear infinite}
+.focus-app.running .ring-progress{animation-duration:9s}
+.ring-center{position:absolute;inset:14px;background:hsl(0,0%,100%);border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px}
+.time-digits{font-size:2.6rem;font-weight:800;font-variant-numeric:tabular-nums;letter-spacing:-1px;animation:digit-pulse-pomodoro-session-timer 2.4s ease-in-out infinite}
+.focus-app.running .time-digits{animation-duration:1.1s}
+.phase-label{font-size:.78rem;letter-spacing:1.5px;text-transform:uppercase;color:hsl(358,30%,48%)}
+.session-dots{display:flex;gap:8px;justify-content:center;margin:0 0 18px}
+.session-dot{width:9px;height:9px;border-radius:50%;background:var(--focus-track)}
+.session-dot.done{background:var(--focus-accent)}
+.session-dot.current{background:hsl(0,78%,62%);animation:dot-breathe-pomodoro-session-timer 1.6s ease-in-out infinite}
+.timer-controls{display:flex;gap:10px;justify-content:center}
+.timer-btn{border:0;border-radius:99px;padding:11px 22px;font-size:.9rem;font-weight:700;cursor:pointer}
+.primary-btn{background:var(--focus-accent);color:#fff}
+.primary-btn:active{transform:scale(0.96)}
+.ghost-btn{background:transparent;border:1px solid var(--focus-track);color:hsl(358,35%,42%)}
+@keyframes spin-ring-pomodoro-session-timer{
+  0%{transform:rotate(0deg)}
+  100%{transform:rotate(360deg)}
+}
+@keyframes digit-pulse-pomodoro-session-timer{
+  0%,100%{opacity:1;transform:scale(1)}
+  50%{opacity:0.62;transform:scale(0.97)}
+}
+@keyframes dot-breathe-pomodoro-session-timer{
+  0%,100%{transform:scale(1) translateY(0)}
+  50%{transform:scale(1.6) translateY(-1px)}
+}


### PR DESCRIPTION
## Component: ease-pomodoro-session-timer - pomodoro session timer with spinning progress ring

**Closes #58892**

### What this adds
A pomodoro session timer. A conic-gradient progress ring sweeps around a 25:00 dial while the digits pulse. Starting the timer accelerates the ring and digit breathing.

### Acceptance Criteria covered
- The progress ring rotates around the dial with a conic gradient
- Session dots reflect completed rounds and pulse the current one
- Start and Pause toggles the running state of the ring and digits

### Files
- `submissions/examples/ease-pomodoro-session-timer-ij/demo.html`
- `submissions/examples/ease-pomodoro-session-timer-ij/style.css`
- `submissions/examples/ease-pomodoro-session-timer-ij/README.md`

### How to review
Open demo.html directly in a browser. The ring spins and the digits pulse; click Start to switch into running mode, then Pause to slow it back down.