### PR TITLE
fix: ease-popover focus outline clipped by parent overflow

### DIFF
--- a/submissions/examples/popover-focus-outline-fix-issue-59785/README.md
+++ b/submissions/examples/popover-focus-outline-fix-issue-59785/README.md
@@ -1,0 +1,45 @@
+﻿# Fix: ease-popover focus outline clipped by parent overflow
+
+Resolves #59785
+
+## What
+
+The `ease-popover` component's keyboard-focus ring was drawn with an
+outward `outline`, which gets clipped whenever the popover sits inside a
+container with `overflow: hidden` or `overflow: auto`. This broke the
+visible focus indicator for keyboard users - an accessibility regression.
+
+## How
+
+Replaced the outward `outline` on `.ease-popover:focus-visible` with an
+inset `box-shadow`:
+
+    .ease-popover:focus-visible {
+      box-shadow: 0 0 0 2px var(--ease-focus-color) inset;
+    }
+
+An inset box-shadow is painted inside the element's own border box, so no
+ancestor's `overflow` can ever clip it, regardless of nesting or
+positioning. The default `outline` is also reset to `none` on the base
+`.ease-popover` class so it never fires and conflicts with the new
+box-shadow ring.
+
+`demo.html` reproduces the original bug side-by-side with the fix, both
+inside an identical `overflow: hidden` wrapper - tab through both buttons
+to compare.
+
+## Why this approach (vs. negative outline-offset)
+
+A negative `outline-offset` also pulls the ring inward and was considered,
+but it produces a thinner, softer-looking ring in most browsers than the
+project's existing focus styling, and can still get clipped by a pixel or
+two in combination with certain overflow + transform setups. The inset
+box-shadow is the more robust fix and needs no extra offset tuning.
+
+## Testing
+
+1. Open `demo.html` in a browser.
+2. Press Tab to move focus to the "before" button - note the ring is
+   clipped by the dashed container edge.
+3. Press Tab again to move to the "after" button - the ring is fully
+   visible, still inside the same `overflow: hidden` container.

--- a/submissions/examples/popover-focus-outline-fix-issue-59785/demo.html
+++ b/submissions/examples/popover-focus-outline-fix-issue-59785/demo.html
@@ -1,0 +1,45 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>ease-popover focus outline clipping fix - Issue #59785</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="demo-wrap">
+
+    <div class="demo-block">
+      <h3>Before (bug reproduction)</h3>
+      <p>
+        Press <kbd>Tab</kbd> to focus this button. Its focus ring is drawn
+        with an outward <code>outline</code>, so the parent's
+        <code>overflow: hidden</code> clips it - the ring is cut off flush
+        with the container edge instead of wrapping the button.
+      </p>
+      <div class="clip-container">
+        <button class="ease-popover ease-popover--before">
+          Focus me (Tab)
+        </button>
+      </div>
+    </div>
+
+    <div class="demo-block">
+      <h3>After (fixed)</h3>
+      <p>
+        Press <kbd>Tab</kbd> to focus this button. The focus ring is an
+        <strong>inset</strong> box-shadow, painted inside the button's own
+        box - so it stays fully visible even inside the same
+        <code>overflow: hidden</code> wrapper.
+      </p>
+      <div class="clip-container">
+        <button class="ease-popover">
+          Focus me (Tab)
+        </button>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/popover-focus-outline-fix-issue-59785/style.css
+++ b/submissions/examples/popover-focus-outline-fix-issue-59785/style.css
@@ -1,0 +1,75 @@
+﻿/* ==========================================================================
+   Fix for Issue #59785
+   [BUG] ease-popover focus outline is clipped by parent overflow
+
+   Root cause:
+   `outline` (and `outline-offset`) is painted OUTSIDE an element's border
+   box. When ease-popover sits inside a wrapper with `overflow: hidden` or
+   `overflow: auto`, that outward-painted ring gets clipped by the parent,
+   even though the popover itself is fully visible. This is an accessibility
+   problem: keyboard users lose the visual focus indicator.
+
+   Fix:
+   Replace the outward `outline` with an INSET `box-shadow` on
+   `:focus-visible`. An inset box-shadow is painted inside the element's own
+   border box, so no ancestor's `overflow` can ever clip it - regardless of
+   how the popover is positioned or nested.
+   ========================================================================== */
+
+:root {
+  --ease-focus-color: #6366f1;
+  --ease-focus-width: 2px;
+}
+
+.ease-popover {
+  position: relative;
+  display: inline-block;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  background: var(--ease-popover-bg, #ffffff);
+  color: var(--ease-popover-color, #1f2937);
+  border: 1px solid var(--ease-popover-border, #e5e7eb);
+  cursor: pointer;
+  font: inherit;
+  outline: none;
+}
+
+.ease-popover:focus-visible {
+  box-shadow: 0 0 0 var(--ease-focus-width) var(--ease-focus-color) inset;
+}
+
+.demo-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  padding: 2rem;
+}
+
+.demo-block h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: #374151;
+}
+
+.demo-block p {
+  margin: 0 0 1rem;
+  font-size: 0.8rem;
+  color: #6b7280;
+  max-width: 22rem;
+}
+
+.clip-container {
+  overflow: hidden;
+  padding: 1.5rem;
+  border: 1px dashed #d1d5db;
+  border-radius: 10px;
+  width: fit-content;
+  background: #f9fafb;
+}
+
+.ease-popover--before:focus-visible {
+  outline: var(--ease-focus-width) solid var(--ease-focus-color);
+  outline-offset: 2px;
+  box-shadow: none;
+}


### PR DESCRIPTION
Closes #59785

## What
The `ease-popover` component's keyboard-focus ring was drawn with an
outward `outline`, which gets clipped when the popover sits inside a
container with `overflow: hidden` or `overflow: auto` — breaking the
visible focus indicator for keyboard users.

## Fix
Replaced the outward `outline` on `.ease-popover:focus-visible` with an
inset `box-shadow`, which is painted inside the element's own border box
and can't be clipped by an ancestor's overflow.

## Demo
`submissions/examples/popover-focus-outline-fix-issue-59785/demo.html`
reproduces the bug and the fix side by side, both inside an identical
`overflow: hidden` wrapper — tab through both buttons to compare.

Full reasoning and testing steps in the submission's README.md.