### PR TITLE
Add ease-coffee-order-cup component

### DIFF
--- a/submissions/examples/ease-coffee-order-cup-ij/README.md
+++ b/submissions/examples/ease-coffee-order-cup-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Coffee Order Cup
+
+A coffee ordering card with a CSS-rendered steaming cup, saucer, size selection and live price tag.
+
+## Run
+Open `demo.html` in any browser.
+
+## Interaction
+- Click an S, M or L chip to change the price and replay the fill wave.

--- a/submissions/examples/ease-coffee-order-cup-ij/demo.html
+++ b/submissions/examples/ease-coffee-order-cup-ij/demo.html
@@ -1,0 +1,51 @@
+<!-- EaseMotion component: coffee-order-cup -->
+<!DOCTYPE html>
+<html lang="en" data-order="coffee">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+<title>Ease Coffee Order Cup</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<section class="order-card">
+  <header class="order-head">
+    <h2>Corner Roast</h2>
+    <span class="brew-tag">fresh pour</span>
+  </header>
+  <div class="cup-scene">
+    <i class="steam s1"></i>
+    <i class="steam s2"></i>
+    <i class="steam s3"></i>
+    <div class="cup">
+      <div class="cup-fill"></div>
+      <div class="cup-handle"></div>
+    </div>
+    <div class="saucer"></div>
+  </div>
+  <div class="size-row" role="group" aria-label="cup size">
+    <button class="size-chip" type="button" data-price="3.25">S $3.25</button>
+    <button class="size-chip" type="button" data-price="4.10">M $4.10</button>
+    <button class="size-chip" type="button" data-price="4.95">L $4.95</button>
+  </div>
+  <footer class="order-foot">
+    <span id="priceTag" class="price-tag">$3.25</span>
+    <button class="order-btn" type="button">Add to order</button>
+  </footer>
+</section>
+<script>
+const price=document.getElementById('priceTag');
+document.querySelectorAll('.size-chip').forEach(chip=>{
+  chip.addEventListener('click',()=>{
+    document.querySelectorAll('.size-chip').forEach(b=>b.classList.remove('chosen'));
+    chip.classList.add('chosen');
+    price.textContent='$'+chip.dataset.price;
+    const fill=document.querySelector('.cup-fill');
+    fill.classList.remove('wave');
+    void fill.offsetWidth;
+    fill.classList.add('wave');
+  });
+});
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-coffee-order-cup-ij/style.css
+++ b/submissions/examples/ease-coffee-order-cup-ij/style.css
@@ -1,0 +1,44 @@
+:root{
+  --cafe-bg:hsl(28,40%,92%);
+  --cafe-ink:hsl(26,35%,22%);
+  --cafe-cup:hsl(0,0%,98%);
+  --cafe-saucer:hsl(28,25%,88%);
+  --cafe-brew:hsl(24,55%,38%);
+  --cafe-accent:hsl(16,85%,52%);
+}
+*{margin:0;box-sizing:border-box;padding:0}
+body{font-family:"Inter",ui-sans-serif,system-ui,sans-serif;background:linear-gradient(180deg,var(--cafe-bg),hsl(28,38%,86%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
+.order-card{width:min(390px,94vw);background:hsl(0,0%,100%);border:1px solid hsl(28,30%,84%);border-radius:24px;padding:20px;box-shadow:0 20px 45px hsl(28,35%,70% / 0.3)}
+.order-head{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:14px}
+.order-head h2{font-size:1.25rem;font-weight:800}
+.brew-tag{font-size:.7rem;font-weight:700;color:var(--cafe-accent);background:hsl(16,85%,52% / 0.12);padding:4px 9px;border-radius:99px}
+.cup-scene{position:relative;height:170px;display:flex;align-items:flex-end;justify-content:center;margin-bottom:6px}
+.steam{position:absolute;width:14px;height:34px;border:2px solid hsl(24,40%,74%);border-bottom:0;border-radius:50% 50% 0 0;opacity:0}
+.s1{left:calc(50% - 26px);animation:steam-rise-coffee-order-cup 2.4s ease-in-out infinite}
+.s2{left:calc(50% - 8px);animation:steam-rise-coffee-order-cup 2.4s 0.4s ease-in-out infinite}
+.s3{left:calc(50% + 12px);animation:steam-rise-coffee-order-cup 2.4s 0.8s ease-in-out infinite}
+.cup{position:relative;width:86px;height:78px;background:var(--cafe-cup);border-radius:4px 4px 16px 16px;overflow:hidden;box-shadow:0 8px 18px hsl(28,35%,60% / 0.4)}
+.cup-fill{position:absolute;left:0;right:0;bottom:0;height:72%;background:var(--cafe-brew);animation:fill-wave-coffee-order-cup 3.6s ease-in-out infinite}
+.cup-fill.wave{animation:fill-wave-coffee-order-cup 0.9s ease-out 1}
+.cup-handle{position:absolute;right:-18px;top:14px;width:22px;height:34px;border:6px solid var(--cafe-cup);border-left:0;border-radius:0 16px 16px 0}
+.saucer{width:150px;height:16px;background:var(--cafe-saucer);border-radius:99px;margin-top:-6px;box-shadow:0 5px 12px hsl(28,25%,60% / 0.4)}
+.size-row{display:flex;gap:8px;margin:14px 0}
+.size-chip{flex:1;border:2px solid hsl(28,30%,86%);background:hsl(0,0%,100%);border-radius:12px;padding:10px 4px;font-size:.85rem;font-weight:700;color:var(--cafe-ink);cursor:pointer;transition:border-color 0.2s,background 0.2s}
+.size-chip:hover,.size-chip.chosen{border-color:var(--cafe-accent);background:hsl(16,85%,52% / 0.1)}
+.order-foot{display:flex;justify-content:space-between;align-items:center;border-top:1px dashed hsl(28,30%,88%);padding-top:12px}
+.price-tag{font-size:1.5rem;font-weight:800;font-variant-numeric:tabular-nums;animation:price-pulse-coffee-order-cup 1.4s ease-in-out infinite}
+.order-btn{border:0;background:var(--cafe-accent);color:#fff;font-weight:800;font-size:.88rem;padding:10px 18px;border-radius:12px;cursor:pointer}
+.order-btn:active{transform:scale(0.96)}
+@keyframes steam-rise-coffee-order-cup{
+  0%{opacity:0;transform:translateY(0) scaleX(1)}
+  45%{opacity:0.85}
+  100%{opacity:0;transform:translateY(-42px) scaleX(1.7)}
+}
+@keyframes fill-wave-coffee-order-cup{
+  0%,100%{height:72%}
+  50%{height:82%}
+}
+@keyframes price-pulse-coffee-order-cup{
+  0%,100%{opacity:1;transform:scale(1)}
+  50%{opacity:0.8;transform:scale(1.04)}
+}


### PR DESCRIPTION
## Component: ease-coffee-order-cup — coffee ordering card with steaming cup and size toggle

**Closes #58977**

### What this adds
A coffee order card for a small cafe. The cup renders with a saucer and a rising steam plume while the size chips S M L highlight on press. Selecting a size updates the price tag and replays the cup fill wave.

### Acceptance Criteria covered
- The cup and saucer render in CSS with a steam plume above the rim
- Steam rises and curls with a looping keyframe
- Clicking a size chip updates the price and replays the fill wave

### Files
- `submissions/examples/ease-coffee-order-cup-ij/demo.html`
- `submissions/examples/ease-coffee-order-cup-ij/style.css`
- `submissions/examples/ease-coffee-order-cup-ij/README.md`

### How to review
Open demo.html directly in a browser. Click an S, M or L chip and watch the price update while the fill wave replays.