### PR TITLE
Add ease-cash-register-drawer component

### DIFF
--- a/submissions/examples/ease-cash-register-drawer-ij/README.md
+++ b/submissions/examples/ease-cash-register-drawer-ij/README.md
@@ -1,0 +1,7 @@
+# ease-cash-register-drawer
+A cash register with a keypad, a green readout, a brass bell, and a drawer that slides open to show coin and bill trays.
+## Run
+Open `demo.html` directly in a browser to watch the drawer slide.
+## Notes
+- The drawer slides out and slams shut on a six-second loop.
+- The readout flickers while the bell rings at each close.

--- a/submissions/examples/ease-cash-register-drawer-ij/demo.html
+++ b/submissions/examples/ease-cash-register-drawer-ij/demo.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.4">
+<title>Cash Register Drawer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="register">
+  <header class="reg-head">
+    <h1 class="reg-title">TOTAL</h1>
+    <p class="reg-total">$12.50</p>
+  </header>
+  <section class="reg-body" aria-label="Cash register keys and display">
+    <div class="reg-screen"><span class="screen-readout">12.50</span></div>
+    <div class="reg-keys">
+      <button class="key key-a" type="button">1</button>
+      <button class="key key-b" type="button">5</button>
+      <button class="key key-c" type="button">9</button>
+      <button class="key key-d" type="button">00</button>
+      <button class="key key-e" type="button">$</button>
+      <button class="key key-f" type="button">CLR</button>
+    </div>
+    <span class="reg-bell"></span>
+  </section>
+  <section class="reg-drawer" aria-label="Cash drawer">
+    <div class="drawer-slot">
+      <div class="drawer-tray">
+        <span class="tray-coin coin-a"></span>
+        <span class="tray-coin coin-b"></span>
+        <span class="tray-bill"></span>
+      </div>
+      <span class="drawer-handle"></span>
+    </div>
+  </section>
+  <footer class="reg-foot">
+    <span class="reg-coin">COINS 24</span>
+    <span class="reg-sale">SALE 8</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-cash-register-drawer-ij/style.css
+++ b/submissions/examples/ease-cash-register-drawer-ij/style.css
@@ -1,0 +1,33 @@
+:root{
+--reg-cream:#f0e8d8;
+--reg-tan:#8a6a44;
+--reg-navy:#232a35;
+}
+*,::before,::after{padding:0;margin:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 35%,hsl(35,25%,16%),hsl(45,30%,6%));font-family:'Palatino Linotype',serif}
+.register{width:340px;padding:16px;border-radius:16px;background:var(--reg-navy);box-shadow:0 0 0 3px #3a4a5a,0 14px 34px rgba(0,0,0,0.7)}
+.reg-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 12px}
+.reg-title{color:var(--reg-cream);font-size:19px;letter-spacing:3px}
+.reg-total{color:#ffcf5c;font-size:13px;font-weight:bold;animation:total-blink-cash-register-drawer 1.6s ease-in-out infinite}
+.reg-body{background:#1b212b;border-radius:12px;padding:12px}
+.reg-screen{margin-bottom:10px;background:#10141b;border-radius:8px;padding:8px;text-align:right}
+.screen-readout{color:#7dff8b;font-size:22px;font-weight:bold;animation:readout-roll-cash-register-drawer 6s steps(2,end) infinite}
+.reg-keys{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+.key{border:none;border-radius:6px;background:var(--reg-tan);color:var(--reg-cream);font-weight:bold;font-family:inherit;padding:10px 0;font-size:13px;box-shadow:inset 0 -3px 0 rgba(0,0,0,0.3)}
+.key-f{background:#c0392b}
+.key-a,.key-c{animation:key-nudge-cash-register-drawer 3s ease-in-out infinite}
+.key-e{background:#f1c40f;color:#4a3a12;animation:key-nudge-cash-register-drawer 4s ease-in-out infinite}
+.reg-bell{display:block;width:26px;height:26px;margin:10px auto 0;border-radius:50%;background:linear-gradient(180deg,#f0e8d8,#b8a488);animation:bell-ring-cash-register-drawer 6s ease-in-out infinite}
+.reg-drawer{margin-top:10px;background:#1b212b;border-radius:12px;padding:10px;overflow:hidden}
+.drawer-slot{position:relative;height:56px;background:#10141b;border-radius:8px}
+.drawer-tray{position:absolute;left:0;top:8px;width:130px;height:40px;background:linear-gradient(180deg,#3d4a5a,#232a35);border-radius:6px;display:flex;align-items:center;gap:6px;padding:6px;animation:drawer-slide-cash-register-drawer 6s ease-in-out infinite}
+.tray-coin{width:16px;height:16px;border-radius:50%;background:radial-gradient(circle,#ffd98a,#b8860b)}
+.tray-bill{width:34px;height:22px;border-radius:3px;background:#4a9e6a}
+.drawer-handle{position:absolute;right:14px;top:16px;width:44px;height:12px;border-radius:4px;background:var(--reg-tan)}
+.reg-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#8a97a6;font-size:12px}
+.reg-sale{color:#ffcf5c;font-weight:bold;animation:total-blink-cash-register-drawer 1.6s ease-in-out infinite}
+@keyframes drawer-slide-cash-register-drawer{0%,30%,100%{transform:translateX(0)}42%,58%{transform:translateX(140px)}}
+@keyframes readout-roll-cash-register-drawer{0%,32%,100%{opacity:1}46%,56%{opacity:0.35}}
+@keyframes bell-ring-cash-register-drawer{0%,30%,100%{transform:scale(1)}44%,52%{transform:scale(1.18)}}
+@keyframes key-nudge-cash-register-drawer{0%,100%{transform:translateY(0)}40%{transform:translateY(2px)}}
+@keyframes total-blink-cash-register-drawer{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-cash-register-drawer — sliding drawer, keypad, and ringing bell

**Closes #60041**

### What this adds
A cash register with a keypad, a green readout, a brass bell, and a drawer that slides open with coin and bill trays on every loop.

### Acceptance Criteria covered
- Drawer slides open and slams back shut
- Readout flickers as the sale total sits
- Bell scales up as the drawer locks shut

### Files
- submissions/examples/ease-cash-register-drawer-ij/demo.html
- submissions/examples/ease-cash-register-drawer-ij/style.css
- submissions/examples/ease-cash-register-drawer-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the drawer slide open to show the coin and bill trays.