### PR TITLE
add before/after image comparision

### DIFF
--- a/submissions/examples/after-before-image-comparision/README.md
+++ b/submissions/examples/after-before-image-comparision/README.md
@@ -1,0 +1,16 @@
+# Before/After Image Comparison Slider
+
+## What does this do?
+Overlays two images (before/after) and reveals one over the other as the
+user drags a slider, using CSS clip-path for the reveal effect.
+
+## How is it used?
+Stack a .compare-before image over .compare-after inside .compare,
+then place a transparent <input type="range"> on top. The slider's
+oninput updates the before image's clip-path inset percentage.
+
+## Why is it useful?
+- Common pattern for portfolios, photo tools, and redesign showcases
+- Uses a native range input for accessibility instead of custom pointer-drag JS
+- CSS clip-path handles the visual reveal — minimal script needed
+- Fits EaseMotion's "CSS does the work" philosophy

--- a/submissions/examples/after-before-image-comparision/demo.html
+++ b/submissions/examples/after-before-image-comparision/demo.html
@@ -1,0 +1,20 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Before/After Slider Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <div class="compare">
+      <img class="compare-after" src="https://picsum.photos/id/1015/480/270" alt="After">
+      <img class="compare-before" src="https://picsum.photos/id/1015/480/270?grayscale" alt="Before">
+      <div class="compare-handle" id="handle"></div>
+      <input type="range" class="compare-slider" min="0" max="100" value="50"
+        oninput="document.querySelector('.compare-before').style.clipPath='inset(0 '+(100-this.value)+'% 0 0)'; document.getElementById('handle').style.left=this.value+'%';">
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/after-before-image-comparision/style.css
+++ b/submissions/examples/after-before-image-comparision/style.css
@@ -1,0 +1,38 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; padding: 40px; }
+.demo-wrap { max-width: 480px; margin: 0 auto; }
+.compare {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+.compare img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.compare-before {
+  clip-path: inset(0 50% 0 0);
+}
+.compare-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 3px;
+  background: #fff;
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+.compare-slider {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  margin: 0;
+  cursor: ew-resize;
+  opacity: 0;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a before/after image comparison slider using a native range input and CSS clip-path reveal, for portfolios and redesign showcases. Closes #<issue-number>.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/before-after-slider-xx/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.compare` component: two stacked images, a visual `.compare-handle`
divider, and a transparent range input driving the `.compare-before`
image's `clip-path` inset in real time.

**How does a developer use it?**

\`\`\`html
<div class="compare">
  <img class="compare-after" src="after.jpg" alt="After">
  <img class="compare-before" src="before.jpg" alt="Before">
  <input type="range" class="compare-slider" min="0" max="100" value="50">
</div>
\`\`\`