### PR TITLE
Add ease-telescope-lens-focus component

### DIFF
--- a/submissions/examples/ease-telescope-lens-focus-ij/README.md
+++ b/submissions/examples/ease-telescope-lens-focus-ij/README.md
@@ -1,0 +1,7 @@
+# ease-telescope-lens-focus
+An optical telescope on a tripod with a rotating focus knob, a lens barrel that racks in and out, and a blinking target reticle.
+## Run
+Open `demo.html` directly in a browser to watch the lens focus.
+## Notes
+- The focus knob spins as the barrel racks toward the target.
+- The AUTO FOCUS badge holds while the reticle blinks.

--- a/submissions/examples/ease-telescope-lens-focus-ij/demo.html
+++ b/submissions/examples/ease-telescope-lens-focus-ij/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.05">
+<title>Telescope Lens Focus</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="scope-rig">
+  <header class="scope-head">
+    <h1 class="scope-model">ORION 4X</h1>
+    <p class="scope-mode">AUTO FOCUS</p>
+  </header>
+  <section class="scope-scene" aria-label="Telescope with lens barrel">
+    <div class="scope-target">
+      <span class="target-ring"></span>
+      <span class="target-cross"></span>
+    </div>
+    <div class="scope-stand">
+      <span class="scope-tripod leg-a"></span>
+      <span class="scope-tripod leg-b"></span>
+      <span class="scope-tripod leg-c"></span>
+    </div>
+    <div class="scope-barrel">
+      <span class="barrel-eyepiece"></span>
+      <span class="barrel-tube"></span>
+      <span class="barrel-lens"></span>
+      <span class="barrel-ring ring-1"></span>
+      <span class="barrel-ring ring-2"></span>
+      <span class="barrel-ring ring-3"></span>
+      <div class="focus-knob"><span class="knob-dial"></span></div>
+    </div>
+  </section>
+  <footer class="scope-foot">
+    <span class="scope-zoom">F/8</span>
+    <span class="scope-lock">LOCK</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-telescope-lens-focus-ij/style.css
+++ b/submissions/examples/ease-telescope-lens-focus-ij/style.css
@@ -1,0 +1,38 @@
+:root{
+--scope-umber:#3d4450;
+--scope-steel:#c6ced6;
+--scope-amber:#ffb01c;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(212,24%,15%),hsl(222,30%,6%));font-family:'Trebuchet MS',sans-serif}
+.scope-rig{width:360px;padding:16px;border-radius:16px;background:#171b22;box-shadow:0 0 0 3px #33404e,0 14px 34px rgba(0,0,0,0.7)}
+.scope-head{display:flex;justify-content:space-between;align-items:center;padding:2px 4px 12px}
+.scope-model{color:var(--scope-steel);font-size:17px;letter-spacing:3px}
+.scope-mode{color:var(--scope-amber);font-size:11px;font-weight:bold;animation:mode-blink-telescope-lens-focus 1.6s ease-in-out infinite}
+.scope-scene{position:relative;height:230px;background:linear-gradient(180deg,#0f1420,#0a0e15 70%,#1c2a38);border-radius:12px;overflow:hidden}
+.scope-target{position:absolute;left:50%;top:26px;width:54px;height:54px;margin-left:-27px;border-radius:50%;border:2px dashed var(--scope-amber);animation:target-blink-telescope-lens-focus 2s ease-in-out infinite}
+.target-ring{position:absolute;inset:8px;border:2px solid rgba(255,176,28,0.5);border-radius:50%}
+.target-cross::before,.target-cross::after{content:"";position:absolute;left:50%;top:50%;background:var(--scope-amber)}
+.target-cross::before{width:44px;height:2px;margin:-1px 0 0 -22px}
+.target-cross::after{width:2px;height:44px;margin:-22px 0 0 -1px}
+.scope-stand{position:absolute;left:50%;bottom:26px;width:176px;height:120px;margin-left:-88px}
+.scope-tripod{position:absolute;top:0;width:8px;height:120px;background:linear-gradient(180deg,#5b6470,#2c3138);border-radius:4px;transform-origin:50% 0}
+.leg-a{left:70px;transform:rotate(0deg)}
+.leg-b{left:18px;transform:rotate(26deg)}
+.leg-c{right:18px;transform:rotate(-26deg)}
+.scope-barrel{position:absolute;left:50%;top:96px;width:240px;height:44px;margin-left:-120px;transform-origin:50% 50%;animation:barrel-slide-telescope-lens-focus 3.6s ease-in-out infinite}
+.barrel-tube{position:absolute;left:30px;right:30px;top:6px;height:32px;border-radius:12px;background:linear-gradient(180deg,#c6ced6,#7a8591);box-shadow:inset 0 0 0 4px #2c3138}
+.barrel-eyepiece{position:absolute;left:2px;top:10px;width:24px;height:24px;border-radius:8px;background:#2c3138}
+.barrel-lens{position:absolute;right:0;top:8px;width:26px;height:28px;border-radius:0 8px 8px 0;background:radial-gradient(circle at 50% 50%,#8fd8ff,#2a5a8a)}
+.barrel-ring{position:absolute;top:0;bottom:0;width:8px;background:#5b6470;border-radius:4px}
+.ring-1{left:60px}
+.ring-2{left:110px}
+.ring-3{left:160px}
+.focus-knob{position:absolute;right:46px;top:-12px;width:34px;height:34px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#ffb01c,#8a5a10);box-shadow:0 3px 6px rgba(0,0,0,0.5);animation:focus-turn-telescope-lens-focus 3.6s ease-in-out infinite}
+.knob-dial{position:absolute;left:50%;top:4px;width:3px;height:10px;margin-left:-1px;background:#2c3138}
+.scope-foot{display:flex;justify-content:space-between;padding:12px 4px 0;color:#8a97a6;font-size:12px}
+.scope-lock{color:var(--scope-amber);font-weight:bold;animation:mode-blink-telescope-lens-focus 1.6s ease-in-out infinite}
+@keyframes focus-turn-telescope-lens-focus{0%,100%{transform:rotate(0deg)}45%{transform:rotate(180deg)}55%{transform:rotate(180deg)}}
+@keyframes barrel-slide-telescope-lens-focus{0%,38%,100%{transform:scaleX(1)}50%,70%{transform:scaleX(1.18)}}
+@keyframes target-blink-telescope-lens-focus{0%,100%{opacity:1}50%{opacity:0.25}}
+@keyframes mode-blink-telescope-lens-focus{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-telescope-lens-focus — focus knob racks the lens barrel, target reticle, and tripod stand

**Closes #60177**

### What this adds
An optical telescope on a tripod: a focus knob that rotates while the lens barrel racks in and out, a star target reticle that blinks over the tube, and an AUTO FOCUS mode badge that holds steady at the top of the card.

### Acceptance Criteria covered
- Focus knob spins and racks the barrel in and out
- Target reticle blinks while the lens stays on aim
- Tripod legs brace the barrel at the aim point

### Files
- submissions/examples/ease-telescope-lens-focus-ij/demo.html
- submissions/examples/ease-telescope-lens-focus-ij/style.css
- submissions/examples/ease-telescope-lens-focus-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the focus knob spin while the lens barrel racks toward the blinking target reticle.