### PR TITLE
fix: hide tabs-auto underline with proper CSS specificity (closes #60095)

### DIFF
--- a/submissions/docs/fix-tabs-auto-underline-final2/README.md
+++ b/submissions/docs/fix-tabs-auto-underline-final2/README.md
@@ -1,0 +1,16 @@
+# Tabs Auto Variant — Underline Hidden Fix
+
+### 1. What does this do?
+Fixes `.ease-tabs-auto` so the sliding underline is properly hidden with CSS specificity instead of being overridden by transform rules.
+
+### 2. How is it used?
+Add `!important` to increase specificity:
+
+```css
+.ease-tabs-auto .ease-tabs-nav .ease-tab-underline {
+  display: none !important;
+}
+```
+
+### 3. Why is it useful?
+The transform rules have higher specificity and include `display: block` through the shorthand. Without `!important`, the `display: none` rule gets overridden.

--- a/submissions/docs/fix-tabs-auto-underline-final2/demo.html
+++ b/submissions/docs/fix-tabs-auto-underline-final2/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tabs Auto — Underline Hidden Fix</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Tabs Auto Variant — Underline Hidden Fix</h1>
+  <p>The sliding underline should be hidden when using <code>ease-tabs-auto</code>.</p>
+  <div class="ease-tabs ease-tabs-auto">
+    <div class="ease-tabs-nav">
+      <label class="ease-tab">
+        <input type="radio" name="tab" class="ease-tab-input" checked>
+        <span class="ease-tab-label">Home</span>
+      </label>
+      <label class="ease-tab">
+        <input type="radio" name="tab" class="ease-tab-input">
+        <span class="ease-tab-label">About</span>
+      </label>
+    </div>
+    <div class="ease-tabs-content">
+      <div class="ease-tab-panel"><h3>Home Content</h3></div>
+      <div class="ease-tab-panel"><h3>About Content</h3></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/docs/fix-tabs-auto-underline-final2/style.css
+++ b/submissions/docs/fix-tabs-auto-underline-final2/style.css
@@ -1,0 +1,16 @@
+/* Fix: ease-tabs-auto underline hidden */
+.ease-tabs-auto .ease-tabs-nav .ease-tab-underline {
+  display: none !important;
+}
+/* Base demo styles */
+body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #eee; padding: 2rem; }
+h1 { color: #fff; }
+.ease-tabs { margin: 2rem 0; }
+.ease-tab-label { padding: 0.75rem 1.5rem; cursor: pointer; border-bottom: 2px solid #444; display: block; }
+.ease-tab-input:checked + .ease-tab-label { border-bottom-color: #6366f1; }
+.ease-tabs-nav { display: flex; gap: 0.5rem; }
+.ease-tab-panel { padding: 1.5rem 0; display: none; }
+.ease-tabs-content { border-top: 1px solid #333; }
+.ease-tab { cursor: pointer; }
+.ease-tab-input { display: none; }
+.ease-tab-input:checked ~ .ease-tabs-content .ease-tab-panel { display: block; }


### PR DESCRIPTION
## Summary

Fixes the CSS specificity issue where `.ease-tabs-auto` variant does not properly hide the sliding underline.

## Issue
Closes #60095

## Problem
The `.ease-tabs-auto` variant does not properly hide the sliding underline because the CSS rule for hiding it has lower specificity than the transform rules.

## Solution
Increase specificity with `!important`:
```css
.ease-tabs-auto .ease-tabs-nav .ease-tab-underline {
  display: none !important;
}
```

## Files
- `submissions/docs/fix-tabs-auto-underline-final2/demo.html`
- `submissions/docs/fix-tabs-auto-underline-final2/style.css`
- `submissions/docs/fix-tabs-auto-underline-final2/README.md`