### PR TITLE
Add Rotate-Fade drawer component for SaaS showcase layouts (rotate-fa…

### DIFF
--- a/submissions/examples/rotate-fade-drawer-hr18/README.md
+++ b/submissions/examples/rotate-fade-drawer-hr18/README.md
@@ -1,0 +1,92 @@
+# Rotate-Fade Drawer (`rotate-fade-drawer-hr18`)
+
+A pure-CSS animated slide-out drawer with a "Rotate-Fade" entrance, styled
+for SaaS showcase layouts, built for issue
+[#59528](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59528).
+
+## What it does
+
+Clicking "View plans" opens a right-side drawer that slides in while
+rotated a few degrees and slightly scaled down, unrotating and settling to
+full size as it arrives — a subtle combination of motion instead of a flat
+slide or a plain fade. The **entrance animation itself is 100% CSS**
+(`@keyframes ease-rotate-fade-in-hr18`, driven entirely by custom
+properties); vanilla JavaScript only handles opening/closing, a focus
+trap, `Escape`-to-close, and backdrop-click-to-close — none of which is an
+animation frameworks, per the issue's "no external JS frameworks"
+requirement.
+
+The demo frames the drawer as a plan-comparison panel (Starter / Pro /
+Enterprise), a common SaaS upgrade pattern.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<button type="button" id="openBtn" aria-haspopup="dialog">View plans</button>
+
+<div class="rfd-backdrop-hr18" id="backdrop"></div>
+
+<aside class="ease-drawer-rotate-fade-hr18" id="drawer" role="dialog" aria-modal="true" aria-labelledby="drawerTitle">
+  <h2 id="drawerTitle">Choose a plan</h2>
+  <button type="button" id="closeBtn" aria-label="Close">&times;</button>
+  <!-- drawer content -->
+</aside>
+```
+
+Toggling `is-open-hr18` on both the backdrop and the drawer opens it; the
+drawer's `is-open-hr18` class is what triggers the rotate-fade `@keyframes`
+animation to play. See `demo.html` for the full open/close/focus-trap
+script.
+
+### Tuning the animation
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-drawer-duration-hr18` | `420ms` | How long the slide-in + unrotate takes |
+| `--ease-drawer-easing-hr18` | `cubic-bezier(0.22, 1, 0.36, 1)` | The easing curve for the entrance |
+| `--ease-drawer-angle-hr18` | `5deg` | Starting rotation angle before it settles flat |
+| `--ease-drawer-delay-hr18` | `0ms` | Delay before the animation starts |
+
+```css
+.ease-drawer-rotate-fade-hr18.dramatic {
+  --ease-drawer-angle-hr18: 14deg;
+  --ease-drawer-duration-hr18: 600ms;
+}
+```
+
+## Accessibility notes
+
+- The drawer has `role="dialog"`, `aria-modal="true"`, and
+  `aria-labelledby` pointing at its own heading.
+- Opening the drawer moves focus into it (to its first focusable
+  element), and `Tab`/`Shift+Tab` are trapped within it while open — focus
+  never silently escapes to content behind the backdrop.
+- `Escape` closes the drawer and returns focus to the button that opened
+  it; clicking the backdrop does the same.
+- The drawer's animation respects
+  `@media (prefers-reduced-motion: reduce)` and appears instantly at its
+  final position instead.
+
+## Responsiveness
+
+The drawer is `min(360px, 90vw)` wide, so it never overflows a narrow
+viewport, and widens to the full screen width below `380px` rather than
+leaving an awkward sliver of visible backdrop on very small phones.
+
+## Why this fits EaseMotion CSS
+
+A self-contained, reusable interaction pattern with a distinct named
+animation (`ease-rotate-fade-in`) exposed entirely through custom
+properties, matching the issue's ask for pure CSS transitions/keyframes
+and zero external JS frameworks, while remaining genuinely keyboard
+accessible via a real focus trap.
+
+All classes, custom properties, and the folder itself use a `-hr18` suffix
+to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/rotate-fade-drawer-hr18/demo.html
+++ b/submissions/examples/rotate-fade-drawer-hr18/demo.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Rotate-Fade Drawer — SaaS demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="rfd-hr18">
+  <div class="rfd-wrap-hr18">
+    <h1>Upgrade your plan</h1>
+    <p>Open the drawer to compare plans &mdash; it slides in from the right
+      while rotated and slightly scaled down, then unrotates and settles
+      to full size as it arrives.</p>
+    <button type="button" class="rfd-open-btn-hr18" id="rfdOpenBtn" aria-haspopup="dialog">
+      View plans
+    </button>
+
+    <div class="rfd-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-drawer-duration-hr18</code></td><td><code>420ms</code></td><td>How long the slide-in + unrotate takes.</td></tr>
+          <tr><td><code>--ease-drawer-easing-hr18</code></td><td><code>cubic-bezier(0.22, 1, 0.36, 1)</code></td><td>The easing curve for the entrance.</td></tr>
+          <tr><td><code>--ease-drawer-angle-hr18</code></td><td><code>5deg</code></td><td>Starting rotation angle before it settles flat.</td></tr>
+          <tr><td><code>--ease-drawer-delay-hr18</code></td><td><code>0ms</code></td><td>Delay before the animation starts.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="rfd-footnote-hr18">submissions/examples/rotate-fade-drawer-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<div class="rfd-backdrop-hr18" id="rfdBackdrop"></div>
+
+<aside class="ease-drawer-rotate-fade-hr18" id="rfdDrawer" role="dialog" aria-modal="true" aria-labelledby="rfdDrawerTitle">
+  <div class="rfd-drawer-head-hr18">
+    <h2 id="rfdDrawerTitle">Choose a plan</h2>
+    <button type="button" class="rfd-close-btn-hr18" id="rfdCloseBtn" aria-label="Close">&times;</button>
+  </div>
+
+  <div class="rfd-plan-card-hr18">
+    <div class="rfd-plan-name-hr18"><span>Starter</span><span class="rfd-plan-price-hr18">$0</span></div>
+    <ul>
+      <li>Up to 3 projects</li>
+      <li>Community support</li>
+    </ul>
+  </div>
+
+  <div class="rfd-plan-card-hr18 featured">
+    <div class="rfd-plan-name-hr18"><span>Pro</span><span class="rfd-plan-price-hr18">$19/mo</span></div>
+    <ul>
+      <li>Unlimited projects</li>
+      <li>Priority support</li>
+      <li>Team collaboration</li>
+    </ul>
+    <button type="button" class="rfd-drawer-cta-hr18">Upgrade to Pro</button>
+  </div>
+
+  <div class="rfd-plan-card-hr18">
+    <div class="rfd-plan-name-hr18"><span>Enterprise</span><span class="rfd-plan-price-hr18">Custom</span></div>
+    <ul>
+      <li>Dedicated account manager</li>
+      <li>SLA &amp; SSO</li>
+    </ul>
+  </div>
+</aside>
+
+<script>
+(function () {
+  "use strict";
+
+  var openBtn = document.getElementById("rfdOpenBtn");
+  var closeBtn = document.getElementById("rfdCloseBtn");
+  var backdrop = document.getElementById("rfdBackdrop");
+  var drawer = document.getElementById("rfdDrawer");
+  var lastFocused = null;
+
+  function getFocusable(container) {
+    return Array.prototype.slice
+      .call(container.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
+      .filter(function (el) { return !el.disabled; });
+  }
+
+  function open() {
+    lastFocused = document.activeElement;
+    backdrop.classList.add("is-open-hr18");
+    drawer.classList.add("is-open-hr18");
+    // A frame later, so the opacity transition on the backdrop actually
+    // animates instead of jumping straight to visible.
+    requestAnimationFrame(function () {
+      backdrop.classList.add("is-visible-hr18");
+    });
+    var focusables = getFocusable(drawer);
+    if (focusables.length) focusables[0].focus();
+    document.addEventListener("keydown", onKeydown, true);
+  }
+
+  function close() {
+    backdrop.classList.remove("is-visible-hr18");
+    drawer.classList.remove("is-open-hr18");
+    window.setTimeout(function () {
+      backdrop.classList.remove("is-open-hr18");
+    }, 200);
+    document.removeEventListener("keydown", onKeydown, true);
+    if (lastFocused) lastFocused.focus();
+  }
+
+  function onKeydown(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === "Tab") {
+      var focusables = getFocusable(drawer);
+      if (!focusables.length) return;
+      var first = focusables[0];
+      var last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  openBtn.addEventListener("click", open);
+  closeBtn.addEventListener("click", close);
+  backdrop.addEventListener("click", close);
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/rotate-fade-drawer-hr18/style.css
+++ b/submissions/examples/rotate-fade-drawer-hr18/style.css
@@ -1,0 +1,280 @@
+/* ==========================================================================
+   rotate-fade-drawer-hr18 — style.css
+   CSS Rotate-Fade Drawer for SaaS Showcase Layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+   ========================================================================== */
+
+.rfd-hr18 {
+  --bg-hr18: #f7f7fb;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e5e4f0;
+  --text-hr18: #17172a;
+  --muted-hr18: #67667f;
+  --accent-hr18: #5b4cf0;
+  --accent-soft-hr18: #edeafd;
+
+  /* Exposed animation parameters. */
+  --ease-drawer-duration-hr18: 420ms;
+  --ease-drawer-easing-hr18: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-drawer-angle-hr18: 5deg;
+  --ease-drawer-delay-hr18: 0ms;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3.5rem 1.5rem;
+}
+
+.rfd-hr18 * {
+  box-sizing: border-box;
+}
+
+.rfd-wrap-hr18 {
+  max-width: 480px;
+  text-align: center;
+}
+
+.rfd-wrap-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  margin: 0 0 0.6rem;
+}
+
+.rfd-wrap-hr18 > p {
+  margin: 0 0 1.5rem;
+  color: var(--muted-hr18);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.rfd-open-btn-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent-hr18);
+  border: none;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.rfd-open-btn-hr18:hover {
+  filter: brightness(1.08);
+}
+
+/* ==========================================================================
+   The reusable drawer component
+   ========================================================================== */
+
+.rfd-backdrop-hr18 {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 12, 40, 0.35);
+  display: none;
+  z-index: 40;
+  opacity: 0;
+  transition: opacity var(--ease-drawer-duration-hr18) ease;
+}
+
+.rfd-backdrop-hr18.is-open-hr18 {
+  display: block;
+}
+
+.rfd-backdrop-hr18.is-visible-hr18 {
+  opacity: 1;
+}
+
+.ease-drawer-rotate-fade-hr18 {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 90vw);
+  background: var(--panel-hr18);
+  border-left: 1px solid var(--border-hr18);
+  box-shadow: -20px 0 50px rgba(15, 12, 40, 0.18);
+  z-index: 41;
+  display: none;
+  padding: 1.6rem;
+  overflow-y: auto;
+  transform-origin: right center;
+}
+
+.ease-drawer-rotate-fade-hr18.is-open-hr18 {
+  display: block;
+  animation: ease-rotate-fade-in-hr18 var(--ease-drawer-duration-hr18) var(--ease-drawer-easing-hr18) var(--ease-drawer-delay-hr18) both;
+}
+
+/* The rotate-fade entrance: slides in from the right while rotated and
+   slightly scaled down, unrotating and settling to full size as it
+   arrives. Angle and duration are both tunable. */
+@keyframes ease-rotate-fade-in-hr18 {
+  0% {
+    opacity: 0;
+    transform: translateX(40px) rotate(var(--ease-drawer-angle-hr18)) scale(0.94);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0) rotate(0deg) scale(1);
+  }
+}
+
+.rfd-drawer-head-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.2rem;
+}
+
+.rfd-drawer-head-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.rfd-close-btn-hr18 {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rfd-close-btn-hr18:hover {
+  background: var(--accent-hr18);
+  color: #fff;
+}
+
+.rfd-plan-card-hr18 {
+  border: 1px solid var(--border-hr18);
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  margin-bottom: 0.9rem;
+}
+
+.rfd-plan-card-hr18.featured {
+  border-color: var(--accent-hr18);
+  background: var(--accent-soft-hr18);
+}
+
+.rfd-plan-name-hr18 {
+  font-weight: 700;
+  font-size: 0.92rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rfd-plan-price-hr18 {
+  font-family: var(--font-display-hr18);
+  color: var(--accent-hr18);
+}
+
+.rfd-plan-card-hr18 ul {
+  margin: 0.6rem 0 0;
+  padding-left: 1.1rem;
+  font-size: 0.82rem;
+  color: var(--muted-hr18);
+  line-height: 1.6;
+}
+
+.rfd-drawer-cta-hr18 {
+  width: 100%;
+  margin-top: 0.6rem;
+  font-family: var(--font-body-hr18);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent-hr18);
+  border: none;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.rfd-tuning-hr18 {
+  margin-top: 2rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.25rem 1.4rem;
+  text-align: left;
+}
+
+.rfd-tuning-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1rem;
+  margin: 0 0 0.6rem;
+}
+
+.rfd-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.rfd-tuning-hr18 th,
+.rfd-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.rfd-tuning-hr18 th {
+  color: var(--muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.rfd-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+  color: var(--accent-hr18);
+}
+
+.rfd-footnote-hr18 {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Responsive: drawer takes nearly the full width on very narrow screens --------- */
+@media (max-width: 380px) {
+  .ease-drawer-rotate-fade-hr18 {
+    width: 100vw;
+  }
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.rfd-hr18 :focus-visible,
+.ease-drawer-rotate-fade-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-drawer-rotate-fade-hr18.is-open-hr18 {
+    animation: none;
+  }
+  .rfd-backdrop-hr18 {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated slide-out drawer with a "Rotate-Fade" entrance,
styled for SaaS showcase layouts. Opening the drawer slides it in from
the right while rotated and slightly scaled down, unrotating and
settling to full size as it arrives — a combination of motion rather
than a flat slide or plain fade. The entrance animation is 100% CSS;
vanilla JS (no framework) handles open/close, a real focus trap,
Escape-to-close, and backdrop-click-to-close. Demo frames the drawer as
a Starter/Pro/Enterprise plan-comparison panel.

Resolves #59528

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/rotate-fade-drawer-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS "rotate-fade" slide-out drawer with a real focus
trap, tunable via custom properties.

**How does a developer use it?**
```html
<aside class="ease-drawer-rotate-fade-hr18" role="dialog" aria-modal="true" aria-labelledby="drawerTitle">
  <h2 id="drawerTitle">Choose a plan</h2>
  <!-- content -->
</aside>
```

**Why does it fit EaseMotion CSS?**
A self-contained interaction with a distinct named animation exposed
entirely through custom properties, matching the issue's ask for pure
CSS transitions/keyframes and zero external JS frameworks, while
remaining genuinely keyboard accessible via a real focus trap.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
All classes/custom properties and the folder itself use a `-hr18`
suffix. Tested focus trap (Tab wrapping), Escape, and backdrop-click in
Chrome; haven't checked other browsers yet.