### PR TITLE
Add ease-camera-viewfinder-app component

### DIFF
--- a/submissions/examples/ease-camera-viewfinder-app-ij/README.md
+++ b/submissions/examples/ease-camera-viewfinder-app-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Camera Viewfinder App
+
+A camera app with a rule-of-thirds viewfinder, a round shutter button and a settings row.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The focus ring pulses while the REC dot blinks.

--- a/submissions/examples/ease-camera-viewfinder-app-ij/demo.html
+++ b/submissions/examples/ease-camera-viewfinder-app-ij/demo.html
@@ -1,0 +1,41 @@
+<!-- EaseMotion component: camera-viewfinder-app -->
+<!DOCTYPE html>
+<html lang="en" data-cam="app">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>Ease Camera Viewfinder App</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="camera-app">
+  <header class="camera-top">
+    <span class="cam-brand">CAMERA</span>
+    <span class="cam-mode">AUTO</span>
+    <span class="cam-battery">100%</span>
+  </header>
+  <div class="viewfinder">
+    <span class="vf-frame"></span>
+    <span class="vf-grid vg-a"></span>
+    <span class="vf-grid vg-b"></span>
+    <span class="vf-focus"></span>
+    <span class="vf-timer">00:00:00</span>
+  </div>
+  <div class="control-row">
+    <div class="settings-grp">
+      <button class="set-btn">FLASH</button>
+      <button class="set-btn">HDR</button>
+    </div>
+    <button class="shutter-btn"><span class="shutter-core"></span></button>
+    <div class="gallery-thumbs">
+      <span class="thumb tn-1"></span>
+      <span class="thumb tn-2"></span>
+    </div>
+  </div>
+  <footer class="recording-strip">
+    <span class="rec-dot"></span>
+    <span class="rec-label">REC</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-camera-viewfinder-app-ij/style.css
+++ b/submissions/examples/ease-camera-viewfinder-app-ij/style.css
@@ -1,0 +1,44 @@
+:root{
+  --cv-bg:hsl(230,30%,9%);
+  --cv-frame:hsl(230,15%,92%);
+  --cv-amber:hsl(48,100%,60%);
+  --cv-red:hsl(0,85%,52%);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 20%,hsl(230,35%,16%),hsl(230,40%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.camera-app{width:330px;border-radius:20px;overflow:hidden;background:hsl(230,30%,12%);border:2px solid hsl(230,20%,28%);box-shadow:0 14px 34px hsl(0,0%,0% / 0.5)}
+.camera-top{display:flex;align-items:center;justify-content:space-between;padding:10px 14px;background:hsl(230,30%,8%)}
+.cam-brand{font-weight:900;letter-spacing:3px;font-size:.8rem;color:var(--cv-frame)}
+.cam-mode{font-size:.7rem;color:var(--cv-amber)}
+.cam-battery{font-size:.7rem;color:hsl(230,20%,70%)}
+.viewfinder{position:relative;height:230px;background:linear-gradient(160deg,hsl(210,60%,38%),hsl(230,50%,22%));overflow:hidden}
+.vf-frame{position:absolute;inset:10px;border:2px solid hsl(0,0%,100% / 0.6);border-radius:4px}
+.vf-grid{position:absolute;background:hsl(0,0%,100% / 0.35)}
+.vg-a{left:33.33%;top:10px;bottom:10px;width:2px}
+.vg-b{top:33.33%;left:10px;right:10px;height:2px}
+.vf-focus{position:absolute;left:50%;top:50%;width:70px;height:70px;margin:-35px 0 0 -35px;border:2px solid var(--cv-amber);border-radius:50%;animation:focus-pulse-camera-viewfinder-app 1.8s ease-in-out infinite}
+.vf-timer{position:absolute;right:14px;top:14px;font-size:.75rem;letter-spacing:1px;color:hsl(0,0%,100% / 0.85)}
+.control-row{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;background:hsl(230,30%,9%)}
+.settings-grp{display:flex;gap:8px}
+.set-btn{padding:6px 8px;font-size:.62rem;font-weight:700;border-radius:6px;border:1px solid hsl(230,25%,34%);color:hsl(230,20%,84%);background:hsl(230,25%,14%)}
+.shutter-btn{width:58px;height:58px;border-radius:50%;border:4px solid hsl(0,0%,90%);background:hsl(0,0%,20%);display:flex;align-items:center;justify-content:center;animation:shutter-recoil-camera-viewfinder-app 2.4s ease-in-out infinite}
+.shutter-core{width:38px;height:38px;border-radius:50%;background:var(--cv-red)}
+.gallery-thumbs{display:flex;gap:6px}
+.thumb{width:34px;height:34px;border-radius:6px;border:1px solid hsl(230,20%,40%)}
+.tn-1{background:linear-gradient(135deg,hsl(30,80%,55%),hsl(300,60%,50%))}
+.tn-2{background:linear-gradient(135deg,hsl(150,70%,45%),hsl(220,80%,50%))}
+.recording-strip{display:flex;align-items:center;gap:8px;justify-content:center;padding:8px;background:hsl(0,0%,0% / 0.3)}
+.rec-dot{width:10px;height:10px;border-radius:50%;background:var(--cv-red);animation:rec-blink-camera-viewfinder-app 1.4s step-end infinite}
+.rec-label{font-size:.72rem;letter-spacing:2px;color:hsl(0,0%,88%)}
+@keyframes focus-pulse-camera-viewfinder-app{
+  0%,100%{transform:scale(1);border-color:var(--cv-amber)}
+  50%{transform:scale(1.08);border-color:hsl(48,100%,75%)}
+}
+@keyframes shutter-recoil-camera-viewfinder-app{
+  0%,80%,100%{transform:scale(1)}
+  90%{transform:scale(0.86)}
+}
+@keyframes rec-blink-camera-viewfinder-app{
+  0%,60%{opacity:1}
+  70%,100%{opacity:0.25}
+}


### PR DESCRIPTION
## Component: ease-camera-viewfinder-app — camera app with viewfinder, shutter button and settings row

**Closes #59543**

### What this adds
A camera app screen. A rule-of-thirds grid overlays the viewfinder with a pulsing focus ring, the round shutter button presses with a recoil, and a row of flash/HDR settings plus gallery thumbnails completes the control deck.

### Acceptance Criteria covered
- The viewfinder shows a grid overlay and focus ring
- The shutter button recoils on press
- The REC indicator blinks while recording

### Files
- `submissions/examples/ease-camera-viewfinder-app-ij/demo.html`
- `submissions/examples/ease-camera-viewfinder-app-ij/style.css`
- `submissions/examples/ease-camera-viewfinder-app-ij/README.md`

### How to review
Open demo.html directly in a browser. The focus ring pulses in the viewfinder, the shutter recoils, and the REC dot blinks below.