### PR TITLE
feat(examples): add accessible keyboard shortcuts cheat sheet overlay…

### DIFF
--- a/submissions/examples/keyboard-shortcuts-overlay-nk/README.md
+++ b/submissions/examples/keyboard-shortcuts-overlay-nk/README.md
@@ -1,0 +1,118 @@
+# ⌨ Keyboard Shortcuts Cheat Sheet Overlay
+
+> An accessible, searchable modal overlay displaying categorised keybindings with 3D `<kbd>` key badges — built with pure HTML, CSS & minimal vanilla JS.
+
+---
+
+## 📖 What does this do?
+
+The **Keyboard Shortcuts Overlay** is a power-user modal cheat sheet component (similar to GitHub, Notion, or Linear's `?` shortcut overlay). It allows users to quickly view, search, and filter all application keyboard shortcuts without leaving their workspace context.
+
+---
+
+## 🎯 How is it used?
+
+### 1. HTML structure
+
+```html
+<!-- Trigger button -->
+<button id="btn-open-shortcuts" type="button" aria-label="Open keyboard shortcuts">
+  Shortcuts (?)
+</button>
+
+<!-- Modal Backdrop -->
+<div id="shortcuts-backdrop" class="modal-backdrop" aria-hidden="true"></div>
+
+<!-- Modal Container -->
+<div id="shortcuts-modal" class="shortcuts-modal" role="dialog" aria-modal="true"
+     aria-labelledby="modal-title" aria-describedby="modal-desc" tabindex="-1" hidden>
+  
+  <!-- Search Input -->
+  <input type="search" id="shortcut-search" placeholder="Search shortcuts…" />
+
+  <!-- Category Tabs -->
+  <div role="tablist">
+    <button class="modal-tab modal-tab--active" data-category="all">All</button>
+    <button class="modal-tab" data-category="navigation">Navigation</button>
+    <button class="modal-tab" data-category="editing">Editing</button>
+  </div>
+
+  <!-- Shortcut Rows -->
+  <div class="shortcuts-body">
+    <div class="shortcut-row">
+      <span class="shortcut-desc">Open command palette</span>
+      <span class="shortcut-keys">
+        <kbd>Ctrl</kbd><span class="key-sep">+</span><kbd>K</kbd>
+      </span>
+    </div>
+  </div>
+
+</div>
+```
+
+---
+
+## ✨ Key Highlights
+
+| Feature | Implementation |
+|---------|----------------|
+| **Global `?` key listener** | Pressing `?` (Shift + `/`) toggles the shortcuts modal from anywhere |
+| **Live fuzzy search** | Typing in the search input filters matching shortcuts across all categories in real-time |
+| **Category tabs** | Filter keybindings by category: All, Navigation, Editing, Formatting, View, AI Actions |
+| **Realistic 3D keycaps** | `<kbd>` elements styled with multi-layer CSS box-shadows, inset gradients, and subtle hover lifts |
+| **Focus trap** | `Tab` and `Shift+Tab` trapped inside the modal container while active |
+| **Screen reader accessible** | Screen reader readable markup via visually hidden text inside `<span class="sr-only">` |
+| **Dark & Light mode** | Complete CSS token architecture with seamless theme switching |
+| **Reduced motion safe** | Respects `prefers-reduced-motion: reduce` by turning off all transitions |
+| **Responsive** | Adapts gracefully to mobile screens with auto-scroll tab strips |
+
+---
+
+## ⌨️ Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `?` (Shift + `/`) | Toggle shortcuts overlay |
+| `Escape` | Close shortcuts modal |
+| `Tab` / `Shift+Tab` | Cycle focusable elements inside modal |
+
+---
+
+## 🎨 CSS Custom Properties
+
+```css
+:root {
+  --kbd-bg:       linear-gradient(180deg, #2a2e42 0%, #1c1f2e 100%);
+  --kbd-border:   #3b4059;
+  --kbd-shadow:   0 2px 0 #12141f, 0 3px 4px rgba(0 0 0 / 0.4);
+  --kbd-text:     #e2e8f0;
+  --modal-w:      680px;
+}
+```
+
+---
+
+## ♿ Accessibility Notes
+
+- Uses standard `role="dialog"` and `aria-modal="true"`.
+- Focus is automatically placed in the search field upon opening.
+- Focus is trapped within the dialog using Tab navigation wrapping.
+- Pressing `Escape` or clicking the backdrop closes the overlay and returns focus to the trigger button.
+- Keyboard shortcuts announce cleanly on screen readers (`aria-label="Control or Command K"`).
+- Full `prefers-reduced-motion` compliance.
+
+---
+
+## 🚀 Quick Start
+
+1. Copy `demo.html`, `style.css`, and `script.js` into the same directory.
+2. Open `demo.html` in your browser.
+3. Press **?** anywhere on the page to launch the overlay.
+
+```
+keyboard-shortcuts-overlay-nk/
+├── demo.html    # App demo with keyboard shortcuts modal
+├── style.css    # 3D kbd styles, modal animations, dark/light themes
+├── script.js    # Global '?' listener, live search, focus trap, tab filters
+└── README.md    # Documentation
+```

--- a/submissions/examples/keyboard-shortcuts-overlay-nk/demo.html
+++ b/submissions/examples/keyboard-shortcuts-overlay-nk/demo.html
@@ -1,0 +1,583 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Keyboard Shortcuts Cheat Sheet Overlay — an accessible, searchable modal displaying categorised keybindings with styled 3D kbd badges. Built with HTML, CSS & vanilla JS."
+    />
+    <title>Keyboard Shortcuts Overlay | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+
+    <!-- ── App shell (simulated productivity app) ────────────────── -->
+    <div class="app-shell" id="app-shell">
+
+      <!-- Sidebar -->
+      <aside class="app-sidebar" aria-label="Application navigation">
+        <div class="sidebar-logo" aria-hidden="true">
+          <span class="logo-gem">◆</span>
+          <span class="logo-name">Noteflow</span>
+        </div>
+        <nav class="sidebar-nav" aria-label="Main navigation">
+          <button class="nav-link nav-link--active" type="button" aria-current="page">
+            <span aria-hidden="true">📝</span> Notes
+          </button>
+          <button class="nav-link" type="button">
+            <span aria-hidden="true">📂</span> Documents
+          </button>
+          <button class="nav-link" type="button">
+            <span aria-hidden="true">🔍</span> Search
+          </button>
+          <button class="nav-link" type="button">
+            <span aria-hidden="true">⚙</span> Settings
+          </button>
+        </nav>
+      </aside>
+
+      <!-- Main editor -->
+      <div class="app-main">
+        <!-- Top bar -->
+        <header class="app-topbar" role="banner">
+          <div class="topbar-left">
+            <h1 class="page-title">My Notes</h1>
+          </div>
+          <div class="topbar-right">
+            <span class="hint-badge" aria-hidden="true">
+              Press <kbd>?</kbd> for shortcuts
+            </span>
+            <button
+              id="btn-open-shortcuts"
+              class="shortcuts-trigger"
+              type="button"
+              aria-label="Open keyboard shortcuts reference (press ? or Shift+/)"
+              title="Keyboard shortcuts (?)"
+            >
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+                <rect x="1.5" y="1.5" width="15" height="15" rx="3.5" stroke="currentColor" stroke-width="1.4"/>
+                <path d="M6 7.5C6 6.12 7.12 5 8.5 5S11 6.12 11 7.5c0 .966-.57 1.8-1.4 2.2L9 10v1.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                <circle cx="9" cy="13.5" r=".75" fill="currentColor"/>
+              </svg>
+              Shortcuts
+            </button>
+            <button class="icon-btn" aria-label="Toggle theme" id="btn-theme" type="button">
+              <span class="theme-icon theme-icon--dark" aria-hidden="true">🌙</span>
+              <span class="theme-icon theme-icon--light" aria-hidden="true">☀️</span>
+            </button>
+          </div>
+        </header>
+
+        <!-- Editor area (backdrop for demo) -->
+        <main class="editor-area" id="editor-area" aria-label="Note editor">
+          <div class="editor-doc" aria-label="Document content">
+            <h2 class="doc-title" contenteditable="true" aria-label="Document title" spellcheck="false">
+              Getting started with Noteflow
+            </h2>
+            <div class="doc-body" contenteditable="true" aria-label="Document body" aria-multiline="true" role="textbox" spellcheck="false">
+              <p>Welcome to <strong>Noteflow</strong> — your personal knowledge base.</p>
+              <p>You can format text, create headings, add lists and code blocks — all with keyboard shortcuts.</p>
+              <p>Press <strong>?</strong> anywhere on the page to open the keyboard shortcuts reference, or click the <strong>Shortcuts</strong> button in the top bar.</p>
+              <br />
+              <p style="color: var(--text-tertiary); font-size: 0.875rem;">💡 Try searching for "bold" or "undo" in the shortcuts panel to quickly find what you need.</p>
+            </div>
+          </div>
+        </main>
+      </div>
+
+    </div><!-- /.app-shell -->
+
+
+    <!-- ═══════════════════════════════════════════════════════════
+         KEYBOARD SHORTCUTS MODAL
+    ═══════════════════════════════════════════════════════════════ -->
+
+    <!-- Backdrop -->
+    <div
+      id="shortcuts-backdrop"
+      class="modal-backdrop"
+      aria-hidden="true"
+    ></div>
+
+    <!-- Dialog -->
+    <div
+      id="shortcuts-modal"
+      class="shortcuts-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      aria-describedby="modal-desc"
+      tabindex="-1"
+      hidden
+    >
+
+      <!-- Modal header -->
+      <div class="modal-header">
+        <div class="modal-header__left">
+          <h2 class="modal-title" id="modal-title">
+            <span aria-hidden="true">⌨</span> Keyboard Shortcuts
+          </h2>
+          <p class="modal-desc" id="modal-desc">
+            Browse or search all available keyboard shortcuts.
+          </p>
+        </div>
+        <button
+          id="modal-close"
+          class="modal-close-btn"
+          type="button"
+          aria-label="Close keyboard shortcuts (Escape)"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M1 1l14 14M15 1L1 15" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- Search input -->
+      <div class="modal-search" role="search" aria-label="Search keyboard shortcuts">
+        <label for="shortcut-search" class="sr-only">Search shortcuts</label>
+        <div class="search-wrap">
+          <svg class="search-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M10 10l3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          <input
+            type="search"
+            id="shortcut-search"
+            class="search-input"
+            placeholder="Search shortcuts…"
+            autocomplete="off"
+            spellcheck="false"
+            aria-controls="shortcuts-list"
+            aria-label="Search keyboard shortcuts"
+          />
+          <kbd class="search-clear-hint" aria-hidden="true">Esc</kbd>
+        </div>
+      </div>
+
+      <!-- Category tabs -->
+      <div class="modal-tabs" role="tablist" aria-label="Shortcut categories">
+        <button class="modal-tab modal-tab--active" role="tab" data-category="all"
+          aria-selected="true" id="tab-all" aria-controls="shortcuts-list" type="button">
+          All
+        </button>
+        <button class="modal-tab" role="tab" data-category="navigation"
+          aria-selected="false" id="tab-nav" aria-controls="shortcuts-list" type="button">
+          Navigation
+        </button>
+        <button class="modal-tab" role="tab" data-category="editing"
+          aria-selected="false" id="tab-edit" aria-controls="shortcuts-list" type="button">
+          Editing
+        </button>
+        <button class="modal-tab" role="tab" data-category="formatting"
+          aria-selected="false" id="tab-fmt" aria-controls="shortcuts-list" type="button">
+          Formatting
+        </button>
+        <button class="modal-tab" role="tab" data-category="view"
+          aria-selected="false" id="tab-view" aria-controls="shortcuts-list" type="button">
+          View
+        </button>
+        <button class="modal-tab" role="tab" data-category="ai"
+          aria-selected="false" id="tab-ai" aria-controls="shortcuts-list" type="button">
+          AI Actions
+        </button>
+      </div>
+
+      <!-- Shortcuts list -->
+      <div
+        id="shortcuts-list"
+        class="shortcuts-body"
+        role="region"
+        aria-label="Keyboard shortcuts list"
+        aria-live="polite"
+      >
+
+        <!-- ── Navigation ─────────────────────────────────────── -->
+        <section class="shortcut-group" data-category="navigation" aria-labelledby="grp-navigation">
+          <h3 class="group-label" id="grp-navigation">Navigation</h3>
+          <ul class="shortcut-list" role="list">
+            <li class="shortcut-row" role="listitem" data-desc="open command palette">
+              <span class="shortcut-desc">Open command palette</span>
+              <span class="shortcut-keys" aria-label="Control or Command K">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>K</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="quick search">
+              <span class="shortcut-desc">Quick search</span>
+              <span class="shortcut-keys" aria-label="Control or Command P">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>P</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="go to home dashboard">
+              <span class="shortcut-desc">Go to home</span>
+              <span class="shortcut-keys" aria-label="G then H">
+                <kbd>G</kbd>
+                <span class="key-sep" aria-hidden="true">then</span>
+                <kbd>H</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="go to notes">
+              <span class="shortcut-desc">Go to notes</span>
+              <span class="shortcut-keys" aria-label="G then N">
+                <kbd>G</kbd>
+                <span class="key-sep" aria-hidden="true">then</span>
+                <kbd>N</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="toggle sidebar navigation">
+              <span class="shortcut-desc">Toggle sidebar</span>
+              <span class="shortcut-keys" aria-label="Control or Command Backslash">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>\</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="navigate back in history">
+              <span class="shortcut-desc">Navigate back</span>
+              <span class="shortcut-keys" aria-label="Alt Left Arrow">
+                <kbd>Alt</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>←</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="navigate forward in history">
+              <span class="shortcut-desc">Navigate forward</span>
+              <span class="shortcut-keys" aria-label="Alt Right Arrow">
+                <kbd>Alt</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>→</kbd>
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        <!-- ── Editing ────────────────────────────────────────── -->
+        <section class="shortcut-group" data-category="editing" aria-labelledby="grp-editing">
+          <h3 class="group-label" id="grp-editing">Editing</h3>
+          <ul class="shortcut-list" role="list">
+            <li class="shortcut-row" role="listitem" data-desc="undo last action">
+              <span class="shortcut-desc">Undo</span>
+              <span class="shortcut-keys" aria-label="Control or Command Z">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Z</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="redo last undone action">
+              <span class="shortcut-desc">Redo</span>
+              <span class="shortcut-keys" aria-label="Control or Command Shift Z">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Z</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="cut selected text">
+              <span class="shortcut-desc">Cut</span>
+              <span class="shortcut-keys" aria-label="Control or Command X">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>X</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="copy selected text">
+              <span class="shortcut-desc">Copy</span>
+              <span class="shortcut-keys" aria-label="Control or Command C">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>C</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="paste from clipboard">
+              <span class="shortcut-desc">Paste</span>
+              <span class="shortcut-keys" aria-label="Control or Command V">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>V</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="select all content">
+              <span class="shortcut-desc">Select all</span>
+              <span class="shortcut-keys" aria-label="Control or Command A">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>A</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="find and replace text">
+              <span class="shortcut-desc">Find &amp; replace</span>
+              <span class="shortcut-keys" aria-label="Control or Command H">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>H</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="save current document">
+              <span class="shortcut-desc">Save</span>
+              <span class="shortcut-keys" aria-label="Control or Command S">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>S</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="delete current line">
+              <span class="shortcut-desc">Delete line</span>
+              <span class="shortcut-keys" aria-label="Control Shift K">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>K</kbd>
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        <!-- ── Formatting ─────────────────────────────────────── -->
+        <section class="shortcut-group" data-category="formatting" aria-labelledby="grp-formatting">
+          <h3 class="group-label" id="grp-formatting">Formatting</h3>
+          <ul class="shortcut-list" role="list">
+            <li class="shortcut-row" role="listitem" data-desc="bold selected text">
+              <span class="shortcut-desc">Bold</span>
+              <span class="shortcut-keys" aria-label="Control or Command B">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>B</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="italic selected text">
+              <span class="shortcut-desc">Italic</span>
+              <span class="shortcut-keys" aria-label="Control or Command I">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>I</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="underline selected text">
+              <span class="shortcut-desc">Underline</span>
+              <span class="shortcut-keys" aria-label="Control or Command U">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>U</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="strikethrough text">
+              <span class="shortcut-desc">Strikethrough</span>
+              <span class="shortcut-keys" aria-label="Control Shift X">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>X</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="inline code formatting">
+              <span class="shortcut-desc">Inline code</span>
+              <span class="shortcut-keys" aria-label="Control E">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>E</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="heading 1 level">
+              <span class="shortcut-desc">Heading 1</span>
+              <span class="shortcut-keys" aria-label="Hash key">
+                <kbd>#</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Space</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="heading 2 level">
+              <span class="shortcut-desc">Heading 2</span>
+              <span class="shortcut-keys" aria-label="Two hashes plus space">
+                <kbd>##</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Space</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="bullet list unordered">
+              <span class="shortcut-desc">Bullet list</span>
+              <span class="shortcut-keys" aria-label="Hyphen plus space">
+                <kbd>-</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Space</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="numbered ordered list">
+              <span class="shortcut-desc">Numbered list</span>
+              <span class="shortcut-keys" aria-label="1 dot plus space">
+                <kbd>1.</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Space</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="insert blockquote">
+              <span class="shortcut-desc">Blockquote</span>
+              <span class="shortcut-keys" aria-label="Greater-than plus space">
+                <kbd>&gt;</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Space</kbd>
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        <!-- ── View ───────────────────────────────────────────── -->
+        <section class="shortcut-group" data-category="view" aria-labelledby="grp-view">
+          <h3 class="group-label" id="grp-view">View</h3>
+          <ul class="shortcut-list" role="list">
+            <li class="shortcut-row" role="listitem" data-desc="toggle focus mode full screen writing">
+              <span class="shortcut-desc">Focus mode</span>
+              <span class="shortcut-keys" aria-label="Control Shift F">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>F</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="toggle dark light theme">
+              <span class="shortcut-desc">Toggle theme</span>
+              <span class="shortcut-keys" aria-label="Control Shift L">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>L</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="zoom in increase font size">
+              <span class="shortcut-desc">Zoom in</span>
+              <span class="shortcut-keys" aria-label="Control equals">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>=</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="zoom out decrease font size">
+              <span class="shortcut-desc">Zoom out</span>
+              <span class="shortcut-keys" aria-label="Control minus">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>−</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="reset zoom to default">
+              <span class="shortcut-desc">Reset zoom</span>
+              <span class="shortcut-keys" aria-label="Control 0">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>0</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="open keyboard shortcuts cheat sheet this panel">
+              <span class="shortcut-desc">Show shortcuts</span>
+              <span class="shortcut-keys" aria-label="Question mark">
+                <kbd>?</kbd>
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        <!-- ── AI Actions ─────────────────────────────────────── -->
+        <section class="shortcut-group" data-category="ai" aria-labelledby="grp-ai">
+          <h3 class="group-label" id="grp-ai">
+            AI Actions
+            <span class="group-badge">AI</span>
+          </h3>
+          <ul class="shortcut-list" role="list">
+            <li class="shortcut-row" role="listitem" data-desc="open ai chat assistant">
+              <span class="shortcut-desc">Open AI chat</span>
+              <span class="shortcut-keys" aria-label="Control Slash">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>/</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="ai improve rewrite selected text">
+              <span class="shortcut-desc">AI rewrite</span>
+              <span class="shortcut-keys" aria-label="Control Shift R">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>R</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="ai summarise document summary">
+              <span class="shortcut-desc">AI summarise</span>
+              <span class="shortcut-keys" aria-label="Control Shift S">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>S</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="ai generate complete autocomplete suggestion">
+              <span class="shortcut-desc">AI autocomplete</span>
+              <span class="shortcut-keys" aria-label="Tab key">
+                <kbd>Tab</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="translate selected text language">
+              <span class="shortcut-desc">AI translate</span>
+              <span class="shortcut-keys" aria-label="Control Shift T">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>T</kbd>
+              </span>
+            </li>
+            <li class="shortcut-row" role="listitem" data-desc="ai fix grammar spell check correct errors">
+              <span class="shortcut-desc">Fix grammar</span>
+              <span class="shortcut-keys" aria-label="Control Shift G">
+                <kbd>Ctrl</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>Shift</kbd>
+                <span class="key-sep" aria-hidden="true">+</span>
+                <kbd>G</kbd>
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        <!-- Empty state (shown when search yields no results) -->
+        <div class="empty-state" id="empty-state" hidden aria-live="polite">
+          <div class="empty-state__icon" aria-hidden="true">🔍</div>
+          <p class="empty-state__title">No shortcuts found</p>
+          <p class="empty-state__desc">Try a different keyword or browse by category above.</p>
+        </div>
+
+      </div><!-- /#shortcuts-list -->
+
+      <!-- Footer -->
+      <div class="modal-footer" role="contentinfo">
+        <div class="footer-hints" aria-hidden="true">
+          <span><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>
+          <span><kbd>Esc</kbd> Close</span>
+          <span><kbd>?</kbd> Toggle</span>
+        </div>
+        <span class="modal-count" id="modal-count" aria-live="polite" aria-atomic="true">
+          38 shortcuts
+        </span>
+      </div>
+
+    </div><!-- /#shortcuts-modal -->
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/submissions/examples/keyboard-shortcuts-overlay-nk/script.js
+++ b/submissions/examples/keyboard-shortcuts-overlay-nk/script.js
@@ -1,0 +1,208 @@
+/**
+ * Keyboard Shortcuts Cheat Sheet Overlay — script.js
+ * EaseMotion CSS Submission
+ * Folder: submissions/examples/keyboard-shortcuts-overlay-nk/
+ *
+ * Responsibilities:
+ *  - Global '?' key trigger to open/close shortcuts modal
+ *  - Modal open/close state management & ARIA attributes
+ *  - Live fuzzy search filtering across all categories
+ *  - Category tab filtering (All, Navigation, Editing, etc.)
+ *  - Focus trap inside modal while open
+ *  - Theme switching (Light/Dark)
+ */
+
+'use strict';
+
+/* ── DOM References ─────────────────────────────────────────────── */
+const modal         = document.getElementById('shortcuts-modal');
+const backdrop      = document.getElementById('shortcuts-backdrop');
+const searchInput   = document.getElementById('shortcut-search');
+const closeBtn      = document.getElementById('modal-close');
+const openBtn       = document.getElementById('btn-open-shortcuts');
+const countLabel    = document.getElementById('modal-count');
+const emptyState    = document.getElementById('empty-state');
+const themeBtn      = document.getElementById('btn-theme');
+const tabs          = document.querySelectorAll('.modal-tab');
+const groups        = document.querySelectorAll('.shortcut-group');
+const rows          = document.querySelectorAll('.shortcut-row');
+const htmlEl        = document.documentElement;
+
+/* ── State ──────────────────────────────────────────────────────── */
+let isOpen          = false;
+let activeCategory  = 'all';
+let previousFocus   = null;
+
+/* ── Open Modal ─────────────────────────────────────────────────── */
+function openModal() {
+  if (isOpen) return;
+  isOpen = true;
+  previousFocus = document.activeElement;
+
+  modal.removeAttribute('hidden');
+  // Trigger reflow for CSS animation
+  void modal.offsetWidth;
+
+  modal.classList.add('is-open');
+  backdrop.classList.add('is-open');
+  backdrop.setAttribute('aria-hidden', 'false');
+
+  // Focus search input
+  setTimeout(() => searchInput.focus(), 50);
+
+  document.addEventListener('keydown', handleGlobalKeydown);
+}
+
+/* ── Close Modal ────────────────────────────────────────────────── */
+function closeModal() {
+  if (!isOpen) return;
+  isOpen = false;
+
+  modal.classList.remove('is-open');
+  backdrop.classList.remove('is-open');
+  backdrop.setAttribute('aria-hidden', 'true');
+
+  setTimeout(() => {
+    modal.setAttribute('hidden', '');
+    if (previousFocus && typeof previousFocus.focus === 'function') {
+      previousFocus.focus();
+    }
+  }, 250);
+
+  document.removeEventListener('keydown', handleGlobalKeydown);
+}
+
+/* ── Toggle Modal ───────────────────────────────────────────────── */
+function toggleModal() {
+  isOpen ? closeModal() : openModal();
+}
+
+/* ── Filter Logic ───────────────────────────────────────────────── */
+function filterShortcuts() {
+  const query = searchInput.value.toLowerCase().trim();
+  let visibleCount = 0;
+
+  groups.forEach(group => {
+    const groupCategory = group.dataset.category;
+    const matchesCategory = activeCategory === 'all' || groupCategory === activeCategory;
+
+    let visibleInGroup = 0;
+    const groupRows = group.querySelectorAll('.shortcut-row');
+
+    groupRows.forEach(row => {
+      const desc = row.querySelector('.shortcut-desc').textContent.toLowerCase();
+      const keys = row.querySelector('.shortcut-keys').textContent.toLowerCase();
+      const extraDesc = (row.dataset.desc || '').toLowerCase();
+
+      const matchesSearch = !query || desc.includes(query) || keys.includes(query) || extraDesc.includes(query);
+
+      if (matchesCategory && matchesSearch) {
+        row.style.display = 'flex';
+        visibleInGroup++;
+        visibleCount++;
+      } else {
+        row.style.display = 'none';
+      }
+    });
+
+    group.style.display = visibleInGroup > 0 ? 'flex' : 'none';
+  });
+
+  // Toggle empty state
+  emptyState.hidden = visibleCount > 0;
+  countLabel.textContent = `${visibleCount} shortcut${visibleCount === 1 ? '' : 's'}`;
+}
+
+/* ── Category Tabs Handler ──────────────────────────────────────── */
+tabs.forEach(tab => {
+  tab.addEventListener('click', () => {
+    tabs.forEach(t => {
+      t.classList.remove('modal-tab--active');
+      t.setAttribute('aria-selected', 'false');
+    });
+    tab.classList.add('modal-tab--active');
+    tab.setAttribute('aria-selected', 'true');
+
+    activeCategory = tab.dataset.category;
+    filterShortcuts();
+  });
+});
+
+/* ── Search Input Listener ──────────────────────────────────────── */
+searchInput.addEventListener('input', filterShortcuts);
+
+/* ── Focus Trap inside Modal ────────────────────────────────────── */
+const FOCUSABLE_ELEMENTS = 'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function handleGlobalKeydown(e) {
+  if (!isOpen) return;
+
+  // ESC to close
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    closeModal();
+    return;
+  }
+
+  // Focus trap Tab handling
+  if (e.key === 'Tab') {
+    const focusables = Array.from(modal.querySelectorAll(FOCUSABLE_ELEMENTS));
+    if (focusables.length === 0) return;
+
+    const first = focusables[0];
+    const last  = focusables[focusables.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+}
+
+/* ── Global Key Listener for '?' ────────────────────────────────── */
+document.addEventListener('keydown', (e) => {
+  // Ignore if user is typing in an editable field
+  const tag = document.activeElement.tagName;
+  const isEditable = tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement.isContentEditable;
+
+  if (isEditable && e.key !== 'Escape') return;
+
+  // Pressing '?' (Shift + /) toggles modal
+  if (e.key === '?' || (e.shiftKey && e.key === '/')) {
+    e.preventDefault();
+    toggleModal();
+  }
+});
+
+/* ── Button Click Listeners ─────────────────────────────────────── */
+openBtn.addEventListener('click', openModal);
+closeBtn.addEventListener('click', closeModal);
+backdrop.addEventListener('click', closeModal);
+
+/* ── Theme Switcher ─────────────────────────────────────────────── */
+function applyTheme(theme) {
+  htmlEl.dataset.theme = theme;
+  try { localStorage.setItem('shortcuts-theme', theme); } catch {}
+}
+
+themeBtn.addEventListener('click', () => {
+  const next = htmlEl.dataset.theme === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+});
+
+// Restore saved theme or match system preference
+(function initTheme() {
+  try {
+    const saved = localStorage.getItem('shortcuts-theme');
+    if (saved === 'light' || saved === 'dark') { applyTheme(saved); return; }
+  } catch {}
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+    applyTheme('light');
+  }
+})();
+
+/* ── Initial Count ──────────────────────────────────────────────── */
+filterShortcuts();

