### PR TITLE
Add ease-crosswalk-signal-ped component

### DIFF
--- a/submissions/examples/ease-crosswalk-signal-ped-ij/README.md
+++ b/submissions/examples/ease-crosswalk-signal-ped-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Crosswalk Signal Ped
+
+A pedestrian crossing signal with a walk figure and ticking countdown.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The walk figure shows while the countdown ticks.

--- a/submissions/examples/ease-crosswalk-signal-ped-ij/demo.html
+++ b/submissions/examples/ease-crosswalk-signal-ped-ij/demo.html
@@ -1,0 +1,33 @@
+<!-- EaseMotion component: crosswalk-signal-ped -->
+<!DOCTYPE html>
+<html lang="en" data-cross="walk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.2">
+<title>Ease Crosswalk Signal Ped</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="ped-signal">
+  <header class="ped-head">
+    <span class="ped-street">MAIN ST</span>
+    <span class="ped-await">WAIT</span>
+  </header>
+  <div class="ped-pole">
+    <span class="ped-box">
+      <span class="ped-figure"></span>
+      <span class="ped-count">7</span>
+    </span>
+    <span class="ped-post"></span>
+  </div>
+  <div class="ped-button">
+    <span class="button-cap"></span>
+    <span class="button-base"></span>
+  </div>
+  <footer class="ped-foot">
+    <span class="ped-zone">SCHOOL ZONE</span>
+    <span class="ped-clear">CLEAR TO WALK</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-crosswalk-signal-ped-ij/style.css
+++ b/submissions/examples/ease-crosswalk-signal-ped-ij/style.css
@@ -1,0 +1,28 @@
+:root{
+  --pd-bg:hsl(200,30%,7%);
+  --pd-ink:hsl(200,20%,92%);
+  --pd-white:hsl(0,0%,94%);
+  --pd-red:hsl(0,85%,55%);
+  --pd-green:hsl(120,80%,50%);
+}
+*{padding:0;box-sizing:border-box}*{margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(200,40%,15%),hsl(205,50%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.ped-signal{width:340px;border-radius:16px;overflow:hidden;background:hsl(200,26%,9%);border:1px solid hsl(200,22%,24%)}
+.ped-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(200,34%,13%)}
+.ped-street{font-size:.82rem;letter-spacing:3px;color:var(--pd-ink)}
+.ped-await{font-size:.68rem;font-weight:800;color:var(--pd-red);animation:await-blink-crosswalk-signal-ped 1s step-end infinite}
+.ped-pole{position:relative;height:220px;margin:14px}
+.ped-box{position:absolute;left:50%;top:0;width:100px;height:150px;transform:translateX(-50%);border-radius:12px;background:hsl(200,22%,16%);border:4px solid hsl(200,20%,30%);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px}
+.ped-figure{width:46px;height:70px;background:var(--pd-white);clip-path:polygon(0 0,0 0,0 0,0 0);animation:walk-figure-crosswalk-signal-ped 1.2s ease-in-out infinite}
+.ped-count{font-size:1.3rem;font-weight:900;color:var(--pd-green);animation:count-tick-crosswalk-signal-ped 1s steps(1) infinite}
+.ped-post{position:absolute;left:50%;bottom:0;width:14px;height:70px;transform:translateX(-50%);border-radius:7px;background:hsl(200,20%,28%)}
+.ped-button{position:relative;height:70px;margin:0 14px}
+.button-cap{position:absolute;left:50%;top:6px;width:40px;height:40px;transform:translateX(-50%);border-radius:50%;background:hsl(200,15%,22%);border:4px solid hsl(200,15%,36%);animation:button-pulse-crosswalk-signal-ped 1.8s ease-in-out infinite}
+.button-base{position:absolute;left:50%;bottom:0;width:26px;height:34px;transform:translateX(-50%);border-radius:6px;background:hsl(200,20%,16%)}
+.ped-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(200,34%,13%)}
+.ped-zone{font-size:.68rem;color:hsl(200,20%,58%)}
+.ped-clear{font-size:.68rem;font-weight:800;color:var(--pd-green)}
+@keyframes walk-figure-crosswalk-signal-ped{0%,100%{opacity:1}50%{opacity:0.3}}
+@keyframes count-tick-crosswalk-signal-ped{0%,90%{opacity:1}91%,100%{opacity:0.2}}
+@keyframes button-pulse-crosswalk-signal-ped{0%,100%{transform:translateX(-50%) scale(1)}50%{transform:translateX(-50%) scale(0.9)}}
+@keyframes await-blink-crosswalk-signal-ped{0%,50%{opacity:1}51%,100%{opacity:0.1}}


### PR DESCRIPTION
## Component: ease-crosswalk-signal-ped — pedestrian signal with walk figure and countdown

**Closes #59851**

### What this adds
A pedestrian crossing signal. A pole-mounted box shows a white walking figure on the walk phase, a countdown digit ticks below the figure, and the header blinks the street name while the footer shows the waiting state.

### Acceptance Criteria covered
- The walk figure shows on the signal face
- The countdown digit ticks below the figure
- The street name blinks in the header

### Files
- `submissions/examples/ease-crosswalk-signal-ped-ij/demo.html`
- `submissions/examples/ease-crosswalk-signal-ped-ij/style.css`
- `submissions/examples/ease-crosswalk-signal-ped-ij/README.md`

### How to review
Open demo.html directly in a browser. The walk figure shows while the countdown ticks.