### PR TITLE
Add ease-elevator-doors-open component

### DIFF
--- a/submissions/examples/ease-elevator-doors-open-ij/README.md
+++ b/submissions/examples/ease-elevator-doors-open-ij/README.md
@@ -1,0 +1,7 @@
+# ease-elevator-doors-open
+An elevator car with a glowing floor readout, call buttons, and sliding doors that part at each stop.
+## Run
+Open `demo.html` directly in a browser to watch the doors part.
+## Notes
+- The two doors slide apart and close on every stop.
+- The floor readout rolls as the doors move.

--- a/submissions/examples/ease-elevator-doors-open-ij/demo.html
+++ b/submissions/examples/ease-elevator-doors-open-ij/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.4">
+<title>Elevator Doors Open</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="lift-shaft">
+  <header class="lift-head">
+    <h1 class="lift-label">TOWER B</h1>
+    <p class="lift-floor">LEVEL 4</p>
+  </header>
+  <section class="lift-cab" aria-label="Elevator cabin">
+    <div class="lift-indicator"><span class="floor-readout">4</span></div>
+    <div class="lift-panel">
+      <button class="call up-call" type="button">UP</button>
+      <button class="call down-call" type="button">DN</button>
+    </div>
+    <div class="door-tracks">
+      <span class="door door-left"></span>
+      <span class="door door-right"></span>
+    </div>
+  </section>
+  <footer class="lift-foot">
+    <span class="lift-capacity">CAP 8</span>
+    <span class="lift-door">DOOR</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-elevator-doors-open-ij/style.css
+++ b/submissions/examples/ease-elevator-doors-open-ij/style.css
@@ -1,0 +1,29 @@
+:root{
+--lift-steel:#b9c2cc;
+--lift-slate:#232a33;
+--lift-panel:#2f7d4f;
+}
+*,*::before,*::after{box-sizing:border-box;padding:0;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 25%,hsl(210,22%,16%),hsl(220,28%,6%));font-family:Arial,sans-serif}
+.lift-shaft{width:330px;padding:16px;border-radius:16px;background:var(--lift-slate);box-shadow:0 0 0 3px #38424d,0 14px 34px rgba(0,0,0,0.7)}
+.lift-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 5px 12px}
+.lift-label{color:var(--lift-steel);font-size:18px;letter-spacing:3px}
+.lift-floor{color:#7fd88f;font-size:12px;font-weight:bold;animation:level-blink-elevator-doors-open 2s ease-in-out infinite}
+.lift-cab{position:relative;height:230px;background:linear-gradient(180deg,#2c3440,#1a1f26);border-radius:12px;overflow:hidden}
+.lift-indicator{position:absolute;left:50%;top:14px;margin-left:-30px;width:60px;height:34px;background:#0e1418;border-radius:8px;display:flex;align-items:center;justify-content:center;box-shadow:inset 0 0 0 3px #333b44}
+.floor-readout{color:#7fd88f;font-size:20px;font-weight:bold;animation:floor-roll-elevator-doors-open 5s steps(2,end) infinite}
+.lift-panel{position:absolute;right:14px;top:58px;display:flex;flex-direction:column;gap:8px}
+.call{width:44px;height:26px;border:none;border-radius:6px;font-size:10px;font-weight:bold;font-family:inherit;color:#0c1013}
+.up-call{background:#8a3a2c}
+.down-call{background:var(--lift-panel);animation:panel-pulse-elevator-doors-open 2s ease-in-out infinite}
+.door-tracks{position:absolute;left:26px;right:26px;top:58px;bottom:26px;background:#0c1013;border-radius:10px;box-shadow:inset 0 0 0 4px #2c3440;overflow:hidden}
+.door{position:absolute;top:0;bottom:0;width:50%;background:linear-gradient(180deg,#b9c2cc,#6e7883);box-shadow:inset 0 0 0 4px #8a939c}
+.door-left{left:0;border-right:2px solid #232a33;animation:door-open-left-elevator-doors-open 5s ease-in-out infinite}
+.door-right{right:0;border-left:2px solid #232a33;animation:door-open-right-elevator-doors-open 5s ease-in-out infinite}
+.lift-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#8a97a6;font-size:12px}
+.lift-door{color:#7fd88f;font-weight:bold;animation:level-blink-elevator-doors-open 2s ease-in-out infinite}
+@keyframes door-open-left-elevator-doors-open{0%,35%,100%{transform:translateX(0)}52%,70%{transform:translateX(-46%)}}
+@keyframes door-open-right-elevator-doors-open{0%,35%,100%{transform:translateX(0)}52%,70%{transform:translateX(46%)}}
+@keyframes floor-roll-elevator-doors-open{0%,35%,100%{opacity:1}52%,70%{opacity:0.3}}
+@keyframes panel-pulse-elevator-doors-open{0%,35%,100%{box-shadow:0 0 0 rgba(47,125,79,0)}50%{box-shadow:0 0 12px rgba(47,125,79,0.8)}}
+@keyframes level-blink-elevator-doors-open{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-elevator-doors-open — sliding car doors, floor readout, and call buttons

**Closes #60137**

### What this adds
An elevator car with a glowing floor readout, UP and DN call buttons, and two sliding doors that part at each stop and let the cabin interior show through.

### Acceptance Criteria covered
- Doors slide apart and close again on every stop
- Floor readout rolls from level to level
- The DN call button pulses as the level badge blinks

### Files
- submissions/examples/ease-elevator-doors-open-ij/demo.html
- submissions/examples/ease-elevator-doors-open-ij/style.css
- submissions/examples/ease-elevator-doors-open-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the doors part to reveal the cabin between stops.