### PR TITLE
Add ease-weather-forecast-widget component

### DIFF
--- a/submissions/examples/ease-weather-forecast-widget-ij/README.md
+++ b/submissions/examples/ease-weather-forecast-widget-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Weather Forecast Widget
+
+A weather widget with current conditions and a five-day forecast list.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The sun icon glows while the cloud drifts.

--- a/submissions/examples/ease-weather-forecast-widget-ij/demo.html
+++ b/submissions/examples/ease-weather-forecast-widget-ij/demo.html
@@ -1,0 +1,30 @@
+<!-- EaseMotion component: weather-forecast-widget -->
+<!DOCTYPE html>
+<html lang="en" data-weather="forecast">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<title>Ease Weather Forecast Widget</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="weather-widget">
+  <header class="weather-head">
+    <span class="weather-city">Tokyo</span>
+    <span class="weather-temp-now">27&deg;C</span>
+  </header>
+  <span class="weather-desc">Partly Cloudy</span>
+  <div class="weather-main">
+    <span class="weather-icon"></span>
+    <span class="weather-hi-lo">H 31&deg; L 22&deg;</span>
+  </div>
+  <ul class="forecast-list">
+    <li class="forecast-row"><span class="fc-day">MON</span><span class="fc-icon cloud-float">&#9729;</span><span class="fc-temp">30&deg;</span></li>
+    <li class="forecast-row"><span class="fc-day">TUE</span><span class="fc-icon">&#9728;</span><span class="fc-temp">32&deg;</span></li>
+    <li class="forecast-row"><span class="fc-day">WED</span><span class="fc-icon">&#127777;</span><span class="fc-temp">28&deg;</span></li>
+    <li class="forecast-row"><span class="fc-day">THU</span><span class="fc-icon">&#127782;</span><span class="fc-temp">26&deg;</span></li>
+    <li class="forecast-row"><span class="fc-day">FRI</span><span class="fc-icon">&#9729;</span><span class="fc-temp">29&deg;</span></li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-weather-forecast-widget-ij/style.css
+++ b/submissions/examples/ease-weather-forecast-widget-ij/style.css
@@ -1,0 +1,29 @@
+:root{
+  --wf-bg:hsl(200,50%,10%);
+  --wf-ink:hsl(200,20%,94%);
+  --wf-sun:hsl(45,100%,62%);
+}
+*{padding:0;box-sizing:border-box;margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 0%,hsl(200,55%,20%),hsl(210,55%,6%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.weather-widget{width:340px;border-radius:18px;overflow:hidden;background:var(--wf-bg);border:1px solid hsl(200,35%,30%)}
+.weather-head{display:flex;align-items:baseline;justify-content:space-between;padding:14px 16px 0}
+.weather-city{font-size:1.1rem;font-weight:800;color:var(--wf-ink)}
+.weather-temp-now{font-size:1.6rem;font-weight:900;color:var(--wf-sun)}
+.weather-desc{display:block;padding:2px 16px;font-size:.75rem;color:hsl(200,20%,72%)}
+.weather-main{display:flex;align-items:center;justify-content:space-around;padding:14px 16px}
+.weather-icon{width:74px;height:74px;border-radius:50%;background:var(--wf-sun);animation:sun-glow-weather-forecast-widget 2.4s ease-in-out infinite}
+.weather-hi-lo{font-size:.9rem;font-weight:700;color:hsl(200,20%,88%)}
+.forecast-list{list-style:none;border-top:1px solid hsl(200,30%,22%)}
+.forecast-row{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;border-bottom:1px solid hsl(200,30%,18%)}
+.fc-day{width:46px;font-size:.72rem;font-weight:800;letter-spacing:1px;color:hsl(200,20%,78%)}
+.fc-icon{font-size:1.1rem;color:var(--wf-sun)}
+.fc-temp{font-size:.8rem;color:hsl(200,20%,85%)}
+.cloud-float{display:inline-block;animation:cloud-drift-weather-forecast-widget 3s ease-in-out infinite}
+@keyframes sun-glow-weather-forecast-widget{
+  0%,100%{box-shadow:0 0 12px hsl(45,100%,60% / 0.7)}
+  50%{box-shadow:0 0 26px hsl(45,100%,60% / 1)}
+}
+@keyframes cloud-drift-weather-forecast-widget{
+  0%,100%{transform:translateX(0)}
+  50%{transform:translateX(10px)}
+}


### PR DESCRIPTION
## Component: ease-weather-forecast-widget — weather widget with current conditions and five-day forecast

**Closes #59652**

### What this adds
A weather forecast widget. A city header shows the current temperature and condition with a glowing sun icon, and a five-day list of rows each carry a day, an icon and a high/low temperature.

### Acceptance Criteria covered
- The city header shows current temperature and condition
- The sun icon glows from its disc
- The forecast list shows five daily rows

### Files
- `submissions/examples/ease-weather-forecast-widget-ij/demo.html`
- `submissions/examples/ease-weather-forecast-widget-ij/style.css`
- `submissions/examples/ease-weather-forecast-widget-ij/README.md`

### How to review
Open demo.html directly in a browser. The sun icon glows above the five-day forecast rows and the cloud drifts.