### PR TITLE
Add ease-waterwheel-turn component

### DIFF
--- a/submissions/examples/ease-waterwheel-turn-ij/README.md
+++ b/submissions/examples/ease-waterwheel-turn-ij/README.md
@@ -1,0 +1,7 @@
+# ease-waterwheel-turn
+A riverside waterwheel with four wooden spokes, rim buckets, and a flowing stream that carries the mill into motion.
+## Run
+Open `demo.html` directly in a browser to watch the wheel turn.
+## Notes
+- The wheel spins a full revolution every nine seconds over the stream.
+- The water pattern ripples beneath the dipping buckets.

--- a/submissions/examples/ease-waterwheel-turn-ij/demo.html
+++ b/submissions/examples/ease-waterwheel-turn-ij/demo.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.6">
+<title>Waterwheel Turn</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="waterwheel">
+  <header class="mill-head">
+    <h1 class="mill-name">RIVER MILL</h1>
+    <p class="mill-flow">FULL FLOW</p>
+  </header>
+  <section class="mill-scene" aria-label="Waterwheel over a stream">
+    <div class="wheel">
+      <span class="wheel-hub"></span>
+      <span class="spoke spoke-a"></span>
+      <span class="spoke spoke-b"></span>
+      <span class="spoke spoke-c"></span>
+      <span class="spoke spoke-d"></span>
+      <span class="bucket bucket-a"></span>
+      <span class="bucket bucket-b"></span>
+      <span class="bucket bucket-c"></span>
+      <span class="bucket bucket-d"></span>
+    </div>
+    <div class="stream"></div>
+  </section>
+  <footer class="mill-foot">
+    <span class="mill-power">TURBINE 2</span>
+    <span class="mill-rpm">12 RPM</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-waterwheel-turn-ij/style.css
+++ b/submissions/examples/ease-waterwheel-turn-ij/style.css
@@ -1,0 +1,31 @@
+:root{
+--mill-wood:#8a5a2b;
+--mill-water:#3fa0d8;
+--mill-moss:#6f9b4e;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 40%,hsl(110,35%,16%),hsl(115,45%,6%));font-family:'Palatino Linotype',serif}
+.waterwheel{width:410px;padding:16px;border-radius:16px;background:#25311f;box-shadow:0 0 0 3px #3d5135,0 14px 34px rgba(0,0,0,0.7)}
+.mill-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 12px}
+.mill-name{color:#efe3c8;font-size:19px;letter-spacing:2px}
+.mill-flow{color:var(--mill-water);font-size:12px;font-weight:bold;animation:flow-pulse-waterwheel-turn 1.6s ease-in-out infinite}
+.mill-scene{position:relative;height:250px;background:linear-gradient(180deg,#86b8a4,#d4e6ce 52%,#3fa0d8 52%,#2a7fb0);border-radius:12px;overflow:hidden}
+.wheel{position:absolute;left:50%;top:150px;width:200px;height:200px;margin-left:-100px;margin-top:-100px;animation:wheel-spin-waterwheel-turn 9s linear infinite}
+.wheel-hub{position:absolute;left:50%;top:50%;width:18px;height:18px;margin-left:-9px;margin-top:-9px;border-radius:50%;background:#4a4f57;z-index:2}
+.spoke{position:absolute;left:50%;top:50%;width:6px;height:96px;margin-left:-3px;margin-top:-96px;background:var(--mill-wood);transform-origin:50% 100%;border-radius:3px}
+.spoke-a{transform:rotate(0deg)}
+.spoke-b{transform:rotate(90deg)}
+.spoke-c{transform:rotate(180deg)}
+.spoke-d{transform:rotate(270deg)}
+.bucket{position:absolute;width:26px;height:22px;border-radius:4px;background:var(--mill-wood);box-shadow:0 2px 4px rgba(0,0,0,0.4);animation:bucket-dunk-waterwheel-turn 9s linear infinite}
+.bucket-a{left:87px;top:65px}
+.bucket-b{left:161px;top:139px}
+.bucket-c{left:87px;top:213px}
+.bucket-d{left:13px;top:139px}
+.stream{position:absolute;left:0;right:0;bottom:0;height:56px;background:repeating-linear-gradient(90deg,rgba(255,255,255,0.22) 0 14px,transparent 14px 30px);animation:current-flow-waterwheel-turn 2s linear infinite}
+.mill-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#a8c09b;font-size:12px}
+.mill-rpm{color:var(--mill-water);font-weight:bold;animation:flow-pulse-waterwheel-turn 1.6s ease-in-out infinite}
+@keyframes wheel-spin-waterwheel-turn{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes bucket-dunk-waterwheel-turn{0%,100%{filter:brightness(1)}45%,55%{filter:brightness(1.4)}}
+@keyframes current-flow-waterwheel-turn{0%{background-position:0 0}100%{background-position:30px 0}}
+@keyframes flow-pulse-waterwheel-turn{0%,100%{opacity:1}50%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-waterwheel-turn — spinning spokes, rim buckets, and stream

**Closes #59999**

### What this adds
A riverside waterwheel with four wooden spokes, rim buckets that orbit as the wheel turns, and a rippling stream running beneath the mill.

### Acceptance Criteria covered
- Wheel turns a full revolution over the stream
- Spokes and buckets orbit the mill hub together
- Water pattern ripples beneath the dipping buckets

### Files
- submissions/examples/ease-waterwheel-turn-ij/demo.html
- submissions/examples/ease-waterwheel-turn-ij/style.css
- submissions/examples/ease-waterwheel-turn-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the wooden wheel spin while the stream ripples underneath.