### PR TITLE
feat: add morph-glow fintech stepper

### DIFF
--- a/submissions/examples/morph-glow-fintech-stepper-59443/README.md
+++ b/submissions/examples/morph-glow-fintech-stepper-59443/README.md
@@ -1,0 +1,45 @@
+# Morph-Glow Fintech Stepper
+
+## What does this do?
+
+This pure HTML and CSS component presents a four-stage fintech verification workflow with a morphing, glowing active node and matching detail panels.
+
+## How is it used?
+
+Place native radio controls before the ordered step labels and panels so checked-state selectors can update both the active node and visible content.
+
+```html
+<input
+  class="step-control"
+  type="radio"
+  name="kyb-step"
+  id="step-risk"
+  checked
+/>
+
+<ol class="step-list">
+  <li>
+    <label for="step-risk">
+      <span class="step-node">3</span>
+      <span><strong>Risk review</strong><small>Screening checks</small></span>
+    </label>
+  </li>
+</ol>
+
+<div class="step-panels">
+  <article class="step-panel panel-risk">...</article>
+</div>
+```
+
+Main custom properties:
+
+| Property           | Purpose                       | Default   |
+| ------------------ | ----------------------------- | --------- |
+| `--morph-duration` | Active-node morph duration    | `520ms`   |
+| `--blue`           | Active step and review accent | `#245eea` |
+| `--blue-soft`      | Glow ring and icon background | `#e3ecff` |
+| `--radius`         | Shell corner radius           | `8px`     |
+
+## Why is it useful?
+
+The stepper makes verification state and supporting account details available without JavaScript. It fits EaseMotion CSS through native keyboard radio controls, reusable checked-state selectors, transform-based morph animation, responsive horizontal and vertical layouts, forced-color support, and a `prefers-reduced-motion` fallback.

