### PR TITLE
feat: Add Global Focus Ring Clipping Prevention example under submiss…

### DIFF
--- a/submissions/examples/global-focus-ring-clipping-59793/README.md
+++ b/submissions/examples/global-focus-ring-clipping-59793/README.md
@@ -1,0 +1,38 @@
+# Global Focus Ring Clipping Prevention (#59793)
+
+An accessibility solution and design pattern for EaseMotion CSS components that prevents keyboard focus rings (`:focus-visible`) from being clipped when placed inside containers with `overflow: hidden` or `overflow: auto`.
+
+## 🎯 Problem Overview
+
+Default browser outlines (`outline: 2px solid <color>`) and positive outline offsets (`outline-offset: 2px`) draw the focus indicator outside an element's bounding box. When interactive elements (buttons, inputs, cards, drawers, tabs) are nested inside containers that use `overflow: hidden` or `overflow: auto` for layout clipping and animations, the focus ring gets partially or entirely cut off, reducing visual accessibility.
+
+## 💡 Solution
+
+By using an **inset box-shadow** (`box-shadow: inset 0 0 0 2px <color>`) paired with `outline: none`, the focus ring is rendered entirely *within* the element's bounding box.
+
+### Key Benefits
+- **No Clipping**: Guaranteed 100% focus indicator visibility inside any container, regardless of `overflow` settings.
+- **High Contrast**: Dual-layer inset shadow for crisp contrast in both dark and light modes.
+- **Reduced Motion Ready**: Full support for `prefers-reduced-motion`.
+
+## 🛠️ Usage
+
+Apply the following utility rule or focus pattern to interactive elements across EaseMotion CSS components:
+
+```css
+/* Prevent focus ring clipping in overflow containers */
+.your-element:focus-visible,
+:focus-visible {
+    outline: none !important;
+    box-shadow: inset 0 0 0 2px #38bdf8, inset 0 0 0 4px rgba(56, 189, 248, 0.2) !important;
+}
+```
+
+## 📁 File Structure
+
+```
+submissions/examples/global-focus-ring-clipping-59793/
+├── demo.html    # Interactive showcase with overflow: hidden containers
+├── style.css    # Raw CSS design system & inset focus ring implementation
+└── README.md    # Documentation and usage guide
+```

--- a/submissions/examples/global-focus-ring-clipping-59793/demo.html
+++ b/submissions/examples/global-focus-ring-clipping-59793/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="EaseMotion CSS - Global focus ring clipping prevention showcase inside overflow containers.">
+    <title>Global Focus Ring Clipping Fix - EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <main class="em-wrapper" id="main-content">
+        <header class="em-header">
+            <span class="em-badge" id="badge-status">Accessibility Fix #59793</span>
+            <h1 class="em-title" id="page-title">Prevent Focus Ring Clipping in Overflow Containers</h1>
+            <p class="em-subtitle" id="page-subtitle">
+                Demonstrating high-contrast inset focus rings (`box-shadow: inset`) that remain 100% visible inside `overflow: hidden` and `overflow: auto` wrappers.
+            </p>
+        </header>
+
+        <!-- Test Grid inside Overflow Hidden Containers -->
+        <section class="em-grid" id="demo-grid">
+            
+            <!-- Card 1: Interactive Button inside Overflow Hidden Container -->
+            <article class="em-card-wrapper" id="card-wrapper-1">
+                <div class="em-card" id="card-1">
+                    <div class="em-card-header">
+                        <h2 class="em-card-title" id="title-1">Interactive Button Showcase</h2>
+                        <span class="em-pill" id="pill-1">Overflow Hidden</span>
+                    </div>
+                    <p class="em-card-text">
+                        Standard `outline` extends beyond element bounds and gets clipped by parent overflow borders. Inset focus rings remain completely contained.
+                    </p>
+                    <div class="em-actions">
+                        <button type="button" class="em-btn em-btn-primary" id="btn-primary-demo">
+                            Focus Action Button
+                        </button>
+                        <button type="button" class="em-btn em-btn-secondary" id="btn-secondary-demo">
+                            Secondary Action
+                        </button>
+                    </div>
+                </div>
+            </article>
+
+            <!-- Card 2: Interactive Form Controls inside Overflow Auto Container -->
+            <article class="em-card-wrapper" id="card-wrapper-2">
+                <div class="em-card" id="card-2">
+                    <div class="em-card-header">
+                        <h2 class="em-card-title" id="title-2">Form Control Focus Ring</h2>
+                        <span class="em-pill" id="pill-2">Overflow Auto</span>
+                    </div>
+                    <form class="em-form" id="sample-form" onsubmit="event.preventDefault();">
+                        <div class="em-form-group">
+                            <label for="input-email" class="em-label">Work Email Address</label>
+                            <input type="email" id="input-email" class="em-input" placeholder="alex@company.com" required>
+                        </div>
+                        <div class="em-form-group">
+                            <label for="select-role" class="em-label">Developer Role</label>
+                            <select id="select-role" class="em-select">
+                                <option value="frontend">Frontend Engineer</option>
+                                <option value="fullstack">Fullstack Engineer</option>
+                                <option value="ui-ux">UI/UX Specialist</option>
+                            </select>
+                        </div>
+                    </form>
+                </div>
+            </article>
+
+            <!-- Card 3: Interactive Tabs & Links inside Clipped Drawer Container -->
+            <article class="em-card-wrapper" id="card-wrapper-3">
+                <div class="em-card" id="card-3">
+                    <div class="em-card-header">
+                        <h2 class="em-card-title" id="title-3">Navigation & Link Focus State</h2>
+                        <span class="em-pill" id="pill-3">Clipped Bounding Box</span>
+                    </div>
+                    <nav class="em-nav" id="demo-nav" aria-label="Demo Navigation">
+                        <a href="#link-dashboard" class="em-nav-link active" id="link-dashboard">Dashboard Overview</a>
+                        <a href="#link-settings" class="em-nav-link" id="link-settings">Account Settings</a>
+                        <a href="#link-docs" class="em-nav-link" id="link-docs">Documentation Portal</a>
+                    </nav>
+                </div>
+            </article>
+
+        </section>
+    </main>
+</body>
+</html>

