### PR TITLE
Add ease-bank-atm-dispenser component

### DIFF
--- a/submissions/examples/ease-bank-atm-dispenser-ij/README.md
+++ b/submissions/examples/ease-bank-atm-dispenser-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Bank ATM Dispenser
+
+An ATM with a flashing balance screen, pulsing keypad and sliding cash note.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The note slides out as the keypad pulses.

--- a/submissions/examples/ease-bank-atm-dispenser-ij/demo.html
+++ b/submissions/examples/ease-bank-atm-dispenser-ij/demo.html
@@ -1,0 +1,45 @@
+<!-- EaseMotion component: bank-atm-dispenser -->
+<!DOCTYPE html>
+<html lang="en" data-atm="dispense">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.2">
+<title>Ease Bank ATM Dispenser</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="atm-kiosk">
+  <header class="atm-head">
+    <span class="atm-bank">FIRST TRUST</span>
+    <span class="atm-ok">ONLINE</span>
+  </header>
+  <div class="atm-screen">
+    <span class="screen-title">BALANCE</span>
+    <span class="screen-amount">$1,240.00</span>
+    <span class="screen-tip">INSERT CARD</span>
+  </div>
+  <div class="atm-keypad">
+    <button class="key">1</button>
+    <button class="key">2</button>
+    <button class="key">3</button>
+    <button class="key">4</button>
+    <button class="key">5</button>
+    <button class="key">6</button>
+    <button class="key">7</button>
+    <button class="key">8</button>
+    <button class="key">9</button>
+    <button class="key key-blank"></button>
+    <button class="key">0</button>
+    <button class="key key-enter">OK</button>
+  </div>
+  <div class="atm-slots">
+    <span class="card-slot"><span class="card-poke"></span></span>
+    <span class="cash-slot"><span class="cash-note">&#36;100</span></span>
+  </div>
+  <footer class="atm-foot">
+    <span class="atm-txn">TX 0082</span>
+    <span class="atm-receipt">RECEIPT</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-bank-atm-dispenser-ij/style.css
+++ b/submissions/examples/ease-bank-atm-dispenser-ij/style.css
@@ -1,0 +1,33 @@
+:root{
+  --at-bg:hsl(230,30%,8%);
+  --at-ink:hsl(230,20%,92%);
+  --at-teal:hsl(170,80%,55%);
+  --at-green:hsl(130,75%,50%);
+  --at-slate:hsl(230,15%,28%);
+}
+*{padding:0;margin:0}*{box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(230,35%,15%),hsl(235,45%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.atm-kiosk{width:340px;border-radius:18px;overflow:hidden;background:hsl(230,28%,10%);border:1px solid hsl(230,25%,24%)}
+.atm-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(230,34%,14%)}
+.atm-bank{font-size:.84rem;letter-spacing:3px;color:var(--at-ink)}
+.atm-ok{font-size:.68rem;font-weight:800;color:var(--at-green);animation:atm-pulse-bank-atm-dispenser 1.8s ease-in-out infinite}
+.atm-screen{display:flex;flex-direction:column;align-items:center;gap:6px;margin:14px;padding:16px;border-radius:12px;background:hsl(230,35%,12%);border:1px solid hsl(230,25%,22%)}
+.screen-title{font-size:.66rem;letter-spacing:2px;color:hsl(230,20%,60%)}
+.screen-amount{font-size:1.6rem;font-weight:900;color:var(--at-teal);animation:screen-flash-bank-atm-dispenser 2s ease-in-out infinite}
+.screen-tip{font-size:.68rem;color:hsl(230,20%,64%)}
+.atm-keypad{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin:0 14px;padding:12px;border-radius:12px;background:hsl(230,25%,14%)}
+.key{min-height:38px;border:none;border-radius:10px;background:var(--at-slate);color:hsl(230,20%,92%);font-size:.9rem;font-weight:800;animation:key-pulse-bank-atm-dispenser 2s ease-in-out infinite}
+.key-blank{visibility:hidden}
+.key-enter{background:var(--at-green);color:hsl(230,30%,8%)}
+.atm-slots{display:flex;align-items:center;justify-content:space-around;margin:14px}
+.card-slot{position:relative;width:96px;height:14px;border-radius:7px;background:hsl(230,20%,22%)}
+.card-poke{position:absolute;left:10px;top:-14px;width:40px;height:20px;border-radius:4px;background:hsl(230,10%,85%)}
+.cash-slot{position:relative;width:120px;height:14px;border-radius:7px;background:hsl(230,20%,22%)}
+.cash-note{position:absolute;left:50%;top:-30px;width:60px;height:34px;transform:translateX(-50%);border-radius:5px;background:hsl(160,60%,42%);color:hsl(160,40%,92%);font-size:.68rem;font-weight:800;display:flex;align-items:center;justify-content:center;animation:note-slide-bank-atm-dispenser 2.6s ease-in-out infinite}
+.atm-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(230,34%,14%)}
+.atm-txn{font-size:.68rem;color:hsl(230,20%,60%)}
+.atm-receipt{font-size:.68rem;font-weight:800;color:var(--at-teal)}
+@keyframes atm-pulse-bank-atm-dispenser{0%,100%{opacity:1}50%{opacity:0.45}}
+@keyframes screen-flash-bank-atm-dispenser{0%,100%{filter:brightness(1)}50%{filter:brightness(1.5)}}
+@keyframes key-pulse-bank-atm-dispenser{0%,100%{transform:scale(1)}50%{transform:scale(0.94)}}
+@keyframes note-slide-bank-atm-dispenser{0%,40%{transform:translateX(-50%) translateY(0)}60%,100%{transform:translateX(-50%) translateY(-26px)}}


### PR DESCRIPTION
## Component: ease-bank-atm-dispenser — ATM screen, keypad, card slot and sliding cash note

**Closes #59799**

### What this adds
A bank ATM dispenser. A teal balance screen flashes above a three-by-four keypad of pulsing keys, a card slot holds a poked-in card, and a green banknote slides up out of the cash slot on a cycle.

### Acceptance Criteria covered
- The balance screen flashes on the ATM
- The keypad keys pulse as the note slides out
- The card slot holds the inserted card

### Files
- `submissions/examples/ease-bank-atm-dispenser-ij/demo.html`
- `submissions/examples/ease-bank-atm-dispenser-ij/style.css`
- `submissions/examples/ease-bank-atm-dispenser-ij/README.md`

### How to review
Open demo.html directly in a browser. The balance flashes while the note slides up from the cash slot.