### PR TITLE
Add ease-speedometer-needle component

### DIFF
--- a/submissions/examples/ease-speedometer-needle-ij/README.md
+++ b/submissions/examples/ease-speedometer-needle-ij/README.md
@@ -1,0 +1,7 @@
+# ease-speedometer-needle
+A car dashboard speedometer with a sweeping needle, 0-160 scale marks, a digital KM/H readout, and a redline badge.
+## Run
+Open `demo.html` directly in a browser to watch the needle surge.
+## Notes
+- The needle climbs to the redline and settles back on a springy loop.
+- The digital readout pulses green as the needle passes the hundred mark.

--- a/submissions/examples/ease-speedometer-needle-ij/demo.html
+++ b/submissions/examples/ease-speedometer-needle-ij/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.7">
+<title>Speedometer Needle</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="dash-speedo">
+  <header class="speed-head">
+    <h1 class="speed-title">VELOCITY</h1>
+    <p class="speed-mode">SPORT MODE</p>
+  </header>
+  <section class="speedo-dial" aria-label="Car speedometer">
+    <div class="dial-arc">
+      <span class="mark mark-a">0</span>
+      <span class="mark mark-b">40</span>
+      <span class="mark mark-c">80</span>
+      <span class="mark mark-d">120</span>
+      <span class="mark mark-e">160</span>
+      <span class="needle"></span>
+      <span class="needle-pin"></span>
+    </div>
+  </section>
+  <section class="speed-digital" aria-label="Digital speed readout">
+    <span class="digit-kph">96</span>
+    <span class="digit-unit">KM/H</span>
+  </section>
+  <footer class="speed-foot">
+    <span class="speed-fuel">FUEL 3/4</span>
+    <span class="speed-redline">REDLINE 7000</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-speedometer-needle-ij/style.css
+++ b/submissions/examples/ease-speedometer-needle-ij/style.css
@@ -1,0 +1,29 @@
+:root{
+--speed-orange:#ff9f1c;
+--speed-navy:#151b2b;
+--speed-white:#eef2f7;
+}
+*,::before,::after{margin:0;padding:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 25%,hsl(220,30%,17%),hsl(230,40%,6%));font-family:'Arial Black',sans-serif}
+.dash-speedo{width:360px;padding:16px;border-radius:16px;background:var(--speed-navy);box-shadow:0 0 0 3px #2c3854,0 14px 34px rgba(0,0,0,0.7)}
+.speed-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 12px}
+.speed-title{color:var(--speed-white);font-size:19px;letter-spacing:3px}
+.speed-mode{color:var(--speed-orange);font-size:11px;font-weight:bold;animation:mode-blink-speedometer-needle 1.4s ease-in-out infinite}
+.speedo-dial{background:#0c1120;border-radius:14px;padding:14px}
+.dial-arc{position:relative;width:290px;height:190px;margin:0 auto;border-radius:145px 145px 0 0;background:radial-gradient(circle at 50% 100%,#1c2742,#0c1120 78%);border-bottom:6px solid var(--speed-orange);overflow:hidden}
+.mark{position:absolute;font-size:11px;color:#7d8aa5}
+.mark-a{bottom:8px;left:18px}
+.mark-b{bottom:8px;left:74px}
+.mark-c{bottom:8px;left:130px}
+.mark-d{bottom:8px;left:186px}
+.mark-e{bottom:8px;left:242px}
+.needle{position:absolute;left:50%;bottom:8px;width:4px;height:120px;margin-left:-2px;background:linear-gradient(180deg,#ff9f1c,#c96f00);transform-origin:50% 100%;animation:needle-surge-speedometer-needle 3s cubic-bezier(0.45,0,0.25,1) infinite}
+.needle-pin{position:absolute;left:50%;bottom:2px;width:16px;height:16px;margin-left:-8px;border-radius:50%;background:var(--speed-orange);box-shadow:0 0 0 3px #0c1120}
+.speed-digital{display:flex;align-items:baseline;justify-content:center;gap:8px;padding:10px 0}
+.digit-kph{color:#7dff8b;font-size:40px;font-weight:bold;animation:readout-count-speedometer-needle 3s ease-in-out infinite}
+.digit-unit{color:#7d8aa5;font-size:13px;letter-spacing:2px}
+.speed-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#7d8aa5;font-size:12px}
+.speed-redline{color:var(--speed-orange);font-weight:bold;animation:mode-blink-speedometer-needle 1.4s ease-in-out infinite}
+@keyframes needle-surge-speedometer-needle{0%{transform:rotate(-52deg)}55%{transform:rotate(58deg)}75%{transform:rotate(44deg)}100%{transform:rotate(-52deg)}}
+@keyframes readout-count-speedometer-needle{0%,100%{transform:scale(1);color:#7dff8b}55%{transform:scale(1.12);color:#a8ffc0}}
+@keyframes mode-blink-speedometer-needle{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-speedometer-needle — sweeping needle, scale marks, and readout

**Closes #60001**

### What this adds
A car dashboard speedometer with a sweeping needle over 0 to 160 scale marks, a digital KM/H readout, and a redline badge on the console.

### Acceptance Criteria covered
- Needle surges toward the redline and settles back
- Digital readout pulses green as the needle climbs
- SPORT MODE badge blinks in the console header

### Files
- submissions/examples/ease-speedometer-needle-ij/demo.html
- submissions/examples/ease-speedometer-needle-ij/style.css
- submissions/examples/ease-speedometer-needle-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the needle surge past the hundred mark and settle back with a spring.