### PR TITLE
Add ease-football-match-scorecard component

### DIFF
--- a/submissions/examples/ease-football-match-scorecard-ij/README.md
+++ b/submissions/examples/ease-football-match-scorecard-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Football Match Scorecard
+
+A live football scorecard with team crests, a center score display and a match status bar.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The score digits pop while the LIVE dot blinks.

--- a/submissions/examples/ease-football-match-scorecard-ij/demo.html
+++ b/submissions/examples/ease-football-match-scorecard-ij/demo.html
@@ -1,0 +1,42 @@
+<!-- EaseMotion component: football-match-scorecard -->
+<!DOCTYPE html>
+<html lang="en" data-foot="match">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ease Football Match Scorecard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="football-card">
+  <header class="match-bar">
+    <span class="match-venue">Wembley Stadium</span>
+    <span class="match-stage">FINAL</span>
+  </header>
+  <div class="score-row">
+    <div class="team-box team-home">
+      <span class="team-crest crest-home"></span>
+      <span class="team-name">Arsenal</span>
+    </div>
+    <div class="score-digits">
+      <span class="score-num score-a">2</span>
+      <span class="score-colon">:</span>
+      <span class="score-num score-b">1</span>
+    </div>
+    <div class="team-box team-away">
+      <span class="team-crest crest-away"></span>
+      <span class="team-name">Chelsea</span>
+    </div>
+  </div>
+  <div class="match-status">
+    <span class="status-dot"></span>
+    <span class="status-text">LIVE 67&rsquo;</span>
+  </div>
+  <footer class="stat-row">
+    <span class="stat">POSS 58%</span>
+    <span class="stat">SHOTS 12</span>
+    <span class="stat">CORNERS 6</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-football-match-scorecard-ij/style.css
+++ b/submissions/examples/ease-football-match-scorecard-ij/style.css
@@ -1,0 +1,40 @@
+:root{
+  --fm-bg:hsl(145,50%,8%);
+  --fm-grass:hsl(145,50%,22%);
+  --fm-ink:hsl(145,20%,94%);
+  --fm-gold:hsl(48,100%,58%);
+  --fm-home:hsl(220,70%,55%);
+  --fm-away:hsl(350,70%,55%);
+}
+*{padding:0;margin:0;box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 35%,hsl(145,45%,14%),hsl(145,55%,6%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.football-card{width:340px;border-radius:18px;overflow:hidden;background:var(--fm-grass);border:2px solid hsl(145,40%,38%);box-shadow:0 12px 30px hsl(0,0%,0% / 0.45)}
+.match-bar{display:flex;justify-content:space-between;padding:10px 14px;background:hsl(145,45%,13%)}
+.match-venue{font-size:.72rem;text-transform:uppercase;letter-spacing:2px;color:hsl(145,25%,72%)}
+.match-stage{font-size:.72rem;font-weight:800;color:var(--fm-gold)}
+.score-row{display:flex;align-items:center;justify-content:space-between;padding:22px 16px}
+.team-box{display:flex;flex-direction:column;align-items:center;gap:8px;width:98px}
+.team-crest{width:44px;height:44px;border-radius:50%;border:3px solid hsl(0,0%,92%)}
+.crest-home{background:repeating-conic-gradient(var(--fm-home) 0 25%,hsl(220,55%,30%) 25% 50%)}
+.crest-away{background:repeating-conic-gradient(var(--fm-away) 0 25%,hsl(350,55%,30%) 25% 50%)}
+.team-name{font-weight:800;font-size:.85rem;color:var(--fm-ink)}
+.score-digits{display:flex;align-items:center;gap:10px;font-size:2.4rem;font-weight:900;color:var(--fm-ink)}
+.score-num{animation:score-pop-football-match-scorecard 2s ease-in-out infinite}
+.score-a{color:var(--fm-gold)}
+.score-b{color:hsl(0,0%,88%)}
+.score-colon{color:hsl(145,30%,62%)}
+.match-status{display:flex;align-items:center;justify-content:center;gap:8px;padding:8px;background:hsl(0,0%,0% / 0.28)}
+.status-dot{width:10px;height:10px;border-radius:50%;background:hsl(0,90%,55%);animation:live-blink-football-match-scorecard 1s step-end infinite}
+.status-text{font-size:.75rem;font-weight:700;letter-spacing:1px;color:hsl(0,0%,90%)}
+.stat-row{display:flex;justify-content:space-around;padding:12px 10px}
+.stat{font-size:.7rem;font-weight:600;color:hsl(145,25%,82%);text-transform:uppercase;letter-spacing:1px}
+@keyframes score-pop-football-match-scorecard{
+  0%,30%{transform:scale(1)}
+  45%{transform:scale(1.18)}
+  60%{transform:scale(0.96)}
+  100%{transform:scale(1)}
+}
+@keyframes live-blink-football-match-scorecard{
+  0%,49%{opacity:1}
+  50%,100%{opacity:0.2}
+}


### PR DESCRIPTION
## Component: ease-football-match-scorecard — football scorecard with team names, live score and match status bar

**Closes #59541**

### What this adds
A live football scorecard. Two team boxes with crests and names face a center score display, the score digits pop on a beat, a blinking LIVE status dot marks the running match, and a stat row shows possession, shots and corners.

### Acceptance Criteria covered
- Team boxes frame the score digits on each side
- The score digits pop in time with the match beat
- The LIVE status dot blinks during the match

### Files
- `submissions/examples/ease-football-match-scorecard-ij/demo.html`
- `submissions/examples/ease-football-match-scorecard-ij/style.css`
- `submissions/examples/ease-football-match-scorecard-ij/README.md`

### How to review
Open demo.html directly in a browser. The score digits pop, the LIVE dot blinks, and the stat row stays aligned under the teams.