### PR TITLE
feat: add float-drift modal for SaaS showcase layouts (closes #59519)

### DIFF
--- a/submissions/examples/float-drift-modal-saas-hr18/README.md
+++ b/submissions/examples/float-drift-modal-saas-hr18/README.md
@@ -1,0 +1,109 @@
+# Float-Drift Modal for SaaS Showcase Layouts
+
+A pure CSS/HTML modal that drifts in from an offset position with a soft
+blur and slight tilt, settles into place, then gently bobs in an idle
+float — like it's hovering just above the page. Built for SaaS showcase
+layouts: feature announcements, "what's new" spotlights, upgrade prompts.
+
+No JavaScript is required. Open/close state is driven entirely by the
+**checkbox + `:checked` + general-sibling-selector** pattern: a visually
+hidden `<input type="checkbox">` holds the state, and any `<label for="...">`
+(the trigger button, the backdrop, the close icon) toggles it.
+
+## Files
+
+- `demo.html` — standalone showcase page: a SaaS feature page with a
+  "See it in action" trigger that opens a product-announcement modal
+- `style.css` — the component styles
+- `README.md` — this file
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- 1. The state-driving checkbox — place once, anywhere before the labels/modal -->
+<input type="checkbox" id="fd-toggle" class="fd-toggle" aria-hidden="true" />
+
+<!-- 2. Any trigger is just a label pointing at the checkbox -->
+<label for="fd-toggle" class="fd-trigger">See it in action</label>
+
+<!-- 3. Backdrop — also a label, so clicking the dimmed area closes the modal -->
+<label for="fd-toggle" class="fd-backdrop" aria-hidden="true"></label>
+
+<!-- 4. The modal itself — a SIBLING of the backdrop, not nested inside it,
+        so clicking the modal never also triggers the backdrop's close -->
+<div class="fd-modal" role="dialog" aria-modal="true" aria-labelledby="fd-modal-title">
+  <label for="fd-toggle" class="fd-modal__close" aria-label="Close" tabindex="0">✕</label>
+  <h2 id="fd-modal-title">Automations, reimagined</h2>
+  <!-- modal content -->
+</div>
+```
+
+**Important:** the checkbox, backdrop, and modal must all be **siblings at
+the same DOM level** (the CSS relies on `~`, the general sibling
+combinator). The modal is fixed-positioned and self-centers with its own
+`top: 50%; left: 50%` + transform — it is deliberately *not* nested inside
+the backdrop, so a click landing on the modal's surface never falls through
+to the backdrop label underneath it.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--fd-accent` | `#4f46e5` | Primary accent color (trigger, CTA button, focus ring) |
+| `--fd-accent-hover` | `#4338ca` | Accent color on trigger hover |
+| `--fd-enter-duration` | `620ms` | Duration of the drift-in entrance |
+| `--fd-enter-ease` | `cubic-bezier(0.16, 1, 0.3, 1)` | Smooth-deceleration easing for the entrance |
+| `--fd-backdrop-duration` | `280ms` | Duration of the backdrop fade |
+| `--fd-drift-x` | `-26px` | Horizontal offset the modal drifts in from |
+| `--fd-drift-y` | `34px` | Vertical offset the modal drifts in from |
+| `--fd-drift-rotate` | `-2.5deg` | Slight rotation applied during the entrance |
+| `--fd-float-duration` | `4.5s` | Period of the idle bobbing loop once settled |
+| `--fd-float-distance` | `6px` | How far the modal bobs up/down while idle |
+
+## Features
+
+- **Pure CSS state management**: no JavaScript, no `<dialog>` polyfills —
+  the checkbox hack drives open/closed state, and works with any number of
+  triggers pointing at the same `id`.
+- **Drift-in entrance**: the modal enters from an off-center offset with a
+  soft blur-to-sharp focus pull and a slight rotation that settles to
+  upright — a softer, more organic alternative to a hard pop-in or a
+  straight slide.
+- **Idle float loop**: once settled, the modal keeps a slow, subtle
+  vertical bob (`fd-idle-float`), reinforcing the "floating" feel without
+  being distracting.
+- **Backdrop + click-outside-to-close**: the backdrop is itself a label, so
+  clicking anywhere in the dimmed area closes the modal — no extra markup
+  or scripting needed. Because the modal is a sibling (not a child) of the
+  backdrop, clicks on the modal's content never accidentally close it.
+- **Keyboard operable**: the trigger and close control are focusable labels
+  (`tabindex="0"` on the close icon), and the checkbox itself is
+  tab-reachable, so the modal can be opened and closed with Space/Enter.
+- **Scroll lock**: while open, the checkbox's `:checked` state also
+  constrains the page's scroll via a sibling selector.
+- **Fully responsive**: the modal's width is clamped with `min()` against
+  the viewport, and the drift offset shrinks on small screens so the
+  entrance never overshoots off-screen.
+- **Accessible by default**: uses `role="dialog"`, `aria-modal="true"`, and
+  `aria-labelledby` pointing at the modal heading, and honors
+  `prefers-reduced-motion` by disabling the idle float and collapsing the
+  entrance transition to near-instant.
+
+## Known limitation
+
+Because this is pure CSS with no JavaScript, the modal **cannot close on
+the Escape key** — CSS has no way to listen for keyboard events beyond
+`:focus`/`:checked`. Closing is available via the backdrop click, the close
+icon, or toggling the trigger again. If Escape-to-close is a hard
+requirement for a given project, a few lines of JavaScript (listening for
+`keydown` and un-checking the input) can be layered on top without changing
+any of the CSS here.
+
+## Browser support
+
+Uses `backdrop-filter` and `filter: blur()`, both supported in all current
+evergreen browsers (Chrome/Edge 76+, Firefox 103+, Safari 9+/6+
+respectively). On browsers without `backdrop-filter` support, the backdrop
+still darkens correctly; it just won't blur the page content behind it.

--- a/submissions/examples/float-drift-modal-saas-hr18/demo.html
+++ b/submissions/examples/float-drift-modal-saas-hr18/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Float-Drift Modal — SaaS Showcase Layouts | EaseMotion CSS</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<!-- State-driving checkbox: toggled by any label with for="fd-toggle" -->
+<input type="checkbox" id="fd-toggle" class="fd-toggle" aria-hidden="true" />
+
+<main class="fd-page">
+  <p class="fd-eyebrow">EaseMotion CSS · Showcase</p>
+  <h1 class="fd-title">Float-Drift Modal<br />for SaaS Showcase Layouts</h1>
+  <p class="fd-subtitle">
+    A centered modal that drifts in from an offset with a soft blur and a
+    slight tilt, settles into place, then gently bobs — like it's floating
+    just above the page. Pure CSS state management via the checkbox
+    pattern, no JavaScript required.
+  </p>
+
+  <label for="fd-toggle" class="fd-trigger">
+    See it in action
+  </label>
+
+  <section class="fd-feature-grid">
+    <div class="fd-feature-card">
+      <h3>Real-time sync</h3>
+      <p>Every change reflects across devices in under 200ms.</p>
+    </div>
+    <div class="fd-feature-card">
+      <h3>Smart automations</h3>
+      <p>Trigger workflows without writing a single line of code.</p>
+    </div>
+    <div class="fd-feature-card">
+      <h3>Team analytics</h3>
+      <p>See exactly where your team spends its time, at a glance.</p>
+    </div>
+  </section>
+</main>
+
+<!-- Clicking anywhere in the dimmed area closes the modal (it's just a label) -->
+<label for="fd-toggle" class="fd-backdrop" aria-hidden="true"></label>
+
+<div class="fd-modal" role="dialog" aria-modal="true" aria-labelledby="fd-modal-title">
+  <label for="fd-toggle" class="fd-modal__close" aria-label="Close" tabindex="0">✕</label>
+
+  <p class="fd-modal__eyebrow">New in v2.4</p>
+  <h2 class="fd-modal__title" id="fd-modal-title">Automations, reimagined</h2>
+  <p class="fd-modal__desc">
+    Build multi-step workflows visually, connect them to any integration in
+    your stack, and let them run themselves — no engineering ticket needed.
+  </p>
+
+  <ul class="fd-modal__list">
+    <li>Drag-and-drop workflow builder</li>
+    <li>120+ pre-built integrations</li>
+    <li>Conditional branching &amp; retries</li>
+    <li>Full audit log for every run</li>
+  </ul>
+
+  <a href="#" class="fd-modal__cta">Try it free</a>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/float-drift-modal-saas-hr18/style.css
+++ b/submissions/examples/float-drift-modal-saas-hr18/style.css
@@ -1,0 +1,320 @@
+/* =========================================================
+   EaseMotion CSS — Float-Drift Modal (SaaS Showcase Layouts)
+   Pure CSS/HTML. No JavaScript, no external frameworks.
+   State (open/closed) is driven entirely by the
+   checkbox + :checked + general-sibling-selector pattern.
+   ========================================================= */
+
+:root {
+  /* Palette */
+  --fd-bg: #f6f7fb;
+  --fd-surface: #ffffff;
+  --fd-border: #e4e7ec;
+  --fd-text: #101828;
+  --fd-text-muted: #667085;
+  --fd-accent: #4f46e5;
+  --fd-accent-hover: #4338ca;
+  --fd-accent-soft: #eef2ff;
+  --fd-success: #12b76a;
+
+  /* Motion */
+  --fd-enter-duration: 620ms;
+  --fd-enter-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --fd-backdrop-duration: 280ms;
+  --fd-float-duration: 4.5s;   /* idle drift once settled */
+  --fd-float-distance: 6px;
+  --fd-drift-x: -26px;         /* horizontal drift offset on entrance */
+  --fd-drift-y: 34px;          /* vertical drift offset on entrance */
+  --fd-drift-rotate: -2.5deg;  /* slight rotation on entrance */
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--fd-bg);
+  color: var(--fd-text);
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+/* Hide the state-driving checkbox completely; it's controlled via labels only */
+.fd-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* ---------- Page shell ---------- */
+
+.fd-page {
+  max-width: 840px;
+  margin: 0 auto;
+  padding: 4.5rem 1.5rem 6rem;
+}
+
+.fd-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--fd-accent);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+
+.fd-title {
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  line-height: 1.1;
+  margin: 0 0 0.85rem;
+}
+
+.fd-subtitle {
+  color: var(--fd-text-muted);
+  max-width: 54ch;
+  line-height: 1.65;
+  margin: 0 0 2.25rem;
+}
+
+.fd-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.5rem;
+  background: var(--fd-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.28);
+  transition: background 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+  border: none;
+}
+
+.fd-trigger:hover {
+  background: var(--fd-accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.34);
+}
+
+.fd-feature-grid {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.fd-feature-card {
+  background: var(--fd-surface);
+  border: 1px solid var(--fd-border);
+  border-radius: 12px;
+  padding: 1.1rem;
+}
+
+.fd-feature-card h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.95rem;
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+}
+
+.fd-feature-card p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--fd-text-muted);
+  line-height: 1.55;
+}
+
+/* ---------- Backdrop ---------- */
+
+.fd-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: rgba(16, 24, 40, 0.5);
+  backdrop-filter: blur(3px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  cursor: default;
+  transition: opacity var(--fd-backdrop-duration) ease, visibility 0s linear var(--fd-backdrop-duration);
+}
+
+/* ---------- Modal ---------- */
+/* A sibling of .fd-backdrop (not nested inside it) and fixed-centered on its
+   own, so that clicking the modal itself never lands on the backdrop label
+   underneath — only clicks in the surrounding dimmed area close the modal. */
+
+.fd-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 31;
+  width: min(480px, calc(100vw - 3rem));
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--fd-surface);
+  border: 1px solid var(--fd-border);
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(16, 24, 40, 0.22);
+  padding: 2rem 2rem 2.25rem;
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  filter: blur(6px);
+  /* entrance: drifts in from an offset position with a slight rotation and
+     blur, always centered around the true midpoint via the -50% base */
+  transform:
+    translate(calc(-50% + var(--fd-drift-x)), calc(-50% + var(--fd-drift-y)))
+    rotate(var(--fd-drift-rotate)) scale(0.94);
+  transition:
+    opacity var(--fd-enter-duration) var(--fd-enter-ease),
+    filter var(--fd-enter-duration) var(--fd-enter-ease),
+    transform var(--fd-enter-duration) var(--fd-enter-ease),
+    visibility 0s linear var(--fd-enter-duration);
+  cursor: default;
+}
+
+.fd-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1.1rem;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--fd-text-muted);
+  background: var(--fd-bg);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.fd-modal__close:hover {
+  background: var(--fd-accent-soft);
+  color: var(--fd-accent);
+}
+
+.fd-modal__eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--fd-accent);
+  font-weight: 600;
+  margin: 0 0 0.6rem;
+}
+
+.fd-modal__title {
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.5rem;
+  margin: 0 0 0.6rem;
+}
+
+.fd-modal__desc {
+  color: var(--fd-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.65;
+  margin: 0 0 1.4rem;
+}
+
+.fd-modal__list {
+  list-style: none;
+  margin: 0 0 1.6rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  font-size: 0.88rem;
+  color: var(--fd-text);
+}
+
+.fd-modal__list li::before {
+  content: "✓";
+  color: var(--fd-success);
+  font-weight: 700;
+  margin-right: 0.5rem;
+}
+
+.fd-modal__cta {
+  display: inline-flex;
+  padding: 0.7rem 1.3rem;
+  background: var(--fd-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.88rem;
+  border-radius: 8px;
+  text-decoration: none;
+}
+
+/* ---------- Open state (driven by the checkbox) ---------- */
+
+.fd-toggle:checked ~ .fd-backdrop {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity var(--fd-backdrop-duration) ease;
+}
+
+.fd-toggle:checked ~ .fd-modal {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  filter: blur(0);
+  transform: translate(-50%, -50%) rotate(0deg) scale(1);
+  /* idle float begins once the entrance transition has finished */
+  animation: fd-idle-float var(--fd-float-duration) ease-in-out var(--fd-enter-duration) infinite;
+}
+
+/* Prevent background scroll while the modal is open */
+.fd-toggle:checked ~ .fd-page {
+  max-height: 100vh;
+  overflow: hidden;
+}
+
+@keyframes fd-idle-float {
+  0%, 100% {
+    transform: translate(-50%, -50%);
+  }
+  50% {
+    transform: translate(-50%, calc(-50% - var(--fd-float-distance)));
+  }
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 560px) {
+  .fd-modal {
+    padding: 1.6rem 1.5rem 1.85rem;
+    border-radius: 16px;
+    max-height: 90vh;
+  }
+  :root {
+    --fd-drift-y: 22px;
+    --fd-drift-x: -14px;
+  }
+}
+
+/* ---------- Accessibility: prefers-reduced-motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .fd-modal,
+  .fd-backdrop,
+  .fd-trigger {
+    transition-duration: 1ms !important;
+  }
+  .fd-toggle:checked ~ .fd-modal {
+    animation: none;
+    filter: none;
+  }
+  .fd-trigger:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new pure-CSS showcase example: a Float-Drift Modal for SaaS Showcase Layouts (closes #59519). The modal drifts in from an offset with a soft blur and slight tilt, settles into place, then gently bobs in an idle float loop — no JavaScript required.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/float-drift-modal-saas-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A centered modal component that drifts, blurs, and tilts into view on open, then idles with a slow vertical bob, giving it a "floating" feel rather than a hard pop-in.

**How does a developer use it?**
```html
<input type="checkbox" id="fd-toggle" class="fd-toggle" aria-hidden="true" />
<label for="fd-toggle" class="fd-trigger">See it in action</label>
<label for="fd-toggle" class="fd-backdrop" aria-hidden="true"></label>
<div class="fd-modal" role="dialog" aria-modal="true" aria-labelledby="fd-modal-title">
  <label for="fd-toggle" class="fd-modal__close" aria-label="Close" tabindex="0">✕</label>
  <h2 id="fd-modal-title">Automations, reimagined</h2>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS state management (checkbox + `:checked` + sibling selectors, no JS), human-readable class names (`fd-modal`, `fd-modal__close`, `fd-trigger`), and an animation-first entrance/idle-loop pairing that matches the framework's philosophy of expressive motion without JS overhead.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Uses `backdrop-filter` and `filter: blur()` — both supported in current evergreen browsers, with graceful degradation (no blur, but correct dimming) on older ones. Deliberately kept the modal as a DOM sibling of the backdrop (not nested inside it) so clicks on the modal content don't fall through and accidentally close it — worth a look if you're used to seeing modals nested inside their overlay. As noted in the README, Escape-to-close isn't possible in pure CSS; happy to add a minimal JS enhancement layer if that's a hard requirement.