### PR TITLE
Add ease-traffic-light-sequence component

### DIFF
--- a/submissions/examples/ease-traffic-light-sequence-ij/README.md
+++ b/submissions/examples/ease-traffic-light-sequence-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Traffic Light Sequence
+
+A three-lamp traffic signal that cycles red, amber and green with glow pulses and a live phase caption.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The full signal cycle repeats every 4 seconds.

--- a/submissions/examples/ease-traffic-light-sequence-ij/demo.html
+++ b/submissions/examples/ease-traffic-light-sequence-ij/demo.html
@@ -1,0 +1,28 @@
+<!-- EaseMotion component: traffic-light-sequence -->
+<!doctype html>
+<html lang="en" data-signal="traffic">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Ease Traffic Light Sequence</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<figure class="signal-rig">
+  <div class="signal-housing">
+    <span class="lamp lamp-red"></span>
+    <span class="lamp lamp-amber"></span>
+    <span class="lamp lamp-green"></span>
+  </div>
+  <figcaption class="signal-caption">
+    <span id="phaseLabel" class="phase-tag">RED</span>
+    <span class="phase-note">automated cycle</span>
+  </figcaption>
+</figure>
+<script>
+const labels=['RED','AMBER','GREEN'];
+let i=0;
+setInterval(()=>{i=(i+1)%3;document.getElementById('phaseLabel').textContent=labels[i];},4000);
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-traffic-light-sequence-ij/style.css
+++ b/submissions/examples/ease-traffic-light-sequence-ij/style.css
@@ -1,0 +1,32 @@
+:root{
+  --sig-body:hsl(0,0%,12%);
+  --sig-rim:hsl(0,0%,30%);
+  --sig-red:hsl(0,92%,54%);
+  --sig-amber:hsl(44,96%,56%);
+  --sig-green:hsl(132,82%,46%);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:hsl(210,30%,14%);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
+.signal-rig{display:flex;flex-direction:column;align-items:center;gap:16px}
+.signal-housing{display:flex;flex-direction:column;gap:16px;padding:20px 16px;background:var(--sig-body);border:3px solid var(--sig-rim);border-radius:22px;box-shadow:0 18px 45px hsl(210,30%,4% / 0.55)}
+.lamp{width:92px;height:92px;border-radius:50%;background:hsl(0,0%,18%);border:4px solid hsl(0,0%,8%);box-shadow:inset 0 4px 10px hsl(0,0%,5% / 0.8)}
+.lamp-red{animation:cycle-red-traffic-light-sequence 4s steps(1) infinite}
+.lamp-amber{animation:cycle-amber-traffic-light-sequence 4s steps(1) infinite}
+.lamp-green{animation:cycle-green-traffic-light-sequence 4s steps(1) infinite}
+.signal-caption{display:flex;align-items:center;gap:10px;padding:9px 16px;background:hsl(0,0%,8%);border:1px solid hsl(0,0%,24%);border-radius:99px}
+.phase-tag{font-size:.85rem;font-weight:800;letter-spacing:2px;color:hsl(0,0%,92%);min-width:64px;text-align:center}
+.phase-note{font-size:.72rem;color:hsl(0,0%,54%)}
+@keyframes cycle-red-traffic-light-sequence{
+  0%{opacity:1;background:var(--sig-red);box-shadow:0 0 30px 12px hsl(0,92%,54% / 0.7)}
+  25%,100%{opacity:0.18;background:hsl(0,92%,30%);box-shadow:none}
+}
+@keyframes cycle-amber-traffic-light-sequence{
+  0%,25%{opacity:0.18;background:hsl(44,96%,30%);box-shadow:none}
+  25%{opacity:1;background:var(--sig-amber);box-shadow:0 0 30px 12px hsl(44,96%,56% / 0.7)}
+  37%,100%{opacity:0.18;background:hsl(44,96%,30%);box-shadow:none}
+}
+@keyframes cycle-green-traffic-light-sequence{
+  0%,50%{opacity:0.18;background:hsl(132,82%,28%);box-shadow:none}
+  50%{opacity:1;background:var(--sig-green);box-shadow:0 0 30px 12px hsl(132,82%,46% / 0.7)}
+  87%,100%{opacity:0.18;background:hsl(132,82%,28%);box-shadow:none}
+}


### PR DESCRIPTION
## Component: ease-traffic-light-sequence — traffic signal cycling red amber green with glow pulses

**Closes #58975**

### What this adds
A traffic signal housing with three lamps. The red lamp glows while the others dim, the amber lamp blinks, then the green lamp takes over before the cycle restarts. A caption under the rig shows the active phase.

### Acceptance Criteria covered
- Three lamps render as stacked circles inside a signal housing
- The active lamp glows while the inactive lamps stay dim
- The cycle repeats red to amber to green on a timed keyframe

### Files
- `submissions/examples/ease-traffic-light-sequence-ij/demo.html`
- `submissions/examples/ease-traffic-light-sequence-ij/style.css`
- `submissions/examples/ease-traffic-light-sequence-ij/README.md`

### How to review
Open demo.html directly in a browser. Watch the red lamp glow, the amber lamp blink, then the green lamp glow in sequence.