### PR TITLE
Add ease-heartbeat-ecg-monitor component

### DIFF
--- a/submissions/examples/ease-heartbeat-ecg-monitor-ij/README.md
+++ b/submissions/examples/ease-heartbeat-ecg-monitor-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Heartbeat ECG Monitor
+
+A bedside monitor with a tracing ECG waveform, a pulsing heart-rate readout and a blinking pulse dot.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The ECG trace scrolls across the gridded screen.

--- a/submissions/examples/ease-heartbeat-ecg-monitor-ij/demo.html
+++ b/submissions/examples/ease-heartbeat-ecg-monitor-ij/demo.html
@@ -1,0 +1,30 @@
+<!-- EaseMotion component: heartbeat-ecg-monitor -->
+<!DOCTYPE html>
+<html lang="en" data-ecg="beat">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1.0">
+<title>Ease Heartbeat ECG Monitor</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="ecg-monitor">
+  <header class="ecg-head">
+    <span class="ecg-title">HEART MONITOR</span>
+    <span class="ecg-mode">AUTO</span>
+  </header>
+  <div class="ecg-screen">
+    <div class="ecg-grid"></div>
+    <svg class="ecg-trace" viewBox="0 0 400 120" preserveAspectRatio="none" aria-hidden="true">
+      <polyline class="ecg-wave" points="0,70 30,72 55,68 75,74 92,60 104,24 116,84 132,70 160,72 190,69 214,73 234,66 250,50 262,82 278,72 310,70 340,74 370,70 400,72"></polyline>
+      <circle class="ecg-dot" cx="400" cy="72" r="3"></circle>
+    </svg>
+  </div>
+  <footer class="ecg-foot">
+    <span class="hr-tag">HEART RATE</span>
+    <span class="hr-val">84</span>
+    <span class="hr-unit">BPM</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-heartbeat-ecg-monitor-ij/style.css
+++ b/submissions/examples/ease-heartbeat-ecg-monitor-ij/style.css
@@ -1,0 +1,34 @@
+:root{
+  --ecg-bg:hsl(150,40%,6%);
+  --ecg-screen:hsl(155,60%,9%);
+  --ecg-line:hsl(155,45%,16%);
+  --ecg-trace:hsl(120,85%,55%);
+  --ecg-ink:hsl(140,20%,88%);
+}
+*{box-sizing:border-box;padding:0;margin:0}
+body{font-family:ui-monospace,Consolas,"Courier New",monospace;background:radial-gradient(circle at 50% 40%,hsl(150,40%,10%),hsl(150,45%,4%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
+.ecg-monitor{width:min(520px,94vw);background:var(--ecg-bg);border:1px solid hsl(155,40%,18%);border-radius:14px;box-shadow:0 18px 40px hsl(150,50%,2% / 0.6)}
+.ecg-head{display:flex;justify-content:space-between;align-items:center;padding:12px 18px;border-bottom:1px solid var(--ecg-line)}
+.ecg-title{font-size:.78rem;font-weight:800;letter-spacing:3px;color:var(--ecg-ink)}
+.ecg-mode{font-size:.66rem;font-weight:700;letter-spacing:2px;padding:3px 9px;border-radius:20px;color:hsl(120,85%,55%);border:1px solid hsl(120,70%,30%)}
+.ecg-screen{position:relative;height:170px;background:var(--ecg-screen);overflow:hidden}
+.ecg-grid{position:absolute;inset:0;background-image:linear-gradient(hsl(155,45%,14% / 0.5) 1px,transparent 1px),linear-gradient(90deg,hsl(155,45%,14% / 0.5) 1px,transparent 1px);background-size:20px 20px}
+.ecg-trace{position:absolute;inset:10px 0 6px;width:100%;height:calc(100% - 16px)}
+.ecg-wave{fill:none;stroke:var(--ecg-trace);stroke-width:2.5;stroke-dasharray:900;stroke-dashoffset:900;filter:drop-shadow(0 0 5px hsl(120,85%,55% / 0.7));animation:ecg-draw-heartbeat-ecg-monitor 3s linear infinite}
+.ecg-dot{fill:hsl(120,90%,60%);animation:dot-blink-heartbeat-ecg-monitor 0.8s ease-in-out infinite}
+.ecg-foot{display:flex;align-items:baseline;justify-content:center;gap:8px;padding:12px 18px;border-top:1px solid var(--ecg-line)}
+.hr-tag{font-size:.62rem;font-weight:800;letter-spacing:3px;color:hsl(140,20%,55%)}
+.hr-val{font-size:2rem;font-weight:800;font-variant-numeric:tabular-nums;color:var(--ecg-trace);animation:hr-blink-heartbeat-ecg-monitor 0.8s ease-in-out infinite}
+.hr-unit{font-size:.7rem;font-weight:700;letter-spacing:2px;color:hsl(140,20%,55%)}
+@keyframes ecg-draw-heartbeat-ecg-monitor{
+  0%{stroke-dashoffset:900}
+  100%{stroke-dashoffset:-900}
+}
+@keyframes hr-blink-heartbeat-ecg-monitor{
+  0%,100%{opacity:1;transform:scale(1.05)}
+  50%{opacity:0.35;transform:scale(0.94)}
+}
+@keyframes dot-blink-heartbeat-ecg-monitor{
+  0%,100%{opacity:1;transform:translateX(0)}
+  50%{opacity:0.2;transform:translateX(3px)}
+}


### PR DESCRIPTION
## Component: ease-heartbeat-ecg-monitor — bedside monitor with tracing ECG waveform and pulsing heart rate

**Closes #58999**

### What this adds
A bedside monitor. An ECG waveform traces across a gridded screen, the heart-rate digits pulse on the readout, and a pulse dot blinks at the end of the trace.

### Acceptance Criteria covered
- The ECG waveform traces across a gridded screen
- Heart-rate digits pulse on the readout
- A pulse dot blinks at the end of the trace

### Files
- `submissions/examples/ease-heartbeat-ecg-monitor-ij/demo.html`
- `submissions/examples/ease-heartbeat-ecg-monitor-ij/style.css`
- `submissions/examples/ease-heartbeat-ecg-monitor-ij/README.md`

### How to review
Open demo.html directly in a browser. The ECG line traces across the monitor while the heart-rate pulses.