### PR TITLE
feat: add shimmer-sweep fintech tooltips

### DIFF
--- a/submissions/examples/shimmer-sweep-fintech-tooltip-59311/README.md
+++ b/submissions/examples/shimmer-sweep-fintech-tooltip-59311/README.md
@@ -1,0 +1,51 @@
+# Shimmer-Sweep Fintech Tooltip
+
+An accessible, pure CSS tooltip system presented inside a fintech payment-risk dashboard. Each tooltip reveals contextual decision data and runs a single shimmer sweep as it opens.
+
+## Features
+
+- Hover and keyboard-focus activation without JavaScript
+- Bottom, left, and right placement variants
+- One-shot shimmer animation with a restrained entrance transition
+- Responsive placement fallback for tablet and mobile layouts
+- Visible focus indicators and semantic `role="tooltip"` relationships
+- Reduced-motion and forced-colors support
+- Fintech-specific exposure, approval, review, and policy context
+
+## Usage
+
+Wrap a trigger and tooltip panel in `.tooltip`. Connect them with `aria-describedby` and a matching panel `id`.
+
+```html
+<div class="tooltip tooltip--bottom">
+  <button class="info-button" aria-describedby="risk-tip" type="button">
+    <span aria-hidden="true">i</span>
+    <span class="sr-only">Explain risk score</span>
+  </button>
+  <span class="tooltip-panel" id="risk-tip" role="tooltip">
+    <span class="tooltip-kicker">Risk score</span>
+    This payment passed all active policy checks.
+  </span>
+</div>
+```
+
+Available placement classes are `.tooltip--bottom`, `.tooltip--left`, and `.tooltip--right`.
+
+## Custom Properties
+
+| Property             | Default   | Purpose                       |
+| -------------------- | --------- | ----------------------------- |
+| `--tooltip-bg`       | `#111a2c` | Tooltip surface color         |
+| `--tooltip-text`     | `#f7f9fc` | Tooltip text color            |
+| `--tooltip-width`    | `17rem`   | Maximum tooltip width         |
+| `--tooltip-radius`   | `6px`     | Tooltip corner radius         |
+| `--tooltip-duration` | `620ms`   | Shimmer sweep duration        |
+| `--tooltip-distance` | `10px`    | Gap between trigger and panel |
+
+## Accessibility
+
+The native buttons are keyboard reachable and use `aria-describedby` to associate each control with its tooltip. `:focus-within` keeps the panel visible during keyboard interaction. The reduced-motion query disables both movement and shimmer, while forced-colors mode restores explicit borders.
+
+## Browser Support
+
+The example uses standard CSS positioning, transitions, keyframes, `:focus-within`, and `:is()`, supported by current Chrome, Edge, Firefox, and Safari releases.

