### PR TITLE
feat: add float-drift drawer for fintech dashboard layouts

### DIFF
--- a/submissions/examples/ease-float-drift-drawer-aan22/README.md
+++ b/submissions/examples/ease-float-drift-drawer-aan22/README.md
@@ -1,0 +1,25 @@
+# Float-Drift Drawer (Fintech Dashboard)
+
+**What does this do?**
+A slide-in filter drawer for dashboard layouts that eases in with a soft "drift" — a combined horizontal slide and slight vertical settle using a custom cubic-bezier — instead of snapping in flat, giving a calmer feel suited to fintech UIs.
+
+**How is it used?**
+Pure CSS + HTML, no JS required (checkbox-driven toggle):
+
+    <label for="drift-toggle" class="drift-trigger">Filters</label>
+
+    <input type="checkbox" id="drift-toggle" class="drift-checkbox">
+    <label for="drift-toggle" class="drift-backdrop"></label>
+
+    <aside class="drift-drawer">
+      <!-- drawer content -->
+    </aside>
+
+Toggling the checkbox (via the trigger or backdrop/close labels) slides the `.drift-drawer` in from the right and fades in the `.drift-backdrop`.
+
+**Why is it useful?**
+Dashboard layouts (fintech especially) often need a filter/detail panel that doesn't interrupt the main view. The drift-in motion — translateX plus a small translateY settle — reads as more deliberate and less mechanical than a flat slide, fitting EaseMotion's animation-first, human-readable philosophy. Built with:
+- Pure CSS/HTML, no external JS frameworks
+- Smooth CSS transitions (no keyframes needed for this interaction)
+- Fully responsive (full-width drawer under 640px)
+- `prefers-reduced-motion` support (transitions disabled entirely)

--- a/submissions/examples/ease-float-drift-drawer-aan22/demo.html
+++ b/submissions/examples/ease-float-drift-drawer-aan22/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Float-Drift Drawer — Fintech Dashboard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="dash-topbar">
+    <span class="dash-brand">Ledger<strong>ly</strong></span>
+    <label for="drift-toggle" class="drift-trigger">
+      Filters
+    </label>
+  </header>
+
+  <main class="dash-main">
+    <h1>Transactions Overview</h1>
+    <p>Open the drawer to filter transactions by account, date range, and category.</p>
+
+    <div class="dash-card-grid">
+      <div class="dash-card">
+        <span class="dash-card-label">Balance</span>
+        <span class="dash-card-value">$48,210.55</span>
+      </div>
+      <div class="dash-card">
+        <span class="dash-card-label">This Month</span>
+        <span class="dash-card-value">−$2,340.12</span>
+      </div>
+      <div class="dash-card">
+        <span class="dash-card-label">Pending</span>
+        <span class="dash-card-value">$610.00</span>
+      </div>
+    </div>
+  </main>
+
+  <input type="checkbox" id="drift-toggle" class="drift-checkbox">
+  <label for="drift-toggle" class="drift-backdrop"></label>
+
+  <aside class="drift-drawer">
+    <div class="drift-drawer-header">
+      <h2>Filter Transactions</h2>
+      <label for="drift-toggle" class="drift-close" aria-label="Close">&times;</label>
+    </div>
+
+    <div class="drift-field">
+      <label>Account</label>
+      <select>
+        <option>All accounts</option>
+        <option>Checking</option>
+        <option>Savings</option>
+      </select>
+    </div>
+
+    <div class="drift-field">
+      <label>Date range</label>
+      <select>
+        <option>Last 30 days</option>
+        <option>Last 90 days</option>
+        <option>This year</option>
+      </select>
+    </div>
+
+    <div class="drift-field">
+      <label>Category</label>
+      <select>
+        <option>All categories</option>
+        <option>Income</option>
+        <option>Transfers</option>
+        <option>Subscriptions</option>
+      </select>
+    </div>
+
+    <button class="drift-apply">Apply Filters</button>
+  </aside>
+
+</body>
+</html>

