### PR TITLE
Add visible keyboard focus styles for magnetic buttons

### DIFF
--- a/submissions/examples/magnetic-btn-focus-visible/README.md
+++ b/submissions/examples/magnetic-btn-focus-visible/README.md
@@ -1,0 +1,34 @@
+\# Magnetic Button — Visible Keyboard Focus State
+
+
+
+\## What does this add?
+
+A visible keyboard focus indicator for `.ease-btn-magnetic`, using `:focus-visible` so the outline only appears for keyboard navigation and not on mouse clicks.
+
+
+
+\## How does a developer use it?
+
+
+
+```html
+
+<button class="ease-btn-magnetic">
+
+&#x20; Magnetic Button
+
+</button>
+
+```
+
+
+
+No extra class is needed — the focus style is applied automatically via `:focus-visible` on the existing `.ease-btn-magnetic` class.
+
+
+
+\## Why does it fit EaseMotion CSS?
+
+This improves accessibility for keyboard users while preserving EaseMotion CSS's animation-first, human-readable philosophy. It does not affect the existing magnetic hover animation or `prefers-reduced-motion` behavior.
+

--- a/submissions/examples/magnetic-btn-focus-visible/demo.html
+++ b/submissions/examples/magnetic-btn-focus-visible/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Magnetic Button — Focus Visible Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    font-family: sans-serif;
+    max-width: 600px;
+    margin: 3rem auto;
+    background: #0f172a;
+    color: #fff;
+    padding: 1rem;
+  }
+  p { color: #94a3b8; font-size: 0.9rem; }
+</style>
+</head>
+<body>
+  <h2>Magnetic Button — Keyboard Focus Demo</h2>
+  <p>Press Tab to focus the buttons below and see the visible outline.</p>
+
+  <button class="ease-btn-magnetic">Magnetic Button</button>
+  <button class="ease-btn-magnetic">Another Button</button>
+
+</body>
+</html>

--- a/submissions/examples/magnetic-btn-focus-visible/style.css
+++ b/submissions/examples/magnetic-btn-focus-visible/style.css
@@ -1,0 +1,29 @@
+/* Magnetic Button — Visible Keyboard Focus State */
+.ease-btn-magnetic {
+  display: inline-block;
+  padding: 0.6rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--ease-color-primary, #6c63ff);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-btn-magnetic:hover {
+  box-shadow: 0 6px 16px rgba(108, 99, 255, 0.35);
+}
+
+/* Visible keyboard focus indicator (does not affect mouse click) */
+.ease-btn-magnetic:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn-magnetic {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a visible `:focus-visible` outline for `.ease-btn-magnetic` to improve keyboard accessibility, without affecting the existing magnetic hover animation.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below) — Accessibility enhancement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (submissions/examples/magnetic-btn-focus-visible/)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A visible keyboard focus indicator for `.ease-btn-magnetic`, using `:focus-visible` so it only appears for keyboard navigation, not mouse clicks.

**How does a developer use it?**

```html
<button class="ease-btn-magnetic">
  Magnetic Button
</button>
```

**Why does it fit EaseMotion CSS?**

Improves accessibility for keyboard users while preserving the animation-first philosophy. Does not affect the existing magnetic hover animation or `prefers-reduced-motion` behavior.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer

Fixes #59922. Implemented exactly as specified in the issue using `:focus-visible` with `outline` and `outline-offset`.