### PR TITLE
fix(css): Standardize Z-Index Scale to Fix Modal Collisions (#59030)

### DIFF
--- a/submissions/docs/engine-z-index/README.md
+++ b/submissions/docs/engine-z-index/README.md
@@ -1,0 +1,23 @@
+# Standardized Z-Index Scale
+
+This submission resolves Issue #59030 by proposing a centralized z-index scale to fix collisions between tooltips and modals.
+
+## Proposed Variables
+To be added to `easemotion/engine/variables.css`:
+
+```css
+:root {
+  --ease-z-base: 0;
+  --ease-z-dropdown: 100;
+  --ease-z-sticky: 200;
+  --ease-z-modal-backdrop: 300;
+  --ease-z-modal: 400;
+  --ease-z-tooltip: 500;
+}
+```
+
+## Why this solves the issue
+Currently, hardcoded `z-index` values mean tooltips can accidentally render behind modals. By establishing a fixed, framework-wide scale, we guarantee that elements with `--ease-z-tooltip` will always render above `--ease-z-modal`.
+
+## Directory Structure
+Due to the contribution freeze on core engine files, this standardization proposal is submitted under `submissions/docs/engine-z-index/`. Maintainers can review the `demo.html` to see the stack in action and integrate the variables into the core engine when the freeze lifts.

--- a/submissions/docs/engine-z-index/demo.html
+++ b/submissions/docs/engine-z-index/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Z-Index Standard Scale Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 40px;
+      margin: 0;
+      background: #f1f5f9;
+      height: 200vh;
+    }
+    .layer {
+      padding: 20px;
+      border-radius: 8px;
+      font-weight: bold;
+      color: white;
+      box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      border: 2px solid rgba(255,255,255,0.2);
+    }
+    
+    .ease-mock-base {
+      background: #64748b;
+      height: 200px;
+      margin-bottom: 20px;
+    }
+    
+    .ease-mock-sticky {
+      background: #3b82f6;
+      padding: 15px;
+    }
+    
+    .ease-mock-dropdown {
+      background: #8b5cf6;
+      top: 150px;
+      left: 100px;
+      width: 200px;
+      height: 150px;
+    }
+    
+    .ease-mock-modal-backdrop {
+      background: rgba(0, 0, 0, 0.5);
+      display: flex;
+      pointer-events: none; /* Just for demo interactions */
+    }
+    
+    .ease-mock-modal {
+      background: #ec4899;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 400px;
+      height: 250px;
+    }
+    
+    .ease-mock-tooltip {
+      background: #10b981;
+      top: 40%;
+      left: 60%;
+      transform: translate(-50%, -50%);
+      width: 150px;
+      height: 60px;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Z-Index Layering Fix</h1>
+  <p>Scroll to see sticky behavior and verify that tooltips always render above modals.</p>
+
+  <div class="layer ease-mock-base">
+    Base Layer (z-index: var(--ease-z-base))
+  </div>
+  
+  <div class="layer ease-mock-sticky">
+    Sticky Nav (z-index: var(--ease-z-sticky))
+  </div>
+  
+  <div class="layer ease-mock-dropdown">
+    Dropdown (z-index: var(--ease-z-dropdown))
+  </div>
+
+  <div class="ease-mock-modal-backdrop"></div>
+  
+  <div class="layer ease-mock-modal">
+    Modal Window (z-index: var(--ease-z-modal))
+  </div>
+  
+  <div class="layer ease-mock-tooltip">
+    Tooltip (z-index: var(--ease-z-tooltip))<br>
+    I am on top!
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/engine-z-index/style.css
+++ b/submissions/docs/engine-z-index/style.css
@@ -1,0 +1,47 @@
+/* submissions/docs/engine-z-index/style.css */
+
+/* 
+ * Proposed Standardized Z-Index Scale
+ * To be merged into: easemotion/engine/variables.css
+ */
+:root {
+  --ease-z-base: 0;
+  --ease-z-dropdown: 100;
+  --ease-z-sticky: 200;
+  --ease-z-modal-backdrop: 300;
+  --ease-z-modal: 400;
+  --ease-z-tooltip: 500;
+}
+
+/* Example implementations demonstrating usage */
+.ease-mock-base {
+  position: relative;
+  z-index: var(--ease-z-base);
+}
+
+.ease-mock-dropdown {
+  position: absolute;
+  z-index: var(--ease-z-dropdown);
+}
+
+.ease-mock-sticky {
+  position: sticky;
+  top: 0;
+  z-index: var(--ease-z-sticky);
+}
+
+.ease-mock-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--ease-z-modal-backdrop);
+}
+
+.ease-mock-modal {
+  position: fixed;
+  z-index: var(--ease-z-modal);
+}
+
+.ease-mock-tooltip {
+  position: absolute;
+  z-index: var(--ease-z-tooltip);
+}


### PR DESCRIPTION
## Description
Resolves #59030

This PR introduces a standardized, centralized `z-index` scale for the framework to prevent component layering collisions, specifically addressing the bug where tooltips render behind modals.

To comply with the current core contribution freeze, this proposal and demonstration are placed in `submissions/docs/engine-z-index/`. Once the freeze is lifted, these variables can be dropped directly into `easemotion/engine/variables.css`.

## Changes
- **`style.css`**: Defines the new custom properties (`--ease-z-base`, `--ease-z-dropdown`, `--ease-z-sticky`, `--ease-z-modal-backdrop`, `--ease-z-modal`, `--ease-z-tooltip`) and mock classes to prove they work.
- **`demo.html`**: A visual test environment proving that elements using `--ease-z-tooltip` correctly overlay elements using `--ease-z-modal`.
- **`README.md`**: Explanation of the fix and integration instructions for the core maintainer.

## Checklist
- [x] Placed in the `submissions/docs/engine-z-index/` directory
- [x] Single commit
- [x] No direct modifications to core files (respecting the contribution freeze)