### PR TITLE
Add ease-guitar-amp-grille component

### DIFF
--- a/submissions/examples/ease-guitar-amp-grille-ij/README.md
+++ b/submissions/examples/ease-guitar-amp-grille-ij/README.md
@@ -1,0 +1,7 @@
+# ease-guitar-amp-grille
+A guitar amplifier with a woven grille, a red speaker cone that thumps, four control knobs, and an EQ strip that dances to the beat.
+## Run
+Open `demo.html` directly in a browser to watch the cone thump.
+## Notes
+- The speaker cone pulses behind the grille cloth.
+- The EQ bars dance at different speeds and heights.

--- a/submissions/examples/ease-guitar-amp-grille-ij/demo.html
+++ b/submissions/examples/ease-guitar-amp-grille-ij/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.9">
+<title>Guitar Amp Grille</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="amp-cab">
+  <header class="amp-head">
+    <h1 class="amp-name">ROAD SERIES</h1>
+    <p class="amp-model">60W</p>
+  </header>
+  <section class="amp-front" aria-label="Amp control panel">
+    <div class="knob-row">
+      <span class="knob knob-a"></span>
+      <span class="knob knob-b"></span>
+      <span class="knob knob-c"></span>
+      <span class="knob knob-d"></span>
+    </div>
+    <div class="eq-bars">
+      <span class="eq-bar eq-a"></span>
+      <span class="eq-bar eq-b"></span>
+      <span class="eq-bar eq-c"></span>
+      <span class="eq-bar eq-d"></span>
+      <span class="eq-bar eq-e"></span>
+    </div>
+    <div class="amp-grille" aria-label="Speaker grille">
+      <div class="speaker-cone">
+        <span class="cone-ring"></span>
+        <span class="cone-dust"></span>
+      </div>
+      <div class="cone-shine"></div>
+    </div>
+    <span class="amp-jack"></span>
+    <span class="amp-light"></span>
+  </section>
+  <footer class="amp-foot">
+    <span class="amp-channel">CH A</span>
+    <span class="amp-volume">GAIN 7</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-guitar-amp-grille-ij/style.css
+++ b/submissions/examples/ease-guitar-amp-grille-ij/style.css
@@ -1,0 +1,41 @@
+:root{
+--amp-charcoal:#1c1e22;
+--amp-chrome:#cfd3da;
+--amp-red:#ff2e2e;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(10,20%,14%),hsl(15,25%,5%));font-family:'Arial Black',sans-serif}
+.amp-cab{width:360px;padding:16px;border-radius:16px;background:var(--amp-charcoal);box-shadow:0 0 0 3px #3a3d42,0 14px 34px rgba(0,0,0,0.7)}
+.amp-head{display:flex;justify-content:space-between;align-items:center;padding:2px 4px 12px}
+.amp-name{color:var(--amp-chrome);font-size:18px;letter-spacing:3px}
+.amp-model{color:#a0a5ac;font-size:12px;font-weight:bold}
+.amp-front{background:#141619;border-radius:14px;padding:14px}
+.knob-row{display:flex;gap:16px;justify-content:center;padding:4px 0 12px}
+.knob{width:30px;height:30px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#e8ecef,#8a9098);box-shadow:0 0 0 4px #1c1e22,0 3px 5px rgba(0,0,0,0.6);position:relative}
+.knob::after{content:"";position:absolute;left:50%;top:3px;width:3px;height:10px;margin-left:-1px;background:#ff2e2e}
+.knob-a{transform:rotate(24deg)}
+.knob-b{transform:rotate(-38deg);animation:knob-trim-guitar-amp-grille 3s ease-in-out infinite}
+.knob-c{transform:rotate(12deg)}
+.knob-d{transform:rotate(-52deg);animation:knob-turn-guitar-amp-grille 4s ease-in-out infinite}
+.eq-bars{display:flex;gap:8px;justify-content:center;align-items:flex-end;height:40px;margin-bottom:14px}
+.eq-bar{width:12px;border-radius:3px;background:linear-gradient(180deg,#7dff8b,#2e9e4a);transform-origin:50% 100%}
+.eq-a{height:14px;animation:eq-dance-guitar-amp-grille 1.4s ease-in-out infinite}
+.eq-b{height:26px;animation:eq-dance-guitar-amp-grille 1.7s ease-in-out infinite}
+.eq-c{height:34px;animation:eq-dance-guitar-amp-grille 1.2s ease-in-out infinite}
+.eq-d{height:22px;animation:eq-dance-guitar-amp-grille 2s ease-in-out infinite}
+.eq-e{height:12px;animation:eq-dance-guitar-amp-grille 1.6s ease-in-out infinite}
+.amp-grille{position:relative;height:150px;background:repeating-linear-gradient(90deg,#15171b 0 6px,#23262c 6px 12px),repeating-linear-gradient(0deg,#15171b 0 6px,#23262c 6px 12px);border-radius:10px;border:4px solid #0f1113;overflow:hidden}
+.speaker-cone{position:absolute;left:50%;top:50%;width:120px;height:120px;margin-left:-60px;margin-top:-60px;border-radius:50%;background:radial-gradient(circle,#2e3138 0 30%,#1c1e22 30% 70%,#2e3138 70% 100%);animation:cone-thump-guitar-amp-grille 1.1s ease-in-out infinite}
+.cone-ring{position:absolute;left:14px;right:14px;top:14px;bottom:14px;border:3px solid #43474e;border-radius:50%}
+.cone-dust{position:absolute;left:50%;top:50%;width:26px;height:26px;margin-left:-13px;margin-top:-13px;border-radius:50%;background:#ff2e2e;box-shadow:0 0 10px rgba(255,46,46,0.7)}
+.cone-shine{position:absolute;inset:0;border-radius:inherit;background:linear-gradient(120deg,rgba(255,255,255,0.14),rgba(255,255,255,0.02) 40%);animation:shine-sweep-guitar-amp-grille 2.6s ease-in-out infinite}
+.amp-jack{display:inline-block;width:22px;height:22px;margin:12px 4px 0 10px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#d9dde2,#767c85);box-shadow:0 0 0 3px #0f1113}
+.amp-light{display:inline-block;width:12px;height:12px;margin-left:8px;border-radius:50%;background:var(--amp-red);box-shadow:0 0 10px rgba(255,46,46,0.8);animation:amp-blink-guitar-amp-grille 1.1s steps(2,end) infinite}
+.amp-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#8a9098;font-size:12px}
+.amp-volume{color:var(--amp-red);font-weight:bold;animation:amp-blink-guitar-amp-grille 1.1s steps(2,end) infinite}
+@keyframes cone-thump-guitar-amp-grille{0%,100%{transform:scale(1)}50%{transform:scale(1.06)}}
+@keyframes eq-dance-guitar-amp-grille{0%,100%{transform:scaleY(0.45)}50%{transform:scaleY(1)}}
+@keyframes shine-sweep-guitar-amp-grille{0%,100%{opacity:0.4}50%{opacity:1}}
+@keyframes knob-trim-guitar-amp-grille{0%,100%{transform:rotate(-38deg)}50%{transform:rotate(-26deg)}}
+@keyframes knob-turn-guitar-amp-grille{0%,100%{transform:rotate(-52deg)}50%{transform:rotate(-40deg)}}
+@keyframes amp-blink-guitar-amp-grille{0%,49%{opacity:1}50%,100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-guitar-amp-grille — speaker cone, knobs, and dancing EQ

**Closes #60058**

### What this adds
A guitar amplifier with a woven grille, a red speaker cone that thumps, four control knobs, and an EQ strip that dances to the beat.

### Acceptance Criteria covered
- Speaker cone thumps behind the grille cloth
- EQ bars dance at their own pace
- Power light blinks red as the gain badge pulses

### Files
- submissions/examples/ease-guitar-amp-grille-ij/demo.html
- submissions/examples/ease-guitar-amp-grille-ij/style.css
- submissions/examples/ease-guitar-amp-grille-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the cone thump while the EQ bars bounce above the grille.