### PR TITLE
Add ease-airport-departure-board component

### DIFF
--- a/submissions/examples/ease-airport-departure-board-ij/README.md
+++ b/submissions/examples/ease-airport-departure-board-ij/README.md
@@ -1,0 +1,7 @@
+# ease-airport-departure-board
+A split-flap departure board with flight numbers, destinations, times, and statuses that flip like real airport flaps.
+## Run
+Open `demo.html` directly in a browser to watch the flap rows turn.
+## Notes
+- The BERLIN and AMSTERDAM rows flip their flaps on alternating loops.
+- The DELAYED status blinks amber while the clock ticks in the header.

--- a/submissions/examples/ease-airport-departure-board-ij/demo.html
+++ b/submissions/examples/ease-airport-departure-board-ij/demo.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.2">
+<title>Airport Departure Board</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="airport-board">
+  <header class="board-head">
+    <h1 class="board-title">DEPARTURES</h1>
+    <p class="board-clock">11:40 AM</p>
+  </header>
+  <section class="board-rows" aria-label="Departure schedule">
+    <div class="row row-a">
+      <span class="cell flight">BA 402</span>
+      <span class="cell dest">LONDON</span>
+      <span class="cell time">11:55</span>
+      <span class="cell stat">ON TIME</span>
+    </div>
+    <div class="row row-b">
+      <span class="cell flight">LH 881</span>
+      <span class="cell dest">BERLIN</span>
+      <span class="cell time">12:10</span>
+      <span class="cell stat">BOARDING</span>
+    </div>
+    <div class="row row-c">
+      <span class="cell flight">AF 115</span>
+      <span class="cell dest">PARIS</span>
+      <span class="cell time">12:30</span>
+      <span class="cell stat">DELAYED</span>
+    </div>
+    <div class="row row-d">
+      <span class="cell flight">KL 620</span>
+      <span class="cell dest">AMSTERDAM</span>
+      <span class="cell time">12:45</span>
+      <span class="cell stat">CHECK-IN</span>
+    </div>
+  </section>
+  <footer class="board-foot">
+    <span class="board-gate">GATES OPEN</span>
+    <span class="board-term">TERMINAL 2</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-airport-departure-board-ij/style.css
+++ b/submissions/examples/ease-airport-departure-board-ij/style.css
@@ -1,0 +1,24 @@
+:root{
+--board-black:#101418;
+--board-green:#d8f2a8;
+--board-amber:#ffb648;
+}
+*{margin:0;box-sizing:border-box;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 25%,hsl(210,35%,15%),hsl(215,45%,5%));font-family:'Segoe UI',sans-serif}
+.airport-board{width:420px;padding:16px;border-radius:16px;background:#0b0e12;box-shadow:0 0 0 3px #2c333b,0 14px 34px rgba(0,0,0,0.7)}
+.board-head{display:flex;justify-content:space-between;align-items:center;padding:2px 4px 12px}
+.board-title{color:#ffffff;font-size:20px;letter-spacing:4px}
+.board-clock{color:var(--board-amber);font-size:13px;font-weight:bold;animation:clock-tick-airport-departure-board 1s steps(2,end) infinite}
+.board-rows{background:#05070a;border-radius:10px;padding:10px;border:2px solid #232a31;display:grid;gap:8px}
+.row{display:grid;grid-template-columns:1fr 1.4fr 0.8fr 1.2fr;gap:8px;background:#171c22;border-radius:6px;padding:8px}
+.cell{color:var(--board-green);font-size:13px;font-weight:bold;letter-spacing:1px;padding:4px 6px;background:#0a0d10;border-radius:4px;text-align:center;overflow:hidden}
+.flight{color:#ffffff}
+.row-b .cell{animation:flap-flip-airport-departure-board 3s ease-in-out infinite}
+.row-d .cell{animation:flap-flip-airport-departure-board 4s ease-in-out infinite}
+.row-c .stat{color:var(--board-amber);animation:status-blink-airport-departure-board 1.2s ease-in-out infinite}
+.row-a .stat{color:#7ddb7d}
+.board-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#7c8792;font-size:12px}
+.board-term{color:var(--board-amber)}
+@keyframes flap-flip-airport-departure-board{0%,30%{transform:rotateX(0deg)}45%{transform:rotateX(90deg)}60%{transform:rotateX(0deg)}100%{transform:rotateX(0deg)}}
+@keyframes status-blink-airport-departure-board{0%,100%{opacity:1}50%{opacity:0.25}}
+@keyframes clock-tick-airport-departure-board{0%,49%{opacity:1}50%,100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-airport-departure-board — split-flap rows, flight statuses, and clock

**Closes #59988**

### What this adds
A split-flap departure board with flight numbers, destinations, and times, plus statuses that flip like real airport flaps and a clock that ticks in the header.

### Acceptance Criteria covered
- BERLIN and AMSTERDAM rows flip their flaps on loops
- DELAYED status blinks amber against the green board
- Header clock ticks with a hard snap every second

### Files
- submissions/examples/ease-airport-departure-board-ij/demo.html
- submissions/examples/ease-airport-departure-board-ij/style.css
- submissions/examples/ease-airport-departure-board-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the flap rows turn over while the DELAYED status blinks amber.