### PR TITLE
Add ease-battery-charge-indicator component

### DIFF
--- a/submissions/examples/ease-battery-charge-indicator-ij/README.md
+++ b/submissions/examples/ease-battery-charge-indicator-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Battery Charge Indicator
+
+A phone-style battery indicator with a rippling charge fill, flashing bolt and climbing percent readout.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The percent label climbs and resets on a timed loop.

--- a/submissions/examples/ease-battery-charge-indicator-ij/demo.html
+++ b/submissions/examples/ease-battery-charge-indicator-ij/demo.html
@@ -1,0 +1,32 @@
+<!-- EaseMotion component: battery-charge-indicator -->
+<!DOCTYPE html>
+<html lang="en" data-battery="charging">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no, user-scalable=yes">
+<title>Ease Battery Charge Indicator</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="battery-rig">
+  <div class="battery-body">
+    <div class="battery-nub"><i class="bolt"></i></div>
+    <div class="charge-fill">
+      <span class="wave-shine"></span>
+    </div>
+    <div class="charge-seg seg-a"></div>
+    <div class="charge-seg seg-b"></div>
+    <div class="charge-seg seg-c"></div>
+  </div>
+  <div class="battery-read">
+    <span id="percentLabel" class="percent-num">72%</span>
+    <span class="charge-note">charging on AC</span>
+  </div>
+</div>
+<script>
+const label=document.getElementById('percentLabel');
+let p=72;
+setInterval(()=>{p=(p>=100?0:p+1);label.textContent=p+'%';},140);
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-battery-charge-indicator-ij/style.css
+++ b/submissions/examples/ease-battery-charge-indicator-ij/style.css
@@ -1,0 +1,40 @@
+:root{
+  --bat-bg:hsl(150,20%,94%);
+  --bat-ink:hsl(150,30%,22%);
+  --bat-shell:hsl(0,0%,10%);
+  --bat-rim:hsl(0,0%,26%);
+  --bat-charge:hsl(140,75%,42%);
+  --bat-bolt:hsl(52,95%,58%);
+}
+*{margin:0;padding:0}*{box-sizing:border-box}
+body{font-family:"Inter",ui-sans-serif,system-ui,sans-serif;background:linear-gradient(180deg,var(--bat-bg),hsl(150,22%,88%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
+.battery-rig{display:flex;flex-direction:column;align-items:center;gap:18px}
+.battery-body{position:relative;width:210px;height:110px;background:var(--bat-shell);border:3px solid var(--bat-rim);border-radius:16px;overflow:hidden;box-shadow:0 18px 40px hsl(150,30%,50% / 0.3)}
+.battery-nub{position:absolute;right:-8px;top:50%;transform:translateY(-50%);width:12px;height:30px;background:var(--bat-shell);border:3px solid var(--bat-rim);border-left:0;border-radius:0 8px 8px 0}
+.bolt{position:absolute;left:-2px;top:50%;transform:translateY(-50%);width:0;height:0;border-left:7px solid transparent;border-right:7px solid transparent;border-top:12px solid var(--bat-bolt);animation:bolt-flash-battery-charge-indicator 1.2s step-end infinite}
+.charge-fill{position:absolute;inset:8px;background:linear-gradient(90deg,var(--bat-charge),hsl(100,65%,48%));border-radius:9px;animation:charge-sweep-battery-charge-indicator 5s linear infinite}
+.wave-shine{position:absolute;inset:0;background:linear-gradient(100deg,transparent 30%,hsl(0,0%,100% / 0.35) 50%,transparent 70%);animation:wave-glide-battery-charge-indicator 1.6s linear infinite}
+.charge-seg{position:absolute;top:0;bottom:0;width:7px;background:hsl(140,40%,18%);opacity:0.85}
+.seg-a{left:25%}
+.seg-b{left:50%}
+.seg-c{left:75%}
+.battery-read{text-align:center}
+.percent-num{display:block;font-size:2.4rem;font-weight:800;font-variant-numeric:tabular-nums;color:var(--bat-ink);animation:percent-flick-battery-charge-indicator 1.2s steps(2) infinite}
+.charge-note{font-size:.78rem;font-weight:600;color:hsl(150,18%,48%)}
+@keyframes charge-sweep-battery-charge-indicator{
+  0%{background:linear-gradient(90deg,hsl(140,75%,42%) 0%,hsl(100,65%,48%) 30%)}
+  50%{background:linear-gradient(90deg,hsl(140,75%,42%) 0%,hsl(100,65%,48%) 75%)}
+  100%{background:linear-gradient(90deg,hsl(140,75%,42%) 0%,hsl(100,65%,48%) 100%)}
+}
+@keyframes wave-glide-battery-charge-indicator{
+  0%{transform:translateX(-100%)}
+  100%{transform:translateX(100%)}
+}
+@keyframes bolt-flash-battery-charge-indicator{
+  0%,60%{opacity:1}
+  61%,100%{opacity:0.15}
+}
+@keyframes percent-flick-battery-charge-indicator{
+  0%{opacity:1;transform:scale(1)}
+  50%{opacity:0.8;transform:scale(0.97)}
+}


### PR DESCRIPTION
## Component: ease-battery-charge-indicator — phone battery indicator charging with pulsing segments

**Closes #58984**

### What this adds
A phone-style battery indicator. Charge segments fill left to right while a lightning bolt flashes on the nub and a soft wave ripples across the fill. The percent readout counts up on a timed loop.

### Acceptance Criteria covered
- The battery shell, nub and segmented fill render in CSS
- Segments fill and the lightning bolt flashes during charge
- The percent label climbs on a timed keyframe loop

### Files
- `submissions/examples/ease-battery-charge-indicator-ij/demo.html`
- `submissions/examples/ease-battery-charge-indicator-ij/style.css`
- `submissions/examples/ease-battery-charge-indicator-ij/README.md`

### How to review
Open demo.html directly in a browser. Watch the wave ripple across the fill and the percent label climb.