### PR TITLE
feat(css): CSS Mask Reveal Transition Utilities (#59857)

### DIFF
--- a/submissions/examples/mask-transitions/README.md
+++ b/submissions/examples/mask-transitions/README.md
@@ -1,0 +1,12 @@
+# CSS Mask Reveal Transition Utilities
+
+Resolves Issue #59857.
+
+This submission introduces modern CSS mask-image utilities that allow elements (like images or cards) to be smoothly revealed using animated masking geometry.
+
+## Implementation Details
+- **`style.css`**: Defines `.ease-mask-circle-reveal` (reveals the element by expanding a radial-gradient mask from the center out via `mask-size`) and `.ease-mask-wipe` (reveals the element by sliding a linear-gradient mask across the element via `mask-position`). Both utilities properly include the `-webkit-` vendor prefix for cross-browser compatibility (e.g., Safari/Chrome).
+- **`demo.html`**: A clean gallery demonstration showcasing both the circle expansion and linear wipe transitions revealing high-quality images on hover.
+
+## Integration
+Once the core directory contribution freeze is lifted, these utilities can be securely integrated into `utilities/mask-transition.css`.

--- a/submissions/examples/mask-transitions/demo.html
+++ b/submissions/examples/mask-transitions/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Mask Reveal Utilities</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: #111;
+      color: #fff;
+    }
+
+    .demo-header {
+      text-align: center;
+      padding: 4rem 2rem;
+    }
+
+    .demo-header p {
+      opacity: 0.7;
+    }
+
+    .container {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4rem;
+      justify-content: center;
+      padding: 2rem;
+    }
+
+    .card-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    /* We need a wrapper to give context to the masked image, 
+       often providing a solid background or border behind it */
+    .image-wrapper {
+      width: 300px;
+      height: 300px;
+      border-radius: 12px;
+      background: #333;
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: crosshair;
+    }
+
+    .image-wrapper img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+  </style>
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>Mask Reveal Transitions</h1>
+    <p>Hover over the placeholders below to reveal the images smoothly.</p>
+  </header>
+
+  <main class="container">
+    
+    <div class="card-container">
+      <h3>Circle Reveal</h3>
+      <div class="image-wrapper">
+        <!-- The class is applied directly to the image -->
+        <img src="https://images.unsplash.com/photo-1707343843437-caacff5cfa74?q=80&w=800&auto=format&fit=crop" alt="Abstract Nature" class="ease-mask-circle-reveal">
+      </div>
+      <p>Hover to expand from center</p>
+    </div>
+
+    <div class="card-container">
+      <h3>Wipe Reveal</h3>
+      <div class="image-wrapper">
+        <img src="https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?q=80&w=800&auto=format&fit=crop" alt="Abstract Landscape" class="ease-mask-wipe">
+      </div>
+      <p>Hover to wipe left-to-right</p>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/mask-transitions/style.css
+++ b/submissions/examples/mask-transitions/style.css
@@ -1,0 +1,70 @@
+/* 
+  CSS Mask Reveal Transition Utilities
+  Provides modern mask-image based reveal effects for images, cards, and containers.
+*/
+
+:root {
+  --ease-mask-duration: 0.8s;
+  --ease-mask-timing: cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* 
+  1. Circle Reveal 
+  Uses a radial gradient that expands from the center out. 
+*/
+.ease-mask-circle-reveal {
+  /* Create a radial mask that is a small circle */
+  -webkit-mask-image: radial-gradient(circle, black 100%, transparent 100%);
+  mask-image: radial-gradient(circle, black 100%, transparent 100%);
+  
+  /* Start with a mask size of 0% so the element is hidden */
+  -webkit-mask-size: 0% 0%;
+  mask-size: 0% 0%;
+  
+  /* Position it perfectly in the center */
+  -webkit-mask-position: center;
+  mask-position: center;
+  
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  
+  transition: 
+    -webkit-mask-size var(--ease-mask-duration) var(--ease-mask-timing),
+    mask-size var(--ease-mask-duration) var(--ease-mask-timing);
+}
+
+.ease-mask-circle-reveal:hover,
+.ease-mask-circle-reveal.is-revealed {
+  /* Expand the mask size enough to cover the entire container (e.g. 200% width/height for safety on rectangles) */
+  -webkit-mask-size: 200% 200%;
+  mask-size: 200% 200%;
+}
+
+/* 
+  2. Wipe Reveal (Left to Right)
+  Uses a linear gradient that is twice the size of the container and slides across.
+*/
+.ease-mask-wipe {
+  /* Create a linear gradient that is 50% black, 50% transparent */
+  -webkit-mask-image: linear-gradient(to right, black 50%, transparent 50%);
+  mask-image: linear-gradient(to right, black 50%, transparent 50%);
+  
+  /* Make the mask twice as wide as the element */
+  -webkit-mask-size: 200% 100%;
+  mask-size: 200% 100%;
+  
+  /* Start positioned to the far left (transparent part is over the element) */
+  -webkit-mask-position: 100% 0;
+  mask-position: 100% 0;
+  
+  transition: 
+    -webkit-mask-position var(--ease-mask-duration) var(--ease-mask-timing),
+    mask-position var(--ease-mask-duration) var(--ease-mask-timing);
+}
+
+.ease-mask-wipe:hover,
+.ease-mask-wipe.is-revealed {
+  /* Slide the mask to the right (black part is now over the element) */
+  -webkit-mask-position: 0 0;
+  mask-position: 0 0;
+}


### PR DESCRIPTION
## Description
Resolves #59857

This PR introduces modern image and container reveal utilities leveraging the CSS `mask-image` property, enabling highly performant geometric masking transitions.

Due to the ongoing core directory freeze, this proposal and its demonstration have been placed in `submissions/examples/mask-transitions/`.

## Implementation Details
- **`style.css`**: Defines `.ease-mask-circle-reveal` (which reveals the element by expanding a `radial-gradient` mask from the center outward by transitioning `mask-size`) and `.ease-mask-wipe` (which reveals the element by sliding a `linear-gradient` mask across the element by transitioning `mask-position`). It ensures broad cross-browser compatibility by explicitly including the `-webkit-mask-image` prefix.
- **`demo.html`**: A fully responsive gallery demonstration showcasing both the circle expansion and linear wipe transitions elegantly revealing images on hover.

## Checklist
- [x] Placed in the `submissions/examples/mask-transitions/` directory
- [x] Single commit
- [x] Proper file structure (`demo.html`, `style.css`, `README.md`)
- [x] Built with pure CSS
- [x] No direct modifications to core files (respecting the contribution freeze)