### PR TITLE
Add ease-tag-cloud component

### DIFF
--- a/submissions/examples/ease-tag-cloud-ij/README.md
+++ b/submissions/examples/ease-tag-cloud-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Tag Cloud
+
+A topic tag cloud with many text tags at varying sizes and hues.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The tags float while the highlighted tag pops.

--- a/submissions/examples/ease-tag-cloud-ij/demo.html
+++ b/submissions/examples/ease-tag-cloud-ij/demo.html
@@ -1,0 +1,42 @@
+<!-- EaseMotion component: tag-cloud -->
+<!DOCTYPE html>
+<html lang="en" data-tag="cloud">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.7">
+<title>Ease Tag Cloud</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="cloud-card">
+  <header class="cloud-head">
+    <span class="cloud-topic">AI TOPICS</span>
+    <span class="cloud-mode">RANDOM</span>
+  </header>
+  <div class="cloud-body">
+    <span class="cloud-tag t-sm">neural</span>
+    <span class="cloud-tag t-md">transformer</span>
+    <span class="cloud-tag t-lg">deep learning</span>
+    <span class="cloud-tag t-sm">encoder</span>
+    <span class="cloud-tag t-md">attention</span>
+    <span class="cloud-tag t-xl">tokenizer</span>
+    <span class="cloud-tag t-sm">gradient</span>
+    <span class="cloud-tag t-md">embedding</span>
+    <span class="cloud-tag t-lg">fine tuning</span>
+    <span class="cloud-tag t-sm">decoder</span>
+    <span class="cloud-tag t-md">inference</span>
+    <span class="cloud-tag t-xl">latent space</span>
+    <span class="cloud-tag t-sm">context</span>
+    <span class="cloud-tag t-md">prompt</span>
+    <span class="cloud-tag t-lg">agent</span>
+    <span class="cloud-tag t-sm">pipeline</span>
+    <span class="cloud-tag t-md">dataset</span>
+    <span class="cloud-tag t-xl">backprop</span>
+  </div>
+  <footer class="cloud-foot">
+    <span class="cloud-count">18 TAGS</span>
+    <span class="cloud-weight">BY FREQ</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-tag-cloud-ij/style.css
+++ b/submissions/examples/ease-tag-cloud-ij/style.css
@@ -1,0 +1,25 @@
+:root{
+  --tc-bg:hsl(265,30%,7%);
+  --tc-ink:hsl(265,25%,92%);
+  --tc-violet:hsl(265,80%,65%);
+  --tc-pink:hsl(330,80%,60%);
+  --tc-blue:hsl(205,85%,60%);
+}
+*{padding:0;margin:0;box-sizing:border-box}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 30%,hsl(265,40%,16%),hsl(270,50%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.cloud-card{width:380px;border-radius:16px;overflow:hidden;background:hsl(265,26%,9%);border:1px solid hsl(265,22%,24%)}
+.cloud-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(265,34%,13%)}
+.cloud-topic{font-size:.84rem;letter-spacing:3px;color:var(--tc-ink)}
+.cloud-mode{font-size:.68rem;font-weight:800;color:var(--tc-violet);animation:mode-blink-tag-cloud 2s ease-in-out infinite}
+.cloud-body{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:10px;padding:18px 14px;min-height:220px;background:hsl(265,28%,11%)}
+.cloud-tag{display:inline-block;border-radius:20px;padding:4px 12px;font-weight:700;animation:tag-float-tag-cloud 2.4s ease-in-out infinite}
+.t-sm{font-size:.72rem;color:var(--tc-blue)}
+.t-md{font-size:.9rem;color:var(--tc-pink)}
+.t-lg{font-size:1.05rem;color:var(--tc-violet)}
+.t-xl{font-size:1.25rem;color:var(--tc-violet);box-shadow:0 0 0 2px hsl(265,80%,65% / 0.5);animation:tag-pop-tag-cloud 2.4s ease-in-out infinite}
+.cloud-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(265,34%,13%)}
+.cloud-count{font-size:.68rem;color:hsl(265,20%,60%)}
+.cloud-weight{font-size:.68rem;font-weight:800;color:var(--tc-pink)}
+@keyframes tag-float-tag-cloud{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+@keyframes tag-pop-tag-cloud{0%,100%{transform:scale(1)}50%{transform:scale(1.12)}}
+@keyframes mode-blink-tag-cloud{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-tag-cloud — tag cloud with many text tags at varying sizes

**Closes #59912**

### What this adds
A topic tag cloud. A card holds many text tags at varying sizes and hues, each tag gently floats while a highlighted tag pops, and the header blinks the topic while the footer shows the total count.

### Acceptance Criteria covered
- The many tags render at varying sizes
- The tags float gently in the card
- The highlighted tag pops in place

### Files
- `submissions/examples/ease-tag-cloud-ij/demo.html`
- `submissions/examples/ease-tag-cloud-ij/style.css`
- `submissions/examples/ease-tag-cloud-ij/README.md`

### How to review
Open demo.html directly in a browser. The tags float while the highlighted one pops.