### PR TITLE
Add ease-tram-station-board component

### DIFF
--- a/submissions/examples/ease-tram-station-board-ij/README.md
+++ b/submissions/examples/ease-tram-station-board-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Tram Station Board
+
+A tram departure board with colored routes and a flashing next-tram row.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The next tram flashes while the clock blinks.

--- a/submissions/examples/ease-tram-station-board-ij/demo.html
+++ b/submissions/examples/ease-tram-station-board-ij/demo.html
@@ -1,0 +1,29 @@
+<!-- EaseMotion component: tram-station-board -->
+<!DOCTYPE html>
+<html lang="en" data-tram="board">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.1">
+<title>Ease Tram Station Board</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="station-board">
+  <header class="board-head">
+    <span class="board-stop">CENTRAL STATION</span>
+    <span class="board-clock">19:42</span>
+  </header>
+  <ul class="route-list">
+    <li class="route-row"><span class="route-line line-green">T1</span><span class="route-dest">Airport Terminal</span><span class="route-min">2m</span></li>
+    <li class="route-row rr-next"><span class="route-line line-blue">T2</span><span class="route-dest">Harborfront</span><span class="route-min">NOW</span></li>
+    <li class="route-row"><span class="route-line line-red">T4</span><span class="route-dest">Museum District</span><span class="route-min delayed">+5m</span></li>
+    <li class="route-row"><span class="route-line line-amber">T6</span><span class="route-dest">Old Town Loop</span><span class="route-min">12m</span></li>
+    <li class="route-row"><span class="route-line line-purple">T8</span><span class="route-dest">University</span><span class="route-min">17m</span></li>
+  </ul>
+  <footer class="board-foot">
+    <span class="board-note">NEXT TRAM</span>
+    <span class="board-live">LIVE</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-tram-station-board-ij/style.css
+++ b/submissions/examples/ease-tram-station-board-ij/style.css
@@ -1,0 +1,33 @@
+:root{
+  --ts-bg:hsl(210,25%,7%);
+  --ts-ink:hsl(210,20%,92%);
+  --ts-green:hsl(140,70%,50%);
+  --ts-blue:hsl(210,80%,60%);
+  --ts-red:hsl(0,75%,58%);
+  --ts-amber:hsl(40,95%,55%);
+  --ts-purple:hsl(275,65%,62%);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(210,30%,15%),hsl(212,35%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.station-board{width:360px;border-radius:14px;overflow:hidden;background:hsl(210,22%,9%);border:1px solid hsl(210,20%,24%)}
+.board-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(210,25%,13%)}
+.board-stop{font-size:.82rem;letter-spacing:3px;color:var(--ts-ink)}
+.board-clock{font-size:.78rem;font-weight:700;color:var(--ts-green);animation:time-tick-tram-station-board 2s ease-in-out infinite}
+.route-list{list-style:none}
+.route-row{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid hsl(210,20%,16%)}
+.rr-next{background:hsl(210,25%,14%)}
+.route-line{width:30px;height:30px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:.72rem;font-weight:900;color:hsl(0,0%,10%)}
+.line-green{background:var(--ts-green)}
+.line-blue{background:var(--ts-blue)}
+.line-red{background:var(--ts-red)}
+.line-amber{background:var(--ts-amber)}
+.line-purple{background:var(--ts-purple)}
+.route-dest{flex:1;font-size:.84rem;color:var(--ts-ink)}
+.route-min{font-size:.76rem;font-weight:700;color:var(--ts-green)}
+.delayed{color:var(--ts-red)}
+.rr-next .route-min{color:var(--ts-amber);animation:next-route-flash-tram-station-board 0.9s step-end infinite}
+.board-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(210,25%,13%)}
+.board-note{font-size:.68rem;letter-spacing:2px;color:hsl(210,20%,60%)}
+.board-live{font-size:.68rem;font-weight:800;color:var(--ts-green)}
+@keyframes next-route-flash-tram-station-board{0%,50%{opacity:1}51%,100%{opacity:0.15}}
+@keyframes time-tick-tram-station-board{0%,100%{opacity:1}50%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-tram-station-board — tram departure board with routes, times and next-tram flash

**Closes #59689**

### What this adds
A tram station departure board. A dark screen lists five colored tram routes with destinations and arrival minutes, the next tram row flashes NOW in amber, and a LIVE clock blinks in the header.

### Acceptance Criteria covered
- The board lists five colored tram routes
- The next-tram row flashes its departure state
- The clock and LIVE badge blink in the header

### Files
- `submissions/examples/ease-tram-station-board-ij/demo.html`
- `submissions/examples/ease-tram-station-board-ij/style.css`
- `submissions/examples/ease-tram-station-board-ij/README.md`

### How to review
Open demo.html directly in a browser. The route rows show destinations and times while the next tram flashes amber.