### PR TITLE
Add ease-airport-control-tower component

### DIFF
--- a/submissions/examples/ease-airport-control-tower-ij/README.md
+++ b/submissions/examples/ease-airport-control-tower-ij/README.md
@@ -1,0 +1,7 @@
+# ease-airport-control-tower
+An airport control tower with a sweeping radar dish, a taxiing plane, and runway lights that blink at the edges.
+## Run
+Open `demo.html` directly in a browser to watch the radar sweep.
+## Notes
+- The radar dish turns above the cab windows.
+- The plane taxis along the runway each loop.

--- a/submissions/examples/ease-airport-control-tower-ij/demo.html
+++ b/submissions/examples/ease-airport-control-tower-ij/demo.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.65">
+<title>Airport Control Tower</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="airport">
+  <header class="airport-head">
+    <h1 class="airport-name">TERMINAL 1</h1>
+    <p class="airport-clear">CLEARANCE</p>
+  </header>
+  <section class="airport-scene" aria-label="Airport control tower and runway">
+    <div class="tower-shaft">
+      <span class="shaft-band band-a"></span>
+      <span class="shaft-band band-b"></span>
+      <span class="shaft-band band-c"></span>
+    </div>
+    <div class="tower-cab">
+      <span class="cab-window cw-1"></span>
+      <span class="cab-window cw-2"></span>
+      <span class="cab-window cw-3"></span>
+      <span class="cab-roof"></span>
+      <div class="radar-dish">
+        <span class="radar-arm"></span>
+        <span class="radar-bowl"></span>
+      </div>
+    </div>
+    <div class="runway">
+      <span class="runway-stripe"></span>
+      <span class="runway-light light-a"></span>
+      <span class="runway-light light-b"></span>
+      <div class="taxi-plane">
+        <span class="plane-body"></span>
+        <span class="plane-wing"></span>
+        <span class="plane-tail"></span>
+      </div>
+    </div>
+  </section>
+  <footer class="airport-foot">
+    <span class="airport-wind">WIND 090</span>
+    <span class="airport-vec">VECTOR</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-airport-control-tower-ij/style.css
+++ b/submissions/examples/ease-airport-control-tower-ij/style.css
@@ -1,0 +1,42 @@
+:root{
+--air-night:#141a24;
+--air-silver:#c6ced6;
+--air-green:#7fd88f;
+}
+*::before,*::after,*{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(220,22%,15%),hsl(230,28%,6%));font-family:'Franklin Gothic Medium',sans-serif}
+.airport{width:390px;padding:16px;border-radius:16px;background:var(--air-night);box-shadow:0 0 0 3px #2e3a4a,0 14px 34px rgba(0,0,0,0.7)}
+.airport-head{display:flex;justify-content:space-between;align-items:center;padding:2px 7px 12px}
+.airport-name{color:var(--air-silver);font-size:18px;letter-spacing:3px}
+.airport-clear{color:var(--air-green);font-size:12px;font-weight:bold;animation:vec-blink-airport-control-tower 1.8s ease-in-out infinite}
+.airport-scene{position:relative;height:230px;background:linear-gradient(180deg,#10141c,#0a0e14 60%,#1e2830);border-radius:12px;overflow:hidden}
+.tower-shaft{position:absolute;left:40px;bottom:0;width:34px;height:160px;background:linear-gradient(90deg,#39465a,#232c38);box-shadow:inset 0 0 0 4px #161d26;border-radius:6px 6px 0 0}
+.shaft-band{position:absolute;left:-4px;right:-4px;height:14px;background:linear-gradient(180deg,#4a5a6e,#2e3a4a);border-radius:4px}
+.band-a{top:20px}
+.band-b{top:60px}
+.band-c{top:100px}
+.tower-cab{position:absolute;left:18px;top:30px;width:78px;height:56px;background:linear-gradient(180deg,#2a3542,#1a222c);border-radius:8px;box-shadow:inset 0 0 0 4px #161d26}
+.cab-window{position:absolute;top:8px;bottom:8px;width:16px;background:linear-gradient(180deg,#7fc8ff,#2a5a8a);border-radius:4px}
+.cw-1{left:8px}
+.cw-2{left:30px;animation:window-blink-airport-control-tower 2.4s ease-in-out infinite}
+.cw-3{left:52px}
+.cab-roof{position:absolute;left:-6px;right:-6px;top:-8px;height:12px;background:linear-gradient(180deg,#4a5a6e,#2e3a4a);border-radius:6px}
+.radar-dish{position:absolute;right:6px;top:8px;width:0;height:0;animation:radar-sweep-airport-control-tower 4s linear infinite;transform-origin:50% 100%}
+.radar-arm{position:absolute;left:16px;top:0;width:40px;height:4px;background:linear-gradient(180deg,#c6ced6,#6e7882);border-radius:2px}
+.radar-bowl{position:absolute;left:14px;top:-2px;width:8px;height:8px;border-radius:50%;background:#c6ced6}
+.runway{position:absolute;left:0;right:0;bottom:0;height:64px;background:linear-gradient(180deg,#1c2430,#12181f);border-top:4px solid #2e3a4a}
+.runway-stripe{position:absolute;left:50%;top:14px;width:6px;height:44px;margin-left:-3px;background:#e8eef4;border-radius:3px;box-shadow:22px 0 0 #e8eef4,-22px 0 0 #e8eef4}
+.runway-light{position:absolute;width:8px;height:8px;border-radius:50%;background:#7fd88f;box-shadow:0 0 8px rgba(127,216,143,0.9);animation:runway-blink-airport-control-tower 1.2s steps(2,end) infinite}
+.light-a{left:70px;bottom:10px}
+.light-b{right:70px;bottom:10px;animation-delay:0.4s}
+.taxi-plane{position:absolute;left:120px;top:6px;width:100px;height:36px;animation:plane-taxi-airport-control-tower 5s ease-in-out infinite}
+.plane-body{position:absolute;left:0;right:0;top:14px;height:14px;border-radius:10px;background:linear-gradient(180deg,#e8eef4,#9aa3ad)}
+.plane-wing{position:absolute;left:14px;top:22px;width:44px;height:8px;background:#c6ced6;border-radius:4px}
+.plane-tail{position:absolute;right:2px;top:6px;width:14px;height:16px;background:#c04a2c;border-radius:3px}
+.airport-foot{display:flex;justify-content:space-between;padding:11px 4px 0;color:#8290a0;font-size:12px}
+.airport-vec{color:var(--air-green);font-weight:bold;animation:vec-blink-airport-control-tower 1.8s ease-in-out infinite}
+@keyframes radar-sweep-airport-control-tower{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes plane-taxi-airport-control-tower{0%,30%,100%{transform:translateX(0)}46%,74%{transform:translateX(70px)}}
+@keyframes runway-blink-airport-control-tower{0%,49%{opacity:1}50%,100%{opacity:0.25}}
+@keyframes window-blink-airport-control-tower{0%,100%{opacity:1}50%{opacity:0.5}}
+@keyframes vec-blink-airport-control-tower{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-airport-control-tower — radar dish sweeps, plane taxis, runway lights blink

**Closes #60232**

### What this adds
An airport control tower: a radar dish that sweeps above the cab, a plane that taxis down the runway between blinking edge lights, and a CLEARANCE badge that holds in the header.

### Acceptance Criteria covered
- Radar dish sweeps above the control cab
- Plane taxis along the runway at each loop
- Runway lights blink while the VECTOR badge blinks

### Files
- submissions/examples/ease-airport-control-tower-ij/demo.html
- submissions/examples/ease-airport-control-tower-ij/style.css
- submissions/examples/ease-airport-control-tower-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the radar sweep while the plane taxis along the runway.