### PR TITLE
feat: add CSS blur entrance carousel SaaS showcase

### DIFF
--- a/submissions/examples/blur-entrance-carousel-saas/README.md
+++ b/submissions/examples/blur-entrance-carousel-saas/README.md
@@ -1,0 +1,33 @@
+# CSS Blur-Entrance Carousel for SaaS Showcase
+
+A responsive SaaS showcase carousel built entirely with HTML and CSS.
+
+The component focuses on smooth blur-to-sharp entrance animations, depth,
+scaling and lightweight interface transitions without requiring JavaScript.
+
+## Features
+
+- Pure HTML and CSS
+- CSS-only carousel navigation
+- Blur-to-sharp entrance animation
+- Smooth scale and translate transitions
+- Product analytics showcase
+- Team collaboration showcase
+- Cloud security showcase
+- Responsive desktop layout
+- Responsive tablet layout
+- Responsive mobile layout
+- CSS custom properties
+- Keyboard-accessible navigation
+- Visible focus states
+- `prefers-reduced-motion` support
+- No JavaScript dependencies
+- No external frameworks
+
+## Folder Structure
+
+```text
+blur-entrance-carousel-saas/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/blur-entrance-carousel-saas/demo.html
+++ b/submissions/examples/blur-entrance-carousel-saas/demo.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="CSS Blur-Entrance Carousel for SaaS Showcase Layouts"
+  >
+
+  <title>Blur Entrance Carousel | EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="showcase">
+
+    <header class="hero">
+      <span class="eyebrow">EaseMotion CSS</span>
+
+      <h1>Blur-Entrance Carousel</h1>
+
+      <p>
+        A lightweight SaaS showcase carousel using pure HTML and CSS
+        with elegant blur, depth and entrance animations.
+      </p>
+    </header>
+
+
+    <section
+      class="carousel"
+      aria-label="SaaS product showcase carousel"
+    >
+
+      <!-- CSS-only carousel controls -->
+
+      <input
+        type="radio"
+        name="carousel"
+        id="slide-1"
+        checked
+      >
+
+      <input
+        type="radio"
+        name="carousel"
+        id="slide-2"
+      >
+
+      <input
+        type="radio"
+        name="carousel"
+        id="slide-3"
+      >
+
+
+      <div class="slides">
+
+        <!-- =========================
+             SLIDE 1
+        ========================== -->
+
+        <article class="slide slide-one">
+
+          <div class="slide-content">
+
+            <span class="slide-index">01 / 03</span>
+
+            <span class="slide-label">
+              PRODUCT INTELLIGENCE
+            </span>
+
+            <h2>
+              Understand your
+              <span>product.</span>
+            </h2>
+
+            <p>
+              Bring customer behavior, product metrics and business
+              insights together in one intelligent workspace.
+            </p>
+
+            <div class="metrics">
+
+              <div class="metric">
+                <strong>87%</strong>
+                <span>Retention</span>
+              </div>
+
+              <div class="metric">
+                <strong>3.8x</strong>
+                <span>Growth</span>
+              </div>
+
+              <div class="metric">
+                <strong>42K</strong>
+                <span>Users</span>
+              </div>
+
+            </div>
+
+            <a href="#" class="action">
+              Explore platform
+              <span aria-hidden="true">→</span>
+            </a>
+
+          </div>
+
+
+          <div class="product-card analytics-card">
+
+            <div class="card-header">
+              <span>PRODUCT OVERVIEW</span>
+
+              <span class="live">
+                <i></i>
+                LIVE
+              </span>
+            </div>
+
+            <div class="score">
+
+              <div>
+                <small>HEALTH SCORE</small>
+                <strong>92.8</strong>
+              </div>
+
+              <span class="score-change">
+                +12.4%
+              </span>
+
+            </div>
+
+            <div class="graph">
+
+              <div class="graph-lines"></div>
+
+              <span class="graph-path path-a"></span>
+              <span class="graph-path path-b"></span>
+
+              <div class="graph-points">
+                <i></i>
+                <i></i>
+                <i></i>
+                <i></i>
+                <i></i>
+              </div>
+
+            </div>
+
+            <div class="graph-labels">
+              <span>JAN</span>
+              <span>FEB</span>
+              <span>MAR</span>
+              <span>APR</span>
+              <span>MAY</span>
+            </div>
+
+          </div>
+
+        </article>
+
+
+        <!-- =========================
+             SLIDE 2
+        ========================== -->
+
+        <article class="slide slide-two">
+
+          <div class="slide-content">
+
+            <span class="slide-index">02 / 03</span>
+
+            <span class="slide-label">
+              TEAM COLLABORATION
+            </span>
+
+            <h2>
+              Work together
+              <span>better.</span>
+            </h2>
+
+            <p>
+              Give every team a shared workspace for planning,
+              reviewing projects and turning ideas into outcomes.
+            </p>
+
+            <div class="metrics">
+
+              <div class="metric">
+                <strong>128</strong>
+                <span>Members</span>
+              </div>
+
+              <div class="metric">
+                <strong>94%</strong>
+                <span>Completion</span>
+              </div>
+
+              <div class="metric">
+                <strong>31</strong>
+                <span>Projects</span>
+              </div>
+
+            </div>
+
+            <a href="#" class="action">
+              View workspace
+              <span aria-hidden="true">→</span>
+            </a>
+
+          </div>
+
+
+          <div class="product-card collaboration-card">
+
+            <div class="card-header">
+              <span>TEAM ACTIVITY</span>
+
+              <span class="online">
+                <i></i>
+                12 ONLINE
+              </span>
+            </div>
+
+            <div class="activity">
+
+              <div class="activity-row">
+                <span class="avatar avatar-one">A</span>
+
+                <div>
+                  <strong>Alex created a project</strong>
+                  <small>2 minutes ago</small>
+                </div>
+
+                <b>+</b>
+              </div>
+
+
+              <div class="activity-row">
+                <span class="avatar avatar-two">M</span>
+
+                <div>
+                  <strong>Maya completed a task</strong>
+                  <small>8 minutes ago</small>
+                </div>
+
+                <b>✓</b>
+              </div>
+
+
+              <div class="activity-row">
+                <span class="avatar avatar-three">R</span>
+
+                <div>
+                  <strong>Ryan joined the team</strong>
+                  <small>15 minutes ago</small>
+                </div>
+
+                <b>+</b>
+              </div>
+
+
+              <div class="activity-row">
+                <span class="avatar avatar-four">S</span>
+
+                <div>
+                  <strong>Sarah reviewed a document</strong>
+                  <small>24 minutes ago</small>
+                </div>
+
+                <b>✓</b>
+              </div>
+
+            </div>
+
+          </div>
+
+        </article>
+
+
+        <!-- =========================
+             SLIDE 3
+        ========================== -->
+
+        <article class="slide slide-three">
+
+          <div class="slide-content">
+
+            <span class="slide-index">03 / 03</span>
+
+            <span class="slide-label">
+              CLOUD SECURITY
+            </span>
+
+            <h2>
+              Secure every
+              <span>workflow.</span>
+            </h2>
+
+            <p>
+              Keep your applications protected with continuous monitoring,
+              intelligent alerts and enterprise-grade security controls.
+            </p>
+
+            <div class="metrics">
+
+              <div class="metric">
+                <strong>99.9%</strong>
+                <span>Uptime</span>
+              </div>
+
+              <div class="metric">
+                <strong>24/7</strong>
+                <span>Monitoring</span>
+              </div>
+
+              <div class="metric">
+                <strong>0</strong>
+                <span>Threats</span>
+              </div>
+
+            </div>
+
+            <a href="#" class="action">
+              Open security
+              <span aria-hidden="true">→</span>
+            </a>
+
+          </div>
+
+
+          <div class="product-card security-card">
+
+            <div class="card-header">
+              <span>SECURITY STATUS</span>
+
+              <span class="secure">
+                <i></i>
+                PROTECTED
+              </span>
+            </div>
+
+            <div class="security-center">
+
+              <div class="shield">
+                <span>✓</span>
+              </div>
+
+              <strong>All systems secure</strong>
+
+              <small>
+                Last scan completed 2 minutes ago
+              </small>
+
+            </div>
+
+            <div class="security-grid">
+
+              <div>
+                <span>Firewall</span>
+                <b>Active</b>
+              </div>
+
+              <div>
+                <span>Encryption</span>
+                <b>Enabled</b>
+              </div>
+
+              <div>
+                <span>Threats</span>
+                <b>0 detected</b>
+              </div>
+
+              <div>
+                <span>Monitoring</span>
+                <b>24 / 7</b>
+              </div>
+
+            </div>
+
+          </div>
+
+        </article>
+
+      </div>
+
+
+      <!-- Navigation -->
+
+      <nav
+        class="navigation"
+        aria-label="Carousel navigation"
+      >
+
+        <label for="slide-1">
+          <span>01</span>
+        </label>
+
+        <label for="slide-2">
+          <span>02</span>
+        </label>
+
+        <label for="slide-3">
+          <span>03</span>
+        </label>
+
+      </nav>
+
+
+      <div class="progress">
+        <span></span>
+      </div>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-carousel-saas/style.css
+++ b/submissions/examples/blur-entrance-carousel-saas/style.css
@@ -1,0 +1,1271 @@
+:root {
+    --bec-bg: #080b11;
+    --bec-surface: #10151e;
+    --bec-surface-soft: #151b26;
+  
+    --bec-text: #f5f7fb;
+    --bec-muted: #8993a4;
+  
+    --bec-border: rgba(255, 255, 255, 0.09);
+    --bec-border-strong: rgba(255, 255, 255, 0.2);
+  
+    --bec-accent: #6f8cff;
+    --bec-accent-soft: rgba(111, 140, 255, 0.12);
+  
+    --bec-success: #72d6a2;
+  
+    --bec-radius: 26px;
+  
+    --bec-transition:
+      650ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  
+  
+  /* =====================================
+     RESET
+  ===================================== */
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+  
+    margin: 0;
+  
+    color: var(--bec-text);
+  
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    background:
+      radial-gradient(
+        circle at 50% -20%,
+        rgba(111, 140, 255, 0.15),
+        transparent 42%
+      ),
+      var(--bec-bg);
+  }
+  
+  a {
+    color: inherit;
+  }
+  
+  
+  /* =====================================
+     MAIN
+  ===================================== */
+  
+  .showcase {
+    width: min(1160px, calc(100% - 32px));
+  
+    margin: 0 auto;
+  
+    padding: 90px 0;
+  }
+  
+  
+  /* =====================================
+     HERO
+  ===================================== */
+  
+  .hero {
+    max-width: 720px;
+  
+    margin: 0 auto 58px;
+  
+    text-align: center;
+  }
+  
+  .eyebrow {
+    display: inline-flex;
+  
+    padding: 7px 13px;
+  
+    border:
+      1px solid var(--bec-border);
+  
+    border-radius: 999px;
+  
+    color: #aebcff;
+  
+    background: var(--bec-accent-soft);
+  
+    font-size: 0.7rem;
+  
+    font-weight: 800;
+  
+    letter-spacing: 0.09em;
+  
+    text-transform: uppercase;
+  }
+  
+  .hero h1 {
+    margin: 18px 0 15px;
+  
+    font-size:
+      clamp(2.5rem, 6vw, 4.7rem);
+  
+    line-height: 0.98;
+  
+    letter-spacing: -0.055em;
+  }
+  
+  .hero p {
+    margin: 0 auto;
+  
+    max-width: 620px;
+  
+    color: var(--bec-muted);
+  
+    line-height: 1.7;
+  }
+  
+  
+  /* =====================================
+     CAROUSEL
+  ===================================== */
+  
+  .carousel {
+    position: relative;
+  
+    overflow: hidden;
+  
+    border:
+      1px solid var(--bec-border);
+  
+    border-radius: var(--bec-radius);
+  
+    background: var(--bec-surface);
+  
+    box-shadow:
+      0 35px 100px rgba(0, 0, 0, 0.38);
+  }
+  
+  .carousel > input {
+    position: absolute;
+  
+    width: 1px;
+    height: 1px;
+  
+    opacity: 0;
+  }
+  
+  
+  /* =====================================
+     SLIDES
+  ===================================== */
+  
+  .slides {
+    position: relative;
+  
+    min-height: 590px;
+  }
+  
+  .slide {
+    position: absolute;
+  
+    inset: 0;
+  
+    display: grid;
+  
+    grid-template-columns: 1fr 0.9fr;
+  
+    align-items: center;
+  
+    gap: 60px;
+  
+    padding: 68px;
+  
+    opacity: 0;
+  
+    visibility: hidden;
+  
+    transform:
+      translateY(35px)
+      scale(0.96);
+  
+    filter: blur(14px);
+  
+    transition:
+      opacity var(--bec-transition),
+      transform var(--bec-transition),
+      filter var(--bec-transition),
+      visibility var(--bec-transition);
+  
+    pointer-events: none;
+  }
+  
+  
+  /* Active slide */
+  
+  #slide-1:checked ~ .slides .slide-one,
+  #slide-2:checked ~ .slides .slide-two,
+  #slide-3:checked ~ .slides .slide-three {
+    position: relative;
+  
+    opacity: 1;
+  
+    visibility: visible;
+  
+    transform:
+      translateY(0)
+      scale(1);
+  
+    filter: blur(0);
+  
+    pointer-events: auto;
+  
+    animation:
+      blur-entrance
+      800ms
+      cubic-bezier(0.16, 1, 0.3, 1)
+      both;
+  }
+  
+  
+  /* =====================================
+     BLUR ENTRANCE
+  ===================================== */
+  
+  @keyframes blur-entrance {
+  
+    0% {
+      opacity: 0;
+  
+      filter:
+        blur(22px);
+  
+      transform:
+        translateY(50px)
+        scale(0.92);
+    }
+  
+    20% {
+      opacity: 0.25;
+  
+      filter:
+        blur(15px);
+  
+      transform:
+        translateY(32px)
+        scale(0.95);
+    }
+  
+    55% {
+      opacity: 0.8;
+  
+      filter:
+        blur(5px);
+  
+      transform:
+        translateY(8px)
+        scale(0.985);
+    }
+  
+    78% {
+      opacity: 1;
+  
+      filter:
+        blur(1px);
+  
+      transform:
+        translateY(-2px)
+        scale(1.008);
+    }
+  
+    100% {
+      opacity: 1;
+  
+      filter:
+        blur(0);
+  
+      transform:
+        translateY(0)
+        scale(1);
+    }
+  }
+  
+  
+  /* =====================================
+     CONTENT
+  ===================================== */
+  
+  .slide-content {
+    position: relative;
+  
+    max-width: 510px;
+  }
+  
+  .slide-index {
+    display: block;
+  
+    margin-bottom: 20px;
+  
+    color: var(--bec-muted);
+  
+    font-family: monospace;
+  
+    font-size: 0.68rem;
+  
+    letter-spacing: 0.08em;
+  }
+  
+  .slide-label {
+    display: inline-block;
+  
+    margin-bottom: 15px;
+  
+    color: #9eb0ff;
+  
+    font-size: 0.69rem;
+  
+    font-weight: 800;
+  
+    letter-spacing: 0.1em;
+  
+    text-transform: uppercase;
+  }
+  
+  .slide h2 {
+    margin: 0 0 18px;
+  
+    font-size:
+      clamp(2.2rem, 4vw, 3.7rem);
+  
+    line-height: 1.02;
+  
+    letter-spacing: -0.055em;
+  }
+  
+  .slide h2 span {
+    color: #9eb0ff;
+  }
+  
+  .slide-content > p {
+    margin: 0 0 28px;
+  
+    color: var(--bec-muted);
+  
+    font-size: 0.95rem;
+  
+    line-height: 1.75;
+  }
+  
+  
+  /* =====================================
+     METRICS
+  ===================================== */
+  
+  .metrics {
+    display: grid;
+  
+    grid-template-columns:
+      repeat(3, 1fr);
+  
+    gap: 9px;
+  
+    margin-bottom: 28px;
+  }
+  
+  .metric {
+    padding: 14px;
+  
+    border:
+      1px solid var(--bec-border);
+  
+    border-radius: 12px;
+  
+    background:
+      rgba(255, 255, 255, 0.025);
+  }
+  
+  .metric strong {
+    display: block;
+  
+    margin-bottom: 5px;
+  
+    font-size: 1rem;
+  }
+  
+  .metric span {
+    color: var(--bec-muted);
+  
+    font-size: 0.63rem;
+  }
+  
+  
+  /* =====================================
+     ACTION
+  ===================================== */
+  
+  .action {
+    display: inline-flex;
+  
+    align-items: center;
+  
+    justify-content: space-between;
+  
+    gap: 25px;
+  
+    min-width: 175px;
+  
+    padding: 12px 15px;
+  
+    border-radius: 11px;
+  
+    background: var(--bec-accent);
+  
+    color: white;
+  
+    font-size: 0.77rem;
+  
+    font-weight: 750;
+  
+    text-decoration: none;
+  
+    transition:
+      transform 220ms ease,
+      filter 220ms ease;
+  }
+  
+  .action:hover,
+  .action:focus-visible {
+    transform: translateY(-2px);
+  
+    filter: brightness(1.12);
+  }
+  
+  .action span {
+    font-size: 1rem;
+  }
+  
+  
+  /* =====================================
+     PRODUCT CARD
+  ===================================== */
+  
+  .product-card {
+    position: relative;
+  
+    min-height: 365px;
+  
+    overflow: hidden;
+  
+    padding: 28px;
+  
+    border:
+      1px solid var(--bec-border);
+  
+    border-radius: 21px;
+  
+    background:
+      linear-gradient(
+        145deg,
+        rgba(255, 255, 255, 0.045),
+        rgba(255, 255, 255, 0.015)
+      );
+  
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+  
+  .product-card::before {
+    position: absolute;
+  
+    inset: 0;
+  
+    content: "";
+  
+    pointer-events: none;
+  
+    background:
+      radial-gradient(
+        circle at 50% 0,
+        rgba(111, 140, 255, 0.1),
+        transparent 55%
+      );
+  }
+  
+  
+  /* =====================================
+     CARD HEADER
+  ===================================== */
+  
+  .card-header {
+    position: relative;
+  
+    z-index: 1;
+  
+    display: flex;
+  
+    align-items: center;
+  
+    justify-content: space-between;
+  
+    margin-bottom: 28px;
+  
+    color: var(--bec-muted);
+  
+    font-size: 0.62rem;
+  
+    letter-spacing: 0.06em;
+  }
+  
+  .live,
+  .online,
+  .secure {
+    display: flex;
+  
+    align-items: center;
+  
+    gap: 6px;
+  
+    color: #aebcff;
+  
+    font-size: 0.58rem;
+  }
+  
+  .live i,
+  .online i,
+  .secure i {
+    width: 6px;
+    height: 6px;
+  
+    border-radius: 50%;
+  
+    background: var(--bec-accent);
+  
+    box-shadow:
+      0 0 12px
+      rgba(111, 140, 255, 0.9);
+  }
+  
+  
+  /* =====================================
+     ANALYTICS CARD
+  ===================================== */
+  
+  .score {
+    position: relative;
+  
+    z-index: 1;
+  
+    display: flex;
+  
+    align-items: end;
+  
+    justify-content: space-between;
+  
+    margin-bottom: 24px;
+  }
+  
+  .score small {
+    display: block;
+  
+    margin-bottom: 5px;
+  
+    color: var(--bec-muted);
+  
+    font-size: 0.55rem;
+  }
+  
+  .score strong {
+    font-size: 2.1rem;
+  
+    letter-spacing: -0.04em;
+  }
+  
+  .score-change {
+    padding: 5px 8px;
+  
+    border-radius: 7px;
+  
+    background:
+      rgba(114, 214, 162, 0.1);
+  
+    color: var(--bec-success);
+  
+    font-size: 0.62rem;
+  }
+  
+  .graph {
+    position: relative;
+  
+    height: 175px;
+  
+    border-bottom:
+      1px solid var(--bec-border);
+  }
+  
+  .graph-lines {
+    position: absolute;
+  
+    inset: 0;
+  
+    opacity: 0.4;
+  
+    background:
+      repeating-linear-gradient(
+        to bottom,
+        transparent 0,
+        transparent 42px,
+        rgba(255, 255, 255, 0.05) 43px
+      );
+  }
+  
+  .graph-path {
+    position: absolute;
+  
+    display: block;
+  
+    height: 2px;
+  
+    border-radius: 99px;
+  
+    transform-origin: left center;
+  
+    animation:
+      graph-reveal
+      900ms
+      ease
+      both;
+  }
+  
+  .path-a {
+    width: 73%;
+  
+    top: 62%;
+  
+    left: 4%;
+  
+    background: var(--bec-accent);
+  
+    transform:
+      rotate(-17deg);
+  }
+  
+  .path-b {
+    width: 55%;
+  
+    top: 45%;
+  
+    left: 38%;
+  
+    background: #b18cff;
+  
+    transform:
+      rotate(14deg);
+  }
+  
+  @keyframes graph-reveal {
+  
+    from {
+      opacity: 0;
+  
+      transform:
+        scaleX(0)
+        rotate(-17deg);
+    }
+  
+    to {
+      opacity: 1;
+    }
+  }
+  
+  .graph-points {
+    position: absolute;
+  
+    inset: 0;
+  }
+  
+  .graph-points i {
+    position: absolute;
+  
+    width: 7px;
+    height: 7px;
+  
+    border:
+      2px solid var(--bec-accent);
+  
+    border-radius: 50%;
+  
+    background: var(--bec-surface);
+  
+    animation:
+      point-enter
+      500ms
+      ease
+      both;
+  }
+  
+  .graph-points i:nth-child(1) {
+    left: 8%;
+    top: 61%;
+  }
+  
+  .graph-points i:nth-child(2) {
+    left: 28%;
+    top: 54%;
+  }
+  
+  .graph-points i:nth-child(3) {
+    left: 49%;
+    top: 42%;
+  }
+  
+  .graph-points i:nth-child(4) {
+    left: 69%;
+    top: 48%;
+  }
+  
+  .graph-points i:nth-child(5) {
+    right: 7%;
+    top: 32%;
+  }
+  
+  @keyframes point-enter {
+  
+    from {
+      opacity: 0;
+  
+      transform: scale(0);
+    }
+  
+    to {
+      opacity: 1;
+  
+      transform: scale(1);
+    }
+  }
+  
+  .graph-labels {
+    display: flex;
+  
+    justify-content: space-between;
+  
+    padding-top: 10px;
+  
+    color: var(--bec-muted);
+  
+    font-size: 0.5rem;
+  }
+  
+  
+  /* =====================================
+     COLLABORATION CARD
+  ===================================== */
+  
+  .activity {
+    position: relative;
+  
+    z-index: 1;
+  
+    display: flex;
+  
+    flex-direction: column;
+  
+    gap: 10px;
+  }
+  
+  .activity-row {
+    display: grid;
+  
+    grid-template-columns: 36px 1fr auto;
+  
+    align-items: center;
+  
+    gap: 11px;
+  
+    padding: 11px;
+  
+    border:
+      1px solid var(--bec-border);
+  
+    border-radius: 12px;
+  
+    background:
+      rgba(255, 255, 255, 0.025);
+  
+    animation:
+      activity-enter
+      600ms
+      ease
+      both;
+  }
+  
+  .activity-row:nth-child(2) {
+    animation-delay: 100ms;
+  }
+  
+  .activity-row:nth-child(3) {
+    animation-delay: 200ms;
+  }
+  
+  .activity-row:nth-child(4) {
+    animation-delay: 300ms;
+  }
+  
+  @keyframes activity-enter {
+  
+    from {
+      opacity: 0;
+  
+      filter: blur(8px);
+  
+      transform:
+        translateX(18px);
+    }
+  
+    to {
+      opacity: 1;
+  
+      filter: blur(0);
+  
+      transform:
+        translateX(0);
+    }
+  }
+  
+  .avatar {
+    display: grid;
+  
+    width: 34px;
+    height: 34px;
+  
+    place-items: center;
+  
+    border-radius: 10px;
+  
+    color: white;
+  
+    font-size: 0.65rem;
+  
+    font-weight: 800;
+  
+    background: var(--bec-accent-soft);
+  }
+  
+  .avatar-two {
+    background: rgba(177, 140, 255, 0.15);
+  }
+  
+  .avatar-three {
+    background: rgba(114, 214, 162, 0.13);
+  }
+  
+  .avatar-four {
+    background: rgba(255, 170, 105, 0.13);
+  }
+  
+  .activity-row strong {
+    display: block;
+  
+    margin-bottom: 3px;
+  
+    font-size: 0.67rem;
+  }
+  
+  .activity-row small {
+    color: var(--bec-muted);
+  
+    font-size: 0.53rem;
+  }
+  
+  .activity-row b {
+    color: #aebcff;
+  
+    font-size: 0.8rem;
+  }
+  
+  
+  /* =====================================
+     SECURITY CARD
+  ===================================== */
+  
+  .security-center {
+    position: relative;
+  
+    z-index: 1;
+  
+    display: flex;
+  
+    flex-direction: column;
+  
+    align-items: center;
+  
+    text-align: center;
+  }
+  
+  .shield {
+    display: grid;
+  
+    width: 88px;
+    height: 88px;
+  
+    margin-bottom: 18px;
+  
+    place-items: center;
+  
+    border:
+      1px solid
+      rgba(111, 140, 255, 0.35);
+  
+    border-radius: 50%;
+  
+    background:
+      radial-gradient(
+        circle,
+        rgba(111, 140, 255, 0.14),
+        transparent
+      );
+  
+    box-shadow:
+      0 0 50px
+      rgba(111, 140, 255, 0.12);
+  
+    animation:
+      shield-pulse
+      2.8s
+      ease-in-out
+      infinite;
+  }
+  
+  .shield span {
+    display: grid;
+  
+    width: 42px;
+    height: 42px;
+  
+    place-items: center;
+  
+    border-radius: 50%;
+  
+    background: var(--bec-accent-soft);
+  
+    color: #b5c1ff;
+  
+    font-size: 1rem;
+  
+    font-weight: 800;
+  }
+  
+  @keyframes shield-pulse {
+  
+    0%,
+    100% {
+      transform: scale(1);
+    }
+  
+    50% {
+      transform: scale(1.06);
+    }
+  }
+  
+  .security-center strong {
+    margin-bottom: 6px;
+  
+    font-size: 0.85rem;
+  }
+  
+  .security-center small {
+    color: var(--bec-muted);
+  
+    font-size: 0.57rem;
+  }
+  
+  .security-grid {
+    position: relative;
+  
+    z-index: 1;
+  
+    display: grid;
+  
+    grid-template-columns:
+      repeat(2, 1fr);
+  
+    gap: 8px;
+  
+    margin-top: 28px;
+  }
+  
+  .security-grid div {
+    padding: 10px;
+  
+    border:
+      1px solid var(--bec-border);
+  
+    border-radius: 9px;
+  }
+  
+  .security-grid span {
+    display: block;
+  
+    margin-bottom: 4px;
+  
+    color: var(--bec-muted);
+  
+    font-size: 0.52rem;
+  }
+  
+  .security-grid b {
+    color: var(--bec-success);
+  
+    font-size: 0.61rem;
+  }
+  
+  
+  /* =====================================
+     NAVIGATION
+  ===================================== */
+  
+  .navigation {
+    display: flex;
+  
+    justify-content: center;
+  
+    gap: 9px;
+  
+    padding: 18px;
+  
+    border-top:
+      1px solid var(--bec-border);
+  }
+  
+  .navigation label {
+    display: grid;
+  
+    width: 48px;
+    height: 32px;
+  
+    place-items: center;
+  
+    border:
+      1px solid var(--bec-border);
+  
+    border-radius: 9px;
+  
+    background:
+      rgba(255, 255, 255, 0.025);
+  
+    color: var(--bec-muted);
+  
+    cursor: pointer;
+  
+    font-family: monospace;
+  
+    font-size: 0.62rem;
+  
+    transition:
+      transform 220ms ease,
+      background 220ms ease,
+      border-color 220ms ease,
+      color 220ms ease;
+  }
+  
+  .navigation label:hover {
+    transform: translateY(-2px);
+  
+    color: var(--bec-text);
+  }
+  
+  #slide-1:checked ~ .navigation label[for="slide-1"],
+  #slide-2:checked ~ .navigation label[for="slide-2"],
+  #slide-3:checked ~ .navigation label[for="slide-3"] {
+    border-color: var(--bec-border-strong);
+  
+    background: var(--bec-accent-soft);
+  
+    color: #b5c1ff;
+  }
+  
+  
+  /* =====================================
+     PROGRESS
+  ===================================== */
+  
+  .progress {
+    height: 2px;
+  
+    overflow: hidden;
+  
+    background:
+      rgba(255, 255, 255, 0.04);
+  }
+  
+  .progress span {
+    display: block;
+  
+    width: 33.333%;
+  
+    height: 100%;
+  
+    background: var(--bec-accent);
+  
+    transition:
+      width var(--bec-transition);
+  }
+  
+  #slide-1:checked ~ .progress span {
+    width: 33.333%;
+  }
+  
+  #slide-2:checked ~ .progress span {
+    width: 66.666%;
+  }
+  
+  #slide-3:checked ~ .progress span {
+    width: 100%;
+  }
+  
+  
+  /* =====================================
+     FOCUS
+  ===================================== */
+  
+  .navigation label:focus-visible,
+  .action:focus-visible {
+    outline:
+      3px solid
+      rgba(111, 140, 255, 0.55);
+  
+    outline-offset: 3px;
+  }
+  
+  
+  /* =====================================
+     TABLET
+  ===================================== */
+  
+  @media (max-width: 900px) {
+  
+    .slide {
+      grid-template-columns: 1fr;
+  
+      gap: 38px;
+  
+      padding: 48px;
+    }
+  
+    .slides {
+      min-height: 900px;
+    }
+  
+    .slide {
+      min-height: 900px;
+    }
+  
+    .slide-content {
+      max-width: none;
+    }
+  
+  }
+  
+  
+  /* =====================================
+     MOBILE
+  ===================================== */
+  
+  @media (max-width: 600px) {
+  
+    .showcase {
+      width: min(100% - 24px, 500px);
+  
+      padding: 60px 0;
+    }
+  
+    .hero {
+      margin-bottom: 40px;
+    }
+  
+    .hero h1 {
+      font-size: 2.45rem;
+    }
+  
+    .hero p {
+      font-size: 0.88rem;
+    }
+  
+    .slides {
+      min-height: 925px;
+    }
+  
+    .slide {
+      min-height: 925px;
+  
+      gap: 28px;
+  
+      padding: 30px 22px;
+    }
+  
+    .slide h2 {
+      font-size: 2rem;
+    }
+  
+    .slide-content > p {
+      font-size: 0.86rem;
+    }
+  
+    .metrics {
+      grid-template-columns: 1fr;
+    }
+  
+    .metric {
+      display: flex;
+  
+      align-items: center;
+  
+      justify-content: space-between;
+    }
+  
+    .metric strong {
+      margin: 0;
+    }
+  
+    .product-card {
+      min-height: 315px;
+  
+      padding: 20px;
+    }
+  
+    .navigation {
+      padding: 14px;
+    }
+  
+  }
+  
+  
+  /* =====================================
+     REDUCED MOTION
+  ===================================== */
+  
+  @media (prefers-reduced-motion: reduce) {
+  
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+  
+      animation-iteration-count: 1 !important;
+  
+      transition-duration: 0.01ms !important;
+  
+      scroll-behavior: auto !important;
+    }
+  
+  }


### PR DESCRIPTION
## What does this PR do?

Adds a responsive CSS Blur-Entrance Carousel for SaaS Showcase Layouts.

## Changes

* Added `demo.html`
* Added `style.css`
* Added `README.md`
* Implemented CSS-only carousel navigation
* Added blur-to-sharp entrance animation
* Added scale and translate transitions
* Added product analytics showcase
* Added team collaboration showcase
* Added cloud security showcase
* Added responsive desktop, tablet and mobile layouts
* Added CSS custom properties
* Added keyboard-friendly navigation
* Added visible focus states
* Added `prefers-reduced-motion` support

## Technical Details

* Pure HTML and CSS
* No JavaScript
* No external frameworks
* Uses radio inputs for CSS-only carousel state
* Uses CSS keyframes for entrance animations
* Uses CSS Grid for responsive layouts
* Uses CSS filters for blur transitions

## Testing

* Tested all three slides
* Tested carousel navigation
* Tested hover and focus states
* Tested responsive layouts
* Tested mobile and tablet layouts
* Tested reduced-motion support

## Issue

Closes #59467
