### PR TITLE
Add ease-traffic-roundabout component

### DIFF
--- a/submissions/examples/ease-traffic-roundabout-ij/README.md
+++ b/submissions/examples/ease-traffic-roundabout-ij/README.md
@@ -1,0 +1,7 @@
+# ease-traffic-roundabout
+An aerial traffic roundabout with a dashed ring road, a planted island, four cars circling on marked lanes, and directional arrows at the compass points.
+## Run
+Open `demo.html` directly in a browser to watch the roundabout flow.
+## Notes
+- Three cars orbit clockwise at different speeds while one car loops counter-clockwise.
+- The north arrow blinks to show the required counter-clockwise flow.

--- a/submissions/examples/ease-traffic-roundabout-ij/demo.html
+++ b/submissions/examples/ease-traffic-roundabout-ij/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.3">
+<title>Traffic Roundabout</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="roundabout">
+  <header class="round-head">
+    <h1 class="round-name">JUNCTION 12</h1>
+    <p class="round-flow">TRAFFIC CLEAR</p>
+  </header>
+  <section class="round-scene" aria-label="Traffic roundabout aerial view">
+    <div class="ring-road"></div>
+    <div class="island"><span class="island-trees"></span></div>
+    <div class="car car-a">A</div>
+    <div class="car car-b">B</div>
+    <div class="car car-c">C</div>
+    <div class="car car-d">D</div>
+    <span class="flow-arrow arrow-n">N</span>
+    <span class="flow-arrow arrow-e">E</span>
+    <span class="flow-arrow arrow-s">S</span>
+    <span class="flow-arrow arrow-w">W</span>
+  </section>
+  <footer class="round-foot">
+    <span class="round-lane">LANE 2</span>
+    <span class="round-yield">YIELD</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-traffic-roundabout-ij/style.css
+++ b/submissions/examples/ease-traffic-roundabout-ij/style.css
@@ -1,0 +1,31 @@
+:root{
+--round-asphalt:#2b2f33;
+--round-line:#f4f4f0;
+--round-green:#4e8f46;
+}
+*,::before,::after{padding:0;margin:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 40%,hsl(0,10%,20%),hsl(0,15%,8%));font-family:"Segoe UI",sans-serif}
+.roundabout{width:340px;padding:16px;border-radius:16px;background:#1d2023;box-shadow:0 0 0 3px #3a3f44,0 14px 34px rgba(0,0,0,0.7)}
+.round-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 12px}
+.round-name{color:#ffffff;font-size:17px;letter-spacing:2px}
+.round-flow{color:#8fe08f;font-size:12px;font-weight:bold;animation:flow-blink-traffic-roundabout 1.6s ease-in-out infinite}
+.round-scene{position:relative;width:290px;height:290px;margin:0 auto;border-radius:50%;background:var(--round-asphalt)}
+.ring-road{position:absolute;inset:26px;border-radius:50%;background:#3a3f44;border:2px solid var(--round-line)}
+.island{position:absolute;inset:64px;border-radius:50%;background:var(--round-green);display:flex;align-items:center;justify-content:center}
+.island-trees{width:34px;height:34px;border-radius:50%;background:#2c5a2a;box-shadow:inset 0 0 0 4px #4e8f46}
+.car{position:absolute;width:22px;height:22px;border-radius:5px;color:#ffffff;font-size:10px;font-weight:bold;display:flex;align-items:center;justify-content:center}
+.car-a{top:34px;left:50%;margin-left:-11px;background:#e0513a;animation:car-circle-traffic-roundabout 7s linear infinite}
+.car-b{top:50%;right:34px;margin-top:-11px;background:#e0c23a;animation:car-circle-traffic-roundabout 9s linear infinite}
+.car-c{bottom:34px;left:50%;margin-left:-11px;background:#3a8ee0;animation:car-circle-traffic-roundabout 11s linear infinite}
+.car-d{top:50%;left:34px;margin-top:-11px;background:#7a3ae0;animation:car-circle-rev-traffic-roundabout 8s linear infinite}
+.flow-arrow{position:absolute;color:var(--round-line);font-size:11px;font-weight:bold}
+.arrow-n{top:8px;left:50%;margin-left:-5px;animation:arrow-blink-traffic-roundabout 1.2s ease-in-out infinite}
+.arrow-e{right:10px;top:50%;margin-top:-8px}
+.arrow-s{bottom:8px;left:50%;margin-left:-5px}
+.arrow-w{left:10px;top:50%;margin-top:-8px}
+.round-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#aab0b6;font-size:12px}
+.round-yield{color:#f0c040;font-weight:bold;animation:flow-blink-traffic-roundabout 1.6s ease-in-out infinite}
+@keyframes car-circle-traffic-roundabout{0%{transform:rotate(0deg) translateX(118px) rotate(0deg)}100%{transform:rotate(360deg) translateX(118px) rotate(-360deg)}}
+@keyframes car-circle-rev-traffic-roundabout{0%{transform:rotate(0deg) translateX(118px) rotate(0deg)}100%{transform:rotate(-360deg) translateX(118px) rotate(360deg)}}
+@keyframes arrow-blink-traffic-roundabout{0%,100%{opacity:1}50%{opacity:0.3}}
+@keyframes flow-blink-traffic-roundabout{0%,100%{opacity:1}50%{opacity:0.45}}


### PR DESCRIPTION
## Component: ease-traffic-roundabout — ring road, island, and four circling cars

**Closes #59983**

### What this adds
An aerial traffic roundabout with a dashed ring road, a planted island, four cars circling on the lanes, and directional arrows at the compass points.

### Acceptance Criteria covered
- Cars circle the ring road at different speeds
- One car loops in the counter-flow direction
- Directional arrows show the compass points

### Files
- submissions/examples/ease-traffic-roundabout-ij/demo.html
- submissions/examples/ease-traffic-roundabout-ij/style.css
- submissions/examples/ease-traffic-roundabout-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch three cars circle clockwise while one loops counter-clockwise around the planted island.