### PR TITLE
fix: ease-pagination focus outline clipped by parent overflow #59783

### DIFF
--- a/submissions/examples/ease-pagination-focus-outline-clipped-59783/README.md
+++ b/submissions/examples/ease-pagination-focus-outline-clipped-59783/README.md
@@ -1,0 +1,18 @@
+# Focus Outline Clipping Fix for ease-pagination
+
+This submission addresses an accessibility bug where the focus outline for `.ease-pagination` (and its items) gets clipped when placed inside a container with `overflow: hidden` or `overflow: auto`.
+
+## Issue
+By default, the browser's focus outline is drawn outside the element's bounding box. When the component is near the edge of a container that clips its overflow, the focus ring becomes partially or fully invisible, degrading accessibility for keyboard users.
+
+## Solution
+We ensure the focus indicator remains visible by pulling it inward using CSS `outline-offset` with a negative value:
+
+```css
+.ease-pagination-item:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: -2px; /* Pulls the outline inward */
+}
+```
+
+This ensures the focus ring is always drawn within the component's boundaries, preventing clipping by parent elements.

--- a/submissions/examples/ease-pagination-focus-outline-clipped-59783/demo.html
+++ b/submissions/examples/ease-pagination-focus-outline-clipped-59783/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-pagination Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        height: 60px; /* Force small height to ensure clipping if focus is outside */
+        display: flex;
+        align-items: center;
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-pagination</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Focus the pagination component below using the <code>Tab</code> key.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <nav aria-label="Pagination">
+        <ul class="ease-pagination">
+          <li><a href="#" class="ease-pagination-item" aria-label="Previous">&laquo;</a></li>
+          <li><a href="#" class="ease-pagination-item">1</a></li>
+          <li><a href="#" class="ease-pagination-item active" aria-current="page">2</a></li>
+          <li><a href="#" class="ease-pagination-item">3</a></li>
+          <li><a href="#" class="ease-pagination-item" aria-label="Next">&raquo;</a></li>
+        </ul>
+      </nav>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-pagination-focus-outline-clipped-59783/style.css
+++ b/submissions/examples/ease-pagination-focus-outline-clipped-59783/style.css
@@ -1,0 +1,47 @@
+/* 
+ * Fix for ease-pagination focus outline clipping
+ * Issue: When .ease-pagination is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-pagination {
+    display: inline-flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: 0.5rem;
+}
+
+.ease-pagination-item {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background-color: #fff;
+    color: #374151;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.ease-pagination-item:hover {
+    background-color: #f3f4f6;
+}
+
+.ease-pagination-item.active {
+    background-color: #3b82f6;
+    color: #fff;
+    border-color: #3b82f6;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-pagination-item:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: -2px; /* Pulls the outline inward */
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes an accessibility bug where the focus ring for the `.ease-pagination` component gets clipped when placed inside a container with `overflow: hidden` or `overflow: auto`. The solution utilizes a negative `outline-offset` to ensure the focus outline is drawn inwards, keeping it fully visible within the bounding box of the pagination item.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This resolves a focus outline clipping bug on the `ease-pagination` component for improved accessibility.

**How does a developer use it?**

```html
<nav aria-label="Pagination">
  <ul class="ease-pagination">
    <li><a href="#" class="ease-pagination-item">1</a></li>
    <li><a href="#" class="ease-pagination-item active" aria-current="page">2</a></li>
    <li><a href="#" class="ease-pagination-item">3</a></li>
  </ul>
</nav>
