### PR TITLE
Add ease-satellite-orbit-view component

### DIFF
--- a/submissions/examples/ease-satellite-orbit-view-ij/README.md
+++ b/submissions/examples/ease-satellite-orbit-view-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Satellite Orbit View
+
+A ground-station view with orbiting satellites, a banded planet and a swaying antenna.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- Satellites orbit the planet while the beacon blinks.

--- a/submissions/examples/ease-satellite-orbit-view-ij/demo.html
+++ b/submissions/examples/ease-satellite-orbit-view-ij/demo.html
@@ -1,0 +1,30 @@
+<!-- EaseMotion component: satellite-orbit-view -->
+<!DOCTYPE html>
+<html lang="en" data-sat="orbit">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+<title>Ease Satellite Orbit View</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="space-panel">
+  <div class="orbit-stage">
+    <div class="orbit ring-a"><i class="sat sat-a"></i></div>
+    <div class="orbit ring-b"><i class="sat sat-b"></i></div>
+    <div class="planet">
+      <span class="band b1"></span>
+      <span class="band b2"></span>
+      <span class="planet-shade"></span>
+    </div>
+  </div>
+  <div class="ground-rig">
+    <div class="antenna-mast">
+      <i class="antenna-dish"></i>
+      <i class="beacon-lamp"></i>
+    </div>
+    <span class="rig-tag">GROUND STATION</span>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-satellite-orbit-view-ij/style.css
+++ b/submissions/examples/ease-satellite-orbit-view-ij/style.css
@@ -1,0 +1,42 @@
+:root{
+  --sat-bg:hsl(255,45%,6%);
+  --sat-ring:hsl(210,80%,60%);
+  --sat-planet:hsl(25,60%,48%);
+  --sat-ink:hsl(255,20%,88%);
+}
+*{padding:0;box-sizing:border-box;margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(255,40%,12%),hsl(255,50%,4%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
+.space-panel{display:flex;flex-direction:column;align-items:center;gap:22px;padding:26px 30px;background:linear-gradient(180deg,hsl(255,38%,13%),hsl(255,48%,7%));border:1px solid hsl(255,35%,22%);border-radius:18px;box-shadow:0 20px 45px hsl(255,60%,2% / 0.55)}
+.orbit-stage{position:relative;width:300px;height:300px}
+.orbit{position:absolute;left:50%;top:50%;border:2px dashed hsl(210,80%,60% / 0.45);border-radius:50%}
+.ring-a{width:230px;height:110px;transform:translate(-50%,-50%) rotate(18deg);animation:orbit-spin-satellite-orbit-view 7s linear infinite}
+.ring-b{width:180px;height:84px;transform:translate(-50%,-50%) rotate(-24deg);animation:orbit-spin-reverse-satellite-orbit-view 9s linear infinite}
+.sat{position:absolute;top:-9px;left:calc(50% - 9px);width:18px;height:18px;border-radius:50%;background:hsl(0,0%,96%);box-shadow:0 0 10px hsl(0,0%,96% / 0.8)}
+.sat::after{content:"";position:absolute;right:-10px;top:3px;width:10px;height:6px;background:hsl(200,90%,60%);border-radius:0 4px 4px 0}
+.sat-b{width:14px;height:14px;background:hsl(120,80%,55%)}
+.planet{position:absolute;left:50%;top:50%;width:120px;height:120px;transform:translate(-50%,-50%);border-radius:50%;background:var(--sat-planet);overflow:hidden;box-shadow:inset -14px -10px 30px hsl(255,40%,10% / 0.55),0 0 28px hsl(25,60%,48% / 0.35)}
+.band{position:absolute;left:0;right:0;height:16px;background:hsl(25,55%,60% / 0.55)}
+.b1{top:30px}
+.b2{top:66px}
+.planet-shade{position:absolute;inset:0;border-radius:50%;background:radial-gradient(circle at 32% 30%,hsl(25,70%,70% / 0.4),transparent 55%)}
+.ground-rig{display:flex;flex-direction:column;align-items:center;gap:8px}
+.antenna-mast{position:relative;width:60px;height:130px;background:linear-gradient(90deg,hsl(255,25%,30%),hsl(255,20%,46%));border-radius:8px 8px 0 0}
+.antenna-dish{position:absolute;top:6px;left:-26px;width:58px;height:34px;border-radius:50%;background:radial-gradient(circle at 38% 38%,hsl(210,90%,70%),hsl(210,80%,42%));border:1px solid hsl(255,20%,55%);transform-origin:right center;animation:dish-sway-satellite-orbit-view 3s ease-in-out infinite}
+.beacon-lamp{position:absolute;top:-8px;left:50%;transform:translateX(-50%);width:10px;height:10px;border-radius:50%;background:hsl(0,90%,62%);animation:beacon-blink-satellite-orbit-view 1.1s ease-in-out infinite}
+.rig-tag{font-size:.62rem;font-weight:800;letter-spacing:3px;color:hsl(255,20%,58%)}
+@keyframes orbit-spin-satellite-orbit-view{
+  0%{transform:translate(-50%,-50%) rotate(18deg)}
+  100%{transform:translate(-50%,-50%) rotate(378deg)}
+}
+@keyframes orbit-spin-reverse-satellite-orbit-view{
+  0%{transform:translate(-50%,-50%) rotate(-24deg)}
+  100%{transform:translate(-50%,-50%) rotate(-384deg)}
+}
+@keyframes dish-sway-satellite-orbit-view{
+  0%,100%{transform:rotate(-26deg)}
+  50%{transform:rotate(26deg)}
+}
+@keyframes beacon-blink-satellite-orbit-view{
+  0%,100%{opacity:1;box-shadow:0 0 0 0 hsl(0,90%,62% / 0.7)}
+  50%{opacity:0.25;box-shadow:0 0 16px 6px hsl(0,90%,62% / 0.5)}
+}


### PR DESCRIPTION
## Component: ease-satellite-orbit-view — space view with orbiting satellites and swaying ground antenna

**Closes #59001**

### What this adds
A ground-station space view. A banded planet sits in the center, two satellites orbit it in elliptical rings, and a ground antenna sways while its beacon blinks.

### Acceptance Criteria covered
- The planet renders with elliptical orbit rings
- Two satellites orbit along the rings
- The antenna sways and the beacon blinks

### Files
- `submissions/examples/ease-satellite-orbit-view-ij/demo.html`
- `submissions/examples/ease-satellite-orbit-view-ij/style.css`
- `submissions/examples/ease-satellite-orbit-view-ij/README.md`

### How to review
Open demo.html directly in a browser. The satellites orbit the planet while the antenna sways and its beacon blinks.