### PR TITLE
Add ease-stadium-floodlights component

### DIFF
--- a/submissions/examples/ease-stadium-floodlights-ij/README.md
+++ b/submissions/examples/ease-stadium-floodlights-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Stadium Floodlights
+
+A night stadium with pulsing floodlight towers, beams and twinkling stars.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The lamp banks pulse while stars twinkle.

--- a/submissions/examples/ease-stadium-floodlights-ij/demo.html
+++ b/submissions/examples/ease-stadium-floodlights-ij/demo.html
@@ -1,0 +1,40 @@
+<!-- EaseMotion component: stadium-floodlights -->
+<!DOCTYPE html>
+<html lang="en" data-stadium="lights">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.2">
+<title>Ease Stadium Floodlights</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="stadium-night">
+  <header class="stadium-head">
+    <span class="stadium-name">ARENA NORD</span>
+    <span class="stadium-score">2 - 1</span>
+  </header>
+  <div class="sky">
+    <span class="night-star star-a"></span>
+    <span class="night-star star-b"></span>
+    <span class="night-star star-c"></span>
+  </div>
+  <div class="flood-tower tower-left">
+    <span class="light-bank bank-row-a"></span>
+    <span class="light-bank bank-row-b"></span>
+    <span class="light-beam beam-left"></span>
+  </div>
+  <div class="flood-tower tower-right">
+    <span class="light-bank bank-row-a"></span>
+    <span class="light-bank bank-row-b"></span>
+    <span class="light-beam beam-right"></span>
+  </div>
+  <div class="pitch">
+    <span class="pitch-line line-center"></span>
+    <span class="pitch-circle"></span>
+  </div>
+  <footer class="stadium-foot">
+    <span class="stadium-status">FULL BRIGHTNESS</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-stadium-floodlights-ij/style.css
+++ b/submissions/examples/ease-stadium-floodlights-ij/style.css
@@ -1,0 +1,33 @@
+:root{
+  --sf-bg:hsl(250,30%,6%);
+  --sf-ink:hsl(250,20%,92%);
+  --sf-glow:hsl(48,100%,75%);
+  --sf-steel:hsl(250,10%,45%);
+  --sf-grass:hsl(120,40%,24%);
+}
+*{margin:0}*{box-sizing:border-box}*{padding:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 20%,hsl(250,25%,14%),hsl(252,40%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.stadium-night{position:relative;width:360px;border-radius:16px;overflow:hidden;background:hsl(250,28%,8%);border:1px solid hsl(250,20%,22%)}
+.stadium-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(250,28%,13%)}
+.stadium-name{font-size:.8rem;letter-spacing:3px;color:var(--sf-ink)}
+.stadium-score{font-size:1rem;font-weight:900;color:var(--sf-glow);animation:beam-pulse-stadium-floodlights 2s ease-in-out infinite}
+.sky{position:relative;height:70px}
+.night-star{position:absolute;width:5px;height:5px;border-radius:50%;background:var(--sf-glow);animation:star-twinkle-stadium-floodlights 2.4s ease-in-out infinite}
+.star-a{left:18%;top:18px}
+.star-b{left:56%;top:34px;animation-delay:.7s}
+.star-c{left:78%;top:14px;animation-delay:1.3s}
+.flood-tower{position:absolute;top:66px;width:44px}
+.tower-left{left:14px}
+.tower-right{right:14px}
+.light-bank{display:block;width:44px;height:12px;border-radius:4px;background:var(--sf-glow);box-shadow:0 0 10px hsl(48,100%,70% / 0.8);animation:beam-pulse-stadium-floodlights 2.4s ease-in-out infinite}
+.bank-row-b{transform:rotate(26deg);transform-origin:50% 100%;animation-delay:.4s}
+.light-beam{position:absolute;top:26px;left:50%;width:10px;height:120px;transform:translateX(-50%);background:linear-gradient(180deg,hsl(48,100%,80% / 0.5),transparent);border-radius:50% 50% 0 0;animation:beam-pulse-stadium-floodlights 2.4s ease-in-out infinite}
+.beam-left{transform:translateX(-50%) rotate(-8deg)}
+.beam-right{transform:translateX(-50%) rotate(8deg);animation-delay:.3s}
+.pitch{position:relative;height:110px;margin:128px 14px 14px;border-radius:8px;background:repeating-linear-gradient(180deg,var(--sf-grass) 0 30px,hsl(120,42%,20%) 30px 60px)}
+.pitch-line{position:absolute;left:0;top:50%;width:100%;height:2px;transform:translateY(-50%);background:hsl(0,0%,92%)}
+.pitch-circle{position:absolute;left:50%;top:50%;width:60px;height:60px;transform:translate(-50%,-50%);border:2px solid hsl(0,0%,92%);border-radius:50%}
+.stadium-foot{display:flex;align-items:center;justify-content:center;padding:10px 16px;background:hsl(250,28%,13%)}
+.stadium-status{font-size:.68rem;letter-spacing:2px;color:var(--sf-glow)}
+@keyframes beam-pulse-stadium-floodlights{0%,100%{opacity:1}50%{opacity:0.6}}
+@keyframes star-twinkle-stadium-floodlights{0%,100%{opacity:1;transform:scale(1)}50%{opacity:0.2;transform:scale(0.6)}}


### PR DESCRIPTION
## Component: ease-stadium-floodlights — night stadium with light towers, beams and twinkling stars

**Closes #59697**

### What this adds
A night stadium scene. Two floodlight towers flank a striped pitch, each tower banks bright lamps that pulse and cast diagonal light beams, while stars twinkle in the sky above and a score line glows in the header.

### Acceptance Criteria covered
- Two floodlight towers frame the pitch
- The lamp banks pulse and cast light beams
- Stars twinkle in the sky above

### Files
- `submissions/examples/ease-stadium-floodlights-ij/demo.html`
- `submissions/examples/ease-stadium-floodlights-ij/style.css`
- `submissions/examples/ease-stadium-floodlights-ij/README.md`

### How to review
Open demo.html directly in a browser. The lamp banks pulse as beams reach across the striped pitch.