### PR TITLE
Add ease-kettle-whistle-steam component

### DIFF
--- a/submissions/examples/ease-kettle-whistle-steam-ij/README.md
+++ b/submissions/examples/ease-kettle-whistle-steam-ij/README.md
@@ -1,0 +1,7 @@
+# ease-kettle-whistle-steam
+A stove kettle on a burner with a brass spout, a whistling cap, and steam that rises while three flames dance beneath the pot.
+## Run
+Open `demo.html` directly in a browser to watch the steam rise.
+## Notes
+- The flames flicker in gold, orange and red under the body.
+- Steam puffs climb from the whistle cap in staggered loops.

--- a/submissions/examples/ease-kettle-whistle-steam-ij/demo.html
+++ b/submissions/examples/ease-kettle-whistle-steam-ij/demo.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.6">
+<title>Kettle Whistle Steam</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="stove-kettle">
+  <header class="kettle-head">
+    <h1 class="kettle-name">BREW YARD</h1>
+    <p class="kettle-heat">HIGH</p>
+  </header>
+  <section class="kettle-scene" aria-label="Kettle on a burner">
+    <div class="burner">
+      <span class="flame flame-a"></span>
+      <span class="flame flame-b"></span>
+      <span class="flame flame-c"></span>
+    </div>
+    <div class="kettle-pot">
+      <span class="pot-lid"></span>
+      <span class="pot-handle"></span>
+      <span class="pot-spout"></span>
+      <div class="whistle">
+        <span class="whistle-tip"></span>
+        <span class="whistle-steam"></span>
+      </div>
+      <span class="pot-body"></span>
+    </div>
+    <div class="steam-plume">
+      <span class="puff puff-a"></span>
+      <span class="puff puff-b"></span>
+      <span class="puff puff-c"></span>
+    </div>
+  </section>
+  <footer class="kettle-foot">
+    <span class="kettle-min">READY 4</span>
+    <span class="kettle-wait">WHISTLE</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-kettle-whistle-steam-ij/style.css
+++ b/submissions/examples/ease-kettle-whistle-steam-ij/style.css
@@ -1,0 +1,36 @@
+:root{
+--kettle-slate:#4a5560;
+--kettle-copper:#b8793a;
+--kettle-flame:#ff8a2a;
+}
+*,::before,::after{padding:0;box-sizing:border-box;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 35%,hsl(25,35%,15%),hsl(30,40%,5%));font-family:Verdana,sans-serif}
+.stove-kettle{width:340px;padding:16px;border-radius:16px;background:#22272d;box-shadow:0 0 0 3px #39434b,0 14px 34px rgba(0,0,0,0.7)}
+.kettle-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 12px}
+.kettle-name{color:#e8dcc4;font-size:19px;letter-spacing:2px}
+.kettle-heat{color:var(--kettle-flame);font-size:12px;font-weight:bold;animation:heat-blink-kettle-whistle-steam 1.6s ease-in-out infinite}
+.kettle-scene{position:relative;height:230px;background:linear-gradient(180deg,#2c333b,#1a1e23);border-radius:12px;overflow:hidden}
+.burner{position:absolute;left:50%;bottom:44px;margin-left:-44px;width:88px;height:16px;background:#101317;border-radius:8px;z-index:1}
+.flame{position:absolute;bottom:16px;border-radius:50% 50% 40% 40%;background:linear-gradient(180deg,#ffd23f,#ff8a2a 60%,#e8503a);transform-origin:50% 100%}
+.flame-a{left:12px;width:18px;height:34px;animation:flame-dance-kettle-whistle-steam 0.5s ease-in-out infinite}
+.flame-b{left:34px;width:22px;height:44px;animation:flame-dance-kettle-whistle-steam 0.7s ease-in-out infinite}
+.flame-c{left:58px;width:18px;height:34px;animation:flame-dance-kettle-whistle-steam 0.6s ease-in-out infinite}
+.kettle-pot{position:absolute;left:50%;bottom:56px;width:190px;height:120px;margin-left:-95px}
+.pot-body{position:absolute;left:0;bottom:0;width:190px;height:96px;border-radius:14px 14px 20px 20px;background:linear-gradient(180deg,#6a7682,#3a434d);box-shadow:inset 0 0 0 4px #2c343c}
+.pot-lid{position:absolute;left:14px;top:0;width:162px;height:22px;border-radius:10px;background:linear-gradient(180deg,#7c8894,#4a5560);box-shadow:inset 0 0 0 3px #2c343c}
+.pot-handle{position:absolute;left:70px;top:-12px;width:50px;height:16px;border:5px solid #2c343c;border-bottom:0;border-radius:10px 10px 0 0}
+.pot-spout{position:absolute;left:178px;top:52px;width:44px;height:22px;background:#4a5560;border-radius:0 12px 12px 0;clip-path:polygon(0 0,100% 18%,100% 82%,0 100%)}
+.whistle{position:absolute;left:86px;top:-20px}
+.whistle-tip{display:block;width:20px;height:20px;border-radius:50% 50% 4px 4px;background:var(--kettle-copper)}
+.whistle-steam{position:absolute;left:50%;top:-14px;width:4px;height:24px;margin-left:-2px;background:#9fb0bd;border-radius:2px;animation:whistle-puff-kettle-whistle-steam 1.8s ease-out infinite}
+.steam-plume{position:absolute;left:50%;top:24px;margin-left:-60px;width:120px;height:0}
+.puff{position:absolute;border-radius:50%;background:rgba(240,245,248,0.6);filter:blur(3px)}
+.puff-a{left:10px;top:0;width:16px;height:16px;animation:puff-rise-kettle-whistle-steam 2.4s linear infinite}
+.puff-b{left:48px;top:0;width:22px;height:22px;animation:puff-rise-kettle-whistle-steam 3s linear infinite 0.6s}
+.puff-c{left:84px;top:0;width:16px;height:16px;animation:puff-rise-kettle-whistle-steam 2.8s linear infinite 1.2s}
+.kettle-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#8a97a6;font-size:12px}
+.kettle-wait{color:var(--kettle-flame);font-weight:bold;animation:heat-blink-kettle-whistle-steam 1.6s ease-in-out infinite}
+@keyframes flame-dance-kettle-whistle-steam{0%,100%{transform:scaleY(1) scaleX(1)}50%{transform:scaleY(1.25) scaleX(0.85)}}
+@keyframes puff-rise-kettle-whistle-steam{0%{transform:translateY(0) scale(0.6);opacity:0}20%{opacity:0.8}100%{transform:translateY(-70px) scale(1.4);opacity:0}}
+@keyframes whistle-puff-kettle-whistle-steam{0%,30%{transform:scaleY(0.4);opacity:0.6}100%{transform:scaleY(1.6);opacity:0}}
+@keyframes heat-blink-kettle-whistle-steam{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-kettle-whistle-steam — brass spout, dancing flame, and steam puffs

**Closes #60048**

### What this adds
A stove kettle on a burner with a brass spout, a whistling cap, and puffs of steam that rise as three flames dance beneath the pot.

### Acceptance Criteria covered
- Flames dance in gold, orange and red under the pot
- Steam puffs rise from the whistle cap
- Whistle tip steams while the HIGH badge blinks

### Files
- submissions/examples/ease-kettle-whistle-steam-ij/demo.html
- submissions/examples/ease-kettle-whistle-steam-ij/style.css
- submissions/examples/ease-kettle-whistle-steam-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the steam rise from the whistle over the dancing flames.