### PR TITLE
fix(tabs.css): ensure underline is hidden in ease-tabs-auto variant

### DIFF
--- a/components/tabs.css
+++ b/components/tabs.css
@@ -153,8 +153,8 @@
     flex: none;
   }
   
-  .ease-tabs-auto .ease-tab-underline {
-    display: none;
+  .ease-tabs-auto .ease-tabs-nav .ease-tab-underline {
+    display: none !important;
   }
 
   /* Fallback static active indicator for auto-width tabs */


### PR DESCRIPTION
## Fix: Tabs Auto Underline Visibility

### Issue
Closes #60095

### Problem
The .ease-tabs-auto variant did not properly hide the sliding underline due to CSS specificity conflict. The transform rules had higher specificity than the display:none rule.

### Solution
- Increased selector specificity: .ease-tabs-auto .ease-tabs-nav .ease-tab-underline
- Added !important to guarantee the underline stays hidden

### Files Changed
- components/tabs.css (+2 lines, -2 lines)