### PR TITLE
Add ease-typing-test-timer component

### DIFF
--- a/submissions/examples/ease-typing-test-timer-ij/README.md
+++ b/submissions/examples/ease-typing-test-timer-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Typing Test Timer
+
+A typing-test card with a rotating countdown ring, blinking caret and a live words-per-minute readout.
+
+## Run
+Open `demo.html` in any browser.
+
+## Interaction
+- Press Start test to reset the ring and begin the 60-second countdown.

--- a/submissions/examples/ease-typing-test-timer-ij/demo.html
+++ b/submissions/examples/ease-typing-test-timer-ij/demo.html
@@ -1,0 +1,51 @@
+<!-- EaseMotion component: typing-test-timer -->
+<!DOCTYPE html>
+<html lang="en" data-test="typing">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, user-scalable=yes">
+<title>Ease Typing Test Timer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<article class="type-card">
+  <header class="type-head">
+    <span class="type-mode">60s test</span>
+    <span class="type-state">idle</span>
+  </header>
+  <div id="timerRing" class="timer-ring">
+    <div class="ring-drain"></div>
+    <div class="ring-face">
+      <span id="timeRead" class="time-num">60</span>
+      <span class="time-unit">seconds left</span>
+    </div>
+  </div>
+  <p class="sample-line">the quick brown fox jumps over the lazy dog</p>
+  <div class="caret-row"><i id="caret" class="caret"></i><span class="caret-note">type to begin</span></div>
+  <div class="stats-row">
+    <span class="stat-box">wpm <b id="wpmRead">0</b></span>
+    <span class="stat-box">accuracy <b>100%</b></span>
+  </div>
+  <button id="startTest" class="start-btn" type="button">Start test</button>
+</article>
+<script>
+const timeRead=document.getElementById('timeRead');
+const ring=document.getElementById('timerRing');
+const wpmRead=document.getElementById('wpmRead');
+document.getElementById('startTest').addEventListener('click',()=>{
+  ring.classList.remove('run');
+  void ring.offsetWidth;
+  ring.classList.add('run');
+  timeRead.classList.remove('roll');
+  void timeRead.offsetWidth;
+  timeRead.classList.add('roll');
+  let t=60;
+  const timer=setInterval(()=>{
+    t--;timeRead.textContent=t;
+    if(t<=0){clearInterval(timer);timeRead.textContent='0';}
+  },1000);
+  wpmRead.textContent=String(24+Math.floor(Math.random()*20));
+});
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-typing-test-timer-ij/style.css
+++ b/submissions/examples/ease-typing-test-timer-ij/style.css
@@ -1,0 +1,46 @@
+:root{
+  --type-bg:hsl(240,25%,96%);
+  --type-ink:hsl(240,30%,22%);
+  --type-line:hsl(240,18%,84%);
+  --type-accent:hsl(265,70%,56%);
+  --type-soft:hsl(265,70%,92%);
+}
+*{box-sizing:border-box}*{padding:0;margin:0}
+body{font-family:"IBM Plex Mono","Courier New",ui-monospace,monospace;background:var(--type-bg);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.type-card{width:min(440px,94vw);background:hsl(0,0%,100%);border:1px solid var(--type-line);border-radius:22px;padding:22px;box-shadow:0 20px 45px hsl(240,30%,60% / 0.3)}
+.type-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.type-mode{font-size:.74rem;font-weight:700;letter-spacing:1.5px;color:var(--type-accent)}
+.type-state{font-size:.72rem;font-weight:700;color:hsl(240,18%,52%)}
+.timer-ring{position:relative;width:150px;height:150px;margin:0 auto 16px}
+.ring-drain{position:absolute;inset:0;border-radius:50%;background:conic-gradient(var(--type-accent) 0 100%,transparent 0 100%);animation:drain-ring-typing-test-timer 60s linear forwards}
+.ring-drain::after{content:"";position:absolute;inset:10px;background:hsl(0,0%,100%);border-radius:50%}
+.ring-face{position:absolute;inset:22px;border-radius:50%;background:hsl(0,0%,100%);border:2px solid var(--type-soft);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px}
+.timer-ring.run .ring-drain{animation-duration:60s}
+.time-num{font-size:2.2rem;font-weight:800;font-variant-numeric:tabular-nums;color:var(--type-ink)}
+.time-num.roll{animation:num-bump-typing-test-timer 0.3s ease both}
+.time-unit{font-size:.62rem;color:hsl(240,18%,50%)}
+.sample-line{padding:12px 14px;border:1.5px solid var(--type-line);border-radius:12px;font-size:.95rem;color:hsl(240,25%,30%);background:hsl(240,30%,98%);margin-bottom:8px}
+.caret-row{display:flex;align-items:center;gap:8px;margin-bottom:14px}
+.caret{width:2px;height:18px;background:var(--type-accent);animation:caret-blink-typing-test-timer 0.9s step-end infinite}
+.caret-note{font-size:.7rem;color:hsl(240,16%,52%)}
+.stats-row{display:flex;gap:10px;margin-bottom:16px}
+.stat-box{flex:1;border:1px solid var(--type-line);border-radius:10px;padding:10px;text-align:center;font-size:.72rem;color:hsl(240,16%,50%)}
+.stat-box b{display:block;font-size:1.3rem;color:var(--type-ink);font-variant-numeric:tabular-nums;animation:stat-bump-typing-test-timer 2.2s ease-in-out infinite}
+.start-btn{width:100%;border:0;background:var(--type-accent);color:#fff;font-weight:800;font-size:.95rem;padding:13px;border-radius:12px;cursor:pointer}
+.start-btn:active{transform:scale(0.98)}
+@keyframes drain-ring-typing-test-timer{
+  0%{transform:rotate(0deg) translateX(0)}
+  100%{transform:rotate(360deg) translateX(0)}
+}
+@keyframes num-bump-typing-test-timer{
+  0%{transform:scale(0.7)}
+  100%{transform:scale(1)}
+}
+@keyframes caret-blink-typing-test-timer{
+  0%,62%{opacity:1}
+  63%,100%{opacity:0.1}
+}
+@keyframes stat-bump-typing-test-timer{
+  0%,100%{transform:scale(1)}
+  50%{transform:scale(1.15)}
+}


### PR DESCRIPTION
## Component: ease-typing-test-timer — typing test with countdown ring and live wpm readout

**Closes #58988**

### What this adds
A typing-test card. A countdown ring rotates around the timer while a blinking caret marks the sample line and the words-per-minute readout bumps on each update. Starting the test resets the ring and countdown.

### Acceptance Criteria covered
- A ring dial shows the remaining test time
- The caret blinks and the wpm readout bumps per update
- Start resets and begins the timed run

### Files
- `submissions/examples/ease-typing-test-timer-ij/demo.html`
- `submissions/examples/ease-typing-test-timer-ij/style.css`
- `submissions/examples/ease-typing-test-timer-ij/README.md`

### How to review
Open demo.html directly in a browser. Press Start test and watch the ring spin, the caret blink and the timer count down.