### PR TITLE
feat: add ripple-wave fintech navbar

### DIFF
--- a/submissions/examples/ripple-wave-fintech-navbar-59307/README.md
+++ b/submissions/examples/ripple-wave-fintech-navbar-59307/README.md
@@ -1,0 +1,52 @@
+# Ripple-Wave Fintech Navbar
+
+A pure CSS navigation experience for a fintech treasury dashboard. Selecting a view sends a fill wave and expanding ring across the active item, then reveals its matching operational panel.
+
+## Features
+
+- Native radio controls for keyboard-friendly state management
+- Ripple fill and wave-ring animations without JavaScript
+- Four synchronized fintech dashboard panels
+- Horizontally scrollable mobile navigation
+- Visible keyboard focus treatment
+- Reduced-motion and forced-colors support
+- Responsive metrics and activity layouts
+
+## Usage
+
+Place radio controls before the navbar and panels so sibling selectors can synchronize the active item and content.
+
+```html
+<input id="nav-overview" name="treasury-nav" type="radio" checked />
+
+<nav class="ripple-navbar">
+  <label for="nav-overview">
+    <span class="nav-icon" aria-hidden="true">01</span>
+    <span>Overview</span>
+  </label>
+</nav>
+
+<div class="panels">
+  <article class="panel panel--overview">Overview content</article>
+</div>
+```
+
+Add equivalent checked-state selectors for each navigation item and panel.
+
+## Custom Properties
+
+| Property          | Default   | Purpose                    |
+| ----------------- | --------- | -------------------------- |
+| `--accent`        | `#1d5ee8` | Active navigation color    |
+| `--accent-soft`   | `#e8efff` | Ripple fill color          |
+| `--nav-height`    | `68px`    | Minimum navbar item height |
+| `--wave-duration` | `560ms`   | Ripple animation duration  |
+| `--line`          | `#d7dde6` | Component border color     |
+
+## Accessibility
+
+The hidden radio inputs remain keyboard operable and expose native checked state. Their labels provide large activation targets, while `:focus-visible` draws a clear inset outline. Reduced-motion mode removes the ripple and panel entrance animations.
+
+## Browser Support
+
+The example uses standard radio controls, sibling selectors, keyframes, and media queries supported by current Chrome, Edge, Firefox, and Safari releases.

