### PR TITLE
Add ease-telescope-stargazer component

### DIFF
--- a/submissions/examples/ease-telescope-stargazer-ij/README.md
+++ b/submissions/examples/ease-telescope-stargazer-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Telescope Stargazer
+
+A tripod telescope with a glowing lens, turning focus dial and twinkling stars.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The stars twinkle while the lens glows.

--- a/submissions/examples/ease-telescope-stargazer-ij/demo.html
+++ b/submissions/examples/ease-telescope-stargazer-ij/demo.html
@@ -1,0 +1,37 @@
+<!-- EaseMotion component: telescope-stargazer -->
+<!DOCTYPE html>
+<html lang="en" data-scope="star">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.5">
+<title>Ease Telescope Stargazer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="observatory">
+  <header class="obs-head">
+    <span class="obs-title">OBSERVATORY</span>
+    <span class="obs-target">TARGET ORION</span>
+  </header>
+  <div class="star-field">
+    <span class="star s-1"></span>
+    <span class="star s-2"></span>
+    <span class="star s-3"></span>
+    <span class="star s-4"></span>
+    <span class="star s-5"></span>
+  </div>
+  <div class="scope-mount">
+    <span class="scope-tube"></span>
+    <span class="scope-eyepiece"></span>
+    <span class="telescope-lens"></span>
+    <span class="telescope-focus"></span>
+    <span class="tripod leg-left"></span>
+    <span class="tripod leg-right"></span>
+  </div>
+  <footer class="obs-foot">
+    <span class="obs-mag">MAG 8.4</span>
+    <span class="obs-tracking">TRACKING</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-telescope-stargazer-ij/style.css
+++ b/submissions/examples/ease-telescope-stargazer-ij/style.css
@@ -1,0 +1,35 @@
+:root{
+  --tg-bg:hsl(230,40%,6%);
+  --tg-ink:hsl(230,25%,92%);
+  --tg-gold:hsl(40,90%,60%);
+  --tg-slate:hsl(230,15%,40%);
+  --tg-navy:hsl(230,35%,12%);
+}
+*{padding:0;box-sizing:border-box}*{margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 25%,hsl(230,45%,14%),hsl(235,50%,4%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.observatory{width:360px;border-radius:16px;overflow:hidden;background:hsl(230,36%,8%);border:1px solid hsl(230,30%,22%)}
+.obs-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(230,44%,12%)}
+.obs-title{font-size:.82rem;letter-spacing:3px;color:var(--tg-ink)}
+.obs-target{font-size:.7rem;font-weight:800;color:var(--tg-gold);animation:target-pulse-telescope-stargazer 2.2s ease-in-out infinite}
+.star-field{position:relative;height:110px;margin:14px 14px 0;border-radius:12px;background:linear-gradient(180deg,hsl(230,45%,9%),hsl(230,40%,6%));border:1px solid hsl(230,30%,18%)}
+.star{position:absolute;width:5px;height:5px;border-radius:50%;background:var(--tg-gold);animation:star-pulse-telescope-stargazer 2.4s ease-in-out infinite}
+.s-1{left:16%;top:22px}
+.s-2{left:44%;top:48px;animation-delay:.6s}
+.s-3{left:68%;top:18px;animation-delay:1s}
+.s-4{left:82%;top:64px;animation-delay:1.4s}
+.s-5{left:28%;top:78px;animation-delay:1.8s}
+.scope-mount{position:relative;height:170px;margin:0 14px 14px;border-radius:12px;background:hsl(230,40%,10%)}
+.scope-tube{position:absolute;left:50%;top:18px;width:150px;height:44px;transform:translateX(-50%) rotate(14deg);border-radius:22px;background:linear-gradient(180deg,hsl(230,15%,34%),hsl(230,15%,22%));box-shadow:0 4px 0 hsl(230,25%,14%)}
+.scope-eyepiece{position:absolute;left:30px;top:38px;width:18px;height:18px;border-radius:50%;background:hsl(230,15%,16%);border:4px solid var(--tg-slate)}
+.telescope-lens{position:absolute;left:118px;top:24px;width:28px;height:28px;border-radius:50%;background:radial-gradient(circle at 50% 50%,hsl(190,80%,70% / 0.6),hsl(230,40%,20%));animation:lens-glow-telescope-stargazer 2.6s ease-in-out infinite}
+.telescope-focus{position:absolute;left:76px;top:46px;width:34px;height:12px;border-radius:6px;background:var(--tg-gold);animation:focus-dial-telescope-stargazer 2.6s ease-in-out infinite}
+.tripod{position:absolute;top:62px;width:6px;height:90px;border-radius:3px;background:var(--tg-slate)}
+.leg-left{left:38%;transform:rotate(18deg);transform-origin:50% 0}
+.leg-right{right:38%;transform:rotate(-18deg);transform-origin:50% 0}
+.obs-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(230,44%,12%)}
+.obs-mag{font-size:.68rem;color:hsl(230,25%,60%)}
+.obs-tracking{font-size:.68rem;letter-spacing:2px;color:var(--tg-gold);animation:target-pulse-telescope-stargazer 2.2s ease-in-out infinite}
+@keyframes target-pulse-telescope-stargazer{0%,100%{opacity:1}50%{opacity:0.4}}
+@keyframes star-pulse-telescope-stargazer{0%,100%{opacity:1;transform:scale(1)}50%{opacity:0.25;transform:scale(0.6)}}
+@keyframes lens-glow-telescope-stargazer{0%,100%{filter:brightness(1)}50%{filter:brightness(1.8)}}
+@keyframes focus-dial-telescope-stargazer{0%,100%{transform:rotate(0deg)}50%{transform:rotate(8deg)}}


### PR DESCRIPTION
## Component: ease-telescope-stargazer — telescope on a tripod with focus dial and stars

**Closes #59811**

### What this adds
A stargazer telescope. A field of twinkling stars sits above a tripod-mounted telescope whose lens glows and focus dial turns, while the header shows the target and a tracking badge blinks below.

### Acceptance Criteria covered
- The star field twinkles above the scope
- The telescope lens glows on the tube
- The focus dial turns on the mount

### Files
- `submissions/examples/ease-telescope-stargazer-ij/demo.html`
- `submissions/examples/ease-telescope-stargazer-ij/style.css`
- `submissions/examples/ease-telescope-stargazer-ij/README.md`

### How to review
Open demo.html directly in a browser. The stars twinkle while the lens glows and the focus dial turns.