### PR TITLE
add animated copy to clip board

### DIFF
--- a/submissions/examples/animated-copy-to-clipboard/README.md
+++ b/submissions/examples/animated-copy-to-clipboard/README.md
@@ -1,0 +1,18 @@
+# Copy-to-Clipboard Button with Checkmark Morph
+
+## What does this do?
+A small button that copies associated text to the clipboard on click, then
+morphs its icon into a checkmark for ~1.5s as visual confirmation before
+reverting.
+
+## How is it used?
+Place .copy-btn next to a code snippet with a data-copy="..."
+attribute holding the text to copy. The accompanying script listens for
+clicks, writes to the clipboard, and toggles a .copied class that drives
+the icon morph transition.
+
+## Why is it useful?
+- The project's own docs page has multiple code blocks with no copy button
+- Extremely common, expected micro-interaction in any documentation site
+- Tiny footprint: a few lines of CSS + JS, no dependencies
+- Directly improves the EaseMotion docs' own usability

--- a/submissions/examples/animated-copy-to-clipboard/demo.html
+++ b/submissions/examples/animated-copy-to-clipboard/demo.html
@@ -1,0 +1,30 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Copy-to-Clipboard Button Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <div class="code-block">
+      <code>npm install easemotion-css</code>
+      <button class="copy-btn" data-copy="npm install easemotion-css">
+        <span class="icon-copy">⧉</span>
+        <span class="icon-check">✓</span>
+      </button>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        navigator.clipboard.writeText(btn.dataset.copy).catch(() => {});
+        btn.classList.add('copied');
+        setTimeout(() => btn.classList.remove('copied'), 1500);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-copy-to-clipboard/style.css
+++ b/submissions/examples/animated-copy-to-clipboard/style.css
@@ -1,0 +1,32 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; padding: 40px; }
+.demo-wrap { max-width: 420px; margin: 0 auto; }
+.code-block {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-family: monospace;
+}
+.copy-btn {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 16px;
+}
+.copy-btn .icon-check {
+  position: absolute;
+  inset: 0;
+  color: #22c55e;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.copy-btn.copied .icon-copy { opacity: 0; }
+.copy-btn.copied .icon-check { opacity: 1; transform: scale(1); }


### PR DESCRIPTION
## Pull Request Description

Adds a copy-to-clipboard button with an icon morph (copy → checkmark) confirmation animation, intended for use next to code snippets in docs. Closes #<issue-number>.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/copy-clipboard-btn-xx/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.copy-btn` component with stacked `.icon-copy`/`.icon-check` spans and a
`.copied` state class, plus a minimal clipboard-write script that toggles
the state for a timed confirmation.

**How does a developer use it?**

\`\`\`html
<button class="copy-btn" data-copy="text to copy">
  <span class="icon-copy">⧉</span>
  <span class="icon-check">✓</span>
</button>
\`\`\`