### PR TITLE
feat(css): Pure CSS Before/After Image Comparison Slider (#59860)

### DIFF
--- a/submissions/examples/image-compare/README.md
+++ b/submissions/examples/image-compare/README.md
@@ -1,0 +1,18 @@
+# Pure CSS Before/After Image Comparison Slider
+
+Resolves Issue #59860.
+
+This submission provides an elegant and lightweight image comparison slider component.
+
+## Implementation Details
+- Relies on CSS `clip-path` and a custom CSS variable (`--slider-value`) to crop the "After" image dynamically.
+- Uses a visually hidden HTML `<input type="range">` overlaid on top of the images. This provides native, accessible touch and mouse dragging interactions for free.
+- The range slider updates the CSS variable using a tiny inline `oninput` handler (`this.parentNode.style.setProperty(...)`), completely avoiding external JS script files or complex event listeners.
+- The visual handle and thumb circle are entirely rendered using the `.ease-image-compare::before` and `::after` pseudo-elements.
+
+## Included Files
+- `image-compare.css`: The stylesheet defining the component layout, clipping, and custom handle rendering.
+- `demo.html`: A functional example demonstrating the slider on an actual image.
+
+## Integration
+Once the core engine contribution freeze is lifted, `image-compare.css` can be seamlessly integrated into the `easemotion/components` directory.

--- a/submissions/examples/image-compare/demo.html
+++ b/submissions/examples/image-compare/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Before/After Image Comparison Slider</title>
+  <link rel="stylesheet" href="image-compare.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      background: #f8fafc;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 20px;
+    }
+    .wrapper {
+      max-width: 800px;
+      width: 100%;
+      text-align: center;
+    }
+    h2 { color: #0f172a; margin-bottom: 8px;}
+    p { color: #475569; margin-bottom: 24px;}
+    .ease-image-compare {
+      border-radius: 12px;
+      box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+      aspect-ratio: 16/9;
+      background: #e2e8f0;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="wrapper">
+    <h2>CSS Image Comparison</h2>
+    <p>Using a native range input bound to a CSS variable via a single inline event handler.</p>
+    
+    <div class="ease-image-compare" style="--slider-value: 50%;">
+      <!-- The Before Image (Bottom Layer) -->
+      <img src="https://images.unsplash.com/photo-1542204165-65bf26472b9b?auto=format&fit=crop&w=800&q=80" alt="Before (Color)">
+      
+      <!-- The After Image (Top Layer, Clipped) -->
+      <!-- Black and white version of the same image for demonstration -->
+      <img class="ease-img-after" style="filter: grayscale(100%);" src="https://images.unsplash.com/photo-1542204165-65bf26472b9b?auto=format&fit=crop&w=800&q=80" alt="After (Grayscale)">
+      
+      <!-- The Range Slider Overlay -->
+      <input type="range" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--slider-value', this.value + '%')" aria-label="Percentage of before photo shown">
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/image-compare/image-compare.css
+++ b/submissions/examples/image-compare/image-compare.css
@@ -1,0 +1,74 @@
+/* submissions/examples/image-compare/image-compare.css */
+
+.ease-image-compare {
+  position: relative;
+  overflow: hidden;
+  --slider-value: 50%;
+  user-select: none;
+}
+
+.ease-image-compare img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+.ease-image-compare .ease-img-after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  /* Use clip-path to reveal the bottom image based on the slider value */
+  clip-path: polygon(var(--slider-value) 0, 100% 0, 100% 100%, var(--slider-value) 100%);
+}
+
+.ease-image-compare input[type="range"] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0; /* Hide the native slider visually, but keep it interactive */
+  cursor: ew-resize;
+  z-index: 10;
+}
+
+/* Custom visual handle vertical line */
+.ease-image-compare::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--slider-value);
+  width: 4px;
+  background: white;
+  transform: translateX(-50%);
+  box-shadow: 0 0 10px rgba(0,0,0,0.5);
+  pointer-events: none; /* Pass interactions to the invisible range slider */
+  z-index: 5;
+}
+
+/* Custom thumb center circle */
+.ease-image-compare::before {
+  content: "↔";
+  position: absolute;
+  top: 50%;
+  left: var(--slider-value);
+  transform: translate(-50%, -50%);
+  width: 36px;
+  height: 36px;
+  background: white;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 34px; 
+  color: #334155;
+  font-weight: bold;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+  pointer-events: none;
+  z-index: 6;
+  font-size: 18px;
+}


### PR DESCRIPTION
## Description
Resolves #59860

This PR introduces an interactive Before/After image comparison slider built on top of a native HTML range input. 

Due to the ongoing core directory freeze, this proposal and its demonstration have been placed in `submissions/examples/image-compare/`.

## Implementation Details
- **`image-compare.css`**: Utilizes `clip-path: polygon()` driven by a CSS variable (`--slider-value`) to crop the top image smoothly. The custom visual handle (vertical line) and drag circle (`↔`) are painted entirely with `::before` and `::after` pseudo-elements.
- The actual interactivity is provided by a native visually-hidden `<input type="range">` with `z-index: 10`, layered directly over the images. This provides flawless, accessible mobile touch and mouse drag interactions for free without needing JS event listeners.
- **`demo.html`**: A fully functional interactive demo testing the slider on a real Unsplash image (using CSS filters to generate a black and white version to demonstrate the "after" effect). A tiny inline `oninput` handler on the range element effortlessly syncs its value to the `--slider-value` CSS variable.

## Checklist
- [x] Placed in the `submissions/examples/image-compare/` directory
- [x] Single commit
- [x] Driven by native range slider without external JS dependencies
- [x] No direct modifications to core files (respecting the contribution freeze)