### PR TITLE
Add ease-neon-sign-buzzing component

### DIFF
--- a/submissions/examples/ease-neon-sign-buzzing-ij/README.md
+++ b/submissions/examples/ease-neon-sign-buzzing-ij/README.md
@@ -1,0 +1,7 @@
+# ease-neon-sign-buzzing
+A bar window sign with pink neon OPEN tubes that buzz and flicker over two transformer boxes.
+## Run
+Open `demo.html` directly in a browser to watch the tubes flicker.
+## Notes
+- Each letter flickers on its own delayed beat.
+- The transformer cores blink while the sign hums.

--- a/submissions/examples/ease-neon-sign-buzzing-ij/demo.html
+++ b/submissions/examples/ease-neon-sign-buzzing-ij/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.2">
+<title>Neon Sign Buzzing</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="neon-bar">
+  <header class="bar-head">
+    <h1 class="bar-name">MIDNIGHT LOUNGE</h1>
+    <p class="bar-mains">120V</p>
+  </header>
+  <section class="bar-sign" aria-label="Neon sign">
+    <div class="sign-frame">
+      <span class="tube tube-o">O</span>
+      <span class="tube tube-p">P</span>
+      <span class="tube tube-e">E</span>
+      <span class="tube tube-n">N</span>
+      <span class="tube tube-dot"></span>
+    </div>
+    <div class="transformer box-a"></div>
+    <div class="transformer box-b"></div>
+  </section>
+  <footer class="bar-foot">
+    <span class="bar-hum">HUM 60Hz</span>
+    <span class="bar-watt">WATT 240</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-neon-sign-buzzing-ij/style.css
+++ b/submissions/examples/ease-neon-sign-buzzing-ij/style.css
@@ -1,0 +1,25 @@
+:root{
+--neon-pink:#ff4fb0;
+--neon-night:#0a0710;
+--neon-ash:#9a8fb0;
+}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(312,30%,12%),hsl(320,40%,4%));font-family:'Arial Narrow',sans-serif}
+.neon-bar{width:360px;padding:16px;border-radius:16px;background:var(--neon-night);box-shadow:0 0 0 3px #2a1f33,0 14px 34px rgba(0,0,0,0.8)}
+.bar-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 4px 11px}
+.bar-name{color:#d9cce8;font-size:16px;letter-spacing:2px}
+.bar-mains{color:var(--neon-ash);font-size:12px;font-weight:bold}
+.bar-sign{position:relative;height:172px;background:#120d1c;border-radius:14px;overflow:hidden}
+.sign-frame{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);display:flex;align-items:center;gap:6px}
+.tube{font-size:46px;font-weight:bold;font-family:'Arial Black',sans-serif;color:transparent;-webkit-text-stroke:1px var(--neon-pink);text-shadow:0 0 8px rgba(255,79,176,0.9),0 0 22px rgba(255,79,176,0.55);animation:buzz-flicker-neon-sign-buzzing 0.9s steps(2,end) infinite}
+.tube-dot{width:14px;height:14px;border-radius:50%;background:var(--neon-pink);box-shadow:0 0 10px var(--neon-pink);animation:buzz-flicker-neon-sign-buzzing 0.7s steps(2,end) infinite}
+.tube-p{animation-delay:0.15s}
+.tube-e{animation-delay:0.3s}
+.tube-n{animation-delay:0.45s}
+.transformer{position:absolute;bottom:18px;width:58px;height:34px;border-radius:8px;background:linear-gradient(180deg,#2a2038,#160e22);box-shadow:inset 0 0 0 3px #241a30}
+.box-a{left:18px}
+.box-b{right:18px}
+.transformer::after{content:"";position:absolute;left:50%;top:50%;width:16px;height:16px;margin:-8px 0 0 -8px;border-radius:50%;background:radial-gradient(circle,#ffd23f,#7a4a10);animation:buzz-flicker-neon-sign-buzzing 1.4s ease-in-out infinite}
+.bar-foot{display:flex;justify-content:space-between;padding:12px 3px 0;color:#9a8fb0;font-size:12px}
+.bar-watt{color:var(--neon-pink);font-weight:bold;animation:buzz-flicker-neon-sign-buzzing 0.9s steps(2,end) infinite}
+@keyframes buzz-flicker-neon-sign-buzzing{0%,30%{opacity:1}35%{opacity:0.5}40%{opacity:1}58%{opacity:1}62%{opacity:0.35}66%,100%{opacity:1}}


### PR DESCRIPTION
## Component: ease-neon-sign-buzzing — pink OPEN tubes, two transformers, and a buzzing flicker

**Closes #60128**

### What this adds
A bar window sign with pink neon tubes spelling OPEN, a glowing dot, two transformer boxes wired beneath, and a 60Hz buzz that makes the tubes flicker unevenly.

### Acceptance Criteria covered
- OPEN tubes buzz and flicker at uneven intervals
- The glowing dot pulses at its own faster beat
- Transformer cores blink while the WATT badge hums

### Files
- submissions/examples/ease-neon-sign-buzzing-ij/demo.html
- submissions/examples/ease-neon-sign-buzzing-ij/style.css
- submissions/examples/ease-neon-sign-buzzing-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the neon tubes flicker above the transformer boxes.