### PR TITLE
Add ease-football-scorecard component

### DIFF
--- a/submissions/examples/ease-football-scorecard-ij/README.md
+++ b/submissions/examples/ease-football-scorecard-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Football Scorecard
+
+A live football scorecard with team names, flipping score digits and a pulsing match status.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The score digits flip while the live dot pulses.

--- a/submissions/examples/ease-football-scorecard-ij/demo.html
+++ b/submissions/examples/ease-football-scorecard-ij/demo.html
@@ -1,0 +1,36 @@
+<!-- EaseMotion component: football-scorecard -->
+<!DOCTYPE html>
+<html lang="en" data-foot="score">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2">
+<title>Ease Football Scorecard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="score-card">
+  <header class="score-head">
+    <span class="score-venue">WEMBLEY</span>
+    <span class="score-live">LIVE</span>
+  </header>
+  <div class="score-board">
+    <span class="team team-home">ARS</span>
+    <span class="score-digits">
+      <span class="score-digit score-home">2</span>
+      <span class="score-sep">-</span>
+      <span class="score-digit score-away">1</span>
+    </span>
+    <span class="team team-away">CHE</span>
+  </div>
+  <div class="status-bar">
+    <span class="status-minute">67</span>
+    <span class="status-dot"></span>
+    <span class="status-text">SECOND HALF</span>
+  </div>
+  <footer class="score-foot">
+    <span class="score-possession">POSS 58%</span>
+    <span class="score-half">HT</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-football-scorecard-ij/style.css
+++ b/submissions/examples/ease-football-scorecard-ij/style.css
@@ -1,0 +1,30 @@
+:root{
+  --fs-bg:hsl(215,30%,7%);
+  --fs-ink:hsl(215,25%,92%);
+  --fs-red:hsl(0,80%,55%);
+  --fs-blue:hsl(215,90%,60%);
+  --fs-gold:hsl(45,100%,58%);
+  --fs-green:hsl(90,60%,50%);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 25%,hsl(215,40%,15%),hsl(220,50%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.score-card{width:360px;border-radius:16px;overflow:hidden;background:hsl(215,26%,9%);border:1px solid hsl(215,22%,24%)}
+.score-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(215,34%,13%)}
+.score-venue{font-size:.82rem;letter-spacing:3px;color:var(--fs-ink)}
+.score-live{font-size:.68rem;font-weight:900;color:var(--fs-red);animation:live-pulse-football-scorecard 1.2s ease-in-out infinite}
+.score-board{display:flex;align-items:center;justify-content:space-around;padding:20px 14px;background:hsl(215,30%,11%)}
+.team{font-size:1.3rem;font-weight:900;letter-spacing:2px}
+.team-home{color:var(--fs-red)}
+.team-away{color:var(--fs-blue)}
+.score-digits{display:flex;align-items:center;gap:8px}
+.score-digit{width:44px;height:56px;border-radius:8px;background:hsl(215,25%,16%);border:2px solid hsl(215,20%,28%);font-family:ui-monospace,Consolas,monospace;font-size:1.9rem;font-weight:900;color:var(--fs-ink);display:flex;align-items:center;justify-content:center;animation:score-flip-football-scorecard 1.6s ease-in-out infinite}
+.score-sep{font-size:1.4rem;font-weight:900;color:var(--fs-gold)}
+.status-bar{display:flex;align-items:center;gap:10px;padding:10px 16px;background:hsl(215,28%,13%)}
+.status-minute{font-family:ui-monospace,Consolas,monospace;font-size:1rem;font-weight:900;color:var(--fs-gold)}
+.status-dot{width:10px;height:10px;border-radius:50%;background:var(--fs-red);animation:live-pulse-football-scorecard 1.2s ease-in-out infinite}
+.status-text{font-size:.68rem;color:hsl(215,20%,60%)}
+.score-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(215,34%,13%)}
+.score-possession{font-size:.68rem;color:hsl(215,20%,58%)}
+.score-half{font-size:.68rem;font-weight:800;color:var(--fs-green)}
+@keyframes score-flip-football-scorecard{0%,100%{transform:rotateX(0deg)}50%{transform:rotateX(50deg)}}
+@keyframes live-pulse-football-scorecard{0%,100%{opacity:1;transform:scale(1)}50%{opacity:0.3;transform:scale(0.85)}}


### PR DESCRIPTION
## Component: ease-football-scorecard — football scorecard with team scores and match status

**Closes #59907**

### What this adds
A live football scorecard. Two team names flank a scoreboard of digit squares, a match-status bar shows the game minute with a pulsing live dot, and the footer lists possession and half while the header shows the venue.

### Acceptance Criteria covered
- The team names flank the score digits
- The score digits flip in the scoreboard
- The live dot pulses on the status bar

### Files
- `submissions/examples/ease-football-scorecard-ij/demo.html`
- `submissions/examples/ease-football-scorecard-ij/style.css`
- `submissions/examples/ease-football-scorecard-ij/README.md`

### How to review
Open demo.html directly in a browser. The score digits flip while the live dot pulses.