### PR TITLE
Add ease-camera-viewfinder component

### DIFF
--- a/submissions/examples/ease-camera-viewfinder-ij/README.md
+++ b/submissions/examples/ease-camera-viewfinder-ij/README.md
@@ -1,0 +1,9 @@
+# Ease Camera Viewfinder
+
+A camera app with a pulsing focus frame, zoom dial and shutter button.
+
+## Run
+Open `demo.html` in any browser.
+
+## Notes
+- The focus frame pulses on the viewfinder.

--- a/submissions/examples/ease-camera-viewfinder-ij/demo.html
+++ b/submissions/examples/ease-camera-viewfinder-ij/demo.html
@@ -1,0 +1,39 @@
+<!-- EaseMotion component: camera-viewfinder -->
+<!DOCTYPE html>
+<html lang="en" data-cam="view">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Ease Camera Viewfinder</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="cam-app">
+  <header class="cam-head">
+    <span class="cam-rec">REC</span>
+    <span class="cam-time">00:12</span>
+  </header>
+  <div class="cam-view">
+    <span class="cam-focus"></span>
+    <span class="cam-grip"></span>
+  </div>
+  <div class="cam-controls">
+    <span class="cam-zoom">2.4x</span>
+    <span class="cam-settings">
+      <span class="cam-chip chip-hdr">HDR</span>
+      <span class="cam-chip chip-raw">RAW</span>
+      <span class="cam-chip chip-4k">4K</span>
+    </span>
+    <span class="cam-battery">92%</span>
+  </div>
+  <div class="cam-shutter">
+    <span class="shutter-ring"></span>
+    <span class="shutter-core"></span>
+  </div>
+  <footer class="cam-foot">
+    <span class="cam-mode">PHOTO</span>
+    <span class="cam-album">ALBUM 14</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-camera-viewfinder-ij/style.css
+++ b/submissions/examples/ease-camera-viewfinder-ij/style.css
@@ -1,0 +1,32 @@
+:root{
+  --cv-bg:hsl(190,25%,7%);
+  --cv-ink:hsl(190,20%,92%);
+  --cv-teal:hsl(170,85%,55%);
+  --cv-red:hsl(0,85%,55%);
+  --cv-dark:hsl(190,30%,14%);
+}
+*{margin:0;box-sizing:border-box;padding:0}
+body{font-family:ui-sans-serif,system-ui,sans-serif;background:radial-gradient(circle at 50% 25%,hsl(190,35%,15%),hsl(195,45%,5%));min-height:100vh;display:flex;align-items:center;justify-content:center;padding:22px}
+.cam-app{width:340px;border-radius:16px;overflow:hidden;background:hsl(190,22%,9%);border:1px solid hsl(190,20%,24%)}
+.cam-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:hsl(190,30%,13%)}
+.cam-rec{font-size:.68rem;font-weight:900;color:var(--cv-red);animation:rec-blink-camera-viewfinder 1.2s step-end infinite}
+.cam-time{font-family:ui-monospace,Consolas,monospace;font-size:.7rem;color:var(--cv-ink)}
+.cam-view{position:relative;height:200px;margin:14px;border-radius:12px;background:linear-gradient(180deg,hsl(190,40%,24%),hsl(195,45%,14%));border:2px solid hsl(190,20%,26%);overflow:hidden}
+.cam-focus{position:absolute;left:50%;top:50%;width:64px;height:64px;transform:translate(-50%,-50%);border:3px solid var(--cv-teal);border-radius:6px;animation:focus-pulse-camera-viewfinder 1.6s ease-in-out infinite}
+.cam-grip{position:absolute;right:12px;top:12px;width:4px;height:26px;border-radius:2px;background:hsl(190,20%,80%)}
+.cam-controls{display:flex;align-items:center;justify-content:space-between;padding:0 16px 12px}
+.cam-zoom{font-size:.7rem;font-weight:800;color:var(--cv-teal)}
+.cam-settings{display:flex;gap:6px}
+.cam-chip{font-size:.6rem;font-weight:800;padding:3px 8px;border-radius:10px;background:hsl(190,25%,20%);color:var(--cv-ink)}
+.chip-raw{color:var(--cv-red)}
+.chip-4k{color:var(--cv-teal)}
+.cam-battery{font-size:.7rem;color:hsl(190,20%,58%)}
+.cam-shutter{display:flex;align-items:center;justify-content:center;padding-bottom:16px}
+.shutter-ring{width:56px;height:56px;border-radius:50%;border:4px solid hsl(190,20%,70%);display:flex;align-items:center;justify-content:center}
+.shutter-core{width:42px;height:42px;border-radius:50%;background:var(--cv-red);animation:shutter-pulse-camera-viewfinder 2s ease-in-out infinite}
+.cam-foot{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;background:hsl(190,30%,13%)}
+.cam-mode{font-size:.68rem;color:hsl(190,20%,58%)}
+.cam-album{font-size:.68rem;font-weight:800;color:var(--cv-teal)}
+@keyframes focus-pulse-camera-viewfinder{0%,100%{transform:translate(-50%,-50%) scale(1);opacity:1}50%{transform:translate(-50%,-50%) scale(0.88);opacity:0.6}}
+@keyframes rec-blink-camera-viewfinder{0%,49%{opacity:1}50%,100%{opacity:0.1}}
+@keyframes shutter-pulse-camera-viewfinder{0%,100%{transform:scale(1)}50%{transform:scale(0.9)}}


### PR DESCRIPTION
## Component: ease-camera-viewfinder — camera app with viewfinder and shutter button

**Closes #59923**

### What this adds
A camera app screen. A viewfinder shows the scene with a focus frame that pulses, a zoom dial and battery readout sit at the top, a large shutter button anchors the bottom, and a settings row holds mode chips while the header blinks REC.

### Acceptance Criteria covered
- The viewfinder shows the focus frame
- The zoom dial marks the current zoom
- The shutter button anchors the bottom row

### Files
- `submissions/examples/ease-camera-viewfinder-ij/demo.html`
- `submissions/examples/ease-camera-viewfinder-ij/style.css`
- `submissions/examples/ease-camera-viewfinder-ij/README.md`

### How to review
Open demo.html directly in a browser. The focus frame pulses on the viewfinder.