### PR TITLE
Add ease-drum-kit-player component

### DIFF
--- a/submissions/examples/ease-drum-kit-player-ij/README.md
+++ b/submissions/examples/ease-drum-kit-player-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Drum Kit Player
+
+A drum kit with five pads that strike on their own beat cycles.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- Each pad strikes in turn while the REC label pulses.

--- a/submissions/examples/ease-drum-kit-player-ij/demo.html
+++ b/submissions/examples/ease-drum-kit-player-ij/demo.html
@@ -1,0 +1,26 @@
+<!-- EaseMotion component: drum-kit-player -->
+<!DOCTYPE html>
+<html lang="en" data-drum="kit">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Ease Drum Kit Player</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="drum-kit">
+  <span class="drum-brand">DRUM KIT</span>
+  <div class="drum-grid">
+    <button class="drum-pad pad-kick">KICK</button>
+    <button class="drum-pad pad-snare">SNARE</button>
+    <button class="drum-pad pad-hat">HAT</button>
+    <button class="drum-pad pad-tom">TOM</button>
+    <button class="drum-pad pad-crash">CRASH</button>
+  </div>
+  <footer class="drum-foot">
+    <span class="drum-beat">BPM 120</span>
+    <span class="drum-rec">REC</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-drum-kit-player-ij/style.css
+++ b/submissions/examples/ease-drum-kit-player-ij/style.css
@@ -1,0 +1,32 @@
+:root{
+  --dk-bg:hsl(0,0%,10%);
+  --dk-ink:hsl(0,0%,90%);
+  --dk-kick:hsl(0,75%,55%);
+  --dk-snare:hsl(45,90%,58%);
+  --dk-hat:hsl(180,75%,55%);
+  --dk-tom:hsl(265,65%,60%);
+  --dk-crash:hsl(150,70%,55%);
+}
+*{margin:0;padding:0}*{box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 25%,hsl(0,0%,20%),hsl(0,0%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.drum-kit{width:360px;border-radius:18px;overflow:hidden;background:var(--dk-bg);border:1px solid hsl(0,0%,24%)}
+.drum-brand{display:block;text-align:center;padding:14px;font-size:1rem;letter-spacing:5px;color:var(--dk-ink)}
+.drum-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;padding:0 16px 16px}
+.drum-pad{min-height:90px;border-radius:14px;border:none;font-weight:900;font-size:.9rem;letter-spacing:2px;color:hsl(0,0%,8%);animation:pad-hit-drum-kit-player 2s ease-in-out infinite}
+.pad-kick{background:var(--dk-kick)}
+.pad-snare{background:var(--dk-snare);animation-delay:.25s}
+.pad-hat{background:var(--dk-hat);animation-delay:.5s}
+.pad-tom{background:var(--dk-tom);animation-delay:.75s}
+.pad-crash{grid-column:span 2;background:var(--dk-crash);animation-delay:1s}
+.drum-foot{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(0,0%,7%)}
+.drum-beat{font-size:.75rem;color:hsl(0,0%,70%)}
+.drum-rec{font-size:.75rem;color:var(--dk-kick);animation:beat-pulse-drum-kit-player 1s ease-in-out infinite}
+@keyframes pad-hit-drum-kit-player{
+  0%,74%,100%{transform:translateY(0)}
+  80%{transform:translateY(7px)}
+  90%{transform:translateY(2px)}
+}
+@keyframes beat-pulse-drum-kit-player{
+  0%,100%{transform:scale(1)}
+  50%{transform:scale(1.06)}
+}


### PR DESCRIPTION
## Component: ease-drum-kit-player — drum kit with pads that strike on beat

**Closes #59666**

### What this adds
A drum kit player. Five labeled pads (kick, snare, hat, tom, crash) sit in a grid and each strikes downward on its own beat cycle, while a footer shows tempo and record status.

### Acceptance Criteria covered
- The drum grid holds five labeled pads
- Each pad strikes on its own beat
- The footer shows tempo and record state

### Files
- `submissions/examples/ease-drum-kit-player-ij/demo.html`
- `submissions/examples/ease-drum-kit-player-ij/style.css`
- `submissions/examples/ease-drum-kit-player-ij/README.md`

### How to review
Open demo.html directly in a browser. The five pads strike in turn across the grid while the REC label pulses.