### PR TITLE
Add ease-oil-derrick-nod component

### DIFF
--- a/submissions/examples/ease-oil-derrick-nod-ij/README.md
+++ b/submissions/examples/ease-oil-derrick-nod-ij/README.md
@@ -1,0 +1,7 @@
+# ease-oil-derrick-nod
+A pumpjack with a nodding walking beam, a turning crank, and a stroking rod.
+## Run
+Open `demo.html` directly in a browser to watch the beam nod.
+## Notes
+- The walking beam rocks around the A-frame apex.
+- The crank wheel turns beside the beam pivot.

--- a/submissions/examples/ease-oil-derrick-nod-ij/demo.html
+++ b/submissions/examples/ease-oil-derrick-nod-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-oil-derrick-nod demo</title>
+</head>
+<body>
+<div class="od-card">
+  <div class="od-head">
+    <span class="od-brand">TEXARKANA</span>
+    <span class="od-badge">PUMP 7</span>
+  </div>
+  <div class="od-scene">
+    <div class="od-frame">
+      <div class="od-beam"></div>
+      <div class="od-horse"></div>
+      <div class="od-crank"></div>
+    </div>
+    <div class="od-stroke"></div>
+    <div class="od-ground"></div>
+  </div>
+  <div class="od-readout">BARRELS 12,400</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-oil-derrick-nod-ij/style.css
+++ b/submissions/examples/ease-oil-derrick-nod-ij/style.css
@@ -1,0 +1,25 @@
+:root{
+--od-rust:#b3402a;
+--od-amber:#f2b84b;
+--od-iron:#6a7076;
+--od-dust:#e6dcc8;
+--od-night:#0f1419;
+}
+*,*::before,*::after{padding:0;margin:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(28,25%,15%),hsl(34,30%,6%));font-family:'Rockwell',serif}
+.od-card{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#232018,#12100b);box-shadow:0 0 0 3px #4a4030,0 14px 34px rgba(0,0,0,0.72)}
+.od-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.od-brand{color:var(--od-dust);font-size:18px;letter-spacing:3px;font-weight:bold}
+.od-badge{color:var(--od-amber);font-size:11px;font-weight:bold;padding:3px 8px;border-radius:9px;background:#241a08;animation:oil-blink-oil-derrick-nod 1.6s ease-in-out infinite}
+.od-scene{position:relative;height:230px;background:linear-gradient(180deg,#242a30,#12161b);border-radius:12px;overflow:hidden}
+.od-frame{position:absolute;left:50%;top:36px;width:220px;height:120px;margin-left:-110px}
+.od-beam{position:absolute;left:20px;top:8px;width:172px;height:7px;background:var(--od-iron);border-radius:4px;transform-origin:102px 3px;animation:beam-nod-oil-derrick-nod 2.8s ease-in-out infinite}
+.od-horse{position:absolute;left:20px;top:-4px;width:26px;height:26px;border-radius:6px 6px 10px 10px;background:var(--od-rust);transform-origin:102px 12px;animation:beam-nod-oil-derrick-nod 2.8s ease-in-out infinite}
+.od-crank{position:absolute;right:24px;top:26px;width:16px;height:16px;border-radius:50%;background:#3a3f45;box-shadow:inset 0 0 0 3px #25292e;animation:crank-turn-oil-derrick-nod 2.8s linear infinite}
+.od-stroke{position:absolute;left:50%;top:118px;width:6px;height:92px;margin-left:-3px;background:linear-gradient(180deg,#2b3238,#1a1e23);transform-origin:50% 0;animation:stroke-nod-oil-derrick-nod 2.8s ease-in-out infinite}
+.od-ground{position:absolute;left:0;right:0;bottom:0;height:26px;background:linear-gradient(180deg,#3a3226,#241f16)}
+.od-readout{color:#cfc4ac;font-size:11px;letter-spacing:2px;text-align:center;padding:10px 6px 2px;font-weight:bold}
+@keyframes beam-nod-oil-derrick-nod{0%,100%{transform:rotate(-7deg)}50%{transform:rotate(7deg)}}
+@keyframes stroke-nod-oil-derrick-nod{0%,100%{transform:translateY(0) scaleY(1)}50%{transform:translateY(22px) scaleY(0.72)}}
+@keyframes crank-turn-oil-derrick-nod{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes oil-blink-oil-derrick-nod{0%,100%{opacity:1}50%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-oil-derrick-nod — walking beam nods, crank wheel turns, and sucker rod strokes

**Closes #60314**

### What this adds
A pumpjack at an oil field: a walking beam that nods between its A-frame, a crank wheel that turns beside the apex, and a sucker rod that strokes the wellhead as the pump badge blinks.

### Acceptance Criteria covered
- Walking beam nods around the A-frame apex
- Crank wheel turns beside the beam pivot
- Sucker rod strokes the wellhead at each loop

### Files
- submissions/examples/ease-oil-derrick-nod-ij/demo.html
- submissions/examples/ease-oil-derrick-nod-ij/style.css
- submissions/examples/ease-oil-derrick-nod-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the beam nod while the crank turns and the rod strokes.