--- a/submissions/examples/global-focus-ring-clipping-59793/style.css
+++ b/submissions/examples/global-focus-ring-clipping-59793/style.css
@@ -1,0 +1,245 @@
+/* -------------------------------------------------------------------
+ * EaseMotion CSS - Global Focus Ring Clipping Fix (#59793)
+ * Design System Tokens & Anti-Clipping Inset Focus Ring Utilities
+ * ------------------------------------------------------------------- */
+
+:root {
+    --em-bg-dark: #090d16;
+    --em-card-bg: rgba(22, 30, 46, 0.75);
+    --em-card-border: rgba(255, 255, 255, 0.08);
+    --em-primary: #6366f1;
+    --em-primary-hover: #4f46e5;
+    --em-primary-glow: rgba(99, 102, 241, 0.35);
+    --em-accent: #06b6d4;
+    --em-text-main: #f8fafc;
+    --em-text-muted: #94a3b8;
+    --em-radius: 14px;
+    --em-transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    background-color: var(--em-bg-dark);
+    color: var(--em-text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+    line-height: 1.5;
+}
+
+.em-wrapper {
+    max-width: 1100px;
+    width: 100%;
+}
+
+.em-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.em-badge {
+    display: inline-block;
+    padding: 0.35rem 0.85rem;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(6, 182, 212, 0.2));
+    border: 1px solid rgba(99, 102, 241, 0.3);
+    color: var(--em-accent);
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.em-title {
+    font-size: 2.25rem;
+    font-weight: 700;
+    letter-spacing: -0.025em;
+    background: linear-gradient(135deg, #ffffff 0%, #cbd5e1 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 0.75rem;
+}
+
+.em-subtitle {
+    color: var(--em-text-muted);
+    font-size: 1.05rem;
+    max-width: 680px;
+    margin: 0 auto;
+}
+
+.em-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.75rem;
+}
+
+/* Container with Overflow Hidden to test clipping */
+.em-card-wrapper {
+    overflow: hidden;
+    border-radius: var(--em-radius);
+    border: 1px solid var(--em-card-border);
+    background: var(--em-card-bg);
+    backdrop-filter: blur(16px);
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+    transition: var(--em-transition);
+}
+
+.em-card-wrapper:hover {
+    border-color: rgba(99, 102, 241, 0.3);
+    transform: translateY(-2px);
+}
+
+.em-card {
+    padding: 1.75rem;
+}
+
+.em-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.em-card-title {
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.em-pill {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.25rem 0.6rem;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--em-text-muted);
+}
+
+.em-card-text {
+    color: var(--em-text-muted);
+    font-size: 0.925rem;
+    margin-bottom: 1.5rem;
+}
+
+.em-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+/* Button Styles */
+.em-btn {
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0.65rem 1.25rem;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    transition: var(--em-transition);
+}
+
+.em-btn-primary {
+    background: linear-gradient(135deg, var(--em-primary), var(--em-primary-hover));
+    color: #ffffff;
+    box-shadow: 0 4px 12px var(--em-primary-glow);
+}
+
+.em-btn-primary:hover {
+    opacity: 0.92;
+}
+
+.em-btn-secondary {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--em-text-main);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.em-btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.14);
+}
+
+/* Form Controls */
+.em-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.em-form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.em-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--em-text-muted);
+}
+
+.em-input,
+.em-select {
+    font-family: inherit;
+    font-size: 0.9rem;
+    padding: 0.65rem 0.9rem;
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--em-text-main);
+    transition: var(--em-transition);
+}
+
+/* Navigation Links */
+.em-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.em-nav-link {
+    color: var(--em-text-muted);
+    text-decoration: none;
+    padding: 0.65rem 0.9rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: var(--em-transition);
+}
+
+.em-nav-link:hover,
+.em-nav-link.active {
+    color: var(--em-text-main);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+/* ===================================================================
+   ACCESSIBILITY: INSET FOCUS RINGS (PREVENTS OVERFLOW CLIPPING)
+   =================================================================== */
+
+.em-btn:focus-visible,
+.em-input:focus-visible,
+.em-select:focus-visible,
+.em-nav-link:focus-visible,
+:focus-visible {
+    outline: none !important;
+    box-shadow: inset 0 0 0 2px #38bdf8, inset 0 0 0 4px rgba(56, 189, 248, 0.2) !important;
+}
+
+/* Reduced Motion Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    *, ::before, ::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a standalone example submission under `submissions/examples/global-focus-ring-clipping-59793/` that demonstrates how to prevent keyboard focus rings from being clipped when interactive components are placed inside wrappers with `overflow: hidden` or `overflow: auto` (#59793).

By leveraging `box-shadow: inset ...` paired with `outline: none`, focus indicators remain 100% visible within their bounding boxes. All files included are newly added under `submissions/examples/` without modifying or deleting any existing repository code.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A standalone submission demonstrating high-contrast inset focus rings (`box-shadow: inset`) that prevent clipping inside overflow-constrained containers.

**How does a developer use it?**

```html
<!-- Apply inset focus ring styling to interactive elements inside overflow containers -->
<button type="button" class="em-btn em-btn-primary" id="btn-demo">
    Focus Action Button
</button>
