### PR TITLE
Add ease-radio-dial-tuner component

### DIFF
--- a/submissions/examples/ease-radio-dial-tuner-ij/README.md
+++ b/submissions/examples/ease-radio-dial-tuner-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Radio Dial Tuner
+
+A retro radio face with a scanning tuning needle, glowing presets and a pulsing grille.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The needle scans the FM band while a preset stays lit.

--- a/submissions/examples/ease-radio-dial-tuner-ij/demo.html
+++ b/submissions/examples/ease-radio-dial-tuner-ij/demo.html
@@ -1,0 +1,42 @@
+<!-- EaseMotion component: radio-dial-tuner -->
+<!DOCTYPE html>
+<html lang="en" data-radio="dial">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+<title>Ease Radio Dial Tuner</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="radio-body">
+  <header class="radio-top">
+    <span class="radio-brand">WAVE FM</span>
+    <span class="radio-led">STEREO</span>
+  </header>
+  <div class="fm-band">
+    <span class="fm-freq f1">88</span>
+    <span class="fm-freq f2">94</span>
+    <span class="fm-freq f3">100</span>
+    <span class="fm-freq f4">106</span>
+    <span class="fm-freq f5">108</span>
+    <div class="dial-needle"></div>
+  </div>
+  <div class="preset-row">
+    <button type="button" class="preset p1">1</button>
+    <button type="button" class="preset p2">2</button>
+    <button type="button" class="preset p3">3</button>
+    <button type="button" class="preset p4">4</button>
+    <button type="button" class="preset p5">5</button>
+    <button type="button" class="preset p6">6</button>
+  </div>
+  <div class="grille">
+    <i class="grill-slot"></i>
+    <i class="grill-slot"></i>
+    <i class="grill-slot"></i>
+    <i class="grill-slot"></i>
+    <i class="grill-slot"></i>
+    <i class="grill-slot"></i>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-radio-dial-tuner-ij/style.css
+++ b/submissions/examples/ease-radio-dial-tuner-ij/style.css
@@ -1,0 +1,42 @@
+:root{
+  --rd-bg:hsl(28,40%,12%);
+  --rd-body:hsl(28,45%,16%);
+  --rd-line:hsl(28,35%,26%);
+  --rd-ink:hsl(28,30%,90%);
+  --rd-mute:hsl(28,25%,58%);
+  --rd-glow:hsl(140,80%,50%);
+}
+*{margin:0;box-sizing:border-box;padding:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 20%,hsl(28,42%,14%),hsl(28,50%,6%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
+.radio-body{width:min(420px,94vw);padding:22px;background:var(--rd-body);border:1px solid var(--rd-line);border-radius:20px;box-shadow:0 22px 45px hsl(28,50%,3% / 0.55)}
+.radio-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px}
+.radio-brand{font-size:1rem;font-weight:900;letter-spacing:2px;color:var(--rd-ink)}
+.radio-led{font-size:.6rem;font-weight:800;letter-spacing:2px;padding:3px 8px;border-radius:20px;color:hsl(140,90%,55%);background:hsl(140,70%,35% / 0.2);animation:led-blink-radio-dial-tuner 1.4s step-end infinite}
+.fm-band{position:relative;height:58px;margin-bottom:16px;border-radius:10px;background:hsl(28,50%,10%);border:1px solid hsl(28,35%,24%);display:flex;align-items:flex-end;justify-content:space-between;padding:0 12px 8px}
+.fm-freq{font-size:.66rem;font-weight:700;color:var(--rd-mute)}
+.dial-needle{position:absolute;top:0;bottom:0;width:2px;background:var(--rd-glow);box-shadow:0 0 8px hsl(140,90%,55% / 0.7);animation:needle-scan-radio-dial-tuner 5s ease-in-out infinite}
+.preset-row{display:flex;gap:10px;justify-content:center;margin-bottom:18px}
+.preset{flex:1;padding:8px 0;font-size:.8rem;font-weight:800;color:var(--rd-ink);background:hsl(28,45%,22%);border:1px solid var(--rd-line);border-radius:8px}
+.preset.p2{animation:preset-glow-radio-dial-tuner 2.4s ease-in-out infinite;color:hsl(140,90%,55%)}
+.grille{display:grid;grid-template-columns:repeat(6,1fr);gap:8px;padding:12px;background:hsl(28,50%,9%);border-radius:10px}
+.grill-slot{height:52px;border-radius:6px;background:hsl(28,40%,14%);box-shadow:inset 0 2px 6px hsl(28,60%,5%)}
+.grille{animation:grille-pulse-radio-dial-tuner 3s ease-in-out infinite}
+@keyframes needle-scan-radio-dial-tuner{
+  0%{left:5%}
+  22%{left:30%}
+  44%{left:52%}
+  68%{left:74%}
+  100%{left:5%}
+}
+@keyframes preset-glow-radio-dial-tuner{
+  0%,100%{box-shadow:0 0 0 0 hsl(140,80%,50% / 0)}
+  50%{box-shadow:0 0 16px 4px hsl(140,80%,50% / 0.55)}
+}
+@keyframes grille-pulse-radio-dial-tuner{
+  0%,100%{transform:scaleY(1.01)}
+  50%{transform:scaleY(0.97)}
+}
+@keyframes led-blink-radio-dial-tuner{
+  0%,100%{opacity:0.9}
+  50%{opacity:0.35}
+}


### PR DESCRIPTION
## Component: ease-radio-dial-tuner — retro radio face with scanning needle and glowing presets

**Closes #59003**

### What this adds
A retro radio face. A tuning needle scans across the FM frequency band, preset buttons glow as active, and the speaker grille pulses subtly below.

### Acceptance Criteria covered
- The tuning needle scans across the FM band
- Preset buttons highlight as active
- The speaker grille pulses subtly

### Files
- `submissions/examples/ease-radio-dial-tuner-ij/demo.html`
- `submissions/examples/ease-radio-dial-tuner-ij/style.css`
- `submissions/examples/ease-radio-dial-tuner-ij/README.md`

### How to review
Open demo.html directly in a browser. The needle scans the FM dial while a preset button glows.