--- a/submissions/examples/ease-float-drift-drawer-aan22/style.css
+++ b/submissions/examples/ease-float-drift-drawer-aan22/style.css
@@ -1,0 +1,192 @@
+:root {
+  --drift-bg: #0f1729;
+  --drift-surface: #ffffff;
+  --drift-primary: #4f6bff;
+  --drift-text: #1e293b;
+  --drift-muted: #64748b;
+  --drift-border: #e2e8f0;
+  --drift-speed: 420ms;
+  --drift-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f5f7fb;
+  color: var(--drift-text);
+}
+
+/* ── Top bar ── */
+.dash-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  background: var(--drift-bg);
+  color: #fff;
+}
+
+.dash-brand { font-size: 1.1rem; font-weight: 400; }
+.dash-brand strong { font-weight: 700; }
+
+.drift-trigger {
+  cursor: pointer;
+  background: var(--drift-primary);
+  color: #fff;
+  padding: 0.5rem 1.1rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.drift-trigger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(79, 107, 255, 0.35);
+}
+
+/* ── Main dashboard content ── */
+.dash-main { padding: 2rem 1.5rem; max-width: 720px; margin: 0 auto; }
+.dash-main h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+.dash-main p { color: var(--drift-muted); margin-bottom: 1.5rem; }
+
+.dash-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.dash-card {
+  background: var(--drift-surface);
+  border: 1px solid var(--drift-border);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.dash-card-label { font-size: 0.8rem; color: var(--drift-muted); }
+.dash-card-value { font-size: 1.25rem; font-weight: 700; }
+
+/* ── Drawer toggle (checkbox hack — no JS needed) ── */
+.drift-checkbox {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── Backdrop ── */
+.drift-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 41, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--drift-speed) var(--drift-ease);
+  z-index: 10;
+}
+
+.drift-checkbox:checked ~ .drift-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── The Float-Drift Drawer itself ──
+   "Drift" = it doesn't just slide in flat; it eases in with a slight
+   float (translateX + subtle vertical settle) using an overshoot-free
+   custom cubic-bezier, giving a soft, weighted landing rather than a
+   mechanical snap — fitting for a calm fintech UI. */
+.drift-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: min(360px, 90vw);
+  background: var(--drift-surface);
+  box-shadow: -8px 0 32px rgba(15, 23, 41, 0.18);
+  padding: 1.5rem;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+
+  transform: translateX(100%) translateY(12px);
+  opacity: 0;
+  transition:
+    transform var(--drift-speed) var(--drift-ease),
+    opacity var(--drift-speed) var(--drift-ease);
+}
+
+.drift-checkbox:checked ~ .drift-drawer {
+  transform: translateX(0) translateY(0);
+  opacity: 1;
+}
+
+.drift-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.drift-drawer-header h2 { font-size: 1.05rem; margin: 0; }
+
+.drift-close {
+  cursor: pointer;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: var(--drift-muted);
+}
+
+.drift-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--drift-muted);
+}
+
+.drift-field select {
+  padding: 0.55rem 0.7rem;
+  border: 1.5px solid var(--drift-border);
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--drift-text);
+  background: #fff;
+}
+
+.drift-apply {
+  margin-top: auto;
+  background: var(--drift-primary);
+  color: #fff;
+  border: none;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.drift-apply:hover { background: #3d59f0; }
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .drift-drawer { width: 100vw; }
+  .dash-card-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 400px) {
+  .dash-card-grid { grid-template-columns: 1fr; }
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .drift-drawer,
+  .drift-backdrop,
+  .drift-trigger {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a Float-Drift Drawer — a slide-in filter panel for dashboard layouts — as a pure CSS/HTML showcase example for fintech-style dashboards. Addresses issue #59279.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-float-drift-drawer-aan22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A checkbox-driven, JS-free filter drawer for dashboard layouts that eases in with a soft horizontal-plus-vertical "drift" motion rather than a flat slide.

**How does a developer use it?**
```html
<label for="drift-toggle" class="drift-trigger">Filters</label>

<input type="checkbox" id="drift-toggle" class="drift-checkbox">
<label for="drift-toggle" class="drift-backdrop"></label>

<aside class="drift-drawer">
  <!-- drawer content -->
</aside>
```

**Why does it fit EaseMotion CSS?**
It's a pure-CSS, animation-first interaction pattern — no JS required — that fits dashboard/fintech layouts needing a non-intrusive filter or detail panel. The drift-in easing (translateX + slight translateY settle via a custom cubic-bezier) gives a more deliberate, calmer feel than a flat slide-in, matching EaseMotion's human-readable animation philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari

## Notes for Maintainer
Built to satisfy the issue's requirements: pure CSS/HTML (no JS frameworks), responsive across viewports (full-width drawer under 640px, card grid reflows at 640px/400px breakpoints), and `prefers-reduced-motion` support (all transitions disabled). Open to naming/timing adjustments — went with a 420ms `cubic-bezier(0.16, 1, 0.3, 1)` for a soft, overshoot-free landing.