### PR TITLE
Add ease-chess-clock-timer component

### DIFF
--- a/submissions/examples/ease-chess-clock-timer-ij/README.md
+++ b/submissions/examples/ease-chess-clock-timer-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Chess Clock Timer
+
+A dual chess clock with an active-side glow, ticking digits and a turn indicator.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The active side glows while its digits tick.

--- a/submissions/examples/ease-chess-clock-timer-ij/demo.html
+++ b/submissions/examples/ease-chess-clock-timer-ij/demo.html
@@ -1,0 +1,28 @@
+<!-- EaseMotion component: chess-clock-timer -->
+<!DOCTYPE html>
+<html lang="en" data-cloc="chess">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>Ease Chess Clock Timer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="chess-clock">
+  <section class="player-panel side-white">
+    <span class="side-name">WHITE</span>
+    <span class="side-time">12:47</span>
+    <span class="side-badge">PLAYING</span>
+  </section>
+  <div class="turn-rail">
+    <span class="turn-puck"></span>
+    <span class="turn-note">WHITE TO MOVE</span>
+  </div>
+  <section class="player-panel side-black">
+    <span class="side-name">BLACK</span>
+    <span class="side-time">12:00</span>
+    <span class="side-badge">WAITING</span>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-chess-clock-timer-ij/style.css
+++ b/submissions/examples/ease-chess-clock-timer-ij/style.css
@@ -1,0 +1,33 @@
+:root{
+  --cc-bg:hsl(0,0%,7%);
+  --cc-panel:hsl(0,0%,12%);
+  --cc-line:hsl(0,0%,22%);
+  --cc-ink:hsl(0,0%,92%);
+  --cc-mute:hsl(0,0%,55%);
+  --cc-glow:hsl(48,95%,58%);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:ui-monospace,Consolas,"Courier New",monospace;background:linear-gradient(180deg,hsl(0,0%,10%),hsl(0,0%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center}
+.chess-clock{display:flex;align-items:center;gap:16px;padding:24px;background:var(--cc-bg);border:1px solid hsl(0,0%,20%);border-radius:16px;box-shadow:0 20px 45px hsl(0,0%,2% / 0.6)}
+.player-panel{display:flex;flex-direction:column;align-items:center;gap:8px;width:150px;padding:18px 12px;border-radius:12px;border:1px solid var(--cc-line);background:var(--cc-panel)}
+.side-white{animation:active-glow-chess-clock-timer 2s ease-in-out infinite}
+.side-black{opacity:0.82}
+.side-name{font-size:.7rem;font-weight:800;letter-spacing:3px;color:var(--cc-mute)}
+.side-time{font-size:2.2rem;font-weight:800;font-variant-numeric:tabular-nums;color:var(--cc-ink)}
+.side-white .side-time{animation:digit-tick-chess-clock-timer 1s steps(1) infinite}
+.side-badge{font-size:.6rem;font-weight:800;letter-spacing:2px;padding:3px 8px;border-radius:20px;background:hsl(48,80%,50% / 0.16);color:var(--cc-glow)}
+.turn-rail{display:flex;flex-direction:column;align-items:center;gap:8px}
+.turn-puck{width:14px;height:14px;border-radius:50%;background:var(--cc-glow);box-shadow:0 0 12px hsl(48,95%,58% / 0.7);animation:puck-bob-chess-clock-timer 1.2s ease-in-out infinite}
+.turn-note{writing-mode:vertical-rl;font-size:.62rem;font-weight:800;letter-spacing:3px;color:var(--cc-mute)}
+@keyframes active-glow-chess-clock-timer{
+  0%,100%{box-shadow:0 0 0 0 hsl(48,95%,58% / 0)}
+  50%{box-shadow:0 0 24px 5px hsl(48,95%,58% / 0.45)}
+}
+@keyframes digit-tick-chess-clock-timer{
+  0%,100%{opacity:1}
+  50%{opacity:0.55}
+}
+@keyframes puck-bob-chess-clock-timer{
+  0%,100%{transform:translateY(0)}
+  50%{transform:translateY(-6px)}
+}


### PR DESCRIPTION
## Component: ease-chess-clock-timer — dual chess clock with active-side glow and ticking digits

**Closes #58997**

### What this adds
A dual chess clock. Two player sides each show a countdown time, the active side glows while its digits tick, and a center rail marks whose turn it is.

### Acceptance Criteria covered
- Two player sides render their own clock faces
- The active side glows while its digits tick
- A center rail marks the current turn

### Files
- `submissions/examples/ease-chess-clock-timer-ij/demo.html`
- `submissions/examples/ease-chess-clock-timer-ij/style.css`
- `submissions/examples/ease-chess-clock-timer-ij/README.md`

### How to review
Open demo.html directly in a browser. The active side glows and ticks while the center rail points to the current player.