### PR TITLE
Add ease-airport-departure-screen component

### DIFF
--- a/submissions/examples/ease-airport-departure-screen/README.md
+++ b/submissions/examples/ease-airport-departure-screen/README.md
@@ -1,0 +1,62 @@
+# ✈ Ease Airport Departure Screen
+
+A retro split-flap style airport departure board component, built with pure HTML, CSS, and a small vanilla JS snippet for the live clock and character-flip animation.
+
+## Features
+
+- Classic airport-board look — dark panel, amber/cyan monospace text
+- Live-updating clock in the header
+- Split-flap style character reveal animation for destination names
+- Status badges with distinct colors and states: **On Time**, **Boarding**, **Delayed**, **Cancelled**, **Departed**
+- Pulse animation on urgent statuses (`Boarding`, `Delayed`) to draw attention
+- Fully responsive — collapses into a stacked card layout on small screens
+- No external dependencies — just `style.css` and vanilla JS
+
+## Usage
+
+1. Include `style.css` in your project.
+2. Copy the `.ease-departure-screen` markup structure from `demo.html`.
+3. Add or edit `.eds-row` blocks for each flight, one per row.
+4. For a destination name, set the flip animation via:
+
+```html
+<span class="eds-flip" data-flip-text="London (LHR)"></span>
+```
+
+5. Include the small JS snippet at the bottom of `demo.html` to power the clock and the flip-in animation. It automatically finds all `.eds-flip` elements on the page and builds the animated characters.
+
+## Status classes
+
+| Class                      | Meaning   | Color  |
+|-----------------------------|-----------|--------|
+| `eds-status--ontime`        | On Time   | Green  |
+| `eds-status--boarding`      | Boarding  | Cyan (pulses) |
+| `eds-status--delayed`       | Delayed   | Amber (pulses) |
+| `eds-status--cancelled`     | Cancelled | Red (strikethrough) |
+| `eds-status--landed`        | Departed  | Grey   |
+
+## Customization
+
+All colors are exposed as CSS custom properties on `.ease-departure-screen`, so you can theme the board without touching the rest of the CSS:
+
+```css
+.ease-departure-screen {
+  --board-bg: #0b0f14;
+  --text-amber: #ffb100;
+  --text-cyan: #4dd8e6;
+  --status-ontime: #3ddc84;
+  --status-delayed: #ffb100;
+  --status-boarding: #4dd8e6;
+  --status-cancelled: #ff4d4d;
+}
+```
+
+## Files
+
+- `demo.html` — working demo with sample flight data
+- `style.css` — all component styles
+- `README.md` — this file
+
+## Preview
+
+Open `demo.html` in any browser to see the live clock and flip-in animation in action.

