### PR TITLE
Add 3D-Flip drawer component for SaaS showcase layouts (flip-drawer-3…

### DIFF
--- a/submissions/examples/flip-drawer-3d-hr18/README.md
+++ b/submissions/examples/flip-drawer-3d-hr18/README.md
@@ -1,0 +1,103 @@
+# 3D-Flip Drawer (`flip-drawer-3d-hr18`)
+
+A pure-CSS animated drawer with a "3D-Flip" entrance, styled for SaaS
+showcase layouts, built for issue
+[#59526](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59526).
+
+## A note on naming
+
+EaseMotion's core already ships an `ease-flip` entrance animation class,
+so every class and animation name in this submission is deliberately
+distinct (`ease-drawer-3dflip-hr18`, not `ease-flip-*`) to avoid any
+collision with it.
+
+## What it does
+
+Clicking "View changelog" opens a panel that flips down from the top edge
+of the viewport, like a folding visor — starting rotated back past
+`-90deg` (briefly hidden edge-on, the way a real hinged panel would be)
+and rotating forward to rest flat. `perspective` is applied to an ancestor
+"stage" element around the panel, which is what gives the rotation real
+depth rather than reading as a flat vertical squash. The **entrance
+animation itself is 100% CSS** (`@keyframes ease-3dflip-down-hr18`); the
+open/close/focus-trap logic is plain vanilla JavaScript, not a framework,
+per the issue's requirement.
+
+The demo frames the drawer as a product changelog panel with tagged
+"New" / "Fix" entries, a common SaaS "what's new" pattern.
+
+## Installation
+
+Nothing to install — `demo.html` is self-contained and opens directly in a
+browser (double-click the file). It links a single local `style.css`; no
+build step, package manager, or external CDN.
+
+## Usage
+
+```html
+<button type="button" id="openBtn" aria-haspopup="dialog">View changelog</button>
+
+<div class="f3d-backdrop-hr18" id="backdrop"></div>
+
+<div class="f3d-drawer-stage-hr18" id="stage">
+  <div class="ease-drawer-3dflip-hr18" role="dialog" aria-modal="true" aria-labelledby="drawerTitle">
+    <h2 id="drawerTitle">Changelog</h2>
+    <button type="button" id="closeBtn" aria-label="Close">&times;</button>
+    <!-- changelog entries -->
+  </div>
+</div>
+```
+
+`perspective` must stay on the `.f3d-drawer-stage-hr18` wrapper, not the
+flipping panel itself — perspective only affects the 3D rendering of an
+element's *children*, so it has to live one level up from
+`.ease-drawer-3dflip-hr18` for the rotation to read as depth. Toggling
+`is-open-hr18` on the stage (and the backdrop) is what triggers the flip
+`@keyframes` animation. See `demo.html` for the full open/close/focus-trap
+script.
+
+### Tuning the animation
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ease-flip-duration-hr18` | `520ms` | How long the flip-down takes |
+| `--ease-flip-easing-hr18` | `cubic-bezier(0.22, 1, 0.36, 1)` | The easing curve for the flip |
+| `--ease-flip-start-angle-hr18` | `-100deg` | Starting rotation before it settles flat |
+
+```css
+.ease-drawer-3dflip-hr18.subtle {
+  --ease-flip-start-angle-hr18: -75deg;
+  --ease-flip-duration-hr18: 350ms;
+}
+```
+
+## Accessibility notes
+
+- The panel has `role="dialog"`, `aria-modal="true"`, and
+  `aria-labelledby` pointing at its own heading.
+- Opening the drawer moves focus into it and traps `Tab`/`Shift+Tab`
+  within it while open, matching the same focus-trap pattern used in this
+  repo's other overlay-style submissions.
+- `Escape` closes the drawer and returns focus to the button that opened
+  it; clicking the backdrop does the same.
+- The flip animation respects `@media (prefers-reduced-motion: reduce)`
+  and appears instantly at its final, flat position instead.
+
+## Responsiveness
+
+The panel's padding and corner radius tighten under a `480px` viewport,
+and its `max-width: 640px` keeps it from stretching edge-to-edge and
+looking unbalanced on very wide desktop viewports.
+
+## Why this fits EaseMotion CSS
+
+A self-contained, reusable interaction pattern with a distinct named
+animation exposed entirely through custom properties, matching the
+issue's ask for pure CSS transitions/keyframes and zero external JS
+frameworks, while remaining genuinely keyboard accessible via a real
+focus trap — and deliberately avoiding any naming collision with the
+framework's existing `ease-flip` class.
+
+All classes, custom properties, and the folder itself use a `-hr18`
+suffix to avoid colliding with any other contributor's submission under
+`submissions/examples/`.

--- a/submissions/examples/flip-drawer-3d-hr18/demo.html
+++ b/submissions/examples/flip-drawer-3d-hr18/demo.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D-Flip Drawer — SaaS demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="f3d-hr18">
+  <div class="f3d-wrap-hr18">
+    <h1>What's new</h1>
+    <p>Open the panel &mdash; it flips down from the top edge like a folding
+      visor, with real perspective depth, instead of a flat slide.</p>
+    <button type="button" class="f3d-open-btn-hr18" id="f3dOpenBtn" aria-haspopup="dialog">
+      View changelog
+    </button>
+
+    <div class="f3d-tuning-hr18">
+      <h2>Custom properties</h2>
+      <table>
+        <thead>
+          <tr><th>Property</th><th>Default</th><th>Controls</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--ease-flip-duration-hr18</code></td><td><code>520ms</code></td><td>How long the flip-down takes.</td></tr>
+          <tr><td><code>--ease-flip-easing-hr18</code></td><td><code>cubic-bezier(0.22, 1, 0.36, 1)</code></td><td>The easing curve for the flip.</td></tr>
+          <tr><td><code>--ease-flip-start-angle-hr18</code></td><td><code>-100deg</code></td><td>Starting rotation before it settles flat &mdash; past -90deg so it's briefly hidden behind its own edge, like a real hinge.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="f3d-footnote-hr18">submissions/examples/flip-drawer-3d-hr18 &middot; no build tools or external CDN required</p>
+  </div>
+</div>
+
+<div class="f3d-backdrop-hr18" id="f3dBackdrop"></div>
+
+<div class="f3d-drawer-stage-hr18" id="f3dStage">
+  <div class="ease-drawer-3dflip-hr18" role="dialog" aria-modal="true" aria-labelledby="f3dDrawerTitle">
+    <div class="f3d-drawer-head-hr18">
+      <h2 id="f3dDrawerTitle">Changelog</h2>
+      <button type="button" class="f3d-close-btn-hr18" id="f3dCloseBtn" aria-label="Close">&times;</button>
+    </div>
+
+    <div class="f3d-update-hr18">
+      <span class="f3d-update-tag-hr18 new">New</span>
+      <div>
+        <h3>Team workspaces</h3>
+        <p>Share dashboards and invite collaborators with role-based access.</p>
+      </div>
+    </div>
+
+    <div class="f3d-update-hr18">
+      <span class="f3d-update-tag-hr18 new">New</span>
+      <div>
+        <h3>Dark mode</h3>
+        <p>Switch themes from Settings, or let it follow your system preference.</p>
+      </div>
+    </div>
+
+    <div class="f3d-update-hr18">
+      <span class="f3d-update-tag-hr18 fix">Fix</span>
+      <div>
+        <h3>Export timing</h3>
+        <p>Fixed a delay when exporting large reports to CSV.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var openBtn = document.getElementById("f3dOpenBtn");
+  var closeBtn = document.getElementById("f3dCloseBtn");
+  var backdrop = document.getElementById("f3dBackdrop");
+  var stage = document.getElementById("f3dStage");
+  var drawer = stage.querySelector(".ease-drawer-3dflip-hr18");
+  var lastFocused = null;
+
+  function getFocusable(container) {
+    return Array.prototype.slice
+      .call(container.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
+      .filter(function (el) { return !el.disabled; });
+  }
+
+  function open() {
+    lastFocused = document.activeElement;
+    backdrop.classList.add("is-open-hr18");
+    stage.classList.add("is-open-hr18");
+    requestAnimationFrame(function () {
+      backdrop.classList.add("is-visible-hr18");
+    });
+    var focusables = getFocusable(drawer);
+    if (focusables.length) focusables[0].focus();
+    document.addEventListener("keydown", onKeydown, true);
+  }
+
+  function close() {
+    backdrop.classList.remove("is-visible-hr18");
+    stage.classList.remove("is-open-hr18");
+    window.setTimeout(function () {
+      backdrop.classList.remove("is-open-hr18");
+    }, 200);
+    document.removeEventListener("keydown", onKeydown, true);
+    if (lastFocused) lastFocused.focus();
+  }
+
+  function onKeydown(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === "Tab") {
+      var focusables = getFocusable(drawer);
+      if (!focusables.length) return;
+      var first = focusables[0];
+      var last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  openBtn.addEventListener("click", open);
+  closeBtn.addEventListener("click", close);
+  backdrop.addEventListener("click", close);
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/flip-drawer-3d-hr18/style.css
+++ b/submissions/examples/flip-drawer-3d-hr18/style.css
@@ -1,0 +1,296 @@
+/* ==========================================================================
+   flip-drawer-3d-hr18 — style.css
+   CSS 3D-Flip Drawer for SaaS Showcase Layouts
+   Unique suffix: -hr18 (github.com/hruthika18)
+
+   Note: EaseMotion's core already ships an `ease-flip` entrance
+   animation class, so every class/animation name here is deliberately
+   distinct (ease-drawer-3dflip-hr18, not ease-flip-*) to avoid any
+   naming collision with it.
+   ========================================================================== */
+
+.f3d-hr18 {
+  --bg-hr18: #f7f7fb;
+  --panel-hr18: #ffffff;
+  --border-hr18: #e5e4f0;
+  --text-hr18: #17172a;
+  --muted-hr18: #67667f;
+  --accent-hr18: #2f6feb;
+  --accent-soft-hr18: #e9f0ff;
+
+  /* Exposed animation parameters. */
+  --ease-flip-duration-hr18: 520ms;
+  --ease-flip-easing-hr18: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-flip-start-angle-hr18: -100deg;
+
+  --font-display-hr18: "Space Grotesk", "Avenir Next", "Segoe UI", ui-sans-serif, sans-serif;
+  --font-body-hr18: "Inter", "Segoe UI", ui-sans-serif, sans-serif;
+
+  background: var(--bg-hr18);
+  color: var(--text-hr18);
+  font-family: var(--font-body-hr18);
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3.5rem 1.5rem;
+}
+
+.f3d-hr18 * {
+  box-sizing: border-box;
+}
+
+.f3d-wrap-hr18 {
+  max-width: 480px;
+  text-align: center;
+}
+
+.f3d-wrap-hr18 h1 {
+  font-family: var(--font-display-hr18);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  margin: 0 0 0.6rem;
+}
+
+.f3d-wrap-hr18 > p {
+  margin: 0 0 1.5rem;
+  color: var(--muted-hr18);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.f3d-open-btn-hr18 {
+  font-family: var(--font-body-hr18);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent-hr18);
+  border: none;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.f3d-open-btn-hr18:hover {
+  filter: brightness(1.08);
+}
+
+/* ==========================================================================
+   The reusable drawer component
+   ========================================================================== */
+
+.f3d-backdrop-hr18 {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 20, 40, 0.35);
+  display: none;
+  z-index: 40;
+  opacity: 0;
+  transition: opacity var(--ease-flip-duration-hr18) ease;
+}
+
+.f3d-backdrop-hr18.is-open-hr18 {
+  display: block;
+}
+
+.f3d-backdrop-hr18.is-visible-hr18 {
+  opacity: 1;
+}
+
+/* perspective must live on an ancestor of the flipping element for the
+   3D rotation to read as depth rather than a flat squash. */
+.f3d-drawer-stage-hr18 {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 41;
+  display: none;
+  perspective: 1400px;
+}
+
+.f3d-drawer-stage-hr18.is-open-hr18 {
+  display: block;
+}
+
+.ease-drawer-3dflip-hr18 {
+  background: var(--panel-hr18);
+  border-bottom: 1px solid var(--border-hr18);
+  box-shadow: 0 30px 60px rgba(15, 20, 40, 0.18);
+  padding: 1.6rem;
+  max-width: 640px;
+  margin: 0 auto;
+  border-radius: 0 0 18px 18px;
+  transform-origin: top center;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+}
+
+.f3d-drawer-stage-hr18.is-open-hr18 .ease-drawer-3dflip-hr18 {
+  animation: ease-3dflip-down-hr18 var(--ease-flip-duration-hr18) var(--ease-flip-easing-hr18) both;
+}
+
+/* The 3D flip: the panel starts rotated back almost flat against the
+   "wall" above the viewport (like a folding sun visor), then rotates
+   down and forward to rest flat, with perspective on the ancestor stage
+   giving it real depth rather than a 2D squash. Starting angle is
+   tunable. */
+@keyframes ease-3dflip-down-hr18 {
+  0% {
+    opacity: 0;
+    transform: rotateX(var(--ease-flip-start-angle-hr18));
+  }
+  100% {
+    opacity: 1;
+    transform: rotateX(0deg);
+  }
+}
+
+.f3d-drawer-head-hr18 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.f3d-drawer-head-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.f3d-close-btn-hr18 {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.f3d-close-btn-hr18:hover {
+  background: var(--accent-hr18);
+  color: #fff;
+}
+
+.f3d-update-hr18 {
+  display: flex;
+  gap: 0.8rem;
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--border-hr18);
+  text-align: left;
+}
+
+.f3d-update-hr18:first-of-type {
+  border-top: none;
+}
+
+.f3d-update-tag-hr18 {
+  flex-shrink: 0;
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  height: fit-content;
+}
+
+.f3d-update-tag-hr18.new {
+  background: var(--accent-soft-hr18);
+  color: var(--accent-hr18);
+}
+
+.f3d-update-tag-hr18.fix {
+  background: #fdeee9;
+  color: #b5432f;
+}
+
+.f3d-update-hr18 h3 {
+  margin: 0 0 0.2rem;
+  font-size: 0.88rem;
+}
+
+.f3d-update-hr18 p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Custom-property tuning note ---------------------------------------------- */
+.f3d-tuning-hr18 {
+  margin-top: 2rem;
+  border: 1px solid var(--border-hr18);
+  background: var(--panel-hr18);
+  border-radius: 14px;
+  padding: 1.25rem 1.4rem;
+  text-align: left;
+}
+
+.f3d-tuning-hr18 h2 {
+  font-family: var(--font-display-hr18);
+  font-size: 1rem;
+  margin: 0 0 0.6rem;
+}
+
+.f3d-tuning-hr18 table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+}
+
+.f3d-tuning-hr18 th,
+.f3d-tuning-hr18 td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-hr18);
+}
+
+.f3d-tuning-hr18 th {
+  color: var(--muted-hr18);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.f3d-tuning-hr18 code {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+  color: var(--accent-hr18);
+}
+
+.f3d-footnote-hr18 {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--muted-hr18);
+}
+
+/* ---- Responsive: full-width panel with tighter padding on narrow screens ----------- */
+@media (max-width: 480px) {
+  .ease-drawer-3dflip-hr18 {
+    padding: 1.2rem;
+    border-radius: 0 0 12px 12px;
+  }
+}
+
+/* ---- Focus & reduced motion --------------------------------------------------------- */
+.f3d-hr18 :focus-visible,
+.ease-drawer-3dflip-hr18 :focus-visible {
+  outline: 2px solid var(--accent-hr18);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .f3d-drawer-stage-hr18.is-open-hr18 .ease-drawer-3dflip-hr18 {
+    animation: none;
+  }
+  .f3d-backdrop-hr18 {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS animated drawer with a "3D-Flip" entrance, styled for
SaaS showcase layouts (a product changelog panel). Opening the drawer
flips it down from the top edge like a folding visor — starting rotated
past -90deg (briefly edge-on) and rotating forward to rest flat, with
perspective on an ancestor "stage" element giving the rotation real
depth. Entrance animation is 100% CSS; open/close/focus-trap is vanilla
JS, no framework.

Resolves #59526

Note for the maintainer: EaseMotion's core already ships an `ease-flip`
entrance class, so all names here are deliberately distinct
(ease-drawer-3dflip-hr18, not ease-flip-*) to avoid any collision.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/flip-drawer-3d-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reusable, pure-CSS "3D-flip" top-hinged drawer with a real focus trap,
tunable via custom properties.

**How does a developer use it?**
```html
<div class="f3d-drawer-stage-hr18" id="stage">
  <div class="ease-drawer-3dflip-hr18" role="dialog" aria-modal="true" aria-labelledby="drawerTitle">
    <!-- content -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
A self-contained interaction with a distinct named animation exposed
entirely through custom properties, matching the issue's ask for pure
CSS transitions/keyframes and zero external JS frameworks, while
avoiding any naming collision with the framework's existing `ease-flip`
class.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
`perspective` deliberately lives on the ancestor stage element, not the
flipping panel — perspective only affects 3D rendering of an element's
children. Tested focus trap, Escape, and backdrop-click in Chrome;
haven't checked other browsers yet.