### PR TITLE
Add ease-telescope-dome component

### DIFF
--- a/submissions/examples/ease-telescope-dome-ij/README.md
+++ b/submissions/examples/ease-telescope-dome-ij/README.md
@@ -1,0 +1,7 @@
+# ease-telescope-dome
+An observatory dome that rotates over a star field, with a slit that opens to a telescope on a three-leg stand.
+## Run
+Open `demo.html` directly in a browser to watch the dome turn.
+## Notes
+- The dome shell rotates a full turn every twenty-two seconds.
+- The shutters part and the telescope tilts toward the open slit.

--- a/submissions/examples/ease-telescope-dome-ij/demo.html
+++ b/submissions/examples/ease-telescope-dome-ij/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.2">
+<title>Telescope Dome</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="observatory">
+  <header class="obs-head">
+    <h1 class="obs-name">SKY LAB</h1>
+    <p class="obs-track">TRACK 3</p>
+  </header>
+  <section class="obs-dome" aria-label="Observatory dome">
+    <div class="dome-shell">
+      <span class="star star-a"></span>
+      <span class="star star-b"></span>
+      <span class="star star-c"></span>
+      <div class="shutter-shift">
+        <span class="shutter shutter-left"></span>
+        <span class="shutter shutter-right"></span>
+      </div>
+    </div>
+    <div class="dome-base"></div>
+  </section>
+  <section class="obs-floor" aria-label="Telescope on the floor">
+    <div class="scope">
+      <span class="scope-tube"></span>
+      <span class="scope-eyepiece"></span>
+      <span class="scope-lens"></span>
+    </div>
+    <div class="tripod">
+      <span class="leg leg-1"></span>
+      <span class="leg leg-2"></span>
+      <span class="leg leg-3"></span>
+    </div>
+  </section>
+  <footer class="obs-foot">
+    <span class="obs-target">ANDROMEDA</span>
+    <span class="obs-zoom">MAG 120</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-telescope-dome-ij/style.css
+++ b/submissions/examples/ease-telescope-dome-ij/style.css
@@ -1,0 +1,39 @@
+:root{
+--scope-silver:#c3cbd6;
+--scope-dark:#10151d;
+--scope-glow:#ffd98a;
+}
+*,::before,::after{margin:0;padding:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 20%,hsl(250,30%,14%),hsl(260,35%,5%));font-family:'Segoe UI',sans-serif}
+.observatory{width:360px;padding:16px;border-radius:16px;background:var(--scope-dark);box-shadow:0 0 0 3px #2a3547,0 14px 34px rgba(0,0,0,0.7)}
+.obs-head{display:flex;justify-content:space-between;align-items:center;padding:2px 4px 12px}
+.obs-name{color:var(--scope-glow);font-size:19px;letter-spacing:3px}
+.obs-track{color:#7f93b0;font-size:12px;font-weight:bold;animation:track-blink-telescope-dome 2s ease-in-out infinite}
+.obs-dome{position:relative;height:190px;background:#0c1017;border-radius:12px;overflow:hidden}
+.dome-shell{position:absolute;left:50%;top:16px;width:210px;height:130px;margin-left:-105px;border-radius:105px 105px 8px 8px;background:linear-gradient(180deg,#232c3a,#161d29);box-shadow:inset 0 0 0 4px #33404f;animation:dome-rotate-telescope-dome 22s linear infinite}
+.shutter-shift{position:absolute;inset:0;border-radius:inherit;background:repeating-linear-gradient(90deg,#1a222f 0 6px,#253042 6px 10px);clip-path:polygon(38% 0,62% 0,62% 100%,38% 100%)}
+.shutter{position:absolute;top:0;bottom:0;width:50%;background:linear-gradient(180deg,#39465a,#202a38)}
+.shutter-left{left:0;border-right:3px solid #0c1017;animation:shutter-open-telescope-dome 22s ease-in-out infinite}
+.shutter-right{right:0;border-left:3px solid #0c1017;animation:shutter-open-telescope-dome 22s ease-in-out infinite}
+.star{position:absolute;width:5px;height:5px;border-radius:50%;background:var(--scope-glow);animation:star-twinkle-telescope-dome 1.6s ease-in-out infinite}
+.star-a{left:30px;top:26px;animation-delay:0.3s}
+.star-b{right:34px;top:18px;animation-delay:0.7s}
+.star-c{left:120px;top:44px;animation-delay:1.1s}
+.dome-base{position:absolute;left:50%;bottom:0;width:250px;height:26px;margin-left:-125px;background:linear-gradient(180deg,#39465a,#202a38);border-radius:8px 8px 0 0}
+.obs-floor{position:relative;height:150px;background:#0c1017;border-radius:12px;margin-top:10px;overflow:hidden}
+.scope{position:absolute;left:50%;top:12px;margin-left:-90px;width:90px;height:96px;transform-origin:50% 96px;animation:scope-aim-telescope-dome 22s ease-in-out infinite}
+.scope-tube{position:absolute;left:16px;top:0;width:58px;height:84px;border-radius:29px;background:linear-gradient(180deg,#e6ecf2,#8b95a3);box-shadow:0 4px 8px rgba(0,0,0,0.5)}
+.scope-eyepiece{position:absolute;left:30px;top:-16px;width:30px;height:16px;border-radius:6px 6px 0 0;background:#5b6a7d}
+.scope-lens{position:absolute;left:16px;bottom:10px;width:58px;height:14px;border-radius:0 0 8px 8px;background:radial-gradient(circle at 50% 50%,#7fc8ff 0 40%,#3a5a8a 100%)}
+.tripod{position:absolute;left:50%;top:96px;margin-left:-70px;width:140px;height:56px}
+.leg{position:absolute;width:6px;height:54px;background:linear-gradient(180deg,#5b6a7d,#33404f);transform-origin:50% 0;border-radius:3px}
+.leg-1{left:70px;top:0;transform:rotate(0deg)}
+.leg-2{left:26px;top:0;transform:rotate(34deg)}
+.leg-3{right:26px;top:0;transform:rotate(-34deg)}
+.obs-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#7f93b0;font-size:12px}
+.obs-zoom{color:var(--scope-glow);font-weight:bold;animation:track-blink-telescope-dome 2s ease-in-out infinite}
+@keyframes dome-rotate-telescope-dome{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes shutter-open-telescope-dome{0%,20%{opacity:0.45}60%,100%{opacity:1}}
+@keyframes scope-aim-telescope-dome{0%,20%{transform:rotate(0deg)}60%,100%{transform:rotate(-8deg)}}
+@keyframes star-twinkle-telescope-dome{0%,100%{opacity:1}50%{opacity:0.15}}
+@keyframes track-blink-telescope-dome{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-telescope-dome — rotating dome, shutter slit, and star field

**Closes #60034**

### What this adds
An observatory dome that rotates over a star field, with a slit that opens to a telescope aiming through the gap on a three-leg stand.

### Acceptance Criteria covered
- Dome shell rotates a full turn every twenty-two seconds
- Shutters open and the telescope tilts toward the slit
- Stars twinkle around the dome as it turns

### Files
- submissions/examples/ease-telescope-dome-ij/demo.html
- submissions/examples/ease-telescope-dome-ij/style.css
- submissions/examples/ease-telescope-dome-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the dome rotate while the telescope tilts toward the open slit.