### PR TITLE
feat: add skew-active drawer for SaaS showcase layouts (closes #59520)

### DIFF
--- a/submissions/examples/skew-active-drawer-saas-hr18/README.md
+++ b/submissions/examples/skew-active-drawer-saas-hr18/README.md
@@ -1,0 +1,107 @@
+# Skew-Active Drawer for SaaS Showcase Layouts
+
+A pure CSS/HTML bottom drawer that leans into a slight skew as it opens —
+as if it has real momentum — then snaps upright with a small counter-lean
+before settling flat. The trigger button echoes the same lean on
+`:active`, tying the "press" and the "open" motions together. Built for
+SaaS showcase layouts: onboarding checklists, setup wizards, guided
+walkthroughs.
+
+No JavaScript is required. Open/close state is driven entirely by the
+**checkbox + `:checked` + general-sibling-selector** pattern: a visually
+hidden `<input type="checkbox">` holds the state, and any `<label for="...">`
+(the trigger button, the backdrop, the close icon) toggles it.
+
+## Files
+
+- `demo.html` — standalone showcase page: a SaaS onboarding hero with a
+  "Start onboarding" trigger that opens a 3-step setup drawer
+- `style.css` — the component styles
+- `README.md` — this file
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- 1. The state-driving checkbox — place once, anywhere before the labels/drawer -->
+<input type="checkbox" id="sk-toggle" class="sk-toggle" aria-hidden="true" />
+
+<!-- 2. Any trigger is just a label pointing at the checkbox -->
+<label for="sk-toggle" class="sk-trigger">Start onboarding</label>
+
+<!-- 3. Backdrop — also a label, so clicking it closes the drawer -->
+<label for="sk-toggle" class="sk-backdrop" aria-hidden="true"></label>
+
+<!-- 4. The drawer itself -->
+<aside class="sk-drawer" role="dialog" aria-modal="true" aria-labelledby="sk-drawer-title">
+  <div class="sk-drawer__handle" aria-hidden="true"></div>
+  <label for="sk-toggle" class="sk-drawer__close" aria-label="Close" tabindex="0">✕</label>
+  <h2 id="sk-drawer-title">Get set up in 3 steps</h2>
+  <!-- drawer content -->
+</aside>
+```
+
+**Important:** the checkbox, backdrop, and drawer must all be **siblings at
+the same DOM level** (the CSS relies on `~`, the general sibling
+combinator) — don't nest the backdrop/drawer inside the page content.
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--sk-accent` | `#4f46e5` | Primary accent color (trigger, step numbers, focus ring) |
+| `--sk-open-duration` | `520ms` | Duration of the opening keyframe animation (translate + skew) |
+| `--sk-close-duration` | `260ms` | Duration of the plain closing transition |
+| `--sk-skew-angle` | `5deg` | How far the drawer leans mid-open, at its peak momentum |
+| `--sk-skew-overshoot` | `-1.2deg` | Small counter-lean applied just before the drawer settles upright |
+| `--sk-backdrop-duration` | `260ms` | Duration of the backdrop fade |
+| `--sk-press-skew` | `-3deg` | How far the trigger button itself leans on `:active` (mouse/touch press) |
+
+## Features
+
+- **Pure CSS state management**: no JavaScript, no `<dialog>` polyfills —
+  the checkbox hack drives open/closed state, and works with any number of
+  triggers pointing at the same `id`.
+- **Momentum-style skew entrance**: the drawer's opening motion is a single
+  keyframe animation (`sk-drawer-open`) that combines a vertical slide with
+  a skew that builds, overshoots slightly past upright, and then settles —
+  evoking real physical momentum rather than a flat linear slide.
+  `transform-origin: bottom center` keeps the skew anchored naturally at
+  the drawer's base.
+- **Matching press feedback**: the trigger button itself skews on
+  `:active`, so the "launch" gesture visually rhymes with the drawer's own
+  entrance.
+- **Calm exit**: closing uses a plain, quick transition back to
+  `translateY(100%)` with no skew — the drawer only "leans" on the way in,
+  keeping the exit understated.
+- **Backdrop + click-outside-to-close**: the backdrop is itself a label, so
+  clicking anywhere outside the drawer closes it.
+- **Keyboard operable**: the trigger and close control are focusable labels
+  (`tabindex="0"` on the close icon), and the checkbox itself is
+  tab-reachable.
+- **Scroll lock**: while open, the checkbox's `:checked` state also
+  constrains the page's scroll via a sibling selector.
+- **Fully responsive**: the drawer's max-width and padding scale down for
+  mobile, and the skew angle itself is reduced on small screens
+  (`--sk-skew-angle: 3deg`) so it stays subtle on narrow viewports.
+- **Accessible by default**: uses `role="dialog"`, `aria-modal="true"`, and
+  `aria-labelledby` pointing at the drawer heading, and honors
+  `prefers-reduced-motion` by disabling the keyframe animation and the
+  trigger's press-skew entirely.
+
+## Known limitation
+
+Because this is pure CSS with no JavaScript, the drawer **cannot close on
+the Escape key** — CSS has no way to listen for keyboard events beyond
+`:focus`/`:checked`. Closing is available via the backdrop click, the close
+icon, or toggling the trigger again. If Escape-to-close is a hard
+requirement for a given project, a few lines of JavaScript (listening for
+`keydown` and un-checking the input) can be layered on top without changing
+any of the CSS here.
+
+## Browser support
+
+Uses only standard `transform: skewY()`/`translateY()` and CSS keyframe
+animations — no bleeding-edge features. Supported in all browsers released
+in the last several years, including older evergreen versions.

--- a/submissions/examples/skew-active-drawer-saas-hr18/demo.html
+++ b/submissions/examples/skew-active-drawer-saas-hr18/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Skew-Active Drawer — SaaS Showcase Layouts | EaseMotion CSS</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<!-- State-driving checkbox: toggled by any label with for="sk-toggle" -->
+<input type="checkbox" id="sk-toggle" class="sk-toggle" aria-hidden="true" />
+
+<main class="sk-page">
+  <p class="sk-eyebrow">EaseMotion CSS · Showcase</p>
+  <h1 class="sk-title">Skew-Active Drawer<br />for SaaS Showcase Layouts</h1>
+  <p class="sk-subtitle">
+    A bottom drawer that leans into a slight skew as it opens — as if it
+    has real momentum — then snaps upright with a small counter-lean
+    before settling. The trigger button itself echoes the same lean when
+    pressed. Pure CSS, no JavaScript required.
+  </p>
+
+  <label for="sk-toggle" class="sk-trigger">
+    Start onboarding
+  </label>
+
+  <section class="sk-preview-grid">
+    <div class="sk-preview-card">
+      <h3>Guided setup</h3>
+      <p>A short checklist to get your workspace production-ready.</p>
+    </div>
+    <div class="sk-preview-card">
+      <h3>Import data</h3>
+      <p>Bring in existing records from a CSV or another tool.</p>
+    </div>
+    <div class="sk-preview-card">
+      <h3>Invite your team</h3>
+      <p>Add teammates and assign roles before you go live.</p>
+    </div>
+  </section>
+</main>
+
+<!-- Clicking the backdrop closes the drawer (it's just another label) -->
+<label for="sk-toggle" class="sk-backdrop" aria-hidden="true"></label>
+
+<aside class="sk-drawer" role="dialog" aria-modal="true" aria-labelledby="sk-drawer-title">
+  <div class="sk-drawer__handle" aria-hidden="true"></div>
+  <label for="sk-toggle" class="sk-drawer__close" aria-label="Close onboarding steps" tabindex="0">✕</label>
+
+  <h2 class="sk-drawer__title" id="sk-drawer-title">Get set up in 3 steps</h2>
+  <p class="sk-drawer__desc">You can pause and come back to this anytime from Settings.</p>
+
+  <ul class="sk-step-list">
+    <li class="sk-step">
+      <span class="sk-step__num" aria-hidden="true">1</span>
+      <span>
+        <p class="sk-step__title">Create your workspace</p>
+        <p class="sk-step__desc">Name it and pick a plan — you can change this later.</p>
+      </span>
+    </li>
+    <li class="sk-step">
+      <span class="sk-step__num" aria-hidden="true">2</span>
+      <span>
+        <p class="sk-step__title">Connect your tools</p>
+        <p class="sk-step__desc">Link Slack, GitHub, or your CRM in a couple of clicks.</p>
+      </span>
+    </li>
+    <li class="sk-step">
+      <span class="sk-step__num" aria-hidden="true">3</span>
+      <span>
+        <p class="sk-step__title">Invite your team</p>
+        <p class="sk-step__desc">Send invites now, or skip and do it later.</p>
+      </span>
+    </li>
+  </ul>
+</aside>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-drawer-saas-hr18/style.css
+++ b/submissions/examples/skew-active-drawer-saas-hr18/style.css
@@ -1,0 +1,330 @@
+/* =========================================================
+   EaseMotion CSS — Skew-Active Drawer (SaaS Showcase Layouts)
+   Pure CSS/HTML. No JavaScript, no external frameworks.
+   State (open/closed) is driven entirely by the
+   checkbox + :checked + general-sibling-selector pattern.
+   ========================================================= */
+
+:root {
+  /* Palette */
+  --sk-bg: #f6f7fb;
+  --sk-surface: #ffffff;
+  --sk-border: #e4e7ec;
+  --sk-text: #101828;
+  --sk-text-muted: #667085;
+  --sk-accent: #4f46e5;
+  --sk-accent-hover: #4338ca;
+  --sk-accent-soft: #eef2ff;
+  --sk-success: #12b76a;
+
+  /* Motion */
+  --sk-open-duration: 520ms;
+  --sk-close-duration: 260ms;
+  --sk-skew-angle: 5deg;       /* how far the drawer leans mid-motion */
+  --sk-skew-overshoot: -1.2deg;/* small counter-lean before settling upright */
+  --sk-backdrop-duration: 260ms;
+  --sk-press-skew: -3deg;      /* trigger's own "pressed" skew on :active */
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--sk-bg);
+  color: var(--sk-text);
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+/* Hide the state-driving checkbox completely; it's controlled via labels only */
+.sk-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* ---------- Page shell ---------- */
+
+.sk-page {
+  max-width: 840px;
+  margin: 0 auto;
+  padding: 4.5rem 1.5rem 8rem;
+}
+
+.sk-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--sk-accent);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+
+.sk-title {
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 4.5vw, 3rem);
+  line-height: 1.1;
+  margin: 0 0 0.85rem;
+}
+
+.sk-subtitle {
+  color: var(--sk-text-muted);
+  max-width: 54ch;
+  line-height: 1.65;
+  margin: 0 0 2.25rem;
+}
+
+.sk-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.5rem;
+  background: var(--sk-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.28);
+  transition: background 180ms ease, transform 140ms ease, box-shadow 180ms ease;
+  border: none;
+  transform: skewX(0deg);
+}
+
+.sk-trigger:hover {
+  background: var(--sk-accent-hover);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.34);
+}
+
+/* The trigger itself leans slightly on press, echoing the drawer's motion */
+.sk-trigger:active {
+  transform: skewX(var(--sk-press-skew));
+}
+
+.sk-preview-grid {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.sk-preview-card {
+  background: var(--sk-surface);
+  border: 1px solid var(--sk-border);
+  border-radius: 12px;
+  padding: 1.1rem;
+}
+
+.sk-preview-card h3 {
+  margin: 0 0 0.3rem;
+  font-size: 0.95rem;
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+}
+
+.sk-preview-card p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--sk-text-muted);
+  line-height: 1.55;
+}
+
+/* ---------- Backdrop ---------- */
+
+.sk-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: rgba(16, 24, 40, 0.42);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  cursor: default;
+  transition: opacity var(--sk-backdrop-duration) ease, visibility 0s linear var(--sk-backdrop-duration);
+}
+
+/* ---------- Drawer (bottom edge) ---------- */
+
+.sk-drawer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 31;
+  max-width: 620px;
+  margin: 0 auto;
+  max-height: min(78vh, 600px);
+  overflow-y: auto;
+  background: var(--sk-surface);
+  border: 1px solid var(--sk-border);
+  border-bottom: none;
+  border-radius: 18px 18px 0 0;
+  box-shadow: 0 -14px 40px rgba(16, 24, 40, 0.18);
+  padding: 1.75rem 1.75rem 2.25rem;
+
+  transform-origin: bottom center;
+  transform: translateY(100%) skewY(0deg);
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    transform var(--sk-close-duration) ease,
+    visibility 0s linear var(--sk-close-duration);
+}
+
+.sk-drawer__handle {
+  width: 44px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--sk-border);
+  margin: 0 auto 1.1rem;
+}
+
+.sk-drawer__close {
+  position: absolute;
+  top: 1.1rem;
+  right: 1.25rem;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--sk-text-muted);
+  background: var(--sk-bg);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.sk-drawer__close:hover {
+  background: var(--sk-accent-soft);
+  color: var(--sk-accent);
+}
+
+.sk-drawer__title {
+  font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 1.3rem;
+  margin: 0 0 0.4rem;
+}
+
+.sk-drawer__desc {
+  color: var(--sk-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0 0 1.4rem;
+}
+
+.sk-step-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.sk-step {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.9rem;
+  border: 1px solid var(--sk-border);
+  border-radius: 12px;
+}
+
+.sk-step__num {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  background: var(--sk-accent-soft);
+  color: var(--sk-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+}
+
+.sk-step__title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  margin: 0 0 0.15rem;
+}
+
+.sk-step__desc {
+  font-size: 0.8rem;
+  color: var(--sk-text-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ---------- Open state (driven by the checkbox) ---------- */
+
+.sk-toggle:checked ~ .sk-backdrop {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity var(--sk-backdrop-duration) ease;
+}
+
+.sk-toggle:checked ~ .sk-drawer {
+  visibility: visible;
+  pointer-events: auto;
+  transition: visibility 0s linear 0s;
+  animation: sk-drawer-open var(--sk-open-duration) cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* Prevent background scroll while the drawer is open */
+.sk-toggle:checked ~ .sk-page {
+  max-height: 100vh;
+  overflow: hidden;
+}
+
+@keyframes sk-drawer-open {
+  0% {
+    transform: translateY(100%) skewY(0deg);
+  }
+  55% {
+    transform: translateY(0%) skewY(calc(-1 * var(--sk-skew-angle)));
+  }
+  80% {
+    transform: translateY(0%) skewY(var(--sk-skew-overshoot));
+  }
+  100% {
+    transform: translateY(0%) skewY(0deg);
+  }
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 560px) {
+  .sk-drawer {
+    max-height: 85vh;
+    border-radius: 14px 14px 0 0;
+    padding: 1.5rem 1.25rem 2rem;
+  }
+  :root {
+    --sk-skew-angle: 3deg;
+  }
+}
+
+/* ---------- Accessibility: prefers-reduced-motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .sk-drawer,
+  .sk-backdrop,
+  .sk-trigger {
+    transition-duration: 1ms !important;
+  }
+  .sk-toggle:checked ~ .sk-drawer {
+    animation: none;
+    transform: translateY(0) skewY(0deg);
+  }
+  .sk-trigger:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a new pure-CSS showcase example: a Skew-Active Drawer for SaaS Showcase Layouts (closes #59520). A bottom drawer that leans into a slight skew as it opens — like it has real momentum — then snaps upright with a small counter-lean before settling flat. No JavaScript required.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/skew-active-drawer-saas-hr18/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A bottom-sheet onboarding drawer whose opening motion combines a vertical slide with a skew that builds, overshoots slightly past upright, then settles — giving it a sense of real momentum rather than a flat linear slide.

**How does a developer use it?**
```html
<input type="checkbox" id="sk-toggle" class="sk-toggle" aria-hidden="true" />
<label for="sk-toggle" class="sk-trigger">Start onboarding</label>
<label for="sk-toggle" class="sk-backdrop" aria-hidden="true"></label>
<aside class="sk-drawer" role="dialog" aria-modal="true" aria-labelledby="sk-drawer-title">
  <label for="sk-toggle" class="sk-drawer__close" aria-label="Close" tabindex="0">✕</label>
  <h2 id="sk-drawer-title">Get set up in 3 steps</h2>
</aside>
```

**Why does it fit EaseMotion CSS?**
Pure CSS state management (checkbox + `:checked` + sibling selectors, no JS), human-readable class names (`sk-drawer`, `sk-trigger`, `sk-step`), and a single expressive keyframe animation that captures physical momentum — matching the framework's animation-first, JS-free philosophy. The trigger's own `:active` skew ties the "press" gesture to the drawer's entrance for a cohesive feel.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The skew is intentionally one-directional — it only appears on open, not close — so the drawer always exits calmly rather than wobbling both ways. `--sk-skew-angle` is reduced automatically on small screens to keep the effect subtle on mobile. As with the other checkbox-hack submissions in this batch, Escape-to-close isn't possible in pure CSS; noted in the README with a suggested minimal-JS enhancement path if that's ever required.