### PR TITLE
Add ease-drawbridge-lift component

### DIFF
--- a/submissions/examples/ease-drawbridge-lift-ij/README.md
+++ b/submissions/examples/ease-drawbridge-lift-ij/README.md
@@ -1,0 +1,7 @@
+# ease-drawbridge-lift
+A castle gatehouse with stone towers, a dropping portcullis, and a wooden bridge that raises over a moat by its chains.
+## Run
+Open `demo.html` directly in a browser to watch the bridge lift.
+## Notes
+- The bridge raises at the deck hinge while the chains tighten in sync.
+- The portcullis drops at mid-cycle and the tower torch glows.

--- a/submissions/examples/ease-drawbridge-lift-ij/demo.html
+++ b/submissions/examples/ease-drawbridge-lift-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=2.0">
+<title>Drawbridge Lift</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="drawbridge">
+  <header class="keep-head">
+    <h1 class="keep-name">CASTLE GATE</h1>
+    <p class="keep-watch">WATCH 3</p>
+  </header>
+  <section class="keep-towers" aria-label="Castle gatehouse towers">
+    <div class="tower tower-left"></div>
+    <div class="tower tower-right"></div>
+    <div class="gate-arch"><span class="portcullis"></span></div>
+  </section>
+  <section class="moat" aria-label="Moat with water">
+    <div class="bridge-deck">
+      <span class="plank plank-a"></span>
+      <span class="plank plank-b"></span>
+      <span class="plank plank-c"></span>
+      <span class="plank plank-d"></span>
+    </div>
+    <span class="chain chain-left"></span>
+    <span class="chain chain-right"></span>
+    <div class="moat-water"></div>
+  </section>
+  <footer class="keep-foot">
+    <span class="keep-chain">CHAINS 2</span>
+    <span class="keep-torch">TORCH LIT</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-drawbridge-lift-ij/style.css
+++ b/submissions/examples/ease-drawbridge-lift-ij/style.css
@@ -1,0 +1,33 @@
+:root{
+--keep-stone:#9aa0a8;
+--keep-dark:#3a3f46;
+--keep-wood:#7c4a21;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(250,20%,15%),hsl(255,25%,6%));font-family:'Book Antiqua',serif}
+.drawbridge{width:390px;padding:16px;border-radius:16px;background:#23262c;box-shadow:0 0 0 3px #3c4048,0 14px 34px rgba(0,0,0,0.7)}
+.keep-head{display:flex;justify-content:space-between;align-items:center;padding:2px 4px 12px}
+.keep-name{color:#e8d9b0;font-size:19px;letter-spacing:3px}
+.keep-watch{color:#e8b64c;font-size:12px;font-weight:bold;animation:watch-blink-drawbridge-lift 1.6s ease-in-out infinite}
+.keep-towers{position:relative;height:150px;background:#2e3239;border-radius:12px;display:flex;align-items:flex-end;justify-content:space-between;padding:0 30px}
+.tower{width:64px;height:120px;background:var(--keep-stone);border-radius:6px 6px 0 0;position:relative}
+.tower::before{content:"";position:absolute;top:-18px;left:-8px;right:-8px;height:22px;background:var(--keep-stone);border-radius:12px 12px 4px 4px}
+.tower-left::after{content:"";position:absolute;bottom:12px;left:8px;right:8px;height:6px;background:repeating-linear-gradient(90deg,#5a6068 0 6px,#31363d 6px 10px)}
+.tower-right{animation:tower-glow-drawbridge-lift 2.2s ease-in-out infinite}
+.gate-arch{position:absolute;left:50%;bottom:0;width:120px;height:96px;margin-left:-60px;border-radius:60px 60px 0 0;background:radial-gradient(circle at 50% 110%,#101216 60%,#23262c 62%)}
+.portcullis{position:absolute;left:22px;right:22px;top:14px;bottom:0;background:repeating-linear-gradient(90deg,#6a6f78 0 6px,#3a3f46 6px 10px);animation:portcullis-drop-drawbridge-lift 6s ease-in-out infinite}
+.moat{position:relative;height:150px;background:#1b1e23;border-radius:12px;margin-top:10px;overflow:hidden}
+.moat-water{position:absolute;left:0;right:0;bottom:0;height:44px;background:linear-gradient(180deg,#3f86b8,#2a5f8f);animation:water-ripple-drawbridge-lift 2s ease-in-out infinite}
+.bridge-deck{position:absolute;left:50%;bottom:0;width:182px;height:14px;margin-left:-91px;background:var(--keep-wood);transform-origin:50% 100%;animation:bridge-raise-drawbridge-lift 6s ease-in-out infinite;display:flex}
+.plank{flex:1;background:repeating-linear-gradient(90deg,#7c4a21 0 8px,#5a3517 8px 10px);border-right:2px solid #4a2c12}
+.chain{position:absolute;width:4px;background:#b8bdc4;transform-origin:50% 0}
+.chain-left{left:50%;margin-left:-58px;top:0;height:70px;animation:chain-tighten-drawbridge-lift 6s ease-in-out infinite}
+.chain-right{left:50%;margin-left:54px;top:0;height:70px;animation:chain-tighten-drawbridge-lift 6s ease-in-out infinite}
+.keep-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#9aa0a8;font-size:12px}
+.keep-torch{color:#ffb648;font-weight:bold;animation:watch-blink-drawbridge-lift 1.6s ease-in-out infinite}
+@keyframes bridge-raise-drawbridge-lift{0%,100%{transform:rotate(0deg)}40%,60%{transform:rotate(-58deg)}}
+@keyframes chain-tighten-drawbridge-lift{0%,100%{height:70px}40%,60%{height:34px}}
+@keyframes portcullis-drop-drawbridge-lift{0%,30%,100%{top:14px}45%,55%{top:44px}}
+@keyframes water-ripple-drawbridge-lift{0%,100%{transform:translateY(0)}50%{transform:translateY(3px)}}
+@keyframes tower-glow-drawbridge-lift{0%,100%{box-shadow:0 0 4px rgba(232,182,76,0.4)}50%{box-shadow:0 0 14px rgba(232,182,76,0.9)}}
+@keyframes watch-blink-drawbridge-lift{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-drawbridge-lift — stone towers, portcullis, and chain bridge

**Closes #60011**

### What this adds
A castle gatehouse with two stone towers, a portcullis that drops in its arch, and a wooden bridge that raises over the moat by two tightening chains.

### Acceptance Criteria covered
- Wooden bridge raises at the deck hinge
- Chains tighten and slacken in sync with the bridge
- Portcullis drops at mid-cycle while a torch glows

### Files
- submissions/examples/ease-drawbridge-lift-ij/demo.html
- submissions/examples/ease-drawbridge-lift-ij/style.css
- submissions/examples/ease-drawbridge-lift-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the bridge lift by its chains while the portcullis drops behind it.