### PR TITLE
Add ease-solar-panel-charger component

### DIFF
--- a/submissions/examples/ease-solar-panel-charger-ij/README.md
+++ b/submissions/examples/ease-solar-panel-charger-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Solar Panel Charger
+
+A solar bank with tilting panels, a glowing sun and a filling charge meter.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The panels tilt while the battery bar fills.

--- a/submissions/examples/ease-solar-panel-charger-ij/demo.html
+++ b/submissions/examples/ease-solar-panel-charger-ij/demo.html
@@ -1,0 +1,46 @@
+<!-- EaseMotion component: solar-panel-charger -->
+<!DOCTYPE html>
+<html lang="en" data-solar="bank">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.1">
+<title>Ease Solar Panel Charger</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="solar-station">
+  <header class="solar-head">
+    <span class="solar-title">SOLAR BANK</span>
+    <span class="solar-watt">310 W</span>
+  </header>
+  <div class="solar-sky">
+    <span class="solar-sun"></span>
+  </div>
+  <div class="solar-frame">
+    <span class="panel panel-left">
+      <span class="cell c1"></span>
+      <span class="cell c2"></span>
+      <span class="cell c3"></span>
+      <span class="cell c4"></span>
+    </span>
+    <span class="panel panel-right">
+      <span class="cell c1"></span>
+      <span class="cell c2"></span>
+      <span class="cell c3"></span>
+      <span class="cell c4"></span>
+    </span>
+    <span class="solar-pole pole-a"></span>
+    <span class="solar-pole pole-b"></span>
+  </div>
+  <div class="charge-meter">
+    <span class="charge-label">BATTERY</span>
+    <span class="charge-bar"><span class="charge-fill"></span></span>
+    <span class="charge-pct">72%</span>
+  </div>
+  <footer class="solar-foot">
+    <span class="solar-mode">GRID-TIE</span>
+    <span class="solar-status">CHARGING</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-solar-panel-charger-ij/style.css
+++ b/submissions/examples/ease-solar-panel-charger-ij/style.css
@@ -1,0 +1,35 @@
+:root{
+  --sp-bg:hsl(45,60%,7%);
+  --sp-ink:hsl(45,25%,92%);
+  --sp-gold:hsl(48,100%,60%);
+  --sp-blue:hsl(215,90%,60%);
+  --sp-frame:hsl(45,20%,28%);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 20%,hsl(45,45%,15%),hsl(48,55%,4%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.solar-station{width:360px;border-radius:16px;overflow:hidden;background:hsl(45,40%,9%);border:1px solid hsl(45,32%,24%)}
+.solar-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(45,50%,13%)}
+.solar-title{font-size:.82rem;letter-spacing:3px;color:var(--sp-ink)}
+.solar-watt{font-size:.76rem;font-weight:900;color:var(--sp-gold);animation:watt-blink-solar-panel-charger 1.8s ease-in-out infinite}
+.solar-sky{position:relative;height:70px;background:linear-gradient(180deg,hsl(48,60%,55% / 0.25),hsl(45,45%,10%))}
+.solar-sun{position:absolute;right:20px;top:12px;width:40px;height:40px;border-radius:50%;background:var(--sp-gold);box-shadow:0 0 24px hsl(48,100%,65% / 0.9);animation:sun-pulse-solar-panel-charger 2.4s ease-in-out infinite}
+.solar-frame{position:relative;height:150px;margin:14px;border-radius:12px;background:hsl(45,40%,12%)}
+.panel{position:absolute;top:26px;width:128px;height:84px;border-radius:8px;background:linear-gradient(135deg,hsl(215,80%,50%),hsl(220,85%,35%));border:3px solid var(--sp-frame);display:grid;grid-template-columns:repeat(2,1fr);grid-template-rows:repeat(2,1fr);gap:2px;padding:4px}
+.panel-left{left:18px;transform:rotate(-8deg);animation:panel-tilt-solar-panel-charger 3s ease-in-out infinite}
+.panel-right{right:18px;transform:rotate(8deg);animation:panel-tilt-solar-panel-charger 3s ease-in-out infinite;animation-delay:1.5s}
+.cell{background:repeating-linear-gradient(90deg,hsl(220,90%,55%) 0 4px,hsl(220,85%,40%) 4px 8px);border-radius:3px}
+.solar-pole{position:absolute;bottom:0;width:6px;height:64px;background:var(--sp-frame)}
+.pole-a{left:30%}
+.pole-b{right:30%}
+.charge-meter{display:flex;align-items:center;gap:12px;padding:0 16px 14px}
+.charge-label{font-size:.68rem;letter-spacing:2px;color:hsl(45,20%,60%)}
+.charge-bar{flex:1;height:14px;border-radius:7px;background:hsl(45,20%,18%)}
+.charge-fill{display:block;width:72%;height:100%;border-radius:7px;background:linear-gradient(90deg,var(--sp-blue),hsl(130,70%,50%));animation:charge-fill-solar-panel-charger 2.6s ease-in-out infinite}
+.charge-pct{font-size:.7rem;font-weight:800;color:var(--sp-ink)}
+.solar-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(45,50%,13%)}
+.solar-mode{font-size:.68rem;color:hsl(45,20%,58%)}
+.solar-status{font-size:.68rem;font-weight:800;color:hsl(130,70%,50%);animation:watt-blink-solar-panel-charger 1.8s ease-in-out infinite}
+@keyframes watt-blink-solar-panel-charger{0%,100%{opacity:1}50%{opacity:0.4}}
+@keyframes sun-pulse-solar-panel-charger{0%,100%{transform:scale(1)}50%{transform:scale(1.15)}}
+@keyframes panel-tilt-solar-panel-charger{0%,100%{transform:rotate(-8deg)}50%{transform:rotate(-14deg)}}
+@keyframes charge-fill-solar-panel-charger{0%,100%{width:72%}50%{width:64%}}


### PR DESCRIPTION
## Component: ease-solar-panel-charger — solar panel bank with tilting cells and charge level

**Closes #59821**

### What this adds
A solar charger station. Two solar panels tilt on a frame under a glowing sun, a charge meter fills its battery bar with pulses, and the header blinks the live wattage while the footer shows the output status.

### Acceptance Criteria covered
- The two solar panels tilt under the sun
- The charge meter fills the battery bar
- The live wattage blinks in the header

### Files
- `submissions/examples/ease-solar-panel-charger-ij/demo.html`
- `submissions/examples/ease-solar-panel-charger-ij/style.css`
- `submissions/examples/ease-solar-panel-charger-ij/README.md`

### How to review
Open demo.html directly in a browser. The panels tilt while the battery bar fills and the wattage blinks.