### PR TITLE
Add ease-steam-locomotive-chuff component

### DIFF
--- a/submissions/examples/ease-steam-locomotive-chuff-ij/README.md
+++ b/submissions/examples/ease-steam-locomotive-chuff-ij/README.md
@@ -1,0 +1,7 @@
+# ease-steam-locomotive-chuff
+A steam locomotive with turning drive wheels, a sliding rod, and drifting smoke.
+## Run
+Open `demo.html` directly in a browser to watch the wheels turn.
+## Notes
+- The drive wheels spin beneath the boiler.
+- Twin steam puffs drift up from the stack.

--- a/submissions/examples/ease-steam-locomotive-chuff-ij/demo.html
+++ b/submissions/examples/ease-steam-locomotive-chuff-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-steam-locomotive-chuff demo</title>
+</head>
+<body>
+<div class="sl-engine">
+  <div class="sl-head">
+    <span class="sl-roadname">PIONEER EXPRESS</span>
+    <span class="sl-badge">4-6-2</span>
+  </div>
+  <div class="sl-frame">
+    <div class="sl-boiler"></div>
+    <div class="sl-cab"></div>
+    <div class="sl-stack">
+      <div class="sl-puff sl-puff-1"></div>
+      <div class="sl-puff sl-puff-2"></div>
+    </div>
+    <div class="sl-dome"></div>
+    <div class="sl-rod"></div>
+    <div class="sl-wheel sl-w1"></div>
+    <div class="sl-wheel sl-w2"></div>
+    <div class="sl-wheel sl-w3"></div>
+    <div class="sl-wheel sl-w4"></div>
+  </div>
+  <div class="sl-tender">TENDER 2,000 GAL</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-steam-locomotive-chuff-ij/style.css
+++ b/submissions/examples/ease-steam-locomotive-chuff-ij/style.css
@@ -1,0 +1,32 @@
+:root{
+--sl-green:#24422e;
+--sl-maroon:#7a2020;
+--sl-brass:#e3b23c;
+--sl-soot:#2a2d33;
+--sl-cloud:#f2f4f6;
+--sl-rail:#101318;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 26%,hsl(120,16%,16%),hsl(140,22%,6%));font-family:'Times New Roman',serif}
+.sl-engine{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#1e2a20,#121a13);box-shadow:0 0 0 3px #3a523e,0 14px 34px rgba(0,0,0,0.72)}
+.sl-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.sl-roadname{color:var(--sl-brass);font-size:18px;letter-spacing:3px;font-weight:bold}
+.sl-badge{color:var(--sl-cloud);font-size:11px;font-weight:bold;padding:3px 8px;border-radius:9px;background:#20262c;animation:whistle-blink-steam-locomotive-chuff 1.5s ease-in-out infinite}
+.sl-frame{position:relative;height:190px;background:linear-gradient(180deg,#333a41,#14181c);border-radius:12px;overflow:hidden}
+.sl-boiler{position:absolute;left:14px;top:26px;width:200px;height:62px;border-radius:34px;background:linear-gradient(180deg,#4a5057,#262b30);box-shadow:inset 0 -12px 0 rgba(0,0,0,0.25)}
+.sl-cab{position:absolute;right:8px;top:14px;width:70px;height:76px;background:var(--sl-green);border-radius:6px 6px 2px 2px;box-shadow:inset -10px 0 0 rgba(0,0,0,0.2)}
+.sl-stack{position:absolute;left:26px;top:4px;width:26px;height:26px;background:var(--sl-maroon);border-radius:6px}
+.sl-puff{position:absolute;left:34px;top:-2px;width:22px;height:22px;border-radius:50%;background:var(--sl-cloud);opacity:0;animation:smoke-puff-steam-locomotive-chuff 2.4s ease-out infinite}
+.sl-puff-2{animation-delay:1.2s}
+.sl-dome{position:absolute;left:120px;top:12px;width:26px;height:20px;border-radius:50% 50% 4px 4px;background:var(--sl-brass)}
+.sl-rod{position:absolute;left:44px;top:128px;width:150px;height:5px;background:#b9bec6;border-radius:3px;transform-origin:4px center;animation:rod-drive-steam-locomotive-chuff 1.2s linear infinite}
+.sl-wheel{position:absolute;bottom:22px;width:34px;height:34px;margin-left:-17px;border-radius:50%;background:var(--sl-soot);box-shadow:inset 0 0 0 5px #4a4f57;animation:wheel-turn-steam-locomotive-chuff 1.2s linear infinite}
+.sl-w1{left:60px}
+.sl-w2{left:100px}
+.sl-w3{left:140px}
+.sl-w4{left:270px}
+.sl-tender{color:#c8cdd3;font-size:11px;letter-spacing:2px;text-align:center;padding:10px 6px 2px;font-weight:bold}
+@keyframes wheel-turn-steam-locomotive-chuff{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes rod-drive-steam-locomotive-chuff{0%,100%{transform:translateX(0)}50%{transform:translateX(16px)}}
+@keyframes smoke-puff-steam-locomotive-chuff{0%{transform:translate(0,0) scale(0.6);opacity:0.9}70%{transform:translate(30px,-46px) scale(1.7);opacity:0.5}100%{transform:translate(56px,-82px) scale(2.2);opacity:0}}
+@keyframes whistle-blink-steam-locomotive-chuff{0%,100%{opacity:1}50%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-steam-locomotive-chuff — drive wheels turn, coupling rod slides, and smoke puffs

**Closes #60344**

### What this adds
A steam locomotive: drive wheels that turn as the coupling rod slides along the frame, a brass dome and smokestack, and twin puffs of steam that drift up from the stack while the road name holds in the header.

### Acceptance Criteria covered
- Drive wheels turn beneath the boiler
- Coupling rod slides with each wheel turn
- Steam puffs drift up from the smokestack

### Files
- submissions/examples/ease-steam-locomotive-chuff-ij/demo.html
- submissions/examples/ease-steam-locomotive-chuff-ij/style.css
- submissions/examples/ease-steam-locomotive-chuff-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the wheels turn while the rod slides and steam puffs rise.