### PR TITLE
Add ease-submarine-controls component

### DIFF
--- a/submissions/examples/ease-submarine-controls-ij/README.md
+++ b/submissions/examples/ease-submarine-controls-ij/README.md
@@ -1,0 +1,7 @@
+# ease-submarine-controls
+A submarine control console with a periscope eyepiece, pressure and heading dials, and a dive depth meter with a sweeping needle.
+## Run
+Open `demo.html` directly in a browser to watch the dive console.
+## Notes
+- The PSI and HDG dial needles sweep on different timing loops.
+- The depth bar rises and falls while the sonar lamp blinks at the panel edge.

--- a/submissions/examples/ease-submarine-controls-ij/demo.html
+++ b/submissions/examples/ease-submarine-controls-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Submarine Controls</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="sub-console">
+  <header class="sub-head">
+    <h1 class="sub-name">U-77 NIGHTWATCH</h1>
+    <p class="sub-depth">DEPTH 120M</p>
+  </header>
+  <section class="periscope" aria-label="Periscope eyepiece">
+    <div class="peri-tube"><span class="peri-lens"></span></div>
+  </section>
+  <section class="sub-gauges" aria-label="Pressure and heading gauges">
+    <div class="gauge">
+      <span class="gauge-label">PSI</span>
+      <div class="dial"><span class="gauge-hand"></span></div>
+    </div>
+    <div class="gauge">
+      <span class="gauge-label">HDG</span>
+      <div class="dial"><span class="gauge-hand"></span></div>
+    </div>
+  </section>
+  <section class="depth-meter" aria-label="Dive depth indicator">
+    <div class="depth-track"><span class="depth-needle"></span></div>
+  </section>
+  <footer class="sub-foot">
+    <span class="sub-ballast">BALLAST AUTO</span>
+    <span class="sub-sonar">SONAR ON</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-submarine-controls-ij/style.css
+++ b/submissions/examples/ease-submarine-controls-ij/style.css
@@ -1,0 +1,29 @@
+:root{
+--sub-teal:#2dd4c8;
+--sub-panel:#0f2830;
+--sub-ink:#b9ece6;
+}
+*{box-sizing:border-box;padding:0;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 35%,hsl(185,40%,14%),hsl(190,50%,5%));font-family:Consolas,monospace}
+.sub-console{width:360px;padding:16px;border-radius:16px;background:var(--sub-panel);box-shadow:0 0 0 3px #2a5f63,0 14px 34px rgba(0,0,0,0.7)}
+.sub-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 12px;border-bottom:1px solid #2a5f63}
+.sub-name{color:var(--sub-ink);font-size:15px;letter-spacing:2px}
+.sub-depth{color:var(--sub-teal);font-weight:bold}
+.periscope{display:flex;justify-content:center;margin:14px 0}
+.peri-tube{width:130px;height:34px;border-radius:6px;background:linear-gradient(180deg,#31424c,#15222a);position:relative;border:1px solid #2a5f63}
+.peri-lens{position:absolute;right:8px;top:6px;width:48px;height:22px;border-radius:4px;background:linear-gradient(90deg,#0f2830,#59d8cf);animation:lens-blink-submarine-controls 2.4s ease-in-out infinite}
+.sub-gauges{display:flex;gap:14px;margin:12px 0}
+.gauge{flex:1;background:#0b2026;border-radius:10px;padding:10px;text-align:center;border:1px solid #2a5f63}
+.gauge-label{color:var(--sub-ink);font-size:12px;display:block;margin-bottom:8px}
+.dial{width:88px;height:88px;margin:0 auto;border-radius:50%;background:radial-gradient(circle,#1c3a44,#0b2026);border:3px solid #2a5f63;position:relative}
+.gauge-hand{position:absolute;left:50%;top:50%;width:4px;height:38px;margin-left:-2px;background:var(--sub-teal);transform-origin:50% 100%;animation:needle-sweep-submarine-controls 4s ease-in-out infinite}
+.gauge:last-child .gauge-hand{animation:needle-sweep-submarine-controls 5s ease-in-out infinite}
+.depth-meter{margin:10px 0 14px;background:#0b2026;border-radius:8px;padding:10px;border:1px solid #2a5f63}
+.depth-track{position:relative;height:16px;background:#15222a;border-radius:8px}
+.depth-needle{position:absolute;left:0;top:0;height:100%;width:34%;border-radius:8px;background:linear-gradient(90deg,#2dd4c8,#7ff0e6);animation:depth-flip-submarine-controls 3s ease-in-out infinite}
+.sub-foot{display:flex;justify-content:space-between;padding:4px;color:var(--sub-ink);font-size:12px}
+.sub-sonar{color:var(--sub-teal);animation:sonar-ping-submarine-controls 1.8s ease-in-out infinite}
+@keyframes needle-sweep-submarine-controls{0%,100%{transform:rotate(-38deg)}50%{transform:rotate(42deg)}}
+@keyframes lens-blink-submarine-controls{0%,100%{box-shadow:0 0 4px #2dd4c8}50%{box-shadow:0 0 16px #59d8cf}}
+@keyframes sonar-ping-submarine-controls{0%,100%{opacity:1}50%{opacity:0.2}}
+@keyframes depth-flip-submarine-controls{0%,100%{width:34%}50%{width:58%}}


### PR DESCRIPTION
## Component: ease-submarine-controls — periscope, pressure dials, and depth meter

**Closes #59977**

### What this adds
A submarine control console with a periscope eyepiece, PSI and HDG dials with sweeping needles, and a depth bar that rises and falls.

### Acceptance Criteria covered
- Periscope eyepiece shows a glowing lens
- Pressure and heading dials sweep on different loops
- Depth meter bar climbs while the sonar lamp blinks

### Files
- submissions/examples/ease-submarine-controls-ij/demo.html
- submissions/examples/ease-submarine-controls-ij/style.css
- submissions/examples/ease-submarine-controls-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch both dial needles sweep while the depth bar rises and the sonar lamp pulses.