### PR TITLE
Add ease-rocket-launch-sequence component

### DIFF
--- a/submissions/examples/ease-rocket-launch-sequence-ij/README.md
+++ b/submissions/examples/ease-rocket-launch-sequence-ij/README.md
@@ -1,0 +1,7 @@
+# ease-rocket-launch-sequence
+A launch pad with a striped gantry, a silver rocket, a growing flame plume, and smoke clouds.
+## Run
+Open `demo.html` directly in a browser to watch the rocket rise.
+## Notes
+- The gantry arms release as the rocket lifts off.
+- The flame plume flickers and grows beneath the rocket.

--- a/submissions/examples/ease-rocket-launch-sequence-ij/demo.html
+++ b/submissions/examples/ease-rocket-launch-sequence-ij/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=2.0">
+<title>Rocket Launch Sequence</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="launch-pad">
+  <header class="rocket-head">
+    <h1 class="rocket-mission">APOLLO 9</h1>
+    <p class="rocket-alt">ALT 0</p>
+  </header>
+  <section class="rocket-scene" aria-label="Rocket on the launch pad">
+    <div class="gantry">
+      <span class="gantry-arm arm-l"></span>
+      <span class="gantry-arm arm-r"></span>
+    </div>
+    <div class="rocket">
+      <span class="rocket-nose"></span>
+      <span class="rocket-body"></span>
+      <span class="rocket-window"></span>
+      <span class="rocket-fin fin-l"></span>
+      <span class="rocket-fin fin-r"></span>
+      <div class="flame">
+        <span class="flame-core"></span>
+        <span class="flame-outer"></span>
+      </div>
+    </div>
+    <div class="pad-base">
+      <span class="pad-leg leg-1"></span>
+      <span class="pad-leg leg-2"></span>
+      <span class="pad-leg leg-3"></span>
+    </div>
+    <div class="smoke-cloud smoke-a"></div>
+    <div class="smoke-cloud smoke-b"></div>
+  </section>
+  <footer class="rocket-foot">
+    <span class="rocket-stage">STAGE 1</span>
+    <span class="rocket-go">GO</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-rocket-launch-sequence-ij/style.css
+++ b/submissions/examples/ease-rocket-launch-sequence-ij/style.css
@@ -1,0 +1,41 @@
+:root{
+--rocket-silver:#e6eaef;
+--rocket-flame:#ff8a2a;
+--rocket-night:#0f1320;
+}
+*::before,*::after,*{box-sizing:border-box;padding:0;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 25%,hsl(228,30%,13%),hsl(240,35%,4%));font-family:'Lucida Console',monospace}
+.launch-pad{width:374px;padding:16px;border-radius:16px;background:var(--rocket-night);box-shadow:0 0 0 3px #2a3344,0 14px 34px rgba(0,0,0,0.7)}
+.rocket-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.rocket-mission{color:var(--rocket-silver);font-size:18px;letter-spacing:3px}
+.rocket-alt{color:#7fd88f;font-size:12px;font-weight:bold;animation:alt-blink-rocket-launch-sequence 1.4s ease-in-out infinite}
+.rocket-scene{position:relative;height:260px;background:linear-gradient(180deg,#111726,#0a0e17 70%,#23303f);border-radius:12px;overflow:hidden}
+.gantry{position:absolute;left:50%;top:40px;width:200px;height:120px;margin-left:-100px}
+.gantry-arm{position:absolute;top:90px;width:70px;height:10px;background:linear-gradient(180deg,#5b6a80,#39465a);border-radius:5px;transform-origin:50% 50%;animation:arm-release-rocket-launch-sequence 5s ease-in-out infinite}
+.arm-l{right:50%;margin-right:16px}
+.arm-r{left:50%;margin-left:16px}
+.rocket{position:absolute;left:50%;top:36px;width:66px;height:170px;margin-left:-33px;animation:rocket-rise-rocket-launch-sequence 5s ease-in-out infinite}
+.rocket-nose{position:absolute;left:50%;top:0;width:0;height:0;margin-left:-17px;border-left:17px solid transparent;border-right:17px solid transparent;border-bottom:34px solid #e6eaef}
+.rocket-body{position:absolute;left:50%;top:34px;width:40px;height:100px;margin-left:-20px;background:linear-gradient(90deg,#aeb6c2,#e6eaef 40%,#8a939f);border-radius:6px 6px 10px 10px}
+.rocket-window{position:absolute;left:50%;top:52px;width:16px;height:16px;margin-left:-8px;border-radius:50%;background:radial-gradient(circle,#7fc8ff,#2a5a8a);box-shadow:0 0 8px rgba(127,200,255,0.8)}
+.rocket-fin{position:absolute;top:118px;width:22px;height:34px;background:linear-gradient(180deg,#e6eaef,#8a939f)}
+.fin-l{left:6px;clip-path:polygon(0 100%,100% 0,100% 100%)}
+.fin-r{right:6px;clip-path:polygon(0 0,100% 100%,0 100%)}
+.flame{position:absolute;left:50%;top:132px;margin-left:-16px;width:32px;height:34px;transform-origin:50% 0;animation:plume-grow-rocket-launch-sequence 0.25s ease-in-out infinite}
+.flame-core{position:absolute;left:50%;bottom:0;width:14px;height:30px;margin-left:-7px;border-radius:4px 4px 12px 12px;background:linear-gradient(180deg,#fff4c8,#ff8a2a 60%,#e8503a);animation:plume-grow-rocket-launch-sequence 0.25s ease-in-out infinite}
+.flame-outer{position:absolute;left:50%;bottom:0;width:30px;height:22px;margin-left:-15px;border-radius:6px 6px 14px 14px;background:linear-gradient(180deg,#ffd23f,#e8503a);filter:blur(2px)}
+.pad-base{position:absolute;left:50%;bottom:26px;width:120px;height:26px;margin-left:-60px;background:linear-gradient(180deg,#3a4a5c,#232c3a);border-radius:6px}
+.pad-leg{position:absolute;bottom:-10px;width:8px;height:20px;background:#39465a;border-radius:3px}
+.leg-1{left:20px;transform:rotate(14deg)}
+.leg-2{left:56px;top:-18px;height:10px;transform:rotate(0deg)}
+.leg-3{right:20px;transform:rotate(-14deg)}
+.smoke-cloud{position:absolute;left:50%;bottom:0;width:120px;height:30px;border-radius:50%;background:radial-gradient(ellipse,rgba(220,230,240,0.5),rgba(160,180,200,0.15));animation:smoke-puff-rocket-launch-sequence 5s ease-in-out infinite}
+.smoke-a{margin-left:-90px;animation-delay:0.1s}
+.smoke-b{margin-left:-30px;animation-delay:0.3s}
+.rocket-foot{display:flex;justify-content:space-between;padding:11px 3px 0;color:#8a97a6;font-size:12px}
+.rocket-go{color:#7fd88f;font-weight:bold;animation:alt-blink-rocket-launch-sequence 1.4s ease-in-out infinite}
+@keyframes rocket-rise-rocket-launch-sequence{0%,22%{transform:translateY(0)}36%{transform:translateY(-12px)}50%,100%{transform:translateY(-120px)}}
+@keyframes plume-grow-rocket-launch-sequence{0%,100%{transform:scaleY(0.7)}50%{transform:scaleY(1.25)}}
+@keyframes arm-release-rocket-launch-sequence{0%,24%,100%{transform:rotate(0deg)}34%,48%{transform:rotate(28deg)}}
+@keyframes smoke-puff-rocket-launch-sequence{0%,24%,100%{opacity:0.2;transform:scale(0.8)}40%,70%{opacity:0.7;transform:scale(1.2)}}
+@keyframes alt-blink-rocket-launch-sequence{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-rocket-launch-sequence — gantry arms, rising rocket, and growing flame plume

**Closes #60154**

### What this adds
A launch pad with a striped gantry, a silver rocket with nose cone, window, and fins, a flame plume that grows beneath it, and smoke clouds that puff as the rocket climbs.

### Acceptance Criteria covered
- Gantry arms release as the rocket lifts
- Flame plume flickers and grows under the rocket
- Smoke clouds puff while the ALT badge blinks

### Files
- submissions/examples/ease-rocket-launch-sequence-ij/demo.html
- submissions/examples/ease-rocket-launch-sequence-ij/style.css
- submissions/examples/ease-rocket-launch-sequence-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the rocket rise on its flickering flame after the gantry arms release.