### PR TITLE
Add ease-french-press-coffee component

### DIFF
--- a/submissions/examples/ease-french-press-coffee-ij/README.md
+++ b/submissions/examples/ease-french-press-coffee-ij/README.md
@@ -1,0 +1,7 @@
+# ease-french-press-coffee
+A cafetiere with a mesh plunger that presses the coffee slurry, a scoop of grounds, and steam rising from the lid.
+## Run
+Open `demo.html` directly in a browser to watch the press.
+## Notes
+- The plunger mesh descends and the coffee level settles.
+- Three steam wisps rise after each press.

--- a/submissions/examples/ease-french-press-coffee-ij/demo.html
+++ b/submissions/examples/ease-french-press-coffee-ij/demo.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.15">
+<title>French Press Coffee</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="press-kit">
+  <header class="press-head">
+    <h1 class="press-brand">CAFE PRESS</h1>
+    <p class="press-brew">BREW 4</p>
+  </header>
+  <section class="press-scene" aria-label="French press coffee maker">
+    <div class="press-carafe">
+      <span class="carafe-glass"></span>
+      <span class="carafe-lid"></span>
+      <span class="carafe-knob"></span>
+      <span class="carafe-handle"></span>
+      <span class="carafe-spout"></span>
+      <div class="press-plunger">
+        <span class="plunger-rod"></span>
+        <span class="plunger-mesh"></span>
+      </div>
+      <span class="coffee-slurry"></span>
+    </div>
+    <div class="press-scoop">
+      <span class="scoop-bowl"></span>
+      <span class="scoop-handle"></span>
+    </div>
+    <div class="press-steam">
+      <span class="steam-rise rise-1"></span>
+      <span class="steam-rise rise-2"></span>
+      <span class="steam-rise rise-3"></span>
+    </div>
+  </section>
+  <footer class="press-foot">
+    <span class="press-temp">92C</span>
+    <span class="press-grind">GRIND 6</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-french-press-coffee-ij/style.css
+++ b/submissions/examples/ease-french-press-coffee-ij/style.css
@@ -1,0 +1,36 @@
+:root{
+--press-ivory:#f0e6d0;
+--press-steel:#6e7680;
+--press-amber:#c97b2a;
+}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 35%,hsl(25,22%,16%),hsl(35,28%,6%));font-family:Georgia,serif}
+.press-kit{width:340px;padding:16px;border-radius:16px;background:#241c14;box-shadow:0 0 0 3px #433327,0 14px 34px rgba(0,0,0,0.7)}
+.press-head{display:flex;justify-content:space-between;align-items:baseline;padding:2px 5px 12px}
+.press-brand{color:var(--press-ivory);font-size:18px;letter-spacing:3px}
+.press-brew{color:var(--press-amber);font-size:12px;font-weight:bold;animation:brew-blink-french-press-coffee 1.8s ease-in-out infinite}
+.press-scene{position:relative;height:220px;background:linear-gradient(180deg,#2b231a,#19130d);border-radius:12px;overflow:hidden}
+.press-carafe{position:absolute;left:50%;top:34px;width:120px;height:150px;margin-left:-60px}
+.carafe-glass{position:absolute;left:8px;right:8px;top:6px;bottom:14px;background:linear-gradient(180deg,rgba(240,230,208,0.28),rgba(240,230,208,0.1));border:3px solid #6e7680;border-radius:6px 6px 14px 14px;overflow:hidden}
+.carafe-lid{position:absolute;left:0;right:0;top:0;height:14px;background:linear-gradient(180deg,#7a8591,#4a525b);border-radius:6px 6px 0 0}
+.carafe-knob{position:absolute;left:50%;top:-10px;width:16px;height:14px;margin-left:-8px;border-radius:4px;background:#4a525b}
+.carafe-handle{position:absolute;left:110px;top:36px;width:30px;height:52px;border:6px solid #4a525b;border-left:0;border-radius:0 16px 16px 0}
+.carafe-spout{position:absolute;right:-4px;top:10px;width:20px;height:12px;background:#6e7680;border-radius:0 8px 8px 0;clip-path:polygon(0 0,100% 20%,100% 80%,0 100%)}
+.press-plunger{position:absolute;left:50%;top:12px;width:0;height:0;margin-left:-3px;animation:plunger-press-french-press-coffee 3.6s ease-in-out infinite}
+.plunger-rod{position:absolute;left:50%;top:0;width:6px;height:88px;margin-left:-3px;background:linear-gradient(180deg,#c6ced6,#7a8591);border-radius:3px}
+.plunger-mesh{position:absolute;left:50%;top:84px;width:92px;height:16px;margin-left:-46px;background:repeating-linear-gradient(90deg,#4a525b 0 4px,#6e7680 4px 8px);border:3px solid #4a525b;border-radius:8px}
+.coffee-slurry{position:absolute;left:16px;right:16px;bottom:18px;height:46px;background:linear-gradient(180deg,#3a2412,#241408);border-radius:4px;animation:slurry-swell-french-press-coffee 3.6s ease-in-out infinite}
+.press-scoop{position:absolute;right:18px;top:18px;width:44px;height:30px}
+.scoop-bowl{position:absolute;left:0;bottom:0;width:26px;height:18px;border-radius:4px;background:#4a525b;box-shadow:inset 0 -4px 0 rgba(0,0,0,0.35)}
+.scoop-handle{position:absolute;left:22px;top:6px;width:22px;height:8px;background:#4a525b;border-radius:0 6px 6px 0}
+.press-steam{position:absolute;left:50%;top:8px;width:0;height:0;margin-left:-26px}
+.steam-rise{position:absolute;width:8px;height:8px;border-radius:50%;background:rgba(240,230,208,0.5);filter:blur(2px);animation:steam-rise-french-press-coffee 2.6s ease-out infinite}
+.rise-1{left:0;top:0}
+.rise-2{left:22px;top:0;animation-delay:0.6s}
+.rise-3{left:44px;top:0;animation-delay:1.2s}
+.press-foot{display:flex;justify-content:space-between;padding:11px 4px 0;color:#a89070;font-size:12px}
+.press-grind{color:var(--press-amber);font-weight:bold;animation:brew-blink-french-press-coffee 1.8s ease-in-out infinite}
+@keyframes plunger-press-french-press-coffee{0%,40%,100%{transform:translateY(0)}52%,76%{transform:translateY(40px)}}
+@keyframes slurry-swell-french-press-coffee{0%,40%,100%{height:46px}52%,76%{height:20px}}
+@keyframes steam-rise-french-press-coffee{0%{transform:translateY(0) scale(0.6);opacity:0}30%{opacity:0.9}100%{transform:translateY(-34px) scale(1.5);opacity:0}}
+@keyframes brew-blink-french-press-coffee{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-french-press-coffee — mesh plunger presses, coffee slurry, and rising steam

**Closes #60188**

### What this adds
A cafetiere on a counter: a mesh plunger that presses the coffee slurry down, a scoop of grounds beside the carafe, and three wisps of steam that rise from the open lid after each press.

### Acceptance Criteria covered
- Plunger mesh presses the slurry down on each loop
- Coffee level swells and settles with the plunge
- Steam wisps rise as the BREW badge blinks

### Files
- submissions/examples/ease-french-press-coffee-ij/demo.html
- submissions/examples/ease-french-press-coffee-ij/style.css
- submissions/examples/ease-french-press-coffee-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the plunger press the grounds while steam rises from the carafe.