### PR TITLE
feat: add CSS 3D-flip drawer for fintech dashboards (#59271)

### DIFF
--- a/submissions/examples/css-3d-flip-drawer-fintech/README.md
+++ b/submissions/examples/css-3d-flip-drawer-fintech/README.md
@@ -1,0 +1,53 @@
+# CSS 3D-Flip Drawer — Fintech Dashboard Layouts
+
+A pure CSS/HTML 3D-flip card component for fintech dashboards. Each account
+card flips 180° on the Y-axis to reveal a "quick actions" panel on the back.
+No JavaScript — flip state is driven entirely by the checkbox hack.
+
+## Files
+
+- `demo.html` — 3 account cards (Checking / Savings / Investments)
+- `style.css` — all flip logic, theming, responsive rules
+- `README.md` — this file
+
+## How it works
+
+- A visually-hidden `<input type="checkbox">` stores the flip state.
+- A `<label for="...">` wraps the two faces (`.flip-card__face--front` / `--back`).
+- Clicking the label toggles the checkbox natively (no JS).
+- `:checked + .flip-card__inner` rotates the inner wrapper `rotateY(180deg)`.
+- `perspective` (on `.flip-card`) + `transform-style: preserve-3d` (on `.flip-card__inner`)
+  create the 3D effect; `backface-visibility: hidden` hides whichever face is turned away.
+
+## Custom properties
+
+| Property | Purpose |
+|---|---|
+| `--flip-duration` | Flip animation speed (default `0.7s`) |
+| `--flip-easing` | Flip timing function |
+| `--card-w` / `--card-h` | Card dimensions, overridden per breakpoint |
+| `--checking-*`, `--savings-*`, `--invest-*` | Gradient colors per card type |
+
+## Accessibility
+
+- The checkbox is keyboard-focusable and toggles with native `Space`/`Enter`
+  (real `<input>` element, not a faked button) — a visible focus ring is
+  drawn around the card via `:focus-visible`.
+- Each checkbox has a descriptive `aria-label`.
+- `prefers-reduced-motion: reduce` swaps the 3D rotation for a simple
+  opacity crossfade so the content still switches without motion.
+
+## Responsive behavior
+
+| Breakpoint | Card width | Layout |
+|---|---|---|
+| Mobile (≤768px) | 100% | single column |
+| Tablet (769–1179px) | 280px | auto-fit grid |
+| Desktop (≥1180px) | 320px | auto-fit grid |
+
+## Usage
+
+Drop `style.css` into your project and reuse the markup pattern in
+`demo.html` for any card you want to flip — swap the front/back content,
+keep the `.flip-card` / `.flip-card__toggle` / `.flip-card__inner` /
+`.flip-card__face` structure.

--- a/submissions/examples/css-3d-flip-drawer-fintech/demo.html
+++ b/submissions/examples/css-3d-flip-drawer-fintech/demo.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS 3D-Flip Drawer — Fintech Dashboard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="dashboard">
+    <h1 class="dashboard__title">Accounts Overview</h1>
+    <p class="dashboard__subtitle">Click a card (or press Enter/Space) to flip it and reveal quick actions.</p>
+
+    <div class="drawer-grid">
+
+      <!-- Card 1 -->
+      <div class="flip-card">
+        <input type="checkbox" id="flip-1" class="flip-card__toggle sr-only" aria-label="Flip Checking account card for quick actions">
+        <label for="flip-1" class="flip-card__inner">
+
+          <!-- Front -->
+          <div class="flip-card__face flip-card__face--front card card--checking">
+            <div class="card__header">
+              <span class="card__label">Checking</span>
+              <span class="card__badge">•••• 4821</span>
+            </div>
+            <p class="card__balance">$12,480.35</p>
+            <p class="card__sub">Available balance</p>
+            <span class="flip-card__hint">Tap to flip ↻</span>
+          </div>
+
+          <!-- Back -->
+          <div class="flip-card__face flip-card__face--back card card--checking-back">
+            <h3 class="card__actions-title">Quick Actions</h3>
+            <ul class="card__actions">
+              <li>➜ Transfer funds</li>
+              <li>➜ Pay a bill</li>
+              <li>➜ View statements</li>
+              <li>➜ Freeze card</li>
+            </ul>
+            <span class="flip-card__hint">Tap to flip back ↺</span>
+          </div>
+
+        </label>
+      </div>
+
+      <!-- Card 2 -->
+      <div class="flip-card">
+        <input type="checkbox" id="flip-2" class="flip-card__toggle sr-only" aria-label="Flip Savings account card for quick actions">
+        <label for="flip-2" class="flip-card__inner">
+
+          <div class="flip-card__face flip-card__face--front card card--savings">
+            <div class="card__header">
+              <span class="card__label">Savings</span>
+              <span class="card__badge">•••• 9930</span>
+            </div>
+            <p class="card__balance">$48,902.10</p>
+            <p class="card__sub">2.5% APY</p>
+            <span class="flip-card__hint">Tap to flip ↻</span>
+          </div>
+
+          <div class="flip-card__face flip-card__face--back card card--savings-back">
+            <h3 class="card__actions-title">Quick Actions</h3>
+            <ul class="card__actions">
+              <li>➜ Move to checking</li>
+              <li>➜ Set savings goal</li>
+              <li>➜ View interest history</li>
+              <li>➜ Lock account</li>
+            </ul>
+            <span class="flip-card__hint">Tap to flip back ↺</span>
+          </div>
+
+        </label>
+      </div>
+
+      <!-- Card 3 -->
+      <div class="flip-card">
+        <input type="checkbox" id="flip-3" class="flip-card__toggle sr-only" aria-label="Flip Investments account card for quick actions">
+        <label for="flip-3" class="flip-card__inner">
+
+          <div class="flip-card__face flip-card__face--front card card--invest">
+            <div class="card__header">
+              <span class="card__label">Investments</span>
+              <span class="card__badge">•••• 1187</span>
+            </div>
+            <p class="card__balance">$76,215.87</p>
+            <p class="card__sub">↑ 3.2% this month</p>
+            <span class="flip-card__hint">Tap to flip ↻</span>
+          </div>
+
+          <div class="flip-card__face flip-card__face--back card card--invest-back">
+            <h3 class="card__actions-title">Quick Actions</h3>
+            <ul class="card__actions">
+              <li>➜ Buy / sell assets</li>
+              <li>➜ View portfolio</li>
+              <li>➜ Rebalance</li>
+              <li>➜ Download tax docs</li>
+            </ul>
+            <span class="flip-card__hint">Tap to flip back ↺</span>
+          </div>
+
+        </label>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-3d-flip-drawer-fintech/style.css
+++ b/submissions/examples/css-3d-flip-drawer-fintech/style.css
@@ -1,0 +1,227 @@
+:root {
+  --bg: #0f1115;
+  --surface: #171a21;
+  --text: #eef1f6;
+  --muted: #9aa3b2;
+
+  --checking-1: #2d5bff;
+  --checking-2: #1533a3;
+  --savings-1: #16b892;
+  --savings-2: #0a6b56;
+  --invest-1: #a855f7;
+  --invest-2: #5b21a8;
+
+  --radius: 18px;
+  --flip-duration: 0.7s;
+  --flip-easing: cubic-bezier(0.4, 0.2, 0.2, 1);
+
+  --card-w: 320px;
+  --card-h: 200px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Segoe UI", system-ui, -apple-system, Roboto, sans-serif;
+  padding: clamp(24px, 5vw, 64px) clamp(16px, 6vw, 80px);
+}
+
+.dashboard__title {
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  margin: 0 0 4px;
+}
+
+.dashboard__subtitle {
+  color: var(--muted);
+  margin: 0 0 clamp(24px, 4vw, 40px);
+  font-size: clamp(0.85rem, 0.5vw + 0.75rem, 1rem);
+}
+
+.drawer-grid {
+  display: grid;
+  gap: clamp(20px, 3vw, 32px);
+  grid-template-columns: repeat(auto-fit, minmax(var(--card-w), 1fr));
+}
+
+.flip-card {
+  perspective: 1200px;
+  width: 100%;
+  max-width: var(--card-w);
+  height: var(--card-h);
+}
+
+.flip-card__toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.flip-card__toggle:focus-visible + .flip-card__inner {
+  outline: 3px solid #fff;
+  outline-offset: 4px;
+  border-radius: var(--radius);
+}
+
+.flip-card__inner {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  transform-style: preserve-3d;
+  transition: transform var(--flip-duration) var(--flip-easing);
+  transform: rotateY(0deg);
+}
+
+.flip-card__toggle:checked + .flip-card__inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card__face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  border-radius: var(--radius);
+  padding: 22px 24px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.flip-card__face--back {
+  transform: rotateY(180deg);
+}
+
+.flip-card__hint {
+  margin-top: auto;
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.card {
+  color: #fff;
+}
+
+.card--checking,
+.card--checking-back {
+  background: linear-gradient(135deg, var(--checking-1), var(--checking-2));
+}
+
+.card--savings,
+.card--savings-back {
+  background: linear-gradient(135deg, var(--savings-1), var(--savings-2));
+}
+
+.card--invest,
+.card--invest-back {
+  background: linear-gradient(135deg, var(--invest-1), var(--invest-2));
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.card__label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.card__badge {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+
+.card__balance {
+  font-size: clamp(1.6rem, 1vw + 1.4rem, 2rem);
+  font-weight: 700;
+  margin: 18px 0 2px;
+}
+
+.card__sub {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.card__actions-title {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+.card__actions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  :root {
+    --card-w: 100%;
+    --card-h: 180px;
+  }
+
+  .drawer-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1179px) {
+  :root {
+    --card-w: 280px;
+    --card-h: 190px;
+  }
+}
+
+@media (min-width: 1180px) {
+  :root {
+    --card-w: 320px;
+    --card-h: 200px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flip-card__inner,
+  .flip-card__face {
+    transition: opacity 0.2s linear;
+  }
+
+  .flip-card__inner {
+    transform: none !important;
+  }
+
+  .flip-card__face {
+    backface-visibility: visible;
+    -webkit-backface-visibility: visible;
+    transform: none !important;
+  }
+
+  .flip-card__face--back {
+    opacity: 0;
+  }
+
+  .flip-card__toggle:checked + .flip-card__inner .flip-card__face--front {
+    opacity: 0;
+  }
+
+  .flip-card__toggle:checked + .flip-card__inner .flip-card__face--back {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS/HTML 3D-flip drawer card for fintech dashboard layouts (issue #59271). Each account card flips 180° on click/keypress to reveal a quick-actions panel on the back — no JavaScript, driven by the checkbox hack.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/css-3d-flip-drawer-fintech/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A reusable 3D card-flip component (front/back faces) suited to fintech dashboards — balance summary on the front, quick actions on the back.

**How does a developer use it?**

```html
<div class="flip-card">
  <input type="checkbox" id="flip-1" class="flip-card__toggle sr-only" aria-label="Flip card">
  <label for="flip-1" class="flip-card__inner">
    <div class="flip-card__face flip-card__face--front card">
      <!-- front content -->
    </div>
    <div class="flip-card__face flip-card__face--back card">
      <!-- back content -->
    </div>
  </label>
</div>
```

**Why does it fit EaseMotion CSS?**

It's a single, readable CSS pattern (`perspective` + `preserve-3d` + `backface-visibility`) with no JS dependency, matching the library's human-readable, animation-first philosophy. It's also fully themeable via CSS custom properties (`--flip-duration`, `--flip-easing`, gradient vars).

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Flip is driven by a native (visually-hidden but focusable) checkbox rather than a faked tabindex button, so keyboard users get real `Space`/`Enter` toggling with no JS. `prefers-reduced-motion` swaps the 3D rotation for a plain opacity crossfade. Happy to adjust the flip duration/easing if you'd like it snappier.