### PR TITLE
fix: prevent focus ring clipping on ease-input via inset box-shadow

### DIFF
--- a/submissions/docs/ease-input-focus-fix-aan22/README.md
+++ b/submissions/docs/ease-input-focus-fix-aan22/README.md
@@ -1,0 +1,16 @@
+# ease-input focus ring clipping fix
+
+**What does this do?**
+Fixes the input focus ring so it stays visible even inside a parent with `overflow: hidden` or `overflow: auto`, by drawing the ring inward (`inset`) instead of outward.
+
+**How is it used?**
+Wrap any input in a container and apply the class:
+
+    <div class="field-wrapper">
+      <input class="demo-input" type="text">
+    </div>
+
+**Why is it useful?**
+The current focus ring is an outward box-shadow, which any ancestor with `overflow: hidden` will clip — a real accessibility regression for keyboard users, since the focus indicator can disappear entirely. Using `inset` keeps the ring inside the element's own bounding box regardless of ancestor overflow, matching the issue's requested expected behavior.
+
+Note: core's `forms.css` also has two competing rules for `.ease-input` — a `:focus-visible` rule and a separate `:focus` rule (tagged `Issue #10869`) with equal specificity, where `:focus` wins on keyboard focus too and dims the ring's alpha (0.18 → 0.1). Flagging this for the maintainer since it's adjacent but likely a separate cleanup.

--- a/submissions/docs/ease-input-focus-fix-aan22/demo.html
+++ b/submissions/docs/ease-input-focus-fix-aan22/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Focus ring clipping fix — ease-input</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>ease-input focus ring: clipping fix</h1>
+
+  <p>The wrapper below has <code>overflow: hidden</code> — exactly like the reported bug. Tab into the input.</p>
+
+  <div class="field-wrapper">
+    <input class="demo-input" type="text" placeholder="Tab to me">
+  </div>
+</body>
+</html>

--- a/submissions/docs/ease-input-focus-fix-aan22/style.css
+++ b/submissions/docs/ease-input-focus-fix-aan22/style.css
@@ -1,0 +1,32 @@
+body {
+  font-family: system-ui, sans-serif;
+  padding: 2rem;
+  max-width: 480px;
+}
+
+/* Reproduces the exact scenario from the issue: a container that
+   clips anything drawn outside its box */
+.field-wrapper {
+  overflow: hidden;
+  border-radius: 8px;
+  padding: 6px;
+}
+
+.demo-input {
+  display: block;
+  width: 100%;
+  padding: 0.625rem 0.875rem;
+  font-size: 1rem;
+  border: 1.5px solid #cbd5e1;
+  border-radius: 0.5rem;
+  outline: none;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+/* Fix: inset box-shadow is drawn INSIDE the element's own border box,
+   so a parent's overflow:hidden can never clip it — unlike the
+   outward `0 0 0 3px` shadow currently used in core. */
+.demo-input:focus-visible {
+  border-color: #6c63ff;
+  box-shadow: inset 0 0 0 3px rgba(108, 99, 255, 0.35);
+}


### PR DESCRIPTION
## Pull Request Description
Fixes the ease-input focus ring so it's no longer clipped when the input sits inside a parent container with `overflow: hidden` or `overflow: auto`, by switching from an outward box-shadow to an inset one. Addresses issue #59767.

## Type of Change
- [x] 🐛 Bug fix in an existing submission

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/ease-input-focus-fix-aan22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
An inset box-shadow variant for the input focus ring, so it stays fully visible inside containers with `overflow: hidden`.

**How does a developer use it?**
```html
<div class="field-wrapper">
  <input class="demo-input" type="text">
</div>
```

**Why does it fit EaseMotion CSS?**
The current focus ring is drawn outward, so any wrapping container that clips overflow (a common layout pattern) cuts off the focus indicator — a real accessibility regression for keyboard users. Drawing the ring inward keeps it inside the element's own bounding box regardless of ancestor overflow, which matches the accessibility-first intent of EaseMotion's animation/interaction states.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari

## Notes for Maintainer
This closes out issue #59767. A related PR (#59768) attempted this earlier but was closed without merging, so I re-approached it from scratch.

Separately, I noticed `components/forms.css` has two competing rules on `.ease-input` with equal specificity — a `:focus-visible` rule and a `:focus` rule (tagged `Issue #10869`) — where `:focus` wins on keyboard focus too and quietly dims the ring's opacity (alpha 0.18 → 0.1). Didn't touch it since it's a separate concern and core files are off-limits for this track, but flagging it in case it's worth a follow-up issue.