### PR TITLE
Add ease-ticket-stub-ripper component

### DIFF
--- a/submissions/examples/ease-ticket-stub-ripper-ij/README.md
+++ b/submissions/examples/ease-ticket-stub-ripper-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Ticket Stub Ripper
+
+A ticket window with advancing stubs, a punch press and a torn stub.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The stubs advance while the punch drops.

--- a/submissions/examples/ease-ticket-stub-ripper-ij/demo.html
+++ b/submissions/examples/ease-ticket-stub-ripper-ij/demo.html
@@ -1,0 +1,38 @@
+<!-- EaseMotion component: ticket-stub-ripper -->
+<!DOCTYPE html>
+<html lang="en" data-stub="rip">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.5">
+<title>Ease Ticket Stub Ripper</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="stub-ripper">
+  <header class="stub-head">
+    <span class="stub-title">ADMIT ONE</span>
+    <span class="stub-count">#144</span>
+  </header>
+  <div class="stub-track">
+    <span class="stub-card">
+      <span class="stub-perf"></span>
+      <span class="stub-row">ROW A</span>
+      <span class="stub-seat">SEAT 12</span>
+    </span>
+    <span class="stub-card stub-card-2">
+      <span class="stub-perf"></span>
+      <span class="stub-row">ROW B</span>
+      <span class="stub-seat">SEAT 05</span>
+    </span>
+  </div>
+  <div class="stub-punch">
+    <span class="punch-press"></span>
+    <span class="punch-anvil"></span>
+  </div>
+  <footer class="stub-foot">
+    <span class="stub-tip">RIP DOWN THE LINE</span>
+    <span class="stub-torn"></span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-ticket-stub-ripper-ij/style.css
+++ b/submissions/examples/ease-ticket-stub-ripper-ij/style.css
@@ -1,0 +1,29 @@
+:root{
+  --tsu-bg:hsl(210,25%,8%);
+  --tsu-ink:hsl(210,20%,92%);
+  --tsu-ticket:hsl(40,40%,88%);
+  --tsu-red:hsl(0,70%,52%);
+  --tsu-steel:hsl(210,10%,52%);
+}
+*{margin:0;box-sizing:border-box;padding:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(210,30%,15%),hsl(215,40%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.stub-ripper{width:360px;border-radius:16px;overflow:hidden;background:hsl(210,22%,9%);border:1px solid hsl(210,20%,24%)}
+.stub-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(210,28%,13%)}
+.stub-title{font-size:.82rem;letter-spacing:3px;color:var(--tsu-ticket)}
+.stub-count{font-size:.7rem;font-weight:800;color:var(--tsu-red);animation:count-tick-ticket-stub-ripper 2s ease-in-out infinite}
+.stub-track{position:relative;height:120px;margin:14px;border-radius:10px;background:hsl(210,20%,14%);overflow:hidden}
+.stub-card{position:absolute;left:50%;top:50%;width:130px;height:84px;transform:translate(-50%,-50%);border-radius:8px;background:var(--tsu-ticket);box-shadow:0 6px 0 hsl(210,15%,26%);animation:stub-advance-ticket-stub-ripper 2.4s ease-in-out infinite}
+.stub-card-2{animation:stub-advance-ticket-stub-ripper 2.4s ease-in-out infinite;animation-delay:1.2s}
+.stub-perf{position:absolute;right:22px;top:0;bottom:0;width:2px;background:repeating-linear-gradient(180deg,hsl(210,25%,8%) 0 5px,transparent 5px 9px)}
+.stub-row{position:absolute;left:12px;top:14px;font-size:.68rem;font-weight:800;letter-spacing:1px;color:hsl(210,40%,18%)}
+.stub-seat{position:absolute;left:12px;bottom:12px;font-size:.62rem;color:hsl(210,30%,30%)}
+.stub-punch{position:relative;height:70px;margin:0 14px 14px;border-radius:10px;background:hsl(210,20%,13%)}
+.punch-press{position:absolute;left:50%;top:8px;width:64px;height:36px;transform:translateX(-50%);border-radius:8px;background:var(--tsu-steel);animation:punch-press-ticket-stub-ripper 2.4s ease-in-out infinite}
+.punch-anvil{position:absolute;left:50%;bottom:12px;width:70px;height:14px;transform:translateX(-50%);border-radius:6px;background:hsl(210,12%,30%)}
+.stub-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(210,28%,13%)}
+.stub-tip{font-size:.68rem;letter-spacing:2px;color:hsl(210,20%,58%)}
+.stub-torn{width:26px;height:26px;background:var(--tsu-ticket);clip-path:polygon(0 0,100% 0,100% 40%,85% 55%,100% 70%,100% 100%,60% 100%,0 100%);animation:zigzag-sway-ticket-stub-ripper 2.4s ease-in-out infinite}
+@keyframes stub-advance-ticket-stub-ripper{0%,45%{transform:translate(-50%,-50%) translateX(0)}70%{transform:translate(-50%,-50%) translateX(40px)}100%{transform:translate(-50%,-50%) translateX(40px)}}
+@keyframes count-tick-ticket-stub-ripper{0%,100%{opacity:1}50%{opacity:0.4}}
+@keyframes punch-press-ticket-stub-ripper{0%,55%{transform:translateX(-50%) translateY(0)}75%{transform:translateX(-50%) translateY(16px)}100%{transform:translateX(-50%) translateY(0)}}
+@keyframes zigzag-sway-ticket-stub-ripper{0%,100%{transform:rotate(0deg)}50%{transform:rotate(6deg)}}


### PR DESCRIPTION
## Component: ease-ticket-stub-ripper — ticket window with advancing stubs and a punch press

**Closes #59719**

### What this adds
A ticket stub ripper. Perforated stubs advance out of a track in pairs, a steel punch press drops onto its anvil on beat, and a torn stub sways in the footer beside the ticket counter.

### Acceptance Criteria covered
- The stubs advance along the track in pairs
- The punch press drops onto the anvil
- The torn stub sways in the footer

### Files
- `submissions/examples/ease-ticket-stub-ripper-ij/demo.html`
- `submissions/examples/ease-ticket-stub-ripper-ij/style.css`
- `submissions/examples/ease-ticket-stub-ripper-ij/README.md`

### How to review
Open demo.html directly in a browser. The stubs advance while the punch press drops on the anvil.