### PR TITLE
fix: ease-link focus outline clipped by parent overflow #59771

### DIFF
--- a/submissions/examples/ease-link-focus-outline-clipped-59771/README.md
+++ b/submissions/examples/ease-link-focus-outline-clipped-59771/README.md
@@ -1,0 +1,14 @@
+# Fix: ease-link focus outline is clipped by parent overflow
+
+### Description
+The `ease-link` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience.
+
+### Expected Behavior
+The focus ring is fully visible, by using a negative outline offset (`outline-offset: -2px;`) so it is contained within the element's bounding box and avoids clipping from a parent container.
+
+### Implementation
+- `style.css`: Uses `outline-offset: -2px` on `:focus-visible` to ensure the focus outline is rendered inward and is not clipped by any parent `overflow` container.
+- `demo.html`: Demonstrates the `ease-link` component inside an `overflow: hidden` wrapper.
+
+### Testing
+Open `demo.html` in a browser and press `Tab` to focus the link. Verify that the focus outline is completely visible and not truncated.

--- a/submissions/examples/ease-link-focus-outline-clipped-59771/demo.html
+++ b/submissions/examples/ease-link-focus-outline-clipped-59771/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-link Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Focus the link below using the <code>Tab</code> key.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <a href="#" class="ease-link">This is an ease-link component</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-link-focus-outline-clipped-59771/style.css
+++ b/submissions/examples/ease-link-focus-outline-clipped-59771/style.css
@@ -1,0 +1,27 @@
+/* 
+ * Fix for ease-link focus outline clipping
+ * Issue: When .ease-link is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-link {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    color: #2563eb;
+    background-color: #eff6ff;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: background-color 0.2s;
+}
+
+.ease-link:hover {
+    background-color: #dbeafe;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-link:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: -2px; /* Pulls the outline inward */
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes issue #59771 where the `ease-link` component's focus ring (outline) gets clipped if the link is placed inside a container with `overflow: hidden` or `overflow: auto`. The clipping has been resolved by utilizing a negative `outline-offset`, ensuring the focus ring renders inward and remains fully visible within the bounding box, preserving a high-quality accessibility experience.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It provides a fix for the `ease-link` focus ring clipping issue by pulling the `outline-offset` inward.

**How does a developer use it?**

```html
<!-- The focus ring will remain fully visible even within bounded parents -->
<div style="overflow: hidden; padding: 1rem; border: 1px solid #ccc;">
  <a href="#" class="ease-link">This is an ease-link component</a>
</div>
