### PR TITLE
Add ease-airport-departure-screen component

### DIFF
--- a/submissions/examples/ease-airport-departure-screen-ij/README.md
+++ b/submissions/examples/ease-airport-departure-screen-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Airport Departure Screen
+
+A departure board with flight rows, gate and time columns, flipping status labels and a ticking header clock.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- Boarding statuses blink and flip in with a roll animation.

--- a/submissions/examples/ease-airport-departure-screen-ij/demo.html
+++ b/submissions/examples/ease-airport-departure-screen-ij/demo.html
@@ -1,0 +1,66 @@
+<!-- EaseMotion component: airport-departure-screen -->
+<!DOCTYPE html>
+<html lang="en" data-board="departures">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=yes">
+<title>Ease Airport Departure Screen</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="flights-board">
+  <header class="board-head">
+    <span class="board-title">DEPARTURES</span>
+    <span id="boardClock" class="board-clock">14:32</span>
+  </header>
+  <div class="col-head">
+    <span>Airline</span><span>Flight</span><span>Destination</span><span>Gate</span><span>Time</span><span>Status</span>
+  </div>
+  <ul class="flight-list">
+    <li class="flight-row">
+      <span class="cell airline">SkyJet</span>
+      <span class="cell flight-num">SJ 224</span>
+      <span class="cell dest">Lisbon</span>
+      <span class="cell gate">B12</span>
+      <span class="cell time">14:45</span>
+      <span class="cell status status-boarding">BOARDING</span>
+    </li>
+    <li class="flight-row">
+      <span class="cell airline">NorthAir</span>
+      <span class="cell flight-num">NA 902</span>
+      <span class="cell dest">Oslo</span>
+      <span class="cell gate">C04</span>
+      <span class="cell time">15:10</span>
+      <span class="cell status status-on-time">ON TIME</span>
+    </li>
+    <li class="flight-row">
+      <span class="cell airline">Vesper</span>
+      <span class="cell flight-num">VE 118</span>
+      <span class="cell dest">Prague</span>
+      <span class="cell gate">A09</span>
+      <span class="cell time">15:35</span>
+      <span class="cell status status-delayed">DELAYED</span>
+    </li>
+    <li class="flight-row">
+      <span class="cell airline">CoastLink</span>
+      <span class="cell flight-num">CL 671</span>
+      <span class="cell dest">Dublin</span>
+      <span class="cell gate">B07</span>
+      <span class="cell time">16:00</span>
+      <span class="cell status status-boarding">BOARDING</span>
+    </li>
+  </ul>
+  <footer class="board-foot">
+    <span class="foot-note">Updates every 30 seconds</span>
+  </footer>
+</main>
+<script>
+let m=32,h=14;
+setInterval(()=>{
+  m++;if(m===60){m=0;h=(h+1)%24;}
+  const pad=n=>String(n).padStart(2,'0');
+  document.getElementById('boardClock').textContent=pad(h)+':'+pad(m);
+}, 1000);
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-airport-departure-screen-ij/style.css
+++ b/submissions/examples/ease-airport-departure-screen-ij/style.css
@@ -1,0 +1,42 @@
+:root{
+  --dep-bg:hsl(0,0%,6%);
+  --dep-panel:hsl(0,0%,9%);
+  --dep-line:hsl(0,0%,20%);
+  --dep-text:hsl(0,0%,92%);
+  --dep-mute:hsl(0,0%,56%);
+  --dep-green:hsl(120,70%,52%);
+  --dep-red:hsl(0,75%,56%);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:"Segoe UI",ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 0%,hsl(210,20%,14%),hsl(0,0%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
+.flights-board{width:min(680px,96vw);background:var(--dep-panel);border:1px solid var(--dep-line);border-radius:16px;overflow:hidden}
+.board-head{display:flex;justify-content:space-between;align-items:center;padding:14px 20px;background:hsl(0,0%,12%);border-bottom:1px solid var(--dep-line)}
+.board-title{font-size:.9rem;font-weight:800;letter-spacing:4px}
+.board-clock{font-size:1.1rem;font-weight:700;font-variant-numeric:tabular-nums;color:var(--dep-text);animation:clock-flick-airport-departure-screen 1s steps(2) infinite}
+.col-head{display:grid;grid-template-columns:1.2fr 0.8fr 1.2fr 0.6fr 0.6fr 1fr;gap:8px;padding:8px 20px;font-size:.66rem;font-weight:700;letter-spacing:1px;color:var(--dep-mute);text-transform:uppercase}
+.flight-list{list-style:none}
+.flight-row{display:grid;grid-template-columns:1.2fr 0.8fr 1.2fr 0.6fr 0.6fr 1fr;gap:8px;padding:11px 20px;border-top:1px solid hsl(0,0%,16%);align-items:center}
+.flight-row:nth-child(even){background:hsl(0,0%,11%)}
+.cell{font-size:.82rem;font-variant-numeric:tabular-nums}
+.airline{font-weight:700}
+.flight-num{color:var(--dep-mute)}
+.time{font-weight:700}
+.status{font-size:.68rem;font-weight:800;letter-spacing:1px;padding:4px 8px;border-radius:6px;text-align:center}
+.status-boarding{color:hsl(48,95%,58%);background:hsl(48,70%,30% / 0.25);animation:status-blink-airport-departure-screen 1.4s step-end infinite}
+.status-on-time{color:var(--dep-green)}
+.status-delayed{color:var(--dep-red)}
+.flight-row:nth-child(1) .status{animation:status-flip-airport-departure-screen 0.6s 0.2s cubic-bezier(0.2,1,0.3,1) both}
+.flight-row:nth-child(3) .status{animation:status-flip-airport-departure-screen 0.6s 0.5s cubic-bezier(0.2,1,0.3,1) both}
+.board-foot{padding:9px 20px;border-top:1px solid var(--dep-line);color:var(--dep-mute);font-size:.68rem;letter-spacing:1px}
+@keyframes clock-flick-airport-departure-screen{
+  0%{opacity:1;transform:translateX(0)}
+  50%{opacity:0.6;transform:translateX(-1px)}
+}
+@keyframes status-flip-airport-departure-screen{
+  0%{opacity:0;transform:translateY(-8px) scale(0.9)}
+  100%{opacity:1;transform:translateY(0) scale(1)}
+}
+@keyframes status-blink-airport-departure-screen{
+  0%,48%{opacity:1}
+  49%,100%{opacity:0.35}
+}


### PR DESCRIPTION
## Component: ease-airport-departure-screen — departure board with flight rows and live status flips

**Closes #58991**

### What this adds
An airport departure board. Flight rows list airline, flight number, destination, gate and time, with boarding statuses flipping in with a roll animation. The header clock ticks and the boarding rows blink.

### Acceptance Criteria covered
- Flight rows render as a tabular departure board
- Status flips in with a roll keyframe when updated
- The header clock ticks and the boarding rows blink

### Files
- `submissions/examples/ease-airport-departure-screen-ij/demo.html`
- `submissions/examples/ease-airport-departure-screen-ij/style.css`
- `submissions/examples/ease-airport-departure-screen-ij/README.md`

### How to review
Open demo.html directly in a browser. See the status labels flip in and the boarding rows blink while the clock ticks.
