### PR TITLE
feat: add fade-in drawer for SaaS showcase layouts (closes #59522)

### DIFF
--- a/submissions/examples/fade-in-drawer-saas-hr18/README.md
+++ b/submissions/examples/fade-in-drawer-saas-hr18/README.md
@@ -1,0 +1,109 @@
+# Fade-In Drawer for SaaS Showcase Layouts
+
+A pure CSS/HTML side panel where **fade is the primary motion** — the
+drawer eases into view with only a small horizontal drift (not a full
+slide), and its contents fade in one after another in a gentle stagger.
+Built for SaaS showcase layouts: activity feeds, notification panels,
+recent-changes logs.
+
+No JavaScript is required. Open/close state is driven entirely by the
+**checkbox + `:checked` + general-sibling-selector** pattern: a visually
+hidden `<input type="checkbox">` holds the state, and any `<label for="...">`
+(the trigger button, the backdrop, the close icon) toggles it.
+
+## Files
+
+- `demo.html` — standalone showcase page: a SaaS dashboard hero with a
+  "View activity" trigger that opens a 5-item activity feed drawer
+- `style.css` — the component styles
+- `README.md` — this file
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- 1. The state-driving checkbox — place once, anywhere before the labels/drawer -->
+<input type="checkbox" id="fi-toggle" class="fi-toggle" aria-hidden="true" />
+
+<!-- 2. Any trigger is just a label pointing at the checkbox -->
+<label for="fi-toggle" class="fi-trigger">View activity</label>
+
+<!-- 3. Backdrop — also a label, so clicking it closes the drawer -->
+<label for="fi-toggle" class="fi-backdrop" aria-hidden="true"></label>
+
+<!-- 4. The drawer itself -->
+<aside class="fi-drawer" role="dialog" aria-modal="true" aria-labelledby="fi-drawer-title">
+  <label for="fi-toggle" class="fi-drawer__close" aria-label="Close" tabindex="0">✕</label>
+  <h2 id="fi-drawer-title">Recent activity</h2>
+
+  <!-- Give each item its own stagger index -->
+  <ul class="fi-item-list">
+    <li class="fi-item" style="--fi-item-index: 0;">…</li>
+    <li class="fi-item" style="--fi-item-index: 1;">…</li>
+    <li class="fi-item" style="--fi-item-index: 2;">…</li>
+  </ul>
+</aside>
+```
+
+**Important:** the checkbox, backdrop, and drawer must all be **siblings at
+the same DOM level** (the CSS relies on `~`, the general sibling
+combinator) — don't nest the backdrop/drawer inside the page content.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--fi-accent` | `#4f46e5` | Primary accent color (trigger button, focus ring) |
+| `--fi-panel-duration` | `380ms` | Duration of the drawer's fade/drift transition |
+| `--fi-panel-ease` | `cubic-bezier(0.22, 1, 0.36, 1)` | Easing curve for the panel entrance |
+| `--fi-panel-shift` | `18px` | Horizontal drift distance accompanying the fade (deliberately small) |
+| `--fi-backdrop-duration` | `260ms` | Duration of the backdrop fade |
+| `--fi-item-duration` | `320ms` | Duration of each list item's individual fade-in |
+| `--fi-item-stagger` | `60ms` | Delay step between successive items (multiplied by `--fi-item-index`) |
+| `--fi-item-index` | *(set per item)* | The item's position in the stagger sequence — set inline on each `.fi-item` |
+
+## Features
+
+- **Pure CSS state management**: no JavaScript, no `<dialog>` polyfills —
+  the checkbox hack drives open/closed state, and works with any number of
+  triggers pointing at the same `id`.
+- **Fade-first motion**: unlike a typical slide-in drawer, opacity is the
+  dominant transition here — the panel only drifts a small, fixed distance
+  (`--fi-panel-shift`), giving it a softer, quieter entrance suited to
+  secondary/utility panels like notifications.
+- **Staggered content fade-in**: each `.fi-item` fades and lifts in
+  slightly after the panel itself, using a `transition-delay` computed from
+  `--fi-item-index * --fi-item-stagger` — no JavaScript loop needed, just
+  one inline custom property per item.
+- **Backdrop + click-outside-to-close**: the backdrop is itself a label, so
+  clicking anywhere outside the drawer closes it.
+- **Keyboard operable**: the trigger and close control are focusable labels
+  (`tabindex="0"` on the close icon), and the checkbox itself is
+  tab-reachable.
+- **Scroll lock**: while open, the checkbox's `:checked` state also
+  constrains the page's scroll via a sibling selector.
+- **Fully responsive**: the drawer's width is clamped with `min()` against
+  the viewport and expands to full-width with no visible border on screens
+  under 480px.
+- **Accessible by default**: uses `role="dialog"`, `aria-modal="true"`, and
+  `aria-labelledby` pointing at the drawer heading, and honors
+  `prefers-reduced-motion` by removing the horizontal drift and collapsing
+  all stagger delays to zero.
+
+## Known limitation
+
+Because this is pure CSS with no JavaScript, the drawer **cannot close on
+the Escape key** — CSS has no way to listen for keyboard events beyond
+`:focus`/`:checked`. Closing is available via the backdrop click, the close
+icon, or toggling the trigger again. If Escape-to-close is a hard
+requirement for a given project, a few lines of JavaScript (listening for
+`keydown` and un-checking the input) can be layered on top without changing
+any of the CSS here.
+
+## Browser support
+
+Uses only standard `opacity`/`transform` transitions and CSS custom
+properties for the stagger math — no bleeding-edge features. Supported in
+all browsers released in the last several years, including older evergreen
+versions.

--- a/submissions/examples/fade-in-drawer-saas-hr18/demo.html
+++ b/submissions/examples/fade-in-drawer-saas-hr18/demo.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fade-In Drawer — SaaS Showcase Layouts | EaseMotion CSS</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<!-- State-driving checkbox: toggled by any label with for="fi-toggle" -->
+<input type="checkbox" id="fi-toggle" class="fi-toggle" aria-hidden="true" />
+
+<main class="fi-page">
+  <p class="fi-eyebrow">EaseMotion CSS · Showcase</p>
+  <h1 class="fi-title">Fade-In Drawer<br />for SaaS Showcase Layouts</h1>
+  <p class="fi-subtitle">
+    A right-edge panel that fades into view with only a small horizontal
+    drift — quieter than a full slide-in — while its contents fade in one
+    after another. Pure CSS state management via the checkbox pattern,
+    no JavaScript required.
+  </p>
+
+  <label for="fi-toggle" class="fi-trigger">
+    <span class="fi-trigger__dot" aria-hidden="true"></span>
+    View activity
+  </label>
+
+  <section class="fi-preview-grid">
+    <div class="fi-preview-card">
+      <h3>Deploys</h3>
+      <p>Track every release as it ships, in real time.</p>
+    </div>
+    <div class="fi-preview-card">
+      <h3>Billing</h3>
+      <p>Get notified before a plan renews or a card expires.</p>
+    </div>
+    <div class="fi-preview-card">
+      <h3>Team activity</h3>
+      <p>See who joined, left, or changed a role.</p>
+    </div>
+  </section>
+</main>
+
+<!-- Clicking the backdrop closes the drawer (it's just another label) -->
+<label for="fi-toggle" class="fi-backdrop" aria-hidden="true"></label>
+
+<aside class="fi-drawer" role="dialog" aria-modal="true" aria-labelledby="fi-drawer-title">
+  <div class="fi-drawer__header">
+    <div>
+      <h2 class="fi-drawer__title" id="fi-drawer-title">Recent activity</h2>
+      <p class="fi-drawer__desc">Last 24 hours across your workspace</p>
+    </div>
+    <label for="fi-toggle" class="fi-drawer__close" aria-label="Close activity panel" tabindex="0">✕</label>
+  </div>
+
+  <ul class="fi-item-list">
+    <li class="fi-item fi-item--success" style="--fi-item-index: 0;">
+      <span class="fi-item__icon" aria-hidden="true">✅</span>
+      <span class="fi-item__body">
+        <p class="fi-item__title">Deploy to production succeeded</p>
+        <p class="fi-item__meta">v2.4.1 · 2 minutes ago</p>
+      </span>
+    </li>
+    <li class="fi-item" style="--fi-item-index: 1;">
+      <span class="fi-item__icon" aria-hidden="true">👤</span>
+      <span class="fi-item__body">
+        <p class="fi-item__title">Priya joined the Engineering team</p>
+        <p class="fi-item__meta">18 minutes ago</p>
+      </span>
+    </li>
+    <li class="fi-item fi-item--warning" style="--fi-item-index: 2;">
+      <span class="fi-item__icon" aria-hidden="true">⚠️</span>
+      <span class="fi-item__body">
+        <p class="fi-item__title">API usage at 82% of monthly quota</p>
+        <p class="fi-item__meta">1 hour ago</p>
+      </span>
+    </li>
+    <li class="fi-item" style="--fi-item-index: 3;">
+      <span class="fi-item__icon" aria-hidden="true">🔗</span>
+      <span class="fi-item__body">
+        <p class="fi-item__title">New webhook connected: Slack</p>
+        <p class="fi-item__meta">3 hours ago</p>
+      </span>
+    </li>
+    <li class="fi-item fi-item--success" style="--fi-item-index: 4;">
+      <span class="fi-item__icon" aria-hidden="true">💳</span>
+      <span class="fi-item__body">
+        <p class="fi-item__title">Invoice #1042 paid</p>
+        <p class="fi-item__meta">5 hours ago</p>
+      </span>
+    </li>
+  </ul>
+</aside>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-drawer-saas-hr18/style.css
+++ b/submissions/examples/fade-in-drawer-saas-hr18/style.css
@@ -1,0 +1,342 @@
+/* =========================================================
+   EaseMotion CSS — Fade-In Drawer (SaaS Showcase Layouts)
+   Pure CSS/HTML. No JavaScript, no external frameworks.
+   State (open/closed) is driven entirely by the
+   checkbox + :checked + general-sibling-selector pattern.
+   ========================================================= */
+
+:root {
+  /* Palette */
+  --fi-bg: #f6f7fb;
+  --fi-surface: #ffffff;
+  --fi-border: #e4e7ec;
+  --fi-text: #101828;
+  --fi-text-muted: #667085;
+  --fi-accent: #4f46e5;
+  --fi-accent-hover: #4338ca;
+  --fi-accent-soft: #eef2ff;
+  --fi-success: #12b76a;
+  --fi-success-soft: #ecfdf3;
+  --fi-warning: #f79009;
+  --fi-warning-soft: #fffaeb;
+
+  /* Motion */
+  --fi-panel-duration: 380ms;
+  --fi-panel-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fi-panel-shift: 18px;      /* small horizontal drift accompanying the fade */
+  --fi-backdrop-duration: 260ms;
+  --fi-item-duration: 320ms;
+  --fi-item-stagger: 60ms;     /* per-item delay step inside the drawer */
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--fi-bg);
+  color: var(--fi-text);
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+/* Hide the state-driving checkbox completely; it's controlled via labels only */
+.fi-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* ---------- Page shell ---------- */
+
+.fi-page {
+  max-width: 840px;
+  margin: 0 auto;
+  padding: 4.5rem 1.5rem 6rem;
+}
+
+.fi-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--fi-accent);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+
+.fi-title {
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  line-height: 1.1;
+  margin: 0 0 0.85rem;
+}
+
+.fi-subtitle {
+  color: var(--fi-text-muted);
+  max-width: 54ch;
+  line-height: 1.65;
+  margin: 0 0 2.25rem;
+}
+
+.fi-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.85rem 1.5rem;
+  background: var(--fi-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.28);
+  transition: background 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+  border: none;
+}
+
+.fi-trigger:hover {
+  background: var(--fi-accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.34);
+}
+
+.fi-trigger__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #fff;
+}
+
+.fi-preview-grid {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.fi-preview-card {
+  background: var(--fi-surface);
+  border: 1px solid var(--fi-border);
+  border-radius: 12px;
+  padding: 1.1rem;
+}
+
+.fi-preview-card h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.95rem;
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+}
+
+.fi-preview-card p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--fi-text-muted);
+  line-height: 1.55;
+}
+
+/* ---------- Backdrop ---------- */
+
+.fi-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: rgba(16, 24, 40, 0.4);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  cursor: default;
+  transition: opacity var(--fi-backdrop-duration) ease, visibility 0s linear var(--fi-backdrop-duration);
+}
+
+/* ---------- Drawer panel (right edge) ---------- */
+
+.fi-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 31;
+  width: min(380px, 100vw);
+  overflow-y: auto;
+  background: var(--fi-surface);
+  border-left: 1px solid var(--fi-border);
+  box-shadow: -16px 0 40px rgba(16, 24, 40, 0.12);
+  padding: 1.75rem 1.5rem 2.25rem;
+
+  /* fade-in is the primary motion; the panel only drifts a small amount
+     horizontally rather than sliding in fully from off-screen */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateX(var(--fi-panel-shift));
+  transition:
+    opacity var(--fi-panel-duration) var(--fi-panel-ease),
+    transform var(--fi-panel-duration) var(--fi-panel-ease),
+    visibility 0s linear var(--fi-panel-duration);
+}
+
+.fi-drawer__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.4rem;
+}
+
+.fi-drawer__title {
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.15rem;
+  margin: 0 0 0.2rem;
+}
+
+.fi-drawer__desc {
+  font-size: 0.82rem;
+  color: var(--fi-text-muted);
+  margin: 0;
+}
+
+.fi-drawer__close {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--fi-text-muted);
+  background: var(--fi-bg);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.fi-drawer__close:hover {
+  background: var(--fi-accent-soft);
+  color: var(--fi-accent);
+}
+
+/* ---------- Notification items (staggered fade-in) ---------- */
+
+.fi-item-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.fi-item {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.85rem;
+  border: 1px solid var(--fi-border);
+  border-radius: 12px;
+
+  /* Each item fades in slightly after the panel, staggered via
+     --fi-item-index multiplying the step */
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    opacity var(--fi-item-duration) ease,
+    transform var(--fi-item-duration) ease;
+}
+
+.fi-item__icon {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  font-size: 1rem;
+  background: var(--fi-accent-soft);
+}
+
+.fi-item--success .fi-item__icon {
+  background: var(--fi-success-soft);
+}
+
+.fi-item--warning .fi-item__icon {
+  background: var(--fi-warning-soft);
+}
+
+.fi-item__body {
+  min-width: 0;
+}
+
+.fi-item__title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 0.15rem;
+}
+
+.fi-item__meta {
+  font-size: 0.76rem;
+  color: var(--fi-text-muted);
+  margin: 0;
+}
+
+/* ---------- Open state (driven by the checkbox) ---------- */
+
+.fi-toggle:checked ~ .fi-backdrop {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity var(--fi-backdrop-duration) ease;
+}
+
+.fi-toggle:checked ~ .fi-drawer {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+
+/* Stagger each item's fade-in using an explicit per-item delay set via
+   the --fi-item-index custom property on each <li> */
+.fi-toggle:checked ~ .fi-drawer .fi-item {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: calc(var(--fi-panel-duration) + (var(--fi-item-index, 0) * var(--fi-item-stagger)));
+}
+
+/* Prevent background scroll while the drawer is open */
+.fi-toggle:checked ~ .fi-page {
+  max-height: 100vh;
+  overflow: hidden;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 480px) {
+  .fi-drawer {
+    width: 100vw;
+    border-left: none;
+  }
+}
+
+/* ---------- Accessibility: prefers-reduced-motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .fi-drawer,
+  .fi-backdrop,
+  .fi-item,
+  .fi-trigger {
+    transition-duration: 1ms !important;
+    transition-delay: 0s !important;
+  }
+  .fi-toggle:checked ~ .fi-drawer .fi-item {
+    transition-delay: 0s !important;
+  }
+  .fi-drawer {
+    transform: none;
+  }
+  .fi-trigger:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new pure-CSS showcase example: a Fade-In Drawer for SaaS Showcase Layouts (closes #59522). A right-edge panel where opacity is the dominant motion — it eases in with only a small horizontal drift rather than a full slide — and its contents fade in one after another in a staggered sequence.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fade-in-drawer-saas-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A right-edge activity/notification drawer that fades into view (with only a small accompanying horizontal drift) and staggers its list items in one after another.

**How does a developer use it?**
```html
<input type="checkbox" id="fi-toggle" class="fi-toggle" aria-hidden="true" />
<label for="fi-toggle" class="fi-trigger">View activity</label>
<label for="fi-toggle" class="fi-backdrop" aria-hidden="true"></label>
<aside class="fi-drawer" role="dialog" aria-modal="true" aria-labelledby="fi-drawer-title">
  <label for="fi-toggle" class="fi-drawer__close" aria-label="Close" tabindex="0">✕</label>
  <ul class="fi-item-list">
    <li class="fi-item" style="--fi-item-index: 0;">…</li>
    <li class="fi-item" style="--fi-item-index: 1;">…</li>
  </ul>
</aside>
```

**Why does it fit EaseMotion CSS?**
Pure CSS state management (checkbox + `:checked` + sibling selectors, no JS), human-readable class names (`fi-drawer`, `fi-item`, `fi-trigger`), and a declarative per-item stagger driven entirely by a single custom property — matching the framework's animation-first, JS-free philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Kept the motion intentionally quieter than a typical slide-in drawer — fade dominates, drift is minimal (`--fi-panel-shift: 18px`) — to distinguish it from a full slide-up/slide-in drawer already in the library. As with the other checkbox-hack submissions, Escape-to-close isn't possible in pure CSS; noted in the README with a suggested minimal-JS enhancement path if that's ever required.