### PR TITLE
Add ease-password-strength-meter component

### DIFF
--- a/submissions/examples/ease-password-strength-meter-ij/README.md
+++ b/submissions/examples/ease-password-strength-meter-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Password Strength Meter
+
+A signup password field with a four-segment strength meter and live validation hints for length, case, digits and symbols.
+
+## Run
+Open `demo.html` in any browser.
+
+## Interaction
+- Type a password to fill the meter and satisfy the rule list.

--- a/submissions/examples/ease-password-strength-meter-ij/demo.html
+++ b/submissions/examples/ease-password-strength-meter-ij/demo.html
@@ -1,0 +1,63 @@
+<!-- EaseMotion component: password-strength-meter -->
+<!DOCTYPE html>
+<html lang="en" data-form="signup">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1">
+<title>Ease Password Strength Meter</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<form class="auth-card" novalidate>
+  <header class="auth-head">
+    <h2>Create account</h2>
+    <p class="auth-sub">Choose a strong password</p>
+  </header>
+  <label class="field-label" for="passField">Password</label>
+  <div id="fieldWrap" class="field-wrap">
+    <input id="passField" class="pass-input" type="password" placeholder="Enter password..." autocomplete="new-password">
+    <button id="revealBtn" class="reveal-btn" type="button" aria-label="show password">show</button>
+  </div>
+  <div class="meter-track">
+    <span class="meter-seg seg-1"></span>
+    <span class="meter-seg seg-2"></span>
+    <span class="meter-seg seg-3"></span>
+    <span class="meter-seg seg-4"></span>
+  </div>
+  <div class="strength-row">
+    <span id="strengthLabel" class="strength-label">None</span>
+    <span class="meter-caption">4 rules to pass</span>
+  </div>
+  <ul class="rule-list">
+    <li id="ruleLen" class="rule">At least 8 characters</li>
+    <li id="ruleCase" class="rule">Upper and lower case</li>
+    <li id="ruleDigit" class="rule">At least one number</li>
+    <li id="ruleSym" class="rule">At least one symbol</li>
+  </ul>
+  <button id="submitBtn" class="submit-btn" type="submit">Sign up</button>
+</form>
+<script>
+const field=document.getElementById('passField');
+const wrap=document.getElementById('fieldWrap');
+const segs=document.querySelectorAll('.meter-seg');
+const label=document.getElementById('strengthLabel');
+const rules={len:document.getElementById('ruleLen'),cas:document.getElementById('ruleCase'),dig:document.getElementById('ruleDigit'),sym:document.getElementById('ruleSym')};
+field.addEventListener('input',()=>{
+  const v=field.value;
+  const ok={len:v.length>=8,cas:/[a-z]/.test(v)&&/[A-Z]/.test(v),dig:/\d/.test(v),sym:/[^A-Za-z0-9]/.test(v)};
+  for(const k in ok){rules[k].classList.toggle('met',ok[k]);}
+  const score=Object.values(ok).filter(Boolean).length;
+  segs.forEach((s,i)=>{s.classList.toggle('on',i<score);});
+  label.textContent=['None','Weak','Fair','Good','Strong'][score];
+});
+document.getElementById('submitBtn').addEventListener('click',(e)=>{
+  if(field.value.length<8){
+    e.preventDefault();
+    wrap.classList.remove('shake');
+    void wrap.offsetWidth;
+    wrap.classList.add('shake');
+  }
+});
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-password-strength-meter-ij/style.css
+++ b/submissions/examples/ease-password-strength-meter-ij/style.css
@@ -1,0 +1,53 @@
+:root{
+  --auth-bg:hsl(220,40%,96%);
+  --auth-ink:hsl(220,30%,22%);
+  --auth-line:hsl(220,18%,84%);
+  --weak:hsl(0,80%,50%);
+  --fair:hsl(38,92%,52%);
+  --good:hsl(120,60%,42%);
+  --strong:hsl(150,65%,38%);
+}
+*{padding:0;box-sizing:border-box;margin:0}
+body{font-family:"Inter",ui-sans-serif,system-ui,sans-serif;background:linear-gradient(160deg,var(--auth-bg),hsl(220,35%,92%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:18px}
+.auth-card{width:min(420px,94vw);background:hsl(0,0%,100%);border:1px solid var(--auth-line);border-radius:22px;padding:22px;box-shadow:0 20px 45px hsl(220,30%,60% / 0.3)}
+.auth-head{margin-bottom:14px}
+.auth-head h2{font-size:1.2rem;font-weight:800}
+.auth-sub{font-size:.8rem;color:hsl(220,20%,52%);margin-top:2px}
+.field-label{display:block;font-size:.78rem;font-weight:700;margin-bottom:6px;color:hsl(220,22%,38%)}
+.field-wrap{position:relative;display:flex;align-items:center}
+.pass-input{flex:1;padding:12px 62px 12px 14px;border:2px solid var(--auth-line);border-radius:12px;font-size:.95rem;outline:none;font-family:inherit}
+.pass-input:focus{border-color:hsl(220,60%,55%)}
+.reveal-btn{position:absolute;right:6px;border:0;background:hsl(220,30%,94%);color:hsl(220,25%,40%);font-size:.72rem;font-weight:700;padding:6px 10px;border-radius:8px;cursor:pointer}
+.meter-track{display:flex;gap:6px;margin:12px 0 6px}
+.meter-seg{flex:1;height:7px;border-radius:99px;background:var(--auth-line);transition:background 0.3s}
+.meter-seg.on.seg-1{background:var(--weak)}
+.meter-seg.on.seg-2{background:var(--fair)}
+.meter-seg.on.seg-3{background:var(--good)}
+.meter-seg.on.seg-4{background:var(--strong)}
+.meter-seg.on{animation:seg-pop-password-strength-meter 0.3s ease both}
+.strength-row{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+.strength-label{font-size:.8rem;font-weight:800;color:hsl(220,25%,40%)}
+.meter-caption{font-size:.68rem;color:hsl(220,16%,56%)}
+.rule-list{list-style:none;display:flex;flex-direction:column;gap:7px;margin-bottom:16px}
+.rule{position:relative;padding-left:22px;font-size:.8rem;color:hsl(220,16%,54%)}
+.rule::before{content:"";position:absolute;left:0;top:2px;width:13px;height:13px;border:2px solid var(--auth-line);border-radius:50%}
+.rule.met{color:hsl(150,45%,32%)}
+.rule.met::before{border-color:var(--strong);background:var(--strong);animation:tick-pop-password-strength-meter 0.3s ease both}
+.rule.met::after{content:"";position:absolute;left:3px;top:5px;width:5px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}
+.submit-btn{width:100%;border:0;background:hsl(220,60%,50%);color:#fff;font-weight:800;font-size:.95rem;padding:13px;border-radius:12px;cursor:pointer}
+.submit-btn:active{transform:scale(0.98)}
+.field-wrap.shake{animation:shake-field-password-strength-meter 0.4s ease both}
+@keyframes seg-pop-password-strength-meter{
+  0%{transform:scaleY(0.4)}
+  100%{transform:scaleY(1)}
+}
+@keyframes tick-pop-password-strength-meter{
+  0%{transform:scale(0.5)}
+  100%{transform:scale(1);opacity:1}
+}
+@keyframes shake-field-password-strength-meter{
+  0%,100%{transform:translateX(0)}
+  25%{transform:translateX(-6px)}
+  50%{transform:translateX(6px)}
+  75%{transform:translateX(-4px)}
+}


### PR DESCRIPTION
## Component: ease-password-strength-meter — password field with segmented strength meter and live hints

**Closes #58981**

### What this adds
A signup password field. Typing fills a four-segment strength meter from None to Strong and updates live hints for length, case, digits and symbols. Submitting a short password shakes the input field.

### Acceptance Criteria covered
- Four segments fill in from left with distinct colors by strength
- Live hints list length, case, digit and symbol checks
- A short password shakes the input when the submit button is pressed

### Files
- `submissions/examples/ease-password-strength-meter-ij/demo.html`
- `submissions/examples/ease-password-strength-meter-ij/style.css`
- `submissions/examples/ease-password-strength-meter-ij/README.md`

### How to review
Open demo.html directly in a browser. Type a password and watch the segments fill; press Sign up with a short password to see the field shake.