### PR TITLE
Add ease-typewriter-carriage component

### DIFF
--- a/submissions/examples/ease-typewriter-carriage-ij/README.md
+++ b/submissions/examples/ease-typewriter-carriage-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Typewriter Carriage
+
+A typewriter with a sliding carriage, feeding paper and tapping keys.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The carriage slides while the keys tap.

--- a/submissions/examples/ease-typewriter-carriage-ij/demo.html
+++ b/submissions/examples/ease-typewriter-carriage-ij/demo.html
@@ -1,0 +1,40 @@
+<!-- EaseMotion component: typewriter-carriage -->
+<!DOCTYPE html>
+<html lang="en" data-type="carriage">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.6">
+<title>Ease Typewriter Carriage</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="type-rig">
+  <header class="type-head">
+    <span class="type-model">HERMES 3000</span>
+    <span class="type-ribbon">RIBBON OK</span>
+  </header>
+  <div class="type-paper">
+    <span class="paper-sheet"></span>
+  </div>
+  <div class="type-carriage">
+    <span class="platen-roller"></span>
+    <span class="carriage-arm"></span>
+    <span class="carriage-head"></span>
+  </div>
+  <div class="type-keys">
+    <span class="type-key key-a"></span>
+    <span class="type-key key-b"></span>
+    <span class="type-key key-c"></span>
+    <span class="type-key key-d"></span>
+    <span class="type-key key-e"></span>
+    <span class="type-key key-f"></span>
+    <span class="type-key key-g"></span>
+    <span class="type-key key-h"></span>
+  </div>
+  <footer class="type-foot">
+    <span class="type-line">LINE 03</span>
+    <span class="type-return">RETURN</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-typewriter-carriage-ij/style.css
+++ b/submissions/examples/ease-typewriter-carriage-ij/style.css
@@ -1,0 +1,36 @@
+:root{
+  --tw-bg:hsl(260,25%,8%);
+  --tw-ink:hsl(260,20%,92%);
+  --tw-paper:hsl(50,35%,94%);
+  --tw-metal:hsl(260,15%,42%);
+  --tw-navy:hsl(260,35%,16%);
+}
+*{box-sizing:border-box;padding:0;margin:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(260,35%,14%),hsl(265,45%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.type-rig{width:360px;border-radius:16px;overflow:hidden;background:hsl(260,22%,9%);border:1px solid hsl(260,20%,24%)}
+.type-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(260,30%,13%)}
+.type-model{font-size:.8rem;letter-spacing:3px;color:var(--tw-ink)}
+.type-ribbon{font-size:.68rem;font-weight:800;color:hsl(0,70%,60%);animation:ribbon-blink-typewriter-carriage 1.8s ease-in-out infinite}
+.type-paper{position:relative;height:90px;margin:14px 14px 0;border-radius:8px;background:hsl(50,30%,20%)}
+.paper-sheet{position:absolute;left:50%;top:8px;width:120px;height:78px;transform:translateX(-50%);border-radius:4px;background:var(--tw-paper);background-image:repeating-linear-gradient(180deg,transparent 0 14px,hsl(50,20%,78%) 14px 15px);animation:paper-feed-typewriter-carriage 3s ease-in-out infinite}
+.type-carriage{position:relative;height:60px;margin:0 14px;background:hsl(260,20%,18%)}
+.platen-roller{position:absolute;left:50%;top:14px;width:150px;height:26px;transform:translateX(-50%);border-radius:13px;background:var(--tw-metal);border:3px solid hsl(260,15%,28%)}
+.carriage-arm{position:absolute;left:50%;top:6px;width:170px;height:6px;transform:translateX(-50%);background:hsl(260,20%,30%);animation:carriage-return-typewriter-carriage 3s ease-in-out infinite}
+.carriage-head{position:absolute;left:52%;top:6px;width:16px;height:34px;transform:translateX(-50%);border-radius:4px;background:hsl(260,30%,24%);animation:carriage-return-typewriter-carriage 3s ease-in-out infinite}
+.type-keys{display:flex;justify-content:center;gap:6px;padding:12px 14px;background:hsl(260,22%,12%)}
+.type-key{width:24px;height:26px;border-radius:50% 50% 4px 4px;background:hsl(260,12%,38%);animation:key-tap-typewriter-carriage 2s ease-in-out infinite}
+.key-a{animation-delay:0s}
+.key-b{animation-delay:.1s}
+.key-c{animation-delay:.2s}
+.key-d{animation-delay:.3s}
+.key-e{animation-delay:.4s}
+.key-f{animation-delay:.5s}
+.key-g{animation-delay:.6s}
+.key-h{animation-delay:.7s}
+.type-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(260,30%,13%)}
+.type-line{font-family:ui-monospace,Consolas,monospace;font-size:.7rem;color:hsl(260,20%,62%)}
+.type-return{font-size:.68rem;font-weight:800;color:var(--tw-ink)}
+@keyframes paper-feed-typewriter-carriage{0%,100%{transform:translateX(-50%) translateY(0)}50%{transform:translateX(-50%) translateY(8px)}}
+@keyframes carriage-return-typewriter-carriage{0%,100%{left:52%}50%{left:34%}}
+@keyframes key-tap-typewriter-carriage{0%,60%{transform:translateY(0)}75%{transform:translateY(6px)}100%{transform:translateY(0)}}
+@keyframes ribbon-blink-typewriter-carriage{0%,100%{opacity:1}50%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-typewriter-carriage — typewriter with returning carriage and tapping keys

**Closes #59878**

### What this adds
A typewriter. A paper sheet feeds up behind a platen roller, a carriage arm slides sideways with the paper, and the key row taps down one by one while the header blinks the model name and the footer shows the line count.

### Acceptance Criteria covered
- The paper sheet feeds behind the platen
- The carriage arm slides sideways
- The keys tap down in sequence

### Files
- `submissions/examples/ease-typewriter-carriage-ij/demo.html`
- `submissions/examples/ease-typewriter-carriage-ij/style.css`
- `submissions/examples/ease-typewriter-carriage-ij/README.md`

### How to review
Open demo.html directly in a browser. The carriage slides while the keys tap one after another.