### PR TITLE
Add ease-morse-code-transmitter component

### DIFF
--- a/submissions/examples/ease-morse-code-transmitter-ij/README.md
+++ b/submissions/examples/ease-morse-code-transmitter-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Morse Code Transmitter
+
+A morse key rig with pressing lever, blinking lamp and scrolling readout.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The key presses while the lamp blinks.

--- a/submissions/examples/ease-morse-code-transmitter-ij/demo.html
+++ b/submissions/examples/ease-morse-code-transmitter-ij/demo.html
@@ -1,0 +1,36 @@
+<!-- EaseMotion component: morse-code-transmitter -->
+<!DOCTYPE html>
+<html lang="en" data-morse="key">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.3">
+<title>Ease Morse Code Transmitter</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="morse-rig">
+  <header class="morse-head">
+    <span class="morse-callsign">W1AW</span>
+    <span class="morse-band">20M</span>
+  </header>
+  <div class="morse-key">
+    <span class="key-base"></span>
+    <span class="key-lever"></span>
+    <span class="key-knob"></span>
+    <span class="key-contact"></span>
+  </div>
+  <div class="morse-output">
+    <span class="signal-lamp"></span>
+    <span class="signal-readout">.- ..- - ---</span>
+  </div>
+  <div class="morse-dial">
+    <span class="dial-label">FREQ</span>
+    <span class="dial-knob"></span>
+    <span class="dial-readout">14.025 MHz</span>
+  </div>
+  <footer class="morse-foot">
+    <span class="morse-status">TRANSMITTING</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-morse-code-transmitter-ij/style.css
+++ b/submissions/examples/ease-morse-code-transmitter-ij/style.css
@@ -1,0 +1,31 @@
+:root{
+  --mc-bg:hsl(140,20%,8%);
+  --mc-ink:hsl(140,15%,92%);
+  --mc-brass:hsl(35,60%,58%);
+  --mc-lamp:hsl(60,100%,60%);
+  --mc-dark:hsl(140,15%,20%);
+}
+*{padding:0}*{box-sizing:border-box}*{margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(140,25%,15%),hsl(142,35%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.morse-rig{width:360px;border-radius:16px;overflow:hidden;background:hsl(140,18%,9%);border:1px solid hsl(140,15%,22%)}
+.morse-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(140,24%,13%)}
+.morse-callsign{font-size:.84rem;letter-spacing:3px;color:var(--mc-ink)}
+.morse-band{font-size:.7rem;color:hsl(140,15%,60%)}
+.morse-key{position:relative;height:90px;margin:14px;border-radius:10px;background:var(--mc-dark);border:1px solid hsl(140,12%,28%)}
+.key-base{position:absolute;left:10px;bottom:8px;width:40px;height:18px;border-radius:6px;background:hsl(0,0%,12%)}
+.key-lever{position:absolute;left:6px;top:26px;width:150px;height:14px;border-radius:7px;background:var(--mc-brass);transform-origin:20% 50%;animation:key-press-morse-code-transmitter 1.4s ease-in-out infinite}
+.key-knob{position:absolute;left:130px;top:18px;width:30px;height:30px;border-radius:50%;background:hsl(30,50%,40%)}
+.key-contact{position:absolute;right:12px;bottom:6px;width:22px;height:8px;border-radius:4px;background:var(--mc-brass)}
+.morse-output{display:flex;align-items:center;gap:12px;padding:0 16px 12px}
+.signal-lamp{width:18px;height:18px;border-radius:50%;background:var(--mc-lamp);box-shadow:0 0 10px hsl(60,100%,60% / 0.8);animation:signal-blink-morse-code-transmitter 1.4s step-end infinite}
+.signal-readout{font-family:ui-monospace,Consolas,monospace;font-size:.78rem;color:var(--mc-lamp);letter-spacing:3px;animation:dash-slide-morse-code-transmitter 1.4s ease-in-out infinite}
+.morse-dial{display:flex;align-items:center;gap:12px;padding:0 16px 14px}
+.dial-label{font-size:.68rem;color:hsl(140,15%,60%)}
+.dial-knob{width:26px;height:26px;border-radius:50%;background:var(--mc-brass);animation:dial-spin-morse-code-transmitter 2.2s ease-in-out infinite}
+.dial-readout{font-size:.72rem;font-weight:700;color:var(--mc-ink)}
+.morse-foot{display:flex;align-items:center;justify-content:center;padding:10px 16px;background:hsl(140,24%,13%)}
+.morse-status{font-size:.68rem;letter-spacing:2px;color:var(--mc-lamp);animation:signal-blink-morse-code-transmitter 1.4s step-end infinite}
+@keyframes key-press-morse-code-transmitter{0%,55%{transform:rotate(0deg)}75%{transform:rotate(-8deg)}100%{transform:rotate(-8deg)}}
+@keyframes signal-blink-morse-code-transmitter{0%,45%{opacity:1}50%,100%{opacity:0.1}}
+@keyframes dash-slide-morse-code-transmitter{0%,100%{transform:translateX(0)}50%{transform:translateX(12px)}}
+@keyframes dial-spin-morse-code-transmitter{0%,100%{transform:rotate(0deg)}50%{transform:rotate(160deg)}}


### PR DESCRIPTION
## Component: ease-morse-code-transmitter — morse key rig with pressing lever and signal lamp

**Closes #59705**

### What this adds
A morse code transmitter. A brass telegraph key presses down on its contacts, a signal lamp blinks the transmission, the readout scrolls dots and dashes, and a frequency dial turns beside the readout.

### Acceptance Criteria covered
- The brass key presses down on its contacts
- The signal lamp blinks in transmission rhythm
- The readout scrolls dots and dashes

### Files
- `submissions/examples/ease-morse-code-transmitter-ij/demo.html`
- `submissions/examples/ease-morse-code-transmitter-ij/style.css`
- `submissions/examples/ease-morse-code-transmitter-ij/README.md`

### How to review
Open demo.html directly in a browser. The key presses while the lamp blinks and the readout scrolls.