--- a/submissions/examples/ease-airport-departure-screen/demo.html
+++ b/submissions/examples/ease-airport-departure-screen/demo.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Ease Airport Departure Screen — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #04070a;
+    padding: 30px 16px;
+    box-sizing: border-box;
+  }
+</style>
+</head>
+<body>
+
+  <div class="ease-departure-screen" id="departureScreen">
+    <div class="eds-header">
+      <span class="eds-header__title">✈ Departures</span>
+      <span class="eds-header__clock" id="edsClock">--:--:--</span>
+    </div>
+
+    <div class="eds-row-labels">
+      <span>Flight</span>
+      <span>Destination</span>
+      <span>Time</span>
+      <span>Gate</span>
+      <span>Status</span>
+    </div>
+
+    <div class="eds-body">
+
+      <div class="eds-row">
+        <span class="eds-row__flight">EM 204</span>
+        <span class="eds-row__dest">
+          <span class="eds-flip" data-flip-text="New York (JFK)"></span>
+        </span>
+        <span class="eds-row__time">14:20</span>
+        <span class="eds-row__gate">Gate 12</span>
+        <span class="eds-row__status">
+          <span class="eds-status eds-status--ontime">On Time</span>
+        </span>
+      </div>
+
+      <div class="eds-row">
+        <span class="eds-row__flight">EM 318</span>
+        <span class="eds-row__dest">
+          <span class="eds-flip" data-flip-text="London (LHR)"></span>
+        </span>
+        <span class="eds-row__time">14:45</span>
+        <span class="eds-row__gate">Gate 7</span>
+        <span class="eds-row__status">
+          <span class="eds-status eds-status--boarding">Boarding</span>
+        </span>
+      </div>
+
+      <div class="eds-row">
+        <span class="eds-row__flight">EM 512</span>
+        <span class="eds-row__dest">
+          <span class="eds-flip" data-flip-text="Dubai (DXB)"></span>
+        </span>
+        <span class="eds-row__time">15:05</span>
+        <span class="eds-row__gate">Gate 3</span>
+        <span class="eds-row__status">
+          <span class="eds-status eds-status--delayed">Delayed</span>
+        </span>
+      </div>
+
+      <div class="eds-row">
+        <span class="eds-row__flight">EM 077</span>
+        <span class="eds-row__dest">
+          <span class="eds-flip" data-flip-text="Tokyo (HND)"></span>
+        </span>
+        <span class="eds-row__time">15:30</span>
+        <span class="eds-row__gate">Gate 9</span>
+        <span class="eds-row__status">
+          <span class="eds-status eds-status--cancelled">Cancelled</span>
+        </span>
+      </div>
+
+      <div class="eds-row">
+        <span class="eds-row__flight">EM 641</span>
+        <span class="eds-row__dest">
+          <span class="eds-flip" data-flip-text="Paris (CDG)"></span>
+        </span>
+        <span class="eds-row__time">13:10</span>
+        <span class="eds-row__gate">Gate 5</span>
+        <span class="eds-row__status">
+          <span class="eds-status eds-status--landed">Departed</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="eds-footer">
+      Please arrive at the gate at least 30 minutes before departure &middot; EaseMotion CSS
+    </div>
+  </div>
+
+  <script>
+    // Live clock
+    function edsUpdateClock() {
+      const clockEl = document.getElementById('edsClock');
+      const now = new Date();
+      const hh = String(now.getHours()).padStart(2, '0');
+      const mm = String(now.getMinutes()).padStart(2, '0');
+      const ss = String(now.getSeconds()).padStart(2, '0');
+      clockEl.textContent = `${hh}:${mm}:${ss}`;
+    }
+    setInterval(edsUpdateClock, 1000);
+    edsUpdateClock();
+
+    // Split-flap style character reveal for destinations
+    function edsBuildFlip(el) {
+      const text = el.getAttribute('data-flip-text') || '';
+      el.innerHTML = '';
+      [...text].forEach((ch, i) => {
+        const span = document.createElement('span');
+        span.className = 'eds-flip__char';
+        span.textContent = ch === ' ' ? '\u00A0' : ch;
+        span.style.animationDelay = `${i * 0.04}s`;
+        el.appendChild(span);
+      });
+    }
+
+    document.querySelectorAll('.eds-flip').forEach(edsBuildFlip);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-airport-departure-screen/style.css
+++ b/submissions/examples/ease-airport-departure-screen/style.css
@@ -1,0 +1,229 @@
+/* ================================
+   Ease Airport Departure Screen
+   ================================ */
+
+.ease-departure-screen {
+  --board-bg: #0b0f14;
+  --board-panel: #10161d;
+  --board-border: #1f2a35;
+  --flip-bg: #141c24;
+  --text-amber: #ffb100;
+  --text-cyan: #4dd8e6;
+  --text-dim: #5c6b78;
+  --status-ontime: #3ddc84;
+  --status-delayed: #ffb100;
+  --status-boarding: #4dd8e6;
+  --status-cancelled: #ff4d4d;
+  --status-landed: #8a97a3;
+
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  background: var(--board-bg);
+  border: 1px solid var(--board-border);
+  border-radius: 12px;
+  padding: 20px;
+  font-family: 'Courier New', 'Consolas', monospace;
+  color: var(--text-amber);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+}
+
+/* Header */
+.eds-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 2px solid var(--board-border);
+  margin-bottom: 12px;
+}
+
+.eds-header__title {
+  font-size: 18px;
+  letter-spacing: 3px;
+  font-weight: bold;
+  color: var(--text-cyan);
+  text-transform: uppercase;
+}
+
+.eds-header__clock {
+  font-size: 16px;
+  letter-spacing: 2px;
+  color: var(--text-amber);
+}
+
+/* Column labels */
+.eds-row-labels,
+.eds-row {
+  display: grid;
+  grid-template-columns: 1.1fr 1.3fr 1fr 0.9fr 1.1fr;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+}
+
+.eds-row-labels {
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--board-border);
+  padding-bottom: 8px;
+  margin-bottom: 4px;
+}
+
+/* Flight rows */
+.eds-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.eds-row {
+  background: var(--board-panel);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  font-size: 14px;
+  letter-spacing: 1px;
+  transition: background 0.2s ease;
+}
+
+.eds-row:hover {
+  background: #161f28;
+}
+
+.eds-row__flight {
+  color: var(--text-cyan);
+  font-weight: bold;
+}
+
+.eds-row__time {
+  color: var(--text-amber);
+  font-variant-numeric: tabular-nums;
+}
+
+.eds-row__gate {
+  color: var(--text-amber);
+}
+
+/* Flip-text effect for destination */
+.eds-flip {
+  display: inline-block;
+  background: var(--flip-bg);
+  padding: 3px 8px;
+  border-radius: 3px;
+  overflow: hidden;
+  position: relative;
+}
+
+.eds-flip__char {
+  display: inline-block;
+  animation: eds-flip-in 0.6s ease both;
+}
+
+@keyframes eds-flip-in {
+  0% {
+    transform: rotateX(90deg);
+    opacity: 0;
+  }
+  60% {
+    transform: rotateX(-10deg);
+    opacity: 1;
+  }
+  100% {
+    transform: rotateX(0deg);
+    opacity: 1;
+  }
+}
+
+/* Status badges */
+.eds-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.eds-status--ontime {
+  color: var(--status-ontime);
+  background: rgba(61, 220, 132, 0.12);
+  border: 1px solid rgba(61, 220, 132, 0.4);
+}
+
+.eds-status--delayed {
+  color: var(--status-delayed);
+  background: rgba(255, 177, 0, 0.12);
+  border: 1px solid rgba(255, 177, 0, 0.4);
+  animation: eds-pulse 1.4s ease-in-out infinite;
+}
+
+.eds-status--boarding {
+  color: var(--status-boarding);
+  background: rgba(77, 216, 230, 0.12);
+  border: 1px solid rgba(77, 216, 230, 0.4);
+  animation: eds-pulse 1.4s ease-in-out infinite;
+}
+
+.eds-status--cancelled {
+  color: var(--status-cancelled);
+  background: rgba(255, 77, 77, 0.12);
+  border: 1px solid rgba(255, 77, 77, 0.4);
+  text-decoration: line-through;
+}
+
+.eds-status--landed {
+  color: var(--status-landed);
+  background: rgba(138, 151, 163, 0.12);
+  border: 1px solid rgba(138, 151, 163, 0.4);
+}
+
+@keyframes eds-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+/* Footer / marquee note */
+.eds-footer {
+  margin-top: 12px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--board-border);
+  font-size: 11px;
+  color: var(--text-dim);
+  letter-spacing: 1px;
+  text-align: center;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .eds-row-labels {
+    display: none;
+  }
+
+  .eds-row {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "flight"
+      "dest"
+      "time"
+      "gate"
+      "status";
+    gap: 4px;
+    padding: 12px 14px;
+  }
+
+  .eds-row__flight { grid-area: flight; }
+  .eds-row__dest { grid-area: dest; }
+  .eds-row__time { grid-area: time; }
+  .eds-row__gate { grid-area: gate; }
+  .eds-row__status { grid-area: status; }
+
+  .eds-header__title {
+    font-size: 15px;
+    letter-spacing: 2px;
+  }
+}


### PR DESCRIPTION
## Description

Adds the **ease-airport-departure-screen** component — a retro split-flap style airport departure board built with pure HTML, CSS, and a small vanilla JS snippet for the live clock and character-flip animation.

## Closes

Closes #58991

## Features

- Classic airport-board look with dark panel and amber/cyan monospace text
- Live-updating clock in the header
- Split-flap style character reveal animation for destination names
- Status badges for On Time, Boarding, Delayed, Cancelled, and Departed states
- Pulse animation on urgent statuses (Boarding, Delayed) to draw attention
- Fully responsive — collapses into a stacked layout on small screens
- No external dependencies

## Files added

- `submissions/examples/ease-airport-departure-screen/demo.html`
- `submissions/examples/ease-airport-departure-screen/style.css`
- `submissions/examples/ease-airport-departure-screen/README.md`


## Checklist

- [x] Files added only inside `submissions/`
- [x] Included `demo.html`, `style.css`, `README.md`
- [x] Tested demo locally in browser
- [x] Followed existing naming/style conventions in the repo
- [x] No console errors