### PR TITLE
Add ease-pinball-flipper-table component

### DIFF
--- a/submissions/examples/ease-pinball-flipper-table-ij/README.md
+++ b/submissions/examples/ease-pinball-flipper-table-ij/README.md
@@ -1,0 +1,7 @@
+# ease-pinball-flipper-table
+A pinball playfield with three bumpers, a rolling steel ball, and animated flippers that slap on the left and right rails.
+## Run
+Open `demo.html` directly in a browser to watch the pinball field.
+## Notes
+- Bumpers pulse with a pink glow while the ball travels around the field.
+- The score bar and multiplier blink in sync with the arcade theme.

--- a/submissions/examples/ease-pinball-flipper-table-ij/demo.html
+++ b/submissions/examples/ease-pinball-flipper-table-ij/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.1">
+<title>Pinball Flipper Table</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="pinball-arcade">
+  <header class="arcade-bar">
+    <h1 class="arcade-title">PINBALL MANIA</h1>
+    <p class="arcade-score">SCORE 8,400</p>
+  </header>
+  <section class="pin-table" aria-label="Pinball playfield">
+    <div class="playfield">
+      <span class="lane lane-a">L</span>
+      <span class="lane lane-b">R</span>
+      <div class="bumper bumper-a">1</div>
+      <div class="bumper bumper-b">2</div>
+      <div class="bumper bumper-c">3</div>
+      <div class="pin-ball"></div>
+      <button class="flipper flipper-left" type="button" aria-label="Left flipper"></button>
+      <button class="flipper flipper-right" type="button" aria-label="Right flipper"></button>
+    </div>
+  </section>
+  <footer class="arcade-foot">
+    <span class="arcade-balls">BALL 2</span>
+    <span class="arcade-mult">3X MULTIPLIER</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-pinball-flipper-table-ij/style.css
+++ b/submissions/examples/ease-pinball-flipper-table-ij/style.css
@@ -1,0 +1,30 @@
+:root{
+--pin-dark:#1a0b0e;
+--pin-bright:#ff2d55;
+--pin-light:#ffd6dd;
+}
+*,::before,::after{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 22%,hsl(345,45%,16%),hsl(350,55%,5%));font-family:Georgia,serif}
+.pinball-arcade{width:420px;padding:18px;border-radius:18px;background:var(--pin-dark);box-shadow:0 0 0 3px var(--pin-bright),0 12px 30px rgba(0,0,0,0.7)}
+.arcade-bar{display:flex;justify-content:space-between;align-items:baseline;padding:4px 6px 12px}
+.arcade-title{color:var(--pin-light);font-size:20px;letter-spacing:2px}
+.arcade-score{color:var(--pin-bright);font-weight:bold;font-size:18px;animation:score-blink-pinball-flipper-table 1s steps(2,end) infinite}
+.pin-table{background:#0d0a0a;border-radius:14px;padding:16px;border:2px solid #3a1520}
+.playfield{position:relative;height:300px;border-radius:10px;background:linear-gradient(180deg,#3a1230,#12040c);overflow:hidden}
+.lane{position:absolute;bottom:74px;width:22px;height:44px;border:2px solid #ff5a7a;border-radius:4px;color:#ff5a7a;text-align:center;line-height:40px;font-size:12px}
+.lane-a{left:30px}
+.lane-b{right:30px}
+.bumper{position:absolute;width:44px;height:44px;border-radius:50%;color:#fff;font-weight:bold;display:flex;align-items:center;justify-content:center;font-size:16px;box-shadow:0 0 14px var(--pin-bright)}
+.bumper-a{top:48px;left:60px;background:#c8102e;animation:bump-bounce-pinball-flipper-table 1.6s ease-in-out infinite}
+.bumper-b{top:70px;right:64px;background:#ff2d55;animation:bump-bounce-pinball-flipper-table 2.1s ease-in-out 0.4s infinite}
+.bumper-c{top:150px;left:190px;background:#e8387a;animation:bump-bounce-pinball-flipper-table 2.6s ease-in-out 0.8s infinite}
+.pin-ball{position:absolute;left:50%;top:96px;width:18px;height:18px;margin-left:-9px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#ffffff,#c0c0c0 45%,#5a5a5a);animation:ball-roll-pinball-flipper-table 3s linear infinite}
+.flipper{position:absolute;bottom:10px;width:96px;height:16px;border:none;border-radius:10px;transform-origin:center;box-shadow:0 0 8px #ff2d55}
+.flipper-left{left:6px;background:linear-gradient(90deg,#ff7a90,#ff2d55);animation:flipper-slap-pinball-flipper-table 1.8s ease-in-out infinite}
+.flipper-right{right:6px;background:linear-gradient(270deg,#ff7a90,#ff2d55);animation:flipper-slap-pinball-flipper-table 1.8s ease-in-out 0.9s infinite}
+.arcade-foot{display:flex;justify-content:space-between;padding:12px 6px 2px;color:var(--pin-light);font-size:14px;letter-spacing:1px}
+.arcade-mult{color:var(--pin-bright);animation:score-blink-pinball-flipper-table 1s steps(2,end) infinite}
+@keyframes bump-bounce-pinball-flipper-table{0%,100%{transform:scale(1)}45%{transform:scale(1.28)}55%{transform:scale(1.28)}}
+@keyframes ball-roll-pinball-flipper-table{0%{transform:translate(-40px,-6px)}25%{transform:translate(30px,46px)}50%{transform:translate(-18px,86px)}75%{transform:translate(34px,140px)}100%{transform:translate(-40px,-6px)}}
+@keyframes flipper-slap-pinball-flipper-table{0%,100%{transform:rotate(0deg)}35%{transform:rotate(-22deg)}50%{transform:rotate(0deg)}}
+@keyframes score-blink-pinball-flipper-table{0%,49%{opacity:1}50%,100%{opacity:0.2}}


### PR DESCRIPTION
## Component: ease-pinball-flipper-table — flippers, bumpers, and a steel ball on a glowing arcade playfield

**Closes #59971**

### What this adds
A pinball machine playfield where three bumpers pulse, a steel ball rolls around the table, and the left and right flippers slap on alternating beats.

### Acceptance Criteria covered
- Flipper paddles animate on the left and right rails
- Bumpers pulse with a themed glow as the ball travels
- Score and multiplier text blink in the arcade header

### Files
- submissions/examples/ease-pinball-flipper-table-ij/demo.html
- submissions/examples/ease-pinball-flipper-table-ij/style.css
- submissions/examples/ease-pinball-flipper-table-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the ball roll around the three bumpers while the flippers slap and the score blinks.