### PR TITLE
Add ease-cinema-reel-change component

### DIFF
--- a/submissions/examples/ease-cinema-reel-change-ij/README.md
+++ b/submissions/examples/ease-cinema-reel-change-ij/README.md
@@ -1,0 +1,7 @@
+# ease-cinema-reel-change
+A projection booth with feed and take reels that spin, a film strip that advances, and marquee bulbs that blink.
+## Run
+Open `demo.html` directly in a browser to watch the reels turn.
+## Notes
+- The two reels spin at their own speeds.
+- The film strip advances between them.

--- a/submissions/examples/ease-cinema-reel-change-ij/demo.html
+++ b/submissions/examples/ease-cinema-reel-change-ij/demo.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.85">
+<title>Cinema Reel Change</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main class="cinema-booth">
+  <header class="cinema-head">
+    <h1 class="cinema-name">PREMIERE</h1>
+    <p class="cinema-reel">REEL 2</p>
+  </header>
+  <section class="cinema-scene" aria-label="Film projector with two reels">
+    <div class="projector">
+      <div class="film-reel feed-reel">
+        <span class="reel-rim"></span>
+        <span class="reel-center"></span>
+      </div>
+      <div class="film-reel take-reel">
+        <span class="reel-rim"></span>
+        <span class="reel-center"></span>
+      </div>
+      <span class="film-strip"></span>
+      <span class="projector-lens"></span>
+      <span class="projector-gate"></span>
+      <span class="projector-body"></span>
+    </div>
+    <div class="beam-screen">
+      <span class="light-beam"></span>
+      <span class="screen-frame"></span>
+    </div>
+    <span class="marquee-bulb bulb-1"></span>
+    <span class="marquee-bulb bulb-2"></span>
+    <span class="marquee-bulb bulb-3"></span>
+  </section>
+  <footer class="cinema-foot">
+    <span class="cinema-count">FRAME 118</span>
+    <span class="cinema-splice">SPLICE</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/ease-cinema-reel-change-ij/style.css
+++ b/submissions/examples/ease-cinema-reel-change-ij/style.css
@@ -1,0 +1,37 @@
+:root{
+--cinema-night:#16100f;
+--cinema-maroon:#8a2c20;
+--cinema-gold:#ffd23f;
+}
+*::before,*::after,*{padding:0;box-sizing:border-box;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(10,22%,14%),hsl(20,28%,5%));font-family:'Consolas',monospace}
+.cinema-booth{width:372px;padding:16px;border-radius:16px;background:var(--cinema-night);box-shadow:0 0 0 3px #3a2c28,0 14px 34px rgba(0,0,0,0.7)}
+.cinema-head{display:flex;justify-content:space-between;align-items:center;padding:2px 4px 11px}
+.cinema-name{color:#f0e8d8;font-size:18px;letter-spacing:3px}
+.cinema-reel{color:var(--cinema-gold);font-size:12px;font-weight:bold;animation:splice-blink-cinema-reel-change 1.6s ease-in-out infinite}
+.cinema-scene{position:relative;height:230px;background:linear-gradient(180deg,#241a16,#120c0a);border-radius:12px;overflow:hidden}
+.projector{position:absolute;left:12px;bottom:16px;width:210px;height:120px}
+.projector-body{position:absolute;left:24px;right:10px;bottom:0;height:52px;background:linear-gradient(180deg,#3a2c28,#241a16);border-radius:10px;box-shadow:inset 0 0 0 4px #16100f}
+.film-reel{position:absolute;width:74px;height:74px;border-radius:50%;background:radial-gradient(circle,#1c1412 0 14px,#3a2c28 14px 22px,#16100f 22px 24px,#3a2c28 24px 34px);box-shadow:0 4px 10px rgba(0,0,0,0.5)}
+.feed-reel{left:6px;bottom:0;animation:feed-spin-cinema-reel-change 3.4s linear infinite}
+.take-reel{right:6px;bottom:0;animation:take-spin-cinema-reel-change 2.6s linear infinite}
+.reel-rim{position:absolute;inset:10px;border-radius:50%;border:6px dashed rgba(90,60,50,0.8)}
+.reel-center{position:absolute;left:50%;top:50%;width:16px;height:16px;margin:-8px 0 0 -8px;border-radius:50%;background:#16100f}
+.film-strip{position:absolute;left:70px;right:70px;top:24px;height:16px;background:repeating-linear-gradient(90deg,#120c0a 0 8px,#f0e8d8 8px 10px);border-radius:3px;animation:strip-advance-cinema-reel-change 0.6s linear infinite}
+.projector-lens{position:absolute;left:94px;top:8px;width:22px;height:16px;background:radial-gradient(circle at 50% 50%,#8fd8ff,#2a5a8a);border-radius:6px;box-shadow:0 0 12px rgba(143,216,255,0.7)}
+.projector-gate{position:absolute;left:100px;bottom:0;width:8px;height:52px;background:#16100f;border-radius:4px}
+.beam-screen{position:absolute;right:10px;bottom:30px;width:110px;height:120px}
+.light-beam{position:absolute;left:6px;top:20px;width:0;height:0;border-top:30px solid transparent;border-bottom:30px solid transparent;border-right:104px solid rgba(143,216,255,0.22);animation:beam-breathe-cinema-reel-change 2.2s ease-in-out infinite}
+.screen-frame{position:absolute;right:0;top:4px;width:56px;height:110px;background:linear-gradient(180deg,#2a201c,#1c1412);border:3px solid #3a2c28;border-radius:6px}
+.marquee-bulb{position:absolute;top:10px;width:10px;height:10px;border-radius:50%;background:var(--cinema-gold);box-shadow:0 0 10px rgba(255,210,63,0.8);animation:bulb-blink-cinema-reel-change 1.2s ease-in-out infinite}
+.bulb-1{left:30px}
+.bulb-2{left:60px;animation-delay:0.3s}
+.bulb-3{left:90px;animation-delay:0.6s}
+.cinema-foot{display:flex;justify-content:space-between;padding:11px 3px 0;color:#9aa0ab;font-size:12px}
+.cinema-splice{color:var(--cinema-gold);font-weight:bold;animation:splice-blink-cinema-reel-change 1.6s ease-in-out infinite}
+@keyframes feed-spin-cinema-reel-change{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes take-spin-cinema-reel-change{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes strip-advance-cinema-reel-change{0%{background-position:0 0}100%{background-position:10px 0}}
+@keyframes beam-breathe-cinema-reel-change{0%,100%{opacity:0.5}50%{opacity:1}}
+@keyframes bulb-blink-cinema-reel-change{0%,100%{opacity:1}50%{opacity:0.3}}
+@keyframes splice-blink-cinema-reel-change{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-cinema-reel-change — feed and take reels spin, film strip advances, beam breathes

**Closes #60248**

### What this adds
A projection booth: a feed reel and a take reel that spin at their own speeds while the film strip advances between them, a projector lens that throws a breathing beam, and marquee bulbs that blink above.

### Acceptance Criteria covered
- Feed and take reels spin at different speeds
- Film strip advances between the two reels
- Marquee bulbs blink while the REEL badge holds

### Files
- submissions/examples/ease-cinema-reel-change-ij/demo.html
- submissions/examples/ease-cinema-reel-change-ij/style.css
- submissions/examples/ease-cinema-reel-change-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the reels turn while the film strip advances toward the screen.