--- a/submissions/examples/shimmer-sweep-fintech-tooltip-59311/demo.html
+++ b/submissions/examples/shimmer-sweep-fintech-tooltip-59311/demo.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Accessible shimmer-sweep tooltips for a fintech risk dashboard."
+    />
+    <title>Fintech Shimmer-Sweep Tooltips</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="dashboard">
+      <header class="dashboard-header">
+        <div>
+          <p class="eyebrow">Treasury intelligence</p>
+          <h1>Payment risk overview</h1>
+          <p class="intro">
+            Inspect the signals behind today's settlement decisions.
+          </p>
+        </div>
+        <div class="live-status">
+          <span aria-hidden="true"></span>Live model
+        </div>
+      </header>
+
+      <section class="metric-grid" aria-label="Risk metrics">
+        <article class="metric-card metric-card--wide">
+          <div class="metric-heading">
+            <div>
+              <p class="metric-label">Settlement exposure</p>
+              <p class="metric-value">$284,900</p>
+            </div>
+            <div class="tooltip tooltip--bottom">
+              <button
+                class="info-button"
+                type="button"
+                aria-describedby="exposure-tip"
+              >
+                <span aria-hidden="true">i</span>
+                <span class="sr-only">Explain settlement exposure</span>
+              </button>
+              <span class="tooltip-panel" id="exposure-tip" role="tooltip">
+                <span class="tooltip-kicker">Exposure window</span>
+                Funds awaiting final network confirmation across 38 transfers.
+              </span>
+            </div>
+          </div>
+          <div
+            class="exposure-chart"
+            aria-label="Exposure is 62 percent of limit"
+          >
+            <span></span>
+          </div>
+          <div class="chart-scale"><span>$0</span><span>$460k limit</span></div>
+        </article>
+
+        <article class="metric-card">
+          <div class="metric-heading">
+            <p class="metric-label">Approval rate</p>
+            <div class="tooltip tooltip--left">
+              <button
+                class="info-button"
+                type="button"
+                aria-describedby="approval-tip"
+              >
+                <span aria-hidden="true">i</span>
+                <span class="sr-only">Explain approval rate</span>
+              </button>
+              <span class="tooltip-panel" id="approval-tip" role="tooltip">
+                <span class="tooltip-kicker">Last 24 hours</span>
+                1,842 of 1,906 evaluated payments passed all policy checks.
+              </span>
+            </div>
+          </div>
+          <p class="metric-value">96.6%</p>
+          <p class="metric-change metric-change--good">+1.8% from yesterday</p>
+        </article>
+
+        <article class="metric-card">
+          <div class="metric-heading">
+            <p class="metric-label">Review queue</p>
+            <div class="tooltip tooltip--right">
+              <button
+                class="info-button"
+                type="button"
+                aria-describedby="review-tip"
+              >
+                <span aria-hidden="true">i</span>
+                <span class="sr-only">Explain review queue</span>
+              </button>
+              <span class="tooltip-panel" id="review-tip" role="tooltip">
+                <span class="tooltip-kicker">Manual review</span>
+                12 transfers need analyst action; the oldest has waited 7
+                minutes.
+              </span>
+            </div>
+          </div>
+          <p class="metric-value">12</p>
+          <p class="metric-change">Within 15-minute SLA</p>
+        </article>
+      </section>
+
+      <section class="activity" aria-labelledby="activity-title">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">Decision stream</p>
+            <h2 id="activity-title">Recent evaluations</h2>
+          </div>
+          <div class="tooltip tooltip--bottom tooltip--align-right">
+            <button
+              class="filter-button"
+              type="button"
+              aria-describedby="filter-tip"
+            >
+              Risk policy <span aria-hidden="true">?</span>
+            </button>
+            <span class="tooltip-panel" id="filter-tip" role="tooltip">
+              <span class="tooltip-kicker">Policy set 4.2</span>
+              Combines velocity, device trust, sanctions, and counterparty
+              signals.
+            </span>
+          </div>
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Transfer</th>
+                <th>Counterparty</th>
+                <th>Signal</th>
+                <th>Decision</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>TRX-8042</td>
+                <td>Northline AG</td>
+                <td>Low velocity</td>
+                <td><span class="pill pill--clear">Cleared</span></td>
+              </tr>
+              <tr>
+                <td>TRX-8039</td>
+                <td>Vale Works</td>
+                <td>Device mismatch</td>
+                <td><span class="pill pill--review">Review</span></td>
+              </tr>
+              <tr>
+                <td>TRX-8037</td>
+                <td>Orchid Labs</td>
+                <td>Known beneficiary</td>
+                <td><span class="pill pill--clear">Cleared</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/shimmer-sweep-fintech-tooltip-59311/style.css
+++ b/submissions/examples/shimmer-sweep-fintech-tooltip-59311/style.css
@@ -1,0 +1,462 @@
+:root {
+  --ink: #172033;
+  --muted: #667085;
+  --line: #d8dee9;
+  --surface: #ffffff;
+  --canvas: #edf1f5;
+  --accent: #2457e6;
+  --accent-soft: #e7edff;
+  --positive: #087a55;
+  --warning: #9a5b00;
+  --tooltip-bg: #111a2c;
+  --tooltip-text: #f7f9fc;
+  --tooltip-width: 17rem;
+  --tooltip-radius: 6px;
+  --tooltip-duration: 620ms;
+  --tooltip-distance: 10px;
+
+  color-scheme: light;
+  font-family: Inter, "Segoe UI", Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background: var(--canvas);
+}
+
+button {
+  font: inherit;
+}
+
+.dashboard {
+  width: min(1120px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.dashboard-header,
+.metric-heading,
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.eyebrow,
+.metric-label,
+.tooltip-kicker {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 750;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  color: var(--accent);
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 720px;
+  margin-bottom: 10px;
+  font-size: clamp(2.25rem, 5vw, 4.5rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0;
+}
+
+.intro {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.live-status {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.live-status span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--positive);
+  box-shadow: 0 0 0 4px rgba(8, 122, 85, 0.12);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: 1.35fr 0.8fr 0.8fr;
+  gap: 14px;
+  margin-top: 42px;
+}
+
+.metric-card,
+.activity {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.metric-card {
+  min-width: 0;
+  padding: 24px;
+}
+
+.metric-label {
+  margin-bottom: 8px;
+  color: var(--muted);
+}
+
+.metric-value {
+  margin-bottom: 8px;
+  font-size: 2.15rem;
+  font-weight: 760;
+  line-height: 1;
+}
+
+.metric-change {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.metric-change--good {
+  color: var(--positive);
+}
+
+.exposure-chart {
+  height: 8px;
+  margin-top: 22px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: #e6eaf0;
+}
+
+.exposure-chart span {
+  display: block;
+  width: 62%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+}
+
+.chart-scale {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.activity {
+  margin-top: 14px;
+  padding: 26px;
+}
+
+.section-heading {
+  margin-bottom: 22px;
+}
+
+.filter-button,
+.info-button {
+  border: 1px solid var(--line);
+  color: var(--ink);
+  background: var(--surface);
+  cursor: help;
+}
+
+.info-button {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 50%;
+  place-items: center;
+  font-weight: 800;
+}
+
+.filter-button {
+  min-height: 38px;
+  padding: 8px 12px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.filter-button span {
+  display: inline-grid;
+  width: 18px;
+  height: 18px;
+  margin-left: 6px;
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--accent-soft);
+  place-items: center;
+}
+
+.info-button:hover,
+.filter-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.info-button:focus-visible,
+.filter-button:focus-visible {
+  outline: 3px solid rgba(36, 87, 230, 0.25);
+  outline-offset: 3px;
+}
+
+.tooltip {
+  position: relative;
+  z-index: 2;
+  flex: 0 0 auto;
+}
+
+.tooltip-panel {
+  position: absolute;
+  z-index: 10;
+  width: min(var(--tooltip-width), calc(100vw - 32px));
+  padding: 14px 15px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--tooltip-radius);
+  color: var(--tooltip-text);
+  background: var(--tooltip-bg);
+  box-shadow: 0 16px 40px rgba(20, 28, 45, 0.22);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 160ms ease,
+    transform 220ms ease,
+    visibility 220ms;
+  visibility: hidden;
+}
+
+.tooltip-panel::before {
+  position: absolute;
+  inset: 0 auto 0 -55%;
+  width: 45%;
+  background: linear-gradient(
+    105deg,
+    transparent,
+    rgba(255, 255, 255, 0.24),
+    transparent
+  );
+  content: "";
+  transform: skewX(-16deg);
+}
+
+.tooltip-kicker {
+  display: block;
+  margin-bottom: 5px;
+  color: #91abff;
+}
+
+.tooltip--bottom .tooltip-panel {
+  top: calc(100% + var(--tooltip-distance));
+  right: 0;
+  transform: translateY(-6px);
+}
+
+.tooltip--left .tooltip-panel {
+  top: 50%;
+  right: calc(100% + var(--tooltip-distance));
+  transform: translate(6px, -50%);
+}
+
+.tooltip--right .tooltip-panel {
+  top: 50%;
+  left: calc(100% + var(--tooltip-distance));
+  transform: translate(-6px, -50%);
+}
+
+.tooltip:is(:hover, :focus-within) {
+  z-index: 20;
+}
+
+.tooltip:is(:hover, :focus-within) .tooltip-panel {
+  opacity: 1;
+  transform: translate(0, 0);
+  visibility: visible;
+}
+
+.tooltip--left:is(:hover, :focus-within) .tooltip-panel,
+.tooltip--right:is(:hover, :focus-within) .tooltip-panel {
+  transform: translate(0, -50%);
+}
+
+.tooltip:is(:hover, :focus-within) .tooltip-panel::before {
+  animation: tooltip-shimmer var(--tooltip-duration) ease-out both;
+}
+
+@keyframes tooltip-shimmer {
+  from {
+    left: -55%;
+  }
+
+  to {
+    left: 125%;
+  }
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 15px 12px;
+  border-top: 1px solid var(--line);
+  white-space: nowrap;
+}
+
+th {
+  color: var(--muted);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.pill {
+  display: inline-block;
+  min-width: 64px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 750;
+  text-align: center;
+}
+
+.pill--clear {
+  color: var(--positive);
+  background: #e4f5ef;
+}
+
+.pill--review {
+  color: var(--warning);
+  background: #fff1d6;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 840px) {
+  .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric-card--wide {
+    grid-column: 1 / -1;
+  }
+
+  .tooltip--left .tooltip-panel,
+  .tooltip--right .tooltip-panel {
+    top: calc(100% + var(--tooltip-distance));
+    right: 0;
+    left: auto;
+    transform: translateY(-6px);
+  }
+
+  .tooltip--left:is(:hover, :focus-within) .tooltip-panel,
+  .tooltip--right:is(:hover, :focus-within) .tooltip-panel {
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .dashboard {
+    width: min(100% - 24px, 1120px);
+    padding: 36px 0;
+  }
+
+  .dashboard-header,
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  h1 {
+    font-size: 2.6rem;
+  }
+
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-card--wide {
+    grid-column: auto;
+  }
+
+  .metric-card,
+  .activity {
+    padding: 20px;
+  }
+
+  .tooltip--align-right .tooltip-panel {
+    right: auto;
+    left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-panel {
+    transition: none;
+  }
+
+  .tooltip:is(:hover, :focus-within) .tooltip-panel::before {
+    animation: none;
+    opacity: 0;
+  }
+}
+
+@media (forced-colors: active) {
+  .info-button,
+  .filter-button,
+  .tooltip-panel {
+    border: 1px solid CanvasText;
+  }
+}


### PR DESCRIPTION
## Description

Adds an accessible CSS shimmer-sweep tooltip system inside a fintech payment-risk dashboard. The example includes multiple placements, keyboard-focus activation, responsive positioning, and domain-specific exposure and policy context.

Fixes #59311

## Type of Change

- [ ] Bug fix
- [x] New animation
- [ ] Documentation update
- [ ] Other

## Submission Checklist

- [x] My submission is placed in `submissions/examples/shimmer-sweep-fintech-tooltip-59311/`
- [x] I created exactly 3 files: `demo.html`, `style.css`, and `README.md`
- [x] I did not modify any files outside my submission folder
- [x] My animation uses only HTML and CSS
- [x] My animation is responsive and works on mobile devices
- [x] I tested my animation in multiple browsers
- [x] I added accessibility features (focus states and reduced motion support)
- [x] My code follows the project's coding standards
- [x] I have read and followed the CONTRIBUTING.md guidelines

## Testing

- Chrome: hidden/visible state, keyboard focus, shimmer animation, reduced-motion mode, desktop and 390px layouts
- Edge: keyboard focus, tooltip visibility, and 390px overflow check
- Prettier 3.8.3
- Stylelint with repository configuration
- HTMLHint
- `git diff --check`

## Notes

This differs from existing generic tooltip examples through its payment-risk dashboard context, placement-aware responsive fallback, synchronized focus behavior, and fintech decision data.
