### PR TITLE
fix: ease-progress focus outline clipped by parent overflow (#59787)

### DIFF
--- a/submissions/examples/ease-progress-focus-outline-clipped-59787/README.md
+++ b/submissions/examples/ease-progress-focus-outline-clipped-59787/README.md
@@ -1,0 +1,14 @@
+# Fix: ease-progress focus outline is clipped by parent overflow
+
+### Description
+The `ease-progress` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience.
+
+### Expected Behavior
+The focus ring should be fully visible, either by using a negative outline offset or an inset box-shadow, so it is contained within the element's bounding box and avoids clipping from a parent container.
+
+### Implementation
+- `style.css`: Uses `outline-offset: -2px` on `:focus-visible` to ensure the focus outline is rendered inward and is not clipped by any parent `overflow` container.
+- `demo.html`: Demonstrates the `ease-progress` component inside an `overflow: hidden` wrapper.
+
+### Testing
+Open `demo.html` in a browser and press `Tab` to focus the progress element. Verify that the focus outline is completely visible and not truncated.

--- a/submissions/examples/ease-progress-focus-outline-clipped-59787/demo.html
+++ b/submissions/examples/ease-progress-focus-outline-clipped-59787/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-progress Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        height: 60px; /* Force small height to ensure clipping if focus is outside */
+        display: flex;
+        align-items: center;
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-progress</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Focus the progress component below using the <code>Tab</code> key.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <progress class="ease-progress" value="75" max="100" tabindex="0">75%</progress>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-progress-focus-outline-clipped-59787/style.css
+++ b/submissions/examples/ease-progress-focus-outline-clipped-59787/style.css
@@ -1,0 +1,38 @@
+/* 
+ * Fix for ease-progress focus outline clipping
+ * Issue: When .ease-progress is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-progress {
+    width: 100%;
+    height: 20px;
+    appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    border-radius: 10px;
+    background-color: #e5e7eb;
+    overflow: hidden;
+}
+
+.ease-progress::-webkit-progress-bar {
+    background-color: #e5e7eb;
+    border-radius: 10px;
+}
+
+.ease-progress::-webkit-progress-value {
+    background-color: #3b82f6;
+    border-radius: 10px;
+}
+
+.ease-progress::-moz-progress-bar {
+    background-color: #3b82f6;
+    border-radius: 10px;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-progress:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: -2px; /* Pulls the outline inward */
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug (Issue #59787) where the `ease-progress` component suffers from a clipping issue when placed inside a parent container with `overflow: hidden` or `overflow: auto`. The focus ring (outline) gets cut off, degrading the accessibility experience. The fix applies a negative `outline-offset` (`-2px`) on the `:focus-visible` state to ensure the focus outline is drawn inward and remains fully visible.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Resolves an accessibility bug by ensuring the focus outline for the `ease-progress` component is never clipped by a parent container's overflow settings.

**How does a developer use it?**

```html
<!-- The fix applies automatically when the progress element is focused -->
<div style="overflow: hidden;">
  <progress class="ease-progress" value="75" max="100" tabindex="0">75%</progress>
</div>