--- a/submissions/examples/morph-glow-fintech-stepper-59443/demo.html
+++ b/submissions/examples/morph-glow-fintech-stepper-59443/demo.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="An accessible CSS morph-glow onboarding stepper for fintech dashboards."
+    />
+    <title>Morph-Glow Fintech Stepper</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="onboarding">
+      <header class="onboarding__header">
+        <div>
+          <p class="eyebrow">Business verification</p>
+          <h1>Activate your treasury account</h1>
+          <p class="subtitle">
+            Review each checkpoint before enabling transfers and automated
+            payouts.
+          </p>
+        </div>
+        <div class="case-id"><span>Case</span><strong>KYB-4821</strong></div>
+      </header>
+
+      <section class="stepper-shell" aria-labelledby="stepper-title">
+        <h2 id="stepper-title" class="visually-hidden">
+          Verification progress
+        </h2>
+
+        <input
+          class="step-control"
+          type="radio"
+          name="kyb-step"
+          id="step-business"
+        />
+        <input
+          class="step-control"
+          type="radio"
+          name="kyb-step"
+          id="step-owners"
+        />
+        <input
+          class="step-control"
+          type="radio"
+          name="kyb-step"
+          id="step-risk"
+          checked
+        />
+        <input
+          class="step-control"
+          type="radio"
+          name="kyb-step"
+          id="step-funding"
+        />
+
+        <ol class="step-list" aria-label="Select a verification stage">
+          <li>
+            <label for="step-business">
+              <span class="step-node" aria-hidden="true">1</span>
+              <span
+                ><strong>Business</strong><small>Company records</small></span
+              >
+            </label>
+          </li>
+          <li>
+            <label for="step-owners">
+              <span class="step-node" aria-hidden="true">2</span>
+              <span><strong>Owners</strong><small>Control persons</small></span>
+            </label>
+          </li>
+          <li>
+            <label for="step-risk">
+              <span class="step-node" aria-hidden="true">3</span>
+              <span
+                ><strong>Risk review</strong
+                ><small>Screening checks</small></span
+              >
+            </label>
+          </li>
+          <li>
+            <label for="step-funding">
+              <span class="step-node" aria-hidden="true">4</span>
+              <span
+                ><strong>Funding</strong><small>Settlement account</small></span
+              >
+            </label>
+          </li>
+        </ol>
+
+        <div class="step-panels">
+          <article class="step-panel panel-business">
+            <div class="panel-heading">
+              <span class="panel-icon" aria-hidden="true">01</span>
+              <div>
+                <p>Business profile</p>
+                <h2>Company records verified</h2>
+              </div>
+              <span class="status status--complete">Complete</span>
+            </div>
+            <p class="panel-copy">
+              Registration, tax identity, and operating address match the
+              submitted records.
+            </p>
+            <dl class="fact-grid">
+              <div>
+                <dt>Entity</dt>
+                <dd>Northstar Labs LLC</dd>
+              </div>
+              <div>
+                <dt>Jurisdiction</dt>
+                <dd>Delaware, US</dd>
+              </div>
+              <div>
+                <dt>Verified</dt>
+                <dd>31 Jul 2026</dd>
+              </div>
+            </dl>
+          </article>
+
+          <article class="step-panel panel-owners">
+            <div class="panel-heading">
+              <span class="panel-icon" aria-hidden="true">02</span>
+              <div>
+                <p>Beneficial owners</p>
+                <h2>Control persons confirmed</h2>
+              </div>
+              <span class="status status--complete">Complete</span>
+            </div>
+            <p class="panel-copy">
+              Identity and ownership evidence is complete for every reportable
+              stakeholder.
+            </p>
+            <ul class="owner-list">
+              <li>
+                <span>AR</span>
+                <div>
+                  <strong>Avery Reed</strong><small>52% ownership</small>
+                </div>
+                <b>Verified</b>
+              </li>
+              <li>
+                <span>MK</span>
+                <div>
+                  <strong>Morgan Kim</strong><small>28% ownership</small>
+                </div>
+                <b>Verified</b>
+              </li>
+            </ul>
+          </article>
+
+          <article class="step-panel panel-risk">
+            <div class="panel-heading">
+              <span class="panel-icon" aria-hidden="true">03</span>
+              <div>
+                <p>Risk review</p>
+                <h2>Screening in progress</h2>
+              </div>
+              <span class="status">In review</span>
+            </div>
+            <p class="panel-copy">
+              Automated sanctions and transaction-risk checks are running
+              against the latest data.
+            </p>
+            <div class="check-grid">
+              <div>
+                <span><i aria-hidden="true"></i>Sanctions screening</span
+                ><strong>Clear</strong>
+              </div>
+              <div>
+                <span><i aria-hidden="true"></i>Adverse media</span
+                ><strong>Clear</strong>
+              </div>
+              <div>
+                <span
+                  ><i class="pending" aria-hidden="true"></i>Transaction
+                  profile</span
+                ><strong>Reviewing</strong>
+              </div>
+            </div>
+          </article>
+
+          <article class="step-panel panel-funding">
+            <div class="panel-heading">
+              <span class="panel-icon" aria-hidden="true">04</span>
+              <div>
+                <p>Funding account</p>
+                <h2>Connect settlement banking</h2>
+              </div>
+              <span class="status status--waiting">Next</span>
+            </div>
+            <p class="panel-copy">
+              Choose the account used for treasury deposits, fees, and payout
+              reconciliation.
+            </p>
+            <div class="bank-preview">
+              <span aria-hidden="true">NB</span>
+              <div>
+                <strong>North Bank</strong
+                ><small>Operating account ending 1842</small>
+              </div>
+              <b>Ready</b>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/morph-glow-fintech-stepper-59443/style.css
+++ b/submissions/examples/morph-glow-fintech-stepper-59443/style.css
@@ -1,0 +1,519 @@
+:root {
+  --page: #eef2f6;
+  --surface: #ffffff;
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8e0e9;
+  --blue: #245eea;
+  --blue-soft: #e3ecff;
+  --green: #16815a;
+  --green-soft: #dcf5e9;
+  --gold: #8d6500;
+  --gold-soft: #fff1bd;
+  --radius: 8px;
+  --morph-duration: 520ms;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.onboarding {
+  width: min(1100px, calc(100% - 40px));
+  margin-inline: auto;
+  padding-block: clamp(44px, 8vw, 88px);
+}
+
+.onboarding__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 28px;
+  margin-bottom: 34px;
+}
+
+.eyebrow,
+.panel-heading p {
+  margin: 0;
+  color: var(--blue);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 720px;
+  margin: 9px 0 12px;
+  font-size: clamp(2.3rem, 6vw, 4.3rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.subtitle {
+  max-width: 660px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.case-id {
+  display: grid;
+  gap: 3px;
+  padding: 13px 17px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 26px rgba(41, 55, 76, 0.08);
+}
+
+.case-id span {
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.stepper-shell {
+  position: relative;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: 0 22px 55px rgba(41, 55, 76, 0.12);
+}
+
+.visually-hidden,
+.step-control {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+}
+
+.step-list {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  padding: 22px 26px;
+  background: #f8fafd;
+  border-bottom: 1px solid var(--line);
+  list-style: none;
+}
+
+.step-list li {
+  position: relative;
+}
+
+.step-list li:not(:last-child)::after {
+  position: absolute;
+  top: 22px;
+  left: calc(50% + 28px);
+  width: calc(100% - 56px);
+  height: 2px;
+  background: #dce3ec;
+  content: "";
+}
+
+.step-list label {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 11px;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.step-list label > span:last-child {
+  display: grid;
+  gap: 3px;
+}
+
+.step-list label strong {
+  color: var(--ink);
+  font-size: 0.84rem;
+}
+
+.step-list label small {
+  font-size: 0.67rem;
+}
+
+.step-node {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  place-items: center;
+  background: var(--surface);
+  border: 2px solid #cad3df;
+  border-radius: 50%;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 850;
+  transition:
+    background 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease;
+}
+
+#step-business:checked ~ .step-list label[for="step-business"] .step-node,
+#step-owners:checked ~ .step-list label[for="step-owners"] .step-node,
+#step-risk:checked ~ .step-list label[for="step-risk"] .step-node,
+#step-funding:checked ~ .step-list label[for="step-funding"] .step-node {
+  background: var(--blue);
+  border-color: var(--blue);
+  border-radius: 12px 50% 12px 50%;
+  box-shadow:
+    0 0 0 6px var(--blue-soft),
+    0 10px 24px rgba(36, 94, 234, 0.3);
+  color: #ffffff;
+  animation: morph-glow var(--morph-duration) both
+    cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+#step-business:focus-visible ~ .step-list label[for="step-business"] .step-node,
+#step-owners:focus-visible ~ .step-list label[for="step-owners"] .step-node,
+#step-risk:focus-visible ~ .step-list label[for="step-risk"] .step-node,
+#step-funding:focus-visible ~ .step-list label[for="step-funding"] .step-node {
+  outline: 3px solid #7fa5ff;
+  outline-offset: 5px;
+}
+
+.step-panels {
+  min-height: 430px;
+}
+
+.step-panel {
+  display: none;
+  min-height: 430px;
+  padding: clamp(32px, 6vw, 68px);
+}
+
+#step-business:checked ~ .step-panels .panel-business,
+#step-owners:checked ~ .step-panels .panel-owners,
+#step-risk:checked ~ .step-panels .panel-risk,
+#step-funding:checked ~ .step-panels .panel-funding {
+  display: block;
+  animation: panel-enter 380ms both ease-out;
+}
+
+.panel-heading {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-icon {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  background: var(--blue-soft);
+  border-radius: 7px;
+  color: var(--blue);
+  font-size: 0.76rem;
+  font-weight: 850;
+}
+
+.panel-heading h2 {
+  margin: 5px 0 0;
+  font-size: clamp(1.45rem, 3vw, 2.1rem);
+  letter-spacing: 0;
+}
+
+.status {
+  padding: 6px 10px;
+  background: var(--blue-soft);
+  border-radius: 999px;
+  color: var(--blue);
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.status--complete {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status--waiting {
+  background: var(--gold-soft);
+  color: var(--gold);
+}
+
+.panel-copy {
+  max-width: 720px;
+  margin: 24px 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.fact-grid,
+.check-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.fact-grid {
+  margin: 0;
+}
+
+.fact-grid div,
+.check-grid div,
+.owner-list li,
+.bank-preview {
+  padding: 16px;
+  background: #f7f9fc;
+  border: 1px solid #e0e6ee;
+  border-radius: 6px;
+}
+
+.fact-grid div {
+  display: grid;
+  gap: 7px;
+}
+
+.fact-grid dt,
+.fact-grid dd,
+.owner-list small,
+.bank-preview small {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.fact-grid dd {
+  color: var(--ink);
+  font-weight: 750;
+}
+
+.owner-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.owner-list li,
+.bank-preview {
+  display: grid;
+  grid-template-columns: 42px 1fr auto;
+  align-items: center;
+  gap: 13px;
+}
+
+.owner-list li > span,
+.bank-preview > span {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  background: var(--blue-soft);
+  border-radius: 6px;
+  color: var(--blue);
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.owner-list li div,
+.bank-preview div {
+  display: grid;
+  gap: 4px;
+}
+
+.owner-list b,
+.bank-preview b {
+  color: var(--green);
+  font-size: 0.72rem;
+}
+
+.check-grid div {
+  display: flex;
+  min-height: 62px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.check-grid span {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.check-grid i {
+  width: 8px;
+  height: 8px;
+  background: var(--green);
+  border-radius: 50%;
+}
+
+.check-grid i.pending {
+  background: var(--blue);
+  box-shadow: 0 0 0 4px var(--blue-soft);
+  animation: review-pulse 1.8s ease-in-out infinite;
+}
+
+.check-grid strong {
+  font-size: 0.78rem;
+}
+
+@keyframes morph-glow {
+  from {
+    border-radius: 50%;
+    box-shadow: 0 0 0 0 rgba(36, 94, 234, 0);
+    transform: scale(0.82) rotate(-12deg);
+  }
+
+  to {
+    border-radius: 12px 50% 12px 50%;
+    box-shadow:
+      0 0 0 6px var(--blue-soft),
+      0 10px 24px rgba(36, 94, 234, 0.3);
+    transform: scale(1) rotate(0);
+  }
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+}
+
+@keyframes review-pulse {
+  50% {
+    box-shadow: 0 0 0 7px rgba(36, 94, 234, 0.12);
+  }
+}
+
+@media (max-width: 800px) {
+  .step-list label {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .step-list li:not(:last-child)::after {
+    top: 21px;
+  }
+
+  .fact-grid,
+  .check-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 580px) {
+  .onboarding {
+    width: min(100% - 24px, 520px);
+    padding-block: 32px;
+  }
+
+  .onboarding__header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .step-list {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 18px;
+  }
+
+  .step-list label {
+    min-height: 58px;
+    justify-content: flex-start;
+    padding: 6px 10px;
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .step-list li:not(:last-child)::after {
+    top: 54px;
+    left: 31px;
+    width: 2px;
+    height: 24px;
+  }
+
+  .step-panels,
+  .step-panel {
+    min-height: 560px;
+  }
+
+  .step-panel {
+    padding: 28px 20px;
+  }
+
+  .panel-heading {
+    grid-template-columns: 48px 1fr;
+  }
+
+  .panel-icon {
+    width: 46px;
+    height: 46px;
+  }
+
+  .panel-heading .status {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #step-business:checked ~ .step-list label[for="step-business"] .step-node,
+  #step-owners:checked ~ .step-list label[for="step-owners"] .step-node,
+  #step-risk:checked ~ .step-list label[for="step-risk"] .step-node,
+  #step-funding:checked ~ .step-list label[for="step-funding"] .step-node,
+  #step-business:checked ~ .step-panels .panel-business,
+  #step-owners:checked ~ .step-panels .panel-owners,
+  #step-risk:checked ~ .step-panels .panel-risk,
+  #step-funding:checked ~ .step-panels .panel-funding,
+  .check-grid i.pending {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .stepper-shell,
+  .step-node,
+  .fact-grid div,
+  .check-grid div,
+  .owner-list li,
+  .bank-preview {
+    border: 1px solid CanvasText;
+  }
+
+  #step-business:checked ~ .step-list label[for="step-business"] .step-node,
+  #step-owners:checked ~ .step-list label[for="step-owners"] .step-node,
+  #step-risk:checked ~ .step-list label[for="step-risk"] .step-node,
+  #step-funding:checked ~ .step-list label[for="step-funding"] .step-node {
+    background: Highlight;
+  }
+}


### PR DESCRIPTION
## Description

Adds a responsive CSS morph-glow stepper for a fintech business-verification dashboard. The selected stage morphs into an asymmetric glowing node while its corresponding KYB detail panel becomes visible.

Fixes #59443

## Type of Change

- [ ] Bug fix
- [x] New animation
- [ ] Documentation update
- [ ] Other

## Submission Checklist

- [x] My submission is placed in `submissions/examples/morph-glow-fintech-stepper-59443/`
- [x] I created exactly 3 files: `demo.html`, `style.css`, and `README.md`
- [x] I did not modify any files outside my submission folder
- [x] My animation uses only HTML and CSS
- [x] My animation is responsive and works on mobile devices
- [x] I tested my animation in multiple browsers
- [x] I added accessibility features (focus states and reduced motion support)
- [x] My code follows the project's coding standards
- [x] I have read and followed the CONTRIBUTING.md guidelines

## Testing

- Chrome: keyboard navigation, one-panel state, animation, 390px mobile layout, and reduced-motion mode
- Edge: stage selection, matching panel visibility, and 390px overflow check
- Prettier 3.8.3
- Stylelint with the repository configuration
- HTMLHint
- `git diff --check`

## Notes

The example uses native radio controls, so stage selection remains keyboard accessible without JavaScript. It is distinct from the existing creative morph-glow steppers through its KYB workflow, fintech-specific status data, responsive vertical mode, and synchronized detail states.

## Screenshots

Desktop and mobile screenshots were verified locally.
