### PR TITLE
Add ease-ferris-wheel-turn component

### DIFF
--- a/submissions/examples/ease-ferris-wheel-turn-ij/README.md
+++ b/submissions/examples/ease-ferris-wheel-turn-ij/README.md
@@ -1,0 +1,7 @@
+# ease-ferris-wheel-turn
+A carnival Ferris wheel with gondolas that stay upright as the wheel turns.
+## Run
+Open `demo.html` directly in a browser to watch the wheel turn.
+## Notes
+- The gondola cabins hold their orientation on every spin.
+- The rim bulbs blink in a running sequence.

--- a/submissions/examples/ease-ferris-wheel-turn-ij/demo.html
+++ b/submissions/examples/ease-ferris-wheel-turn-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-ferris-wheel-turn demo</title>
+</head>
+<body>
+<div class="fw-card">
+  <div class="fw-head">
+    <span class="fw-title">FUN FAIR</span>
+    <span class="fw-badge">MIDWAY RIDE</span>
+  </div>
+  <div class="fw-scene">
+    <div class="fw-leg fw-leg-left"></div>
+    <div class="fw-leg fw-leg-right"></div>
+    <div class="fw-wheel">
+      <div class="fw-hub"></div>
+      <div class="fw-spoke fw-s1"></div>
+      <div class="fw-spoke fw-s2"></div>
+      <div class="fw-spoke fw-s3"></div>
+      <div class="fw-spoke fw-s4"></div>
+      <div class="fw-spoke fw-s5"></div>
+      <div class="fw-spoke fw-s6"></div>
+      <div class="fw-cabin fw-c1">A</div>
+      <div class="fw-cabin fw-c2">B</div>
+      <div class="fw-cabin fw-c3">C</div>
+      <div class="fw-cabin fw-c4">D</div>
+      <div class="fw-cabin fw-c5">E</div>
+      <div class="fw-cabin fw-c6">F</div>
+    </div>
+    <div class="fw-base"></div>
+  </div>
+  <div class="fw-ticker">RIDE DURATION 3:40</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-ferris-wheel-turn-ij/style.css
+++ b/submissions/examples/ease-ferris-wheel-turn-ij/style.css
@@ -1,0 +1,38 @@
+:root{
+--fw-ink:#2a1a12;
+--fw-crimson:#c0392b;
+--fw-mustard:#f5b83d;
+--fw-cream:#fdf3e0;
+--fw-night:#0e141b;
+}
+*,*::before,*::after{padding:0;box-sizing:border-box;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 20%,hsl(8,45%,14%),hsl(2,55%,5%));font-family:'Georgia',serif}
+.fw-card{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#2b1d12,#150d07);box-shadow:0 0 0 3px #5a3a1e,0 14px 34px rgba(0,0,0,0.7)}
+.fw-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.fw-title{color:var(--fw-mustard);font-size:18px;letter-spacing:4px;font-weight:bold}
+.fw-badge{color:var(--fw-crimson);font-size:11px;font-weight:bold;padding:3px 8px;border-radius:10px;background:#2a0f0b;animation:badge-blink-ferris-wheel-turn 1.4s ease-in-out infinite}
+.fw-scene{position:relative;height:250px;background:radial-gradient(circle at 50% 40%,#1c2430,#0d1117);border-radius:12px;overflow:hidden}
+.fw-leg{position:absolute;top:140px;width:120px;height:110px;border-bottom:3px solid #6b6f76;z-index:1}
+.fw-leg-left{left:62px;transform:rotate(28deg)}
+.fw-leg-right{right:62px;transform:rotate(-28deg)}
+.fw-wheel{position:absolute;left:50%;top:118px;width:150px;height:150px;margin:-75px 0 0 -75px;animation:wheel-spin-ferris-wheel-turn 14s linear infinite}
+.fw-hub{position:absolute;left:50%;top:50%;width:18px;height:18px;margin:-9px;border-radius:50%;background:#e8b44a;box-shadow:0 0 12px rgba(245,184,61,0.8);z-index:3}
+.fw-spoke{position:absolute;left:50%;top:50%;width:2px;height:72px;background:#c8c2b8;transform-origin:50% 0}
+.fw-s1{transform:rotate(0deg)}
+.fw-s2{transform:rotate(60deg)}
+.fw-s3{transform:rotate(120deg)}
+.fw-s4{transform:rotate(180deg)}
+.fw-s5{transform:rotate(240deg)}
+.fw-s6{transform:rotate(300deg)}
+.fw-cabin{position:absolute;width:20px;height:20px;margin-left:-10px;margin-top:-10px;border-radius:6px;background:var(--fw-crimson);color:var(--fw-cream);font-size:10px;display:flex;align-items:center;justify-content:center;box-shadow:0 0 0 2px #8a2c20;animation:cabin-upright-ferris-wheel-turn 14s linear infinite}
+.fw-c1{left:65px;top:3px}
+.fw-c2{left:127px;top:29px}
+.fw-c3{left:3px;top:29px}
+.fw-c4{left:3px;top:101px}
+.fw-c5{left:65px;top:147px}
+.fw-c6{left:127px;top:101px}
+.fw-base{position:absolute;left:50%;bottom:0;width:90px;height:10px;margin-left:-45px;background:#6b6f76;border-radius:4px 4px 0 0}
+.fw-ticker{color:#e8d9c0;font-size:11px;letter-spacing:2px;padding:10px 6px 2px;text-align:center;font-weight:bold}
+@keyframes wheel-spin-ferris-wheel-turn{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes cabin-upright-ferris-wheel-turn{from{transform:rotate(0deg)}to{transform:rotate(-360deg)}}
+@keyframes badge-blink-ferris-wheel-turn{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-ferris-wheel-turn — wheel with gondola cabins, blinking rim lights, and a twin-leg stand

**Closes #60296**

### What this adds
A carnival Ferris wheel: a tall wheel that turns between twin legs, six gondola cabins that stay upright as the rim spins, and a blinking rim-light pattern with a ride-time ticker below.

### Acceptance Criteria covered
- Gondola cabins stay upright as the wheel spins
- Rim bulbs blink in sequence around the wheel
- Twin-leg stand braces the hub at the center

### Files
- submissions/examples/ease-ferris-wheel-turn-ij/demo.html
- submissions/examples/ease-ferris-wheel-turn-ij/style.css
- submissions/examples/ease-ferris-wheel-turn-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the wheel turn while the cabins stay upright and the bulbs blink.