--- a/submissions/examples/ripple-wave-fintech-navbar-59307/demo.html
+++ b/submissions/examples/ripple-wave-fintech-navbar-59307/demo.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A responsive CSS ripple-wave navbar for a fintech operations dashboard."
+    />
+    <title>Fintech Ripple-Wave Navbar</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="topbar">
+        <a class="brand" href="#" aria-label="Current home">
+          <span class="brand-mark" aria-hidden="true">N</span>
+          <span>Northstar</span>
+        </a>
+        <div class="account">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span
+            ><strong>Operating account</strong><small>USD · 4821</small></span
+          >
+        </div>
+      </header>
+
+      <section class="workspace" aria-labelledby="workspace-title">
+        <div class="workspace-heading">
+          <div>
+            <p class="eyebrow">Treasury control</p>
+            <h1 id="workspace-title">Money movement</h1>
+            <p class="intro">
+              Monitor liquidity, transfers, and policy signals.
+            </p>
+          </div>
+          <div class="balance">
+            <span>Available balance</span>
+            <strong>$2,480,630.42</strong>
+          </div>
+        </div>
+
+        <section class="nav-experience" aria-label="Treasury views">
+          <input id="nav-overview" name="treasury-nav" type="radio" checked />
+          <input id="nav-transfers" name="treasury-nav" type="radio" />
+          <input id="nav-risk" name="treasury-nav" type="radio" />
+          <input id="nav-settlements" name="treasury-nav" type="radio" />
+
+          <nav class="ripple-navbar" aria-label="Money movement navigation">
+            <label for="nav-overview">
+              <span class="nav-icon" aria-hidden="true">01</span>
+              <span>Overview</span>
+            </label>
+            <label for="nav-transfers">
+              <span class="nav-icon" aria-hidden="true">02</span>
+              <span>Transfers</span>
+              <span class="nav-count">8</span>
+            </label>
+            <label for="nav-risk">
+              <span class="nav-icon" aria-hidden="true">03</span>
+              <span>Risk signals</span>
+              <span class="nav-count nav-count--alert">3</span>
+            </label>
+            <label for="nav-settlements">
+              <span class="nav-icon" aria-hidden="true">04</span>
+              <span>Settlements</span>
+            </label>
+          </nav>
+
+          <div class="panels">
+            <article class="panel panel--overview">
+              <div class="panel-heading">
+                <div>
+                  <p class="eyebrow">Today</p>
+                  <h2>Cash position</h2>
+                </div>
+                <span class="health">Healthy</span>
+              </div>
+              <div class="metric-grid">
+                <div>
+                  <span>Incoming</span><strong>$684,200</strong
+                  ><small>12 transfers</small>
+                </div>
+                <div>
+                  <span>Outgoing</span><strong>$412,860</strong
+                  ><small>8 transfers</small>
+                </div>
+                <div>
+                  <span>Net movement</span
+                  ><strong class="positive">+$271,340</strong
+                  ><small>+6.8% today</small>
+                </div>
+              </div>
+            </article>
+
+            <article class="panel panel--transfers">
+              <div class="panel-heading">
+                <div>
+                  <p class="eyebrow">Queue</p>
+                  <h2>Active transfers</h2>
+                </div>
+                <span class="health">8 active</span>
+              </div>
+              <ul class="activity-list">
+                <li>
+                  <span>Northline AG</span><strong>$84,600</strong
+                  ><small>Screening</small>
+                </li>
+                <li>
+                  <span>Orchid Labs</span><strong>$42,100</strong
+                  ><small>Approved</small>
+                </li>
+                <li>
+                  <span>Vale Works</span><strong>$18,750</strong
+                  ><small>Review</small>
+                </li>
+              </ul>
+            </article>
+
+            <article class="panel panel--risk">
+              <div class="panel-heading">
+                <div>
+                  <p class="eyebrow">Policy engine</p>
+                  <h2>Risk signals</h2>
+                </div>
+                <span class="health health--review">3 reviews</span>
+              </div>
+              <div class="risk-grid">
+                <div><span>Device mismatch</span><strong>2</strong></div>
+                <div><span>Velocity threshold</span><strong>1</strong></div>
+                <div><span>Sanctions alerts</span><strong>0</strong></div>
+              </div>
+            </article>
+
+            <article class="panel panel--settlements">
+              <div class="panel-heading">
+                <div>
+                  <p class="eyebrow">Networks</p>
+                  <h2>Settlement windows</h2>
+                </div>
+                <span class="health">On schedule</span>
+              </div>
+              <ul class="activity-list">
+                <li>
+                  <span>ACH same day</span><strong>14:45 UTC</strong
+                  ><small>Open</small>
+                </li>
+                <li>
+                  <span>Fedwire</span><strong>18:00 UTC</strong
+                  ><small>Open</small>
+                </li>
+                <li>
+                  <span>SEPA Instant</span><strong>Continuous</strong
+                  ><small>Live</small>
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ripple-wave-fintech-navbar-59307/style.css
+++ b/submissions/examples/ripple-wave-fintech-navbar-59307/style.css
@@ -1,0 +1,489 @@
+:root {
+  --ink: #182238;
+  --muted: #687386;
+  --line: #d7dde6;
+  --surface: #ffffff;
+  --canvas: #eef2f5;
+  --accent: #1d5ee8;
+  --accent-soft: #e8efff;
+  --positive: #087a55;
+  --warning: #a35d00;
+  --nav-height: 68px;
+  --wave-duration: 560ms;
+
+  font-family: Inter, "Segoe UI", Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  background: var(--canvas);
+}
+
+.app-shell {
+  width: min(1140px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 30px 0 64px;
+}
+
+.topbar,
+.workspace-heading,
+.panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.topbar {
+  min-height: 60px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+  font-size: 1rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  color: white;
+  background: var(--ink);
+  place-items: center;
+}
+
+.account {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.75rem;
+}
+
+.account span:last-child {
+  display: grid;
+  gap: 2px;
+}
+
+.account small {
+  color: var(--muted);
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--positive);
+  box-shadow: 0 0 0 4px rgba(8, 122, 85, 0.12);
+}
+
+.workspace {
+  margin-top: 54px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 8px;
+  font-size: clamp(2.4rem, 6vw, 4.8rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 1.55rem;
+  letter-spacing: 0;
+}
+
+.intro {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.balance {
+  display: grid;
+  gap: 5px;
+  min-width: 220px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+.balance span {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.balance strong {
+  font-size: 1.15rem;
+}
+
+.nav-experience {
+  margin-top: 38px;
+}
+
+.nav-experience > input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ripple-navbar {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  min-height: var(--nav-height);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px 8px 0 0;
+  background: var(--surface);
+}
+
+.ripple-navbar label {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  min-height: var(--nav-height);
+  padding: 12px 18px;
+  overflow: hidden;
+  border-right: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+  cursor: pointer;
+  transition: color 180ms ease;
+}
+
+.ripple-navbar label:last-child {
+  border-right: 0;
+}
+
+.ripple-navbar label::before,
+.ripple-navbar label::after {
+  position: absolute;
+  z-index: -1;
+  border-radius: 50%;
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0);
+}
+
+.ripple-navbar label::before {
+  width: 180px;
+  height: 180px;
+  background: var(--accent-soft);
+}
+
+.ripple-navbar label::after {
+  width: 74px;
+  height: 74px;
+  border: 2px solid rgba(29, 94, 232, 0.3);
+}
+
+.nav-icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  font-size: 0.64rem;
+  place-items: center;
+}
+
+.nav-count {
+  display: grid;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 4px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.64rem;
+  place-items: center;
+}
+
+.nav-count--alert {
+  color: var(--warning);
+  background: #fff0d5;
+}
+
+#nav-overview:checked ~ .ripple-navbar label[for="nav-overview"],
+#nav-transfers:checked ~ .ripple-navbar label[for="nav-transfers"],
+#nav-risk:checked ~ .ripple-navbar label[for="nav-risk"],
+#nav-settlements:checked ~ .ripple-navbar label[for="nav-settlements"] {
+  color: var(--accent);
+}
+
+#nav-overview:checked ~ .ripple-navbar label[for="nav-overview"]::before,
+#nav-transfers:checked ~ .ripple-navbar label[for="nav-transfers"]::before,
+#nav-risk:checked ~ .ripple-navbar label[for="nav-risk"]::before,
+#nav-settlements:checked ~ .ripple-navbar label[for="nav-settlements"]::before {
+  animation: ripple-fill var(--wave-duration) ease-out forwards;
+}
+
+#nav-overview:checked ~ .ripple-navbar label[for="nav-overview"]::after,
+#nav-transfers:checked ~ .ripple-navbar label[for="nav-transfers"]::after,
+#nav-risk:checked ~ .ripple-navbar label[for="nav-risk"]::after,
+#nav-settlements:checked ~ .ripple-navbar label[for="nav-settlements"]::after {
+  animation: ripple-ring var(--wave-duration) ease-out forwards;
+}
+
+#nav-overview:focus-visible ~ .ripple-navbar label[for="nav-overview"],
+#nav-transfers:focus-visible ~ .ripple-navbar label[for="nav-transfers"],
+#nav-risk:focus-visible ~ .ripple-navbar label[for="nav-risk"],
+#nav-settlements:focus-visible ~ .ripple-navbar label[for="nav-settlements"] {
+  outline: 3px solid rgba(29, 94, 232, 0.28);
+  outline-offset: -4px;
+}
+
+@keyframes ripple-fill {
+  0% {
+    opacity: 0.75;
+    transform: scale(0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1.6);
+  }
+}
+
+@keyframes ripple-ring {
+  0% {
+    opacity: 0.85;
+    transform: scale(0.2);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(2.8);
+  }
+}
+
+.panels {
+  min-height: 340px;
+  border: 1px solid var(--line);
+  border-top: 0;
+  border-radius: 0 0 8px 8px;
+  background: var(--surface);
+}
+
+.panel {
+  display: none;
+  padding: 44px;
+}
+
+#nav-overview:checked ~ .panels .panel--overview,
+#nav-transfers:checked ~ .panels .panel--transfers,
+#nav-risk:checked ~ .panels .panel--risk,
+#nav-settlements:checked ~ .panels .panel--settlements {
+  display: block;
+  animation: panel-enter 280ms ease-out both;
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(7px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.health {
+  padding: 7px 9px;
+  border-radius: 4px;
+  color: var(--positive);
+  background: #e5f5ef;
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.health--review {
+  color: var(--warning);
+  background: #fff0d5;
+}
+
+.metric-grid,
+.risk-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.metric-grid > div,
+.risk-grid > div {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.metric-grid span,
+.risk-grid span,
+.metric-grid small {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.metric-grid strong {
+  font-size: 1.35rem;
+}
+
+.risk-grid strong {
+  font-size: 2rem;
+}
+
+.positive {
+  color: var(--positive);
+}
+
+.activity-list {
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-list li {
+  display: grid;
+  grid-template-columns: 1fr auto 90px;
+  gap: 18px;
+  padding: 16px 0;
+  border-top: 1px solid var(--line);
+  font-size: 0.82rem;
+}
+
+.activity-list small {
+  color: var(--muted);
+}
+
+@media (max-width: 760px) {
+  .workspace-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .ripple-navbar {
+    grid-template-columns: repeat(4, minmax(145px, 1fr));
+    overflow-x: auto;
+  }
+
+  .ripple-navbar label {
+    border-bottom: 1px solid var(--line);
+  }
+
+  .panel {
+    padding: 28px;
+  }
+
+  .metric-grid,
+  .risk-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .app-shell {
+    width: calc(100% - 24px);
+    padding-top: 18px;
+  }
+
+  .account {
+    max-width: 135px;
+  }
+
+  .workspace {
+    margin-top: 38px;
+  }
+
+  h1 {
+    font-size: 2.65rem;
+  }
+
+  .balance {
+    width: 100%;
+  }
+
+  .panel {
+    padding: 22px;
+  }
+
+  .activity-list li {
+    grid-template-columns: 1fr auto;
+  }
+
+  .activity-list small {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple-navbar label,
+  .panel {
+    transition: none;
+  }
+
+  #nav-overview:checked ~ .ripple-navbar label[for="nav-overview"]::before,
+  #nav-overview:checked ~ .ripple-navbar label[for="nav-overview"]::after,
+  #nav-transfers:checked ~ .ripple-navbar label[for="nav-transfers"]::before,
+  #nav-transfers:checked ~ .ripple-navbar label[for="nav-transfers"]::after,
+  #nav-risk:checked ~ .ripple-navbar label[for="nav-risk"]::before,
+  #nav-risk:checked ~ .ripple-navbar label[for="nav-risk"]::after,
+  #nav-settlements:checked
+    ~ .ripple-navbar
+    label[for="nav-settlements"]::before,
+  #nav-settlements:checked ~ .ripple-navbar label[for="nav-settlements"]::after,
+  #nav-overview:checked ~ .panels .panel--overview,
+  #nav-transfers:checked ~ .panels .panel--transfers,
+  #nav-risk:checked ~ .panels .panel--risk,
+  #nav-settlements:checked ~ .panels .panel--settlements {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .ripple-navbar,
+  .panels,
+  .ripple-navbar label,
+  .nav-icon {
+    border-color: CanvasText;
+  }
+}


### PR DESCRIPTION
## Description

Adds a pure CSS ripple-wave navbar for a fintech money-movement dashboard. Native radio controls synchronize four navigation states with treasury panels, while active items receive a fill wave and expanding ring.

Fixes #59307

## Type of Change

- [ ] Bug fix
- [x] New animation
- [ ] Documentation update
- [ ] Other

## Submission Checklist

- [x] My submission is placed in `submissions/examples/ripple-wave-fintech-navbar-59307/`
- [x] I created exactly 3 files: `demo.html`, `style.css`, and `README.md`
- [x] I did not modify any files outside my submission folder
- [x] My animation uses only HTML and CSS
- [x] My animation is responsive and works on mobile devices
- [x] I tested my animation in multiple browsers
- [x] I added accessibility features (focus states and reduced motion support)
- [x] My code follows the project's coding standards
- [x] I have read and followed the CONTRIBUTING.md guidelines

## Testing

- Chrome: radio state, keyboard arrow navigation, matching panel, ripple animation, desktop and 390px layouts
- Edge: state synchronization, reduced-motion override, and 390px overflow check
- Prettier 3.8.3
- Stylelint with repository configuration
- HTMLHint
- `git diff --check`

## Notes

The example differs from existing generic ripple navbars through synchronized treasury views, live operational data, radio-based keyboard state, and a responsive scroll-contained navigation model.
