### PR TITLE
feat(css): Page Transition Overlay Utilities (#59861)

### DIFF
--- a/submissions/examples/page-transitions/README.md
+++ b/submissions/examples/page-transitions/README.md
@@ -1,0 +1,19 @@
+# Page Transition Overlay Utilities
+
+Resolves Issue #59861.
+
+This submission introduces full-screen CSS page transition utilities that developers can easily integrate into single-page applications (SPAs) or multi-page apps to mask route changes.
+
+## Implementation Details
+- Uses `body::before` to create a fixed full-screen overlay, eliminating the need to add extra empty `<div>` elements to the DOM.
+- The `animation` swaps `transform-origin` perfectly halfway through (at 50%), allowing the overlay to scale in from one side, and scale out towards the opposite side seamlessly.
+- Provides `ease-transition-sweep-right` and `ease-transition-curtain-drop` animations.
+- Provides optional `.ease-duration-fast` and `.ease-duration-slow` modifiers to override the default animation duration.
+- The default overlay color can be customized easily using the CSS variable `--ease-transition-color` (defaults to a dark slate `#0f172a`).
+
+## Included Files
+- `page-transitions.css`: The core utility classes.
+- `demo.html`: An interactive demonstration of the transitions in action, including speed modifiers and a custom color implementation via CSS variables.
+
+## Usage
+Simply append `.ease-transition-sweep-right` to the `<body>` element when a route change begins. The animation will play out completely over 1.2s by default. You can use JavaScript logic within an SPA router to trigger this class immediately prior to fetching the next view.

--- a/submissions/examples/page-transitions/demo.html
+++ b/submissions/examples/page-transitions/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Transition Overlay Utilities Demo</title>
+  <link rel="stylesheet" href="page-transitions.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f8fafc;
+      color: #334155;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      overflow: hidden;
+    }
+    .content {
+      text-align: center;
+      z-index: 10;
+    }
+    h1 { color: #0f172a; }
+    button {
+      padding: 12px 24px;
+      margin: 10px;
+      font-size: 1rem;
+      cursor: pointer;
+      border: none;
+      border-radius: 6px;
+      background: #3b82f6;
+      color: white;
+      font-weight: bold;
+      transition: background 0.2s;
+    }
+    button:hover { background: #2563eb; }
+    
+    .color-btn {
+      background: #10b981;
+    }
+    .color-btn:hover { background: #059669; }
+  </style>
+</head>
+<body>
+
+  <div class="content">
+    <h1>EaseMotion Page Transitions</h1>
+    <p>Click a button to trigger a CSS-only full-screen overlay transition.</p>
+    
+    <div>
+      <button onclick="triggerTransition('ease-transition-sweep-right')">Sweep Right (Default Speed)</button>
+      <button onclick="triggerTransition('ease-transition-curtain-drop', 'ease-duration-fast')">Curtain Drop (Fast Speed)</button>
+      <button onclick="triggerTransition('ease-transition-sweep-right', 'ease-duration-slow')">Sweep Right (Slow Speed)</button>
+    </div>
+    
+    <div style="margin-top: 20px;">
+      <button class="color-btn" onclick="triggerCustomColorTransition('ease-transition-curtain-drop', '#8b5cf6')">Curtain Drop (Purple Overlay)</button>
+    </div>
+  </div>
+
+  <script>
+    function triggerTransition(transitionClass, durationClass = '') {
+      // Reset color variable if it was modified
+      document.documentElement.style.removeProperty('--ease-transition-color');
+      
+      // Remove any existing transition classes to reset
+      document.body.className = '';
+      
+      // Force a reflow so the browser registers the removal
+      void document.body.offsetWidth;
+      
+      // Add the transition classes
+      const classes = [transitionClass];
+      if (durationClass) classes.push(durationClass);
+      
+      document.body.classList.add(...classes);
+    }
+    
+    function triggerCustomColorTransition(transitionClass, color) {
+      document.documentElement.style.setProperty('--ease-transition-color', color);
+      document.body.className = '';
+      void document.body.offsetWidth;
+      document.body.classList.add(transitionClass);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/page-transitions/page-transitions.css
+++ b/submissions/examples/page-transitions/page-transitions.css
@@ -1,0 +1,76 @@
+/* submissions/examples/page-transitions/page-transitions.css */
+
+/* Base pseudo-element styling for page transitions */
+body.ease-transition-sweep-right::before,
+body.ease-transition-curtain-drop::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: var(--ease-transition-color, #0f172a);
+  z-index: 9999;
+  pointer-events: none; /* Let clicks pass through when not active */
+}
+
+/* Sweep Right Transition */
+body.ease-transition-sweep-right::before {
+  transform-origin: left;
+  transform: scaleX(0);
+  animation: easeSweepRight 1.2s cubic-bezier(0.77, 0, 0.175, 1) forwards;
+}
+
+@keyframes easeSweepRight {
+  0% {
+    transform-origin: left;
+    transform: scaleX(0);
+  }
+  49.9% {
+    transform-origin: left;
+    transform: scaleX(1);
+  }
+  50% {
+    transform-origin: right;
+    transform: scaleX(1);
+  }
+  100% {
+    transform-origin: right;
+    transform: scaleX(0);
+  }
+}
+
+/* Curtain Drop (Sweep Down) Transition */
+body.ease-transition-curtain-drop::before {
+  transform-origin: top;
+  transform: scaleY(0);
+  animation: easeCurtainDrop 1.2s cubic-bezier(0.77, 0, 0.175, 1) forwards;
+}
+
+@keyframes easeCurtainDrop {
+  0% {
+    transform-origin: top;
+    transform: scaleY(0);
+  }
+  49.9% {
+    transform-origin: top;
+    transform: scaleY(1);
+  }
+  50% {
+    transform-origin: bottom;
+    transform: scaleY(1);
+  }
+  100% {
+    transform-origin: bottom;
+    transform: scaleY(0);
+  }
+}
+
+/* Duration Modifiers */
+body.ease-duration-fast::before {
+  animation-duration: 0.6s !important;
+}
+
+body.ease-duration-slow::before {
+  animation-duration: 2s !important;
+}


### PR DESCRIPTION
## Description
Resolves #59861

This PR introduces CSS-only full-screen page transition utilities designed to mask page loads and SPA route changes.

Due to the ongoing core directory freeze, this proposal and its demonstration have been placed in `submissions/examples/page-transitions/`.

## Implementation Details
- **`page-transitions.css`**: Uses the `::before` pseudo-element on the `<body>` to generate fixed, 100vw/vh overlays when the classes `.ease-transition-sweep-right` or `.ease-transition-curtain-drop` are applied.
- The animations intelligently swap `transform-origin` at the 50% mark, allowing the sweep effect to expand in from one side and smoothly collapse out the other side without Javascript coordinate calculations.
- Includes duration modifiers: `.ease-duration-fast` and `.ease-duration-slow`.
- Uses a CSS variable `--ease-transition-color` for rapid overlay color customization.
- **`demo.html`**: A fully functional interactive demo testing the transitions and proving the CSS variables concept.

## Checklist
- [x] Placed in the `submissions/examples/page-transitions/` directory
- [x] Single commit
- [x] Pure CSS animation logic
- [x] No direct modifications to core files (respecting the contribution freeze)