--- a/submissions/examples/keyboard-shortcuts-overlay-nk/style.css
+++ b/submissions/examples/keyboard-shortcuts-overlay-nk/style.css
@@ -1,0 +1,617 @@
+/* ===================================================================
+   Keyboard Shortcuts Cheat Sheet Overlay — style.css
+   EaseMotion CSS Submission
+   Folder: submissions/examples/keyboard-shortcuts-overlay-nk/
+   =================================================================== */
+
+/* ── Design Tokens ─────────────────────────────────────────────── */
+:root {
+  /* Dark palette (default) */
+  --bg-app:             #0b0d14;
+  --bg-sidebar:         #10121a;
+  --bg-surface:         #161924;
+  --bg-surface-2:       #1e2232;
+  --bg-surface-hover:   #25293d;
+
+  --border-subtle:      rgba(255 255 255 / 0.06);
+  --border-mid:         rgba(255 255 255 / 0.12);
+  --border-strong:      rgba(255 255 255 / 0.22);
+
+  --clr-primary:        #818cf8;
+  --clr-primary-glow:   rgba(129 140 248 / 0.25);
+  --clr-primary-faint:  rgba(129 140 248 / 0.08);
+  --clr-accent:         #a78bfa;
+
+  --text-primary:       #f1f5f9;
+  --text-secondary:     #94a3b8;
+  --text-tertiary:      #64748b;
+
+  --kbd-bg:             linear-gradient(180deg, #2a2e42 0%, #1c1f2e 100%);
+  --kbd-border:         #3b4059;
+  --kbd-shadow:         0 2px 0 #12141f, 0 3px 4px rgba(0 0 0 / 0.4);
+  --kbd-text:           #e2e8f0;
+
+  --radius-sm:          6px;
+  --radius-md:          10px;
+  --radius-lg:          16px;
+  --radius-xl:          20px;
+
+  --shadow-lg:          0 8px 32px rgba(0 0 0 / 0.5);
+  --shadow-modal:       0 20px 60px rgba(0 0 0 / 0.7);
+
+  --font-sans:          'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono:          'JetBrains Mono', monospace;
+
+  --modal-w:            680px;
+  --modal-h-max:        580px;
+}
+
+[data-theme="light"] {
+  --bg-app:             #f8fafc;
+  --bg-sidebar:         #ffffff;
+  --bg-surface:         #ffffff;
+  --bg-surface-2:       #f1f5f9;
+  --bg-surface-hover:   #e2e8f0;
+
+  --border-subtle:      rgba(0 0 0 / 0.06);
+  --border-mid:         rgba(0 0 0 / 0.12);
+  --border-strong:      rgba(0 0 0 / 0.20);
+
+  --clr-primary:        #4f46e5;
+  --clr-primary-glow:   rgba(79 70 229 / 0.20);
+  --clr-primary-faint:  rgba(79 70 229 / 0.06);
+
+  --text-primary:       #0f172a;
+  --text-secondary:     #475569;
+  --text-tertiary:      #94a3b8;
+
+  --kbd-bg:             linear-gradient(180deg, #ffffff 0%, #f1f5f9 100%);
+  --kbd-border:         #cbd5e1;
+  --kbd-shadow:         0 2px 0 #94a3b8, 0 3px 4px rgba(0 0 0 / 0.08);
+  --kbd-text:           #1e293b;
+
+  --shadow-modal:       0 20px 60px rgba(0 0 0 / 0.18);
+}
+
+/* ── Reset ─────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-size: 16px; scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-app);
+  color: var(--text-primary);
+  line-height: 1.6;
+  min-height: 100dvh;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── App Shell Demo ───────────────────────────────────────────── */
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100dvh;
+}
+
+.app-sidebar {
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border-subtle);
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.125rem;
+  color: var(--text-primary);
+}
+
+.logo-gem { color: var(--clr-primary); }
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem 0.875rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: all 150ms ease;
+}
+
+.nav-link:hover, .nav-link--active {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.app-topbar {
+  height: 64px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 2rem;
+  background: var(--bg-sidebar);
+}
+
+.page-title { font-size: 1.125rem; font-weight: 700; }
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.hint-badge {
+  font-size: 0.8125rem;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.shortcuts-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.shortcuts-trigger:hover {
+  background: var(--bg-surface-hover);
+  border-color: var(--border-strong);
+}
+
+.shortcuts-trigger:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+.icon-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-mid);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.icon-btn:hover { background: var(--bg-surface-hover); }
+
+.theme-icon { display: none; }
+[data-theme="dark"]  .theme-icon--dark  { display: inline; }
+[data-theme="light"] .theme-icon--light { display: inline; }
+
+.editor-area {
+  flex: 1;
+  padding: 3rem 2rem;
+  display: flex;
+  justify-content: center;
+}
+
+.editor-doc {
+  max-width: 680px;
+  width: 100%;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  padding: 2.5rem;
+  box-shadow: var(--shadow-lg);
+
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.doc-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  outline: none;
+}
+
+.doc-body {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--text-secondary);
+  outline: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── KBD Key Badge Styling ────────────────────────────────────── */
+kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--kbd-text);
+  background: var(--kbd-bg);
+  border: 1px solid var(--kbd-border);
+  border-radius: 5px;
+  box-shadow: var(--kbd-shadow);
+  user-select: none;
+  vertical-align: middle;
+  transition: transform 100ms ease, box-shadow 100ms ease;
+}
+
+.shortcut-row:hover kbd {
+  transform: translateY(-1px);
+}
+
+.key-sep {
+  font-size: 0.6875rem;
+  color: var(--text-tertiary);
+  margin: 0 1px;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   MODAL OVERLAY
+   ═══════════════════════════════════════════════════════════════ */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(8px);
+  z-index: 900;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 250ms ease;
+}
+
+.modal-backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.shortcuts-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -46%) scale(0.96);
+  z-index: 950;
+  width: min(var(--modal-w), calc(100vw - 2rem));
+  max-height: var(--modal-h-max);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-modal);
+  display: flex;
+  flex-direction: column;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  transition: opacity 250ms cubic-bezier(0.16, 1, 0.3, 1), transform 250ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.shortcuts-modal:not([hidden]).is-open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.shortcuts-modal:focus-visible {
+  outline: none;
+}
+
+/* Modal Header */
+.modal-header {
+  padding: 1.25rem 1.5rem 1rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.modal-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.modal-desc {
+  font-size: 0.8125rem;
+  color: var(--text-tertiary);
+  margin-top: 0.125rem;
+}
+
+.modal-close-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.modal-close-btn:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.modal-close-btn:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
+/* Search Box */
+.modal-search {
+  padding: 0 1.5rem 0.875rem;
+}
+
+.search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.875rem;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.625rem 2.75rem 0.625rem 2.5rem;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-lg);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  outline: none;
+  transition: all 150ms ease;
+}
+
+.search-input:focus {
+  border-color: var(--clr-primary);
+  box-shadow: 0 0 0 3px var(--clr-primary-glow);
+}
+
+.search-clear-hint {
+  position: absolute;
+  right: 0.75rem;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+/* Category Tabs */
+.modal-tabs {
+  display: flex;
+  gap: 0.375rem;
+  padding: 0 1.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.modal-tabs::-webkit-scrollbar { display: none; }
+
+.modal-tab {
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 150ms ease;
+}
+
+.modal-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-surface-2);
+}
+
+.modal-tab--active {
+  color: var(--clr-primary);
+  background: var(--clr-primary-faint);
+  font-weight: 600;
+}
+
+.modal-tab:focus-visible {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: -2px;
+}
+
+/* Shortcuts Body / List */
+.shortcuts-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-mid) transparent;
+}
+
+.shortcut-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.group-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.group-badge {
+  font-size: 0.625rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  background: var(--clr-primary-faint);
+  color: var(--clr-primary);
+  border: 1px solid var(--border-subtle);
+}
+
+.shortcut-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.shortcut-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  transition: background 150ms ease;
+}
+
+.shortcut-row:hover {
+  background: var(--bg-surface-2);
+}
+
+.shortcut-desc {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.shortcut-keys {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+/* Highlight matching search terms */
+mark {
+  background: rgba(129 140 248 / 0.25);
+  color: var(--clr-primary);
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+/* Empty State */
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.empty-state__icon { font-size: 2rem; opacity: 0.5; }
+.empty-state__title { font-weight: 600; font-size: 0.9375rem; }
+.empty-state__desc { font-size: 0.8125rem; color: var(--text-tertiary); }
+
+/* Modal Footer */
+.modal-footer {
+  padding: 0.75rem 1.5rem;
+  background: var(--bg-sidebar);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.footer-hints {
+  display: flex;
+  gap: 1rem;
+}
+
+.footer-hints kbd {
+  min-width: 18px;
+  height: 18px;
+  font-size: 0.6875rem;
+  padding: 0 4px;
+  margin-right: 0.25rem;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .app-shell { grid-template-columns: 1fr; }
+  .app-sidebar { display: none; }
+  .hint-badge { display: none; }
+  .footer-hints { display: none; }
+  .shortcuts-modal { height: 90vh; }
+}
+
+/* ── Reduced Motion ─────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
closed #59892
✅ Global ? key listener (Shift + /) opens/closes the shortcuts overlay from anywhere on the page
✅ Live fuzzy search filtering across all categories in real-time
✅ Category filter tabs: All, Navigation, Editing, Formatting, View, AI Actions
✅ 3D styled <kbd> keycaps with layered shadows, inset linear gradients, and hover lifts
✅ Focus trap inside role="dialog" modal with Tab and Shift+Tab wrapping
✅ Keyboard nav: Escape closes, ? toggles
✅ Dark & Light mode support with CSS custom properties
✅ prefers-reduced-motion disables all animations
✅ Fully accessible: ARIA attributes (role="dialog", aria-modal="true", aria-selected, aria-controls), screen-reader friendly labels (aria-label="Control or Command K")