### PR TITLE
feat(examples): add CSS clip-path onboarding tour spotlight component

### DIFF
--- a/submissions/examples/onboarding-tour-spotlight-ag/README.md
+++ b/submissions/examples/onboarding-tour-spotlight-ag/README.md
@@ -1,0 +1,163 @@
+# 🗺 Onboarding Tour Spotlight
+
+> A CSS `clip-path` guided onboarding tour overlay with smooth spotlight transitions, auto-positioned tooltips, and full keyboard accessibility — built with pure HTML, CSS & vanilla JS.
+
+---
+
+## 📖 What does this do?
+
+The **Onboarding Tour Spotlight** is a lightweight, guided feature walkthrough component. When the user clicks "Start Tour", a dark backdrop appears with a transparent spotlight cutout revealing the currently highlighted element. A floating tooltip with step navigation appears next to the target element.
+
+The spotlight rectangle transitions smoothly between elements as the user progresses through the tour steps.
+
+---
+
+## 🎯 How is it used?
+
+### 1. HTML structure (three elements outside your app shell)
+
+```html
+<!-- 1. Backdrop with clip-path hole -->
+<div id="tour-backdrop" class="tour-backdrop" aria-hidden="true"></div>
+
+<!-- 2. Highlight ring around target -->
+<div id="tour-highlight" class="tour-highlight" aria-hidden="true"></div>
+
+<!-- 3. Tooltip popover -->
+<div id="tour-tooltip" class="tour-tooltip" role="dialog" aria-modal="true"
+     aria-labelledby="tooltip-title" aria-describedby="tooltip-desc" tabindex="-1">
+  <!-- header, body, arrow, footer inside -->
+</div>
+```
+
+### 2. Define tour steps in `script.js`
+
+```js
+const TOUR_STEPS = [
+  {
+    targetId:  'kpi-row',          // ID of the element to highlight
+    icon:      '📊',
+    title:     'Key Metrics',
+    desc:      'Your most important numbers, all in one place.',
+    placement: 'bottom',           // 'top' | 'bottom' | 'left' | 'right'
+  },
+  // ...more steps
+];
+```
+
+### 3. The clip-path spotlight is driven entirely by CSS custom properties
+
+```css
+.tour-backdrop {
+  clip-path: polygon(
+    0% 0%, 100% 0%, 100% 100%, 0% 100%, 0% 0%,   /* outer frame */
+    var(--tour-spotlight-x) var(--tour-spotlight-y),
+    calc(var(--tour-spotlight-x) + var(--tour-spotlight-w)) var(--tour-spotlight-y),
+    ...   /* inner cutout rectangle */
+  );
+  transition: clip-path 380ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+```
+
+JavaScript only updates the four CSS variables — the animation is handled entirely by CSS.
+
+---
+
+## ✨ Key Highlights
+
+| Feature | Implementation |
+|---------|----------------|
+| **CSS clip-path spotlight** | `polygon()` with inner cutout rectangle; smooth CSS transition |
+| **Smooth spotlight move** | `clip-path` transitions via CSS custom props (`--tour-spotlight-x/y/w/h`) |
+| **Pulsing highlight ring** | `@keyframes tour-ring-pulse` border glow animation |
+| **Auto-positioned tooltip** | Smart placement (bottom/top/right/left) with viewport overflow detection + auto-flip |
+| **Directional arrow** | Four placement modifier classes (`.arrow--top/bottom/left/right`) |
+| **Step progress dots** | Animated pill-expand for active dot |
+| **Focus trap** | Tab/Shift+Tab contained inside `role="dialog"` tooltip |
+| **Keyboard navigation** | `Escape` → close, `ArrowRight` → next, `ArrowLeft` → prev |
+| **Dark & Light mode** | Full CSS custom property theme system |
+| **Responsive** | Tooltip re-positions on window resize; mobile stacks layout |
+| **Reduced motion** | All transitions and animations disabled for motion-sensitive users |
+
+---
+
+## ⌨️ Keyboard Support
+
+| Key | Action |
+|-----|--------|
+| `Space` / `Enter` (on "Start Tour") | Open the tour |
+| `→ ArrowRight` | Advance to next step |
+| `← ArrowLeft` | Go to previous step |
+| `Escape` | Close/exit the tour |
+| `Tab` / `Shift+Tab` | Move focus within tooltip (trapped) |
+
+---
+
+## 🎨 CSS Custom Properties
+
+```css
+:root {
+  --tour-backdrop:     rgba(6 8 20 / 0.82);  /* backdrop darkness */
+  --tour-tooltip-w:    320px;                 /* tooltip width */
+  --tour-arrow-size:   10px;                  /* directional arrow size */
+  --tour-highlight-clr: var(--clr-primary);   /* highlight ring colour */
+
+  /* Updated by JS — do not hardcode */
+  --tour-spotlight-x:  0px;
+  --tour-spotlight-y:  0px;
+  --tour-spotlight-w:  0px;
+  --tour-spotlight-h:  0px;
+}
+```
+
+---
+
+## ♿ Accessibility
+
+- Backdrop has `aria-hidden="true"` — screen readers skip the decorative overlay.
+- Tooltip uses `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, and `aria-describedby`.
+- `tabindex="-1"` on tooltip allows programmatic focus.
+- Focus is automatically trapped inside the tooltip with Tab/Shift+Tab wrapping.
+- `Escape` always closes the tour and returns focus to the triggering element.
+- Step dots use `role="tab"` with `aria-selected` state updates.
+- `prefers-reduced-motion: reduce` eliminates all keyframe animations and smooths transitions to instant.
+
+---
+
+## 🚀 Quick Start
+
+1. Copy `demo.html`, `style.css`, and `script.js` into the same folder.
+2. Open `demo.html` in any modern browser.
+3. Click **Start Tour** in the top bar.
+4. Use **Next / Prev** buttons or `Arrow keys` to walk through steps.
+5. Press `Escape` or click **Finish** to exit.
+
+```
+onboarding-tour-spotlight-ag/
+├── demo.html    ← Mock SaaS dashboard + tour overlay markup
+├── style.css    ← Dashboard UI + tour overlay styles (clip-path, ring, tooltip)
+├── script.js    ← Tour engine (step rendering, spotlight calc, focus trap, keyboard)
+└── README.md    ← This documentation
+```
+
+---
+
+## 🔍 Why is it useful?
+
+Onboarding tours traditionally rely on JavaScript-heavy libraries (Shepherd.js, Intro.js, Driver.js) that calculate bounding boxes, inject large DOM structures, and override page scroll. This submission shows that the **same visual effect can be driven by CSS** — the spotlight is purely a `clip-path: polygon()` hole cut from a dark backdrop, animated via CSS transitions and updated by four simple CSS variable assignments.
+
+This pattern is:
+- **Lightweight** — zero dependencies, ~350 lines of JS
+- **Performant** — clip-path runs on the GPU compositor thread
+- **Composable** — drop the three overlay elements into any existing page
+
+---
+
+## 🔬 Browser Support
+
+| Browser | Support |
+|---------|---------|
+| Chrome 80+ | ✅ Full |
+| Firefox 72+ | ✅ Full |
+| Safari 13.1+ | ✅ Full |
+| Edge 80+ | ✅ Full |

--- a/submissions/examples/onboarding-tour-spotlight-ag/demo.html
+++ b/submissions/examples/onboarding-tour-spotlight-ag/demo.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Onboarding Tour Spotlight — CSS clip-path guided tour overlay with smooth spotlight transitions and tooltip navigation, built with HTML, CSS & vanilla JS."
+    />
+    <title>Onboarding Tour Spotlight | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+
+    <!-- ── Page shell ───────────────────────────────────────────── -->
+    <div class="page-shell">
+
+      <!-- ── Sidebar ─────────────────────────────────────────────── -->
+      <aside class="sidebar" id="sidebar" aria-label="Main navigation">
+        <div class="sidebar__logo">
+          <span class="logo-mark" aria-hidden="true">✦</span>
+          <span class="logo-name">Dashify</span>
+        </div>
+
+        <nav class="sidebar__nav" aria-label="Sidebar navigation">
+          <a href="#" class="nav-item nav-item--active" id="nav-dashboard" aria-current="page">
+            <span class="nav-item__icon" aria-hidden="true">⊞</span>
+            <span class="nav-item__label">Dashboard</span>
+          </a>
+          <a href="#" class="nav-item" id="nav-analytics" aria-label="Analytics page">
+            <span class="nav-item__icon" aria-hidden="true">📈</span>
+            <span class="nav-item__label">Analytics</span>
+          </a>
+          <a href="#" class="nav-item" id="nav-projects">
+            <span class="nav-item__icon" aria-hidden="true">⊡</span>
+            <span class="nav-item__label">Projects</span>
+          </a>
+          <a href="#" class="nav-item" id="nav-team">
+            <span class="nav-item__icon" aria-hidden="true">👥</span>
+            <span class="nav-item__label">Team</span>
+          </a>
+          <a href="#" class="nav-item" id="nav-settings">
+            <span class="nav-item__icon" aria-hidden="true">⚙</span>
+            <span class="nav-item__label">Settings</span>
+          </a>
+        </nav>
+
+        <div class="sidebar__footer">
+          <div class="user-chip">
+            <div class="user-chip__avatar" aria-hidden="true">A</div>
+            <div class="user-chip__info">
+              <span class="user-chip__name">Arpita</span>
+              <span class="user-chip__role">Admin</span>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <!-- ── Main area ────────────────────────────────────────────── -->
+      <div class="main-area">
+
+        <!-- Top bar -->
+        <header class="topbar" id="topbar" role="banner">
+          <div class="topbar__left">
+            <h1 class="topbar__title">Dashboard</h1>
+          </div>
+          <div class="topbar__right">
+            <button
+              id="btn-start-tour"
+              class="tour-start-btn"
+              type="button"
+              aria-label="Start onboarding tour"
+            >
+              <span aria-hidden="true">🗺</span>
+              Start Tour
+            </button>
+            <button class="icon-btn" aria-label="Notifications" id="notif-btn">
+              <span aria-hidden="true">🔔</span>
+              <span class="notif-badge" aria-label="3 unread notifications">3</span>
+            </button>
+            <button class="icon-btn" aria-label="Toggle theme" id="theme-btn">
+              <span class="theme-icon theme-icon--dark" aria-hidden="true">🌙</span>
+              <span class="theme-icon theme-icon--light" aria-hidden="true">☀️</span>
+            </button>
+          </div>
+        </header>
+
+        <!-- Dashboard content -->
+        <main class="dashboard" id="main-content">
+
+          <!-- KPI row -->
+          <div class="kpi-row" id="kpi-row" role="list" aria-label="Key metrics">
+            <div class="kpi-card" role="listitem" aria-label="Total Revenue metric">
+              <div class="kpi-card__icon kpi-card__icon--green" aria-hidden="true">💰</div>
+              <div class="kpi-card__body">
+                <div class="kpi-card__value">$84,210</div>
+                <div class="kpi-card__label">Total Revenue</div>
+              </div>
+              <div class="kpi-card__badge kpi-card__badge--up" aria-label="Up 12.4 percent">+12.4%</div>
+            </div>
+            <div class="kpi-card" role="listitem" aria-label="Active Users metric">
+              <div class="kpi-card__icon kpi-card__icon--blue" aria-hidden="true">👤</div>
+              <div class="kpi-card__body">
+                <div class="kpi-card__value">3,842</div>
+                <div class="kpi-card__label">Active Users</div>
+              </div>
+              <div class="kpi-card__badge kpi-card__badge--up" aria-label="Up 8.1 percent">+8.1%</div>
+            </div>
+            <div class="kpi-card" role="listitem" aria-label="Open Tickets metric">
+              <div class="kpi-card__icon kpi-card__icon--amber" aria-hidden="true">🎫</div>
+              <div class="kpi-card__body">
+                <div class="kpi-card__value">128</div>
+                <div class="kpi-card__label">Open Tickets</div>
+              </div>
+              <div class="kpi-card__badge kpi-card__badge--down" aria-label="Down 3.2 percent">-3.2%</div>
+            </div>
+            <div class="kpi-card" role="listitem" aria-label="Conversion Rate metric">
+              <div class="kpi-card__icon kpi-card__icon--purple" aria-hidden="true">🎯</div>
+              <div class="kpi-card__body">
+                <div class="kpi-card__value">4.7%</div>
+                <div class="kpi-card__label">Conversion</div>
+              </div>
+              <div class="kpi-card__badge kpi-card__badge--up" aria-label="Up 1.3 percent">+1.3%</div>
+            </div>
+          </div>
+
+          <!-- Action bar -->
+          <div class="action-bar" id="action-bar">
+            <button class="action-btn action-btn--primary" id="btn-new-project" type="button">
+              <span aria-hidden="true">+</span> New Project
+            </button>
+            <button class="action-btn" type="button">Import Data</button>
+            <button class="action-btn" type="button">Export CSV</button>
+          </div>
+
+          <!-- Content grid -->
+          <div class="content-grid">
+            <!-- Chart card -->
+            <div class="dash-card dash-card--chart" id="chart-card" aria-label="Revenue chart">
+              <div class="dash-card__header">
+                <span class="dash-card__title">Revenue Overview</span>
+                <div class="dash-card__controls">
+                  <button class="tab-pill tab-pill--active" type="button">7d</button>
+                  <button class="tab-pill" type="button">30d</button>
+                  <button class="tab-pill" type="button">90d</button>
+                </div>
+              </div>
+              <div class="chart-placeholder" aria-hidden="true">
+                <svg viewBox="0 0 400 120" preserveAspectRatio="none" role="img" aria-label="Revenue trend chart">
+                  <defs>
+                    <linearGradient id="chartGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.4"/>
+                      <stop offset="100%" stop-color="#818cf8" stop-opacity="0.02"/>
+                    </linearGradient>
+                  </defs>
+                  <path d="M0,90 C40,85 60,60 100,55 C140,50 160,70 200,45 C240,20 270,60 310,30 C340,10 370,25 400,20 L400,120 L0,120 Z" fill="url(#chartGrad)"/>
+                  <path d="M0,90 C40,85 60,60 100,55 C140,50 160,70 200,45 C240,20 270,60 310,30 C340,10 370,25 400,20" fill="none" stroke="#818cf8" stroke-width="2.5" stroke-linecap="round"/>
+                </svg>
+              </div>
+            </div>
+
+            <!-- Activity feed -->
+            <div class="dash-card" id="activity-card" aria-label="Recent activity">
+              <div class="dash-card__header">
+                <span class="dash-card__title">Recent Activity</span>
+                <button class="link-btn" type="button">View all</button>
+              </div>
+              <ul class="activity-list" role="list">
+                <li class="activity-item" role="listitem">
+                  <div class="activity-dot activity-dot--green" aria-hidden="true"></div>
+                  <div class="activity-text">
+                    <strong>New project created</strong>
+                    <span>Brand Redesign 2026</span>
+                  </div>
+                  <time class="activity-time" datetime="2026-08-02T10:00">2h ago</time>
+                </li>
+                <li class="activity-item" role="listitem">
+                  <div class="activity-dot activity-dot--blue" aria-hidden="true"></div>
+                  <div class="activity-text">
+                    <strong>User invited</strong>
+                    <span>design@example.com</span>
+                  </div>
+                  <time class="activity-time" datetime="2026-08-02T08:00">4h ago</time>
+                </li>
+                <li class="activity-item" role="listitem">
+                  <div class="activity-dot activity-dot--amber" aria-hidden="true"></div>
+                  <div class="activity-text">
+                    <strong>Report exported</strong>
+                    <span>Q2 Analytics.csv</span>
+                  </div>
+                  <time class="activity-time" datetime="2026-08-01T18:00">1d ago</time>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+        </main>
+      </div><!-- /.main-area -->
+    </div><!-- /.page-shell -->
+
+    <!-- ═══════════════════════════════════════════════════════════
+         TOUR OVERLAY SYSTEM
+    ═══════════════════════════════════════════════════════════════ -->
+
+    <!-- Dark backdrop with clip-path spotlight cutout -->
+    <div
+      id="tour-backdrop"
+      class="tour-backdrop"
+      aria-hidden="true"
+    ></div>
+
+    <!-- Highlight ring around target element -->
+    <div id="tour-highlight" class="tour-highlight" aria-hidden="true"></div>
+
+    <!-- Tooltip / popover -->
+    <div
+      id="tour-tooltip"
+      class="tour-tooltip"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tooltip-title"
+      aria-describedby="tooltip-desc"
+      tabindex="-1"
+    >
+      <div class="tour-tooltip__header">
+        <span class="tour-badge" id="tooltip-step-badge" aria-label="Step 1 of 5">1 / 5</span>
+        <button
+          id="tour-close"
+          class="tour-close-btn"
+          type="button"
+          aria-label="Close tour"
+          title="Close tour (Escape)"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+            <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="tour-tooltip__body">
+        <div class="tooltip-icon" id="tooltip-icon" aria-hidden="true">⊞</div>
+        <h2 class="tour-tooltip__title" id="tooltip-title">Dashboard Overview</h2>
+        <p class="tour-tooltip__desc" id="tooltip-desc">
+          Welcome! This is your main dashboard where you can see all key metrics at a glance.
+        </p>
+      </div>
+
+      <!-- Directional arrow -->
+      <div class="tour-tooltip__arrow" id="tooltip-arrow" aria-hidden="true"></div>
+
+      <div class="tour-tooltip__footer">
+        <!-- Step dots -->
+        <div class="tour-dots" id="tour-dots" role="tablist" aria-label="Tour steps"></div>
+
+        <div class="tour-nav-btns">
+          <button id="tour-prev" class="tour-nav-btn tour-nav-btn--ghost" type="button" aria-label="Previous step">
+            ← Prev
+          </button>
+          <button id="tour-next" class="tour-nav-btn tour-nav-btn--primary" type="button" aria-label="Next step">
+            Next →
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/submissions/examples/onboarding-tour-spotlight-ag/script.js
+++ b/submissions/examples/onboarding-tour-spotlight-ag/script.js
@@ -1,0 +1,410 @@
+/**
+ * Onboarding Tour Spotlight — script.js
+ * EaseMotion CSS Submission
+ * Folder: submissions/examples/onboarding-tour-spotlight-ag/
+ *
+ * Responsibilities:
+ *  - Tour open/close lifecycle
+ *  - CSS custom property updates for clip-path spotlight + highlight ring
+ *  - Tooltip positioning (auto-flip: below / above / left / right)
+ *  - Step navigation (next, prev, dot jump)
+ *  - Focus trap inside tooltip while tour is active
+ *  - Keyboard: Escape → close, ArrowRight → next, ArrowLeft → prev
+ *  - Theme toggle
+ *  - Responsive target fallbacks
+ */
+
+'use strict';
+
+/* ─────────────────────────────────────────────────────────────────
+   TOUR STEPS DEFINITION
+   Each step maps to an element ID in the DOM.
+───────────────────────────────────────────────────────────────── */
+const TOUR_STEPS = [
+  {
+    targetId:  'kpi-row',
+    icon:      '📊',
+    title:     'Key Metrics at a Glance',
+    desc:      'These cards show your most important KPIs — revenue, users, tickets, and conversion. They update in real time.',
+    placement: 'bottom',
+  },
+  {
+    targetId:  'sidebar',
+    icon:      '🗂',
+    title:     'Navigation Sidebar',
+    desc:      'Use the sidebar to jump between Dashboard, Analytics, Projects, your Team, and Settings.',
+    placement: 'right',
+  },
+  {
+    targetId:  'topbar',
+    icon:      '🔔',
+    title:     'Action Toolbar',
+    desc:      'Quickly access notifications, toggle the theme, or kick off a new project from the top bar.',
+    placement: 'bottom',
+  },
+  {
+    targetId:  'action-bar',
+    icon:      '➕',
+    title:     'Quick Actions',
+    desc:      'Create a new project, import data, or export a CSV report — all from this action bar.',
+    placement: 'bottom',
+  },
+  {
+    targetId:  'chart-card',
+    icon:      '📈',
+    title:     'Revenue Chart',
+    desc:      'Visualise revenue trends over 7, 30, or 90 days. Hover data points to inspect individual values.',
+    placement: 'top',
+  },
+];
+
+const PADDING = 10; // px padding around the spotlight target
+const TOOLTIP_GAP = 18; // px gap between target and tooltip
+
+/* ─────────────────────────────────────────────────────────────────
+   DOM REFERENCES
+───────────────────────────────────────────────────────────────── */
+const backdrop    = document.getElementById('tour-backdrop');
+const highlight   = document.getElementById('tour-highlight');
+const tooltip     = document.getElementById('tour-tooltip');
+const tooltipIcon = document.getElementById('tooltip-icon');
+const tipTitle    = document.getElementById('tooltip-title');
+const tipDesc     = document.getElementById('tooltip-desc');
+const tipBadge    = document.getElementById('tooltip-step-badge');
+const tipArrow    = document.getElementById('tooltip-arrow');
+const dotsWrap    = document.getElementById('tour-dots');
+
+const btnNext    = document.getElementById('tour-next');
+const btnPrev    = document.getElementById('tour-prev');
+const btnClose   = document.getElementById('tour-close');
+const btnStart   = document.getElementById('btn-start-tour');
+const btnTheme   = document.getElementById('theme-btn');
+const htmlEl     = document.documentElement;
+
+/* ─────────────────────────────────────────────────────────────────
+   STATE
+───────────────────────────────────────────────────────────────── */
+let currentStep  = 0;
+let isActive     = false;
+let prevFocus    = null; // element that had focus before tour opened
+
+/* ─────────────────────────────────────────────────────────────────
+   HELPER: GET ELEMENT RECT WITH PADDING
+───────────────────────────────────────────────────────────────── */
+function getPaddedRect(el) {
+  const r = el.getBoundingClientRect();
+  return {
+    top:    r.top    - PADDING,
+    left:   r.left   - PADDING,
+    width:  r.width  + PADDING * 2,
+    height: r.height + PADDING * 2,
+    right:  r.right  + PADDING,
+    bottom: r.bottom + PADDING,
+    cx:     r.left   + r.width  / 2,
+    cy:     r.top    + r.height / 2,
+  };
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   STEP DOTS
+───────────────────────────────────────────────────────────────── */
+function buildDots() {
+  dotsWrap.innerHTML = '';
+  TOUR_STEPS.forEach((_, i) => {
+    const dot = document.createElement('button');
+    dot.className = 'tour-dot';
+    dot.setAttribute('role', 'tab');
+    dot.setAttribute('aria-label', `Go to step ${i + 1} of ${TOUR_STEPS.length}`);
+    dot.setAttribute('aria-selected', String(i === currentStep));
+    dot.addEventListener('click', () => goToStep(i));
+    dotsWrap.appendChild(dot);
+  });
+}
+
+function updateDots() {
+  const dots = dotsWrap.querySelectorAll('.tour-dot');
+  dots.forEach((dot, i) => {
+    dot.classList.toggle('is-active', i === currentStep);
+    dot.setAttribute('aria-selected', String(i === currentStep));
+  });
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   SPOTLIGHT — update clip-path + highlight ring position
+───────────────────────────────────────────────────────────────── */
+function positionSpotlight(rect) {
+  const root = document.documentElement;
+
+  // Update backdrop clip-path vars (percentage strings for stability)
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const x = Math.max(0, rect.left);
+  const y = Math.max(0, rect.top);
+  const w = Math.min(rect.width,  vw - x);
+  const h = Math.min(rect.height, vh - y);
+
+  root.style.setProperty('--tour-spotlight-x', `${x}px`);
+  root.style.setProperty('--tour-spotlight-y', `${y}px`);
+  root.style.setProperty('--tour-spotlight-w', `${w}px`);
+  root.style.setProperty('--tour-spotlight-h', `${h}px`);
+
+  // Position highlight ring
+  highlight.style.top    = `${y}px`;
+  highlight.style.left   = `${x}px`;
+  highlight.style.width  = `${w}px`;
+  highlight.style.height = `${h}px`;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   TOOLTIP POSITIONING
+   Determines best placement (bottom / top / right / left) and
+   positions the tooltip so it doesn't overflow the viewport.
+───────────────────────────────────────────────────────────────── */
+function positionTooltip(rect, placement) {
+  const vw  = window.innerWidth;
+  const vh  = window.innerHeight;
+  const tw  = tooltip.offsetWidth  || 320;
+  const th  = tooltip.offsetHeight || 220;
+
+  // Arrow direction classes
+  const arrowClasses = ['arrow--top', 'arrow--bottom', 'arrow--left', 'arrow--right'];
+  tipArrow.classList.remove(...arrowClasses);
+
+  let top, left;
+
+  // Auto-flip if preferred placement overflows
+  const fits = {
+    bottom: rect.bottom + TOOLTIP_GAP + th <= vh,
+    top:    rect.top    - TOOLTIP_GAP - th >= 0,
+    right:  rect.right  + TOOLTIP_GAP + tw <= vw,
+    left:   rect.left   - TOOLTIP_GAP - tw >= 0,
+  };
+
+  const resolved =
+    fits[placement] ? placement :
+    (placement === 'bottom' && fits.top)   ? 'top'   :
+    (placement === 'top'    && fits.bottom) ? 'bottom':
+    (placement === 'right'  && fits.left)   ? 'left'  :
+    (placement === 'left'   && fits.right)  ? 'right' :
+    'bottom'; // fallback
+
+  if (resolved === 'bottom') {
+    top  = rect.bottom + TOOLTIP_GAP;
+    left = rect.cx - tw / 2;
+    tipArrow.classList.add('arrow--top');
+  } else if (resolved === 'top') {
+    top  = rect.top - TOOLTIP_GAP - th;
+    left = rect.cx - tw / 2;
+    tipArrow.classList.add('arrow--bottom');
+  } else if (resolved === 'right') {
+    top  = rect.cy - th / 2;
+    left = rect.right + TOOLTIP_GAP;
+    tipArrow.classList.add('arrow--left');
+  } else { // left
+    top  = rect.cy - th / 2;
+    left = rect.left - TOOLTIP_GAP - tw;
+    tipArrow.classList.add('arrow--right');
+  }
+
+  // Clamp inside viewport (16px margin)
+  const MARGIN = 16;
+  left = Math.max(MARGIN, Math.min(left, vw - tw - MARGIN));
+  top  = Math.max(MARGIN, Math.min(top,  vh - th - MARGIN));
+
+  tooltip.style.left = `${left}px`;
+  tooltip.style.top  = `${top}px`;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   RENDER STEP
+───────────────────────────────────────────────────────────────── */
+function renderStep(index) {
+  const step = TOUR_STEPS[index];
+  if (!step) return;
+
+  // Update tooltip text
+  tooltipIcon.textContent = step.icon;
+  tipTitle.textContent    = step.title;
+  tipDesc.textContent     = step.desc;
+  tipBadge.textContent    = `${index + 1} / ${TOUR_STEPS.length}`;
+  tipBadge.setAttribute('aria-label', `Step ${index + 1} of ${TOUR_STEPS.length}`);
+
+  // Prev / Next button states
+  btnPrev.disabled = index === 0;
+  btnNext.textContent = index === TOUR_STEPS.length - 1 ? 'Finish ✓' : 'Next →';
+  btnNext.setAttribute('aria-label', index === TOUR_STEPS.length - 1 ? 'Finish tour' : 'Next step');
+
+  // Update dots
+  updateDots();
+
+  // Get target element
+  const targetEl = document.getElementById(step.targetId);
+  if (!targetEl) return;
+
+  // Scroll target into view (without disrupting the page scroll)
+  targetEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+
+  // Wait one frame so layout settles after scroll
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const rect = getPaddedRect(targetEl);
+      positionSpotlight(rect);
+      positionTooltip(rect, step.placement);
+    });
+  });
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   FOCUS TRAP
+───────────────────────────────────────────────────────────────── */
+const FOCUSABLE = 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function trapFocus(e) {
+  if (!isActive) return;
+
+  const focusable = [...tooltip.querySelectorAll(FOCUSABLE)];
+  if (!focusable.length) return;
+
+  const first = focusable[0];
+  const last  = focusable[focusable.length - 1];
+
+  if (e.key === 'Tab') {
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   OPEN / CLOSE TOUR
+───────────────────────────────────────────────────────────────── */
+function openTour() {
+  if (isActive) return;
+  isActive    = true;
+  currentStep = 0;
+
+  prevFocus = document.activeElement;
+
+  backdrop.classList.add('is-active');
+  highlight.classList.add('is-active');
+  tooltip.classList.add('is-active');
+
+  buildDots();
+  renderStep(currentStep);
+
+  // Focus tooltip after transition
+  setTimeout(() => tooltip.focus(), 320);
+
+  document.addEventListener('keydown', handleKeydown);
+}
+
+function closeTour() {
+  if (!isActive) return;
+  isActive = false;
+
+  backdrop.classList.remove('is-active');
+  highlight.classList.remove('is-active');
+  tooltip.classList.remove('is-active');
+
+  document.removeEventListener('keydown', handleKeydown);
+
+  // Return focus to trigger
+  if (prevFocus) prevFocus.focus();
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   STEP NAVIGATION
+───────────────────────────────────────────────────────────────── */
+function goToStep(index) {
+  currentStep = index;
+  renderStep(currentStep);
+}
+
+function nextStep() {
+  if (currentStep >= TOUR_STEPS.length - 1) {
+    closeTour();
+    return;
+  }
+  goToStep(currentStep + 1);
+}
+
+function prevStep() {
+  if (currentStep <= 0) return;
+  goToStep(currentStep - 1);
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   KEYBOARD HANDLER
+───────────────────────────────────────────────────────────────── */
+function handleKeydown(e) {
+  switch (e.key) {
+    case 'Escape':
+      e.preventDefault();
+      closeTour();
+      break;
+    case 'ArrowRight':
+      e.preventDefault();
+      nextStep();
+      break;
+    case 'ArrowLeft':
+      e.preventDefault();
+      prevStep();
+      break;
+    default:
+      trapFocus(e);
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   EVENT LISTENERS
+───────────────────────────────────────────────────────────────── */
+btnStart.addEventListener('click', openTour);
+btnNext.addEventListener('click',  nextStep);
+btnPrev.addEventListener('click',  prevStep);
+btnClose.addEventListener('click', closeTour);
+
+// Click outside tooltip (on backdrop) — do not close; keep tour active.
+// Only Escape or Finish closes the tour, by design (guided flow).
+
+/* ─────────────────────────────────────────────────────────────────
+   REPOSITION ON RESIZE
+───────────────────────────────────────────────────────────────── */
+let resizeTimer;
+window.addEventListener('resize', () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    if (isActive) renderStep(currentStep);
+  }, 80);
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   THEME TOGGLE
+───────────────────────────────────────────────────────────────── */
+function applyTheme(theme) {
+  htmlEl.dataset.theme = theme;
+  try { localStorage.setItem('spotlight-theme', theme); } catch {}
+}
+
+btnTheme.addEventListener('click', () => {
+  applyTheme(htmlEl.dataset.theme === 'dark' ? 'light' : 'dark');
+});
+
+// Restore saved / OS theme
+(function initTheme() {
+  try {
+    const saved = localStorage.getItem('spotlight-theme');
+    if (saved === 'light' || saved === 'dark') { applyTheme(saved); return; }
+  } catch {}
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+    applyTheme('light');
+  }
+})();

--- a/submissions/examples/onboarding-tour-spotlight-ag/style.css
+++ b/submissions/examples/onboarding-tour-spotlight-ag/style.css
@@ -1,0 +1,927 @@
+/* ===================================================================
+   Onboarding Tour Spotlight — style.css
+   EaseMotion CSS Submission
+   Folder: submissions/examples/onboarding-tour-spotlight-ag/
+   =================================================================== */
+
+/* ── Design Tokens ─────────────────────────────────────────────── */
+:root {
+  /* Colours */
+  --bg-page:            #0c0e1a;
+  --bg-sidebar:         #111420;
+  --bg-surface:         #151825;
+  --bg-surface-2:       #1b1e2d;
+  --bg-surface-hover:   #1f2235;
+  --bg-topbar:          #111420;
+
+  --border-subtle:      rgba(255 255 255 / 0.06);
+  --border-mid:         rgba(255 255 255 / 0.11);
+
+  --clr-primary:        #818cf8;
+  --clr-primary-dk:     #6366f1;
+  --clr-primary-glow:   rgba(129 140 248 / 0.30);
+  --clr-primary-faint:  rgba(129 140 248 / 0.08);
+  --clr-green:          #34d399;
+  --clr-amber:          #fbbf24;
+  --clr-red:            #f87171;
+  --clr-blue:           #60a5fa;
+  --clr-purple:         #a78bfa;
+
+  --text-primary:       #e2e8f0;
+  --text-secondary:     #94a3b8;
+  --text-tertiary:      #4b5568;
+
+  --radius-sm:          6px;
+  --radius-md:          10px;
+  --radius-lg:          14px;
+  --radius-xl:          20px;
+
+  --shadow-md:          0 4px 24px rgba(0 0 0 / 0.5);
+  --shadow-lg:          0 8px 40px rgba(0 0 0 / 0.65);
+  --shadow-xl:          0 16px 64px rgba(0 0 0 / 0.75);
+
+  --font-sans:          'Inter', system-ui, -apple-system, sans-serif;
+
+  --sidebar-w:          220px;
+  --topbar-h:           60px;
+
+  /* Tour-specific tokens */
+  --tour-backdrop:      rgba(6 8 20 / 0.82);
+  --tour-spotlight-r:   0px;
+  --tour-spotlight-x:   0px;
+  --tour-spotlight-y:   0px;
+  --tour-spotlight-w:   0px;
+  --tour-spotlight-h:   0px;
+  --tour-highlight-clr: var(--clr-primary);
+  --tour-tooltip-w:     320px;
+  --tour-arrow-size:    10px;
+}
+
+[data-theme="light"] {
+  --bg-page:            #f0f4ff;
+  --bg-sidebar:         #ffffff;
+  --bg-surface:         #ffffff;
+  --bg-surface-2:       #f8faff;
+  --bg-surface-hover:   #eef2ff;
+  --bg-topbar:          #ffffff;
+
+  --border-subtle:      rgba(0 0 0 / 0.06);
+  --border-mid:         rgba(0 0 0 / 0.10);
+
+  --clr-primary:        #4f46e5;
+  --clr-primary-dk:     #4338ca;
+  --clr-primary-glow:   rgba(79 70 229 / 0.22);
+  --clr-primary-faint:  rgba(79 70 229 / 0.06);
+
+  --text-primary:       #1e293b;
+  --text-secondary:     #475569;
+  --text-tertiary:      #94a3b8;
+
+  --tour-backdrop:      rgba(15 23 42 / 0.78);
+
+  --shadow-md:          0 4px 24px rgba(0 0 0 / 0.10);
+  --shadow-lg:          0 8px 40px rgba(0 0 0 / 0.14);
+  --shadow-xl:          0 16px 64px rgba(0 0 0 / 0.18);
+}
+
+/* ── Reset ─────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-size: 16px; scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-page);
+  color: var(--text-primary);
+  line-height: 1.6;
+  min-height: 100dvh;
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+  transition: background var(--t, 220ms) ease, color var(--t, 220ms) ease;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+/* ── Dashboard shell ───────────────────────────────────────────── */
+.page-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  height: 100dvh;
+}
+
+/* ── Sidebar ───────────────────────────────────────────────────── */
+.sidebar {
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
+}
+
+.sidebar__logo {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1.25rem 1.25rem 1rem;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.logo-mark {
+  color: var(--clr-primary);
+  font-size: 1.1rem;
+}
+
+.sidebar__nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0.75rem 0.625rem;
+  overflow-y: auto;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5625rem 0.75rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: background 200ms ease, color 200ms ease;
+}
+
+.nav-item:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.nav-item--active {
+  background: var(--clr-primary-faint);
+  color: var(--clr-primary);
+}
+
+.nav-item__icon { font-size: 1rem; flex-shrink: 0; }
+
+.sidebar__footer {
+  padding: 0.75rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.user-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-md);
+}
+
+.user-chip__avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--clr-primary), var(--clr-purple));
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.user-chip__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  line-height: 1.3;
+}
+
+.user-chip__name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.user-chip__role {
+  font-size: 0.6875rem;
+  color: var(--text-tertiary);
+}
+
+/* ── Main area ─────────────────────────────────────────────────── */
+.main-area {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+/* ── Topbar ────────────────────────────────────────────────────── */
+.topbar {
+  height: var(--topbar-h);
+  background: var(--bg-topbar);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  gap: 1rem;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.topbar__title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.topbar__right {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.tour-start-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 1rem;
+  background: var(--clr-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  transition: filter 200ms ease, box-shadow 200ms ease;
+}
+
+.tour-start-btn:hover {
+  filter: brightness(1.12);
+  box-shadow: 0 0 0 6px var(--clr-primary-glow);
+}
+
+.tour-start-btn:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 3px;
+}
+
+.icon-btn {
+  position: relative;
+  width: 2.125rem;
+  height: 2.125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-md);
+  font-size: 1rem;
+  transition: background 200ms ease;
+}
+
+.icon-btn:hover { background: var(--bg-surface-hover); }
+
+.icon-btn:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+.notif-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--clr-red);
+  color: #fff;
+  font-size: 0.625rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--bg-topbar);
+}
+
+.theme-icon { display: none; }
+[data-theme="dark"]  .theme-icon--dark  { display: inline; }
+[data-theme="light"] .theme-icon--light { display: inline; }
+
+/* ── Dashboard main ─────────────────────────────────────────────── */
+.dashboard {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-mid) transparent;
+}
+
+/* ── KPI row ────────────────────────────────────────────────────── */
+.kpi-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+.kpi-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.125rem;
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  transition: box-shadow 200ms ease, border-color 200ms ease;
+}
+
+.kpi-card:hover {
+  border-color: var(--border-mid);
+  box-shadow: var(--shadow-md);
+}
+
+.kpi-card__icon {
+  width: 2.375rem;
+  height: 2.375rem;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.kpi-card__icon--green  { background: rgba(52 211 153 / 0.12); }
+.kpi-card__icon--blue   { background: rgba(96 165 250 / 0.12); }
+.kpi-card__icon--amber  { background: rgba(251 191 36 / 0.12); }
+.kpi-card__icon--purple { background: rgba(167 139 250 / 0.12); }
+
+.kpi-card__body { flex: 1; min-width: 0; }
+
+.kpi-card__value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.kpi-card__label {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 0.125rem;
+}
+
+.kpi-card__badge {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.kpi-card__badge--up {
+  background: rgba(52 211 153 / 0.12);
+  color: var(--clr-green);
+}
+
+.kpi-card__badge--down {
+  background: rgba(248 113 113 / 0.12);
+  color: var(--clr-red);
+}
+
+/* ── Action bar ─────────────────────────────────────────────────── */
+.action-bar {
+  display: flex;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.action-btn {
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border: 1px solid var(--border-mid);
+  transition: background 200ms ease, border-color 200ms ease;
+}
+
+.action-btn:hover {
+  background: var(--bg-surface-hover);
+}
+
+.action-btn:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+.action-btn--primary {
+  background: var(--clr-primary);
+  color: #fff;
+  border-color: transparent;
+}
+
+.action-btn--primary:hover {
+  filter: brightness(1.1);
+}
+
+/* ── Content grid ───────────────────────────────────────────────── */
+.content-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
+  flex: 1;
+}
+
+/* ── Dash card ──────────────────────────────────────────────────── */
+.dash-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1.125rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dash-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dash-card__title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.dash-card__controls {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.tab-pill {
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid var(--border-mid);
+  color: var(--text-secondary);
+  transition: all 200ms ease;
+}
+
+.tab-pill--active, .tab-pill:hover {
+  background: var(--clr-primary-faint);
+  color: var(--clr-primary);
+  border-color: var(--clr-primary-glow);
+}
+
+.tab-pill:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+.chart-placeholder {
+  height: 130px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.chart-placeholder svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Activity list ──────────────────────────────────────────────── */
+.activity-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.activity-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.activity-item:last-child { border-bottom: none; }
+
+.activity-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 0.35rem;
+  flex-shrink: 0;
+}
+
+.activity-dot--green  { background: var(--clr-green); }
+.activity-dot--blue   { background: var(--clr-blue); }
+.activity-dot--amber  { background: var(--clr-amber); }
+
+.activity-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  font-size: 0.8125rem;
+}
+
+.activity-text strong { font-weight: 600; color: var(--text-primary); }
+.activity-text span   { color: var(--text-secondary); }
+
+.activity-time {
+  font-size: 0.6875rem;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+}
+
+.link-btn {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--clr-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.link-btn:hover { text-decoration: underline; }
+
+/* ═══════════════════════════════════════════════════════════════
+   TOUR OVERLAY SYSTEM
+═══════════════════════════════════════════════════════════════ */
+
+/* ── Backdrop with clip-path spotlight cutout ─────────────────── */
+.tour-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--tour-backdrop);
+  z-index: 900;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 300ms ease;
+
+  /* The spotlight is cut out using clip-path polygon:
+     We punch a rectangular "hole" at the target element's position.
+     JS updates the CSS custom properties which drive this. */
+  clip-path: polygon(
+    /* Outer boundary (whole screen — counterclockwise) */
+    0% 0%,
+    100% 0%,
+    100% 100%,
+    0% 100%,
+    0% 0%,
+    /* Inner hole (target rect — clockwise) */
+    var(--tour-spotlight-x) var(--tour-spotlight-y),
+    calc(var(--tour-spotlight-x) + var(--tour-spotlight-w)) var(--tour-spotlight-y),
+    calc(var(--tour-spotlight-x) + var(--tour-spotlight-w)) calc(var(--tour-spotlight-y) + var(--tour-spotlight-h)),
+    var(--tour-spotlight-x) calc(var(--tour-spotlight-y) + var(--tour-spotlight-h)),
+    var(--tour-spotlight-x) var(--tour-spotlight-y)
+  );
+
+  transition:
+    opacity 300ms ease,
+    clip-path 380ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tour-backdrop.is-active {
+  opacity: 1;
+  pointer-events: all;
+}
+
+/* ── Highlight ring ──────────────────────────────────────────── */
+.tour-highlight {
+  position: fixed;
+  z-index: 901;
+  border-radius: var(--radius-md);
+  border: 2px solid var(--clr-primary);
+  box-shadow:
+    0 0 0 4px var(--clr-primary-glow),
+    0 0 24px var(--clr-primary-glow);
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity 280ms ease,
+    top    380ms cubic-bezier(0.4, 0, 0.2, 1),
+    left   380ms cubic-bezier(0.4, 0, 0.2, 1),
+    width  380ms cubic-bezier(0.4, 0, 0.2, 1),
+    height 380ms cubic-bezier(0.4, 0, 0.2, 1);
+  animation: tour-ring-pulse 2.2s ease-in-out infinite;
+}
+
+.tour-highlight.is-active { opacity: 1; }
+
+@keyframes tour-ring-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 4px var(--clr-primary-glow),
+      0 0 20px var(--clr-primary-glow);
+  }
+  50% {
+    box-shadow:
+      0 0 0 8px rgba(129 140 248 / 0.15),
+      0 0 36px rgba(129 140 248 / 0.28);
+  }
+}
+
+/* ── Tour tooltip ─────────────────────────────────────────────── */
+.tour-tooltip {
+  position: fixed;
+  z-index: 950;
+  width: var(--tour-tooltip-w);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.94) translateY(6px);
+  transition:
+    opacity 280ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 280ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    top  380ms cubic-bezier(0.4, 0, 0.2, 1),
+    left 380ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tour-tooltip.is-active {
+  opacity: 1;
+  pointer-events: all;
+  transform: scale(1) translateY(0);
+}
+
+.tour-tooltip:focus {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+.tour-tooltip__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1rem 0.5rem;
+}
+
+.tour-badge {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: var(--clr-primary);
+  background: var(--clr-primary-faint);
+  border: 1px solid rgba(129 140 248 / 0.2);
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+.tour-close-btn {
+  width: 1.75rem;
+  height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  transition: background 200ms ease, color 200ms ease;
+}
+
+.tour-close-btn:hover {
+  background: rgba(248 113 113 / 0.1);
+  color: var(--clr-red);
+  border-color: rgba(248 113 113 / 0.3);
+}
+
+.tour-close-btn:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+.tour-tooltip__body {
+  padding: 0.375rem 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tooltip-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.tour-tooltip__title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+
+.tour-tooltip__desc {
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+/* Tooltip directional arrow */
+.tour-tooltip__arrow {
+  position: absolute;
+  width: calc(var(--tour-arrow-size) * 2);
+  height: calc(var(--tour-arrow-size) * 2);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-mid);
+  pointer-events: none;
+  transition: top 380ms ease, left 380ms ease;
+}
+
+/* Arrow placement classes toggled by JS */
+.tour-tooltip__arrow.arrow--top {
+  top: calc(-1 * var(--tour-arrow-size) - 1px);
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  border-bottom: none;
+  border-right: none;
+}
+
+.tour-tooltip__arrow.arrow--bottom {
+  bottom: calc(-1 * var(--tour-arrow-size) - 1px);
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  border-top: none;
+  border-left: none;
+}
+
+.tour-tooltip__arrow.arrow--left {
+  left: calc(-1 * var(--tour-arrow-size) - 1px);
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+  border-right: none;
+  border-top: none;
+}
+
+.tour-tooltip__arrow.arrow--right {
+  right: calc(-1 * var(--tour-arrow-size) - 1px);
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+  border-left: none;
+  border-bottom: none;
+}
+
+.tour-tooltip__footer {
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+/* ── Step dots ──────────────────────────────────────────────────── */
+.tour-dots {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.tour-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--border-mid);
+  transition: background 250ms ease, width 250ms ease, border-radius 250ms ease;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+.tour-dot.is-active {
+  width: 18px;
+  border-radius: 3px;
+  background: var(--clr-primary);
+}
+
+.tour-dot:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+/* ── Nav buttons ───────────────────────────────────────────────── */
+.tour-nav-btns {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.tour-nav-btn {
+  padding: 0.4rem 0.875rem;
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  transition: all 200ms ease;
+  border: 1px solid transparent;
+}
+
+.tour-nav-btn:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+.tour-nav-btn--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-mid);
+}
+
+.tour-nav-btn--ghost:hover {
+  background: var(--bg-surface-2);
+  color: var(--text-primary);
+}
+
+.tour-nav-btn--ghost:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tour-nav-btn--primary {
+  background: var(--clr-primary);
+  color: #fff;
+}
+
+.tour-nav-btn--primary:hover {
+  filter: brightness(1.1);
+  box-shadow: 0 0 0 4px var(--clr-primary-glow);
+}
+
+/* ── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .page-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar { display: none; }
+
+  .kpi-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  :root { --tour-tooltip-w: 280px; }
+}
+
+@media (max-width: 540px) {
+  .kpi-row { grid-template-columns: 1fr 1fr; }
+  :root { --tour-tooltip-w: calc(100vw - 2rem); }
+
+  .tour-tooltip {
+    left: 1rem !important;
+    right: 1rem !important;
+    width: auto !important;
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .tour-backdrop, .tour-highlight, .tour-tooltip {
+    transition: opacity 0.01ms !important;
+  }
+}


### PR DESCRIPTION
closed #59881
✅ CSS clip-path polygon spotlight with inner rectangular cutout — smooth 380ms animated transition between steps via CSS variables (--tour-spotlight-x/y/w/h)
✅ Pulsing highlight ring (@keyframes tour-ring-pulse) around the active target element
✅ Auto-positioned tooltip — resolves best placement (bottom/top/left/right) and auto-flips when it would overflow the viewport
✅ Directional arrow on tooltip pointing toward the highlighted target
✅ Focus trap — Tab/Shift+Tab stays inside the role="dialog" tooltip
✅ Keyboard nav: Escape closes, →/← arrow keys navigate steps
✅ Step progress dots with animated pill-expand for the active dot
✅ Dark & Light mode with CSS custom properties
✅ prefers-reduced-motion disables all animations
✅ Responsive — re-positions on resize, mobile-friendly layout