### PR TITLE
fix(compiler.js): add defensive check for ast.fill

### DIFF
--- a/easemotion/engine/compiler.js
+++ b/easemotion/engine/compiler.js
@@ -97,7 +97,7 @@ export function compile(ast, cls) {
   const delayStr      = ast.delay > 0 ? ` ${ast.delay}ms` : '';
   const iterationsStr = ast.iterations !== 1 ? ` ${ast.iterations}` : '';
   const directionStr  = ast.direction !== 'normal' ? ` ${ast.direction}` : '';
-  const fillStr       = ` ${ast.fill}`;
+  const fillStr       = ast.fill ? ` ${ast.fill}` : '';
 
   // Shorthand: name duration easing delay iteration-count direction fill-mode
   const shorthand = `${keyframe} ${durationStr} ${ast.easing}${delayStr}${iterationsStr}${directionStr}${fillStr}`;


### PR DESCRIPTION
## Fix: Defensive Check for ast.fill

### Issue
Closes #60094

### Problem
The compile() function used ast.fill without null/undefined checking. If ast.fill is undefined, the generated CSS would contain 'undefined' as a literal string.

### Solution
Added defensive ternary check: ast.fill ? ' ${ast.fill}' : ''

### Files Changed
- easemotion/engine/compiler.js (+1 line, -1 line)