### PR TITLE
Add ease-metronome-swing-arm component

### DIFF
--- a/submissions/examples/ease-metronome-swing-arm-ij/README.md
+++ b/submissions/examples/ease-metronome-swing-arm-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Metronome Swing Arm
+
+A metronome with a swinging arm, sliding weight and flashing tempo.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The arm swings while the weight shifts.

--- a/submissions/examples/ease-metronome-swing-arm-ij/demo.html
+++ b/submissions/examples/ease-metronome-swing-arm-ij/demo.html
@@ -1,0 +1,33 @@
+<!-- EaseMotion component: metronome-swing-arm -->
+<!DOCTYPE html>
+<html lang="en" data-beat="metro">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.4">
+<title>Ease Metronome Swing Arm</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="metronome">
+  <header class="metro-head">
+    <span class="metro-name">MIGNON</span>
+    <span class="metro-tempo">84 BPM</span>
+  </header>
+  <div class="metro-body">
+    <span class="metro-scale">
+      <span class="metro-tick">40</span>
+      <span class="metro-tick">60</span>
+      <span class="metro-tick">84</span>
+      <span class="metro-tick">120</span>
+      <span class="metro-tick">208</span>
+    </span>
+    <span class="metro-arm"><span class="metro-weight"></span></span>
+    <span class="metro-pivot"></span>
+  </div>
+  <footer class="metro-foot">
+    <span class="metro-note">ALLEGRO</span>
+    <span class="metro-blink">&#9834;</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-metronome-swing-arm-ij/style.css
+++ b/submissions/examples/ease-metronome-swing-arm-ij/style.css
@@ -1,0 +1,25 @@
+:root{
+  --me-bg:hsl(25,40%,9%);
+  --me-ink:hsl(25,20%,90%);
+  --me-wood:hsl(25,45%,28%);
+  --me-accent:hsl(330,70%,60%);
+  --me-steel:hsl(25,10%,50%);
+}
+*{box-sizing:border-box}*{padding:0}*{margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(25,45%,16%),hsl(28,50%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.metronome{width:320px;border-radius:16px;overflow:hidden;background:hsl(25,38%,10%);border:1px solid hsl(25,32%,24%)}
+.metro-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(25,46%,14%)}
+.metro-name{font-size:.82rem;letter-spacing:3px;color:var(--me-ink)}
+.metro-tempo{font-size:.72rem;font-weight:800;color:var(--me-accent);animation:tempo-flash-metronome-swing-arm 1.6s ease-in-out infinite}
+.metro-body{position:relative;height:190px;margin:14px;border-radius:14px;background:var(--me-wood);clip-path:polygon(50% 0,100% 100%,0 100%);display:flex;align-items:flex-start;justify-content:center}
+.metro-scale{position:absolute;top:20px;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:14px;font-size:.58rem;color:hsl(25,25%,70%)}
+.metro-tick{display:block}
+.metro-arm{position:absolute;left:50%;top:0;width:6px;height:120px;transform:translateX(-50%);transform-origin:50% 100%;background:var(--me-steel);animation:arm-swing-metronome-swing-arm 1.6s ease-in-out infinite}
+.metro-weight{position:absolute;left:-7px;top:8px;width:20px;height:16px;border-radius:4px;background:var(--me-accent);animation:weight-shift-metronome-swing-arm 1.6s ease-in-out infinite}
+.metro-pivot{position:absolute;left:50%;bottom:26px;width:18px;height:18px;transform:translateX(-50%);border-radius:50%;background:hsl(25,30%,12%)}
+.metro-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(25,46%,14%)}
+.metro-note{font-size:.68rem;letter-spacing:2px;color:hsl(25,25%,64%)}
+.metro-blink{font-size:1rem;color:var(--me-accent);animation:tempo-flash-metronome-swing-arm 1.6s ease-in-out infinite}
+@keyframes arm-swing-metronome-swing-arm{0%,100%{transform:translateX(-50%) rotate(-24deg)}50%{transform:translateX(-50%) rotate(24deg)}}
+@keyframes weight-shift-metronome-swing-arm{0%,100%{transform:translateX(0)}50%{transform:translateX(6px)}}
+@keyframes tempo-flash-metronome-swing-arm{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-metronome-swing-arm — metronome with swinging arm, sliding weight and tempo

**Closes #59807**

### What this adds
A metronome. A wooden triangular body shows a tempo scale, a steel arm swings side to side with a pink weight that shifts, and a pivot dot sits at the base while the BPM label flashes in the header.

### Acceptance Criteria covered
- The arm swings across the tempo scale
- The sliding weight shifts on the arm
- The BPM label flashes in the header

### Files
- `submissions/examples/ease-metronome-swing-arm-ij/demo.html`
- `submissions/examples/ease-metronome-swing-arm-ij/style.css`
- `submissions/examples/ease-metronome-swing-arm-ij/README.md`

### How to review
Open demo.html directly in a browser. The arm swings while the weight shifts across the scale.