### PR TITLE
Add ease-mobile-pull-refresh-spinner component

### DIFF
--- a/submissions/examples/ease-mobile-pull-refresh-spinner-ij/README.md
+++ b/submissions/examples/ease-mobile-pull-refresh-spinner-ij/README.md
@@ -1,0 +1,7 @@
+# ease-mobile-pull-refresh-spinner
+A mobile feed header with a pull-to-refresh gesture: a ring spinner rotates against a dashed track as the feed rebuilds.
+## Run
+Open `demo.html` directly in a browser to watch the pull loop.
+## Notes
+- Pull progress is exposed as `--pull-progress` and drives the spinner rotation.
+- The feed cards shuffle to the back on each completed pull.

--- a/submissions/examples/ease-mobile-pull-refresh-spinner-ij/demo.html
+++ b/submissions/examples/ease-mobile-pull-refresh-spinner-ij/demo.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.1">
+<title>Mobile Pull Refresh Spinner</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="mobile-feed" id="feed">
+  <header class="feed-head">
+    <h1 class="feed-app">FEEDLY</h1>
+    <p class="feed-status">PULL TO REFRESH</p>
+  </header>
+  <section class="refresh-zone" aria-label="Pull to refresh control">
+    <div class="refresh-track">
+      <span class="refresh-spinner"></span>
+    </div>
+    <p class="refresh-hint">drag down, release</p>
+  </section>
+  <section class="feed-stack" aria-label="Feed cards">
+    <article class="feed-card card-a">
+      <span class="card-avatar av-a"></span>
+      <div class="card-copy">
+        <strong class="card-name">Maya</strong>
+        <p class="card-note">sunset from the ridge</p>
+      </div>
+    </article>
+    <article class="feed-card card-b">
+      <span class="card-avatar av-b"></span>
+      <div class="card-copy">
+        <strong class="card-name">Jon</strong>
+        <p class="card-note">new recipe test</p>
+      </div>
+    </article>
+    <article class="feed-card card-c">
+      <span class="card-avatar av-c"></span>
+      <div class="card-copy">
+        <strong class="card-name">Priya</strong>
+        <p class="card-note">commute photo</p>
+      </div>
+    </article>
+  </section>
+  <footer class="feed-foot">
+    <span class="feed-sync">SYNC 9:41</span>
+    <span class="feed-count">NEW 3</span>
+  </footer>
+</main>
+<script>
+(function(){
+  var feed = document.getElementById('feed');
+  var stack = feed.querySelector('.feed-stack');
+  var tick = 0;
+  setInterval(function(){
+    tick = (tick + 1) % 120;
+    feed.style.setProperty('--pull-progress', String(tick / 120));
+    if (tick === 0) {
+      stack.appendChild(stack.querySelector('.feed-card'));
+    }
+  }, 40);
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/ease-mobile-pull-refresh-spinner-ij/style.css
+++ b/submissions/examples/ease-mobile-pull-refresh-spinner-ij/style.css
@@ -1,0 +1,29 @@
+:root{
+--pull-ink:#16181d;
+--pull-sky:#cfe3ff;
+--pull-accent:#4f8cff;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 20%,hsl(218,35%,18%),hsl(224,40%,7%));font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
+.mobile-feed{width:320px;padding:14px;border-radius:22px;background:var(--pull-ink);box-shadow:0 0 0 3px #2b3442,0 16px 34px rgba(0,0,0,0.7);--pull-progress:0}
+.feed-head{display:flex;justify-content:space-between;align-items:center;padding:2px 4px 10px}
+.feed-app{color:var(--pull-sky);font-size:17px;letter-spacing:2px}
+.feed-status{color:var(--pull-accent);font-size:11px;font-weight:bold;animation:status-blink-mobile-pull-refresh-spinner 1.3s ease-in-out infinite}
+.refresh-zone{height:86px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;background:#10131a;border-radius:14px;overflow:hidden}
+.refresh-track{width:54px;height:54px;border:3px dashed #34445c;border-radius:50%;display:flex;align-items:center;justify-content:center;background:conic-gradient(rgba(79,140,255,0.55) calc(var(--pull-progress,0)*360deg),rgba(255,255,255,0.04) 0)}
+.refresh-spinner{width:34px;height:34px;border-radius:50%;background:conic-gradient(from 0deg,var(--pull-accent),transparent 62%);-webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 5px));mask:radial-gradient(farthest-side,transparent calc(100% - 6px),#000 calc(100% - 5px));transform:rotate(calc(var(--pull-progress,0)*360deg))}
+.refresh-hint{color:#5d6f8c;font-size:10px;letter-spacing:1px;animation:status-blink-mobile-pull-refresh-spinner 1.3s ease-in-out infinite}
+.feed-stack{margin-top:10px;display:flex;flex-direction:column;gap:8px}
+.feed-card{display:flex;align-items:center;gap:10px;padding:9px 10px;background:#1c2230;border-radius:12px;animation:card-shuffle-mobile-pull-refresh-spinner 2.4s ease-in-out infinite}
+.card-avatar{width:34px;height:34px;border-radius:50%;background:linear-gradient(135deg,#6a86d6,#3a4f8a)}
+.av-b{background:linear-gradient(135deg,#e29a5a,#8a5a2b)}
+.av-c{background:linear-gradient(135deg,#5ac2a0,#2b7a5e)}
+.card-copy{flex:1}
+.card-name{display:block;color:#dbe6f5;font-size:12px}
+.card-note{color:#5d6f8c;font-size:10px;margin-top:2px}
+.card-b{animation-delay:0.3s}
+.card-c{animation-delay:0.6s}
+.feed-foot{display:flex;justify-content:space-between;padding:11px 4px 0;color:#5d6f8c;font-size:11px}
+.feed-count{color:var(--pull-accent);font-weight:bold;animation:status-blink-mobile-pull-refresh-spinner 1.3s ease-in-out infinite}
+@keyframes status-blink-mobile-pull-refresh-spinner{0%,100%{opacity:1}50%{opacity:0.35}}
+@keyframes card-shuffle-mobile-pull-refresh-spinner{0%,85%{opacity:1;transform:translateY(0)}92%,100%{opacity:0.35;transform:translateY(-4px)}}


### PR DESCRIPTION
## Component: ease-mobile-pull-refresh-spinner — drag down on a mobile page, a spinner rotates against a dashed track while a pull-to-refresh loop rebuilds the feed

**Closes #60123**

### What this adds
A mobile feed header exposes a pull-to-refresh gesture: a ring spinner rotates against a dashed track in time with the pull, then the stack rebuilds when the pull completes and the feed status blinks.

### Acceptance Criteria covered
- Pull progress is exposed as `--pull-progress` and drives the spinner rotation
- Spinner spins against a dashed track as the gesture loops
- Feed cards shuffle and the status badge blinks at the end of each pull

### Files
- submissions/examples/ease-mobile-pull-refresh-spinner-ij/demo.html
- submissions/examples/ease-mobile-pull-refresh-spinner-ij/style.css
- submissions/examples/ease-mobile-pull-refresh-spinner-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the spinner rotate against the dashed track as the feed cards rebuild.