### PR TITLE
Add ease-cinema-marquee-bulbs component

### DIFF
--- a/submissions/examples/ease-cinema-marquee-bulbs-ij/README.md
+++ b/submissions/examples/ease-cinema-marquee-bulbs-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Cinema Marquee Bulbs
+
+A cinema marquee with chasing bulbs around a glowing show title.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The bulbs chase while the title glows.

--- a/submissions/examples/ease-cinema-marquee-bulbs-ij/demo.html
+++ b/submissions/examples/ease-cinema-marquee-bulbs-ij/demo.html
@@ -1,0 +1,37 @@
+<!-- EaseMotion component: cinema-marquee-bulbs -->
+<!DOCTYPE html>
+<html lang="en" data-cine="marquee">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+<title>Ease Cinema Marquee Bulbs</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="cine-marquee">
+  <header class="cine-head">
+    <span class="cine-name">REX CINEMA</span>
+    <span class="cine-time">7:30 PM</span>
+  </header>
+  <div class="cine-board">
+    <span class="bulb b-1"></span>
+    <span class="bulb b-2"></span>
+    <span class="bulb b-3"></span>
+    <span class="bulb b-4"></span>
+    <span class="bulb b-5"></span>
+    <span class="bulb b-6"></span>
+    <span class="bulb b-7"></span>
+    <span class="bulb b-8"></span>
+    <span class="bulb b-9"></span>
+    <span class="bulb b-10"></span>
+    <span class="bulb b-11"></span>
+    <span class="bulb b-12"></span>
+    <span class="cine-title">MIDNIGHT RUNNER</span>
+  </div>
+  <footer class="cine-foot">
+    <span class="cine-session">SESSION 2</span>
+    <span class="cine-sold">SOLD 92%</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-cinema-marquee-bulbs-ij/style.css
+++ b/submissions/examples/ease-cinema-marquee-bulbs-ij/style.css
@@ -1,0 +1,34 @@
+:root{
+  --ci-bg:hsl(280,30%,7%);
+  --ci-ink:hsl(280,20%,92%);
+  --ci-yellow:hsl(50,100%,58%);
+  --ci-red:hsl(0,85%,55%);
+  --ci-dark:hsl(280,25%,14%);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 25%,hsl(280,35%,15%),hsl(285,45%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.cine-marquee{width:360px;border-radius:14px;overflow:hidden;background:hsl(280,26%,9%);border:1px solid hsl(280,22%,24%)}
+.cine-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(280,32%,13%)}
+.cine-name{font-size:.84rem;letter-spacing:3px;color:var(--ci-yellow)}
+.cine-time{font-size:.7rem;font-weight:800;color:var(--ci-red);animation:time-blink-cinema-marquee-bulbs 1.6s ease-in-out infinite}
+.cine-board{position:relative;height:150px;margin:14px;border-radius:12px;background:hsl(280,30%,11%);border:2px solid hsl(280,20%,26%);display:flex;align-items:center;justify-content:center}
+.bulb{position:absolute;width:12px;height:12px;border-radius:50%;background:var(--ci-yellow);box-shadow:0 0 8px hsl(50,100%,60% / 0.9);animation:bulb-chase-cinema-marquee-bulbs 1.4s ease-in-out infinite}
+.b-1{left:10px;top:8px}
+.b-2{left:38%;top:8px}
+.b-3{left:68%;top:8px}
+.b-4{right:10px;top:8px}
+.b-5{right:10px;top:50%;animation-delay:.2s}
+.b-6{right:10px;bottom:8px;animation-delay:.4s}
+.b-7{left:68%;bottom:8px;animation-delay:.6s}
+.b-8{left:38%;bottom:8px;animation-delay:.8s}
+.b-9{left:10px;bottom:8px;animation-delay:1s}
+.b-10{left:10px;top:50%;animation-delay:1.2s}
+.b-11{left:50%;top:8px;animation-delay:.3s}
+.b-12{left:50%;bottom:8px;animation-delay:.9s}
+.cine-title{font-size:1.15rem;font-weight:900;letter-spacing:2px;color:var(--ci-yellow);text-shadow:0 0 10px hsl(50,100%,60% / 0.8);animation:title-glow-cinema-marquee-bulbs 2s ease-in-out infinite}
+.cine-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(280,32%,13%)}
+.cine-session{font-size:.68rem;color:hsl(280,20%,60%)}
+.cine-sold{font-size:.68rem;font-weight:800;color:var(--ci-yellow)}
+@keyframes bulb-chase-cinema-marquee-bulbs{0%,100%{opacity:1}50%{opacity:0.15}}
+@keyframes title-glow-cinema-marquee-bulbs{0%,100%{text-shadow:0 0 6px hsl(50,100%,60% / 0.5)}50%{text-shadow:0 0 16px hsl(50,100%,70% / 1)}}
+@keyframes time-blink-cinema-marquee-bulbs{0%,100%{opacity:1}50%{opacity:0.25}}


### PR DESCRIPTION
## Component: ease-cinema-marquee-bulbs — cinema marquee with chasing bulbs and showtime

**Closes #59831**

### What this adds
A cinema marquee. A dark fascia holds a row of glass bulbs that chase in sequence around the title board, the show title glows behind the bulbs, and the header blinks the showtime while the footer lists the session.

### Acceptance Criteria covered
- The bulb row chases around the title board
- The show title glows on the fascia
- The showtime blinks in the header

### Files
- `submissions/examples/ease-cinema-marquee-bulbs-ij/demo.html`
- `submissions/examples/ease-cinema-marquee-bulbs-ij/style.css`
- `submissions/examples/ease-cinema-marquee-bulbs-ij/README.md`

### How to review
Open demo.html directly in a browser. The bulbs chase around the glowing title board.