### PR TITLE
Add ease-film-projector-reels component

### DIFF
--- a/submissions/examples/ease-film-projector-reels-ij/README.md
+++ b/submissions/examples/ease-film-projector-reels-ij/README.md
@@ -1,0 +1,7 @@
+# ease-film-projector-reels
+A cinema projector with two spinning film reels, a gold lens, a rolling film strip, and a flickering light beam.
+## Run
+Open `demo.html` directly in a browser to watch the reels unwind.
+## Notes
+- The supply reel turns clockwise while the take-up reel spins counter-clockwise.
+- The light beam stutters like an old projector lamp.

--- a/submissions/examples/ease-film-projector-reels-ij/demo.html
+++ b/submissions/examples/ease-film-projector-reels-ij/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.8">
+<title>Film Projector Reels</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="projector">
+  <header class="proj-head">
+    <h1 class="proj-title">PALACE CINEMA</h1>
+    <p class="proj-reel">REEL 2 OF 3</p>
+  </header>
+  <section class="proj-body" aria-label="Film projector">
+    <div class="reel reel-supply"></div>
+    <div class="reel reel-take"></div>
+    <div class="proj-lens"></div>
+    <div class="film-loop"></div>
+    <div class="light-beam"></div>
+  </section>
+  <footer class="proj-foot">
+    <span class="proj-thread">THREADED</span>
+    <span class="proj-lamp">LAMP 800W</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-film-projector-reels-ij/style.css
+++ b/submissions/examples/ease-film-projector-reels-ij/style.css
@@ -1,0 +1,24 @@
+:root{
+--proj-black:#17181c;
+--proj-gold:#d9a93f;
+--proj-silver:#aeb4bd;
+}
+*{padding:0;box-sizing:border-box;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(35,25%,14%),hsl(40,30%,5%));font-family:Verdana,sans-serif}
+.projector{width:410px;padding:16px;border-radius:16px;background:var(--proj-black);box-shadow:0 0 0 3px #3a3b40,0 14px 34px rgba(0,0,0,0.7)}
+.proj-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 12px}
+.proj-title{color:var(--proj-gold);font-size:18px;letter-spacing:3px}
+.proj-reel{color:#9aa0a8;font-size:12px}
+.proj-body{position:relative;height:190px;background:#0d0e11;border-radius:12px;overflow:hidden}
+.reel{position:absolute;top:20px;width:120px;height:120px;border-radius:50%;border:10px solid #33363d;background:repeating-conic-gradient(#1e2026 0 12deg,#3a3e46 12deg 24deg);box-shadow:0 0 0 2px #4a4e56}
+.reel-supply{left:34px;animation:reel-spin-film-projector-reels 2.4s linear infinite}
+.reel-take{right:34px;animation:reel-spin-rev-film-projector-reels 2.4s linear infinite}
+.proj-lens{position:absolute;top:76px;left:50%;margin-left:-16px;width:32px;height:34px;border-radius:8px;background:linear-gradient(180deg,#2a2d33,#111216);border:2px solid var(--proj-gold)}
+.film-loop{position:absolute;top:150px;left:0;right:0;height:10px;background:repeating-linear-gradient(90deg,#111111 0 6px,#d9a93f 6px 8px,#111111 8px 14px);animation:film-roll-film-projector-reels 1.2s linear infinite}
+.light-beam{position:absolute;top:86px;right:0;width:150px;height:0;border-top:5px solid rgba(255,240,170,0.6);border-bottom:5px solid rgba(255,240,170,0.6);border-left:5px solid transparent;animation:beam-flicker-film-projector-reels 0.3s steps(2,end) infinite}
+.proj-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#9aa0a8;font-size:12px}
+.proj-lamp{color:var(--proj-gold);animation:beam-flicker-film-projector-reels 0.3s steps(2,end) infinite}
+@keyframes reel-spin-film-projector-reels{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes reel-spin-rev-film-projector-reels{0%{transform:rotate(0deg)}100%{transform:rotate(-360deg)}}
+@keyframes film-roll-film-projector-reels{0%{background-position:0 0}100%{background-position:14px 0}}
+@keyframes beam-flicker-film-projector-reels{0%,100%{opacity:1}50%{opacity:0.55}}


### PR DESCRIPTION
## Component: ease-film-projector-reels — twin reels, gold lens, and light beam

**Closes #60005**

### What this adds
A cinema projector with a supply reel and take-up reel spinning in opposite directions, a gold lens, a rolling film strip, and a flickering light beam.

### Acceptance Criteria covered
- Supply reel spins clockwise while the take-up reel reverses
- Film strip rolls past the gold lens
- Light beam stutters like an old projector lamp

### Files
- submissions/examples/ease-film-projector-reels-ij/demo.html
- submissions/examples/ease-film-projector-reels-ij/style.css
- submissions/examples/ease-film-projector-reels-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the two reels unwind in opposite directions while the beam flickers.