### PR TITLE
Add ease-submarine-periscope component

### DIFF
--- a/submissions/examples/ease-submarine-periscope-ij/README.md
+++ b/submissions/examples/ease-submarine-periscope-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Submarine Periscope
+
+A periscope with a scanning lens, turning focus ring and rising bubbles.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The lens scans while the bubbles rise.

--- a/submissions/examples/ease-submarine-periscope-ij/demo.html
+++ b/submissions/examples/ease-submarine-periscope-ij/demo.html
@@ -1,0 +1,34 @@
+<!-- EaseMotion component: submarine-periscope -->
+<!DOCTYPE html>
+<html lang="en" data-sub="scope">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.1">
+<title>Ease Submarine Periscope</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="periscope-rig">
+  <header class="ps-head">
+    <span class="ps-title">PERISCOPE</span>
+    <span class="ps-depth">DEPTH 40M</span>
+  </header>
+  <div class="scope-bubbles">
+    <span class="bubble bub-1"></span>
+    <span class="bubble bub-2"></span>
+    <span class="bubble bub-3"></span>
+  </div>
+  <div class="scope-tube">
+    <span class="scope-lens"></span>
+    <span class="scope-body"></span>
+    <span class="scope-focus"></span>
+    <span class="scope-eye"></span>
+    <span class="scope-handle"></span>
+  </div>
+  <footer class="ps-foot">
+    <span class="ps-bearing">BEARING 045</span>
+    <span class="ps-scan">SCANNING</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-submarine-periscope-ij/style.css
+++ b/submissions/examples/ease-submarine-periscope-ij/style.css
@@ -1,0 +1,31 @@
+:root{
+  --sp-bg:hsl(200,45%,7%);
+  --sp-ink:hsl(200,25%,92%);
+  --sp-brass:hsl(35,55%,52%);
+  --sp-teal:hsl(175,70%,55%);
+  --sp-dark:hsl(200,35%,14%);
+}
+*{box-sizing:border-box}*{padding:0;margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 20%,hsl(200,50%,15%),hsl(205,60%,4%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.periscope-rig{width:340px;border-radius:16px;overflow:hidden;background:hsl(200,42%,9%);border:1px solid hsl(200,35%,22%)}
+.ps-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(200,48%,13%)}
+.ps-title{font-size:.82rem;letter-spacing:3px;color:var(--sp-ink)}
+.ps-depth{font-size:.7rem;font-weight:800;color:var(--sp-teal);animation:depth-blink-submarine-periscope 2.2s ease-in-out infinite}
+.scope-bubbles{position:relative;height:60px}
+.bubble{position:absolute;width:12px;height:12px;border-radius:50%;border:2px solid hsl(200,60%,70% / 0.7);background:hsl(200,70%,75% / 0.15);animation:bubble-rise-submarine-periscope 2.6s ease-in-out infinite}
+.bub-1{left:22%;bottom:0}
+.bub-2{left:56%;bottom:0;animation-delay:.8s}
+.bub-3{left:76%;bottom:0;animation-delay:1.5s}
+.scope-tube{position:relative;height:210px;margin:0 14px;border-radius:14px;background:repeating-linear-gradient(180deg,hsl(200,30%,16%) 0 14px,hsl(200,34%,12%) 14px 28px);border:2px solid hsl(200,28%,24%)}
+.scope-lens{position:absolute;left:50%;top:-16px;width:54px;height:54px;transform:translateX(-50%);border-radius:50%;background:radial-gradient(circle at 50% 50%,hsl(190,80%,70% / 0.5),hsl(200,60%,30%) 70%);box-shadow:inset 0 0 12px hsl(190,80%,70% / 0.4);animation:lens-scan-submarine-periscope 3s ease-in-out infinite}
+.scope-body{position:absolute;left:50%;top:38px;width:46px;height:120px;transform:translateX(-50%);border-radius:8px;background:hsl(200,30%,20%)}
+.scope-focus{position:absolute;left:50%;top:72px;width:66px;height:18px;transform:translateX(-50%);border-radius:9px;background:var(--sp-brass);animation:focus-ring-turn-submarine-periscope 2.4s ease-in-out infinite}
+.scope-eye{position:absolute;left:50%;bottom:12px;width:34px;height:34px;transform:translateX(-50%);border-radius:50%;background:hsl(200,30%,10%);border:6px solid var(--sp-brass);box-shadow:inset 0 0 8px hsl(200,20%,8%)}
+.scope-handle{position:absolute;left:8px;top:120px;width:10px;height:58px;border-radius:5px;background:var(--sp-brass)}
+.ps-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(200,48%,13%)}
+.ps-bearing{font-size:.68rem;color:hsl(200,20%,62%)}
+.ps-scan{font-size:.68rem;letter-spacing:2px;color:var(--sp-teal);animation:depth-blink-submarine-periscope 2.2s ease-in-out infinite}
+@keyframes lens-scan-submarine-periscope{0%,100%{filter:brightness(1)}50%{filter:brightness(1.7)}}
+@keyframes bubble-rise-submarine-periscope{0%{transform:translateY(0);opacity:0.9}100%{transform:translateY(-46px);opacity:0.2}}
+@keyframes focus-ring-turn-submarine-periscope{0%,100%{transform:translateX(-50%) rotate(0deg)}50%{transform:translateX(-50%) rotate(6deg)}}
+@keyframes depth-blink-submarine-periscope{0%,100%{opacity:1}50%{opacity:0.45}}


### PR DESCRIPTION
## Component: ease-submarine-periscope — periscope with lens scan, focus ring and rising bubbles

**Closes #59795**

### What this adds
A submarine periscope. A brass-ringed tube holds a glowing objective lens that scans at the top and an eyepiece at the bottom, a focus ring turns on the barrel, and bubbles rise beside the rig while a depth readout blinks.

### Acceptance Criteria covered
- The objective lens scans at the top of the tube
- The focus ring turns on the barrel
- Bubbles rise beside the rig

### Files
- `submissions/examples/ease-submarine-periscope-ij/demo.html`
- `submissions/examples/ease-submarine-periscope-ij/style.css`
- `submissions/examples/ease-submarine-periscope-ij/README.md`

### How to review
Open demo.html directly in a browser. The lens scans while the focus ring turns and bubbles rise.