### PR TITLE
Add ease-jack-in-box-pop component

### DIFF
--- a/submissions/examples/ease-jack-in-box-pop-ij/README.md
+++ b/submissions/examples/ease-jack-in-box-pop-ij/README.md
@@ -1,0 +1,7 @@
+# ease-jack-in-box-pop
+A striped jack-in-the-box with a winding crank, a popping lid, and a jester that springs up.
+## Run
+Open `demo.html` directly in a browser to watch the jester pop.
+## Notes
+- The crank winds before the lid pops open.
+- Music notes float beside the box after the pop.

--- a/submissions/examples/ease-jack-in-box-pop-ij/demo.html
+++ b/submissions/examples/ease-jack-in-box-pop-ij/demo.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.9">
+<title>Jack In Box Pop</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="jackbox">
+  <header class="jack-head">
+    <h1 class="jack-title">SURPRISE</h1>
+    <p class="jack-tune">TUNE 8</p>
+  </header>
+  <section class="jack-scene" aria-label="Jack in the box">
+    <div class="jack-box">
+      <span class="box-stripe stripe-a"></span>
+      <span class="box-stripe stripe-b"></span>
+      <span class="box-stripe stripe-c"></span>
+      <span class="box-stripe stripe-d"></span>
+      <span class="box-lid"></span>
+      <span class="box-crank"></span>
+    </div>
+    <div class="jack-pop">
+      <span class="jester-head"></span>
+      <span class="jester-body"></span>
+      <span class="jester-ear ear-l"></span>
+      <span class="jester-ear ear-r"></span>
+    </div>
+    <span class="music-note note-1">&#9834;</span>
+    <span class="music-note note-2">&#9835;</span>
+  </section>
+  <footer class="jack-foot">
+    <span class="jack-wind">WIND 12</span>
+    <span class="jack-popbadge">POP</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-jack-in-box-pop-ij/style.css
+++ b/submissions/examples/ease-jack-in-box-pop-ij/style.css
@@ -1,0 +1,36 @@
+:root{
+--jack-purple:#5a3aa8;
+--jack-gold:#f0c23a;
+--jack-cardboard:#b0864a;
+}
+*::before,*::after,*{padding:0;box-sizing:border-box;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 40%,hsl(262,26%,16%),hsl(275,30%,6%));font-family:Impact,sans-serif}
+.jackbox{width:340px;padding:16px;border-radius:16px;background:#1e1a2e;box-shadow:0 0 0 3px #3a3150,0 14px 34px rgba(0,0,0,0.7)}
+.jack-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 5px 11px}
+.jack-title{color:var(--jack-gold);font-size:18px;letter-spacing:4px}
+.jack-tune{color:#c9b6f0;font-size:12px;font-weight:bold;animation:tune-tap-jack-in-box-pop 1.2s ease-in-out infinite}
+.jack-scene{position:relative;height:210px;background:linear-gradient(180deg,#241d38,#141021);border-radius:12px;overflow:hidden}
+.jack-box{position:absolute;left:50%;top:120px;width:150px;height:70px;margin-left:-75px;border-radius:8px;background:repeating-linear-gradient(90deg,#5a3aa8 0 18px,#7a5ac8 18px 36px);box-shadow:0 6px 14px rgba(0,0,0,0.5)}
+.box-stripe{position:absolute;top:0;bottom:0;width:4px;background:#2a1e48}
+.stripe-a{left:26px}
+.stripe-b{left:62px}
+.stripe-c{left:98px}
+.stripe-d{left:122px}
+.box-lid{position:absolute;left:-8px;right:-8px;top:-10px;height:18px;background:linear-gradient(180deg,#c9a24a,#8a6a28);border-radius:8px;transform-origin:50% 100%;animation:lid-pop-jack-in-box-pop 5s ease-in-out infinite}
+.box-crank{position:absolute;left:50%;top:-30px;width:26px;height:30px;margin-left:-13px;border-radius:8px 8px 4px 4px;background:linear-gradient(180deg,#f0c23a,#b08a1e);transform-origin:50% 100%;animation:crank-turn-jack-in-box-pop 5s ease-in-out infinite}
+.jack-pop{position:absolute;left:50%;top:88px;width:70px;height:70px;margin-left:-35px;transform-origin:50% 100%;animation:jester-pop-jack-in-box-pop 5s ease-in-out infinite}
+.jester-head{position:absolute;left:50%;top:0;width:46px;height:46px;margin-left:-23px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#f0e6d0,#d8c8a0)}
+.jester-body{position:absolute;left:50%;top:44px;width:44px;height:30px;margin-left:-22px;border-radius:8px;background:repeating-linear-gradient(90deg,#5a3aa8 0 8px,#f0c23a 8px 16px)}
+.jester-ear{position:absolute;top:6px;width:14px;height:26px;border-radius:50%;background:var(--jack-purple)}
+.ear-l{left:2px;transform:rotate(14deg)}
+.ear-r{right:2px;transform:rotate(-14deg)}
+.music-note{position:absolute;font-size:22px;color:var(--jack-gold);opacity:0}
+.note-1{left:70px;top:34px;animation:note-float-jack-in-box-pop 5s ease-in-out infinite}
+.note-2{right:64px;top:60px;animation:note-float-jack-in-box-pop 5s ease-in-out infinite 0.4s}
+.jack-foot{display:flex;justify-content:space-between;padding:12px 3px 0;color:#a0998a;font-size:12px}
+.jack-popbadge{color:var(--jack-gold);font-weight:bold;animation:tune-tap-jack-in-box-pop 1.2s ease-in-out infinite}
+@keyframes crank-turn-jack-in-box-pop{0%,18%{transform:rotate(0deg)}30%,42%{transform:rotate(90deg)}56%,100%{transform:rotate(180deg)}}
+@keyframes lid-pop-jack-in-box-pop{0%,40%{transform:rotate(0deg)}48%,100%{transform:rotate(-70deg)}}
+@keyframes jester-pop-jack-in-box-pop{0%,42%{transform:scaleY(0.1);opacity:0}50%,100%{transform:scaleY(1);opacity:1}}
+@keyframes note-float-jack-in-box-pop{0%,42%{opacity:0;transform:translateY(10px)}55%{opacity:1;transform:translateY(-14px)}75%,100%{opacity:0;transform:translateY(-26px)}}
+@keyframes tune-tap-jack-in-box-pop{0%,100%{transform:scale(1)}50%{transform:scale(1.1)}}


### PR DESCRIPTION
## Component: ease-jack-in-box-pop — crank handle, popping lid, and a jester that springs

**Closes #60151**

### What this adds
A striped jack-in-the-box with a crank that winds, a lid that pops open, a jester head and body that spring up on the surge, and two music notes that float beside the box.

### Acceptance Criteria covered
- Crank winds before the lid pops
- Jester springs up from the box on each turn
- Music notes float away while the POP badge taps

### Files
- submissions/examples/ease-jack-in-box-pop-ij/demo.html
- submissions/examples/ease-jack-in-box-pop-ij/style.css
- submissions/examples/ease-jack-in-box-pop-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the lid pop and the jester spring up after the crank winds.